### PR TITLE
Download bundle compressed datasets file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
 
         # Run tests without optional dependencies
         - env: PYTHON_VERSION=3.7 CMD='make test'
-               CONDA_DEPENDENCIES='Cython click regions'
+               CONDA_DEPENDENCIES='Cython click regions requests tqdm'
                PIP_DEPENDENCIES='pytest-astropy parfive pydantic'
 
         # Run tests without GAMMAPY_DATA available

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ env:
         - ASTROPY_VERSION=stable
         - ASTROPY_USE_SYSTEM_PYTEST=1
 
-        - CONDA_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit'
-        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit'
-        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml pandas naima regions reproject pandoc ipython iminuit'
-        - CONDA_DEPENDENCIES_DOCS='Cython click scipy healpy matplotlib pyyaml pandas naima pygments sherpa regions reproject pandoc ipython jupyter iminuit'
+        - CONDA_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit tqdm'
+        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit tqdm'
+        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml pandas naima regions reproject pandoc ipython iminuit tqdm'
+        - CONDA_DEPENDENCIES_DOCS='Cython click scipy healpy matplotlib pyyaml pandas naima pygments sherpa regions reproject pandoc ipython jupyter iminuit tqdm'
 
         - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-gallery sphinx-click sphinx_rtd_theme pytest-astropy parfive pydantic pytest-astropy-header'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ env:
         - ASTROPY_VERSION=stable
         - ASTROPY_USE_SYSTEM_PYTEST=1
 
-        - CONDA_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit tqdm'
-        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit tqdm'
-        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml pandas naima regions reproject pandoc ipython iminuit tqdm'
-        - CONDA_DEPENDENCIES_DOCS='Cython click scipy healpy matplotlib pyyaml pandas naima pygments sherpa regions reproject pandoc ipython jupyter iminuit tqdm'
+        - CONDA_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit tqdm requests'
+        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit tqdm requests'
+        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml pandas naima regions reproject pandoc ipython iminuit tqdm requests'
+        - CONDA_DEPENDENCIES_DOCS='Cython click scipy healpy matplotlib pyyaml pandas naima pygments sherpa regions reproject pandoc ipython jupyter iminuit tqdm requests'
 
         - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-gallery sphinx-click sphinx_rtd_theme pytest-astropy parfive pydantic pytest-astropy-header'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip setuptools wheel
-      pip install pytest pytest-cov cython numpy astropy regions pyyaml click pytest-astropy parfive tqdm pydantic pytest-astropy-header
+      pip install pytest pytest-cov cython numpy astropy regions pyyaml click pytest-astropy parfive tqdm requests pydantic pytest-astropy-header
       pip install matplotlib reproject iminuit
     displayName: 'Install dependencies'
 
@@ -66,7 +66,7 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip setuptools wheel
-      pip install cython numpy astropy regions pyyaml click parfive tqdm pydantic jupyter
+      pip install cython numpy astropy regions pyyaml click parfive tqdm requests pydantic jupyter
       pip install matplotlib reproject iminuit emcee corner
     displayName: 'Install dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip setuptools wheel
-      pip install pytest pytest-cov cython numpy astropy regions pyyaml click pytest-astropy parfive pydantic pytest-astropy-header
+      pip install pytest pytest-cov cython numpy astropy regions pyyaml click pytest-astropy parfive tqdm pydantic pytest-astropy-header
       pip install matplotlib reproject iminuit
     displayName: 'Install dependencies'
 
@@ -66,7 +66,7 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip setuptools wheel
-      pip install cython numpy astropy regions pyyaml click parfive pydantic jupyter
+      pip install cython numpy astropy regions pyyaml click parfive tqdm pydantic jupyter
       pip install matplotlib reproject iminuit emcee corner
     displayName: 'Install dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,7 @@ jobs:
       key: gammapy_data | $(Build.SourceVersion)
       restoreKeys: |
          gammapy_data | $(Build.SourceVersion)
+         gammapy_data
       path: $(GAMMAPY_DATA)
     displayName: Cache GAMMAPY_DATA
 
@@ -88,6 +89,7 @@ jobs:
       key: gammapy_data | $(Build.SourceVersion)
       restoreKeys: |
          gammapy_data | $(Build.SourceVersion)
+         gammapy_data
       path: $(GAMMAPY_DATA)
     displayName: Cache GAMMAPY_DATA
 
@@ -165,6 +167,7 @@ jobs:
       key: gammapy_data | $(Build.SourceVersion)
       restoreKeys: |
          gammapy_data | $(Build.SourceVersion)
+         gammapy_data
       path: $(GAMMAPY_DATA)
     displayName: Cache GAMMAPY_DATA
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,14 @@ jobs:
       python -m gammapy info
     displayName: 'Install Gammapy'
 
+  - task: Cache@2
+    inputs:
+      key: gammapy_data | $(Build.SourceVersion)
+      restoreKeys: |
+         gammapy_data | $(Build.SourceVersion)
+      path: $(GAMMAPY_DATA)
+    displayName: Cache GAMMAPY_DATA
+
   - script: |
       gammapy download datasets --out=$(GAMMAPY_DATA) --silent --tests
     displayName: 'Get GAMMAPY_DATA'
@@ -74,6 +82,14 @@ jobs:
       pip install -e .
       python -m gammapy info
     displayName: 'Install Gammapy'
+
+  - task: Cache@2
+    inputs:
+      key: gammapy_data | $(Build.SourceVersion)
+      restoreKeys: |
+         gammapy_data | $(Build.SourceVersion)
+      path: $(GAMMAPY_DATA)
+    displayName: Cache GAMMAPY_DATA
 
   - script: |
       gammapy download datasets --out=$(GAMMAPY_DATA) --silent --tests
@@ -143,6 +159,14 @@ jobs:
       pip install -e .
       gammapy info
     displayName: 'Create gammapy-dev conda environment'
+
+  - task: Cache@2
+    inputs:
+      key: gammapy_data | $(Build.SourceVersion)
+      restoreKeys: |
+         gammapy_data | $(Build.SourceVersion)
+      path: $(GAMMAPY_DATA)
+    displayName: Cache GAMMAPY_DATA
 
   - script: |
       source activate gammapy-dev

--- a/dev/datasets/gammapy-data-index.json
+++ b/dev/datasets/gammapy-data-index.json
@@ -7,64 +7,55 @@
     "path": "cta-1dc/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/README.md",
     "filesize": 497,
-    "hashmd5": "64cde583f9a4f2c655d008a0c6a69da3",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/README.md"
+    "hashmd5": "64cde583f9a4f2c655d008a0c6a69da3"
    },
    {
     "path": "cta-1dc/make.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/make.py",
     "filesize": 1940,
-    "hashmd5": "3d5004b41f25d0fbc98d8307c30932cb",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/make.py"
+    "hashmd5": "3d5004b41f25d0fbc98d8307c30932cb"
    },
    {
     "path": "cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits",
     "filesize": 3755520,
-    "hashmd5": "6e71aeaef4283c3011c538c8e10fef3e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+    "hashmd5": "6e71aeaef4283c3011c538c8e10fef3e"
    },
    {
     "path": "cta-1dc/index/gps/hdu-index.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/index/gps/hdu-index.fits.gz",
     "filesize": 951,
-    "hashmd5": "909dd4ba6a9a4b0a02c64cc42a834526",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/index/gps/hdu-index.fits.gz"
+    "hashmd5": "909dd4ba6a9a4b0a02c64cc42a834526"
    },
    {
     "path": "cta-1dc/index/gps/obs-index.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/index/gps/obs-index.fits.gz",
     "filesize": 1315,
-    "hashmd5": "a717b56f14f1de38916d2fc48f4e3d09",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/index/gps/obs-index.fits.gz"
+    "hashmd5": "a717b56f14f1de38916d2fc48f4e3d09"
    },
    {
     "path": "cta-1dc/data/baseline/gps/gps_baseline_111140.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/data/baseline/gps/gps_baseline_111140.fits",
     "filesize": 3862080,
-    "hashmd5": "5f2cd2bd3f7d6f6f0da0a96ecabda530",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/data/baseline/gps/gps_baseline_111140.fits"
+    "hashmd5": "5f2cd2bd3f7d6f6f0da0a96ecabda530"
    },
    {
     "path": "cta-1dc/data/baseline/gps/gps_baseline_111630.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/data/baseline/gps/gps_baseline_111630.fits",
     "filesize": 4078080,
-    "hashmd5": "80ea55ad321c2caa3d31a12a6f6982cf",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/data/baseline/gps/gps_baseline_111630.fits"
+    "hashmd5": "80ea55ad321c2caa3d31a12a6f6982cf"
    },
    {
     "path": "cta-1dc/data/baseline/gps/gps_baseline_110380.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits",
     "filesize": 3859200,
-    "hashmd5": "4605e912a2bd2d6ef584df99b8d98243",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits"
+    "hashmd5": "4605e912a2bd2d6ef584df99b8d98243"
    },
    {
     "path": "cta-1dc/data/baseline/gps/gps_baseline_111159.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/data/baseline/gps/gps_baseline_111159.fits",
     "filesize": 3841920,
-    "hashmd5": "2900521b08396c81b5053c5c5a7e9278",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/data/baseline/gps/gps_baseline_111159.fits"
+    "hashmd5": "2900521b08396c81b5053c5c5a7e9278"
    }
   ]
  },
@@ -76,15 +67,13 @@
     "path": "dark_matter_spectra/AtProduction_gammas.dat",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/dark_matter_spectra/AtProduction_gammas.dat",
     "filesize": 3884096,
-    "hashmd5": "a15c7536755030b04fdef20edda49ce0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/dark_matter_spectra/AtProduction_gammas.dat"
+    "hashmd5": "a15c7536755030b04fdef20edda49ce0"
    },
    {
     "path": "dark_matter_spectra/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/dark_matter_spectra/README.md",
     "filesize": 84,
-    "hashmd5": "88512ffffe8df62d57271fc4e9be4641",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/dark_matter_spectra/README.md"
+    "hashmd5": "88512ffffe8df62d57271fc4e9be4641"
    }
   ]
  },
@@ -96,1660 +85,1423 @@
     "path": "catalogs/2HWC.ecsv",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/2HWC.ecsv",
     "filesize": 7113,
