### PR TITLE
Modify exposure map geom in EDispMap.to_edisp_kernel_map

### DIFF
--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -302,8 +302,13 @@ class EDispMap(IRFMap):
         geom_image = self.edisp_map.geom.to_image()
         geom = geom_image.to_cube([energy_axis, energy_axis_true])
         edisp_kernel_map = Map.from_geom(geom=geom, data=data)
+        exposure_map = Map.from_geom(geom.squash(axis=energy_axis.name),
+                                     data=self.exposure_map.data,
+                                     unit=self.exposure_map.unit,
+                                     meta=self.exposure_map.meta,
+                                     )
         return EDispKernelMap(
-            edisp_kernel_map=edisp_kernel_map, exposure_map=self.exposure_map
+            edisp_kernel_map=edisp_kernel_map, exposure_map=exposure_map
         )
 
 

--- a/gammapy/irf/tests/test_edisp_map.py
+++ b/gammapy/irf/tests/test_edisp_map.py
@@ -156,6 +156,23 @@ def test_edisp_from_diagonal_response(position):
     # e_reco to contribute to
     assert_allclose(sum_kernel[1:-1], 1)
 
+def test_edisp_map_to_edisp_kernel_map():
+    energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=5)
+
+    energy_axis_true = MapAxis.from_energy_bounds(
+        "0.3 TeV", "30 TeV", nbin=10, per_decade=True, name="energy_true"
+    )
+    migra_axis = MapAxis(nodes=np.linspace(0.0, 3.0, 51), unit="", name="migra")
+
+    edisp_map = EDispMap.from_diagonal_response(energy_axis_true,migra_axis)
+
+    edisp_kernel_map = edisp_map.to_edisp_kernel_map(energy_axis)
+    position = SkyCoord(0, 0, unit="deg")
+    kernel = edisp_kernel_map.get_edisp_kernel(position)
+
+    assert edisp_kernel_map.exposure_map.geom.axes[0].name == 'energy'
+    actual = kernel.pdf_matrix.sum(axis=0)
+    assert_allclose(actual, 2.0)
 
 def test_edisp_kernel_map_stack():
     energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=5)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects an issue in `EDispMap.to_edisp_kernel_map`. The exposure map created by the `MapDatasetMaker` has the `migra` axis squashed (e.g. it has only 1 bin). 
When converting to an `EDispKernelMap` one has to change the `geom` of the `exposure_map` to keep it consistent with that of the main map. Namely one has to create a new geom with the `energy` axis squashed.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This is ready