### PR TITLE
Correct IRFMap.stack

### DIFF
--- a/gammapy/irf/irf_map.py
+++ b/gammapy/irf/irf_map.py
@@ -113,8 +113,8 @@ class IRFMap:
 
         # stack exposure map
         if weights and "energy" in weights.geom.axes_names:
-            weights = weights.slice_by_idx({"energy": slice(0, 1)})
-
+#            weights = weights.slice_by_idx({"energy": slice(0, 1)})
+            weights = weights.reduce_over_axes(func=np.logical_or, axes=["energy"], keepdims=True)
         self.exposure_map.stack(other.exposure_map, weights=weights)
 
         with np.errstate(invalid="ignore"):

--- a/gammapy/irf/irf_map.py
+++ b/gammapy/irf/irf_map.py
@@ -98,7 +98,7 @@ class IRFMap:
 
         """
         if self.exposure_map is None or other.exposure_map is None:
-            raise ValueError("Missing exposure map for PSFMap.stack")
+            raise ValueError("Missing exposure map for IRFMap.stack")
 
         cutout_info = other._irf_map.geom.cutout_info
 
@@ -113,7 +113,6 @@ class IRFMap:
 
         # stack exposure map
         if weights and "energy" in weights.geom.axes_names:
-#            weights = weights.slice_by_idx({"energy": slice(0, 1)})
             weights = weights.reduce_over_axes(func=np.logical_or, axes=["energy"], keepdims=True)
         self.exposure_map.stack(other.exposure_map, weights=weights)
 

--- a/gammapy/irf/irf_map.py
+++ b/gammapy/irf/irf_map.py
@@ -98,7 +98,7 @@ class IRFMap:
 
         """
         if self.exposure_map is None or other.exposure_map is None:
-            raise ValueError("Missing exposure map for IRFMap.stack")
+            raise ValueError(f"Missing exposure map for {self.__class__.__name__}.stack")
 
         cutout_info = other._irf_map.geom.cutout_info
 

--- a/gammapy/irf/tests/test_edisp_map.py
+++ b/gammapy/irf/tests/test_edisp_map.py
@@ -200,4 +200,7 @@ def test_edisp_kernel_map_stack():
     kernel = edisp_1.get_edisp_kernel(position)
 
     actual = kernel.pdf_matrix.sum(axis=0)
-    assert_allclose(actual, [2.0, 2.0, 6.0, 6.0, 6.0])
+    exposure = edisp_1.exposure_map.data[:,0,0,0]
+
+    assert_allclose(actual, [2./3., 2./3., 2.0, 2.0, 2.0])
+    assert_allclose(exposure, 3.)

--- a/gammapy/irf/tests/test_edisp_map.py
+++ b/gammapy/irf/tests/test_edisp_map.py
@@ -204,3 +204,23 @@ def test_edisp_kernel_map_stack():
 
     assert_allclose(actual, [2./3., 2./3., 2.0, 2.0, 2.0])
     assert_allclose(exposure, 3.)
+
+def test__incorrect_edisp_kernel_map_stack():
+    energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=5)
+
+    energy_axis_true = MapAxis.from_energy_bounds(
+        "0.3 TeV", "30 TeV", nbin=10, per_decade=True, name="energy_true"
+    )
+
+    edisp_1 = EDispKernelMap.from_diagonal_response(
+        energy_axis=energy_axis, energy_axis_true=energy_axis_true
+    )
+    edisp_1.exposure_map.data += 1
+
+    edisp_2 = EDispKernelMap.from_diagonal_response(
+        energy_axis=energy_axis, energy_axis_true=energy_axis_true
+    )
+    edisp_2.exposure_map = None
+
+    with pytest.raises(ValueError):
+        edisp_1.stack(edisp_2)

--- a/gammapy/irf/tests/test_edisp_map.py
+++ b/gammapy/irf/tests/test_edisp_map.py
@@ -222,5 +222,6 @@ def test__incorrect_edisp_kernel_map_stack():
     )
     edisp_2.exposure_map = None
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as except_info:
         edisp_1.stack(edisp_2)
+    assert except_info.match("Missing exposure map for EDispKernelMap.stack")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects `IRFMap.stack`. The weights for the `exposure_map` were incorrectly defined as the first slice in `energy`. This leads to an incorrect behavior. The test based on `EDispKernelMap.stack()` was incorrect. 

Now the `weights` for the `exposure_map` are computed with `weights.reduce_over_axis(np.logical_or, axes=['energy'])`. This allows to take into account any position which has at least one energy bin not excluded. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This should be OK