-    "hashmd5": "869634db5af53014eedd68f0db937c0e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/2HWC.ecsv"
+    "hashmd5": "869634db5af53014eedd68f0db937c0e"
    },
    {
     "path": "catalogs/make_2hwc.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/make_2hwc.py",
     "filesize": 3468,
-    "hashmd5": "4a7246cb30132070f975923dbb712b63",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/make_2hwc.py"
+    "hashmd5": "4a7246cb30132070f975923dbb712b63"
    },
    {
     "path": "catalogs/2HWC.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/2HWC.yaml",
     "filesize": 18588,
-    "hashmd5": "75aa4e1c8c7f7a404f798eaf1406d80f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/2HWC.yaml"
+    "hashmd5": "75aa4e1c8c7f7a404f798eaf1406d80f"
    },
    {
     "path": "catalogs/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/README.rst",
     "filesize": 178,
-    "hashmd5": "5a19a76774d175e5ba8ddc915c828816",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/README.rst"
+    "hashmd5": "5a19a76774d175e5ba8ddc915c828816"
    },
    {
     "path": "catalogs/hgps_catalog_v1.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/hgps_catalog_v1.fits.gz",
     "filesize": 49518,
-    "hashmd5": "be68a10cfcf1fa64f7488da957475b0f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/hgps_catalog_v1.fits.gz"
+    "hashmd5": "be68a10cfcf1fa64f7488da957475b0f"
    },
    {
     "path": "catalogs/fermi/gll_psch_v09.fit.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psch_v09.fit.gz",
     "filesize": 521889,
-    "hashmd5": "0fc06485f80ac4970bb7aafd8672b2a2",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/gll_psch_v09.fit.gz"
+    "hashmd5": "0fc06485f80ac4970bb7aafd8672b2a2"
    },
    {
     "path": "catalogs/fermi/gll_psch_v13.fit.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psch_v13.fit.gz",
     "filesize": 373649,
-    "hashmd5": "ac56115c72199a6686cb03616226d234",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/gll_psch_v13.fit.gz"
+    "hashmd5": "ac56115c72199a6686cb03616226d234"
    },
    {
     "path": "catalogs/fermi/gll_psc_v20.fit.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psc_v20.fit.gz",
     "filesize": 6362843,
-    "hashmd5": "c65ca6ae4df4210bb766f02720233166",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/gll_psc_v20.fit.gz"
+    "hashmd5": "c65ca6ae4df4210bb766f02720233166"
    },
    {
     "path": "catalogs/fermi/gll_psch_v08.fit.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psch_v08.fit.gz",
     "filesize": 205855,
-    "hashmd5": "60f2f72841cc6217da6a4de0af155b6e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/gll_psch_v08.fit.gz"
+    "hashmd5": "60f2f72841cc6217da6a4de0af155b6e"
    },
    {
     "path": "catalogs/fermi/gll_psc_v16.fit.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psc_v16.fit.gz",
     "filesize": 2422086,
-    "hashmd5": "8e6adab5eeaad9d97008344a574617e1",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/gll_psc_v16.fit.gz"
+    "hashmd5": "8e6adab5eeaad9d97008344a574617e1"
    },
    {
     "path": "catalogs/fermi/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/README.rst",
     "filesize": 307,
-    "hashmd5": "3c4970ea0ec1c15fec3690d1d6ba3b9a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/README.rst"
+    "hashmd5": "3c4970ea0ec1c15fec3690d1d6ba3b9a"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/LAT_ext_v15.reg",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/LAT_ext_v15.reg",
     "filesize": 1999,
-    "hashmd5": "7bea2a762ceadb62241649ded131fc1a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/LAT_ext_v15.reg"
+    "hashmd5": "7bea2a762ceadb62241649ded131fc1a"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/LAT_extended_sources_v15.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/LAT_extended_sources_v15.fits",
     "filesize": 20160,
-    "hashmd5": "7e99fd02217d8935bb3171aa213b9dbb",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/LAT_extended_sources_v15.fits"
+    "hashmd5": "7e99fd02217d8935bb3171aa213b9dbb"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/LAT_ext_rev15.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/LAT_ext_rev15.txt",
     "filesize": 7252,
-    "hashmd5": "fd4b63d879de449c5af3d8cac0bb3d91",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/LAT_ext_rev15.txt"
+    "hashmd5": "fd4b63d879de449c5af3d8cac0bb3d91"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/SMC.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/SMC.xml",
     "filesize": 728,
-    "hashmd5": "57907c29b171e0c62a1623840d0c8c0e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/SMC.xml"
+    "hashmd5": "57907c29b171e0c62a1623840d0c8c0e"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1837-069.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1837-069.xml",
     "filesize": 825,
-    "hashmd5": "aa9231b6bfc9f53911e4ccc4485c321f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1837-069.xml"
+    "hashmd5": "aa9231b6bfc9f53911e4ccc4485c321f"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1303-631.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1303-631.xml",
     "filesize": 824,
-    "hashmd5": "efdfb98b00d414968699d2c6c551dfd1",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1303-631.xml"
+    "hashmd5": "efdfb98b00d414968699d2c6c551dfd1"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/CenALobes.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/CenALobes.xml",
     "filesize": 815,
-    "hashmd5": "898394d4a8de0d4545627c8ee63422bf",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/CenALobes.xml"
+    "hashmd5": "898394d4a8de0d4545627c8ee63422bf"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1614-518.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1614-518.xml",
     "filesize": 825,
-    "hashmd5": "7d0b3c098d7124c4a119aa868d417099",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1614-518.xml"
+    "hashmd5": "7d0b3c098d7124c4a119aa868d417099"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/LMC.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/LMC.xml",
     "filesize": 780,
-    "hashmd5": "36164cbaf921070e5f59c5de78c87bbe",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/LMC.xml"
+    "hashmd5": "36164cbaf921070e5f59c5de78c87bbe"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/RXJ1713.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/RXJ1713.xml",
     "filesize": 819,
-    "hashmd5": "e8e759e841f9df3c0ea5551bdd8e0226",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/RXJ1713.xml"
+    "hashmd5": "e8e759e841f9df3c0ea5551bdd8e0226"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1632-478.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1632-478.xml",
     "filesize": 824,
-    "hashmd5": "c23da546eace2f52514dda042694cdee",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1632-478.xml"
+    "hashmd5": "c23da546eace2f52514dda042694cdee"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HB21.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HB21.xml",
     "filesize": 809,
-    "hashmd5": "4cff9e2832ebe5b96b2ce48d58a2d88c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HB21.xml"
+    "hashmd5": "4cff9e2832ebe5b96b2ce48d58a2d88c"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/W28.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/W28.xml",
     "filesize": 789,
-    "hashmd5": "b902629cc9511f1b5c32de199f54e561",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/W28.xml"
+    "hashmd5": "b902629cc9511f1b5c32de199f54e561"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/S147.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/S147.xml",
     "filesize": 806,
-    "hashmd5": "021822e460df969349fc965e5386b231",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/S147.xml"
+    "hashmd5": "021822e460df969349fc965e5386b231"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1825-137.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1825-137.xml",
     "filesize": 825,
-    "hashmd5": "58473fa87e05d079ac78afe39f8f69e2",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1825-137.xml"
+    "hashmd5": "58473fa87e05d079ac78afe39f8f69e2"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/CygnusLoop.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/CygnusLoop.xml",
     "filesize": 821,
-    "hashmd5": "cc539813370a095d0d0e54bf06add70f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/CygnusLoop.xml"
+    "hashmd5": "cc539813370a095d0d0e54bf06add70f"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1616-508.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1616-508.xml",
     "filesize": 824,
-    "hashmd5": "70dc5a47c647f9ca9a8c15dedc99bd02",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1616-508.xml"
+    "hashmd5": "70dc5a47c647f9ca9a8c15dedc99bd02"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/W51C.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/W51C.xml",
     "filesize": 777,
-    "hashmd5": "8b5459014ea877d7da0fd5ec502a9c90",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/W51C.xml"
+    "hashmd5": "8b5459014ea877d7da0fd5ec502a9c90"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/MSH15-52.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/MSH15-52.xml",
     "filesize": 810,
-    "hashmd5": "4158ea0c750f282d9d11f4abffb1e985",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/MSH15-52.xml"
+    "hashmd5": "4158ea0c750f282d9d11f4abffb1e985"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/CygnusCocoon.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/CygnusCocoon.xml",
     "filesize": 809,
-    "hashmd5": "3b790aff2a3db9619dd2e56c1a299489",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/CygnusCocoon.xml"
+    "hashmd5": "3b790aff2a3db9619dd2e56c1a299489"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/IC443.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/IC443.xml",
     "filesize": 833,
-    "hashmd5": "6520a86b4325edd8dcbc13cc37f33bce",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/IC443.xml"
+    "hashmd5": "6520a86b4325edd8dcbc13cc37f33bce"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/W30.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/W30.xml",
     "filesize": 804,
-    "hashmd5": "d6b1281b8d94887f7c6e3ab73ead740e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/W30.xml"
+    "hashmd5": "d6b1281b8d94887f7c6e3ab73ead740e"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/gammaCygni.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/gammaCygni.xml",
     "filesize": 804,
-    "hashmd5": "91c8eccb3e50b7d36bc4e40ee3936213",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/gammaCygni.xml"
+    "hashmd5": "91c8eccb3e50b7d36bc4e40ee3936213"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/VelaJr.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/VelaJr.xml",
     "filesize": 810,
-    "hashmd5": "5906184c853f734330970d3afc56d574",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/VelaJr.xml"
+    "hashmd5": "5906184c853f734330970d3afc56d574"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/PuppisA.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/PuppisA.xml",
     "filesize": 734,
-    "hashmd5": "6d3916821b652a2b046d4491d7af6832",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/PuppisA.xml"
+    "hashmd5": "6d3916821b652a2b046d4491d7af6832"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1841-055.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1841-055.xml",
     "filesize": 824,
-    "hashmd5": "df3c67b2c923965470f95ceea47c15fd",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1841-055.xml"
+    "hashmd5": "df3c67b2c923965470f95ceea47c15fd"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/VelaX.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/VelaX.xml",
     "filesize": 792,
-    "hashmd5": "4842a102c7c2c55f2de49aeadaf22bfc",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/VelaX.xml"
+    "hashmd5": "4842a102c7c2c55f2de49aeadaf22bfc"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/W44.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/W44.xml",
     "filesize": 790,
-    "hashmd5": "2b2bcfd2a54e003ea0007925342f3c05",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/W44.xml"
+    "hashmd5": "2b2bcfd2a54e003ea0007925342f3c05"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/SMC.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/SMC.fits",
     "filesize": 164160,
-    "hashmd5": "5873391917ed1b38997961a936c4bcb1",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/SMC.fits"
+    "hashmd5": "5873391917ed1b38997961a936c4bcb1"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/CygnusLoop.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/CygnusLoop.fits",
     "filesize": 43200,
-    "hashmd5": "58239e37ad7215638fc0a12b4d59fcee",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/CygnusLoop.fits"
+    "hashmd5": "58239e37ad7215638fc0a12b4d59fcee"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/gammaCygni.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/gammaCygni.fits",
     "filesize": 31680,
-    "hashmd5": "5db7b578300f6271da735d0403db13d2",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/gammaCygni.fits"
+    "hashmd5": "5db7b578300f6271da735d0403db13d2"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/CenALobes.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/CenALobes.fits",
     "filesize": 103680,
-    "hashmd5": "750789bc7adb1287abfae28a76f7c593",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/CenALobes.fits"
+    "hashmd5": "750789bc7adb1287abfae28a76f7c593"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1837-069.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1837-069.fits",
     "filesize": 31680,
-    "hashmd5": "f83eaddf097daa4b05df6952e6bd2b60",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1837-069.fits"
+    "hashmd5": "f83eaddf097daa4b05df6952e6bd2b60"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1632-478.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1632-478.fits",
     "filesize": 31680,
-    "hashmd5": "2c97549741663d2910e6cafef783cb39",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1632-478.fits"
+    "hashmd5": "2c97549741663d2910e6cafef783cb39"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1841-055.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1841-055.fits",
     "filesize": 31680,
-    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1841-055.fits"
+    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/PuppisA.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/PuppisA.fits",
     "filesize": 31680,
-    "hashmd5": "739433150d2dd8a30c0e70cfd05aa9e4",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/PuppisA.fits"
+    "hashmd5": "739433150d2dd8a30c0e70cfd05aa9e4"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/W44.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/W44.fits",
     "filesize": 23040,
-    "hashmd5": "622426056c3931be2c77f149a920e87a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/W44.fits"
+    "hashmd5": "622426056c3931be2c77f149a920e87a"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1614-518.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1614-518.fits",
     "filesize": 31680,
-    "hashmd5": "91039728e5e1543dd99f37e73272868a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1614-518.fits"
+    "hashmd5": "91039728e5e1543dd99f37e73272868a"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/W28.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/W28.fits",
     "filesize": 46080,
-    "hashmd5": "581e177258b7d71d6975c9b096b835b5",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/W28.fits"
+    "hashmd5": "581e177258b7d71d6975c9b096b835b5"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1303-631.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1303-631.fits",
     "filesize": 31680,
-    "hashmd5": "7854547f001a8c39ecf82aea8dade4b6",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1303-631.fits"
+    "hashmd5": "7854547f001a8c39ecf82aea8dade4b6"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/IC443.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/IC443.fits",
     "filesize": 69120,
-    "hashmd5": "5180b14063e00fa7b2cf88fbb97331fd",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/IC443.fits"
+    "hashmd5": "5180b14063e00fa7b2cf88fbb97331fd"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/CygnusCocoon.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/CygnusCocoon.fits",
     "filesize": 31680,
-    "hashmd5": "83bbfd306df67f2591245b142eefca3c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/CygnusCocoon.fits"
+    "hashmd5": "83bbfd306df67f2591245b142eefca3c"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1616-508.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1616-508.fits",
     "filesize": 31680,
-    "hashmd5": "396c63111ee42651e60ac52c3a99dee8",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1616-508.fits"
+    "hashmd5": "396c63111ee42651e60ac52c3a99dee8"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/MSH15-52.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/MSH15-52.fits",
     "filesize": 46080,
-    "hashmd5": "fe22e8789fe7479bd4650f98949d14e3",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/MSH15-52.fits"
+    "hashmd5": "fe22e8789fe7479bd4650f98949d14e3"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/VelaJr.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/VelaJr.fits",
     "filesize": 31680,
-    "hashmd5": "504b98555ee389b76f504fa69a900625",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/VelaJr.fits"
+    "hashmd5": "504b98555ee389b76f504fa69a900625"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.fits",
     "filesize": 20160,
-    "hashmd5": "3cc2dc521fdaa85450f4fcfa453d5843",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.fits"
+    "hashmd5": "3cc2dc521fdaa85450f4fcfa453d5843"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/W30.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/W30.fits",
     "filesize": 31680,
-    "hashmd5": "31badb1fcbf6870e6f3be6b2261b835c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/W30.fits"
+    "hashmd5": "31badb1fcbf6870e6f3be6b2261b835c"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HB21.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HB21.fits",
     "filesize": 31680,
-    "hashmd5": "88a9e5fdac58358fbc8d84014519b947",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HB21.fits"
+    "hashmd5": "88a9e5fdac58358fbc8d84014519b947"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/S147.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/S147.fits",
     "filesize": 40320,
-    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/S147.fits"
+    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1825-137.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1825-137.fits",
     "filesize": 46080,
-    "hashmd5": "0137d054a62eb62c5e872b7a8ba5f14b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1825-137.fits"
+    "hashmd5": "0137d054a62eb62c5e872b7a8ba5f14b"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/LMC.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/LMC.fits",
     "filesize": 1005120,
-    "hashmd5": "bfc3b99ebe78b56a1415433a5f8fb04b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/LMC.fits"
+    "hashmd5": "bfc3b99ebe78b56a1415433a5f8fb04b"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/VelaX.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/VelaX.fits",
     "filesize": 46080,
-    "hashmd5": "a6fed48ebd0bf917049dc54a509e5b25",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/VelaX.fits"
+    "hashmd5": "a6fed48ebd0bf917049dc54a509e5b25"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.7-3946.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.7-3946.fits",
     "filesize": 20160,
-    "hashmd5": "3cc2dc521fdaa85450f4fcfa453d5843",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.7-3946.fits"
+    "hashmd5": "3cc2dc521fdaa85450f4fcfa453d5843"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/W51C.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/W51C.fits",
     "filesize": 8640,
-    "hashmd5": "fe1cfdd061a069b72a19c5a47c807e3d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/W51C.fits"
+    "hashmd5": "fe1cfdd061a069b72a19c5a47c807e3d"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Extended_8years.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Extended_8years.txt",
     "filesize": 2636,
-    "hashmd5": "e9d6436927837c7160855a12dd689e25",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Extended_8years.txt"
+    "hashmd5": "e9d6436927837c7160855a12dd689e25"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.fits",
     "filesize": 34560,
-    "hashmd5": "70f8b8c19e8698fab4264701ec497100",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.fits"
+    "hashmd5": "70f8b8c19e8698fab4264701ec497100"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.reg",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.reg",
     "filesize": 6068,
-    "hashmd5": "dd5b44333ab6848f3f562fcd2a15435f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.reg"
+    "hashmd5": "dd5b44333ab6848f3f562fcd2a15435f"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2208.4+6443.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2208.4+6443.xml",
     "filesize": 822,
-    "hashmd5": "54e199baa242ebbbcd87eb10c392eb60",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2208.4+6443.xml"
+    "hashmd5": "54e199baa242ebbbcd87eb10c392eb60"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1741.6-3917.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1741.6-3917.xml",
     "filesize": 803,
-    "hashmd5": "aca86a5cf6f8b4281a48c7cad9c573ac",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1741.6-3917.xml"
+    "hashmd5": "aca86a5cf6f8b4281a48c7cad9c573ac"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1626.9-2431.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1626.9-2431.xml",
     "filesize": 823,
-    "hashmd5": "b0ffc299179daeed50d965168ba86b01",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1626.9-2431.xml"
+    "hashmd5": "b0ffc299179daeed50d965168ba86b01"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/Rosette.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Rosette.xml",
     "filesize": 791,
-    "hashmd5": "1ca7e7e35384272f0f6510f65d82b214",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Rosette.xml"
+    "hashmd5": "1ca7e7e35384272f0f6510f65d82b214"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1501.0-6310.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1501.0-6310.xml",
     "filesize": 822,
-    "hashmd5": "bcd84361066c314ec016e3460aa69a10",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1501.0-6310.xml"
+    "hashmd5": "bcd84361066c314ec016e3460aa69a10"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/RXJ1713-3946.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/RXJ1713-3946.xml",
     "filesize": 715,
-    "hashmd5": "d383d0e670f4217f28e1f08608be84b9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/RXJ1713-3946.xml"
+    "hashmd5": "d383d0e670f4217f28e1f08608be84b9"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1813-178.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1813-178.xml",
     "filesize": 828,
-    "hashmd5": "403bd93e54b31b66cf62ff41da315a71",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1813-178.xml"
+    "hashmd5": "403bd93e54b31b66cf62ff41da315a71"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ2301.9+5855.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ2301.9+5855.xml",
     "filesize": 790,
-    "hashmd5": "fdd6cfae127fd4bb1c957cbf30df8198",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ2301.9+5855.xml"
+    "hashmd5": "fdd6cfae127fd4bb1c957cbf30df8198"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56PWN.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56PWN.xml",
     "filesize": 703,
-    "hashmd5": "6661dd66c5558a79f1fca087a70b920f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56PWN.xml"
+    "hashmd5": "6661dd66c5558a79f1fca087a70b920f"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/Kes73.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Kes73.xml",
     "filesize": 788,
-    "hashmd5": "854154a0a0dce3037b6a5c433ef3c31a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Kes73.xml"
+    "hashmd5": "854154a0a0dce3037b6a5c433ef3c31a"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1303-631.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1303-631.xml",
     "filesize": 805,
-    "hashmd5": "b0f87ed39eab2222a6bd636e86013aeb",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1303-631.xml"
+    "hashmd5": "b0f87ed39eab2222a6bd636e86013aeb"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0427.2+5533.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0427.2+5533.xml",
     "filesize": 793,
-    "hashmd5": "bc12f5c956fb3c5d9f87c800ea78ae91",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0427.2+5533.xml"
+    "hashmd5": "bc12f5c956fb3c5d9f87c800ea78ae91"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HB9.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB9.xml",
     "filesize": 784,
-    "hashmd5": "5022037145b31450de49d4e6e69647b8",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB9.xml"
+    "hashmd5": "5022037145b31450de49d4e6e69647b8"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0851.9-4620.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0851.9-4620.xml",
     "filesize": 800,
-    "hashmd5": "0c0a0dd10ff1c96a5c14d9fe96b21b09",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0851.9-4620.xml"
+    "hashmd5": "0c0a0dd10ff1c96a5c14d9fe96b21b09"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/CenALobes.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CenALobes.xml",
     "filesize": 703,
-    "hashmd5": "5a920a8081fad93d41fdea69aa14917a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CenALobes.xml"
+    "hashmd5": "5a920a8081fad93d41fdea69aa14917a"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1614-518.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1614-518.xml",
     "filesize": 803,
-    "hashmd5": "97e04e460c13df28adc18cb80ff04471",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1614-518.xml"
+    "hashmd5": "97e04e460c13df28adc18cb80ff04471"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1036.3-5833.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1036.3-5833.xml",
     "filesize": 805,
-    "hashmd5": "3a3cd74d391d804f3117655e514cd147",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1036.3-5833.xml"
+    "hashmd5": "3a3cd74d391d804f3117655e514cd147"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/LMC-30DorWest.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-30DorWest.xml",
     "filesize": 703,
-    "hashmd5": "474a44c712fe21fd866828a5c49820af",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-30DorWest.xml"
+    "hashmd5": "474a44c712fe21fd866828a5c49820af"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1553.8-5325.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1553.8-5325.xml",
     "filesize": 802,
-    "hashmd5": "8d27014e08a93d03df676f51b57c37ea",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1553.8-5325.xml"
+    "hashmd5": "8d27014e08a93d03df676f51b57c37ea"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1514.2-5909.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1514.2-5909.xml",
     "filesize": 796,
-    "hashmd5": "a0e2ec76761a430426c45bf505580c09",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1514.2-5909.xml"
+    "hashmd5": "a0e2ec76761a430426c45bf505580c09"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1213.3-6240.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1213.3-6240.xml",
     "filesize": 806,
-    "hashmd5": "d8e3200cdbb5d9f919cde91c7ee327fb",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1213.3-6240.xml"
+    "hashmd5": "d8e3200cdbb5d9f919cde91c7ee327fb"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1636.3-4731.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1636.3-4731.xml",
     "filesize": 883,
-    "hashmd5": "efee681766839745640d54d335f0ccc6",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1636.3-4731.xml"
+    "hashmd5": "efee681766839745640d54d335f0ccc6"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1642.1-5428.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1642.1-5428.xml",
     "filesize": 820,
-    "hashmd5": "7a61acafc9f564ee92cc233c8f0c93a0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1642.1-5428.xml"
+    "hashmd5": "7a61acafc9f564ee92cc233c8f0c93a0"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/Monoceros.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Monoceros.xml",
     "filesize": 889,
-    "hashmd5": "42cab4707b94fa1f8d3e75a1691768d2",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Monoceros.xml"
+    "hashmd5": "42cab4707b94fa1f8d3e75a1691768d2"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2304.0+5406.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2304.0+5406.xml",
     "filesize": 822,
-    "hashmd5": "3235a9879518fd1418db95605e7daebe",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2304.0+5406.xml"
+    "hashmd5": "3235a9879518fd1418db95605e7daebe"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HB21.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB21.xml",
     "filesize": 893,
-    "hashmd5": "3771a421bd1b197526380fcef0358632",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB21.xml"
+    "hashmd5": "3771a421bd1b197526380fcef0358632"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1804.7-2144.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1804.7-2144.xml",
     "filesize": 803,
-    "hashmd5": "d9ea65af5264e3ec4cd4af042bbf4ebc",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1804.7-2144.xml"
+    "hashmd5": "d9ea65af5264e3ec4cd4af042bbf4ebc"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1809-193.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1809-193.xml",
     "filesize": 793,
-    "hashmd5": "da9f2e7da23937110c7388eccd70d815",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1809-193.xml"
+    "hashmd5": "da9f2e7da23937110c7388eccd70d815"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1023.3-5747.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1023.3-5747.xml",
     "filesize": 800,
-    "hashmd5": "29f3aa8744813e96eb1aea836b19f23e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1023.3-5747.xml"
+    "hashmd5": "29f3aa8744813e96eb1aea836b19f23e"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/RCW86.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/RCW86.xml",
     "filesize": 688,
-    "hashmd5": "7f8d15c142785329d037e7a27c0347e5",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/RCW86.xml"
+    "hashmd5": "7f8d15c142785329d037e7a27c0347e5"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1745.8-3028.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1745.8-3028.xml",
     "filesize": 802,
-    "hashmd5": "96ade2a42cc3644c2d0cef199633b6fc",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1745.8-3028.xml"
+    "hashmd5": "96ade2a42cc3644c2d0cef199633b6fc"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W28.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W28.xml",
     "filesize": 893,
-    "hashmd5": "3cbc8bbb5fc20f471faa7e4145bfea21",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W28.xml"
+    "hashmd5": "3cbc8bbb5fc20f471faa7e4145bfea21"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1857.7+0246.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1857.7+0246.xml",
     "filesize": 799,
-    "hashmd5": "958096535dddfa1fa399152a81f37067",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1857.7+0246.xml"
+    "hashmd5": "958096535dddfa1fa399152a81f37067"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/S147.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/S147.xml",
     "filesize": 692,
-    "hashmd5": "6f8ce195b1b8fc654cd7d1951b69ee44",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/S147.xml"
+    "hashmd5": "6f8ce195b1b8fc654cd7d1951b69ee44"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1409.1-6121.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1409.1-6121.xml",
     "filesize": 803,
-    "hashmd5": "74fae54c61bbfe7cd490d319cd45edaf",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1409.1-6121.xml"
+    "hashmd5": "74fae54c61bbfe7cd490d319cd45edaf"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1825-137.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1825-137.xml",
     "filesize": 909,
-    "hashmd5": "72ccdf2a056a3165d54d3084bdc53dad",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1825-137.xml"
+    "hashmd5": "72ccdf2a056a3165d54d3084bdc53dad"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/CygnusLoop.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CygnusLoop.xml",
     "filesize": 807,
-    "hashmd5": "e5d28e2984356121cffe913e4ca89334",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CygnusLoop.xml"
+    "hashmd5": "e5d28e2984356121cffe913e4ca89334"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FornaxA.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FornaxA.xml",
     "filesize": 691,
-    "hashmd5": "074f2ed5ab6b5b7a2153b21d1ef97c34",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FornaxA.xml"
+    "hashmd5": "074f2ed5ab6b5b7a2153b21d1ef97c34"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1616-508.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1616-508.xml",
     "filesize": 803,
-    "hashmd5": "f185b774124e2c75dca2286dcb41be42",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1616-508.xml"
+    "hashmd5": "f185b774124e2c75dca2286dcb41be42"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1836.5-0651.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1836.5-0651.xml",
     "filesize": 802,
-    "hashmd5": "bf97234dda826019fc67add047fb211f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1836.5-0651.xml"
+    "hashmd5": "bf97234dda826019fc67add047fb211f"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1355.1-6420.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1355.1-6420.xml",
     "filesize": 818,
-    "hashmd5": "23af2e257e7c20d8f8631ed57ce68585",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1355.1-6420.xml"
+    "hashmd5": "23af2e257e7c20d8f8631ed57ce68585"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W51C.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W51C.xml",
     "filesize": 777,
-    "hashmd5": "b2ab4fc57e378573bef826d176d757b7",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W51C.xml"
+    "hashmd5": "b2ab4fc57e378573bef826d176d757b7"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/CygnusCocoon.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CygnusCocoon.xml",
     "filesize": 778,
-    "hashmd5": "b2fcb235260d755aadde6e31cbfccb19",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CygnusCocoon.xml"
+    "hashmd5": "b2fcb235260d755aadde6e31cbfccb19"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/LMC-North.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-North.xml",
     "filesize": 695,
-    "hashmd5": "ecf7c247ebac33311b1b8e53a6ea7cfe",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-North.xml"
+    "hashmd5": "ecf7c247ebac33311b1b8e53a6ea7cfe"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/IC443.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/IC443.xml",
     "filesize": 901,
-    "hashmd5": "43f0fba75ffa4ccee0de3098809ca3b9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/IC443.xml"
+    "hashmd5": "43f0fba75ffa4ccee0de3098809ca3b9"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1507.9-6228.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1507.9-6228.xml",
     "filesize": 800,
-    "hashmd5": "e88e6df5bd9e6c5d6bddeb0b434b2264",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1507.9-6228.xml"
+    "hashmd5": "e88e6df5bd9e6c5d6bddeb0b434b2264"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1109.4-6115.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1109.4-6115.xml",
     "filesize": 890,
-    "hashmd5": "2555c7d77e47cde241dbb773c2b19b7d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1109.4-6115.xml"
+    "hashmd5": "2555c7d77e47cde241dbb773c2b19b7d"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56SNR.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56SNR.xml",
     "filesize": 706,
-    "hashmd5": "b2f9fe354039f2ef223361e9e0c0b75f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56SNR.xml"
+    "hashmd5": "b2f9fe354039f2ef223361e9e0c0b75f"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W30.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W30.xml",
     "filesize": 892,
-    "hashmd5": "f743f9af42bef960306abe32da4e1b02",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W30.xml"
+    "hashmd5": "f743f9af42bef960306abe32da4e1b02"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1808-204.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1808-204.xml",
     "filesize": 940,
-    "hashmd5": "15d59ebb417712178b718394b5335b09",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1808-204.xml"
+    "hashmd5": "15d59ebb417712178b718394b5335b09"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/LMC-FarWest.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-FarWest.xml",
     "filesize": 699,
-    "hashmd5": "8244d49e689d932b4df6b7584288f683",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-FarWest.xml"
+    "hashmd5": "8244d49e689d932b4df6b7584288f683"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1652.2-4633.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1652.2-4633.xml",
     "filesize": 803,
-    "hashmd5": "8ba14e3558b20fda37139a8fbde5fad7",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1652.2-4633.xml"
+    "hashmd5": "8ba14e3558b20fda37139a8fbde5fad7"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/gammaCygni.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/gammaCygni.xml",
     "filesize": 770,
-    "hashmd5": "ac3815894c2485972c345a84e886ec5e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/gammaCygni.xml"
+    "hashmd5": "ac3815894c2485972c345a84e886ec5e"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1420.3-6046.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1420.3-6046.xml",
     "filesize": 820,
-    "hashmd5": "6698224f6c35fd37aa1a418e47290adf",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1420.3-6046.xml"
+    "hashmd5": "6698224f6c35fd37aa1a418e47290adf"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1834.1-0706.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1834.1-0706.xml",
     "filesize": 797,
-    "hashmd5": "b4e9c21a34a7e442f6bb825cae9e7452",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1834.1-0706.xml"
+    "hashmd5": "b4e9c21a34a7e442f6bb825cae9e7452"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/G42.8+0.6.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/G42.8+0.6.xml",
     "filesize": 787,
-    "hashmd5": "85818b8a09fba029bbb3e43d631afff3",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/G42.8+0.6.xml"
+    "hashmd5": "85818b8a09fba029bbb3e43d631afff3"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/Kes79.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Kes79.xml",
     "filesize": 917,
-    "hashmd5": "1cda5e4c884f35ff5f2f2eae41b7e74a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Kes79.xml"
+    "hashmd5": "1cda5e4c884f35ff5f2f2eae41b7e74a"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W41.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W41.xml",
     "filesize": 810,
-    "hashmd5": "824e31cc79280757299e49101eb7f059",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W41.xml"
+    "hashmd5": "824e31cc79280757299e49101eb7f059"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1838.9-0704.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1838.9-0704.xml",
     "filesize": 802,
-    "hashmd5": "c5ae234cf243b7134913cb1c12aaab90",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1838.9-0704.xml"
+    "hashmd5": "c5ae234cf243b7134913cb1c12aaab90"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1534-571.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1534-571.xml",
     "filesize": 824,
-    "hashmd5": "858c2927abadfb2965ff791c4316c42e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1534-571.xml"
+    "hashmd5": "858c2927abadfb2965ff791c4316c42e"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HB3.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB3.xml",
     "filesize": 885,
-    "hashmd5": "06186e2e8b01d51eb0fc99b40551b74c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB3.xml"
+    "hashmd5": "06186e2e8b01d51eb0fc99b40551b74c"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/G296.5+10.0.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/G296.5+10.0.xml",
     "filesize": 793,
-    "hashmd5": "bba3bf33919731d46c0c887a4a7c5827",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/G296.5+10.0.xml"
+    "hashmd5": "bba3bf33919731d46c0c887a4a7c5827"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1655.5-4737.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1655.5-4737.xml",
     "filesize": 800,
-    "hashmd5": "7f74d1441bb3ed960d69fe483b89e5b9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1655.5-4737.xml"
+    "hashmd5": "7f74d1441bb3ed960d69fe483b89e5b9"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ0534.5+2201.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ0534.5+2201.xml",
     "filesize": 851,
-    "hashmd5": "a09aec5b26fdd7559378af2ac2e700dc",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ0534.5+2201.xml"
+    "hashmd5": "a09aec5b26fdd7559378af2ac2e700dc"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0822.1-4253.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0822.1-4253.xml",
     "filesize": 795,
-    "hashmd5": "f77abea3e1c1187f36ca8d0a8dd8bcbf",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0822.1-4253.xml"
+    "hashmd5": "f77abea3e1c1187f36ca8d0a8dd8bcbf"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1841-055.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1841-055.xml",
     "filesize": 707,
-    "hashmd5": "54ee071708fba0c813312bd77de2b940",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1841-055.xml"
+    "hashmd5": "54ee071708fba0c813312bd77de2b940"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2129.9+5833.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2129.9+5833.xml",
     "filesize": 822,
-    "hashmd5": "cb605c9230eab6f5e3bcbba03c53017d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2129.9+5833.xml"
+    "hashmd5": "cb605c9230eab6f5e3bcbba03c53017d"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1631.6-4756.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1631.6-4756.xml",
     "filesize": 805,
-    "hashmd5": "2753ce53ca29ab8e0b5560dbde18f27c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1631.6-4756.xml"
+    "hashmd5": "2753ce53ca29ab8e0b5560dbde18f27c"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W3.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W3.xml",
     "filesize": 782,
-    "hashmd5": "8ffb643cd1f8a2c8ff0579cc441d8ad9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W3.xml"
+    "hashmd5": "8ffb643cd1f8a2c8ff0579cc441d8ad9"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/LMC-Galaxy.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-Galaxy.xml",
     "filesize": 791,
-    "hashmd5": "2f603483711898cb2a9416bcc18ce1e0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-Galaxy.xml"
+    "hashmd5": "2f603483711898cb2a9416bcc18ce1e0"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/VelaX.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/VelaX.xml",
     "filesize": 770,
-    "hashmd5": "77983c0573c3e3812d3175dc06e88f5e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/VelaX.xml"
+    "hashmd5": "77983c0573c3e3812d3175dc06e88f5e"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W44.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W44.xml",
     "filesize": 790,
-    "hashmd5": "8ba67c7b48ce07f24f2ab6b17e877310",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W44.xml"
+    "hashmd5": "8ba67c7b48ce07f24f2ab6b17e877310"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/SMC-Galaxy.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/SMC-Galaxy.xml",
     "filesize": 881,
-    "hashmd5": "e3e6754bc63da2e2fa5cc43d34e2d22d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/SMC-Galaxy.xml"
+    "hashmd5": "e3e6754bc63da2e2fa5cc43d34e2d22d"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1633.0-4746.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1633.0-4746.xml",
     "filesize": 805,
-    "hashmd5": "1f6f45da0acc2e2e04b846bf158d30f7",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1633.0-4746.xml"
+    "hashmd5": "1f6f45da0acc2e2e04b846bf158d30f7"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1723.5-0501.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1723.5-0501.xml",
     "filesize": 822,
-    "hashmd5": "f57763367b4ac14da65e972cd8cca755",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1723.5-0501.xml"
+    "hashmd5": "f57763367b4ac14da65e972cd8cca755"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/CygnusLoop.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/CygnusLoop.fits",
     "filesize": 31680,
-    "hashmd5": "a7ea3625dc4c9506e579724f61702f78",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/CygnusLoop.fits"
+    "hashmd5": "a7ea3625dc4c9506e579724f61702f78"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-North.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-North.fits",
     "filesize": 383040,
-    "hashmd5": "e3af30b762f6793347a9bd837790707c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-North.fits"
+    "hashmd5": "e3af30b762f6793347a9bd837790707c"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_SNRmask.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_SNRmask.fits",
     "filesize": 164160,
-    "hashmd5": "eedcc05f842917106bd9ae1e68f48984",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_SNRmask.fits"
+    "hashmd5": "eedcc05f842917106bd9ae1e68f48984"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/CenALobes.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/CenALobes.fits",
     "filesize": 103680,
-    "hashmd5": "750789bc7adb1287abfae28a76f7c593",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/CenALobes.fits"
+    "hashmd5": "750789bc7adb1287abfae28a76f7c593"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/RCW86.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/RCW86.fits",
     "filesize": 17280,
-    "hashmd5": "69de80b1f5b8d45f962adcebffa263b9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/RCW86.fits"
+    "hashmd5": "69de80b1f5b8d45f962adcebffa263b9"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/HB9.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/HB9.fits",
     "filesize": 25920,
-    "hashmd5": "02f69bffabd133fd9f6035f9f9e11f32",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/HB9.fits"
+    "hashmd5": "02f69bffabd133fd9f6035f9f9e11f32"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/Rosette.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/Rosette.fits",
     "filesize": 14400,
-    "hashmd5": "7a0306cf469404fae6230c9b218edbb1",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/Rosette.fits"
+    "hashmd5": "7a0306cf469404fae6230c9b218edbb1"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-FarWest.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-FarWest.fits",
     "filesize": 846720,
-    "hashmd5": "09e78a3b993c93e26752c2ed1808f718",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-FarWest.fits"
+    "hashmd5": "09e78a3b993c93e26752c2ed1808f718"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/HESSJ1841-055.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/HESSJ1841-055.fits",
     "filesize": 31680,
-    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/HESSJ1841-055.fits"
+    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/W44.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W44.fits",
     "filesize": 23040,
-    "hashmd5": "622426056c3931be2c77f149a920e87a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W44.fits"
+    "hashmd5": "622426056c3931be2c77f149a920e87a"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/SMC-Galaxy.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/SMC-Galaxy.fits",
     "filesize": 2905920,
-    "hashmd5": "31d7a9a2fb20cb93302f93ad642a0162",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/SMC-Galaxy.fits"
+    "hashmd5": "31d7a9a2fb20cb93302f93ad642a0162"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_PWN.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_PWN.fits",
     "filesize": 14400,
-    "hashmd5": "d122bc019d970720b28f4c9b1dea11f8",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_PWN.fits"
+    "hashmd5": "d122bc019d970720b28f4c9b1dea11f8"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-30DorWest.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-30DorWest.fits",
     "filesize": 846720,
-    "hashmd5": "90325239f6002a1bdf3644d99fbd3027",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-30DorWest.fits"
+    "hashmd5": "90325239f6002a1bdf3644d99fbd3027"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/W3.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W3.fits",
     "filesize": 5760,
-    "hashmd5": "d8884fbb37563e29c61c1c5d3852fe25",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W3.fits"
+    "hashmd5": "d8884fbb37563e29c61c1c5d3852fe25"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/S147.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/S147.fits",
     "filesize": 40320,
-    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/S147.fits"
+    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/FornaxA.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/FornaxA.fits",
     "filesize": 144000,
-    "hashmd5": "a46b46c69a78eb334856b5ee434ab184",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/FornaxA.fits"
+    "hashmd5": "a46b46c69a78eb334856b5ee434ab184"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/RXJ1713_2016_250GeV.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/RXJ1713_2016_250GeV.fits",
     "filesize": 69120,
-    "hashmd5": "a6ff1b27d7f888516729a166a5405d3c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/RXJ1713_2016_250GeV.fits"
+    "hashmd5": "a6ff1b27d7f888516729a166a5405d3c"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-Galaxy.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-Galaxy.fits",
     "filesize": 4167360,
-    "hashmd5": "4226cd77a2ea0d703c4e9b94120bafb0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-Galaxy.fits"
+    "hashmd5": "4226cd77a2ea0d703c4e9b94120bafb0"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/W51C.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W51C.fits",
     "filesize": 43200,
-    "hashmd5": "dea38edcb9002c986bfccef5e9b99ffe",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W51C.fits"
+    "hashmd5": "dea38edcb9002c986bfccef5e9b99ffe"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Extended_v18.log",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Extended_v18.log",
     "filesize": 337,
-    "hashmd5": "c19ee72784841df50f38d4b7262f5725",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Extended_v18.log"
+    "hashmd5": "c19ee72784841df50f38d4b7262f5725"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/LAT_extended_sources_v18.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/LAT_extended_sources_v18.fits",
     "filesize": 20160,
-    "hashmd5": "d7ca863afe96fd2b646b90a5612dfd9f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/LAT_extended_sources_v18.fits"
+    "hashmd5": "d7ca863afe96fd2b646b90a5612dfd9f"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/LAT_ext_v18.reg",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/LAT_ext_v18.reg",
     "filesize": 2669,
-    "hashmd5": "3858fd1ff6bd339f60de78fc28b5b275",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/LAT_ext_v18.reg"
+    "hashmd5": "3858fd1ff6bd339f60de78fc28b5b275"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/RXJ1713-3946.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/RXJ1713-3946.xml",
     "filesize": 715,
-    "hashmd5": "d383d0e670f4217f28e1f08608be84b9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/RXJ1713-3946.xml"
+    "hashmd5": "d383d0e670f4217f28e1f08608be84b9"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1837-069.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1837-069.xml",
     "filesize": 708,
-    "hashmd5": "a4636955a555c71a63aa5a8447720acc",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1837-069.xml"
+    "hashmd5": "a4636955a555c71a63aa5a8447720acc"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1303-631.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1303-631.xml",
     "filesize": 708,
-    "hashmd5": "df4fb01867da9a1e24b82fe7e976566c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1303-631.xml"
+    "hashmd5": "df4fb01867da9a1e24b82fe7e976566c"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HB9.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HB9.xml",
     "filesize": 784,
-    "hashmd5": "5022037145b31450de49d4e6e69647b8",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HB9.xml"
+    "hashmd5": "5022037145b31450de49d4e6e69647b8"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/CenALobes.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/CenALobes.xml",
     "filesize": 703,
-    "hashmd5": "5a920a8081fad93d41fdea69aa14917a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/CenALobes.xml"
+    "hashmd5": "5a920a8081fad93d41fdea69aa14917a"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1614-518.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1614-518.xml",
     "filesize": 710,
-    "hashmd5": "5d52f42bfbc1eb38986d07b979bdb199",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1614-518.xml"
+    "hashmd5": "5d52f42bfbc1eb38986d07b979bdb199"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/LMC-30DorWest.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-30DorWest.xml",
     "filesize": 705,
-    "hashmd5": "2b6da038a258f7a78298649873b0a391",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-30DorWest.xml"
+    "hashmd5": "2b6da038a258f7a78298649873b0a391"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1632-478.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1632-478.xml",
     "filesize": 711,
-    "hashmd5": "aeae18b6478fdb15f26aae6fc86245f2",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1632-478.xml"
+    "hashmd5": "aeae18b6478fdb15f26aae6fc86245f2"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HB21.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HB21.xml",
     "filesize": 792,
-    "hashmd5": "da5cca7822ec77c8589e35793629bb4e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HB21.xml"
+    "hashmd5": "da5cca7822ec77c8589e35793629bb4e"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/RCW86.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/RCW86.xml",
     "filesize": 688,
-    "hashmd5": "7f8d15c142785329d037e7a27c0347e5",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/RCW86.xml"
+    "hashmd5": "7f8d15c142785329d037e7a27c0347e5"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/W28.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/W28.xml",
     "filesize": 790,
-    "hashmd5": "5850d54034c9066bf7ea2a91b27cacee",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/W28.xml"
+    "hashmd5": "5850d54034c9066bf7ea2a91b27cacee"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/S147.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/S147.xml",
     "filesize": 692,
-    "hashmd5": "6f8ce195b1b8fc654cd7d1951b69ee44",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/S147.xml"
+    "hashmd5": "6f8ce195b1b8fc654cd7d1951b69ee44"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1825-137.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1825-137.xml",
     "filesize": 808,
-    "hashmd5": "dd9486dbb8e1dcc50fc6592ecdc04ac8",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1825-137.xml"
+    "hashmd5": "dd9486dbb8e1dcc50fc6592ecdc04ac8"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/CygnusLoop.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/CygnusLoop.xml",
     "filesize": 807,
-    "hashmd5": "e5d28e2984356121cffe913e4ca89334",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/CygnusLoop.xml"
+    "hashmd5": "e5d28e2984356121cffe913e4ca89334"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/FornaxA.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/FornaxA.xml",
     "filesize": 691,
-    "hashmd5": "074f2ed5ab6b5b7a2153b21d1ef97c34",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/FornaxA.xml"
+    "hashmd5": "074f2ed5ab6b5b7a2153b21d1ef97c34"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1616-508.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1616-508.xml",
     "filesize": 710,
-    "hashmd5": "667caebdcab64d5a2149b74ece54f99a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1616-508.xml"
+    "hashmd5": "667caebdcab64d5a2149b74ece54f99a"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/W51C.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/W51C.xml",
     "filesize": 777,
-    "hashmd5": "b2ab4fc57e378573bef826d176d757b7",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/W51C.xml"
+    "hashmd5": "b2ab4fc57e378573bef826d176d757b7"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/MSH15-52.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/MSH15-52.xml",
     "filesize": 672,
-    "hashmd5": "a47f63858c065562cd9780c47190fe72",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/MSH15-52.xml"
+    "hashmd5": "a47f63858c065562cd9780c47190fe72"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/CygnusCocoon.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/CygnusCocoon.xml",
     "filesize": 682,
-    "hashmd5": "067f9200374057ce4aabd72c35a62c07",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/CygnusCocoon.xml"
+    "hashmd5": "067f9200374057ce4aabd72c35a62c07"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/LMC-North.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-North.xml",
     "filesize": 697,
-    "hashmd5": "a38b24fc3cb3513a5789de914d660132",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-North.xml"
+    "hashmd5": "a38b24fc3cb3513a5789de914d660132"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/IC443.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/IC443.xml",
     "filesize": 796,
-    "hashmd5": "f9176f010a12934541ebd78708b16815",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/IC443.xml"
+    "hashmd5": "f9176f010a12934541ebd78708b16815"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/W30.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/W30.xml",
     "filesize": 790,
-    "hashmd5": "f3d234c30847edd084bd0dcb06b8dbf8",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/W30.xml"
+    "hashmd5": "f3d234c30847edd084bd0dcb06b8dbf8"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/LMC-FarWest.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-FarWest.xml",
     "filesize": 701,
-    "hashmd5": "954c8589751066c7157f3bc57dcfcff4",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-FarWest.xml"
+    "hashmd5": "954c8589751066c7157f3bc57dcfcff4"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/MSH15-56.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/MSH15-56.xml",
     "filesize": 697,
-    "hashmd5": "6e90dd4fc513055519101b14783f584f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/MSH15-56.xml"
+    "hashmd5": "6e90dd4fc513055519101b14783f584f"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/gammaCygni.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/gammaCygni.xml",
     "filesize": 675,
-    "hashmd5": "c284fa8f3c74112bc18077a8e39f819a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/gammaCygni.xml"
+    "hashmd5": "c284fa8f3c74112bc18077a8e39f819a"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/VelaJr.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/VelaJr.xml",
     "filesize": 697,
-    "hashmd5": "15add68801db41a235fb18d43fa162a0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/VelaJr.xml"
+    "hashmd5": "15add68801db41a235fb18d43fa162a0"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HB3.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HB3.xml",
     "filesize": 784,
-    "hashmd5": "fb9198f2c91b76f210b73cb656cb8505",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HB3.xml"
+    "hashmd5": "fb9198f2c91b76f210b73cb656cb8505"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/G296.5+10.0.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/G296.5+10.0.xml",
     "filesize": 701,
-    "hashmd5": "6e959e6e0560130d926af72a1512a6ec",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/G296.5+10.0.xml"
+    "hashmd5": "6e959e6e0560130d926af72a1512a6ec"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/PuppisA.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/PuppisA.xml",
     "filesize": 714,
-    "hashmd5": "61c41c23b948cb905e7ebcdda66d5d71",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/PuppisA.xml"
+    "hashmd5": "61c41c23b948cb905e7ebcdda66d5d71"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1841-055.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1841-055.xml",
     "filesize": 707,
-    "hashmd5": "54ee071708fba0c813312bd77de2b940",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1841-055.xml"
+    "hashmd5": "54ee071708fba0c813312bd77de2b940"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/W3.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/W3.xml",
     "filesize": 782,
-    "hashmd5": "8ffb643cd1f8a2c8ff0579cc441d8ad9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/W3.xml"
+    "hashmd5": "8ffb643cd1f8a2c8ff0579cc441d8ad9"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/LMC-Galaxy.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-Galaxy.xml",
     "filesize": 791,
-    "hashmd5": "2f603483711898cb2a9416bcc18ce1e0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-Galaxy.xml"
+    "hashmd5": "2f603483711898cb2a9416bcc18ce1e0"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/VelaX.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/VelaX.xml",
     "filesize": 664,
-    "hashmd5": "0f46f9bde3c7da6519b8c023f2736e46",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/VelaX.xml"
+    "hashmd5": "0f46f9bde3c7da6519b8c023f2736e46"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/W44.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/W44.xml",
     "filesize": 790,
-    "hashmd5": "8ba67c7b48ce07f24f2ab6b17e877310",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/W44.xml"
+    "hashmd5": "8ba67c7b48ce07f24f2ab6b17e877310"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/SMC-Galaxy.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/SMC-Galaxy.xml",
     "filesize": 881,
-    "hashmd5": "e3e6754bc63da2e2fa5cc43d34e2d22d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/SMC-Galaxy.xml"
+    "hashmd5": "e3e6754bc63da2e2fa5cc43d34e2d22d"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/CygnusLoop.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/CygnusLoop.fits",
     "filesize": 43200,
-    "hashmd5": "58239e37ad7215638fc0a12b4d59fcee",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/CygnusLoop.fits"
+    "hashmd5": "58239e37ad7215638fc0a12b4d59fcee"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/LMC-North.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-North.fits",
     "filesize": 383040,
-    "hashmd5": "e3af30b762f6793347a9bd837790707c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-North.fits"
+    "hashmd5": "e3af30b762f6793347a9bd837790707c"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/gammaCygni.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/gammaCygni.fits",
     "filesize": 31680,
-    "hashmd5": "3bb0b713a453429f4c9f51d7a1fabeb9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/gammaCygni.fits"
+    "hashmd5": "3bb0b713a453429f4c9f51d7a1fabeb9"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/CenALobes.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/CenALobes.fits",
     "filesize": 103680,
-    "hashmd5": "750789bc7adb1287abfae28a76f7c593",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/CenALobes.fits"
+    "hashmd5": "750789bc7adb1287abfae28a76f7c593"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1837-069.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1837-069.fits",
     "filesize": 31680,
-    "hashmd5": "308f6be96cb6365cffe58ef2c6362c94",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1837-069.fits"
+    "hashmd5": "308f6be96cb6365cffe58ef2c6362c94"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/RCW86.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/RCW86.fits",
     "filesize": 17280,
-    "hashmd5": "69de80b1f5b8d45f962adcebffa263b9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/RCW86.fits"
+    "hashmd5": "69de80b1f5b8d45f962adcebffa263b9"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HB9.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB9.fits",
     "filesize": 37440,
-    "hashmd5": "c62c6da4316010ac0ba1fcbe1b4197b4",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB9.fits"
+    "hashmd5": "c62c6da4316010ac0ba1fcbe1b4197b4"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1632-478.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1632-478.fits",
     "filesize": 31680,
-    "hashmd5": "d00c3e9c6f5ac8dea855df2b0b997d03",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1632-478.fits"
+    "hashmd5": "d00c3e9c6f5ac8dea855df2b0b997d03"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/MSH15-56.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/MSH15-56.fits",
     "filesize": 31680,
-    "hashmd5": "46fac415edd9e6bc2e7648bc7424cc8b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/MSH15-56.fits"
+    "hashmd5": "46fac415edd9e6bc2e7648bc7424cc8b"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/LMC-FarWest.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-FarWest.fits",
     "filesize": 846720,
-    "hashmd5": "09e78a3b993c93e26752c2ed1808f718",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-FarWest.fits"
+    "hashmd5": "09e78a3b993c93e26752c2ed1808f718"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1841-055.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1841-055.fits",
     "filesize": 31680,
-    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1841-055.fits"
+    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/PuppisA.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/PuppisA.fits",
     "filesize": 31680,
-    "hashmd5": "067b9548d246438ca6d7696537cbbcaf",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/PuppisA.fits"
+    "hashmd5": "067b9548d246438ca6d7696537cbbcaf"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/W44.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/W44.fits",
     "filesize": 23040,
-    "hashmd5": "622426056c3931be2c77f149a920e87a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/W44.fits"
+    "hashmd5": "622426056c3931be2c77f149a920e87a"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1614-518.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1614-518.fits",
     "filesize": 31680,
-    "hashmd5": "2ac8597db1888c7486f3bf332fb32e46",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1614-518.fits"
+    "hashmd5": "2ac8597db1888c7486f3bf332fb32e46"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HB3.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB3.fits",
     "filesize": 31680,
-    "hashmd5": "628c379062b5fd6d2ba80d330af787f6",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB3.fits"
+    "hashmd5": "628c379062b5fd6d2ba80d330af787f6"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/W28.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/W28.fits",
     "filesize": 46080,
-    "hashmd5": "916b048c306dd646fcbe2223a118f43a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/W28.fits"
+    "hashmd5": "916b048c306dd646fcbe2223a118f43a"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1303-631.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1303-631.fits",
     "filesize": 31680,
-    "hashmd5": "7854547f001a8c39ecf82aea8dade4b6",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1303-631.fits"
+    "hashmd5": "7854547f001a8c39ecf82aea8dade4b6"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/IC443.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/IC443.fits",
     "filesize": 69120,
-    "hashmd5": "f67a4e5118cf489df83f19eb9db9ad6d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/IC443.fits"
+    "hashmd5": "f67a4e5118cf489df83f19eb9db9ad6d"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/CygnusCocoon.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/CygnusCocoon.fits",
     "filesize": 31680,
-    "hashmd5": "4f8bc64e84a5f146a537e45f8da9d30a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/CygnusCocoon.fits"
+    "hashmd5": "4f8bc64e84a5f146a537e45f8da9d30a"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1616-508.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1616-508.fits",
     "filesize": 31680,
-    "hashmd5": "cacf9de67d3711193e630cd973ff73bc",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1616-508.fits"
+    "hashmd5": "cacf9de67d3711193e630cd973ff73bc"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/SMC-Galaxy.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/SMC-Galaxy.fits",
     "filesize": 2905920,
-    "hashmd5": "31d7a9a2fb20cb93302f93ad642a0162",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/SMC-Galaxy.fits"
+    "hashmd5": "31d7a9a2fb20cb93302f93ad642a0162"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/LMC-30DorWest.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-30DorWest.fits",
     "filesize": 846720,
-    "hashmd5": "90325239f6002a1bdf3644d99fbd3027",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-30DorWest.fits"
+    "hashmd5": "90325239f6002a1bdf3644d99fbd3027"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/MSH15-52.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/MSH15-52.fits",
     "filesize": 46080,
-    "hashmd5": "7f9c93ecb7bba1fc18fb35ca6c3e9555",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/MSH15-52.fits"
+    "hashmd5": "7f9c93ecb7bba1fc18fb35ca6c3e9555"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/VelaJr.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/VelaJr.fits",
     "filesize": 31680,
-    "hashmd5": "504b98555ee389b76f504fa69a900625",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/VelaJr.fits"
+    "hashmd5": "504b98555ee389b76f504fa69a900625"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/W30.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/W30.fits",
     "filesize": 31680,
-    "hashmd5": "51e7172e1cda0a9339c17b6353b03dd9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/W30.fits"
+    "hashmd5": "51e7172e1cda0a9339c17b6353b03dd9"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/W3.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/W3.fits",
     "filesize": 5760,
-    "hashmd5": "d8884fbb37563e29c61c1c5d3852fe25",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/W3.fits"
+    "hashmd5": "d8884fbb37563e29c61c1c5d3852fe25"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HB21.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB21.fits",
     "filesize": 31680,
-    "hashmd5": "88a9e5fdac58358fbc8d84014519b947",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB21.fits"
+    "hashmd5": "88a9e5fdac58358fbc8d84014519b947"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/S147.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/S147.fits",
     "filesize": 40320,
-    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/S147.fits"
+    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1825-137.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1825-137.fits",
     "filesize": 46080,
-    "hashmd5": "d1b7bb32f9c6efbfc5d8ee7d04e00c3d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1825-137.fits"
+    "hashmd5": "d1b7bb32f9c6efbfc5d8ee7d04e00c3d"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/FornaxA.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/FornaxA.fits",
     "filesize": 144000,
-    "hashmd5": "2fdc377bac4b7c1813e12da44f82a61f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/FornaxA.fits"
+    "hashmd5": "2fdc377bac4b7c1813e12da44f82a61f"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/VelaX.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/VelaX.fits",
     "filesize": 46080,
-    "hashmd5": "881b0b2e8828e1bbb901a3e15515914d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/VelaX.fits"
+    "hashmd5": "881b0b2e8828e1bbb901a3e15515914d"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits",
     "filesize": 69120,
-    "hashmd5": "a6ff1b27d7f888516729a166a5405d3c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
+    "hashmd5": "a6ff1b27d7f888516729a166a5405d3c"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/G296.5+10.0.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/G296.5+10.0.fits",
     "filesize": 31680,
-    "hashmd5": "2e65b0d0bd9e045e33dd9cd4df98c882",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/G296.5+10.0.fits"
+    "hashmd5": "2e65b0d0bd9e045e33dd9cd4df98c882"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/LMC-Galaxy.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-Galaxy.fits",
     "filesize": 4167360,
-    "hashmd5": "4226cd77a2ea0d703c4e9b94120bafb0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-Galaxy.fits"
+    "hashmd5": "4226cd77a2ea0d703c4e9b94120bafb0"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/W51C.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/W51C.fits",
     "filesize": 43200,
-    "hashmd5": "dea38edcb9002c986bfccef5e9b99ffe",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/W51C.fits"
+    "hashmd5": "dea38edcb9002c986bfccef5e9b99ffe"
    },
    {
     "path": "catalogs/gammacat/gammacat-datasets.json",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/gammacat/gammacat-datasets.json",
     "filesize": 125360,
-    "hashmd5": "4fed701d65ecc72cd6fcf4fe78cd2259",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/gammacat/gammacat-datasets.json"
+    "hashmd5": "4fed701d65ecc72cd6fcf4fe78cd2259"
    },
    {
     "path": "catalogs/gammacat/gammacat.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/gammacat/gammacat.fits.gz",
     "filesize": 33941,
-    "hashmd5": "b2c6bf26a090245d47a11b7b9b7f8586",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/gammacat/gammacat.fits.gz"
+    "hashmd5": "b2c6bf26a090245d47a11b7b9b7f8586"
    }
   ]
  },
@@ -1761,36 +1513,31 @@
     "path": "fermi_3fhl/fermi_3fhl_exposure_cube_hpx.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/fermi_3fhl/fermi_3fhl_exposure_cube_hpx.fits.gz",
     "filesize": 3858696,
-    "hashmd5": "a3963741e22e09651aeefb5c646d8c37",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/fermi_3fhl/fermi_3fhl_exposure_cube_hpx.fits.gz"
+    "hashmd5": "a3963741e22e09651aeefb5c646d8c37"
    },
    {
     "path": "fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt",
     "filesize": 1255,
-    "hashmd5": "85de2d6a9896fe15f1a4298edd9d7641",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt"
+    "hashmd5": "85de2d6a9896fe15f1a4298edd9d7641"
    },
    {
     "path": "fermi_3fhl/fermi_3fhl_events_selected.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/fermi_3fhl/fermi_3fhl_events_selected.fits.gz",
     "filesize": 39307510,
-    "hashmd5": "da91bb56be09ea68ea00c8079ed178a0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/fermi_3fhl/fermi_3fhl_events_selected.fits.gz"
+    "hashmd5": "da91bb56be09ea68ea00c8079ed178a0"
    },
    {
     "path": "fermi_3fhl/fermi_3fhl_psf_gc.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/fermi_3fhl/fermi_3fhl_psf_gc.fits.gz",
     "filesize": 42267,
-    "hashmd5": "2d18ca761629320ae1e3e7da224eb595",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/fermi_3fhl/fermi_3fhl_psf_gc.fits.gz"
+    "hashmd5": "2d18ca761629320ae1e3e7da224eb595"
    },
    {
     "path": "fermi_3fhl/gll_iem_v06_cutout.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/fermi_3fhl/gll_iem_v06_cutout.fits",
     "filesize": 515520,
-    "hashmd5": "a6ab040128cba3100670d6f4e00a76fa",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/fermi_3fhl/gll_iem_v06_cutout.fits"
+    "hashmd5": "a6ab040128cba3100670d6f4e00a76fa"
    }
   ]
  },
@@ -1802,778 +1549,667 @@
     "path": "hess-dl3-dr1/hdu-index.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/hdu-index.fits.gz",
     "filesize": 5230,
