### PR TITLE
Fix bug in MapDatasetEventSampler

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -86,7 +86,11 @@ class MapDatasetEventSampler:
                 temporal_model = ConstantTemporalModel()
 
             table = self._sample_coord_time(npred, temporal_model, dataset.gti)
-            table["MC_ID"] = idx + 1
+            if len(table) > 0:
+                table["MC_ID"] = idx + 1
+            else:
+                mcid = table.Column(name="MC_ID", length=len(table), dtype=int)
+                table.add_column(mcid)
             events_all.append(EventList(table))
 
         return EventList.stack(events_all)
@@ -316,13 +320,13 @@ class MapDatasetEventSampler:
         if len(dataset.models) > 1:
             events_src = self.sample_sources(dataset)
 
-            if dataset.psf:
+            if dataset.psf and (len(events_src.table) > 0):
                 events_src = self.sample_psf(dataset.psf, events_src)
             else:
                 events_src.table["RA"] = events_src.table["RA_TRUE"]
                 events_src.table["DEC"] = events_src.table["DEC_TRUE"]
 
-            if dataset.edisp:
+            if dataset.edisp and (len(events_src.table) > 0):
                 events_src = self.sample_edisp(dataset.edisp, events_src)
             else:
                 events_src.table["ENERGY"] = events_src.table["ENERGY_TRUE"]

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -89,7 +89,7 @@ class MapDatasetEventSampler:
             if len(table) > 0:
                 table["MC_ID"] = idx + 1
             else:
-                mcid = table.Column(name="MC_ID", length=len(table), dtype=int)
+                mcid = table.Column(name="MC_ID", length=0, dtype=int)
                 table.add_column(mcid)
             events_all.append(EventList(table))
 
@@ -320,16 +320,17 @@ class MapDatasetEventSampler:
         if len(dataset.models) > 1:
             events_src = self.sample_sources(dataset)
 
-            if dataset.psf and (len(events_src.table) > 0):
-                events_src = self.sample_psf(dataset.psf, events_src)
-            else:
-                events_src.table["RA"] = events_src.table["RA_TRUE"]
-                events_src.table["DEC"] = events_src.table["DEC_TRUE"]
+            if len(events_src.table) > 0:
+                if dataset.psf:
+                    events_src = self.sample_psf(dataset.psf, events_src)
+                else:
+                    events_src.table["RA"] = events_src.table["RA_TRUE"]
+                    events_src.table["DEC"] = events_src.table["DEC_TRUE"]
 
-            if dataset.edisp and (len(events_src.table) > 0):
-                events_src = self.sample_edisp(dataset.edisp, events_src)
-            else:
-                events_src.table["ENERGY"] = events_src.table["ENERGY_TRUE"]
+                if dataset.edisp:
+                    events_src = self.sample_edisp(dataset.edisp, events_src)
+                else:
+                    events_src.table["ENERGY"] = events_src.table["ENERGY_TRUE"]
 
             if dataset.background_model:
                 events_bkg = self.sample_background(dataset)

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -93,6 +93,29 @@ def test_mde_sample_sources(dataset):
 
 
 @requires_data()
+def test_mde_sample_weak_src(dataset):
+    irfs = load_cta_irfs(
+        "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+    )
+    livetime = 10.0 * u.hr
+    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    obs = Observation.create(
+        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
+    )
+
+    dataset_weak_src = dataset.copy()
+    dataset_weak_src.models[0].parameters["amplitude"].value = 1e-25
+
+    sampler = MapDatasetEventSampler(random_state=0)
+    events = sampler.run(dataset=dataset_weak_src, observation=obs)
+
+    assert len(events.table) == 18
+    assert_allclose(
+        len(np.where(events.table["MC_ID"] == 0)[0]), len(events.table), rtol=1e-5
+    )
+
+
+@requires_data()
 def test_mde_sample_background(dataset):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.sample_background(dataset=dataset)


### PR DESCRIPTION
This PR fixs a minor bug of the `~gammapy.dataset.MapDatasetEventSampler`. Currently, when the sampled source is very weak and no source events are generated, the code breaks. This is due to a bug in the creation of the `~astropy.Table` of the events. 
The PR corrects the issue by introducing a simple if condition based on the number of simulated source events.