### PR TITLE
TemplateSpatialModel in sr-1

### DIFF
--- a/examples/models/spatial/plot_template.py
+++ b/examples/models/spatial/plot_template.py
@@ -23,6 +23,7 @@ from gammapy.modeling.models import (
 filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
 
 m = Map.read(filename)
+m.unit = "sr^-1"
 model = TemplateSpatialModel(m)
 
 model.plot(add_cbar=True)

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -607,8 +607,9 @@ class TemplateSpatialModel(SpatialModel):
         """
         m = Map.read(filename, **kwargs)
 
-        if m.unit == "":
+        if not m.unit.is_equivalent("sr-1"):
             m.unit = "sr-1"
+            log.warning("Spatial template unit is not equivalent to sr^-1")
 
         return cls(m, normalize=normalize, filename=filename)
 
@@ -631,8 +632,9 @@ class TemplateSpatialModel(SpatialModel):
     def from_dict(cls, data):
         m = Map.read(data["filename"])
 
-        if m.unit == "":
+        if not m.unit.is_equivalent("sr-1"):
             m.unit = "sr-1"
+            log.warning("Spatial template unit is not equivalent to sr^-1")
 
         parameters = Parameters.from_dict(data["parameters"])
         return cls.from_parameters(

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -609,7 +609,9 @@ class TemplateSpatialModel(SpatialModel):
 
         if not m.unit.is_equivalent("sr-1"):
             m.unit = "sr-1"
-            log.warning("Spatial template unit is not equivalent to sr^-1")
+            log.warning(
+                "Spatial template unit is not equivalent to sr^-1, unit changed to sr^-1"
+            )
 
         return cls(m, normalize=normalize, filename=filename)
 
@@ -634,7 +636,9 @@ class TemplateSpatialModel(SpatialModel):
 
         if not m.unit.is_equivalent("sr-1"):
             m.unit = "sr-1"
-            log.warning("Spatial template unit is not equivalent to sr^-1")
+            log.warning(
+                "Spatial template unit is not equivalent to sr^-1, unit changed to sr^-1"
+            )
 
         parameters = Parameters.from_dict(data["parameters"])
         return cls.from_parameters(

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -157,7 +157,9 @@ def test_absorption_io(tmp_path):
 def make_all_models():
     """Make an instance of each model, for testing."""
     yield Model.create("ConstantSpatialModel")
-    yield Model.create("TemplateSpatialModel", map=Map.create(npix=(10, 20)))
+    map = Map.create(npix=(10, 20))
+    map.unit = "sr-1"
+    yield Model.create("TemplateSpatialModel", map=map)
     yield Model.create("DiskSpatialModel", lon_0="1 deg", lat_0="2 deg", r_0="3 deg")
     yield Model.create(
         "GaussianSpatialModel", lon_0="1 deg", lat_0="2 deg", sigma="3 deg"

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -157,9 +157,8 @@ def test_absorption_io(tmp_path):
 def make_all_models():
     """Make an instance of each model, for testing."""
     yield Model.create("ConstantSpatialModel")
-    map = Map.create(npix=(10, 20))
-    map.unit = "sr-1"
-    yield Model.create("TemplateSpatialModel", map=map)
+    map_constantmodel = Map.create(npix=(10, 20), unit="sr-1")
+    yield Model.create("TemplateSpatialModel", map=map_constantmodel)
     yield Model.create("DiskSpatialModel", lon_0="1 deg", lat_0="2 deg", r_0="3 deg")
     yield Model.create(
         "GaussianSpatialModel", lon_0="1 deg", lat_0="2 deg", sigma="3 deg"

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -184,7 +184,7 @@ def test_sky_shell():
     lon = [1, 2, 4] * u.deg
     lat = 45 * u.deg
     val = model(lon, lat)
-    assert val.unit == "sr-1"
+    assert val.unit == "deg-2"
     desired = [55.979449, 57.831651, 94.919895]
     assert_allclose(val.to_value("sr-1"), desired)
     radius = model.evaluation_radius

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -184,7 +184,7 @@ def test_sky_shell():
     lon = [1, 2, 4] * u.deg
     lat = 45 * u.deg
     val = model(lon, lat)
-    assert val.unit == "deg-2"
+    assert val.unit == "sr-1"
     desired = [55.979449, 57.831651, 94.919895]
     assert_allclose(val.to_value("sr-1"), desired)
     radius = model.evaluation_radius
@@ -227,6 +227,7 @@ def test_sky_diffuse_map_normalize():
     # define model map with a constant value of 1
     model_map = Map.create(map_type="wcs", width=(10, 5), binsz=0.5)
     model_map.data += 1.0
+    model_map.unit = "sr-1"
     model = TemplateSpatialModel(model_map)
 
     # define data map with a different spatial binning


### PR DESCRIPTION
This PR fix a small bug for the TemplateSpatialModel. In the evaluate model, it is returning a Quantity in Map.unit instead of sr-1. This create unit error for example in the compute_npred() of the cube if you didn't define the unit of the model as sr-1.

It is now forced to give the unit as sr-1.

- harmonise the return of the API for the `ShellSpatialModel` and `ConstantSpatialModel` for the return of evaluate