-    "hashmd5": "8041ab9767c00ea32ab8d8ed2b8fa03f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/hdu-index.fits.gz"
+    "hashmd5": "8041ab9767c00ea32ab8d8ed2b8fa03f"
    },
    {
     "path": "hess-dl3-dr1/test.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/test.py",
     "filesize": 926,
-    "hashmd5": "818e96917b956c801fe1a9db29414022",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/test.py"
+    "hashmd5": "818e96917b956c801fe1a9db29414022"
    },
    {
     "path": "hess-dl3-dr1/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/README.md",
     "filesize": 684,
-    "hashmd5": "32f5975f738551fa80bb37df2d8f0d02",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/README.md"
+    "hashmd5": "32f5975f738551fa80bb37df2d8f0d02"
    },
    {
     "path": "hess-dl3-dr1/make.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/make.py",
     "filesize": 2608,
-    "hashmd5": "a624cfcb294d70731dbfb33b4f3b877b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/make.py"
+    "hashmd5": "a624cfcb294d70731dbfb33b4f3b877b"
    },
    {
     "path": "hess-dl3-dr1/README.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/README.txt",
     "filesize": 1184,
-    "hashmd5": "4933f9aaf2263c5985663f5836ab7a29",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/README.txt"
+    "hashmd5": "4933f9aaf2263c5985663f5836ab7a29"
    },
    {
     "path": "hess-dl3-dr1/obs-index.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/obs-index.fits.gz",
     "filesize": 9365,
-    "hashmd5": "5b8ca87042c0ee33da3e387a771efba7",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/obs-index.fits.gz"
+    "hashmd5": "5b8ca87042c0ee33da3e387a771efba7"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033798.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033798.fits.gz",
     "filesize": 572633,
-    "hashmd5": "47a5998f4ee515f2552368f5eb34e6fb",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033798.fits.gz"
+    "hashmd5": "47a5998f4ee515f2552368f5eb34e6fb"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033788.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033788.fits.gz",
     "filesize": 539227,
-    "hashmd5": "82e30cc16709cd02efc9fdc204c0c3f2",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033788.fits.gz"
+    "hashmd5": "82e30cc16709cd02efc9fdc204c0c3f2"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027121.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027121.fits.gz",
     "filesize": 536228,
-    "hashmd5": "104eab1fc4935b81c57431410b581e37",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027121.fits.gz"
+    "hashmd5": "104eab1fc4935b81c57431410b581e37"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020561.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020561.fits.gz",
     "filesize": 634331,
-    "hashmd5": "2a26c4e77ed63ff8e15b76ddea9023c0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020561.fits.gz"
+    "hashmd5": "2a26c4e77ed63ff8e15b76ddea9023c0"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020324.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020324.fits.gz",
     "filesize": 659824,
-    "hashmd5": "cd51bd5cb3df288ae358cd79f30a0135",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020324.fits.gz"
+    "hashmd5": "cd51bd5cb3df288ae358cd79f30a0135"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020346.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020346.fits.gz",
     "filesize": 650913,
-    "hashmd5": "fe01cd76e1bcb044d6ba85f7c7b98078",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020346.fits.gz"
+    "hashmd5": "fe01cd76e1bcb044d6ba85f7c7b98078"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021851.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021851.fits.gz",
     "filesize": 539205,
-    "hashmd5": "09080554060ad222ee2352595f973f19",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021851.fits.gz"
+    "hashmd5": "09080554060ad222ee2352595f973f19"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020900.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020900.fits.gz",
     "filesize": 659063,
-    "hashmd5": "bfa072df7d74020960baa6fd8c8a6c86",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020900.fits.gz"
+    "hashmd5": "bfa072df7d74020960baa6fd8c8a6c86"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033791.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033791.fits.gz",
     "filesize": 604425,
-    "hashmd5": "b7183345521aba049ff9ef8db1f38030",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033791.fits.gz"
+    "hashmd5": "b7183345521aba049ff9ef8db1f38030"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020302.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020302.fits.gz",
     "filesize": 640318,
-    "hashmd5": "2649a7d67799c16410f9a7d831c595ba",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020302.fits.gz"
+    "hashmd5": "2649a7d67799c16410f9a7d831c595ba"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020151.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020151.fits.gz",
     "filesize": 620141,
-    "hashmd5": "a2272d8a7cb093b3d98140571f28bae0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020151.fits.gz"
+    "hashmd5": "a2272d8a7cb093b3d98140571f28bae0"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047802.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047802.fits.gz",
     "filesize": 524477,
-    "hashmd5": "530de706e574b114f5a3cf9b062d6859",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047802.fits.gz"
+    "hashmd5": "530de706e574b114f5a3cf9b062d6859"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033800.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033800.fits.gz",
     "filesize": 525372,
-    "hashmd5": "ad4373ffb55ed7cb81815deecda90b50",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033800.fits.gz"
+    "hashmd5": "ad4373ffb55ed7cb81815deecda90b50"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023736.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023736.fits.gz",
     "filesize": 510540,
-    "hashmd5": "4c0b01d84153c350841dd6682e78dc05",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023736.fits.gz"
+    "hashmd5": "4c0b01d84153c350841dd6682e78dc05"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022022.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022022.fits.gz",
     "filesize": 479333,
-    "hashmd5": "a8d040c895d7b952843aac19ee9daf8e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022022.fits.gz"
+    "hashmd5": "a8d040c895d7b952843aac19ee9daf8e"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033790.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033790.fits.gz",
     "filesize": 601307,
-    "hashmd5": "7d9a197e9b7fa0e7580de123a960989c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033790.fits.gz"
+    "hashmd5": "7d9a197e9b7fa0e7580de123a960989c"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020303.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020303.fits.gz",
     "filesize": 640104,
-    "hashmd5": "3ff02d8833338fa9992d5f62eb99327a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020303.fits.gz"
+    "hashmd5": "3ff02d8833338fa9992d5f62eb99327a"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047803.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047803.fits.gz",
     "filesize": 533120,
-    "hashmd5": "217056f50690ace16a6528f46c7c3442",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047803.fits.gz"
+    "hashmd5": "217056f50690ace16a6528f46c7c3442"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033801.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033801.fits.gz",
     "filesize": 507088,
-    "hashmd5": "1ff180aa4ff752139283b1861bf8e466",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033801.fits.gz"
+    "hashmd5": "1ff180aa4ff752139283b1861bf8e466"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023635.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023635.fits.gz",
     "filesize": 575723,
-    "hashmd5": "5c645147fc3c1c38fe944913f8eb2076",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023635.fits.gz"
+    "hashmd5": "5c645147fc3c1c38fe944913f8eb2076"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020368.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020368.fits.gz",
     "filesize": 621670,
-    "hashmd5": "734ab15443c98eb9573ebef9f3f7867c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020368.fits.gz"
+    "hashmd5": "734ab15443c98eb9573ebef9f3f7867c"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033789.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033789.fits.gz",
     "filesize": 585867,
-    "hashmd5": "be7af3e3c342ac3ddd083386f43ee5ab",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033789.fits.gz"
+    "hashmd5": "be7af3e3c342ac3ddd083386f43ee5ab"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033799.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033799.fits.gz",
     "filesize": 553752,
-    "hashmd5": "a3e7cc49ec8b6ed37c963c0b5c29ddc3",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033799.fits.gz"
+    "hashmd5": "a3e7cc49ec8b6ed37c963c0b5c29ddc3"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020325.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020325.fits.gz",
     "filesize": 660167,
-    "hashmd5": "d744e4fccb9bef199753d1bc41d91a62",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020325.fits.gz"
+    "hashmd5": "d744e4fccb9bef199753d1bc41d91a62"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029072.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029072.fits.gz",
     "filesize": 516059,
-    "hashmd5": "2d768b262274cf9ac7bc718f2227baae",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029072.fits.gz"
+    "hashmd5": "2d768b262274cf9ac7bc718f2227baae"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029024.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029024.fits.gz",
     "filesize": 554693,
-    "hashmd5": "6bffd5c6141cd7074e268f57a3862137",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029024.fits.gz"
+    "hashmd5": "6bffd5c6141cd7074e268f57a3862137"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026850.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026850.fits.gz",
     "filesize": 575620,
-    "hashmd5": "ebad06491d0bcb69f5c6c9e40006b75b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026850.fits.gz"
+    "hashmd5": "ebad06491d0bcb69f5c6c9e40006b75b"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020301.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020301.fits.gz",
     "filesize": 636783,
-    "hashmd5": "df2c38f9fd4908c36408b1012a90a647",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020301.fits.gz"
+    "hashmd5": "df2c38f9fd4908c36408b1012a90a647"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033792.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033792.fits.gz",
     "filesize": 601842,
-    "hashmd5": "ecbeaf2a7fdbe2e7009ea28835cda835",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033792.fits.gz"
+    "hashmd5": "ecbeaf2a7fdbe2e7009ea28835cda835"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027987.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027987.fits.gz",
     "filesize": 568566,
-    "hashmd5": "446225bc952801baf14848a14e935fc9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027987.fits.gz"
+    "hashmd5": "446225bc952801baf14848a14e935fc9"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020397.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020397.fits.gz",
     "filesize": 707272,
-    "hashmd5": "a4991eca27ddf25827646a64ee026e39",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020397.fits.gz"
+    "hashmd5": "a4991eca27ddf25827646a64ee026e39"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020519.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020519.fits.gz",
     "filesize": 676791,
-    "hashmd5": "cbd003475340da563e11e7af06cb9da9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020519.fits.gz"
+    "hashmd5": "cbd003475340da563e11e7af06cb9da9"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz",
     "filesize": 522418,
-    "hashmd5": "6c22e9b732c8dcc402f781c052c7527b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
+    "hashmd5": "6c22e9b732c8dcc402f781c052c7527b"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047827.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047827.fits.gz",
     "filesize": 519018,
-    "hashmd5": "48f24bbe200ab9c38a6cf817d762f39e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047827.fits.gz"
+    "hashmd5": "48f24bbe200ab9c38a6cf817d762f39e"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029118.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029118.fits.gz",
     "filesize": 504442,
-    "hashmd5": "ed3aeafe3b9ef9a2eb288ca8c57aef13",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029118.fits.gz"
+    "hashmd5": "ed3aeafe3b9ef9a2eb288ca8c57aef13"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020345.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020345.fits.gz",
     "filesize": 654817,
-    "hashmd5": "def375ace7d5e37b292c655fe946eb12",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020345.fits.gz"
+    "hashmd5": "def375ace7d5e37b292c655fe946eb12"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020327.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020327.fits.gz",
     "filesize": 729323,
-    "hashmd5": "b3329e87618dbae2ba3d6999e7267589",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020327.fits.gz"
+    "hashmd5": "b3329e87618dbae2ba3d6999e7267589"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025511.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025511.fits.gz",
     "filesize": 520929,
-    "hashmd5": "9686f40bd57e5e5fcec2d5e5d5d6228e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025511.fits.gz"
+    "hashmd5": "9686f40bd57e5e5fcec2d5e5d5d6228e"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021613.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021613.fits.gz",
     "filesize": 624838,
-    "hashmd5": "40d0d0d904d91dee13a64963c1a4013c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021613.fits.gz"
+    "hashmd5": "40d0d0d904d91dee13a64963c1a4013c"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020344.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020344.fits.gz",
     "filesize": 658082,
-    "hashmd5": "d55c9c1c12bf738485271553c60e15fd",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020344.fits.gz"
+    "hashmd5": "d55c9c1c12bf738485271553c60e15fd"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020326.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020326.fits.gz",
     "filesize": 727305,
-    "hashmd5": "6a264244bebb5572378a8d7207c5f3d9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020326.fits.gz"
+    "hashmd5": "6a264244bebb5572378a8d7207c5f3d9"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025345.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025345.fits.gz",
     "filesize": 574222,
-    "hashmd5": "6e7154dff8b227b98cd73bf4622cd711",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025345.fits.gz"
+    "hashmd5": "6e7154dff8b227b98cd73bf4622cd711"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023559.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023559.fits.gz",
     "filesize": 526028,
-    "hashmd5": "c0be8eddee2b81573f835adcb6bbd555",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023559.fits.gz"
+    "hashmd5": "c0be8eddee2b81573f835adcb6bbd555"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021807.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021807.fits.gz",
     "filesize": 595843,
-    "hashmd5": "f1f2bbd098e2454e0a0e1ab5d1309e9b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021807.fits.gz"
+    "hashmd5": "f1f2bbd098e2454e0a0e1ab5d1309e9b"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033793.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033793.fits.gz",
     "filesize": 599133,
-    "hashmd5": "9b67de3419487d19b926c5ff87d43fb2",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033793.fits.gz"
+    "hashmd5": "9b67de3419487d19b926c5ff87d43fb2"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023592.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023592.fits.gz",
     "filesize": 517549,
-    "hashmd5": "31ada70a02d0eebbb107b341cf08ab53",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023592.fits.gz"
+    "hashmd5": "31ada70a02d0eebbb107b341cf08ab53"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020396.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020396.fits.gz",
     "filesize": 718253,
-    "hashmd5": "5cb3c868b43befd40de48c427978d9f4",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020396.fits.gz"
+    "hashmd5": "5cb3c868b43befd40de48c427978d9f4"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020518.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020518.fits.gz",
     "filesize": 685579,
-    "hashmd5": "dc591e81fb6796d6baaf7617ff6e6629",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020518.fits.gz"
+    "hashmd5": "dc591e81fb6796d6baaf7617ff6e6629"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022997.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022997.fits.gz",
     "filesize": 589811,
-    "hashmd5": "574306b89e0c3c4e7d3624900a13867f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022997.fits.gz"
+    "hashmd5": "574306b89e0c3c4e7d3624900a13867f"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026964.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026964.fits.gz",
     "filesize": 568294,
-    "hashmd5": "094d4d92cd6c435f218d02d1714e021e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026964.fits.gz"
+    "hashmd5": "094d4d92cd6c435f218d02d1714e021e"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029433.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029433.fits.gz",
     "filesize": 478919,
-    "hashmd5": "e25d5178f754a7b1a8b74e842c8139a4",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029433.fits.gz"
+    "hashmd5": "e25d5178f754a7b1a8b74e842c8139a4"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029177.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029177.fits.gz",
     "filesize": 539364,
-    "hashmd5": "fe8cce5ba320720a2f5e92ae46670081",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029177.fits.gz"
+    "hashmd5": "fe8cce5ba320720a2f5e92ae46670081"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023040.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023040.fits.gz",
     "filesize": 597077,
-    "hashmd5": "478c6b8ac90e148c2250bfe472bc6852",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023040.fits.gz"
+    "hashmd5": "478c6b8ac90e148c2250bfe472bc6852"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023573.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023573.fits.gz",
     "filesize": 609511,
-    "hashmd5": "02a3d540cb39467c36a53fdf5b328193",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023573.fits.gz"
+    "hashmd5": "02a3d540cb39467c36a53fdf5b328193"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033796.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033796.fits.gz",
     "filesize": 597036,
-    "hashmd5": "337406df10a4b5ec7b32906973e5d277",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033796.fits.gz"
+    "hashmd5": "337406df10a4b5ec7b32906973e5d277"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020367.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020367.fits.gz",
     "filesize": 620807,
-    "hashmd5": "343a41600c54412cf1b9bf9b172784d1",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020367.fits.gz"
+    "hashmd5": "343a41600c54412cf1b9bf9b172784d1"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023143.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023143.fits.gz",
     "filesize": 599612,
-    "hashmd5": "2708483a6377029336545d6225cbc59a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023143.fits.gz"
+    "hashmd5": "2708483a6377029336545d6225cbc59a"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021824.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021824.fits.gz",
     "filesize": 629810,
-    "hashmd5": "58d54549605bb10cf2cb74177ee42f9d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021824.fits.gz"
+    "hashmd5": "58d54549605bb10cf2cb74177ee42f9d"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020323.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020323.fits.gz",
     "filesize": 669369,
-    "hashmd5": "bf9b3651f61577e85ca0743f88974daa",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020323.fits.gz"
+    "hashmd5": "bf9b3651f61577e85ca0743f88974daa"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026077.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026077.fits.gz",
     "filesize": 510164,
-    "hashmd5": "cb71425331bc3458737f1041338111f4",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026077.fits.gz"
+    "hashmd5": "cb71425331bc3458737f1041338111f4"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023651.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023651.fits.gz",
     "filesize": 566669,
-    "hashmd5": "24a90cbf94e220638ab2bbfba9ea35da",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023651.fits.gz"
+    "hashmd5": "24a90cbf94e220638ab2bbfba9ea35da"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020421.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020421.fits.gz",
     "filesize": 716681,
-    "hashmd5": "469679f1fd44334d82b6514018ae06e6",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020421.fits.gz"
+    "hashmd5": "469679f1fd44334d82b6514018ae06e6"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026791.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026791.fits.gz",
     "filesize": 456067,
-    "hashmd5": "79f501c7cc5a64b6639373c6b8f8f226",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026791.fits.gz"
+    "hashmd5": "79f501c7cc5a64b6639373c6b8f8f226"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029556.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029556.fits.gz",
     "filesize": 562762,
-    "hashmd5": "ea4eb4fcad32e59ad83c58b062e6b283",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029556.fits.gz"
+    "hashmd5": "ea4eb4fcad32e59ad83c58b062e6b283"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020350.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020350.fits.gz",
     "filesize": 712473,
-    "hashmd5": "2dd5b04775b2110f89fbbffa47f41dd4",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020350.fits.gz"
+    "hashmd5": "2dd5b04775b2110f89fbbffa47f41dd4"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029487.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029487.fits.gz",
     "filesize": 550331,
-    "hashmd5": "85507efc26b278fa35de8b32a0396c93",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029487.fits.gz"
+    "hashmd5": "85507efc26b278fa35de8b32a0396c93"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020322.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020322.fits.gz",
     "filesize": 661749,
-    "hashmd5": "ed2e1a6d4d6d05796a706addd9d6db47",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020322.fits.gz"
+    "hashmd5": "ed2e1a6d4d6d05796a706addd9d6db47"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023246.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023246.fits.gz",
     "filesize": 516177,
-    "hashmd5": "de4c0c8335d3d97c290f736af5645501",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023246.fits.gz"
+    "hashmd5": "de4c0c8335d3d97c290f736af5645501"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023526.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023526.fits.gz",
     "filesize": 524967,
-    "hashmd5": "142f766ac0c7ba4ca1fe0749869ce592",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023526.fits.gz"
+    "hashmd5": "142f766ac0c7ba4ca1fe0749869ce592"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020734.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020734.fits.gz",
     "filesize": 632200,
-    "hashmd5": "5de98ef8b0f45ef68644d1b86e90ba19",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020734.fits.gz"
+    "hashmd5": "5de98ef8b0f45ef68644d1b86e90ba19"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020275.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020275.fits.gz",
     "filesize": 617436,
-    "hashmd5": "6339a508bedc6b4fe09ec0c5a92b596f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020275.fits.gz"
+    "hashmd5": "6339a508bedc6b4fe09ec0c5a92b596f"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023077.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023077.fits.gz",
     "filesize": 536721,
-    "hashmd5": "62b8859a8688d4bcbc79878929b37301",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023077.fits.gz"
+    "hashmd5": "62b8859a8688d4bcbc79878929b37301"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025443.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025443.fits.gz",
     "filesize": 571433,
-    "hashmd5": "99c1c4a1c4da7a2937ff7080645cda50",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025443.fits.gz"
+    "hashmd5": "99c1c4a1c4da7a2937ff7080645cda50"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028341.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028341.fits.gz",
     "filesize": 549414,
-    "hashmd5": "7ee54df596cadc2b71847f7fc843ee26",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028341.fits.gz"
+    "hashmd5": "7ee54df596cadc2b71847f7fc843ee26"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020349.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020349.fits.gz",
     "filesize": 712857,
-    "hashmd5": "6dd61fafbae8e86814de69800937db3a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020349.fits.gz"
+    "hashmd5": "6dd61fafbae8e86814de69800937db3a"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047804.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047804.fits.gz",
     "filesize": 539539,
-    "hashmd5": "402309d638b9ddd894eed813339dbf9c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047804.fits.gz"
+    "hashmd5": "402309d638b9ddd894eed813339dbf9c"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028981.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028981.fits.gz",
     "filesize": 530802,
-    "hashmd5": "8cf530c3307ccb781b8ac4658a858b27",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028981.fits.gz"
+    "hashmd5": "8cf530c3307ccb781b8ac4658a858b27"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020366.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020366.fits.gz",
     "filesize": 631710,
-    "hashmd5": "3849ac03a122d80fbe218285016e9176",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020366.fits.gz"
+    "hashmd5": "3849ac03a122d80fbe218285016e9176"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033797.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033797.fits.gz",
     "filesize": 588862,
-    "hashmd5": "64f6881782dd19af61bca2e27e9f4423",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033797.fits.gz"
+    "hashmd5": "64f6881782dd19af61bca2e27e9f4423"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033787.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033787.fits.gz",
     "filesize": 504999,
-    "hashmd5": "600541521d39e327d04a0eefbb4ee72b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033787.fits.gz"
+    "hashmd5": "600541521d39e327d04a0eefbb4ee72b"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026827.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026827.fits.gz",
     "filesize": 501570,
-    "hashmd5": "9deff24c0e71e2a41c87f18f11ef7508",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026827.fits.gz"
+    "hashmd5": "9deff24c0e71e2a41c87f18f11ef7508"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029526.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029526.fits.gz",
     "filesize": 479577,
-    "hashmd5": "cb28f47a486edac87a6a7fdecf98b139",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029526.fits.gz"
+    "hashmd5": "cb28f47a486edac87a6a7fdecf98b139"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020283.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020283.fits.gz",
     "filesize": 561500,
-    "hashmd5": "b0770dfc2467e20aaf9d4fd2d90a817b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020283.fits.gz"
+    "hashmd5": "b0770dfc2467e20aaf9d4fd2d90a817b"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020517.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020517.fits.gz",
     "filesize": 687783,
-    "hashmd5": "1c7074ea471645261385a774d4638100",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020517.fits.gz"
+    "hashmd5": "1c7074ea471645261385a774d4638100"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020422.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020422.fits.gz",
     "filesize": 714000,
-    "hashmd5": "eab11bf96bab7ef0f9370dd66eb43b0b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020422.fits.gz"
+    "hashmd5": "eab11bf96bab7ef0f9370dd66eb43b0b"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020898.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020898.fits.gz",
     "filesize": 652604,
-    "hashmd5": "522b7eb864c8ebc3e420a1c2d722aae2",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020898.fits.gz"
+    "hashmd5": "522b7eb864c8ebc3e420a1c2d722aae2"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028967.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028967.fits.gz",
     "filesize": 541208,
-    "hashmd5": "ac82a15b66d5adab72f728e37b9bf69a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028967.fits.gz"
+    "hashmd5": "ac82a15b66d5adab72f728e37b9bf69a"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020137.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020137.fits.gz",
     "filesize": 514852,
-    "hashmd5": "1ba7504cf078558e65f89154589c30f1",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020137.fits.gz"
+    "hashmd5": "1ba7504cf078558e65f89154589c30f1"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020339.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020339.fits.gz",
     "filesize": 721226,
-    "hashmd5": "96d64cfad2a009712ed5993a6c550271",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020339.fits.gz"
+    "hashmd5": "96d64cfad2a009712ed5993a6c550271"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027939.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027939.fits.gz",
     "filesize": 584350,
-    "hashmd5": "24af3345ba809bfe2e470261dd1a6d3a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027939.fits.gz"
+    "hashmd5": "24af3345ba809bfe2e470261dd1a6d3a"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027044.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027044.fits.gz",
     "filesize": 579864,
-    "hashmd5": "ff64e716a0670668b7b73d34a3df86c7",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027044.fits.gz"
+    "hashmd5": "ff64e716a0670668b7b73d34a3df86c7"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020521.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020521.fits.gz",
     "filesize": 672342,
-    "hashmd5": "9f8eb5053215d92674830ca66b64398f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020521.fits.gz"
+    "hashmd5": "9f8eb5053215d92674830ca66b64398f"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047829.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047829.fits.gz",
     "filesize": 540430,
-    "hashmd5": "25b19a4080af64445e5e41bef50778b9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047829.fits.gz"
+    "hashmd5": "25b19a4080af64445e5e41bef50778b9"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033795.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033795.fits.gz",
     "filesize": 595392,
-    "hashmd5": "8dd3e667973d49ac69bed2d3d7752a01",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033795.fits.gz"
+    "hashmd5": "8dd3e667973d49ac69bed2d3d7752a01"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029683.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029683.fits.gz",
     "filesize": 500322,
-    "hashmd5": "add0b97c3ded5cd809e024a0155e056c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029683.fits.gz"
+    "hashmd5": "add0b97c3ded5cd809e024a0155e056c"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022593.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022593.fits.gz",
     "filesize": 566251,
-    "hashmd5": "6841676ea7b1ae6a5aed15ba4edb280d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022593.fits.gz"
+    "hashmd5": "6841676ea7b1ae6a5aed15ba4edb280d"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz",
     "filesize": 630275,
-    "hashmd5": "000a1fddf93ef5d2348ae525acdd6c99",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+    "hashmd5": "000a1fddf93ef5d2348ae525acdd6c99"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033794.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033794.fits.gz",
     "filesize": 604278,
-    "hashmd5": "3375ef356b32a9461e4bbd70097e1ff6",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033794.fits.gz"
+    "hashmd5": "3375ef356b32a9461e4bbd70097e1ff6"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047828.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047828.fits.gz",
     "filesize": 532155,
-    "hashmd5": "a6dff73830229ffc52c15286c9253e0f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047828.fits.gz"
+    "hashmd5": "a6dff73830229ffc52c15286c9253e0f"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020365.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020365.fits.gz",
     "filesize": 626775,
-    "hashmd5": "53e2dea966a0e5c5d45539cfa1a33c1d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020365.fits.gz"
+    "hashmd5": "53e2dea966a0e5c5d45539cfa1a33c1d"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021753.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021753.fits.gz",
     "filesize": 601014,
-    "hashmd5": "83d13254830878890d4922e352ad886c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021753.fits.gz"
+    "hashmd5": "83d13254830878890d4922e352ad886c"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020343.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020343.fits.gz",
     "filesize": 655348,
-    "hashmd5": "d1b48e4770578138d6701a8ba162ca5c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020343.fits.gz"
+    "hashmd5": "d1b48e4770578138d6701a8ba162ca5c"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020915.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020915.fits.gz",
     "filesize": 619874,
-    "hashmd5": "188f6bbca8a74eb2d505dea84154f605",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020915.fits.gz"
+    "hashmd5": "188f6bbca8a74eb2d505dea84154f605"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020282.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020282.fits.gz",
     "filesize": 626686,
-    "hashmd5": "85004da7b17fc7ee3571c186946dee54",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020282.fits.gz"
+    "hashmd5": "85004da7b17fc7ee3571c186946dee54"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020899.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020899.fits.gz",
     "filesize": 664353,
-    "hashmd5": "cf61b0388caf3bbdf9441ced303317eb",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020899.fits.gz"
+    "hashmd5": "cf61b0388caf3bbdf9441ced303317eb"
    }
   ]
  },
@@ -2585,281 +2221,241 @@
     "path": "joint-crab/spectra/hess/arf_obs23523.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/arf_obs23523.fits",
     "filesize": 8640,
-    "hashmd5": "26ed95b824b56ee4631b9063b2316b7a",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/arf_obs23523.fits"
+    "hashmd5": "26ed95b824b56ee4631b9063b2316b7a"
    },
    {
     "path": "joint-crab/spectra/hess/arf_obs23559.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/arf_obs23559.fits",
     "filesize": 8640,
-    "hashmd5": "cf7087a9f7cac11767036501bc6d43de",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/arf_obs23559.fits"
+    "hashmd5": "cf7087a9f7cac11767036501bc6d43de"
    },
    {
     "path": "joint-crab/spectra/hess/rmf_obs23526.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/rmf_obs23526.fits",
     "filesize": 20160,
-    "hashmd5": "9f7613b6f5233ddf70457174bec37c6f",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/rmf_obs23526.fits"
+    "hashmd5": "9f7613b6f5233ddf70457174bec37c6f"
    },
    {
     "path": "joint-crab/spectra/hess/pha_obs23559.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/pha_obs23559.fits",
     "filesize": 17280,
-    "hashmd5": "5e3dc496ee2a57692560c2e9e9b63d22",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/pha_obs23559.fits"
+    "hashmd5": "5e3dc496ee2a57692560c2e9e9b63d22"
    },
    {
     "path": "joint-crab/spectra/hess/rmf_obs23592.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/rmf_obs23592.fits",
     "filesize": 20160,
-    "hashmd5": "da08f79d9337b5fa0cb5e3f13dfe3554",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/rmf_obs23592.fits"
+    "hashmd5": "da08f79d9337b5fa0cb5e3f13dfe3554"
    },
    {
     "path": "joint-crab/spectra/hess/bkg_obs23592.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/bkg_obs23592.fits",
     "filesize": 14400,
-    "hashmd5": "6cb46f78803e974312ac6ddaa02f0862",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/bkg_obs23592.fits"
+    "hashmd5": "6cb46f78803e974312ac6ddaa02f0862"
    },
    {
     "path": "joint-crab/spectra/hess/pha_obs23523.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/pha_obs23523.fits",
     "filesize": 17280,
-    "hashmd5": "f58d32234e5fdf6d2a47c32421c88c5a",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/pha_obs23523.fits"
+    "hashmd5": "f58d32234e5fdf6d2a47c32421c88c5a"
    },
    {
     "path": "joint-crab/spectra/hess/bkg_obs23526.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/bkg_obs23526.fits",
     "filesize": 14400,
-    "hashmd5": "6f68c5ce6395fdd5ff05704083161370",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/bkg_obs23526.fits"
+    "hashmd5": "6f68c5ce6395fdd5ff05704083161370"
    },
    {
     "path": "joint-crab/spectra/hess/arf_obs23526.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/arf_obs23526.fits",
     "filesize": 8640,
-    "hashmd5": "ef507d28db3afd41da7786c19b9cfd1c",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/arf_obs23526.fits"
+    "hashmd5": "ef507d28db3afd41da7786c19b9cfd1c"
    },
    {
     "path": "joint-crab/spectra/hess/arf_obs23592.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/arf_obs23592.fits",
     "filesize": 8640,
-    "hashmd5": "55fb38a1e371e5a74a04f4df73c59c32",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/arf_obs23592.fits"
+    "hashmd5": "55fb38a1e371e5a74a04f4df73c59c32"
    },
    {
     "path": "joint-crab/spectra/hess/pha_obs23592.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/pha_obs23592.fits",
     "filesize": 17280,
-    "hashmd5": "94fe3939659befbd1ebc0159ddd9e5a4",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/pha_obs23592.fits"
+    "hashmd5": "94fe3939659befbd1ebc0159ddd9e5a4"
    },
    {
     "path": "joint-crab/spectra/hess/rmf_obs23559.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/rmf_obs23559.fits",
     "filesize": 20160,
-    "hashmd5": "7d9b110d99c2299ed014e656204c92da",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/rmf_obs23559.fits"
+    "hashmd5": "7d9b110d99c2299ed014e656204c92da"
    },
    {
     "path": "joint-crab/spectra/hess/pha_obs23526.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/pha_obs23526.fits",
     "filesize": 17280,
-    "hashmd5": "215c77f17084ad5c8b5697f67fe7c7cc",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/pha_obs23526.fits"
+    "hashmd5": "215c77f17084ad5c8b5697f67fe7c7cc"
    },
    {
     "path": "joint-crab/spectra/hess/bkg_obs23523.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/bkg_obs23523.fits",
     "filesize": 14400,
-    "hashmd5": "2c6e6f4a6094aac89a6fca8f0a88be47",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/bkg_obs23523.fits"
+    "hashmd5": "2c6e6f4a6094aac89a6fca8f0a88be47"
    },
    {
     "path": "joint-crab/spectra/hess/rmf_obs23523.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/rmf_obs23523.fits",
     "filesize": 20160,
-    "hashmd5": "21774ead32e57501e672177e29df7da9",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/rmf_obs23523.fits"
+    "hashmd5": "21774ead32e57501e672177e29df7da9"
    },
    {
     "path": "joint-crab/spectra/hess/bkg_obs23559.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/bkg_obs23559.fits",
     "filesize": 14400,
-    "hashmd5": "7af2369c2517431c6f88cbede44131da",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/bkg_obs23559.fits"
+    "hashmd5": "7af2369c2517431c6f88cbede44131da"
    },
    {
     "path": "joint-crab/spectra/magic/arf_obs5029748.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/arf_obs5029748.fits",
     "filesize": 8640,
-    "hashmd5": "e5d59ae10543fc105a7a6996e216c313",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/arf_obs5029748.fits"
+    "hashmd5": "e5d59ae10543fc105a7a6996e216c313"
    },
    {
     "path": "joint-crab/spectra/magic/pha_obs5029747.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/pha_obs5029747.fits",
     "filesize": 17280,
-    "hashmd5": "a6245e03687937e4fcdac6a36e72d864",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/pha_obs5029747.fits"
+    "hashmd5": "a6245e03687937e4fcdac6a36e72d864"
    },
    {
     "path": "joint-crab/spectra/magic/rmf_obs5029747.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/rmf_obs5029747.fits",
     "filesize": 23040,
-    "hashmd5": "30dcf11e109c9bc253adb5efa1481445",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/rmf_obs5029747.fits"
+    "hashmd5": "30dcf11e109c9bc253adb5efa1481445"
    },
    {
     "path": "joint-crab/spectra/magic/bkg_obs5029747.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/bkg_obs5029747.fits",
     "filesize": 14400,
-    "hashmd5": "49aa0e9a160c112cdf4118c01a0ef054",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/bkg_obs5029747.fits"
+    "hashmd5": "49aa0e9a160c112cdf4118c01a0ef054"
    },
    {
     "path": "joint-crab/spectra/magic/bkg_obs5029748.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/bkg_obs5029748.fits",
     "filesize": 14400,
-    "hashmd5": "433ac4e639626ed9266d6a87318d22f0",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/bkg_obs5029748.fits"
+    "hashmd5": "433ac4e639626ed9266d6a87318d22f0"
    },
    {
     "path": "joint-crab/spectra/magic/pha_obs5029748.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/pha_obs5029748.fits",
     "filesize": 17280,
-    "hashmd5": "6b60eb115bda81ecda0fe1111688735a",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/pha_obs5029748.fits"
+    "hashmd5": "6b60eb115bda81ecda0fe1111688735a"
    },
    {
     "path": "joint-crab/spectra/magic/rmf_obs5029748.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/rmf_obs5029748.fits",
     "filesize": 23040,
-    "hashmd5": "298c8d829fa8368d28f0700f94b23717",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/rmf_obs5029748.fits"
+    "hashmd5": "298c8d829fa8368d28f0700f94b23717"
    },
    {
     "path": "joint-crab/spectra/magic/arf_obs5029747.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/arf_obs5029747.fits",
     "filesize": 8640,
-    "hashmd5": "702aa5a352a9b58628f6e6b05afa856e",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/arf_obs5029747.fits"
+    "hashmd5": "702aa5a352a9b58628f6e6b05afa856e"
    },
    {
     "path": "joint-crab/spectra/fermi/arf_obs0.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fermi/arf_obs0.fits",
     "filesize": 8640,
-    "hashmd5": "3e59a877f189081b700ba47bbc73c9eb",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fermi/arf_obs0.fits"
+    "hashmd5": "3e59a877f189081b700ba47bbc73c9eb"
    },
    {
     "path": "joint-crab/spectra/fermi/pha_obs0.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fermi/pha_obs0.fits",
     "filesize": 17280,
-    "hashmd5": "ee26efa7407dbafccde4d49bb5b43b68",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fermi/pha_obs0.fits"
+    "hashmd5": "ee26efa7407dbafccde4d49bb5b43b68"
    },
    {
     "path": "joint-crab/spectra/fermi/bkg_obs0.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fermi/bkg_obs0.fits",
     "filesize": 14400,
-    "hashmd5": "9b81ecd635750ed0d5072a4ce49adf36",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fermi/bkg_obs0.fits"
+    "hashmd5": "9b81ecd635750ed0d5072a4ce49adf36"
    },
    {
     "path": "joint-crab/spectra/fermi/rmf_obs0.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fermi/rmf_obs0.fits",
     "filesize": 14400,
-    "hashmd5": "eb4479bce949475f61a4971b96dde39c",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fermi/rmf_obs0.fits"
+    "hashmd5": "eb4479bce949475f61a4971b96dde39c"
    },
    {
     "path": "joint-crab/spectra/fact/bkg_stacked.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fact/bkg_stacked.fits",
     "filesize": 25920,
-    "hashmd5": "cfa3fd913e41f06537740cbf87edf3da",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fact/bkg_stacked.fits"
+    "hashmd5": "cfa3fd913e41f06537740cbf87edf3da"
    },
    {
     "path": "joint-crab/spectra/fact/rmf_stacked.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fact/rmf_stacked.fits",
     "filesize": 23040,
-    "hashmd5": "4ee7efb2181d973139154b06e32ba029",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fact/rmf_stacked.fits"
+    "hashmd5": "4ee7efb2181d973139154b06e32ba029"
    },
    {
     "path": "joint-crab/spectra/fact/arf_stacked.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fact/arf_stacked.fits",
     "filesize": 8640,
-    "hashmd5": "d6aba229280f677d2b3e2334f7d17718",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fact/arf_stacked.fits"
+    "hashmd5": "d6aba229280f677d2b3e2334f7d17718"
    },
    {
     "path": "joint-crab/spectra/fact/pha_stacked.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fact/pha_stacked.fits",
     "filesize": 25920,
-    "hashmd5": "02e3b0005b3e407f7b8170c5d21e5104",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fact/pha_stacked.fits"
+    "hashmd5": "02e3b0005b3e407f7b8170c5d21e5104"
    },
    {
     "path": "joint-crab/spectra/veritas/arf_obs57993.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/arf_obs57993.fits",
     "filesize": 8640,
-    "hashmd5": "ca3b6ad785b36083b5fec6461a11f019",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/arf_obs57993.fits"
+    "hashmd5": "ca3b6ad785b36083b5fec6461a11f019"
    },
    {
     "path": "joint-crab/spectra/veritas/arf_obs54809.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/arf_obs54809.fits",
     "filesize": 8640,
-    "hashmd5": "541c02fa3be8384ed4aab20e784dc327",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/arf_obs54809.fits"
+    "hashmd5": "541c02fa3be8384ed4aab20e784dc327"
    },
    {
     "path": "joint-crab/spectra/veritas/pha_obs54809.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/pha_obs54809.fits",
     "filesize": 17280,
-    "hashmd5": "114828f35ea4cede066ac4e8b36122fb",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/pha_obs54809.fits"
+    "hashmd5": "114828f35ea4cede066ac4e8b36122fb"
    },
    {
     "path": "joint-crab/spectra/veritas/pha_obs57993.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/pha_obs57993.fits",
     "filesize": 17280,
-    "hashmd5": "cd181b3ab18256c6109abfbb44c785b5",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/pha_obs57993.fits"
+    "hashmd5": "cd181b3ab18256c6109abfbb44c785b5"
    },
    {
     "path": "joint-crab/spectra/veritas/rmf_obs57993.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/rmf_obs57993.fits",
     "filesize": 20160,
-    "hashmd5": "985c47683de83325e38bcce30e357dbc",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/rmf_obs57993.fits"
+    "hashmd5": "985c47683de83325e38bcce30e357dbc"
    },
    {
     "path": "joint-crab/spectra/veritas/rmf_obs54809.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/rmf_obs54809.fits",
     "filesize": 20160,
-    "hashmd5": "221d94dbafffc8657ebe5dc8e3428d44",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/rmf_obs54809.fits"
+    "hashmd5": "221d94dbafffc8657ebe5dc8e3428d44"
    },
    {
     "path": "joint-crab/spectra/veritas/bkg_obs54809.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/bkg_obs54809.fits",
     "filesize": 14400,
-    "hashmd5": "b02838d9b80b620308efe8af93289d8e",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/bkg_obs54809.fits"
+    "hashmd5": "b02838d9b80b620308efe8af93289d8e"
    },
    {
     "path": "joint-crab/spectra/veritas/bkg_obs57993.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/bkg_obs57993.fits",
     "filesize": 14400,
-    "hashmd5": "f169cd9655a172d3ce229d4d678decbb",
-    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/bkg_obs57993.fits"
+    "hashmd5": "f169cd9655a172d3ce229d4d678decbb"
    }
   ]
  },
@@ -2871,36 +2467,31 @@
     "path": "ebl/frd_abs.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/ebl/frd_abs.fits.gz",
     "filesize": 120837,
-    "hashmd5": "1259686d4790c86a63b426698acceebc",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/ebl/frd_abs.fits.gz"
+    "hashmd5": "1259686d4790c86a63b426698acceebc"
    },
    {
     "path": "ebl/ebl_franceschini.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/ebl/ebl_franceschini.fits.gz",
     "filesize": 274043,
-    "hashmd5": "a77a14de3fc36727087c861083389620",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/ebl/ebl_franceschini.fits.gz"
+    "hashmd5": "a77a14de3fc36727087c861083389620"
    },
    {
     "path": "ebl/ebl_models.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/ebl/ebl_models.png",
     "filesize": 51560,
-    "hashmd5": "9e2a290184fe9effddd533af61d5a985",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/ebl/ebl_models.png"
+    "hashmd5": "9e2a290184fe9effddd533af61d5a985"
    },
    {
     "path": "ebl/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/ebl/README.md",
     "filesize": 435,
-    "hashmd5": "20a2f39ea2f707bb4b597d1ac186d2a5",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/ebl/README.md"
+    "hashmd5": "20a2f39ea2f707bb4b597d1ac186d2a5"
    },
    {
     "path": "ebl/ebl_dominguez11.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/ebl/ebl_dominguez11.fits.gz",
     "filesize": 431576,
-    "hashmd5": "02f0e2324256bd5070490dccedbad0df",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/ebl/ebl_dominguez11.fits.gz"
+    "hashmd5": "02f0e2324256bd5070490dccedbad0df"
    }
   ]
  },
@@ -2912,71 +2503,61 @@
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-background.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-background.fits.gz",
     "filesize": 276011,
