### PR TITLE
Change models handling on dataset copy and stack 

### DIFF
--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -73,6 +73,8 @@ class Dataset(abc.ABC):
                     for k, d in enumerate(m.datasets_names):
                         if d == self.name:
                             m.datasets_names[k] = name
+                    if hasattr(new, "background_model") and m == new.background_model:
+                        m._name = name + "-bkg"
         return new
 
     @staticmethod

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -64,7 +64,15 @@ class Dataset(abc.ABC):
     def copy(self, name=None):
         """A deep copy."""
         new = copy.deepcopy(self)
-        new._name = make_name(name)
+        name = make_name(name)
+        new._name = name
+        # propagate new dataset name
+        if new.models is not None:
+            for m in new.models:
+                if m.datasets_names is not None:
+                    for k, d in enumerate(m.datasets_names):
+                        if d == self.name:
+                            m.datasets_names[k] = name
         return new
 
     @staticmethod

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -415,6 +415,8 @@ class MapDataset(Dataset):
             background_model = other.background_model
 
         if self.background_model and background_model:
+            self._background_model.map *= self.mask_safe
+            self._background_model.stack(background_model, other.mask_safe)
             self.models = Models([self.background_model])
         else:
             self.models = None

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -417,6 +417,9 @@ class MapDataset(Dataset):
         if self.background_model and background_model:
             self._background_model.map *= self.mask_safe
             self._background_model.stack(background_model, other.mask_safe)
+            self.models = Models([background_model])
+        else:
+            self.models = None
 
         if self.mask_safe is not None and other.mask_safe is not None:
             self.mask_safe.stack(other.mask_safe)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -415,9 +415,7 @@ class MapDataset(Dataset):
             background_model = other.background_model
 
         if self.background_model and background_model:
-            self._background_model.map *= self.mask_safe
-            self._background_model.stack(background_model, other.mask_safe)
-            self.models = Models([background_model])
+            self.models = Models([self.background_model])
         else:
             self.models = None
 

--- a/gammapy/datasets/tests/test_io.py
+++ b/gammapy/datasets/tests/test_io.py
@@ -71,3 +71,6 @@ def test_datasets_to_io(tmp_path):
         datasets.models["background_irf_g09"].covariance,
         datasets.models["background_irf_gc"].covariance,
     )
+
+    dataset_copy = dataset0.copy(name="dataset0-copy")
+    assert dataset_copy.background_model.datasets_names == ["dataset0-copy"]

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -825,9 +825,9 @@ def test_names(geom, geom_etrue, sky_model):
     dataset2 = dataset1.copy(name="dataset2")
     assert dataset2.name == "dataset2"
     assert dataset2.background_model.name == "dataset2-bkg"
-    assert dataset1.background_model is not dataset2.background_model
-    assert dataset1.models.names == ["model1", "model2", "dataset2-bkg"]
-    assert dataset1.models is not dataset2.models
+    assert dataset2.background_model is not dataset1.background_model
+    assert dataset2.models.names == ["model1", "model2", "dataset2-bkg"]
+    assert dataset2.models is not dataset1.models
 
 
 def test_stack_dataset_dataset_on_off():

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -824,9 +824,9 @@ def test_names(geom, geom_etrue, sky_model):
     assert dataset2.background_model
     dataset2 = dataset1.copy(name="dataset2")
     assert dataset2.name == "dataset2"
-    assert dataset2.background_model.name == "bkg1"
+    assert dataset2.background_model.name == "dataset2-bkg"
     assert dataset1.background_model is not dataset2.background_model
-    assert dataset1.models.names == dataset2.models.names
+    assert dataset1.models.names == ["model1", "model2", "dataset2-bkg"]
     assert dataset1.models is not dataset2.models
 
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -512,6 +512,7 @@ def test_stack(geom, geom_etrue):
     assert_allclose(dataset1.background_model.map.data.sum(), 5987)
     assert_allclose(dataset1.exposure.data, 2.0 * dataset2.exposure.data)
     assert_allclose(dataset1.mask_safe.data.sum(), 20000)
+    assert len(dataset1.models) == 1
 
 
 def to_cube(image):

--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -258,15 +258,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_fit.models[\"dataset-simu-bkg\"].datasets_names = [\"dataset-fit\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Define sky model to fit the data\n",
     "spatial_model1 = GaussianSpatialModel(\n",
     "    lon_0=\"0.1 deg\", lat_0=\"0.1 deg\", sigma=\"0.5 deg\", frame=\"galactic\"\n",
@@ -377,7 +368,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
@@ -425,7 +416,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0.0,
+       "index": 0,
        "layout": "IPY_MODEL_af4d5cf4a93b4c2aa9fd249e0ebea901",
        "orientation": "horizontal",
        "readout": true,
@@ -703,7 +694,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0.0,
+       "index": 0,
        "layout": "IPY_MODEL_ad8503b6c8494978874f7c11be4e77f8",
        "style": "IPY_MODEL_3cf9799567f44cc2a06127e22b70907d"
       }
@@ -724,8 +715,8 @@
       }
      }
     },
-    "version_major": 2.0,
-    "version_minor": 0.0
+    "version_major": 2,
+    "version_minor": 0
    }
   }
  },


### PR DESCRIPTION
- propagate new dataset name on models during dataset.copy()
- redefine dataset.models with only background model or None on dataset.stack()
resolve #2868