### PR TITLE
Mcmc init

### DIFF
--- a/gammapy/modeling/sampling.py
+++ b/gammapy/modeling/sampling.py
@@ -82,15 +82,26 @@ def run_mcmc(dataset, nwalkers=8, nrun=1000, threads=1):
     import emcee
 
     dataset.models.parameters.autoscale()  # Autoscale parameters
-    pars = [par.factor for par in dataset.models.parameters.free_parameters]
-    ndim = len(pars)
+    #pars = [par.factor for par in dataset.models.parameters.free_parameters]
+    #ndim = len(pars)
 
     # Initialize walkers in a ball of relative size 0.5% in all dimensions if the
     # parameters have been fit, or to 10% otherwise
+    # Handle source position spread differently with a spread of 0.1°
     # TODO: the spread of 0.5% below is valid if a pre-fit of the model has been obtained.
     # currently the run_mcmc() doesn't know the status of previous fit.
-    spread = 0.5 / 100
-    p0var = np.array([spread * pp for pp in pars])
+    p0var = []
+    pars = []
+    spread = 0.5/100
+    spread_pos = 0.1 # in degrees
+    for par in dataset.models.parameters.free_parameters:
+        pars.append(par.factor)
+        if par.name in ["lon_0", "lat_0"]:
+            p0var.append(spread_pos/par.scale)
+        else:
+            p0var.append(spread*par.factor)
+
+    ndim = len(pars)
     p0 = emcee.utils.sample_ball(pars, p0var, nwalkers)
 
     labels = []

--- a/gammapy/modeling/sampling.py
+++ b/gammapy/modeling/sampling.py
@@ -82,8 +82,6 @@ def run_mcmc(dataset, nwalkers=8, nrun=1000, threads=1):
     import emcee
 
     dataset.models.parameters.autoscale()  # Autoscale parameters
-    #pars = [par.factor for par in dataset.models.parameters.free_parameters]
-    #ndim = len(pars)
 
     # Initialize walkers in a ball of relative size 0.5% in all dimensions if the
     # parameters have been fit, or to 10% otherwise


### PR DESCRIPTION
**Description**
In testing the MCMC for different sources, the evaluation of the likelihood sometime returned an error with a message like `cannot evaluate PSF at given location`. Turns out that the walker was initialized out of the ROI.
So far the walker are initialized with a `spread = p0 * 0.5%` (copied from naima).
This is giving a small spread for Norm and index parameters (too small?) but for spatial coordinates (lon, lat) this doesn't make sense.
For lon = 0° the spread is 0° and for lon = 300° the sigma is 1.5° which can initiate some walkers several degrees from the ROI producing the error described above.

This pull request initiate the spread of the spectral parameters and spatial parameters differently. The spread for lon, lat is no longer a fraction but fixed to 0.1°.


**Dear reviewer**
This is a pretty simple change.
Are the names `lon_0`, `lat_0` the same across all spatial models ? (I think so but double checking)