-    "hashmd5": "d5cc4205d0d7f9fea9e6d032fe7392ac",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-background.fits.gz"
+    "hashmd5": "d5cc4205d0d7f9fea9e6d032fe7392ac"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-background-cube.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-background-cube.fits.gz",
     "filesize": 3544798,
-    "hashmd5": "34be0106614921d5a6b3a196993b4cf8",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-background-cube.fits.gz"
+    "hashmd5": "34be0106614921d5a6b3a196993b4cf8"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-counts.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-counts.fits.gz",
     "filesize": 25987,
-    "hashmd5": "9a1efcf66efd8690fcf8b252666b2a25",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-counts.fits.gz"
+    "hashmd5": "9a1efcf66efd8690fcf8b252666b2a25"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-counts-cube.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-counts-cube.fits.gz",
     "filesize": 551140,
-    "hashmd5": "10ddcd4ea5b253b54e9db80cd5c2fa12",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-counts-cube.fits.gz"
+    "hashmd5": "10ddcd4ea5b253b54e9db80cd5c2fa12"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-events.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-events.fits.gz",
     "filesize": 2409727,
-    "hashmd5": "fc195f11fdef7f53774bc80f12a0db81",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-events.fits.gz"
+    "hashmd5": "fc195f11fdef7f53774bc80f12a0db81"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-exposure-cube.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-exposure-cube.fits.gz",
     "filesize": 572834,
-    "hashmd5": "64088e1015b1b1bdd3f6b047fbd8b033",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-exposure-cube.fits.gz"
+    "hashmd5": "64088e1015b1b1bdd3f6b047fbd8b033"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-exposure.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-exposure.fits.gz",
     "filesize": 7062,
-    "hashmd5": "dfbd4d9494ca7c3de21faaf499765c6e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-exposure.fits.gz"
+    "hashmd5": "dfbd4d9494ca7c3de21faaf499765c6e"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-psf.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-psf.fits.gz",
     "filesize": 1299,
-    "hashmd5": "f84b64a46bc2946489553438f91c048f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-psf.fits.gz"
+    "hashmd5": "f84b64a46bc2946489553438f91c048f"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-psf-cube.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-psf-cube.fits.gz",
     "filesize": 28072,
-    "hashmd5": "ff6c8b0fa64f703880d2ecefe7e83df0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-psf-cube.fits.gz"
+    "hashmd5": "ff6c8b0fa64f703880d2ecefe7e83df0"
    },
    {
     "path": "fermi-3fhl-gc/gll_iem_v06_gc.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/gll_iem_v06_gc.fits.gz",
     "filesize": 823469,
-    "hashmd5": "37c3c5d8ad72a918360c6d2b6a72db1e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/gll_iem_v06_gc.fits.gz"
+    "hashmd5": "37c3c5d8ad72a918360c6d2b6a72db1e"
    }
   ]
  },
@@ -2988,22 +2569,19 @@
     "path": "fermi-3fhl-crab/Fermi-LAT-3FHL_data_Fermi-LAT.fits",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/crab/Fermi-LAT-3FHL_data_Fermi-LAT.fits",
     "filesize": 391680,
-    "hashmd5": "3ca12b9f8f8100a9c8254566c5054e71",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/crab/Fermi-LAT-3FHL_data_Fermi-LAT.fits"
+    "hashmd5": "3ca12b9f8f8100a9c8254566c5054e71"
    },
    {
     "path": "fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/crab/Fermi-LAT-3FHL_datasets.yaml",
     "filesize": 124,
-    "hashmd5": "5e17b2f385049b660ce2bd6c1bebf65d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/crab/Fermi-LAT-3FHL_datasets.yaml"
+    "hashmd5": "5e17b2f385049b660ce2bd6c1bebf65d"
    },
    {
     "path": "fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/crab/Fermi-LAT-3FHL_models.yaml",
     "filesize": 1283,
-    "hashmd5": "e99438be2fe12115cada40b5c2ace4a7",
-    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/crab/Fermi-LAT-3FHL_models.yaml"
+    "hashmd5": "e99438be2fe12115cada40b5c2ace4a7"
    }
   ]
  },
@@ -3015,15 +2593,13 @@
     "path": "hawc_crab/HAWC19_flux_points.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hawc_crab/HAWC19_flux_points.fits",
     "filesize": 8640,
-    "hashmd5": "afa06335c5a3e559b2ff0e73d254315f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hawc_crab/HAWC19_flux_points.fits"
+    "hashmd5": "afa06335c5a3e559b2ff0e73d254315f"
    },
    {
     "path": "hawc_crab/prepare.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hawc_crab/prepare.py",
     "filesize": 1222,
-    "hashmd5": "d13cdc457ff979e7a86b9c2d740659bb",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hawc_crab/prepare.py"
+    "hashmd5": "d13cdc457ff979e7a86b9c2d740659bb"
    }
   ]
  },
@@ -3035,491 +2611,421 @@
     "path": "tests/phasecurve_LSI_DC.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/phasecurve_LSI_DC.fits",
     "filesize": 8640,
-    "hashmd5": "fe0444d0c51306c4626840e744127da6",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/phasecurve_LSI_DC.fits"
+    "hashmd5": "fe0444d0c51306c4626840e744127da6"
    },
    {
     "path": "tests/pointing_table.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/pointing_table.fits.gz",
     "filesize": 999284,
-    "hashmd5": "9efaebe942886a2d7e4112764a347b22",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/pointing_table.fits.gz"
+    "hashmd5": "9efaebe942886a2d7e4112764a347b22"
    },
    {
     "path": "tests/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/README.md",
     "filesize": 155,
-    "hashmd5": "01f54cdf3f0f41f7cc2da6fb9707f24e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/README.md"
+    "hashmd5": "01f54cdf3f0f41f7cc2da6fb9707f24e"
    },
    {
     "path": "tests/hess_psf_king_023523.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/hess_psf_king_023523.fits.gz",
     "filesize": 1935,
-    "hashmd5": "d5374ccd22a7644bbc8da4387daa6e54",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/hess_psf_king_023523.fits.gz"
+    "hashmd5": "d5374ccd22a7644bbc8da4387daa6e54"
    },
    {
     "path": "tests/models/gc_example_data_g09.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/gc_example_data_g09.fits",
     "filesize": 60480,
-    "hashmd5": "be7edf33962f9237b62e9fcb3b45f78c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/gc_example_data_g09.fits"
+    "hashmd5": "be7edf33962f9237b62e9fcb3b45f78c"
    },
    {
     "path": "tests/models/shell.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/shell.xml",
     "filesize": 1491,
-    "hashmd5": "25832149ee91987d1698cbbd5a09ecf0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/shell.xml"
+    "hashmd5": "25832149ee91987d1698cbbd5a09ecf0"
    },
    {
     "path": "tests/models/fermi_model.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/fermi_model.xml",
     "filesize": 2656,
-    "hashmd5": "9bd8ffcad7e2a2e53356207b31320193",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/fermi_model.xml"
+    "hashmd5": "9bd8ffcad7e2a2e53356207b31320193"
    },
    {
     "path": "tests/models/ctadc_skymodel_gps_sources_bright.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/ctadc_skymodel_gps_sources_bright.xml",
     "filesize": 29281,
-    "hashmd5": "da20a7007173d86930ec22625be495e1",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/ctadc_skymodel_gps_sources_bright.xml"
+    "hashmd5": "da20a7007173d86930ec22625be495e1"
    },
    {
     "path": "tests/models/examples.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/examples.xml",
     "filesize": 5178,
-    "hashmd5": "9c68dbe906afc246367811fbfea090a3",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/examples.xml"
+    "hashmd5": "9c68dbe906afc246367811fbfea090a3"
    },
    {
     "path": "tests/models/gc_example_datasets.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/gc_example_datasets.yaml",
     "filesize": 198,
-    "hashmd5": "72e07fe7aca6d77d18e61261334aab49",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/gc_example_datasets.yaml"
+    "hashmd5": "72e07fe7aca6d77d18e61261334aab49"
    },
    {
     "path": "tests/models/gc_example_models.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/gc_example_models.yaml",
     "filesize": 2238,
-    "hashmd5": "430b3ee537c243fbc1952d697efad079",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/gc_example_models.yaml"
+    "hashmd5": "430b3ee537c243fbc1952d697efad079"
    },
    {
     "path": "tests/models/gc_example_data_gc.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/gc_example_data_gc.fits",
     "filesize": 60480,
-    "hashmd5": "d4b9246a9ccea0c82f7d72c57376fbab",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/gc_example_data_gc.fits"
+    "hashmd5": "d4b9246a9ccea0c82f7d72c57376fbab"
    },
    {
     "path": "tests/models/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/README.rst",
     "filesize": 461,
-    "hashmd5": "c382cec8b5f5c621d4c4f3f6c5c7258c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/README.rst"
+    "hashmd5": "c382cec8b5f5c621d4c4f3f6c5c7258c"
    },
    {
     "path": "tests/models/light_curve/model.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/light_curve/model.xml",
     "filesize": 944,
-    "hashmd5": "73c3f10e8da1946f2554a0be7380f6cf",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/light_curve/model.xml"
+    "hashmd5": "73c3f10e8da1946f2554a0be7380f6cf"
    },
    {
     "path": "tests/models/light_curve/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/light_curve/README.md",
     "filesize": 622,
-    "hashmd5": "78f49339b3cacf2e33e6b8353aa8a292",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/light_curve/README.md"
+    "hashmd5": "78f49339b3cacf2e33e6b8353aa8a292"
    },
    {
     "path": "tests/models/light_curve/lightcrv_PKSB1222+216.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/light_curve/lightcrv_PKSB1222+216.fits",
     "filesize": 48960,
-    "hashmd5": "de1018e14e03b1f89f3734437cebbf89",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/light_curve/lightcrv_PKSB1222+216.fits"
+    "hashmd5": "de1018e14e03b1f89f3734437cebbf89"
    },
    {
     "path": "tests/spectrum/total_spectrum_stats_reference.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/total_spectrum_stats_reference.yaml",
     "filesize": 175,
-    "hashmd5": "c60e95c6e319724f85d6ed6303dfc039",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/total_spectrum_stats_reference.yaml"
+    "hashmd5": "c60e95c6e319724f85d6ed6303dfc039"
    },
    {
     "path": "tests/spectrum/fit_result_PowerLaw_reference.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/fit_result_PowerLaw_reference.yaml",
     "filesize": 531,
-    "hashmd5": "e0f06bbb36f9ef17fd39dea08e83e3da",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/fit_result_PowerLaw_reference.yaml"
+    "hashmd5": "e0f06bbb36f9ef17fd39dea08e83e3da"
    },
    {
     "path": "tests/spectrum/spectrum_analysis_example.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/spectrum_analysis_example.yaml",
     "filesize": 377,
-    "hashmd5": "9cd19c8e71e8d808144f2fdd033a0aad",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/spectrum_analysis_example.yaml"
+    "hashmd5": "9cd19c8e71e8d808144f2fdd033a0aad"
    },
    {
     "path": "tests/spectrum/flux_points/1es0229_hess_spectrum.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/1es0229_hess_spectrum.fits",
     "filesize": 8640,
-    "hashmd5": "e6900ce51bee3b3dfc36f35798a65f14",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/1es0229_hess_spectrum.fits"
+    "hashmd5": "e6900ce51bee3b3dfc36f35798a65f14"
    },
    {
     "path": "tests/spectrum/flux_points/flux_points.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/flux_points.fits",
     "filesize": 8640,
-    "hashmd5": "a8c527216d0e2cf0665c67553511176e",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/flux_points.fits"
+    "hashmd5": "a8c527216d0e2cf0665c67553511176e"
    },
    {
     "path": "tests/spectrum/flux_points/flux_points.ecsv",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/flux_points.ecsv",
     "filesize": 2063,
-    "hashmd5": "e562dde1a2fc05438901338de2cd6acd",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/flux_points.ecsv"
+    "hashmd5": "e562dde1a2fc05438901338de2cd6acd"
    },
    {
     "path": "tests/spectrum/flux_points/1es0229_hess_spectrum.ecsv",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/1es0229_hess_spectrum.ecsv",
     "filesize": 603,
-    "hashmd5": "bee0793ddad5328b39bbcba1a8ce01cd",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/1es0229_hess_spectrum.ecsv"
+    "hashmd5": "bee0793ddad5328b39bbcba1a8ce01cd"
    },
    {
     "path": "tests/spectrum/flux_points/diff_flux_points.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/diff_flux_points.fits",
     "filesize": 8640,
-    "hashmd5": "c8974f171c0022674a011f2c3e827c3a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/diff_flux_points.fits"
+    "hashmd5": "c8974f171c0022674a011f2c3e827c3a"
    },
    {
     "path": "tests/spectrum/flux_points/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/README.md",
     "filesize": 378,
-    "hashmd5": "dff522a0fa9e389a6aac6c927993d9e6",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/README.md"
+    "hashmd5": "dff522a0fa9e389a6aac6c927993d9e6"
    },
    {
     "path": "tests/spectrum/flux_points/diff_flux_points.ecsv",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/diff_flux_points.ecsv",
     "filesize": 1570,
-    "hashmd5": "d1c351e8680435118c6f08593c8778a6",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/diff_flux_points.ecsv"
+    "hashmd5": "d1c351e8680435118c6f08593c8778a6"
    },
    {
     "path": "tests/spectrum/flux_points/flux_points_ctb_37b.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/flux_points_ctb_37b.txt",
     "filesize": 386,
-    "hashmd5": "7a0340e0a568ad9755304f4f4cf0fb1a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/flux_points_ctb_37b.txt"
+    "hashmd5": "7a0340e0a568ad9755304f4f4cf0fb1a"
    },
    {
     "path": "tests/spectrum/flux_points/binlike.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/binlike.fits",
     "filesize": 20160,
-    "hashmd5": "92209c4d47784f5c9db70541ecd0fb4f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/binlike.fits"
+    "hashmd5": "92209c4d47784f5c9db70541ecd0fb4f"
    },
    {
     "path": "tests/unbundled/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/README.rst",
     "filesize": 257,
-    "hashmd5": "7f2b2e7e963faf6464224434fbe474b3",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/README.rst"
+    "hashmd5": "7f2b2e7e963faf6464224434fbe474b3"
    },
    {
     "path": "tests/unbundled/hess/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/hess/README.rst",
     "filesize": 407,
-    "hashmd5": "514cb2ee58686547234bd6a6360a4e86",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/hess/README.rst"
+    "hashmd5": "514cb2ee58686547234bd6a6360a4e86"
    },
    {
     "path": "tests/unbundled/hess/survey/hess_survey_snippet.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/hess/survey/hess_survey_snippet.fits.gz",
     "filesize": 1491989,
-    "hashmd5": "a17033e411f6f1b14c59167783731cda",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/hess/survey/hess_survey_snippet.fits.gz"
+    "hashmd5": "a17033e411f6f1b14c59167783731cda"
    },
    {
     "path": "tests/unbundled/hess/survey/make.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/hess/survey/make.py",
     "filesize": 2023,
-    "hashmd5": "89b1b90b82d99508fb60abce7669456d",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/hess/survey/make.py"
+    "hashmd5": "89b1b90b82d99508fb60abce7669456d"
    },
    {
     "path": "tests/unbundled/fermi/gll_iem_v02_cutout.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/gll_iem_v02_cutout.fits",
     "filesize": 167040,
-    "hashmd5": "74ff01baa83fc9faf09137ae4f5ba7fd",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/gll_iem_v02_cutout.fits"
+    "hashmd5": "74ff01baa83fc9faf09137ae4f5ba7fd"
    },
    {
     "path": "tests/unbundled/fermi/make.sh",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/make.sh",
     "filesize": 747,
-    "hashmd5": "769340ef97c95c225852234f28c4dde4",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/make.sh"
+    "hashmd5": "769340ef97c95c225852234f28c4dde4"
    },
    {
     "path": "tests/unbundled/fermi/psf.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/psf.fits",
     "filesize": 60480,
-    "hashmd5": "1c1ea4e148592a9532a7b6593716115b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/psf.fits"
+    "hashmd5": "1c1ea4e148592a9532a7b6593716115b"
    },
    {
     "path": "tests/unbundled/fermi/isotropic_iem_v02.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/isotropic_iem_v02.txt",
     "filesize": 649,
-    "hashmd5": "b3cca3fc4e5db1c3b0c96856962692ec",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/isotropic_iem_v02.txt"
+    "hashmd5": "b3cca3fc4e5db1c3b0c96856962692ec"
    },
    {
     "path": "tests/unbundled/fermi/fermi_exposure.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/fermi_exposure.fits.gz",
     "filesize": 26271,
-    "hashmd5": "452cc0460dd5bb5561db04e97aa0c3f5",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/fermi_exposure.fits.gz"
+    "hashmd5": "452cc0460dd5bb5561db04e97aa0c3f5"
    },
    {
     "path": "tests/unbundled/fermi/fermi_irf_data.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/fermi_irf_data.fits",
     "filesize": 25920,
-    "hashmd5": "5c37c62623761487fd0d2498f357d61c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/fermi_irf_data.fits"
+    "hashmd5": "5c37c62623761487fd0d2498f357d61c"
    },
    {
     "path": "tests/unbundled/fermi/fermi_counts.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/fermi_counts.fits.gz",
     "filesize": 20912,
-    "hashmd5": "e8076e99111323c5c5bc3655574bb1d9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/fermi_counts.fits.gz"
+    "hashmd5": "e8076e99111323c5c5bc3655574bb1d9"
    },
    {
     "path": "tests/unbundled/fermi/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/README.rst",
     "filesize": 1710,
-    "hashmd5": "dbdc9ad06a186cb955414939241881d3",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/README.rst"
+    "hashmd5": "dbdc9ad06a186cb955414939241881d3"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/expected_ts_0.200.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.200.fits.gz",
     "filesize": 158597,
-    "hashmd5": "9ce87f442aae7131e5f43229ab83090a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.200.fits.gz"
+    "hashmd5": "9ce87f442aae7131e5f43229ab83090a"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/fit_sherpa_output.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/fit_sherpa_output.txt",
     "filesize": 1545,
-    "hashmd5": "c28b5c12dba4b9226a3ed26717eb8c8c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/fit_sherpa_output.txt"
+    "hashmd5": "c28b5c12dba4b9226a3ed26717eb8c8c"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/exclusion.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/exclusion.fits.gz",
     "filesize": 733,
-    "hashmd5": "ded0afa7af66204b6619f54b460009a7",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/exclusion.fits.gz"
+    "hashmd5": "ded0afa7af66204b6619f54b460009a7"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/counts.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/counts.fits.gz",
     "filesize": 15736,
-    "hashmd5": "8547c52beba37132ae90c0d5e1df5f87",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/counts.fits.gz"
+    "hashmd5": "8547c52beba37132ae90c0d5e1df5f87"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/expected_ts_0.050.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.050.fits.gz",
     "filesize": 372466,
-    "hashmd5": "01f9f8569c59f664e8ff8977e95613a0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.050.fits.gz"
+    "hashmd5": "01f9f8569c59f664e8ff8977e95613a0"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/fit_sherpa.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/fit_sherpa.py",
     "filesize": 1656,
-    "hashmd5": "d7fc6bf5f86fed4c3c04a5b346e6fdba",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/fit_sherpa.py"
+    "hashmd5": "d7fc6bf5f86fed4c3c04a5b346e6fdba"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/psf.json",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/psf.json",
     "filesize": 201,
-    "hashmd5": "3f748d332f91bf84cc2e72be8c87b9a6",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/psf.json"
+    "hashmd5": "3f748d332f91bf84cc2e72be8c87b9a6"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/expected_ts_0.000.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.000.fits.gz",
     "filesize": 357359,
-    "hashmd5": "495536584aef49fba5cd73394d8fdbe1",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.000.fits.gz"
+    "hashmd5": "495536584aef49fba5cd73394d8fdbe1"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/input_all.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/input_all.fits.gz",
     "filesize": 21958,
-    "hashmd5": "17af22fe4aa722acd2cbb2d2cd7a4636",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/input_all.fits.gz"
+    "hashmd5": "17af22fe4aa722acd2cbb2d2cd7a4636"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/README.md",
     "filesize": 1748,
-    "hashmd5": "c08cf45e24ca23f1437efe0c578c0b1f",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/README.md"
+    "hashmd5": "c08cf45e24ca23f1437efe0c578c0b1f"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/background.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/background.fits.gz",
     "filesize": 614,
-    "hashmd5": "e49c0d50b26a818f930397978f20cb1c",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/background.fits.gz"
+    "hashmd5": "e49c0d50b26a818f930397978f20cb1c"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/exposure.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/exposure.fits.gz",
     "filesize": 615,
-    "hashmd5": "0d270a544a1e134c8e645088a494ccad",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/exposure.fits.gz"
+    "hashmd5": "0d270a544a1e134c8e645088a494ccad"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/make.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/make.py",
     "filesize": 4519,
-    "hashmd5": "5add240ba9eebe98f0f09b5456edc4f5",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/make.py"
+    "hashmd5": "5add240ba9eebe98f0f09b5456edc4f5"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/model.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/model.fits.gz",
     "filesize": 4222,
-    "hashmd5": "bc256ff4b8e8699162dc1f59da60ede3",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/model.fits.gz"
+    "hashmd5": "bc256ff4b8e8699162dc1f59da60ede3"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/expected_ts_0.100.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.100.fits.gz",
     "filesize": 278529,
-    "hashmd5": "e78f838abcf84fe9ceb99b236638561b",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.100.fits.gz"
+    "hashmd5": "e78f838abcf84fe9ceb99b236638561b"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/source.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/source.fits.gz",
     "filesize": 33637,
-    "hashmd5": "45ba50d3e49c2dcd138a681650620161",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/source.fits.gz"
+    "hashmd5": "45ba50d3e49c2dcd138a681650620161"
    },
    {
     "path": "tests/unbundled/irfs/aeff2D.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/irfs/aeff2D.fits",
     "filesize": 20160,
-    "hashmd5": "0111e52b2d764effaa5b52a6d6248628",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/irfs/aeff2D.fits"
+    "hashmd5": "0111e52b2d764effaa5b52a6d6248628"
    },
    {
     "path": "tests/unbundled/irfs/psf.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/irfs/psf.fits",
     "filesize": 14400,
-    "hashmd5": "c7be3386faab9bcff09865988e3957c0",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/irfs/psf.fits"
+    "hashmd5": "c7be3386faab9bcff09865988e3957c0"
    },
    {
     "path": "tests/unbundled/irfs/arf.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/irfs/arf.fits",
     "filesize": 11520,
-    "hashmd5": "e63c21afb39ab6319a1e578a50401700",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/irfs/arf.fits"
+    "hashmd5": "e63c21afb39ab6319a1e578a50401700"
    },
    {
     "path": "tests/unbundled/tev_spectra/electron_spectrum_fermi.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/electron_spectrum_fermi.txt",
     "filesize": 5757,
-    "hashmd5": "7ad394aa1c4fbe64baf9aa4495000c15",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/electron_spectrum_fermi.txt"
+    "hashmd5": "7ad394aa1c4fbe64baf9aa4495000c15"
    },
    {
     "path": "tests/unbundled/tev_spectra/format_crab_sed.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/format_crab_sed.py",
     "filesize": 5895,
-    "hashmd5": "d56f8fd5ff9daca34f258e71c6c673ea",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/format_crab_sed.py"
+    "hashmd5": "d56f8fd5ff9daca34f258e71c6c673ea"
    },
    {
     "path": "tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy_systematic_uncertainty.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy_systematic_uncertainty.txt",
     "filesize": 551,
-    "hashmd5": "eac8ed2f88ada7971ee9d831ba9250a3",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy_systematic_uncertainty.txt"
+    "hashmd5": "eac8ed2f88ada7971ee9d831ba9250a3"
    },
    {
     "path": "tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy.txt",
     "filesize": 602,
-    "hashmd5": "d8652a02161768523c0c0d9ac4fb9882",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy.txt"
+    "hashmd5": "d8652a02161768523c0c0d9ac4fb9882"
    },
    {
     "path": "tests/unbundled/tev_spectra/crab_mwl.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/crab_mwl.rst",
     "filesize": 798,
-    "hashmd5": "af9cad4e8b3fac6962473ffb0a00cb54",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/crab_mwl.rst"
+    "hashmd5": "af9cad4e8b3fac6962473ffb0a00cb54"
    },
    {
     "path": "tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi.txt",
     "filesize": 1065,
-    "hashmd5": "ebfd873e126764669a37351fdae9e148",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi.txt"
+    "hashmd5": "ebfd873e126764669a37351fdae9e148"
    },
    {
     "path": "tests/unbundled/tev_spectra/electron_spectrum_hess_systematic_uncertainty.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_systematic_uncertainty.txt",
     "filesize": 461,
-    "hashmd5": "8501c3e531ad8dbf08896b90945cbfa4",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_systematic_uncertainty.txt"
+    "hashmd5": "8501c3e531ad8dbf08896b90945cbfa4"
    },
    {
     "path": "tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi2.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi2.txt",
     "filesize": 2398,
-    "hashmd5": "7c7f170911f246fdeb342e097f0907b4",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi2.txt"
+    "hashmd5": "7c7f170911f246fdeb342e097f0907b4"
    },
    {
     "path": "tests/unbundled/tev_spectra/crab_hess_spec.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/crab_hess_spec.txt",
     "filesize": 1160,
-    "hashmd5": "ddfe9884be993372d57da86b9e4074f6",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/crab_hess_spec.txt"
+    "hashmd5": "ddfe9884be993372d57da86b9e4074f6"
    },
    {
     "path": "tests/unbundled/tev_spectra/crab_mwl.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/crab_mwl.fits.gz",
     "filesize": 14132,
-    "hashmd5": "008c8993e87831d8af9a35d13717d6be",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/crab_mwl.fits.gz"
+    "hashmd5": "008c8993e87831d8af9a35d13717d6be"
    },
    {
     "path": "tests/unbundled/tev_spectra/electron_spectrum_hess.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess.txt",
     "filesize": 491,
-    "hashmd5": "197d86aecb7f765d6c58e04ade159104",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess.txt"
+    "hashmd5": "197d86aecb7f765d6c58e04ade159104"
    }
   ]
  },
@@ -3531,106 +3037,91 @@
     "path": "figures/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/README.rst",
     "filesize": 394,
-    "hashmd5": "f1c2f5041cfec175494a49e23b7f0549",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/README.rst"
+    "hashmd5": "f1c2f5041cfec175494a49e23b7f0549"
    },
    {
     "path": "figures/detect/fermi_ts_image.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/detect/fermi_ts_image.png",
     "filesize": 86096,
-    "hashmd5": "4e86dc05a5987812aa879b8fcf0864d2",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/detect/fermi_ts_image.png"
+    "hashmd5": "4e86dc05a5987812aa879b8fcf0864d2"
    },
    {
     "path": "figures/background/bg_cube_model_true_reco.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/background/bg_cube_model_true_reco.png",
     "filesize": 270031,
-    "hashmd5": "9d78b3514ae1c7c2d90f76b1feb99b75",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/background/bg_cube_model_true_reco.png"
+    "hashmd5": "9d78b3514ae1c7c2d90f76b1feb99b75"
    },
    {
     "path": "figures/general/data_flow_full.drawio",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_full.drawio",
     "filesize": 1813,
-    "hashmd5": "4f114280150a7dc519e545eb9c69b106",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_full.drawio"
+    "hashmd5": "4f114280150a7dc519e545eb9c69b106"
    },
    {
     "path": "figures/general/data_flow_full.pdf",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_full.pdf",
     "filesize": 49800,
-    "hashmd5": "4077d9ec587b0eb0d0935a969aa22157",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_full.pdf"
+    "hashmd5": "4077d9ec587b0eb0d0935a969aa22157"
    },
    {
     "path": "figures/general/data_flow_full.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_full.png",
     "filesize": 35283,
-    "hashmd5": "b7fbdf92174bb589587b07ccf30f67f5",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_full.png"
+    "hashmd5": "b7fbdf92174bb589587b07ccf30f67f5"
    },
    {
     "path": "figures/general/data_flow_gammapy.drawio",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_gammapy.drawio",
     "filesize": 205449,
-    "hashmd5": "c25b7700328f4675f462c2ea7a2c59fa",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_gammapy.drawio"
+    "hashmd5": "c25b7700328f4675f462c2ea7a2c59fa"
    },
    {
     "path": "figures/general/data_flow_gammapy.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_gammapy.png",
     "filesize": 433104,
-    "hashmd5": "bd1eddc23b2260e6fcf4411e69f28daf",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_gammapy.png"
+    "hashmd5": "bd1eddc23b2260e6fcf4411e69f28daf"
    },
    {
     "path": "figures/general/data_flow_gammapy.pdf",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_gammapy.pdf",
     "filesize": 211135,
-    "hashmd5": "4e7fb139af8ff0ad98a7d8b34865ab7a",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_gammapy.pdf"
+    "hashmd5": "4e7fb139af8ff0ad98a7d8b34865ab7a"
    },
    {
     "path": "figures/image/survey_example.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/image/survey_example.png",
     "filesize": 18305,
-    "hashmd5": "5cc9be28fb1f5675043c9c6574ef81ac",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/image/survey_example.png"
+    "hashmd5": "5cc9be28fb1f5675043c9c6574ef81ac"
    },
    {
     "path": "figures/time/example_robust_periodogram.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/time/example_robust_periodogram.png",
     "filesize": 87468,
-    "hashmd5": "2b567895a0f68f026806782e8fd06b29",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/time/example_robust_periodogram.png"
+    "hashmd5": "2b567895a0f68f026806782e8fd06b29"
    },
    {
     "path": "figures/time/example_spectral_window_function.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/time/example_spectral_window_function.png",
     "filesize": 51871,
-    "hashmd5": "fe2286ca3f07d9199a97d0f3ab9b97c9",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/time/example_spectral_window_function.png"
+    "hashmd5": "fe2286ca3f07d9199a97d0f3ab9b97c9"
    },
    {
     "path": "figures/time/example_robust_periodogram.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/time/example_robust_periodogram.py",
     "filesize": 2670,
-    "hashmd5": "fb502cd1fa578fd2d4a11d7a8db387ed",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/time/example_robust_periodogram.py"
+    "hashmd5": "fb502cd1fa578fd2d4a11d7a8db387ed"
    },
    {
     "path": "figures/tutorials/crab_mwl.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/tutorials/crab_mwl.png",
     "filesize": 55226,
-    "hashmd5": "59d7ce08ce854701acb96a2f2bd593aa",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/tutorials/crab_mwl.png"
+    "hashmd5": "59d7ce08ce854701acb96a2f2bd593aa"
    },
    {
     "path": "figures/spectrum/simulated_obs.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/spectrum/simulated_obs.png",
     "filesize": 100201,
-    "hashmd5": "01c2b735983713674b69ff981f6cc374",
-    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/spectrum/simulated_obs.png"
+    "hashmd5": "01c2b735983713674b69ff981f6cc374"
    }
   ]
  }

--- a/dev/datasets/gammapy-data-index.json
+++ b/dev/datasets/gammapy-data-index.json
@@ -7,55 +7,64 @@
     "path": "cta-1dc/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/README.md",
     "filesize": 497,
-    "hashmd5": "64cde583f9a4f2c655d008a0c6a69da3"
+    "hashmd5": "64cde583f9a4f2c655d008a0c6a69da3",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/README.md"
    },
    {
     "path": "cta-1dc/make.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/make.py",
     "filesize": 1940,
-    "hashmd5": "3d5004b41f25d0fbc98d8307c30932cb"
+    "hashmd5": "3d5004b41f25d0fbc98d8307c30932cb",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/make.py"
    },
    {
     "path": "cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits",
     "filesize": 3755520,
-    "hashmd5": "6e71aeaef4283c3011c538c8e10fef3e"
+    "hashmd5": "6e71aeaef4283c3011c538c8e10fef3e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
    },
    {
     "path": "cta-1dc/index/gps/hdu-index.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/index/gps/hdu-index.fits.gz",
     "filesize": 951,
-    "hashmd5": "909dd4ba6a9a4b0a02c64cc42a834526"
+    "hashmd5": "909dd4ba6a9a4b0a02c64cc42a834526",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/index/gps/hdu-index.fits.gz"
    },
    {
     "path": "cta-1dc/index/gps/obs-index.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/index/gps/obs-index.fits.gz",
     "filesize": 1315,
-    "hashmd5": "a717b56f14f1de38916d2fc48f4e3d09"
+    "hashmd5": "a717b56f14f1de38916d2fc48f4e3d09",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/index/gps/obs-index.fits.gz"
    },
    {
     "path": "cta-1dc/data/baseline/gps/gps_baseline_111140.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/data/baseline/gps/gps_baseline_111140.fits",
     "filesize": 3862080,
-    "hashmd5": "5f2cd2bd3f7d6f6f0da0a96ecabda530"
+    "hashmd5": "5f2cd2bd3f7d6f6f0da0a96ecabda530",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/data/baseline/gps/gps_baseline_111140.fits"
    },
    {
     "path": "cta-1dc/data/baseline/gps/gps_baseline_111630.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/data/baseline/gps/gps_baseline_111630.fits",
     "filesize": 4078080,
-    "hashmd5": "80ea55ad321c2caa3d31a12a6f6982cf"
+    "hashmd5": "80ea55ad321c2caa3d31a12a6f6982cf",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/data/baseline/gps/gps_baseline_111630.fits"
    },
    {
     "path": "cta-1dc/data/baseline/gps/gps_baseline_110380.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits",
     "filesize": 3859200,
-    "hashmd5": "4605e912a2bd2d6ef584df99b8d98243"
+    "hashmd5": "4605e912a2bd2d6ef584df99b8d98243",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits"
    },
    {
     "path": "cta-1dc/data/baseline/gps/gps_baseline_111159.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/cta-1dc/data/baseline/gps/gps_baseline_111159.fits",
     "filesize": 3841920,
-    "hashmd5": "2900521b08396c81b5053c5c5a7e9278"
+    "hashmd5": "2900521b08396c81b5053c5c5a7e9278",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/cta-1dc/data/baseline/gps/gps_baseline_111159.fits"
    }
   ]
  },
@@ -67,13 +76,15 @@
     "path": "dark_matter_spectra/AtProduction_gammas.dat",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/dark_matter_spectra/AtProduction_gammas.dat",
     "filesize": 3884096,
-    "hashmd5": "a15c7536755030b04fdef20edda49ce0"
+    "hashmd5": "a15c7536755030b04fdef20edda49ce0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/dark_matter_spectra/AtProduction_gammas.dat"
    },
    {
     "path": "dark_matter_spectra/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/dark_matter_spectra/README.md",
     "filesize": 84,
-    "hashmd5": "88512ffffe8df62d57271fc4e9be4641"
+    "hashmd5": "88512ffffe8df62d57271fc4e9be4641",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/dark_matter_spectra/README.md"
    }
   ]
  },
@@ -85,1423 +96,1660 @@
     "path": "catalogs/2HWC.ecsv",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/2HWC.ecsv",
     "filesize": 7113,
-    "hashmd5": "869634db5af53014eedd68f0db937c0e"
+    "hashmd5": "869634db5af53014eedd68f0db937c0e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/2HWC.ecsv"
    },
    {
     "path": "catalogs/make_2hwc.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/make_2hwc.py",
     "filesize": 3468,
-    "hashmd5": "4a7246cb30132070f975923dbb712b63"
+    "hashmd5": "4a7246cb30132070f975923dbb712b63",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/make_2hwc.py"
    },
    {
     "path": "catalogs/2HWC.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/2HWC.yaml",
     "filesize": 18588,
-    "hashmd5": "75aa4e1c8c7f7a404f798eaf1406d80f"
+    "hashmd5": "75aa4e1c8c7f7a404f798eaf1406d80f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/2HWC.yaml"
    },
    {
     "path": "catalogs/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/README.rst",
     "filesize": 178,
-    "hashmd5": "5a19a76774d175e5ba8ddc915c828816"
+    "hashmd5": "5a19a76774d175e5ba8ddc915c828816",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/README.rst"
    },
    {
     "path": "catalogs/hgps_catalog_v1.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/hgps_catalog_v1.fits.gz",
     "filesize": 49518,
-    "hashmd5": "be68a10cfcf1fa64f7488da957475b0f"
+    "hashmd5": "be68a10cfcf1fa64f7488da957475b0f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/hgps_catalog_v1.fits.gz"
    },
    {
     "path": "catalogs/fermi/gll_psch_v09.fit.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psch_v09.fit.gz",
     "filesize": 521889,
-    "hashmd5": "0fc06485f80ac4970bb7aafd8672b2a2"
+    "hashmd5": "0fc06485f80ac4970bb7aafd8672b2a2",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/gll_psch_v09.fit.gz"
    },
    {
     "path": "catalogs/fermi/gll_psch_v13.fit.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psch_v13.fit.gz",
     "filesize": 373649,
-    "hashmd5": "ac56115c72199a6686cb03616226d234"
+    "hashmd5": "ac56115c72199a6686cb03616226d234",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/gll_psch_v13.fit.gz"
    },
    {
     "path": "catalogs/fermi/gll_psc_v20.fit.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psc_v20.fit.gz",
     "filesize": 6362843,
-    "hashmd5": "c65ca6ae4df4210bb766f02720233166"
+    "hashmd5": "c65ca6ae4df4210bb766f02720233166",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/gll_psc_v20.fit.gz"
    },
    {
     "path": "catalogs/fermi/gll_psch_v08.fit.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psch_v08.fit.gz",
     "filesize": 205855,
-    "hashmd5": "60f2f72841cc6217da6a4de0af155b6e"
+    "hashmd5": "60f2f72841cc6217da6a4de0af155b6e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/gll_psch_v08.fit.gz"
    },
    {
     "path": "catalogs/fermi/gll_psc_v16.fit.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psc_v16.fit.gz",
     "filesize": 2422086,
-    "hashmd5": "8e6adab5eeaad9d97008344a574617e1"
+    "hashmd5": "8e6adab5eeaad9d97008344a574617e1",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/gll_psc_v16.fit.gz"
    },
    {
     "path": "catalogs/fermi/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/README.rst",
     "filesize": 307,
-    "hashmd5": "3c4970ea0ec1c15fec3690d1d6ba3b9a"
+    "hashmd5": "3c4970ea0ec1c15fec3690d1d6ba3b9a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/README.rst"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/LAT_ext_v15.reg",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/LAT_ext_v15.reg",
     "filesize": 1999,
-    "hashmd5": "7bea2a762ceadb62241649ded131fc1a"
+    "hashmd5": "7bea2a762ceadb62241649ded131fc1a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/LAT_ext_v15.reg"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/LAT_extended_sources_v15.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/LAT_extended_sources_v15.fits",
     "filesize": 20160,
-    "hashmd5": "7e99fd02217d8935bb3171aa213b9dbb"
+    "hashmd5": "7e99fd02217d8935bb3171aa213b9dbb",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/LAT_extended_sources_v15.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/LAT_ext_rev15.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/LAT_ext_rev15.txt",
     "filesize": 7252,
-    "hashmd5": "fd4b63d879de449c5af3d8cac0bb3d91"
+    "hashmd5": "fd4b63d879de449c5af3d8cac0bb3d91",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/LAT_ext_rev15.txt"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/SMC.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/SMC.xml",
     "filesize": 728,
-    "hashmd5": "57907c29b171e0c62a1623840d0c8c0e"
+    "hashmd5": "57907c29b171e0c62a1623840d0c8c0e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/SMC.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1837-069.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1837-069.xml",
     "filesize": 825,
-    "hashmd5": "aa9231b6bfc9f53911e4ccc4485c321f"
+    "hashmd5": "aa9231b6bfc9f53911e4ccc4485c321f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1837-069.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1303-631.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1303-631.xml",
     "filesize": 824,
-    "hashmd5": "efdfb98b00d414968699d2c6c551dfd1"
+    "hashmd5": "efdfb98b00d414968699d2c6c551dfd1",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1303-631.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/CenALobes.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/CenALobes.xml",
     "filesize": 815,
-    "hashmd5": "898394d4a8de0d4545627c8ee63422bf"
+    "hashmd5": "898394d4a8de0d4545627c8ee63422bf",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/CenALobes.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1614-518.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1614-518.xml",
     "filesize": 825,
-    "hashmd5": "7d0b3c098d7124c4a119aa868d417099"
+    "hashmd5": "7d0b3c098d7124c4a119aa868d417099",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1614-518.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/LMC.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/LMC.xml",
     "filesize": 780,
-    "hashmd5": "36164cbaf921070e5f59c5de78c87bbe"
+    "hashmd5": "36164cbaf921070e5f59c5de78c87bbe",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/LMC.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/RXJ1713.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/RXJ1713.xml",
     "filesize": 819,
-    "hashmd5": "e8e759e841f9df3c0ea5551bdd8e0226"
+    "hashmd5": "e8e759e841f9df3c0ea5551bdd8e0226",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/RXJ1713.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1632-478.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1632-478.xml",
     "filesize": 824,
-    "hashmd5": "c23da546eace2f52514dda042694cdee"
+    "hashmd5": "c23da546eace2f52514dda042694cdee",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1632-478.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HB21.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HB21.xml",
     "filesize": 809,
-    "hashmd5": "4cff9e2832ebe5b96b2ce48d58a2d88c"
+    "hashmd5": "4cff9e2832ebe5b96b2ce48d58a2d88c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HB21.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/W28.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/W28.xml",
     "filesize": 789,
-    "hashmd5": "b902629cc9511f1b5c32de199f54e561"
+    "hashmd5": "b902629cc9511f1b5c32de199f54e561",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/W28.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/S147.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/S147.xml",
     "filesize": 806,
-    "hashmd5": "021822e460df969349fc965e5386b231"
+    "hashmd5": "021822e460df969349fc965e5386b231",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/S147.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1825-137.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1825-137.xml",
     "filesize": 825,
-    "hashmd5": "58473fa87e05d079ac78afe39f8f69e2"
+    "hashmd5": "58473fa87e05d079ac78afe39f8f69e2",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1825-137.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/CygnusLoop.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/CygnusLoop.xml",
     "filesize": 821,
-    "hashmd5": "cc539813370a095d0d0e54bf06add70f"
+    "hashmd5": "cc539813370a095d0d0e54bf06add70f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/CygnusLoop.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1616-508.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1616-508.xml",
     "filesize": 824,
-    "hashmd5": "70dc5a47c647f9ca9a8c15dedc99bd02"
+    "hashmd5": "70dc5a47c647f9ca9a8c15dedc99bd02",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1616-508.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/W51C.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/W51C.xml",
     "filesize": 777,
-    "hashmd5": "8b5459014ea877d7da0fd5ec502a9c90"
+    "hashmd5": "8b5459014ea877d7da0fd5ec502a9c90",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/W51C.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/MSH15-52.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/MSH15-52.xml",
     "filesize": 810,
-    "hashmd5": "4158ea0c750f282d9d11f4abffb1e985"
+    "hashmd5": "4158ea0c750f282d9d11f4abffb1e985",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/MSH15-52.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/CygnusCocoon.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/CygnusCocoon.xml",
     "filesize": 809,
-    "hashmd5": "3b790aff2a3db9619dd2e56c1a299489"
+    "hashmd5": "3b790aff2a3db9619dd2e56c1a299489",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/CygnusCocoon.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/IC443.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/IC443.xml",
     "filesize": 833,
-    "hashmd5": "6520a86b4325edd8dcbc13cc37f33bce"
+    "hashmd5": "6520a86b4325edd8dcbc13cc37f33bce",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/IC443.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/W30.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/W30.xml",
     "filesize": 804,
-    "hashmd5": "d6b1281b8d94887f7c6e3ab73ead740e"
+    "hashmd5": "d6b1281b8d94887f7c6e3ab73ead740e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/W30.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/gammaCygni.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/gammaCygni.xml",
     "filesize": 804,
-    "hashmd5": "91c8eccb3e50b7d36bc4e40ee3936213"
+    "hashmd5": "91c8eccb3e50b7d36bc4e40ee3936213",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/gammaCygni.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/VelaJr.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/VelaJr.xml",
     "filesize": 810,
-    "hashmd5": "5906184c853f734330970d3afc56d574"
+    "hashmd5": "5906184c853f734330970d3afc56d574",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/VelaJr.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/PuppisA.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/PuppisA.xml",
     "filesize": 734,
-    "hashmd5": "6d3916821b652a2b046d4491d7af6832"
+    "hashmd5": "6d3916821b652a2b046d4491d7af6832",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/PuppisA.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/HESSJ1841-055.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1841-055.xml",
     "filesize": 824,
-    "hashmd5": "df3c67b2c923965470f95ceea47c15fd"
+    "hashmd5": "df3c67b2c923965470f95ceea47c15fd",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/HESSJ1841-055.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/VelaX.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/VelaX.xml",
     "filesize": 792,
-    "hashmd5": "4842a102c7c2c55f2de49aeadaf22bfc"
+    "hashmd5": "4842a102c7c2c55f2de49aeadaf22bfc",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/VelaX.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/XML/W44.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/XML/W44.xml",
     "filesize": 790,
-    "hashmd5": "2b2bcfd2a54e003ea0007925342f3c05"
+    "hashmd5": "2b2bcfd2a54e003ea0007925342f3c05",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/XML/W44.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/SMC.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/SMC.fits",
     "filesize": 164160,
-    "hashmd5": "5873391917ed1b38997961a936c4bcb1"
+    "hashmd5": "5873391917ed1b38997961a936c4bcb1",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/SMC.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/CygnusLoop.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/CygnusLoop.fits",
     "filesize": 43200,
-    "hashmd5": "58239e37ad7215638fc0a12b4d59fcee"
+    "hashmd5": "58239e37ad7215638fc0a12b4d59fcee",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/CygnusLoop.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/gammaCygni.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/gammaCygni.fits",
     "filesize": 31680,
-    "hashmd5": "5db7b578300f6271da735d0403db13d2"
+    "hashmd5": "5db7b578300f6271da735d0403db13d2",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/gammaCygni.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/CenALobes.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/CenALobes.fits",
     "filesize": 103680,
-    "hashmd5": "750789bc7adb1287abfae28a76f7c593"
+    "hashmd5": "750789bc7adb1287abfae28a76f7c593",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/CenALobes.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1837-069.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1837-069.fits",
     "filesize": 31680,
-    "hashmd5": "f83eaddf097daa4b05df6952e6bd2b60"
+    "hashmd5": "f83eaddf097daa4b05df6952e6bd2b60",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1837-069.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1632-478.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1632-478.fits",
     "filesize": 31680,
-    "hashmd5": "2c97549741663d2910e6cafef783cb39"
+    "hashmd5": "2c97549741663d2910e6cafef783cb39",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1632-478.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1841-055.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1841-055.fits",
     "filesize": 31680,
-    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230"
+    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1841-055.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/PuppisA.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/PuppisA.fits",
     "filesize": 31680,
-    "hashmd5": "739433150d2dd8a30c0e70cfd05aa9e4"
+    "hashmd5": "739433150d2dd8a30c0e70cfd05aa9e4",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/PuppisA.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/W44.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/W44.fits",
     "filesize": 23040,
-    "hashmd5": "622426056c3931be2c77f149a920e87a"
+    "hashmd5": "622426056c3931be2c77f149a920e87a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/W44.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1614-518.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1614-518.fits",
     "filesize": 31680,
-    "hashmd5": "91039728e5e1543dd99f37e73272868a"
+    "hashmd5": "91039728e5e1543dd99f37e73272868a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1614-518.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/W28.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/W28.fits",
     "filesize": 46080,
-    "hashmd5": "581e177258b7d71d6975c9b096b835b5"
+    "hashmd5": "581e177258b7d71d6975c9b096b835b5",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/W28.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1303-631.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1303-631.fits",
     "filesize": 31680,
-    "hashmd5": "7854547f001a8c39ecf82aea8dade4b6"
+    "hashmd5": "7854547f001a8c39ecf82aea8dade4b6",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1303-631.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/IC443.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/IC443.fits",
     "filesize": 69120,
-    "hashmd5": "5180b14063e00fa7b2cf88fbb97331fd"
+    "hashmd5": "5180b14063e00fa7b2cf88fbb97331fd",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/IC443.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/CygnusCocoon.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/CygnusCocoon.fits",
     "filesize": 31680,
-    "hashmd5": "83bbfd306df67f2591245b142eefca3c"
+    "hashmd5": "83bbfd306df67f2591245b142eefca3c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/CygnusCocoon.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1616-508.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1616-508.fits",
     "filesize": 31680,
-    "hashmd5": "396c63111ee42651e60ac52c3a99dee8"
+    "hashmd5": "396c63111ee42651e60ac52c3a99dee8",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1616-508.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/MSH15-52.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/MSH15-52.fits",
     "filesize": 46080,
-    "hashmd5": "fe22e8789fe7479bd4650f98949d14e3"
+    "hashmd5": "fe22e8789fe7479bd4650f98949d14e3",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/MSH15-52.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/VelaJr.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/VelaJr.fits",
     "filesize": 31680,
-    "hashmd5": "504b98555ee389b76f504fa69a900625"
+    "hashmd5": "504b98555ee389b76f504fa69a900625",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/VelaJr.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.fits",
     "filesize": 20160,
-    "hashmd5": "3cc2dc521fdaa85450f4fcfa453d5843"
+    "hashmd5": "3cc2dc521fdaa85450f4fcfa453d5843",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/W30.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/W30.fits",
     "filesize": 31680,
-    "hashmd5": "31badb1fcbf6870e6f3be6b2261b835c"
+    "hashmd5": "31badb1fcbf6870e6f3be6b2261b835c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/W30.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HB21.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HB21.fits",
     "filesize": 31680,
-    "hashmd5": "88a9e5fdac58358fbc8d84014519b947"
+    "hashmd5": "88a9e5fdac58358fbc8d84014519b947",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HB21.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/S147.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/S147.fits",
     "filesize": 40320,
-    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb"
+    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/S147.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/HESSJ1825-137.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1825-137.fits",
     "filesize": 46080,
-    "hashmd5": "0137d054a62eb62c5e872b7a8ba5f14b"
+    "hashmd5": "0137d054a62eb62c5e872b7a8ba5f14b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/HESSJ1825-137.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/LMC.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/LMC.fits",
     "filesize": 1005120,
-    "hashmd5": "bfc3b99ebe78b56a1415433a5f8fb04b"
+    "hashmd5": "bfc3b99ebe78b56a1415433a5f8fb04b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/LMC.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/VelaX.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/VelaX.fits",
     "filesize": 46080,
-    "hashmd5": "a6fed48ebd0bf917049dc54a509e5b25"
+    "hashmd5": "a6fed48ebd0bf917049dc54a509e5b25",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/VelaX.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.7-3946.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.7-3946.fits",
     "filesize": 20160,
-    "hashmd5": "3cc2dc521fdaa85450f4fcfa453d5843"
+    "hashmd5": "3cc2dc521fdaa85450f4fcfa453d5843",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/RXJ1713.7-3946.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v15/Templates/W51C.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v15/Templates/W51C.fits",
     "filesize": 8640,
-    "hashmd5": "fe1cfdd061a069b72a19c5a47c807e3d"
+    "hashmd5": "fe1cfdd061a069b72a19c5a47c807e3d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v15/Templates/W51C.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Extended_8years.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Extended_8years.txt",
     "filesize": 2636,
-    "hashmd5": "e9d6436927837c7160855a12dd689e25"
+    "hashmd5": "e9d6436927837c7160855a12dd689e25",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Extended_8years.txt"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.fits",
     "filesize": 34560,
-    "hashmd5": "70f8b8c19e8698fab4264701ec497100"
+    "hashmd5": "70f8b8c19e8698fab4264701ec497100",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.reg",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.reg",
     "filesize": 6068,
-    "hashmd5": "dd5b44333ab6848f3f562fcd2a15435f"
+    "hashmd5": "dd5b44333ab6848f3f562fcd2a15435f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/LAT_extended_sources_8years.reg"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2208.4+6443.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2208.4+6443.xml",
     "filesize": 822,
-    "hashmd5": "54e199baa242ebbbcd87eb10c392eb60"
+    "hashmd5": "54e199baa242ebbbcd87eb10c392eb60",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2208.4+6443.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1741.6-3917.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1741.6-3917.xml",
     "filesize": 803,
-    "hashmd5": "aca86a5cf6f8b4281a48c7cad9c573ac"
+    "hashmd5": "aca86a5cf6f8b4281a48c7cad9c573ac",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1741.6-3917.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1626.9-2431.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1626.9-2431.xml",
     "filesize": 823,
-    "hashmd5": "b0ffc299179daeed50d965168ba86b01"
+    "hashmd5": "b0ffc299179daeed50d965168ba86b01",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1626.9-2431.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/Rosette.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Rosette.xml",
     "filesize": 791,
-    "hashmd5": "1ca7e7e35384272f0f6510f65d82b214"
+    "hashmd5": "1ca7e7e35384272f0f6510f65d82b214",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Rosette.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1501.0-6310.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1501.0-6310.xml",
     "filesize": 822,
-    "hashmd5": "bcd84361066c314ec016e3460aa69a10"
+    "hashmd5": "bcd84361066c314ec016e3460aa69a10",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1501.0-6310.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/RXJ1713-3946.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/RXJ1713-3946.xml",
     "filesize": 715,
-    "hashmd5": "d383d0e670f4217f28e1f08608be84b9"
+    "hashmd5": "d383d0e670f4217f28e1f08608be84b9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/RXJ1713-3946.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1813-178.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1813-178.xml",
     "filesize": 828,
-    "hashmd5": "403bd93e54b31b66cf62ff41da315a71"
+    "hashmd5": "403bd93e54b31b66cf62ff41da315a71",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1813-178.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ2301.9+5855.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ2301.9+5855.xml",
     "filesize": 790,
-    "hashmd5": "fdd6cfae127fd4bb1c957cbf30df8198"
+    "hashmd5": "fdd6cfae127fd4bb1c957cbf30df8198",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ2301.9+5855.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56PWN.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56PWN.xml",
     "filesize": 703,
-    "hashmd5": "6661dd66c5558a79f1fca087a70b920f"
+    "hashmd5": "6661dd66c5558a79f1fca087a70b920f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56PWN.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/Kes73.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Kes73.xml",
     "filesize": 788,
-    "hashmd5": "854154a0a0dce3037b6a5c433ef3c31a"
+    "hashmd5": "854154a0a0dce3037b6a5c433ef3c31a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Kes73.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1303-631.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1303-631.xml",
     "filesize": 805,
-    "hashmd5": "b0f87ed39eab2222a6bd636e86013aeb"
+    "hashmd5": "b0f87ed39eab2222a6bd636e86013aeb",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1303-631.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0427.2+5533.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0427.2+5533.xml",
     "filesize": 793,
-    "hashmd5": "bc12f5c956fb3c5d9f87c800ea78ae91"
+    "hashmd5": "bc12f5c956fb3c5d9f87c800ea78ae91",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0427.2+5533.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HB9.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB9.xml",
     "filesize": 784,
-    "hashmd5": "5022037145b31450de49d4e6e69647b8"
+    "hashmd5": "5022037145b31450de49d4e6e69647b8",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB9.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0851.9-4620.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0851.9-4620.xml",
     "filesize": 800,
-    "hashmd5": "0c0a0dd10ff1c96a5c14d9fe96b21b09"
+    "hashmd5": "0c0a0dd10ff1c96a5c14d9fe96b21b09",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0851.9-4620.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/CenALobes.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CenALobes.xml",
     "filesize": 703,
-    "hashmd5": "5a920a8081fad93d41fdea69aa14917a"
+    "hashmd5": "5a920a8081fad93d41fdea69aa14917a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CenALobes.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1614-518.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1614-518.xml",
     "filesize": 803,
-    "hashmd5": "97e04e460c13df28adc18cb80ff04471"
+    "hashmd5": "97e04e460c13df28adc18cb80ff04471",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1614-518.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1036.3-5833.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1036.3-5833.xml",
     "filesize": 805,
-    "hashmd5": "3a3cd74d391d804f3117655e514cd147"
+    "hashmd5": "3a3cd74d391d804f3117655e514cd147",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1036.3-5833.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/LMC-30DorWest.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-30DorWest.xml",
     "filesize": 703,
-    "hashmd5": "474a44c712fe21fd866828a5c49820af"
+    "hashmd5": "474a44c712fe21fd866828a5c49820af",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-30DorWest.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1553.8-5325.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1553.8-5325.xml",
     "filesize": 802,
-    "hashmd5": "8d27014e08a93d03df676f51b57c37ea"
+    "hashmd5": "8d27014e08a93d03df676f51b57c37ea",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1553.8-5325.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1514.2-5909.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1514.2-5909.xml",
     "filesize": 796,
-    "hashmd5": "a0e2ec76761a430426c45bf505580c09"
+    "hashmd5": "a0e2ec76761a430426c45bf505580c09",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1514.2-5909.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1213.3-6240.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1213.3-6240.xml",
     "filesize": 806,
-    "hashmd5": "d8e3200cdbb5d9f919cde91c7ee327fb"
+    "hashmd5": "d8e3200cdbb5d9f919cde91c7ee327fb",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1213.3-6240.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1636.3-4731.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1636.3-4731.xml",
     "filesize": 883,
-    "hashmd5": "efee681766839745640d54d335f0ccc6"
+    "hashmd5": "efee681766839745640d54d335f0ccc6",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1636.3-4731.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1642.1-5428.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1642.1-5428.xml",
     "filesize": 820,
-    "hashmd5": "7a61acafc9f564ee92cc233c8f0c93a0"
+    "hashmd5": "7a61acafc9f564ee92cc233c8f0c93a0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1642.1-5428.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/Monoceros.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Monoceros.xml",
     "filesize": 889,
-    "hashmd5": "42cab4707b94fa1f8d3e75a1691768d2"
+    "hashmd5": "42cab4707b94fa1f8d3e75a1691768d2",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Monoceros.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2304.0+5406.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2304.0+5406.xml",
     "filesize": 822,
-    "hashmd5": "3235a9879518fd1418db95605e7daebe"
+    "hashmd5": "3235a9879518fd1418db95605e7daebe",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2304.0+5406.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HB21.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB21.xml",
     "filesize": 893,
-    "hashmd5": "3771a421bd1b197526380fcef0358632"
+    "hashmd5": "3771a421bd1b197526380fcef0358632",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB21.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1804.7-2144.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1804.7-2144.xml",
     "filesize": 803,
-    "hashmd5": "d9ea65af5264e3ec4cd4af042bbf4ebc"
+    "hashmd5": "d9ea65af5264e3ec4cd4af042bbf4ebc",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1804.7-2144.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1809-193.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1809-193.xml",
     "filesize": 793,
-    "hashmd5": "da9f2e7da23937110c7388eccd70d815"
+    "hashmd5": "da9f2e7da23937110c7388eccd70d815",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1809-193.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1023.3-5747.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1023.3-5747.xml",
     "filesize": 800,
-    "hashmd5": "29f3aa8744813e96eb1aea836b19f23e"
+    "hashmd5": "29f3aa8744813e96eb1aea836b19f23e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1023.3-5747.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/RCW86.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/RCW86.xml",
     "filesize": 688,
-    "hashmd5": "7f8d15c142785329d037e7a27c0347e5"
+    "hashmd5": "7f8d15c142785329d037e7a27c0347e5",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/RCW86.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1745.8-3028.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1745.8-3028.xml",
     "filesize": 802,
-    "hashmd5": "96ade2a42cc3644c2d0cef199633b6fc"
+    "hashmd5": "96ade2a42cc3644c2d0cef199633b6fc",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1745.8-3028.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W28.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W28.xml",
     "filesize": 893,
-    "hashmd5": "3cbc8bbb5fc20f471faa7e4145bfea21"
+    "hashmd5": "3cbc8bbb5fc20f471faa7e4145bfea21",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W28.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1857.7+0246.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1857.7+0246.xml",
     "filesize": 799,
-    "hashmd5": "958096535dddfa1fa399152a81f37067"
+    "hashmd5": "958096535dddfa1fa399152a81f37067",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1857.7+0246.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/S147.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/S147.xml",
     "filesize": 692,
-    "hashmd5": "6f8ce195b1b8fc654cd7d1951b69ee44"
+    "hashmd5": "6f8ce195b1b8fc654cd7d1951b69ee44",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/S147.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1409.1-6121.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1409.1-6121.xml",
     "filesize": 803,
-    "hashmd5": "74fae54c61bbfe7cd490d319cd45edaf"
+    "hashmd5": "74fae54c61bbfe7cd490d319cd45edaf",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1409.1-6121.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1825-137.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1825-137.xml",
     "filesize": 909,
-    "hashmd5": "72ccdf2a056a3165d54d3084bdc53dad"
+    "hashmd5": "72ccdf2a056a3165d54d3084bdc53dad",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1825-137.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/CygnusLoop.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CygnusLoop.xml",
     "filesize": 807,
-    "hashmd5": "e5d28e2984356121cffe913e4ca89334"
+    "hashmd5": "e5d28e2984356121cffe913e4ca89334",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CygnusLoop.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FornaxA.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FornaxA.xml",
     "filesize": 691,
-    "hashmd5": "074f2ed5ab6b5b7a2153b21d1ef97c34"
+    "hashmd5": "074f2ed5ab6b5b7a2153b21d1ef97c34",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FornaxA.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1616-508.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1616-508.xml",
     "filesize": 803,
-    "hashmd5": "f185b774124e2c75dca2286dcb41be42"
+    "hashmd5": "f185b774124e2c75dca2286dcb41be42",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1616-508.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1836.5-0651.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1836.5-0651.xml",
     "filesize": 802,
-    "hashmd5": "bf97234dda826019fc67add047fb211f"
+    "hashmd5": "bf97234dda826019fc67add047fb211f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1836.5-0651.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1355.1-6420.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1355.1-6420.xml",
     "filesize": 818,
-    "hashmd5": "23af2e257e7c20d8f8631ed57ce68585"
+    "hashmd5": "23af2e257e7c20d8f8631ed57ce68585",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1355.1-6420.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W51C.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W51C.xml",
     "filesize": 777,
-    "hashmd5": "b2ab4fc57e378573bef826d176d757b7"
+    "hashmd5": "b2ab4fc57e378573bef826d176d757b7",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W51C.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/CygnusCocoon.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CygnusCocoon.xml",
     "filesize": 778,
-    "hashmd5": "b2fcb235260d755aadde6e31cbfccb19"
+    "hashmd5": "b2fcb235260d755aadde6e31cbfccb19",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/CygnusCocoon.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/LMC-North.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-North.xml",
     "filesize": 695,
-    "hashmd5": "ecf7c247ebac33311b1b8e53a6ea7cfe"
+    "hashmd5": "ecf7c247ebac33311b1b8e53a6ea7cfe",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-North.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/IC443.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/IC443.xml",
     "filesize": 901,
-    "hashmd5": "43f0fba75ffa4ccee0de3098809ca3b9"
+    "hashmd5": "43f0fba75ffa4ccee0de3098809ca3b9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/IC443.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1507.9-6228.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1507.9-6228.xml",
     "filesize": 800,
-    "hashmd5": "e88e6df5bd9e6c5d6bddeb0b434b2264"
+    "hashmd5": "e88e6df5bd9e6c5d6bddeb0b434b2264",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1507.9-6228.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1109.4-6115.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1109.4-6115.xml",
     "filesize": 890,
-    "hashmd5": "2555c7d77e47cde241dbb773c2b19b7d"
+    "hashmd5": "2555c7d77e47cde241dbb773c2b19b7d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1109.4-6115.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56SNR.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56SNR.xml",
     "filesize": 706,
-    "hashmd5": "b2f9fe354039f2ef223361e9e0c0b75f"
+    "hashmd5": "b2f9fe354039f2ef223361e9e0c0b75f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/MSH15-56SNR.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W30.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W30.xml",
     "filesize": 892,
-    "hashmd5": "f743f9af42bef960306abe32da4e1b02"
+    "hashmd5": "f743f9af42bef960306abe32da4e1b02",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W30.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1808-204.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1808-204.xml",
     "filesize": 940,
-    "hashmd5": "15d59ebb417712178b718394b5335b09"
+    "hashmd5": "15d59ebb417712178b718394b5335b09",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1808-204.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/LMC-FarWest.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-FarWest.xml",
     "filesize": 699,
-    "hashmd5": "8244d49e689d932b4df6b7584288f683"
+    "hashmd5": "8244d49e689d932b4df6b7584288f683",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-FarWest.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1652.2-4633.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1652.2-4633.xml",
     "filesize": 803,
-    "hashmd5": "8ba14e3558b20fda37139a8fbde5fad7"
+    "hashmd5": "8ba14e3558b20fda37139a8fbde5fad7",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1652.2-4633.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/gammaCygni.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/gammaCygni.xml",
     "filesize": 770,
-    "hashmd5": "ac3815894c2485972c345a84e886ec5e"
+    "hashmd5": "ac3815894c2485972c345a84e886ec5e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/gammaCygni.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1420.3-6046.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1420.3-6046.xml",
     "filesize": 820,
-    "hashmd5": "6698224f6c35fd37aa1a418e47290adf"
+    "hashmd5": "6698224f6c35fd37aa1a418e47290adf",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1420.3-6046.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1834.1-0706.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1834.1-0706.xml",
     "filesize": 797,
-    "hashmd5": "b4e9c21a34a7e442f6bb825cae9e7452"
+    "hashmd5": "b4e9c21a34a7e442f6bb825cae9e7452",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1834.1-0706.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/G42.8+0.6.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/G42.8+0.6.xml",
     "filesize": 787,
-    "hashmd5": "85818b8a09fba029bbb3e43d631afff3"
+    "hashmd5": "85818b8a09fba029bbb3e43d631afff3",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/G42.8+0.6.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/Kes79.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Kes79.xml",
     "filesize": 917,
-    "hashmd5": "1cda5e4c884f35ff5f2f2eae41b7e74a"
+    "hashmd5": "1cda5e4c884f35ff5f2f2eae41b7e74a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/Kes79.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W41.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W41.xml",
     "filesize": 810,
-    "hashmd5": "824e31cc79280757299e49101eb7f059"
+    "hashmd5": "824e31cc79280757299e49101eb7f059",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W41.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1838.9-0704.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1838.9-0704.xml",
     "filesize": 802,
-    "hashmd5": "c5ae234cf243b7134913cb1c12aaab90"
+    "hashmd5": "c5ae234cf243b7134913cb1c12aaab90",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1838.9-0704.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1534-571.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1534-571.xml",
     "filesize": 824,
-    "hashmd5": "858c2927abadfb2965ff791c4316c42e"
+    "hashmd5": "858c2927abadfb2965ff791c4316c42e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1534-571.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HB3.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB3.xml",
     "filesize": 885,
-    "hashmd5": "06186e2e8b01d51eb0fc99b40551b74c"
+    "hashmd5": "06186e2e8b01d51eb0fc99b40551b74c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HB3.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/G296.5+10.0.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/G296.5+10.0.xml",
     "filesize": 793,
-    "hashmd5": "bba3bf33919731d46c0c887a4a7c5827"
+    "hashmd5": "bba3bf33919731d46c0c887a4a7c5827",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/G296.5+10.0.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1655.5-4737.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1655.5-4737.xml",
     "filesize": 800,
-    "hashmd5": "7f74d1441bb3ed960d69fe483b89e5b9"
+    "hashmd5": "7f74d1441bb3ed960d69fe483b89e5b9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1655.5-4737.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ0534.5+2201.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ0534.5+2201.xml",
     "filesize": 851,
-    "hashmd5": "a09aec5b26fdd7559378af2ac2e700dc"
+    "hashmd5": "a09aec5b26fdd7559378af2ac2e700dc",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ0534.5+2201.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0822.1-4253.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0822.1-4253.xml",
     "filesize": 795,
-    "hashmd5": "f77abea3e1c1187f36ca8d0a8dd8bcbf"
+    "hashmd5": "f77abea3e1c1187f36ca8d0a8dd8bcbf",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ0822.1-4253.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1841-055.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1841-055.xml",
     "filesize": 707,
-    "hashmd5": "54ee071708fba0c813312bd77de2b940"
+    "hashmd5": "54ee071708fba0c813312bd77de2b940",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/HESSJ1841-055.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2129.9+5833.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2129.9+5833.xml",
     "filesize": 822,
-    "hashmd5": "cb605c9230eab6f5e3bcbba03c53017d"
+    "hashmd5": "cb605c9230eab6f5e3bcbba03c53017d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ2129.9+5833.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1631.6-4756.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1631.6-4756.xml",
     "filesize": 805,
-    "hashmd5": "2753ce53ca29ab8e0b5560dbde18f27c"
+    "hashmd5": "2753ce53ca29ab8e0b5560dbde18f27c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1631.6-4756.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W3.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W3.xml",
     "filesize": 782,
-    "hashmd5": "8ffb643cd1f8a2c8ff0579cc441d8ad9"
+    "hashmd5": "8ffb643cd1f8a2c8ff0579cc441d8ad9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W3.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/LMC-Galaxy.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-Galaxy.xml",
     "filesize": 791,
-    "hashmd5": "2f603483711898cb2a9416bcc18ce1e0"
+    "hashmd5": "2f603483711898cb2a9416bcc18ce1e0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/LMC-Galaxy.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/VelaX.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/VelaX.xml",
     "filesize": 770,
-    "hashmd5": "77983c0573c3e3812d3175dc06e88f5e"
+    "hashmd5": "77983c0573c3e3812d3175dc06e88f5e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/VelaX.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/W44.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W44.xml",
     "filesize": 790,
-    "hashmd5": "8ba67c7b48ce07f24f2ab6b17e877310"
+    "hashmd5": "8ba67c7b48ce07f24f2ab6b17e877310",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/W44.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/SMC-Galaxy.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/SMC-Galaxy.xml",
     "filesize": 881,
-    "hashmd5": "e3e6754bc63da2e2fa5cc43d34e2d22d"
+    "hashmd5": "e3e6754bc63da2e2fa5cc43d34e2d22d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/SMC-Galaxy.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1633.0-4746.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1633.0-4746.xml",
     "filesize": 805,
-    "hashmd5": "1f6f45da0acc2e2e04b846bf158d30f7"
+    "hashmd5": "1f6f45da0acc2e2e04b846bf158d30f7",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FGESJ1633.0-4746.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1723.5-0501.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1723.5-0501.xml",
     "filesize": 822,
-    "hashmd5": "f57763367b4ac14da65e972cd8cca755"
+    "hashmd5": "f57763367b4ac14da65e972cd8cca755",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/XML/FHESJ1723.5-0501.xml"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/CygnusLoop.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/CygnusLoop.fits",
     "filesize": 31680,
-    "hashmd5": "a7ea3625dc4c9506e579724f61702f78"
+    "hashmd5": "a7ea3625dc4c9506e579724f61702f78",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/CygnusLoop.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-North.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-North.fits",
     "filesize": 383040,
-    "hashmd5": "e3af30b762f6793347a9bd837790707c"
+    "hashmd5": "e3af30b762f6793347a9bd837790707c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-North.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_SNRmask.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_SNRmask.fits",
     "filesize": 164160,
-    "hashmd5": "eedcc05f842917106bd9ae1e68f48984"
+    "hashmd5": "eedcc05f842917106bd9ae1e68f48984",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_SNRmask.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/CenALobes.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/CenALobes.fits",
     "filesize": 103680,
-    "hashmd5": "750789bc7adb1287abfae28a76f7c593"
+    "hashmd5": "750789bc7adb1287abfae28a76f7c593",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/CenALobes.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/RCW86.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/RCW86.fits",
     "filesize": 17280,
-    "hashmd5": "69de80b1f5b8d45f962adcebffa263b9"
+    "hashmd5": "69de80b1f5b8d45f962adcebffa263b9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/RCW86.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/HB9.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/HB9.fits",
     "filesize": 25920,
-    "hashmd5": "02f69bffabd133fd9f6035f9f9e11f32"
+    "hashmd5": "02f69bffabd133fd9f6035f9f9e11f32",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/HB9.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/Rosette.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/Rosette.fits",
     "filesize": 14400,
-    "hashmd5": "7a0306cf469404fae6230c9b218edbb1"
+    "hashmd5": "7a0306cf469404fae6230c9b218edbb1",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/Rosette.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-FarWest.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-FarWest.fits",
     "filesize": 846720,
-    "hashmd5": "09e78a3b993c93e26752c2ed1808f718"
+    "hashmd5": "09e78a3b993c93e26752c2ed1808f718",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-FarWest.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/HESSJ1841-055.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/HESSJ1841-055.fits",
     "filesize": 31680,
-    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230"
+    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/HESSJ1841-055.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/W44.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W44.fits",
     "filesize": 23040,
-    "hashmd5": "622426056c3931be2c77f149a920e87a"
+    "hashmd5": "622426056c3931be2c77f149a920e87a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W44.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/SMC-Galaxy.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/SMC-Galaxy.fits",
     "filesize": 2905920,
-    "hashmd5": "31d7a9a2fb20cb93302f93ad642a0162"
+    "hashmd5": "31d7a9a2fb20cb93302f93ad642a0162",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/SMC-Galaxy.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_PWN.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_PWN.fits",
     "filesize": 14400,
-    "hashmd5": "d122bc019d970720b28f4c9b1dea11f8"
+    "hashmd5": "d122bc019d970720b28f4c9b1dea11f8",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/MSH15-56_PWN.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-30DorWest.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-30DorWest.fits",
     "filesize": 846720,
-    "hashmd5": "90325239f6002a1bdf3644d99fbd3027"
+    "hashmd5": "90325239f6002a1bdf3644d99fbd3027",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-30DorWest.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/W3.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W3.fits",
     "filesize": 5760,
-    "hashmd5": "d8884fbb37563e29c61c1c5d3852fe25"
+    "hashmd5": "d8884fbb37563e29c61c1c5d3852fe25",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W3.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/S147.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/S147.fits",
     "filesize": 40320,
-    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb"
+    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/S147.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/FornaxA.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/FornaxA.fits",
     "filesize": 144000,
-    "hashmd5": "a46b46c69a78eb334856b5ee434ab184"
+    "hashmd5": "a46b46c69a78eb334856b5ee434ab184",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/FornaxA.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/RXJ1713_2016_250GeV.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/RXJ1713_2016_250GeV.fits",
     "filesize": 69120,
-    "hashmd5": "a6ff1b27d7f888516729a166a5405d3c"
+    "hashmd5": "a6ff1b27d7f888516729a166a5405d3c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/RXJ1713_2016_250GeV.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-Galaxy.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-Galaxy.fits",
     "filesize": 4167360,
-    "hashmd5": "4226cd77a2ea0d703c4e9b94120bafb0"
+    "hashmd5": "4226cd77a2ea0d703c4e9b94120bafb0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/LMC-Galaxy.fits"
    },
    {
     "path": "catalogs/fermi/LAT_extended_sources_8years/Templates/W51C.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W51C.fits",
     "filesize": 43200,
-    "hashmd5": "dea38edcb9002c986bfccef5e9b99ffe"
+    "hashmd5": "dea38edcb9002c986bfccef5e9b99ffe",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/LAT_extended_sources_8years/Templates/W51C.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Extended_v18.log",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Extended_v18.log",
     "filesize": 337,
-    "hashmd5": "c19ee72784841df50f38d4b7262f5725"
+    "hashmd5": "c19ee72784841df50f38d4b7262f5725",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Extended_v18.log"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/LAT_extended_sources_v18.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/LAT_extended_sources_v18.fits",
     "filesize": 20160,
-    "hashmd5": "d7ca863afe96fd2b646b90a5612dfd9f"
+    "hashmd5": "d7ca863afe96fd2b646b90a5612dfd9f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/LAT_extended_sources_v18.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/LAT_ext_v18.reg",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/LAT_ext_v18.reg",
     "filesize": 2669,
-    "hashmd5": "3858fd1ff6bd339f60de78fc28b5b275"
+    "hashmd5": "3858fd1ff6bd339f60de78fc28b5b275",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/LAT_ext_v18.reg"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/RXJ1713-3946.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/RXJ1713-3946.xml",
     "filesize": 715,
-    "hashmd5": "d383d0e670f4217f28e1f08608be84b9"
+    "hashmd5": "d383d0e670f4217f28e1f08608be84b9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/RXJ1713-3946.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1837-069.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1837-069.xml",
     "filesize": 708,
-    "hashmd5": "a4636955a555c71a63aa5a8447720acc"
+    "hashmd5": "a4636955a555c71a63aa5a8447720acc",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1837-069.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1303-631.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1303-631.xml",
     "filesize": 708,
-    "hashmd5": "df4fb01867da9a1e24b82fe7e976566c"
+    "hashmd5": "df4fb01867da9a1e24b82fe7e976566c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1303-631.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HB9.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HB9.xml",
     "filesize": 784,
-    "hashmd5": "5022037145b31450de49d4e6e69647b8"
+    "hashmd5": "5022037145b31450de49d4e6e69647b8",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HB9.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/CenALobes.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/CenALobes.xml",
     "filesize": 703,
-    "hashmd5": "5a920a8081fad93d41fdea69aa14917a"
+    "hashmd5": "5a920a8081fad93d41fdea69aa14917a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/CenALobes.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1614-518.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1614-518.xml",
     "filesize": 710,
-    "hashmd5": "5d52f42bfbc1eb38986d07b979bdb199"
+    "hashmd5": "5d52f42bfbc1eb38986d07b979bdb199",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1614-518.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/LMC-30DorWest.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-30DorWest.xml",
     "filesize": 705,
-    "hashmd5": "2b6da038a258f7a78298649873b0a391"
+    "hashmd5": "2b6da038a258f7a78298649873b0a391",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-30DorWest.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1632-478.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1632-478.xml",
     "filesize": 711,
-    "hashmd5": "aeae18b6478fdb15f26aae6fc86245f2"
+    "hashmd5": "aeae18b6478fdb15f26aae6fc86245f2",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1632-478.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HB21.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HB21.xml",
     "filesize": 792,
-    "hashmd5": "da5cca7822ec77c8589e35793629bb4e"
+    "hashmd5": "da5cca7822ec77c8589e35793629bb4e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HB21.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/RCW86.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/RCW86.xml",
     "filesize": 688,
-    "hashmd5": "7f8d15c142785329d037e7a27c0347e5"
+    "hashmd5": "7f8d15c142785329d037e7a27c0347e5",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/RCW86.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/W28.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/W28.xml",
     "filesize": 790,
-    "hashmd5": "5850d54034c9066bf7ea2a91b27cacee"
+    "hashmd5": "5850d54034c9066bf7ea2a91b27cacee",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/W28.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/S147.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/S147.xml",
     "filesize": 692,
-    "hashmd5": "6f8ce195b1b8fc654cd7d1951b69ee44"
+    "hashmd5": "6f8ce195b1b8fc654cd7d1951b69ee44",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/S147.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1825-137.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1825-137.xml",
     "filesize": 808,
-    "hashmd5": "dd9486dbb8e1dcc50fc6592ecdc04ac8"
+    "hashmd5": "dd9486dbb8e1dcc50fc6592ecdc04ac8",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1825-137.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/CygnusLoop.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/CygnusLoop.xml",
     "filesize": 807,
-    "hashmd5": "e5d28e2984356121cffe913e4ca89334"
+    "hashmd5": "e5d28e2984356121cffe913e4ca89334",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/CygnusLoop.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/FornaxA.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/FornaxA.xml",
     "filesize": 691,
-    "hashmd5": "074f2ed5ab6b5b7a2153b21d1ef97c34"
+    "hashmd5": "074f2ed5ab6b5b7a2153b21d1ef97c34",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/FornaxA.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1616-508.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1616-508.xml",
     "filesize": 710,
-    "hashmd5": "667caebdcab64d5a2149b74ece54f99a"
+    "hashmd5": "667caebdcab64d5a2149b74ece54f99a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1616-508.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/W51C.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/W51C.xml",
     "filesize": 777,
-    "hashmd5": "b2ab4fc57e378573bef826d176d757b7"
+    "hashmd5": "b2ab4fc57e378573bef826d176d757b7",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/W51C.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/MSH15-52.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/MSH15-52.xml",
     "filesize": 672,
-    "hashmd5": "a47f63858c065562cd9780c47190fe72"
+    "hashmd5": "a47f63858c065562cd9780c47190fe72",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/MSH15-52.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/CygnusCocoon.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/CygnusCocoon.xml",
     "filesize": 682,
-    "hashmd5": "067f9200374057ce4aabd72c35a62c07"
+    "hashmd5": "067f9200374057ce4aabd72c35a62c07",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/CygnusCocoon.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/LMC-North.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-North.xml",
     "filesize": 697,
-    "hashmd5": "a38b24fc3cb3513a5789de914d660132"
+    "hashmd5": "a38b24fc3cb3513a5789de914d660132",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-North.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/IC443.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/IC443.xml",
     "filesize": 796,
-    "hashmd5": "f9176f010a12934541ebd78708b16815"
+    "hashmd5": "f9176f010a12934541ebd78708b16815",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/IC443.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/W30.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/W30.xml",
     "filesize": 790,
-    "hashmd5": "f3d234c30847edd084bd0dcb06b8dbf8"
+    "hashmd5": "f3d234c30847edd084bd0dcb06b8dbf8",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/W30.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/LMC-FarWest.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-FarWest.xml",
     "filesize": 701,
-    "hashmd5": "954c8589751066c7157f3bc57dcfcff4"
+    "hashmd5": "954c8589751066c7157f3bc57dcfcff4",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-FarWest.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/MSH15-56.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/MSH15-56.xml",
     "filesize": 697,
-    "hashmd5": "6e90dd4fc513055519101b14783f584f"
+    "hashmd5": "6e90dd4fc513055519101b14783f584f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/MSH15-56.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/gammaCygni.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/gammaCygni.xml",
     "filesize": 675,
-    "hashmd5": "c284fa8f3c74112bc18077a8e39f819a"
+    "hashmd5": "c284fa8f3c74112bc18077a8e39f819a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/gammaCygni.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/VelaJr.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/VelaJr.xml",
     "filesize": 697,
-    "hashmd5": "15add68801db41a235fb18d43fa162a0"
+    "hashmd5": "15add68801db41a235fb18d43fa162a0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/VelaJr.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HB3.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HB3.xml",
     "filesize": 784,
-    "hashmd5": "fb9198f2c91b76f210b73cb656cb8505"
+    "hashmd5": "fb9198f2c91b76f210b73cb656cb8505",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HB3.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/G296.5+10.0.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/G296.5+10.0.xml",
     "filesize": 701,
-    "hashmd5": "6e959e6e0560130d926af72a1512a6ec"
+    "hashmd5": "6e959e6e0560130d926af72a1512a6ec",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/G296.5+10.0.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/PuppisA.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/PuppisA.xml",
     "filesize": 714,
-    "hashmd5": "61c41c23b948cb905e7ebcdda66d5d71"
+    "hashmd5": "61c41c23b948cb905e7ebcdda66d5d71",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/PuppisA.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/HESSJ1841-055.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1841-055.xml",
     "filesize": 707,
-    "hashmd5": "54ee071708fba0c813312bd77de2b940"
+    "hashmd5": "54ee071708fba0c813312bd77de2b940",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/HESSJ1841-055.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/W3.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/W3.xml",
     "filesize": 782,
-    "hashmd5": "8ffb643cd1f8a2c8ff0579cc441d8ad9"
+    "hashmd5": "8ffb643cd1f8a2c8ff0579cc441d8ad9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/W3.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/LMC-Galaxy.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-Galaxy.xml",
     "filesize": 791,
-    "hashmd5": "2f603483711898cb2a9416bcc18ce1e0"
+    "hashmd5": "2f603483711898cb2a9416bcc18ce1e0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/LMC-Galaxy.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/VelaX.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/VelaX.xml",
     "filesize": 664,
-    "hashmd5": "0f46f9bde3c7da6519b8c023f2736e46"
+    "hashmd5": "0f46f9bde3c7da6519b8c023f2736e46",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/VelaX.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/W44.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/W44.xml",
     "filesize": 790,
-    "hashmd5": "8ba67c7b48ce07f24f2ab6b17e877310"
+    "hashmd5": "8ba67c7b48ce07f24f2ab6b17e877310",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/W44.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/XML/SMC-Galaxy.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/XML/SMC-Galaxy.xml",
     "filesize": 881,
-    "hashmd5": "e3e6754bc63da2e2fa5cc43d34e2d22d"
+    "hashmd5": "e3e6754bc63da2e2fa5cc43d34e2d22d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/XML/SMC-Galaxy.xml"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/CygnusLoop.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/CygnusLoop.fits",
     "filesize": 43200,
-    "hashmd5": "58239e37ad7215638fc0a12b4d59fcee"
+    "hashmd5": "58239e37ad7215638fc0a12b4d59fcee",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/CygnusLoop.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/LMC-North.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-North.fits",
     "filesize": 383040,
-    "hashmd5": "e3af30b762f6793347a9bd837790707c"
+    "hashmd5": "e3af30b762f6793347a9bd837790707c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-North.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/gammaCygni.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/gammaCygni.fits",
     "filesize": 31680,
-    "hashmd5": "3bb0b713a453429f4c9f51d7a1fabeb9"
+    "hashmd5": "3bb0b713a453429f4c9f51d7a1fabeb9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/gammaCygni.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/CenALobes.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/CenALobes.fits",
     "filesize": 103680,
-    "hashmd5": "750789bc7adb1287abfae28a76f7c593"
+    "hashmd5": "750789bc7adb1287abfae28a76f7c593",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/CenALobes.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1837-069.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1837-069.fits",
     "filesize": 31680,
-    "hashmd5": "308f6be96cb6365cffe58ef2c6362c94"
+    "hashmd5": "308f6be96cb6365cffe58ef2c6362c94",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1837-069.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/RCW86.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/RCW86.fits",
     "filesize": 17280,
-    "hashmd5": "69de80b1f5b8d45f962adcebffa263b9"
+    "hashmd5": "69de80b1f5b8d45f962adcebffa263b9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/RCW86.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HB9.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB9.fits",
     "filesize": 37440,
-    "hashmd5": "c62c6da4316010ac0ba1fcbe1b4197b4"
+    "hashmd5": "c62c6da4316010ac0ba1fcbe1b4197b4",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB9.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1632-478.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1632-478.fits",
     "filesize": 31680,
-    "hashmd5": "d00c3e9c6f5ac8dea855df2b0b997d03"
+    "hashmd5": "d00c3e9c6f5ac8dea855df2b0b997d03",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1632-478.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/MSH15-56.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/MSH15-56.fits",
     "filesize": 31680,
-    "hashmd5": "46fac415edd9e6bc2e7648bc7424cc8b"
+    "hashmd5": "46fac415edd9e6bc2e7648bc7424cc8b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/MSH15-56.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/LMC-FarWest.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-FarWest.fits",
     "filesize": 846720,
-    "hashmd5": "09e78a3b993c93e26752c2ed1808f718"
+    "hashmd5": "09e78a3b993c93e26752c2ed1808f718",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-FarWest.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1841-055.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1841-055.fits",
     "filesize": 31680,
-    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230"
+    "hashmd5": "e1c7594d2d3e625a9e288c8ac5781230",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1841-055.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/PuppisA.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/PuppisA.fits",
     "filesize": 31680,
-    "hashmd5": "067b9548d246438ca6d7696537cbbcaf"
+    "hashmd5": "067b9548d246438ca6d7696537cbbcaf",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/PuppisA.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/W44.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/W44.fits",
     "filesize": 23040,
-    "hashmd5": "622426056c3931be2c77f149a920e87a"
+    "hashmd5": "622426056c3931be2c77f149a920e87a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/W44.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1614-518.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1614-518.fits",
     "filesize": 31680,
-    "hashmd5": "2ac8597db1888c7486f3bf332fb32e46"
+    "hashmd5": "2ac8597db1888c7486f3bf332fb32e46",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1614-518.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HB3.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB3.fits",
     "filesize": 31680,
-    "hashmd5": "628c379062b5fd6d2ba80d330af787f6"
+    "hashmd5": "628c379062b5fd6d2ba80d330af787f6",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB3.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/W28.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/W28.fits",
     "filesize": 46080,
-    "hashmd5": "916b048c306dd646fcbe2223a118f43a"
+    "hashmd5": "916b048c306dd646fcbe2223a118f43a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/W28.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1303-631.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1303-631.fits",
     "filesize": 31680,
-    "hashmd5": "7854547f001a8c39ecf82aea8dade4b6"
+    "hashmd5": "7854547f001a8c39ecf82aea8dade4b6",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1303-631.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/IC443.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/IC443.fits",
     "filesize": 69120,
-    "hashmd5": "f67a4e5118cf489df83f19eb9db9ad6d"
+    "hashmd5": "f67a4e5118cf489df83f19eb9db9ad6d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/IC443.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/CygnusCocoon.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/CygnusCocoon.fits",
     "filesize": 31680,
-    "hashmd5": "4f8bc64e84a5f146a537e45f8da9d30a"
+    "hashmd5": "4f8bc64e84a5f146a537e45f8da9d30a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/CygnusCocoon.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1616-508.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1616-508.fits",
     "filesize": 31680,
-    "hashmd5": "cacf9de67d3711193e630cd973ff73bc"
+    "hashmd5": "cacf9de67d3711193e630cd973ff73bc",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1616-508.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/SMC-Galaxy.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/SMC-Galaxy.fits",
     "filesize": 2905920,
-    "hashmd5": "31d7a9a2fb20cb93302f93ad642a0162"
+    "hashmd5": "31d7a9a2fb20cb93302f93ad642a0162",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/SMC-Galaxy.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/LMC-30DorWest.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-30DorWest.fits",
     "filesize": 846720,
-    "hashmd5": "90325239f6002a1bdf3644d99fbd3027"
+    "hashmd5": "90325239f6002a1bdf3644d99fbd3027",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-30DorWest.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/MSH15-52.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/MSH15-52.fits",
     "filesize": 46080,
-    "hashmd5": "7f9c93ecb7bba1fc18fb35ca6c3e9555"
+    "hashmd5": "7f9c93ecb7bba1fc18fb35ca6c3e9555",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/MSH15-52.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/VelaJr.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/VelaJr.fits",
     "filesize": 31680,
-    "hashmd5": "504b98555ee389b76f504fa69a900625"
+    "hashmd5": "504b98555ee389b76f504fa69a900625",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/VelaJr.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/W30.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/W30.fits",
     "filesize": 31680,
-    "hashmd5": "51e7172e1cda0a9339c17b6353b03dd9"
+    "hashmd5": "51e7172e1cda0a9339c17b6353b03dd9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/W30.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/W3.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/W3.fits",
     "filesize": 5760,
-    "hashmd5": "d8884fbb37563e29c61c1c5d3852fe25"
+    "hashmd5": "d8884fbb37563e29c61c1c5d3852fe25",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/W3.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HB21.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB21.fits",
     "filesize": 31680,
-    "hashmd5": "88a9e5fdac58358fbc8d84014519b947"
+    "hashmd5": "88a9e5fdac58358fbc8d84014519b947",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HB21.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/S147.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/S147.fits",
     "filesize": 40320,
-    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb"
+    "hashmd5": "ef6e4f86de0ae34948b7c4d396f5f8bb",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/S147.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/HESSJ1825-137.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1825-137.fits",
     "filesize": 46080,
-    "hashmd5": "d1b7bb32f9c6efbfc5d8ee7d04e00c3d"
+    "hashmd5": "d1b7bb32f9c6efbfc5d8ee7d04e00c3d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/HESSJ1825-137.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/FornaxA.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/FornaxA.fits",
     "filesize": 144000,
-    "hashmd5": "2fdc377bac4b7c1813e12da44f82a61f"
+    "hashmd5": "2fdc377bac4b7c1813e12da44f82a61f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/FornaxA.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/VelaX.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/VelaX.fits",
     "filesize": 46080,
-    "hashmd5": "881b0b2e8828e1bbb901a3e15515914d"
+    "hashmd5": "881b0b2e8828e1bbb901a3e15515914d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/VelaX.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits",
     "filesize": 69120,
-    "hashmd5": "a6ff1b27d7f888516729a166a5405d3c"
+    "hashmd5": "a6ff1b27d7f888516729a166a5405d3c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/G296.5+10.0.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/G296.5+10.0.fits",
     "filesize": 31680,
-    "hashmd5": "2e65b0d0bd9e045e33dd9cd4df98c882"
+    "hashmd5": "2e65b0d0bd9e045e33dd9cd4df98c882",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/G296.5+10.0.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/LMC-Galaxy.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-Galaxy.fits",
     "filesize": 4167360,
-    "hashmd5": "4226cd77a2ea0d703c4e9b94120bafb0"
+    "hashmd5": "4226cd77a2ea0d703c4e9b94120bafb0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/LMC-Galaxy.fits"
    },
    {
     "path": "catalogs/fermi/Extended_archive_v18/Templates/W51C.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/Extended_archive_v18/Templates/W51C.fits",
     "filesize": 43200,
-    "hashmd5": "dea38edcb9002c986bfccef5e9b99ffe"
+    "hashmd5": "dea38edcb9002c986bfccef5e9b99ffe",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/fermi/Extended_archive_v18/Templates/W51C.fits"
    },
    {
     "path": "catalogs/gammacat/gammacat-datasets.json",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/gammacat/gammacat-datasets.json",
     "filesize": 125360,
-    "hashmd5": "4fed701d65ecc72cd6fcf4fe78cd2259"
+    "hashmd5": "4fed701d65ecc72cd6fcf4fe78cd2259",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/gammacat/gammacat-datasets.json"
    },
    {
     "path": "catalogs/gammacat/gammacat.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/gammacat/gammacat.fits.gz",
     "filesize": 33941,
-    "hashmd5": "b2c6bf26a090245d47a11b7b9b7f8586"
+    "hashmd5": "b2c6bf26a090245d47a11b7b9b7f8586",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/catalogs/gammacat/gammacat.fits.gz"
    }
   ]
  },
@@ -1513,31 +1761,36 @@
     "path": "fermi_3fhl/fermi_3fhl_exposure_cube_hpx.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/fermi_3fhl/fermi_3fhl_exposure_cube_hpx.fits.gz",
     "filesize": 3858696,
-    "hashmd5": "a3963741e22e09651aeefb5c646d8c37"
+    "hashmd5": "a3963741e22e09651aeefb5c646d8c37",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/fermi_3fhl/fermi_3fhl_exposure_cube_hpx.fits.gz"
    },
    {
     "path": "fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt",
     "filesize": 1255,
-    "hashmd5": "85de2d6a9896fe15f1a4298edd9d7641"
+    "hashmd5": "85de2d6a9896fe15f1a4298edd9d7641",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt"
    },
    {
     "path": "fermi_3fhl/fermi_3fhl_events_selected.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/fermi_3fhl/fermi_3fhl_events_selected.fits.gz",
     "filesize": 39307510,
-    "hashmd5": "da91bb56be09ea68ea00c8079ed178a0"
+    "hashmd5": "da91bb56be09ea68ea00c8079ed178a0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/fermi_3fhl/fermi_3fhl_events_selected.fits.gz"
    },
    {
     "path": "fermi_3fhl/fermi_3fhl_psf_gc.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/fermi_3fhl/fermi_3fhl_psf_gc.fits.gz",
     "filesize": 42267,
-    "hashmd5": "2d18ca761629320ae1e3e7da224eb595"
+    "hashmd5": "2d18ca761629320ae1e3e7da224eb595",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/fermi_3fhl/fermi_3fhl_psf_gc.fits.gz"
    },
    {
     "path": "fermi_3fhl/gll_iem_v06_cutout.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/fermi_3fhl/gll_iem_v06_cutout.fits",
     "filesize": 515520,
-    "hashmd5": "a6ab040128cba3100670d6f4e00a76fa"
+    "hashmd5": "a6ab040128cba3100670d6f4e00a76fa",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/fermi_3fhl/gll_iem_v06_cutout.fits"
    }
   ]
  },
@@ -1549,667 +1802,778 @@
     "path": "hess-dl3-dr1/hdu-index.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/hdu-index.fits.gz",
     "filesize": 5230,
-    "hashmd5": "8041ab9767c00ea32ab8d8ed2b8fa03f"
+    "hashmd5": "8041ab9767c00ea32ab8d8ed2b8fa03f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/hdu-index.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/test.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/test.py",
     "filesize": 926,
-    "hashmd5": "818e96917b956c801fe1a9db29414022"
+    "hashmd5": "818e96917b956c801fe1a9db29414022",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/test.py"
    },
    {
     "path": "hess-dl3-dr1/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/README.md",
     "filesize": 684,
-    "hashmd5": "32f5975f738551fa80bb37df2d8f0d02"
+    "hashmd5": "32f5975f738551fa80bb37df2d8f0d02",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/README.md"
    },
    {
     "path": "hess-dl3-dr1/make.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/make.py",
     "filesize": 2608,
-    "hashmd5": "a624cfcb294d70731dbfb33b4f3b877b"
+    "hashmd5": "a624cfcb294d70731dbfb33b4f3b877b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/make.py"
    },
    {
     "path": "hess-dl3-dr1/README.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/README.txt",
     "filesize": 1184,
-    "hashmd5": "4933f9aaf2263c5985663f5836ab7a29"
+    "hashmd5": "4933f9aaf2263c5985663f5836ab7a29",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/README.txt"
    },
    {
     "path": "hess-dl3-dr1/obs-index.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/obs-index.fits.gz",
     "filesize": 9365,
-    "hashmd5": "5b8ca87042c0ee33da3e387a771efba7"
+    "hashmd5": "5b8ca87042c0ee33da3e387a771efba7",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/obs-index.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033798.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033798.fits.gz",
     "filesize": 572633,
-    "hashmd5": "47a5998f4ee515f2552368f5eb34e6fb"
+    "hashmd5": "47a5998f4ee515f2552368f5eb34e6fb",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033798.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033788.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033788.fits.gz",
     "filesize": 539227,
-    "hashmd5": "82e30cc16709cd02efc9fdc204c0c3f2"
+    "hashmd5": "82e30cc16709cd02efc9fdc204c0c3f2",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033788.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027121.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027121.fits.gz",
     "filesize": 536228,
-    "hashmd5": "104eab1fc4935b81c57431410b581e37"
+    "hashmd5": "104eab1fc4935b81c57431410b581e37",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027121.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020561.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020561.fits.gz",
     "filesize": 634331,
-    "hashmd5": "2a26c4e77ed63ff8e15b76ddea9023c0"
+    "hashmd5": "2a26c4e77ed63ff8e15b76ddea9023c0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020561.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020324.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020324.fits.gz",
     "filesize": 659824,
-    "hashmd5": "cd51bd5cb3df288ae358cd79f30a0135"
+    "hashmd5": "cd51bd5cb3df288ae358cd79f30a0135",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020324.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020346.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020346.fits.gz",
     "filesize": 650913,
-    "hashmd5": "fe01cd76e1bcb044d6ba85f7c7b98078"
+    "hashmd5": "fe01cd76e1bcb044d6ba85f7c7b98078",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020346.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021851.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021851.fits.gz",
     "filesize": 539205,
-    "hashmd5": "09080554060ad222ee2352595f973f19"
+    "hashmd5": "09080554060ad222ee2352595f973f19",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021851.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020900.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020900.fits.gz",
     "filesize": 659063,
-    "hashmd5": "bfa072df7d74020960baa6fd8c8a6c86"
+    "hashmd5": "bfa072df7d74020960baa6fd8c8a6c86",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020900.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033791.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033791.fits.gz",
     "filesize": 604425,
-    "hashmd5": "b7183345521aba049ff9ef8db1f38030"
+    "hashmd5": "b7183345521aba049ff9ef8db1f38030",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033791.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020302.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020302.fits.gz",
     "filesize": 640318,
-    "hashmd5": "2649a7d67799c16410f9a7d831c595ba"
+    "hashmd5": "2649a7d67799c16410f9a7d831c595ba",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020302.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020151.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020151.fits.gz",
     "filesize": 620141,
-    "hashmd5": "a2272d8a7cb093b3d98140571f28bae0"
+    "hashmd5": "a2272d8a7cb093b3d98140571f28bae0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020151.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047802.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047802.fits.gz",
     "filesize": 524477,
-    "hashmd5": "530de706e574b114f5a3cf9b062d6859"
+    "hashmd5": "530de706e574b114f5a3cf9b062d6859",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047802.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033800.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033800.fits.gz",
     "filesize": 525372,
-    "hashmd5": "ad4373ffb55ed7cb81815deecda90b50"
+    "hashmd5": "ad4373ffb55ed7cb81815deecda90b50",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033800.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023736.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023736.fits.gz",
     "filesize": 510540,
-    "hashmd5": "4c0b01d84153c350841dd6682e78dc05"
+    "hashmd5": "4c0b01d84153c350841dd6682e78dc05",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023736.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022022.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022022.fits.gz",
     "filesize": 479333,
-    "hashmd5": "a8d040c895d7b952843aac19ee9daf8e"
+    "hashmd5": "a8d040c895d7b952843aac19ee9daf8e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022022.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033790.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033790.fits.gz",
     "filesize": 601307,
-    "hashmd5": "7d9a197e9b7fa0e7580de123a960989c"
+    "hashmd5": "7d9a197e9b7fa0e7580de123a960989c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033790.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020303.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020303.fits.gz",
     "filesize": 640104,
-    "hashmd5": "3ff02d8833338fa9992d5f62eb99327a"
+    "hashmd5": "3ff02d8833338fa9992d5f62eb99327a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020303.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047803.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047803.fits.gz",
     "filesize": 533120,
-    "hashmd5": "217056f50690ace16a6528f46c7c3442"
+    "hashmd5": "217056f50690ace16a6528f46c7c3442",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047803.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033801.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033801.fits.gz",
     "filesize": 507088,
-    "hashmd5": "1ff180aa4ff752139283b1861bf8e466"
+    "hashmd5": "1ff180aa4ff752139283b1861bf8e466",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033801.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023635.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023635.fits.gz",
     "filesize": 575723,
-    "hashmd5": "5c645147fc3c1c38fe944913f8eb2076"
+    "hashmd5": "5c645147fc3c1c38fe944913f8eb2076",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023635.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020368.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020368.fits.gz",
     "filesize": 621670,
-    "hashmd5": "734ab15443c98eb9573ebef9f3f7867c"
+    "hashmd5": "734ab15443c98eb9573ebef9f3f7867c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020368.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033789.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033789.fits.gz",
     "filesize": 585867,
-    "hashmd5": "be7af3e3c342ac3ddd083386f43ee5ab"
+    "hashmd5": "be7af3e3c342ac3ddd083386f43ee5ab",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033789.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033799.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033799.fits.gz",
     "filesize": 553752,
-    "hashmd5": "a3e7cc49ec8b6ed37c963c0b5c29ddc3"
+    "hashmd5": "a3e7cc49ec8b6ed37c963c0b5c29ddc3",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033799.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020325.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020325.fits.gz",
     "filesize": 660167,
-    "hashmd5": "d744e4fccb9bef199753d1bc41d91a62"
+    "hashmd5": "d744e4fccb9bef199753d1bc41d91a62",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020325.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029072.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029072.fits.gz",
     "filesize": 516059,
-    "hashmd5": "2d768b262274cf9ac7bc718f2227baae"
+    "hashmd5": "2d768b262274cf9ac7bc718f2227baae",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029072.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029024.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029024.fits.gz",
     "filesize": 554693,
-    "hashmd5": "6bffd5c6141cd7074e268f57a3862137"
+    "hashmd5": "6bffd5c6141cd7074e268f57a3862137",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029024.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026850.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026850.fits.gz",
     "filesize": 575620,
-    "hashmd5": "ebad06491d0bcb69f5c6c9e40006b75b"
+    "hashmd5": "ebad06491d0bcb69f5c6c9e40006b75b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026850.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020301.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020301.fits.gz",
     "filesize": 636783,
-    "hashmd5": "df2c38f9fd4908c36408b1012a90a647"
+    "hashmd5": "df2c38f9fd4908c36408b1012a90a647",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020301.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033792.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033792.fits.gz",
     "filesize": 601842,
-    "hashmd5": "ecbeaf2a7fdbe2e7009ea28835cda835"
+    "hashmd5": "ecbeaf2a7fdbe2e7009ea28835cda835",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033792.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027987.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027987.fits.gz",
     "filesize": 568566,
-    "hashmd5": "446225bc952801baf14848a14e935fc9"
+    "hashmd5": "446225bc952801baf14848a14e935fc9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027987.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020397.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020397.fits.gz",
     "filesize": 707272,
-    "hashmd5": "a4991eca27ddf25827646a64ee026e39"
+    "hashmd5": "a4991eca27ddf25827646a64ee026e39",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020397.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020519.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020519.fits.gz",
     "filesize": 676791,
-    "hashmd5": "cbd003475340da563e11e7af06cb9da9"
+    "hashmd5": "cbd003475340da563e11e7af06cb9da9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020519.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz",
     "filesize": 522418,
-    "hashmd5": "6c22e9b732c8dcc402f781c052c7527b"
+    "hashmd5": "6c22e9b732c8dcc402f781c052c7527b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047827.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047827.fits.gz",
     "filesize": 519018,
-    "hashmd5": "48f24bbe200ab9c38a6cf817d762f39e"
+    "hashmd5": "48f24bbe200ab9c38a6cf817d762f39e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047827.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029118.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029118.fits.gz",
     "filesize": 504442,
-    "hashmd5": "ed3aeafe3b9ef9a2eb288ca8c57aef13"
+    "hashmd5": "ed3aeafe3b9ef9a2eb288ca8c57aef13",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029118.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020345.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020345.fits.gz",
     "filesize": 654817,
-    "hashmd5": "def375ace7d5e37b292c655fe946eb12"
+    "hashmd5": "def375ace7d5e37b292c655fe946eb12",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020345.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020327.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020327.fits.gz",
     "filesize": 729323,
-    "hashmd5": "b3329e87618dbae2ba3d6999e7267589"
+    "hashmd5": "b3329e87618dbae2ba3d6999e7267589",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020327.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025511.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025511.fits.gz",
     "filesize": 520929,
-    "hashmd5": "9686f40bd57e5e5fcec2d5e5d5d6228e"
+    "hashmd5": "9686f40bd57e5e5fcec2d5e5d5d6228e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025511.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021613.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021613.fits.gz",
     "filesize": 624838,
-    "hashmd5": "40d0d0d904d91dee13a64963c1a4013c"
+    "hashmd5": "40d0d0d904d91dee13a64963c1a4013c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021613.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020344.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020344.fits.gz",
     "filesize": 658082,
-    "hashmd5": "d55c9c1c12bf738485271553c60e15fd"
+    "hashmd5": "d55c9c1c12bf738485271553c60e15fd",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020344.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020326.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020326.fits.gz",
     "filesize": 727305,
-    "hashmd5": "6a264244bebb5572378a8d7207c5f3d9"
+    "hashmd5": "6a264244bebb5572378a8d7207c5f3d9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020326.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025345.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025345.fits.gz",
     "filesize": 574222,
-    "hashmd5": "6e7154dff8b227b98cd73bf4622cd711"
+    "hashmd5": "6e7154dff8b227b98cd73bf4622cd711",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025345.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023559.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023559.fits.gz",
     "filesize": 526028,
-    "hashmd5": "c0be8eddee2b81573f835adcb6bbd555"
+    "hashmd5": "c0be8eddee2b81573f835adcb6bbd555",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023559.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021807.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021807.fits.gz",
     "filesize": 595843,
-    "hashmd5": "f1f2bbd098e2454e0a0e1ab5d1309e9b"
+    "hashmd5": "f1f2bbd098e2454e0a0e1ab5d1309e9b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021807.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033793.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033793.fits.gz",
     "filesize": 599133,
-    "hashmd5": "9b67de3419487d19b926c5ff87d43fb2"
+    "hashmd5": "9b67de3419487d19b926c5ff87d43fb2",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033793.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023592.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023592.fits.gz",
     "filesize": 517549,
-    "hashmd5": "31ada70a02d0eebbb107b341cf08ab53"
+    "hashmd5": "31ada70a02d0eebbb107b341cf08ab53",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023592.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020396.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020396.fits.gz",
     "filesize": 718253,
-    "hashmd5": "5cb3c868b43befd40de48c427978d9f4"
+    "hashmd5": "5cb3c868b43befd40de48c427978d9f4",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020396.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020518.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020518.fits.gz",
     "filesize": 685579,
-    "hashmd5": "dc591e81fb6796d6baaf7617ff6e6629"
+    "hashmd5": "dc591e81fb6796d6baaf7617ff6e6629",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020518.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022997.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022997.fits.gz",
     "filesize": 589811,
-    "hashmd5": "574306b89e0c3c4e7d3624900a13867f"
+    "hashmd5": "574306b89e0c3c4e7d3624900a13867f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022997.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026964.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026964.fits.gz",
     "filesize": 568294,
-    "hashmd5": "094d4d92cd6c435f218d02d1714e021e"
+    "hashmd5": "094d4d92cd6c435f218d02d1714e021e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026964.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029433.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029433.fits.gz",
     "filesize": 478919,
-    "hashmd5": "e25d5178f754a7b1a8b74e842c8139a4"
+    "hashmd5": "e25d5178f754a7b1a8b74e842c8139a4",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029433.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029177.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029177.fits.gz",
     "filesize": 539364,
-    "hashmd5": "fe8cce5ba320720a2f5e92ae46670081"
+    "hashmd5": "fe8cce5ba320720a2f5e92ae46670081",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029177.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023040.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023040.fits.gz",
     "filesize": 597077,
-    "hashmd5": "478c6b8ac90e148c2250bfe472bc6852"
+    "hashmd5": "478c6b8ac90e148c2250bfe472bc6852",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023040.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023573.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023573.fits.gz",
     "filesize": 609511,
-    "hashmd5": "02a3d540cb39467c36a53fdf5b328193"
+    "hashmd5": "02a3d540cb39467c36a53fdf5b328193",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023573.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033796.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033796.fits.gz",
     "filesize": 597036,
-    "hashmd5": "337406df10a4b5ec7b32906973e5d277"
+    "hashmd5": "337406df10a4b5ec7b32906973e5d277",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033796.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020367.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020367.fits.gz",
     "filesize": 620807,
-    "hashmd5": "343a41600c54412cf1b9bf9b172784d1"
+    "hashmd5": "343a41600c54412cf1b9bf9b172784d1",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020367.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023143.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023143.fits.gz",
     "filesize": 599612,
-    "hashmd5": "2708483a6377029336545d6225cbc59a"
+    "hashmd5": "2708483a6377029336545d6225cbc59a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023143.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021824.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021824.fits.gz",
     "filesize": 629810,
-    "hashmd5": "58d54549605bb10cf2cb74177ee42f9d"
+    "hashmd5": "58d54549605bb10cf2cb74177ee42f9d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021824.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020323.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020323.fits.gz",
     "filesize": 669369,
-    "hashmd5": "bf9b3651f61577e85ca0743f88974daa"
+    "hashmd5": "bf9b3651f61577e85ca0743f88974daa",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020323.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026077.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026077.fits.gz",
     "filesize": 510164,
-    "hashmd5": "cb71425331bc3458737f1041338111f4"
+    "hashmd5": "cb71425331bc3458737f1041338111f4",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026077.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023651.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023651.fits.gz",
     "filesize": 566669,
-    "hashmd5": "24a90cbf94e220638ab2bbfba9ea35da"
+    "hashmd5": "24a90cbf94e220638ab2bbfba9ea35da",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023651.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020421.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020421.fits.gz",
     "filesize": 716681,
-    "hashmd5": "469679f1fd44334d82b6514018ae06e6"
+    "hashmd5": "469679f1fd44334d82b6514018ae06e6",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020421.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026791.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026791.fits.gz",
     "filesize": 456067,
-    "hashmd5": "79f501c7cc5a64b6639373c6b8f8f226"
+    "hashmd5": "79f501c7cc5a64b6639373c6b8f8f226",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026791.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029556.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029556.fits.gz",
     "filesize": 562762,
-    "hashmd5": "ea4eb4fcad32e59ad83c58b062e6b283"
+    "hashmd5": "ea4eb4fcad32e59ad83c58b062e6b283",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029556.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020350.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020350.fits.gz",
     "filesize": 712473,
-    "hashmd5": "2dd5b04775b2110f89fbbffa47f41dd4"
+    "hashmd5": "2dd5b04775b2110f89fbbffa47f41dd4",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020350.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029487.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029487.fits.gz",
     "filesize": 550331,
-    "hashmd5": "85507efc26b278fa35de8b32a0396c93"
+    "hashmd5": "85507efc26b278fa35de8b32a0396c93",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029487.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020322.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020322.fits.gz",
     "filesize": 661749,
-    "hashmd5": "ed2e1a6d4d6d05796a706addd9d6db47"
+    "hashmd5": "ed2e1a6d4d6d05796a706addd9d6db47",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020322.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023246.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023246.fits.gz",
     "filesize": 516177,
-    "hashmd5": "de4c0c8335d3d97c290f736af5645501"
+    "hashmd5": "de4c0c8335d3d97c290f736af5645501",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023246.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023526.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023526.fits.gz",
     "filesize": 524967,
-    "hashmd5": "142f766ac0c7ba4ca1fe0749869ce592"
+    "hashmd5": "142f766ac0c7ba4ca1fe0749869ce592",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023526.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020734.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020734.fits.gz",
     "filesize": 632200,
-    "hashmd5": "5de98ef8b0f45ef68644d1b86e90ba19"
+    "hashmd5": "5de98ef8b0f45ef68644d1b86e90ba19",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020734.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020275.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020275.fits.gz",
     "filesize": 617436,
-    "hashmd5": "6339a508bedc6b4fe09ec0c5a92b596f"
+    "hashmd5": "6339a508bedc6b4fe09ec0c5a92b596f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020275.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023077.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023077.fits.gz",
     "filesize": 536721,
-    "hashmd5": "62b8859a8688d4bcbc79878929b37301"
+    "hashmd5": "62b8859a8688d4bcbc79878929b37301",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023077.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025443.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025443.fits.gz",
     "filesize": 571433,
-    "hashmd5": "99c1c4a1c4da7a2937ff7080645cda50"
+    "hashmd5": "99c1c4a1c4da7a2937ff7080645cda50",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_025443.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028341.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028341.fits.gz",
     "filesize": 549414,
-    "hashmd5": "7ee54df596cadc2b71847f7fc843ee26"
+    "hashmd5": "7ee54df596cadc2b71847f7fc843ee26",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028341.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020349.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020349.fits.gz",
     "filesize": 712857,
-    "hashmd5": "6dd61fafbae8e86814de69800937db3a"
+    "hashmd5": "6dd61fafbae8e86814de69800937db3a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020349.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047804.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047804.fits.gz",
     "filesize": 539539,
-    "hashmd5": "402309d638b9ddd894eed813339dbf9c"
+    "hashmd5": "402309d638b9ddd894eed813339dbf9c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047804.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028981.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028981.fits.gz",
     "filesize": 530802,
-    "hashmd5": "8cf530c3307ccb781b8ac4658a858b27"
+    "hashmd5": "8cf530c3307ccb781b8ac4658a858b27",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028981.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020366.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020366.fits.gz",
     "filesize": 631710,
-    "hashmd5": "3849ac03a122d80fbe218285016e9176"
+    "hashmd5": "3849ac03a122d80fbe218285016e9176",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020366.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033797.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033797.fits.gz",
     "filesize": 588862,
-    "hashmd5": "64f6881782dd19af61bca2e27e9f4423"
+    "hashmd5": "64f6881782dd19af61bca2e27e9f4423",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033797.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033787.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033787.fits.gz",
     "filesize": 504999,
-    "hashmd5": "600541521d39e327d04a0eefbb4ee72b"
+    "hashmd5": "600541521d39e327d04a0eefbb4ee72b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033787.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026827.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026827.fits.gz",
     "filesize": 501570,
-    "hashmd5": "9deff24c0e71e2a41c87f18f11ef7508"
+    "hashmd5": "9deff24c0e71e2a41c87f18f11ef7508",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_026827.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029526.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029526.fits.gz",
     "filesize": 479577,
-    "hashmd5": "cb28f47a486edac87a6a7fdecf98b139"
+    "hashmd5": "cb28f47a486edac87a6a7fdecf98b139",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029526.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020283.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020283.fits.gz",
     "filesize": 561500,
-    "hashmd5": "b0770dfc2467e20aaf9d4fd2d90a817b"
+    "hashmd5": "b0770dfc2467e20aaf9d4fd2d90a817b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020283.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020517.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020517.fits.gz",
     "filesize": 687783,
-    "hashmd5": "1c7074ea471645261385a774d4638100"
+    "hashmd5": "1c7074ea471645261385a774d4638100",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020517.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020422.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020422.fits.gz",
     "filesize": 714000,
-    "hashmd5": "eab11bf96bab7ef0f9370dd66eb43b0b"
+    "hashmd5": "eab11bf96bab7ef0f9370dd66eb43b0b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020422.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020898.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020898.fits.gz",
     "filesize": 652604,
-    "hashmd5": "522b7eb864c8ebc3e420a1c2d722aae2"
+    "hashmd5": "522b7eb864c8ebc3e420a1c2d722aae2",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020898.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028967.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028967.fits.gz",
     "filesize": 541208,
-    "hashmd5": "ac82a15b66d5adab72f728e37b9bf69a"
+    "hashmd5": "ac82a15b66d5adab72f728e37b9bf69a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_028967.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020137.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020137.fits.gz",
     "filesize": 514852,
-    "hashmd5": "1ba7504cf078558e65f89154589c30f1"
+    "hashmd5": "1ba7504cf078558e65f89154589c30f1",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020137.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020339.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020339.fits.gz",
     "filesize": 721226,
-    "hashmd5": "96d64cfad2a009712ed5993a6c550271"
+    "hashmd5": "96d64cfad2a009712ed5993a6c550271",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020339.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027939.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027939.fits.gz",
     "filesize": 584350,
-    "hashmd5": "24af3345ba809bfe2e470261dd1a6d3a"
+    "hashmd5": "24af3345ba809bfe2e470261dd1a6d3a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027939.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027044.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027044.fits.gz",
     "filesize": 579864,
-    "hashmd5": "ff64e716a0670668b7b73d34a3df86c7"
+    "hashmd5": "ff64e716a0670668b7b73d34a3df86c7",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_027044.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020521.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020521.fits.gz",
     "filesize": 672342,
-    "hashmd5": "9f8eb5053215d92674830ca66b64398f"
+    "hashmd5": "9f8eb5053215d92674830ca66b64398f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020521.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047829.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047829.fits.gz",
     "filesize": 540430,
-    "hashmd5": "25b19a4080af64445e5e41bef50778b9"
+    "hashmd5": "25b19a4080af64445e5e41bef50778b9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047829.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033795.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033795.fits.gz",
     "filesize": 595392,
-    "hashmd5": "8dd3e667973d49ac69bed2d3d7752a01"
+    "hashmd5": "8dd3e667973d49ac69bed2d3d7752a01",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033795.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029683.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029683.fits.gz",
     "filesize": 500322,
-    "hashmd5": "add0b97c3ded5cd809e024a0155e056c"
+    "hashmd5": "add0b97c3ded5cd809e024a0155e056c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_029683.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022593.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022593.fits.gz",
     "filesize": 566251,
-    "hashmd5": "6841676ea7b1ae6a5aed15ba4edb280d"
+    "hashmd5": "6841676ea7b1ae6a5aed15ba4edb280d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_022593.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz",
     "filesize": 630275,
-    "hashmd5": "000a1fddf93ef5d2348ae525acdd6c99"
+    "hashmd5": "000a1fddf93ef5d2348ae525acdd6c99",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033794.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033794.fits.gz",
     "filesize": 604278,
-    "hashmd5": "3375ef356b32a9461e4bbd70097e1ff6"
+    "hashmd5": "3375ef356b32a9461e4bbd70097e1ff6",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_033794.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047828.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047828.fits.gz",
     "filesize": 532155,
-    "hashmd5": "a6dff73830229ffc52c15286c9253e0f"
+    "hashmd5": "a6dff73830229ffc52c15286c9253e0f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_047828.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020365.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020365.fits.gz",
     "filesize": 626775,
-    "hashmd5": "53e2dea966a0e5c5d45539cfa1a33c1d"
+    "hashmd5": "53e2dea966a0e5c5d45539cfa1a33c1d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020365.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021753.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021753.fits.gz",
     "filesize": 601014,
-    "hashmd5": "83d13254830878890d4922e352ad886c"
+    "hashmd5": "83d13254830878890d4922e352ad886c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_021753.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020343.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020343.fits.gz",
     "filesize": 655348,
-    "hashmd5": "d1b48e4770578138d6701a8ba162ca5c"
+    "hashmd5": "d1b48e4770578138d6701a8ba162ca5c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020343.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020915.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020915.fits.gz",
     "filesize": 619874,
-    "hashmd5": "188f6bbca8a74eb2d505dea84154f605"
+    "hashmd5": "188f6bbca8a74eb2d505dea84154f605",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020915.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020282.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020282.fits.gz",
     "filesize": 626686,
-    "hashmd5": "85004da7b17fc7ee3571c186946dee54"
+    "hashmd5": "85004da7b17fc7ee3571c186946dee54",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020282.fits.gz"
    },
    {
     "path": "hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020899.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020899.fits.gz",
     "filesize": 664353,
-    "hashmd5": "cf61b0388caf3bbdf9441ced303317eb"
+    "hashmd5": "cf61b0388caf3bbdf9441ced303317eb",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020899.fits.gz"
    }
   ]
  },
@@ -2221,241 +2585,281 @@
     "path": "joint-crab/spectra/hess/arf_obs23523.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/arf_obs23523.fits",
     "filesize": 8640,
-    "hashmd5": "26ed95b824b56ee4631b9063b2316b7a"
+    "hashmd5": "26ed95b824b56ee4631b9063b2316b7a",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/arf_obs23523.fits"
    },
    {
     "path": "joint-crab/spectra/hess/arf_obs23559.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/arf_obs23559.fits",
     "filesize": 8640,
-    "hashmd5": "cf7087a9f7cac11767036501bc6d43de"
+    "hashmd5": "cf7087a9f7cac11767036501bc6d43de",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/arf_obs23559.fits"
    },
    {
     "path": "joint-crab/spectra/hess/rmf_obs23526.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/rmf_obs23526.fits",
     "filesize": 20160,
-    "hashmd5": "9f7613b6f5233ddf70457174bec37c6f"
+    "hashmd5": "9f7613b6f5233ddf70457174bec37c6f",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/rmf_obs23526.fits"
    },
    {
     "path": "joint-crab/spectra/hess/pha_obs23559.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/pha_obs23559.fits",
     "filesize": 17280,
-    "hashmd5": "5e3dc496ee2a57692560c2e9e9b63d22"
+    "hashmd5": "5e3dc496ee2a57692560c2e9e9b63d22",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/pha_obs23559.fits"
    },
    {
     "path": "joint-crab/spectra/hess/rmf_obs23592.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/rmf_obs23592.fits",
     "filesize": 20160,
-    "hashmd5": "da08f79d9337b5fa0cb5e3f13dfe3554"
+    "hashmd5": "da08f79d9337b5fa0cb5e3f13dfe3554",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/rmf_obs23592.fits"
    },
    {
     "path": "joint-crab/spectra/hess/bkg_obs23592.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/bkg_obs23592.fits",
     "filesize": 14400,
-    "hashmd5": "6cb46f78803e974312ac6ddaa02f0862"
+    "hashmd5": "6cb46f78803e974312ac6ddaa02f0862",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/bkg_obs23592.fits"
    },
    {
     "path": "joint-crab/spectra/hess/pha_obs23523.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/pha_obs23523.fits",
     "filesize": 17280,
-    "hashmd5": "f58d32234e5fdf6d2a47c32421c88c5a"
+    "hashmd5": "f58d32234e5fdf6d2a47c32421c88c5a",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/pha_obs23523.fits"
    },
    {
     "path": "joint-crab/spectra/hess/bkg_obs23526.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/bkg_obs23526.fits",
     "filesize": 14400,
-    "hashmd5": "6f68c5ce6395fdd5ff05704083161370"
+    "hashmd5": "6f68c5ce6395fdd5ff05704083161370",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/bkg_obs23526.fits"
    },
    {
     "path": "joint-crab/spectra/hess/arf_obs23526.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/arf_obs23526.fits",
     "filesize": 8640,
-    "hashmd5": "ef507d28db3afd41da7786c19b9cfd1c"
+    "hashmd5": "ef507d28db3afd41da7786c19b9cfd1c",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/arf_obs23526.fits"
    },
    {
     "path": "joint-crab/spectra/hess/arf_obs23592.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/arf_obs23592.fits",
     "filesize": 8640,
-    "hashmd5": "55fb38a1e371e5a74a04f4df73c59c32"
+    "hashmd5": "55fb38a1e371e5a74a04f4df73c59c32",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/arf_obs23592.fits"
    },
    {
     "path": "joint-crab/spectra/hess/pha_obs23592.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/pha_obs23592.fits",
     "filesize": 17280,
-    "hashmd5": "94fe3939659befbd1ebc0159ddd9e5a4"
+    "hashmd5": "94fe3939659befbd1ebc0159ddd9e5a4",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/pha_obs23592.fits"
    },
    {
     "path": "joint-crab/spectra/hess/rmf_obs23559.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/rmf_obs23559.fits",
     "filesize": 20160,
-    "hashmd5": "7d9b110d99c2299ed014e656204c92da"
+    "hashmd5": "7d9b110d99c2299ed014e656204c92da",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/rmf_obs23559.fits"
    },
    {
     "path": "joint-crab/spectra/hess/pha_obs23526.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/pha_obs23526.fits",
     "filesize": 17280,
-    "hashmd5": "215c77f17084ad5c8b5697f67fe7c7cc"
+    "hashmd5": "215c77f17084ad5c8b5697f67fe7c7cc",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/pha_obs23526.fits"
    },
    {
     "path": "joint-crab/spectra/hess/bkg_obs23523.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/bkg_obs23523.fits",
     "filesize": 14400,
-    "hashmd5": "2c6e6f4a6094aac89a6fca8f0a88be47"
+    "hashmd5": "2c6e6f4a6094aac89a6fca8f0a88be47",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/bkg_obs23523.fits"
    },
    {
     "path": "joint-crab/spectra/hess/rmf_obs23523.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/rmf_obs23523.fits",
     "filesize": 20160,
-    "hashmd5": "21774ead32e57501e672177e29df7da9"
+    "hashmd5": "21774ead32e57501e672177e29df7da9",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/rmf_obs23523.fits"
    },
    {
     "path": "joint-crab/spectra/hess/bkg_obs23559.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/hess/bkg_obs23559.fits",
     "filesize": 14400,
-    "hashmd5": "7af2369c2517431c6f88cbede44131da"
+    "hashmd5": "7af2369c2517431c6f88cbede44131da",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/hess/bkg_obs23559.fits"
    },
    {
     "path": "joint-crab/spectra/magic/arf_obs5029748.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/arf_obs5029748.fits",
     "filesize": 8640,
-    "hashmd5": "e5d59ae10543fc105a7a6996e216c313"
+    "hashmd5": "e5d59ae10543fc105a7a6996e216c313",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/arf_obs5029748.fits"
    },
    {
     "path": "joint-crab/spectra/magic/pha_obs5029747.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/pha_obs5029747.fits",
     "filesize": 17280,
-    "hashmd5": "a6245e03687937e4fcdac6a36e72d864"
+    "hashmd5": "a6245e03687937e4fcdac6a36e72d864",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/pha_obs5029747.fits"
    },
    {
     "path": "joint-crab/spectra/magic/rmf_obs5029747.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/rmf_obs5029747.fits",
     "filesize": 23040,
-    "hashmd5": "30dcf11e109c9bc253adb5efa1481445"
+    "hashmd5": "30dcf11e109c9bc253adb5efa1481445",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/rmf_obs5029747.fits"
    },
    {
     "path": "joint-crab/spectra/magic/bkg_obs5029747.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/bkg_obs5029747.fits",
     "filesize": 14400,
-    "hashmd5": "49aa0e9a160c112cdf4118c01a0ef054"
+    "hashmd5": "49aa0e9a160c112cdf4118c01a0ef054",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/bkg_obs5029747.fits"
    },
    {
     "path": "joint-crab/spectra/magic/bkg_obs5029748.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/bkg_obs5029748.fits",
     "filesize": 14400,
-    "hashmd5": "433ac4e639626ed9266d6a87318d22f0"
+    "hashmd5": "433ac4e639626ed9266d6a87318d22f0",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/bkg_obs5029748.fits"
    },
    {
     "path": "joint-crab/spectra/magic/pha_obs5029748.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/pha_obs5029748.fits",
     "filesize": 17280,
-    "hashmd5": "6b60eb115bda81ecda0fe1111688735a"
+    "hashmd5": "6b60eb115bda81ecda0fe1111688735a",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/pha_obs5029748.fits"
    },
    {
     "path": "joint-crab/spectra/magic/rmf_obs5029748.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/rmf_obs5029748.fits",
     "filesize": 23040,
-    "hashmd5": "298c8d829fa8368d28f0700f94b23717"
+    "hashmd5": "298c8d829fa8368d28f0700f94b23717",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/rmf_obs5029748.fits"
    },
    {
     "path": "joint-crab/spectra/magic/arf_obs5029747.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/magic/arf_obs5029747.fits",
     "filesize": 8640,
-    "hashmd5": "702aa5a352a9b58628f6e6b05afa856e"
+    "hashmd5": "702aa5a352a9b58628f6e6b05afa856e",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/magic/arf_obs5029747.fits"
    },
    {
     "path": "joint-crab/spectra/fermi/arf_obs0.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fermi/arf_obs0.fits",
     "filesize": 8640,
-    "hashmd5": "3e59a877f189081b700ba47bbc73c9eb"
+    "hashmd5": "3e59a877f189081b700ba47bbc73c9eb",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fermi/arf_obs0.fits"
    },
    {
     "path": "joint-crab/spectra/fermi/pha_obs0.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fermi/pha_obs0.fits",
     "filesize": 17280,
-    "hashmd5": "ee26efa7407dbafccde4d49bb5b43b68"
+    "hashmd5": "ee26efa7407dbafccde4d49bb5b43b68",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fermi/pha_obs0.fits"
    },
    {
     "path": "joint-crab/spectra/fermi/bkg_obs0.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fermi/bkg_obs0.fits",
     "filesize": 14400,
-    "hashmd5": "9b81ecd635750ed0d5072a4ce49adf36"
+    "hashmd5": "9b81ecd635750ed0d5072a4ce49adf36",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fermi/bkg_obs0.fits"
    },
    {
     "path": "joint-crab/spectra/fermi/rmf_obs0.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fermi/rmf_obs0.fits",
     "filesize": 14400,
-    "hashmd5": "eb4479bce949475f61a4971b96dde39c"
+    "hashmd5": "eb4479bce949475f61a4971b96dde39c",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fermi/rmf_obs0.fits"
    },
    {
     "path": "joint-crab/spectra/fact/bkg_stacked.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fact/bkg_stacked.fits",
     "filesize": 25920,
-    "hashmd5": "cfa3fd913e41f06537740cbf87edf3da"
+    "hashmd5": "cfa3fd913e41f06537740cbf87edf3da",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fact/bkg_stacked.fits"
    },
    {
     "path": "joint-crab/spectra/fact/rmf_stacked.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fact/rmf_stacked.fits",
     "filesize": 23040,
-    "hashmd5": "4ee7efb2181d973139154b06e32ba029"
+    "hashmd5": "4ee7efb2181d973139154b06e32ba029",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fact/rmf_stacked.fits"
    },
    {
     "path": "joint-crab/spectra/fact/arf_stacked.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fact/arf_stacked.fits",
     "filesize": 8640,
-    "hashmd5": "d6aba229280f677d2b3e2334f7d17718"
+    "hashmd5": "d6aba229280f677d2b3e2334f7d17718",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fact/arf_stacked.fits"
    },
    {
     "path": "joint-crab/spectra/fact/pha_stacked.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/fact/pha_stacked.fits",
     "filesize": 25920,
-    "hashmd5": "02e3b0005b3e407f7b8170c5d21e5104"
+    "hashmd5": "02e3b0005b3e407f7b8170c5d21e5104",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/fact/pha_stacked.fits"
    },
    {
     "path": "joint-crab/spectra/veritas/arf_obs57993.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/arf_obs57993.fits",
     "filesize": 8640,
-    "hashmd5": "ca3b6ad785b36083b5fec6461a11f019"
+    "hashmd5": "ca3b6ad785b36083b5fec6461a11f019",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/arf_obs57993.fits"
    },
    {
     "path": "joint-crab/spectra/veritas/arf_obs54809.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/arf_obs54809.fits",
     "filesize": 8640,
-    "hashmd5": "541c02fa3be8384ed4aab20e784dc327"
+    "hashmd5": "541c02fa3be8384ed4aab20e784dc327",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/arf_obs54809.fits"
    },
    {
     "path": "joint-crab/spectra/veritas/pha_obs54809.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/pha_obs54809.fits",
     "filesize": 17280,
-    "hashmd5": "114828f35ea4cede066ac4e8b36122fb"
+    "hashmd5": "114828f35ea4cede066ac4e8b36122fb",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/pha_obs54809.fits"
    },
    {
     "path": "joint-crab/spectra/veritas/pha_obs57993.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/pha_obs57993.fits",
     "filesize": 17280,
-    "hashmd5": "cd181b3ab18256c6109abfbb44c785b5"
+    "hashmd5": "cd181b3ab18256c6109abfbb44c785b5",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/pha_obs57993.fits"
    },
    {
     "path": "joint-crab/spectra/veritas/rmf_obs57993.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/rmf_obs57993.fits",
     "filesize": 20160,
-    "hashmd5": "985c47683de83325e38bcce30e357dbc"
+    "hashmd5": "985c47683de83325e38bcce30e357dbc",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/rmf_obs57993.fits"
    },
    {
     "path": "joint-crab/spectra/veritas/rmf_obs54809.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/rmf_obs54809.fits",
     "filesize": 20160,
-    "hashmd5": "221d94dbafffc8657ebe5dc8e3428d44"
+    "hashmd5": "221d94dbafffc8657ebe5dc8e3428d44",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/rmf_obs54809.fits"
    },
    {
     "path": "joint-crab/spectra/veritas/bkg_obs54809.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/bkg_obs54809.fits",
     "filesize": 14400,
-    "hashmd5": "b02838d9b80b620308efe8af93289d8e"
+    "hashmd5": "b02838d9b80b620308efe8af93289d8e",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/bkg_obs54809.fits"
    },
    {
     "path": "joint-crab/spectra/veritas/bkg_obs57993.fits",
     "url": "https://github.com/open-gamma-ray-astro/joint-crab/raw/master/results/spectra/veritas/bkg_obs57993.fits",
     "filesize": 14400,
-    "hashmd5": "f169cd9655a172d3ce229d4d678decbb"
+    "hashmd5": "f169cd9655a172d3ce229d4d678decbb",
+    "itempath": "/Users/jer/git/open-gamma-ray-astro/joint-crab/results/spectra/veritas/bkg_obs57993.fits"
    }
   ]
  },
@@ -2467,31 +2871,36 @@
     "path": "ebl/frd_abs.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/ebl/frd_abs.fits.gz",
     "filesize": 120837,
-    "hashmd5": "1259686d4790c86a63b426698acceebc"
+    "hashmd5": "1259686d4790c86a63b426698acceebc",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/ebl/frd_abs.fits.gz"
    },
    {
     "path": "ebl/ebl_franceschini.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/ebl/ebl_franceschini.fits.gz",
     "filesize": 274043,
-    "hashmd5": "a77a14de3fc36727087c861083389620"
+    "hashmd5": "a77a14de3fc36727087c861083389620",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/ebl/ebl_franceschini.fits.gz"
    },
    {
     "path": "ebl/ebl_models.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/ebl/ebl_models.png",
     "filesize": 51560,
-    "hashmd5": "9e2a290184fe9effddd533af61d5a985"
+    "hashmd5": "9e2a290184fe9effddd533af61d5a985",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/ebl/ebl_models.png"
    },
    {
     "path": "ebl/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/ebl/README.md",
     "filesize": 435,
-    "hashmd5": "20a2f39ea2f707bb4b597d1ac186d2a5"
+    "hashmd5": "20a2f39ea2f707bb4b597d1ac186d2a5",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/ebl/README.md"
    },
    {
     "path": "ebl/ebl_dominguez11.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/ebl/ebl_dominguez11.fits.gz",
     "filesize": 431576,
-    "hashmd5": "02f0e2324256bd5070490dccedbad0df"
+    "hashmd5": "02f0e2324256bd5070490dccedbad0df",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/ebl/ebl_dominguez11.fits.gz"
    }
   ]
  },
@@ -2503,61 +2912,71 @@
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-background.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-background.fits.gz",
     "filesize": 276011,
-    "hashmd5": "d5cc4205d0d7f9fea9e6d032fe7392ac"
+    "hashmd5": "d5cc4205d0d7f9fea9e6d032fe7392ac",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-background.fits.gz"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-background-cube.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-background-cube.fits.gz",
     "filesize": 3544798,
-    "hashmd5": "34be0106614921d5a6b3a196993b4cf8"
+    "hashmd5": "34be0106614921d5a6b3a196993b4cf8",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-background-cube.fits.gz"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-counts.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-counts.fits.gz",
     "filesize": 25987,
-    "hashmd5": "9a1efcf66efd8690fcf8b252666b2a25"
+    "hashmd5": "9a1efcf66efd8690fcf8b252666b2a25",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-counts.fits.gz"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-counts-cube.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-counts-cube.fits.gz",
     "filesize": 551140,
-    "hashmd5": "10ddcd4ea5b253b54e9db80cd5c2fa12"
+    "hashmd5": "10ddcd4ea5b253b54e9db80cd5c2fa12",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-counts-cube.fits.gz"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-events.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-events.fits.gz",
     "filesize": 2409727,
-    "hashmd5": "fc195f11fdef7f53774bc80f12a0db81"
+    "hashmd5": "fc195f11fdef7f53774bc80f12a0db81",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-events.fits.gz"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-exposure-cube.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-exposure-cube.fits.gz",
     "filesize": 572834,
-    "hashmd5": "64088e1015b1b1bdd3f6b047fbd8b033"
+    "hashmd5": "64088e1015b1b1bdd3f6b047fbd8b033",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-exposure-cube.fits.gz"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-exposure.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-exposure.fits.gz",
     "filesize": 7062,
-    "hashmd5": "dfbd4d9494ca7c3de21faaf499765c6e"
+    "hashmd5": "dfbd4d9494ca7c3de21faaf499765c6e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-exposure.fits.gz"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-psf.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-psf.fits.gz",
     "filesize": 1299,
-    "hashmd5": "f84b64a46bc2946489553438f91c048f"
+    "hashmd5": "f84b64a46bc2946489553438f91c048f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-psf.fits.gz"
    },
    {
     "path": "fermi-3fhl-gc/fermi-3fhl-gc-psf-cube.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/fermi-3fhl-gc-psf-cube.fits.gz",
     "filesize": 28072,
-    "hashmd5": "ff6c8b0fa64f703880d2ecefe7e83df0"
+    "hashmd5": "ff6c8b0fa64f703880d2ecefe7e83df0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/fermi-3fhl-gc-psf-cube.fits.gz"
    },
    {
     "path": "fermi-3fhl-gc/gll_iem_v06_gc.fits.gz",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/galactic-center/gll_iem_v06_gc.fits.gz",
     "filesize": 823469,
-    "hashmd5": "37c3c5d8ad72a918360c6d2b6a72db1e"
+    "hashmd5": "37c3c5d8ad72a918360c6d2b6a72db1e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/galactic-center/gll_iem_v06_gc.fits.gz"
    }
   ]
  },
@@ -2569,19 +2988,22 @@
     "path": "fermi-3fhl-crab/Fermi-LAT-3FHL_data_Fermi-LAT.fits",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/crab/Fermi-LAT-3FHL_data_Fermi-LAT.fits",
     "filesize": 391680,
-    "hashmd5": "3ca12b9f8f8100a9c8254566c5054e71"
+    "hashmd5": "3ca12b9f8f8100a9c8254566c5054e71",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/crab/Fermi-LAT-3FHL_data_Fermi-LAT.fits"
    },
    {
     "path": "fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/crab/Fermi-LAT-3FHL_datasets.yaml",
-    "filesize": 194,
-    "hashmd5": "5e17b2f385049b660ce2bd6c1bebf65d"
+    "filesize": 124,
+    "hashmd5": "5e17b2f385049b660ce2bd6c1bebf65d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/crab/Fermi-LAT-3FHL_datasets.yaml"
    },
    {
     "path": "fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/crab/Fermi-LAT-3FHL_models.yaml",
-    "filesize": 1251,
-    "hashmd5": "e99438be2fe12115cada40b5c2ace4a7"
+    "filesize": 1283,
+    "hashmd5": "e99438be2fe12115cada40b5c2ace4a7",
+    "itempath": "/Users/jer/git/gammapy/gammapy-fermi-lat-data/3fhl/crab/Fermi-LAT-3FHL_models.yaml"
    }
   ]
  },
@@ -2593,13 +3015,15 @@
     "path": "hawc_crab/HAWC19_flux_points.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hawc_crab/HAWC19_flux_points.fits",
     "filesize": 8640,
-    "hashmd5": "afa06335c5a3e559b2ff0e73d254315f"
+    "hashmd5": "afa06335c5a3e559b2ff0e73d254315f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hawc_crab/HAWC19_flux_points.fits"
    },
    {
     "path": "hawc_crab/prepare.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/hawc_crab/prepare.py",
     "filesize": 1222,
-    "hashmd5": "d13cdc457ff979e7a86b9c2d740659bb"
+    "hashmd5": "d13cdc457ff979e7a86b9c2d740659bb",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/hawc_crab/prepare.py"
    }
   ]
  },
@@ -2611,421 +3035,491 @@
     "path": "tests/phasecurve_LSI_DC.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/phasecurve_LSI_DC.fits",
     "filesize": 8640,
-    "hashmd5": "fe0444d0c51306c4626840e744127da6"
+    "hashmd5": "fe0444d0c51306c4626840e744127da6",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/phasecurve_LSI_DC.fits"
    },
    {
     "path": "tests/pointing_table.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/pointing_table.fits.gz",
     "filesize": 999284,
-    "hashmd5": "9efaebe942886a2d7e4112764a347b22"
+    "hashmd5": "9efaebe942886a2d7e4112764a347b22",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/pointing_table.fits.gz"
    },
    {
     "path": "tests/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/README.md",
     "filesize": 155,
-    "hashmd5": "01f54cdf3f0f41f7cc2da6fb9707f24e"
+    "hashmd5": "01f54cdf3f0f41f7cc2da6fb9707f24e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/README.md"
    },
    {
     "path": "tests/hess_psf_king_023523.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/hess_psf_king_023523.fits.gz",
     "filesize": 1935,
-    "hashmd5": "d5374ccd22a7644bbc8da4387daa6e54"
+    "hashmd5": "d5374ccd22a7644bbc8da4387daa6e54",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/hess_psf_king_023523.fits.gz"
    },
    {
     "path": "tests/models/gc_example_data_g09.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/gc_example_data_g09.fits",
     "filesize": 60480,
-    "hashmd5": "be7edf33962f9237b62e9fcb3b45f78c"
+    "hashmd5": "be7edf33962f9237b62e9fcb3b45f78c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/gc_example_data_g09.fits"
    },
    {
     "path": "tests/models/shell.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/shell.xml",
     "filesize": 1491,
-    "hashmd5": "25832149ee91987d1698cbbd5a09ecf0"
+    "hashmd5": "25832149ee91987d1698cbbd5a09ecf0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/shell.xml"
    },
    {
     "path": "tests/models/fermi_model.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/fermi_model.xml",
     "filesize": 2656,
-    "hashmd5": "9bd8ffcad7e2a2e53356207b31320193"
+    "hashmd5": "9bd8ffcad7e2a2e53356207b31320193",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/fermi_model.xml"
    },
    {
     "path": "tests/models/ctadc_skymodel_gps_sources_bright.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/ctadc_skymodel_gps_sources_bright.xml",
     "filesize": 29281,
-    "hashmd5": "da20a7007173d86930ec22625be495e1"
+    "hashmd5": "da20a7007173d86930ec22625be495e1",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/ctadc_skymodel_gps_sources_bright.xml"
    },
    {
     "path": "tests/models/examples.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/examples.xml",
     "filesize": 5178,
-    "hashmd5": "9c68dbe906afc246367811fbfea090a3"
+    "hashmd5": "9c68dbe906afc246367811fbfea090a3",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/examples.xml"
    },
    {
     "path": "tests/models/gc_example_datasets.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/gc_example_datasets.yaml",
-    "filesize": 344,
-    "hashmd5": "72e07fe7aca6d77d18e61261334aab49"
+    "filesize": 198,
+    "hashmd5": "72e07fe7aca6d77d18e61261334aab49",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/gc_example_datasets.yaml"
    },
    {
     "path": "tests/models/gc_example_models.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/gc_example_models.yaml",
-    "filesize": 2092,
-    "hashmd5": "430b3ee537c243fbc1952d697efad079"
+    "filesize": 2238,
+    "hashmd5": "430b3ee537c243fbc1952d697efad079",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/gc_example_models.yaml"
    },
    {
     "path": "tests/models/gc_example_data_gc.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/gc_example_data_gc.fits",
     "filesize": 60480,
-    "hashmd5": "d4b9246a9ccea0c82f7d72c57376fbab"
+    "hashmd5": "d4b9246a9ccea0c82f7d72c57376fbab",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/gc_example_data_gc.fits"
    },
    {
     "path": "tests/models/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/README.rst",
     "filesize": 461,
-    "hashmd5": "c382cec8b5f5c621d4c4f3f6c5c7258c"
+    "hashmd5": "c382cec8b5f5c621d4c4f3f6c5c7258c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/README.rst"
    },
    {
     "path": "tests/models/light_curve/model.xml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/light_curve/model.xml",
     "filesize": 944,
-    "hashmd5": "73c3f10e8da1946f2554a0be7380f6cf"
+    "hashmd5": "73c3f10e8da1946f2554a0be7380f6cf",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/light_curve/model.xml"
    },
    {
     "path": "tests/models/light_curve/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/light_curve/README.md",
     "filesize": 622,
-    "hashmd5": "78f49339b3cacf2e33e6b8353aa8a292"
+    "hashmd5": "78f49339b3cacf2e33e6b8353aa8a292",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/light_curve/README.md"
    },
    {
     "path": "tests/models/light_curve/lightcrv_PKSB1222+216.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/light_curve/lightcrv_PKSB1222+216.fits",
     "filesize": 48960,
-    "hashmd5": "de1018e14e03b1f89f3734437cebbf89"
+    "hashmd5": "de1018e14e03b1f89f3734437cebbf89",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/models/light_curve/lightcrv_PKSB1222+216.fits"
    },
    {
     "path": "tests/spectrum/total_spectrum_stats_reference.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/total_spectrum_stats_reference.yaml",
     "filesize": 175,
-    "hashmd5": "c60e95c6e319724f85d6ed6303dfc039"
+    "hashmd5": "c60e95c6e319724f85d6ed6303dfc039",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/total_spectrum_stats_reference.yaml"
    },
    {
     "path": "tests/spectrum/fit_result_PowerLaw_reference.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/fit_result_PowerLaw_reference.yaml",
     "filesize": 531,
-    "hashmd5": "e0f06bbb36f9ef17fd39dea08e83e3da"
+    "hashmd5": "e0f06bbb36f9ef17fd39dea08e83e3da",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/fit_result_PowerLaw_reference.yaml"
    },
    {
     "path": "tests/spectrum/spectrum_analysis_example.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/spectrum_analysis_example.yaml",
     "filesize": 377,
-    "hashmd5": "9cd19c8e71e8d808144f2fdd033a0aad"
+    "hashmd5": "9cd19c8e71e8d808144f2fdd033a0aad",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/spectrum_analysis_example.yaml"
    },
    {
     "path": "tests/spectrum/flux_points/1es0229_hess_spectrum.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/1es0229_hess_spectrum.fits",
     "filesize": 8640,
-    "hashmd5": "e6900ce51bee3b3dfc36f35798a65f14"
+    "hashmd5": "e6900ce51bee3b3dfc36f35798a65f14",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/1es0229_hess_spectrum.fits"
    },
    {
     "path": "tests/spectrum/flux_points/flux_points.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/flux_points.fits",
     "filesize": 8640,
-    "hashmd5": "a8c527216d0e2cf0665c67553511176e"
+    "hashmd5": "a8c527216d0e2cf0665c67553511176e",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/flux_points.fits"
    },
    {
     "path": "tests/spectrum/flux_points/flux_points.ecsv",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/flux_points.ecsv",
     "filesize": 2063,
-    "hashmd5": "e562dde1a2fc05438901338de2cd6acd"
+    "hashmd5": "e562dde1a2fc05438901338de2cd6acd",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/flux_points.ecsv"
    },
    {
     "path": "tests/spectrum/flux_points/1es0229_hess_spectrum.ecsv",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/1es0229_hess_spectrum.ecsv",
     "filesize": 603,
-    "hashmd5": "bee0793ddad5328b39bbcba1a8ce01cd"
+    "hashmd5": "bee0793ddad5328b39bbcba1a8ce01cd",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/1es0229_hess_spectrum.ecsv"
    },
    {
     "path": "tests/spectrum/flux_points/diff_flux_points.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/diff_flux_points.fits",
     "filesize": 8640,
-    "hashmd5": "c8974f171c0022674a011f2c3e827c3a"
+    "hashmd5": "c8974f171c0022674a011f2c3e827c3a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/diff_flux_points.fits"
    },
    {
     "path": "tests/spectrum/flux_points/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/README.md",
     "filesize": 378,
-    "hashmd5": "dff522a0fa9e389a6aac6c927993d9e6"
+    "hashmd5": "dff522a0fa9e389a6aac6c927993d9e6",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/README.md"
    },
    {
     "path": "tests/spectrum/flux_points/diff_flux_points.ecsv",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/diff_flux_points.ecsv",
     "filesize": 1570,
-    "hashmd5": "d1c351e8680435118c6f08593c8778a6"
+    "hashmd5": "d1c351e8680435118c6f08593c8778a6",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/diff_flux_points.ecsv"
    },
    {
     "path": "tests/spectrum/flux_points/flux_points_ctb_37b.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/flux_points_ctb_37b.txt",
     "filesize": 386,
-    "hashmd5": "7a0340e0a568ad9755304f4f4cf0fb1a"
+    "hashmd5": "7a0340e0a568ad9755304f4f4cf0fb1a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/flux_points_ctb_37b.txt"
    },
    {
     "path": "tests/spectrum/flux_points/binlike.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/spectrum/flux_points/binlike.fits",
     "filesize": 20160,
-    "hashmd5": "92209c4d47784f5c9db70541ecd0fb4f"
+    "hashmd5": "92209c4d47784f5c9db70541ecd0fb4f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/spectrum/flux_points/binlike.fits"
    },
    {
     "path": "tests/unbundled/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/README.rst",
     "filesize": 257,
-    "hashmd5": "7f2b2e7e963faf6464224434fbe474b3"
+    "hashmd5": "7f2b2e7e963faf6464224434fbe474b3",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/README.rst"
    },
    {
     "path": "tests/unbundled/hess/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/hess/README.rst",
     "filesize": 407,
-    "hashmd5": "514cb2ee58686547234bd6a6360a4e86"
+    "hashmd5": "514cb2ee58686547234bd6a6360a4e86",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/hess/README.rst"
    },
    {
     "path": "tests/unbundled/hess/survey/hess_survey_snippet.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/hess/survey/hess_survey_snippet.fits.gz",
     "filesize": 1491989,
-    "hashmd5": "a17033e411f6f1b14c59167783731cda"
+    "hashmd5": "a17033e411f6f1b14c59167783731cda",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/hess/survey/hess_survey_snippet.fits.gz"
    },
    {
     "path": "tests/unbundled/hess/survey/make.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/hess/survey/make.py",
     "filesize": 2023,
-    "hashmd5": "89b1b90b82d99508fb60abce7669456d"
+    "hashmd5": "89b1b90b82d99508fb60abce7669456d",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/hess/survey/make.py"
    },
    {
     "path": "tests/unbundled/fermi/gll_iem_v02_cutout.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/gll_iem_v02_cutout.fits",
     "filesize": 167040,
-    "hashmd5": "74ff01baa83fc9faf09137ae4f5ba7fd"
+    "hashmd5": "74ff01baa83fc9faf09137ae4f5ba7fd",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/gll_iem_v02_cutout.fits"
    },
    {
     "path": "tests/unbundled/fermi/make.sh",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/make.sh",
     "filesize": 747,
-    "hashmd5": "769340ef97c95c225852234f28c4dde4"
+    "hashmd5": "769340ef97c95c225852234f28c4dde4",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/make.sh"
    },
    {
     "path": "tests/unbundled/fermi/psf.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/psf.fits",
     "filesize": 60480,
-    "hashmd5": "1c1ea4e148592a9532a7b6593716115b"
+    "hashmd5": "1c1ea4e148592a9532a7b6593716115b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/psf.fits"
    },
    {
     "path": "tests/unbundled/fermi/isotropic_iem_v02.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/isotropic_iem_v02.txt",
     "filesize": 649,
-    "hashmd5": "b3cca3fc4e5db1c3b0c96856962692ec"
+    "hashmd5": "b3cca3fc4e5db1c3b0c96856962692ec",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/isotropic_iem_v02.txt"
    },
    {
     "path": "tests/unbundled/fermi/fermi_exposure.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/fermi_exposure.fits.gz",
     "filesize": 26271,
-    "hashmd5": "452cc0460dd5bb5561db04e97aa0c3f5"
+    "hashmd5": "452cc0460dd5bb5561db04e97aa0c3f5",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/fermi_exposure.fits.gz"
    },
    {
     "path": "tests/unbundled/fermi/fermi_irf_data.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/fermi_irf_data.fits",
     "filesize": 25920,
-    "hashmd5": "5c37c62623761487fd0d2498f357d61c"
+    "hashmd5": "5c37c62623761487fd0d2498f357d61c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/fermi_irf_data.fits"
    },
    {
     "path": "tests/unbundled/fermi/fermi_counts.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/fermi_counts.fits.gz",
     "filesize": 20912,
-    "hashmd5": "e8076e99111323c5c5bc3655574bb1d9"
+    "hashmd5": "e8076e99111323c5c5bc3655574bb1d9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/fermi_counts.fits.gz"
    },
    {
     "path": "tests/unbundled/fermi/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/fermi/README.rst",
     "filesize": 1710,
-    "hashmd5": "dbdc9ad06a186cb955414939241881d3"
+    "hashmd5": "dbdc9ad06a186cb955414939241881d3",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/fermi/README.rst"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/expected_ts_0.200.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.200.fits.gz",
     "filesize": 158597,
-    "hashmd5": "9ce87f442aae7131e5f43229ab83090a"
+    "hashmd5": "9ce87f442aae7131e5f43229ab83090a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.200.fits.gz"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/fit_sherpa_output.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/fit_sherpa_output.txt",
     "filesize": 1545,
-    "hashmd5": "c28b5c12dba4b9226a3ed26717eb8c8c"
+    "hashmd5": "c28b5c12dba4b9226a3ed26717eb8c8c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/fit_sherpa_output.txt"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/exclusion.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/exclusion.fits.gz",
     "filesize": 733,
-    "hashmd5": "ded0afa7af66204b6619f54b460009a7"
+    "hashmd5": "ded0afa7af66204b6619f54b460009a7",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/exclusion.fits.gz"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/counts.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/counts.fits.gz",
     "filesize": 15736,
-    "hashmd5": "8547c52beba37132ae90c0d5e1df5f87"
+    "hashmd5": "8547c52beba37132ae90c0d5e1df5f87",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/counts.fits.gz"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/expected_ts_0.050.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.050.fits.gz",
     "filesize": 372466,
-    "hashmd5": "01f9f8569c59f664e8ff8977e95613a0"
+    "hashmd5": "01f9f8569c59f664e8ff8977e95613a0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.050.fits.gz"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/fit_sherpa.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/fit_sherpa.py",
     "filesize": 1656,
-    "hashmd5": "d7fc6bf5f86fed4c3c04a5b346e6fdba"
+    "hashmd5": "d7fc6bf5f86fed4c3c04a5b346e6fdba",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/fit_sherpa.py"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/psf.json",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/psf.json",
     "filesize": 201,
-    "hashmd5": "3f748d332f91bf84cc2e72be8c87b9a6"
+    "hashmd5": "3f748d332f91bf84cc2e72be8c87b9a6",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/psf.json"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/expected_ts_0.000.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.000.fits.gz",
     "filesize": 357359,
-    "hashmd5": "495536584aef49fba5cd73394d8fdbe1"
+    "hashmd5": "495536584aef49fba5cd73394d8fdbe1",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.000.fits.gz"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/input_all.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/input_all.fits.gz",
     "filesize": 21958,
-    "hashmd5": "17af22fe4aa722acd2cbb2d2cd7a4636"
+    "hashmd5": "17af22fe4aa722acd2cbb2d2cd7a4636",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/input_all.fits.gz"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/README.md",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/README.md",
     "filesize": 1748,
-    "hashmd5": "c08cf45e24ca23f1437efe0c578c0b1f"
+    "hashmd5": "c08cf45e24ca23f1437efe0c578c0b1f",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/README.md"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/background.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/background.fits.gz",
     "filesize": 614,
-    "hashmd5": "e49c0d50b26a818f930397978f20cb1c"
+    "hashmd5": "e49c0d50b26a818f930397978f20cb1c",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/background.fits.gz"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/exposure.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/exposure.fits.gz",
     "filesize": 615,
-    "hashmd5": "0d270a544a1e134c8e645088a494ccad"
+    "hashmd5": "0d270a544a1e134c8e645088a494ccad",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/exposure.fits.gz"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/make.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/make.py",
     "filesize": 4519,
-    "hashmd5": "5add240ba9eebe98f0f09b5456edc4f5"
+    "hashmd5": "5add240ba9eebe98f0f09b5456edc4f5",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/make.py"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/model.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/model.fits.gz",
     "filesize": 4222,
-    "hashmd5": "bc256ff4b8e8699162dc1f59da60ede3"
+    "hashmd5": "bc256ff4b8e8699162dc1f59da60ede3",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/model.fits.gz"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/expected_ts_0.100.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.100.fits.gz",
     "filesize": 278529,
-    "hashmd5": "e78f838abcf84fe9ceb99b236638561b"
+    "hashmd5": "e78f838abcf84fe9ceb99b236638561b",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/expected_ts_0.100.fits.gz"
    },
    {
     "path": "tests/unbundled/poisson_stats_image/source.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/poisson_stats_image/source.fits.gz",
     "filesize": 33637,
-    "hashmd5": "45ba50d3e49c2dcd138a681650620161"
+    "hashmd5": "45ba50d3e49c2dcd138a681650620161",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/poisson_stats_image/source.fits.gz"
    },
    {
     "path": "tests/unbundled/irfs/aeff2D.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/irfs/aeff2D.fits",
     "filesize": 20160,
-    "hashmd5": "0111e52b2d764effaa5b52a6d6248628"
+    "hashmd5": "0111e52b2d764effaa5b52a6d6248628",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/irfs/aeff2D.fits"
    },
    {
     "path": "tests/unbundled/irfs/psf.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/irfs/psf.fits",
     "filesize": 14400,
-    "hashmd5": "c7be3386faab9bcff09865988e3957c0"
+    "hashmd5": "c7be3386faab9bcff09865988e3957c0",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/irfs/psf.fits"
    },
    {
     "path": "tests/unbundled/irfs/arf.fits",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/irfs/arf.fits",
     "filesize": 11520,
-    "hashmd5": "e63c21afb39ab6319a1e578a50401700"
+    "hashmd5": "e63c21afb39ab6319a1e578a50401700",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/irfs/arf.fits"
    },
    {
     "path": "tests/unbundled/tev_spectra/electron_spectrum_fermi.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/electron_spectrum_fermi.txt",
     "filesize": 5757,
-    "hashmd5": "7ad394aa1c4fbe64baf9aa4495000c15"
+    "hashmd5": "7ad394aa1c4fbe64baf9aa4495000c15",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/electron_spectrum_fermi.txt"
    },
    {
     "path": "tests/unbundled/tev_spectra/format_crab_sed.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/format_crab_sed.py",
     "filesize": 5895,
-    "hashmd5": "d56f8fd5ff9daca34f258e71c6c673ea"
+    "hashmd5": "d56f8fd5ff9daca34f258e71c6c673ea",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/format_crab_sed.py"
    },
    {
     "path": "tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy_systematic_uncertainty.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy_systematic_uncertainty.txt",
     "filesize": 551,
-    "hashmd5": "eac8ed2f88ada7971ee9d831ba9250a3"
+    "hashmd5": "eac8ed2f88ada7971ee9d831ba9250a3",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy_systematic_uncertainty.txt"
    },
    {
     "path": "tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy.txt",
     "filesize": 602,
-    "hashmd5": "d8652a02161768523c0c0d9ac4fb9882"
+    "hashmd5": "d8652a02161768523c0c0d9ac4fb9882",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_low_energy.txt"
    },
    {
     "path": "tests/unbundled/tev_spectra/crab_mwl.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/crab_mwl.rst",
     "filesize": 798,
-    "hashmd5": "af9cad4e8b3fac6962473ffb0a00cb54"
+    "hashmd5": "af9cad4e8b3fac6962473ffb0a00cb54",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/crab_mwl.rst"
    },
    {
     "path": "tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi.txt",
     "filesize": 1065,
-    "hashmd5": "ebfd873e126764669a37351fdae9e148"
+    "hashmd5": "ebfd873e126764669a37351fdae9e148",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi.txt"
    },
    {
     "path": "tests/unbundled/tev_spectra/electron_spectrum_hess_systematic_uncertainty.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_systematic_uncertainty.txt",
     "filesize": 461,
-    "hashmd5": "8501c3e531ad8dbf08896b90945cbfa4"
+    "hashmd5": "8501c3e531ad8dbf08896b90945cbfa4",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess_systematic_uncertainty.txt"
    },
    {
     "path": "tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi2.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi2.txt",
     "filesize": 2398,
-    "hashmd5": "7c7f170911f246fdeb342e097f0907b4"
+    "hashmd5": "7c7f170911f246fdeb342e097f0907b4",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/diffuse_isotropic_gamma_spectrum_fermi2.txt"
    },
    {
     "path": "tests/unbundled/tev_spectra/crab_hess_spec.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/crab_hess_spec.txt",
     "filesize": 1160,
-    "hashmd5": "ddfe9884be993372d57da86b9e4074f6"
+    "hashmd5": "ddfe9884be993372d57da86b9e4074f6",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/crab_hess_spec.txt"
    },
    {
     "path": "tests/unbundled/tev_spectra/crab_mwl.fits.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/crab_mwl.fits.gz",
     "filesize": 14132,
-    "hashmd5": "008c8993e87831d8af9a35d13717d6be"
+    "hashmd5": "008c8993e87831d8af9a35d13717d6be",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/crab_mwl.fits.gz"
    },
    {
     "path": "tests/unbundled/tev_spectra/electron_spectrum_hess.txt",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess.txt",
     "filesize": 491,
-    "hashmd5": "197d86aecb7f765d6c58e04ade159104"
+    "hashmd5": "197d86aecb7f765d6c58e04ade159104",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/datasets/tests/unbundled/tev_spectra/electron_spectrum_hess.txt"
    }
   ]
  },
@@ -3037,55 +3531,106 @@
     "path": "figures/README.rst",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/README.rst",
     "filesize": 394,
-    "hashmd5": "f1c2f5041cfec175494a49e23b7f0549"
+    "hashmd5": "f1c2f5041cfec175494a49e23b7f0549",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/README.rst"
    },
    {
     "path": "figures/detect/fermi_ts_image.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/detect/fermi_ts_image.png",
     "filesize": 86096,
-    "hashmd5": "4e86dc05a5987812aa879b8fcf0864d2"
+    "hashmd5": "4e86dc05a5987812aa879b8fcf0864d2",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/detect/fermi_ts_image.png"
    },
    {
     "path": "figures/background/bg_cube_model_true_reco.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/background/bg_cube_model_true_reco.png",
     "filesize": 270031,
-    "hashmd5": "9d78b3514ae1c7c2d90f76b1feb99b75"
+    "hashmd5": "9d78b3514ae1c7c2d90f76b1feb99b75",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/background/bg_cube_model_true_reco.png"
+   },
+   {
+    "path": "figures/general/data_flow_full.drawio",
+    "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_full.drawio",
+    "filesize": 1813,
+    "hashmd5": "4f114280150a7dc519e545eb9c69b106",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_full.drawio"
+   },
+   {
+    "path": "figures/general/data_flow_full.pdf",
+    "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_full.pdf",
+    "filesize": 49800,
+    "hashmd5": "4077d9ec587b0eb0d0935a969aa22157",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_full.pdf"
+   },
+   {
+    "path": "figures/general/data_flow_full.png",
+    "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_full.png",
+    "filesize": 35283,
+    "hashmd5": "b7fbdf92174bb589587b07ccf30f67f5",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_full.png"
+   },
+   {
+    "path": "figures/general/data_flow_gammapy.drawio",
+    "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_gammapy.drawio",
+    "filesize": 205449,
+    "hashmd5": "c25b7700328f4675f462c2ea7a2c59fa",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_gammapy.drawio"
+   },
+   {
+    "path": "figures/general/data_flow_gammapy.png",
+    "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_gammapy.png",
+    "filesize": 433104,
+    "hashmd5": "bd1eddc23b2260e6fcf4411e69f28daf",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_gammapy.png"
+   },
+   {
+    "path": "figures/general/data_flow_gammapy.pdf",
+    "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/general/data_flow_gammapy.pdf",
+    "filesize": 211135,
+    "hashmd5": "4e7fb139af8ff0ad98a7d8b34865ab7a",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/general/data_flow_gammapy.pdf"
    },
    {
     "path": "figures/image/survey_example.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/image/survey_example.png",
     "filesize": 18305,
-    "hashmd5": "5cc9be28fb1f5675043c9c6574ef81ac"
+    "hashmd5": "5cc9be28fb1f5675043c9c6574ef81ac",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/image/survey_example.png"
    },
    {
     "path": "figures/time/example_robust_periodogram.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/time/example_robust_periodogram.png",
     "filesize": 87468,
-    "hashmd5": "2b567895a0f68f026806782e8fd06b29"
+    "hashmd5": "2b567895a0f68f026806782e8fd06b29",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/time/example_robust_periodogram.png"
    },
    {
     "path": "figures/time/example_spectral_window_function.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/time/example_spectral_window_function.png",
     "filesize": 51871,
-    "hashmd5": "fe2286ca3f07d9199a97d0f3ab9b97c9"
+    "hashmd5": "fe2286ca3f07d9199a97d0f3ab9b97c9",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/time/example_spectral_window_function.png"
    },
    {
     "path": "figures/time/example_robust_periodogram.py",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/time/example_robust_periodogram.py",
     "filesize": 2670,
-    "hashmd5": "fb502cd1fa578fd2d4a11d7a8db387ed"
+    "hashmd5": "fb502cd1fa578fd2d4a11d7a8db387ed",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/time/example_robust_periodogram.py"
    },
    {
     "path": "figures/tutorials/crab_mwl.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/tutorials/crab_mwl.png",
     "filesize": 55226,
-    "hashmd5": "59d7ce08ce854701acb96a2f2bd593aa"
+    "hashmd5": "59d7ce08ce854701acb96a2f2bd593aa",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/tutorials/crab_mwl.png"
    },
    {
     "path": "figures/spectrum/simulated_obs.png",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/figures/spectrum/simulated_obs.png",
     "filesize": 100201,
-    "hashmd5": "01c2b735983713674b69ff981f6cc374"
+    "hashmd5": "01c2b735983713674b69ff981f6cc374",
+    "itempath": "/Users/jer/git/gammapy/gammapy-extra/figures/spectrum/simulated_obs.png"
    }
   ]
  }

--- a/dev/datasets/make_dataset_index.py
+++ b/dev/datasets/make_dataset_index.py
@@ -228,6 +228,7 @@ class DownloadDatasetIndex:
                 destination = Path(os.environ["GAMMAPY_DATA"]) / f["path"]
                 log.info(f"Moving {f['itempath']}")
                 shutil.copyfile(f["itempath"], destination)
+                del f["itempath"]
 
         txt = json.dumps(records, indent=True)
         log.info("Writing {}".format(self.path))

--- a/dev/datasets/make_dataset_index.py
+++ b/dev/datasets/make_dataset_index.py
@@ -4,13 +4,13 @@
 This is very much work in progress.
 Probably we should add a static website build step.
 """
-import logging
+import hashlib
 import json
+import logging
 import os
+import shutil
 from pathlib import Path
 import click
-import hashlib
-import shutil
 
 log = logging.getLogger(__name__)
 path_temp = Path("datasets")
@@ -225,9 +225,9 @@ class DownloadDatasetIndex:
         records = list(self.make_records())
         for rec in records:
             for f in rec["files"]:
-                destination = Path(os.environ["GAMMAPY_DATA"]) / f['path']
+                destination = Path(os.environ["GAMMAPY_DATA"]) / f["path"]
                 log.info(f"Moving {f['itempath']}")
-                shutil.copyfile(f['itempath'], destination)
+                shutil.copyfile(f["itempath"], destination)
 
         txt = json.dumps(records, indent=True)
         log.info("Writing {}".format(self.path))

--- a/dev/datasets/make_dataset_index.py
+++ b/dev/datasets/make_dataset_index.py
@@ -10,8 +10,10 @@ import os
 from pathlib import Path
 import click
 import hashlib
+import shutil
 
 log = logging.getLogger(__name__)
+path_temp = Path("datasets")
 
 
 def hashmd5(path):
@@ -36,8 +38,8 @@ class DownloadDataset:
 
     The followLinks flag declares how to build the destination paths in the local desktop
     according to the datasets paths used in the tutorials.
-        GAMMAPY-EXTRA: datasets stored in Gammapy-extra reporsitory
-        JOINT-CRAB: datasets stored in Joint-crab reporsitory
+        GAMMAPY-EXTRA: datasets stored in Gammapy-extra repository
+        JOINT-CRAB: datasets stored in Joint-crab repository
         OTHERS: datasets stored in others repositories
     """
 
@@ -79,6 +81,7 @@ class DownloadDataset:
                 "url": self.base_url + urlpath,
                 "filesize": filesize,
                 "hashmd5": md5,
+                "itempath": str(itempath),
             }
 
 
@@ -220,6 +223,12 @@ class DownloadDatasetIndex:
 
     def make(self):
         records = list(self.make_records())
+        for rec in records:
+            for f in rec["files"]:
+                destination = Path(os.environ["GAMMAPY_DATA"]) / f['path']
+                log.info(f"Moving {f['itempath']}")
+                shutil.copyfile(f['itempath'], destination)
+
         txt = json.dumps(records, indent=True)
         log.info("Writing {}".format(self.path))
         Path(self.path).write_text(txt)
@@ -244,7 +253,7 @@ def cli_all(ctx):
 
 @cli.command("dataset-index")
 def cli_download_dataset_index():
-    """Generate dataset index JSON file"""
+    """Generate dataset index JSON file and write files in gammapy-data local repo"""
     DownloadDatasetIndex().make()
 
 

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -54,10 +54,7 @@ For three or more things, using a Python ``dict`` instead should be preferred.
 Python version support
 ----------------------
 
-In Gammapy we currently support Python 3.5 or later.
-
-We plan to discuss later in 2019 whether to bump the version requirement to Python 3.6,
-to be able to take advantage of the new features introduced there.
+In Gammapy we currently support Python 3.7 or later.
 
 .. _dev-skip_tests:
 
@@ -73,6 +70,22 @@ Skip unit tests for some Astropy versions
    @pytest.mark.xfail(ASTROPY_VERSION < (0, 4), reason="Astropy API change")
    def test_something():
       ...
+
+Making a pull request with new or modified datasets
+---------------------------------------------------
+
+Datasets used in tests and tutorials are hosted in the
+`gammapy-data Github repository <https://github.com/gammapy/gammapy-data>`__. It is recommended that developers
+have `$GAMMAPY_DATA` environment variable pointing to the local folder where they have fetched the `gammapy-data` Github
+repository, so they can push and pull eventual modification of its content. In the cases they want to make a pull
+request with new or modified datasets, these are the steps to follow:
+
+#. Update the content of the remote specific dataset repository (i.e. `gammapy-extra`, `gammapy-fermi-lat-data`,
+   `gamma-cat`).
+#. Update the content of your local `gammapy-data` repository and JSON index file by runinng
+   `python make_datasets_index.py` in the `dev/datasets/` folder.
+#. Push eventual changes in `gammapy-data` to remote repository and re-tag the `master` tag.
+
 
 Fix non-Unix line endings
 -------------------------
@@ -90,7 +103,6 @@ Here's to commands to check for and fix this (see `here <http://stackoverflow.co
     $ cd astropy_helpers && git checkout -- . && cd ..
 
 .. _dev-check_html_links:
-
 
 What checks and conversions should I do for inputs?
 ---------------------------------------------------

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -82,9 +82,9 @@ request with new or modified datasets, these are the steps to follow:
 
 #. Update the content of the remote specific dataset repository (i.e. `gammapy-extra`, `gammapy-fermi-lat-data`,
    `gamma-cat`).
-#. Update the content of your local `gammapy-data` repository and JSON index file by runinng
+#. Update the content of your local `gammapy-data` repository and JSON index file by running
    `python make_datasets_index.py` in the `dev/datasets/` folder.
-#. Push eventual changes in `gammapy-data` to remote repository and re-tag the `master` tag.
+#. Push eventual changes to remote `gammapy-data` Github repository.
 
 
 Fix non-Unix line endings

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -60,6 +60,7 @@ Steps for the day of the release:
 
 #. Update the dataset index file by running `make dataset-index` and copy it over to `gammapy-0.14-data-index.json` in
    the webpage repo.
+#. Check if content in `gammapy-data` repository has changed and push the content and re-tag as master if so.
 #. Copy over `notebooks.yaml` to `gammapy-0.14-tutorials.yml` and adapt the links contained
    in the file to point to `https://docs.gammapy.org/0.14/_static/notebooks`.
 #. Copy the script index file from the last release to `gammapy-0.14-scripts.yml`

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -60,7 +60,6 @@ Steps for the day of the release:
 
 #. Update the dataset index file by running `make dataset-index` and copy it over to `gammapy-0.14-data-index.json` in
    the webpage repo.
-#. Check if content in `gammapy-data` repository has changed and push the content and re-tag as master if so.
 #. Copy over `notebooks.yaml` to `gammapy-0.14-tutorials.yml` and adapt the links contained
    in the file to point to `https://docs.gammapy.org/0.14/_static/notebooks`.
 #. Copy the script index file from the last release to `gammapy-0.14-scripts.yml`

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -52,5 +52,6 @@ dependencies:
   - numdifftools
   - twine
   - parfive
+  - tqdm
   - yamllint
   - pydantic

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -52,6 +52,7 @@ dependencies:
   - numdifftools
   - twine
   - parfive
+  - requests
   - tqdm
   - yamllint
   - pydantic

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -65,22 +65,23 @@ def cli_download_scripts(src, out, release, modetutorials, silent):
 
 @click.command(name="datasets")
 @click.option("--src", default="", help="Specific dataset to download.")
-@click.option("--release", default="", help="Number of release - ex: 0.12")
 @click.option(
     "--out",
     default="gammapy-datasets",
-    help="Path where datasets will be copied.",
+    help="Destination folder.",
     show_default=True,
 )
-@click.option(
-    "--tests",
-    default=False,
-    is_flag=True,
-    help="Include datasets needed for development tests.",
-)
+@click.option("--release", default="", help="Number of release - ex: 0.12")
 @click.option("--modetutorials", default=False, hidden=True)
 @click.option("--silent", default=True, is_flag=True, hidden=True)
-def cli_download_datasets(src, out, release, tests, modetutorials, silent):
+@click.option(
+    "--tests",
+    default=True,
+    is_flag=True,
+    help="Include datasets needed for tests. [default: True]",
+    hidden=True
+)
+def cli_download_datasets(src, out, release, modetutorials, silent, tests):
     """Download datasets"""
     plan = ComputePlan(
         src, out, release, "datasets", modetutorials=modetutorials, download_tests=tests

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -19,7 +19,7 @@ def progress_download(source, destination):
         return
 
     with requests.get(source, stream=True) as r:
-        total_size = int(r.headers.get('content-length'))
+        total_size = int(r.headers.get('content-length')) if r.headers.get('content-length') else 152*1024*1024
         progress_bar = tqdm(total=total_size, unit='B', unit_scale=True, unit_divisor=1024)
         with open(destination, 'wb') as f:
             for chunk in r.iter_content(chunk_size=1024):

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -3,6 +3,7 @@
 import logging
 import click
 from .downloadclasses import ComputePlan, ParallelDownload
+from pathlib import Path
 
 log = logging.getLogger(__name__)
 
@@ -86,15 +87,23 @@ def cli_download_datasets(src, out, release, modetutorials, silent, tests):
     plan = ComputePlan(
         src, out, release, "datasets", modetutorials=modetutorials, download_tests=tests
     )
+    filelist = plan.getfilelist()
+    localfolder = plan.getlocalfolder()
     down = ParallelDownload(
-        plan.getfilelist(),
-        plan.getlocalfolder(),
+        filelist,
+        localfolder,
         release,
         "datasets",
         modetutorials,
         silent,
     )
-    down.run()
+    # tar bundle
+    if "bundle" in filelist:
+        log.info(f"Downloading datasets from {filelist['bundle']['url']}")
+        tar_destination_file = Path(localfolder) / "datasets.tar.gz"
+    # specific collection
+    else:
+        down.run()
     down.show_info_datasets()
 
 

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -1,13 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Command line tool to download datasets and notebooks"""
 import logging
+import tarfile
+from pathlib import Path
 import click
 import requests
-import tarfile
-from .downloadclasses import ComputePlan, ParallelDownload
-from pathlib import Path
 from tqdm import tqdm
-
+from .downloadclasses import ComputePlan, ParallelDownload
 
 log = logging.getLogger(__name__)
 
@@ -19,9 +18,9 @@ def progress_download(source, destination):
         return
 
     with requests.get(source, stream=True) as r:
-        total_size = int(r.headers.get('content-length')) if r.headers.get('content-length') else 152*1024*1024
-        progress_bar = tqdm(total=total_size, unit='B', unit_scale=True, unit_divisor=1024)
-        with open(destination, 'wb') as f:
+        total_size = (int(r.headers.get("content-length")) if r.headers.get("content-length") else 152 * 1024 * 1024)
+        progress_bar = tqdm(total=total_size, unit="B", unit_scale=True, unit_divisor=1024)
+        with open(destination, "wb") as f:
             for chunk in r.iter_content(chunk_size=1024):
                 if chunk:
                     f.write(chunk)
@@ -102,10 +101,7 @@ def cli_download_scripts(src, out, release, modetutorials, silent):
 @click.command(name="datasets")
 @click.option("--src", default="", help="Specific dataset to download.")
 @click.option(
-    "--out",
-    default="gammapy-datasets",
-    help="Destination folder.",
-    show_default=True,
+    "--out", default="gammapy-datasets", help="Destination folder.", show_default=True,
 )
 @click.option("--release", default="", help="Number of release - ex: 0.12")
 @click.option("--modetutorials", default=False, hidden=True)
@@ -115,7 +111,7 @@ def cli_download_scripts(src, out, release, modetutorials, silent):
     default=True,
     is_flag=True,
     help="Include datasets needed for tests. [default: True]",
-    hidden=True
+    hidden=True,
 )
 def cli_download_datasets(src, out, release, modetutorials, silent, tests):
     """Download datasets"""
@@ -125,18 +121,13 @@ def cli_download_datasets(src, out, release, modetutorials, silent, tests):
     filelist = plan.getfilelist()
     localfolder = plan.getlocalfolder()
     down = ParallelDownload(
-        filelist,
-        localfolder,
-        release,
-        "datasets",
-        modetutorials,
-        silent,
+        filelist, localfolder, release, "datasets", modetutorials, silent,
     )
     # tar bundle
     if "bundle" in filelist:
         log.info(f"Downloading datasets from {filelist['bundle']['url']}")
         tar_destination_file = Path(localfolder) / "datasets.tar.gz"
-        progress_download(filelist['bundle']['url'], tar_destination_file)
+        progress_download(filelist["bundle"]["url"], tar_destination_file)
         log.info(f"Extracting {tar_destination_file}")
         extract_bundle(tar_destination_file, localfolder)
 

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -27,17 +27,18 @@ def progress_download(source, destination):
     progress_bar.close()
 
 
-def members(tf, master_folder):
-    l = len(master_folder)
-    for member in tf.getmembers():
-        if member.path.startswith(master_folder):
-            member.path = member.path[l:]
+def members(tf):
+    list_members = tf.getmembers()
+    root_folder = list_members[0].name
+    for member in list_members:
+        if member.path.startswith(root_folder):
+            member.path = member.path[len(root_folder)+1:]
             yield member
 
 
 def extract_bundle(bundle, destination):
     with tarfile.open(bundle) as tar:
-        tar.extractall(path=destination, members=members(tar, "gammapy-data-master/"))
+        tar.extractall(path=destination, members=members(tar))
     Path(bundle).unlink()
 
 

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -8,17 +8,15 @@ import requests
 from tqdm import tqdm
 from .downloadclasses import ComputePlan, ParallelDownload
 
+
+BUNDLESIZE = 152  # in MB
 log = logging.getLogger(__name__)
 
 
 def progress_download(source, destination):
     destination.parent.mkdir(parents=True, exist_ok=True)
-    if destination.exists():
-        print("Already exists !!!")
-        return
-
     with requests.get(source, stream=True) as r:
-        total_size = (int(r.headers.get("content-length")) if r.headers.get("content-length") else 152 * 1024 * 1024)
+        total_size = (int(r.headers.get("content-length")) if r.headers.get("content-length") else BUNDLESIZE * 1024 * 1024)
         progress_bar = tqdm(total=total_size, unit="B", unit_scale=True, unit_divisor=1024)
         with open(destination, "wb") as f:
             for chunk in r.iter_content(chunk_size=1024):

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -4,8 +4,6 @@ import logging
 import tarfile
 from pathlib import Path
 import click
-import requests
-from tqdm import tqdm
 from .downloadclasses import ComputePlan, ParallelDownload
 
 
@@ -14,6 +12,9 @@ log = logging.getLogger(__name__)
 
 
 def progress_download(source, destination):
+    import requests
+    from tqdm import tqdm
+
     destination.parent.mkdir(parents=True, exist_ok=True)
     with requests.get(source, stream=True) as r:
         total_size = (int(r.headers.get("content-length")) if r.headers.get("content-length") else BUNDLESIZE * 1024 * 1024)

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -129,7 +129,12 @@ class ComputePlan:
                 return self.listfiles
             # collection of files
             if self.release:
-                url_datasets_json = RELEASES_BASE_URL + "/data/gammapy-" + self.release + "-data-index.json"
+                url_datasets_json = (
+                    RELEASES_BASE_URL
+                    + "/data/gammapy-"
+                    + self.release
+                    + "-data-index.json"
+                )
                 log.info(f"Reading {url_datasets_json}")
                 try:
                     txt = urlopen(url_datasets_json).read().decode("utf-8")
@@ -138,7 +143,9 @@ class ComputePlan:
                     return False
             else:
                 # for development just use the local index file
-                local_datasets_json = (Path(__file__).parent / DEV_DATA_JSON_LOCAL).resolve()
+                local_datasets_json = (
+                    Path(__file__).parent / DEV_DATA_JSON_LOCAL
+                ).resolve()
                 log.info(f"Reading {local_datasets_json}")
                 txt = local_datasets_json.read_text()
             datasets = json.loads(txt)

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -11,11 +11,11 @@ from gammapy import __version__
 
 log = logging.getLogger(__name__)
 
-BASE_URL = "https://gammapy.org/download"
-BASE_URL_DEV = "https://raw.githubusercontent.com/gammapy/gammapy/master/"
-DEV_NBS_YAML_URL = BASE_URL_DEV + "tutorials/notebooks.yaml"
-DEV_SCRIPTS_YAML_URL = BASE_URL_DEV + "examples/scripts.yaml"
-DEV_DATA_JSON_LOCAL = "../../dev/datasets/gammapy-data-index.json"
+RELEASES_BASE_URL = "https://gammapy.org/download"
+DEV_NBS_YAML_URL = "https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/notebooks.yaml"
+DEV_SCRIPTS_YAML_URL = "https://raw.githubusercontent.com/gammapy/gammapy/master/examples/scripts.yaml"
+TAR_BUNDLE = "https://github.com/gammapy/gammapy-data/archive/master.tar.gz"    # Curated datasets bundle
+DEV_DATA_JSON_LOCAL = "../../dev/datasets/gammapy-data-index.json"              # CI tests
 
 
 def parse_datafiles(datasearch, datasetslist, download_tests=False):
@@ -74,7 +74,7 @@ class ComputePlan:
 
         dl = Downloader(progress=False, file_progress=False)
         filename_env = "gammapy-" + self.release + "-environment.yml"
-        url_file_env = BASE_URL + "/install/" + filename_env
+        url_file_env = RELEASES_BASE_URL + "/install/" + filename_env
         filepath_env = str(self.outfolder / filename_env)
         dl.enqueue_file(url_file_env, path=filepath_env)
         try:
@@ -125,20 +125,18 @@ class ComputePlan:
                 sys.exit()
 
             if self.release:
-                filename_datasets = "gammapy-" + self.release + "-data-index.json"
-                url = BASE_URL + "/data/" + filename_datasets
-                log.info(f"Reading {url}")
+                url_datasets_json = RELEASES_BASE_URL + "/data/gammapy-" + self.release + "-data-index.json"
+                log.info(f"Reading {url_datasets_json}")
                 try:
-                    txt = urlopen(url).read().decode("utf-8")
+                    txt = urlopen(url_datasets_json).read().decode("utf-8")
                 except Exception as ex:
                     log.error(ex)
                     return False
             else:
                 # for development just use the local index file
-                filename = (Path(__file__).parent / DEV_DATA_JSON_LOCAL).resolve()
-                log.info(f"Reading {filename}")
-                txt = filename.read_text()
-
+                local_datasets_json = (Path(__file__).parent / DEV_DATA_JSON_LOCAL).resolve()
+                log.info(f"Reading {local_datasets_json}")
+                txt = local_datasets_json.read_text()
             datasets = json.loads(txt)
             datafound = {}
             if not self.modetutorials:
@@ -166,7 +164,7 @@ class ComputePlan:
         url = DEV_NBS_YAML_URL
         if self.release:
             filename_nbs = "gammapy-" + self.release + "-tutorials.yml"
-            url = BASE_URL + "/tutorials/" + filename_nbs
+            url = RELEASES_BASE_URL + "/tutorials/" + filename_nbs
 
         log.info(f"Reading {url}")
         try:
@@ -194,7 +192,7 @@ class ComputePlan:
         url = DEV_SCRIPTS_YAML_URL
         if self.release:
             filename_scripts = "gammapy-" + self.release + "-scripts.yml"
-            url = BASE_URL + "/tutorials/" + filename_scripts
+            url = RELEASES_BASE_URL + "/tutorials/" + filename_scripts
 
         log.info(f"Reading {url}")
         try:

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -123,7 +123,11 @@ class ComputePlan:
         if self.option == "datasets":
             if self.modetutorials and not self.listfiles:
                 sys.exit()
-
+            # datasets bundle
+            if not self.src:
+                self.listfiles = {"bundle": {"path": self.outfolder, "url": TAR_BUNDLE}}
+                return self.listfiles
+            # collection of files
             if self.release:
                 url_datasets_json = RELEASES_BASE_URL + "/data/gammapy-" + self.release + "-data-index.json"
                 log.info(f"Reading {url_datasets_json}")

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -14,8 +14,8 @@ log = logging.getLogger(__name__)
 RELEASES_BASE_URL = "https://gammapy.org/download"
 DEV_NBS_YAML_URL = "https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/notebooks.yaml"
 DEV_SCRIPTS_YAML_URL = "https://raw.githubusercontent.com/gammapy/gammapy/master/examples/scripts.yaml"
-TAR_BUNDLE = "https://github.com/gammapy/gammapy-data/archive/master.tar.gz"    # Curated datasets bundle
-DEV_DATA_JSON_LOCAL = "../../dev/datasets/gammapy-data-index.json"              # CI tests
+TAR_BUNDLE = "https://github.com/gammapy/gammapy-data/tarball/master"       # Curated datasets bundle
+DEV_DATA_JSON_LOCAL = "../../dev/datasets/gammapy-data-index.json"          # CI tests
 
 
 def parse_datafiles(datasearch, datasetslist, download_tests=False):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request significantly modifies the way how the datasets are downloaded internally with `gammapy download datasets` and `gammapy download tutorials`. It solves latest issues found with parallelized download of files due to *"[429] too many requests"* errors that Github throws (see also https://github.com/gammapy/gammapy/pull/2838)

The datasets are now downloaded as a single compressed file hosted in the new [gammapy-data Github repository](https://github.com/gammapy/gammapy-data), and then extracted into the destination folder. This modification is completely transparent to the user since  `gammapy download` keeps the same options, parameters and behaves in the same way in the front-end. 

On the other hand, it changes the development workflow for PRs where datasets are added or modified. In these rare cases, a previous sync  with [gammapy-data Github repository](https://github.com/gammapy/gammapy-data) has to be done, as well as re-tagging the `master` tag.

