### PR TITLE
Add `event_det_coord()` to `MapDatasetEventSampler`

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -180,7 +180,8 @@ class MapDatasetEventSampler:
         events.table["DEC"] = coords_reco["lat"] * u.deg
         return events
 
-    def event_det_coords(self, observation, events):
+    @staticmethod
+    def event_det_coords(observation, events):
         """Add columns of detector coordinates (DETX-DETY) to the event list.
 
         Parameters
@@ -367,7 +368,7 @@ class MapDatasetEventSampler:
             events_bkg = self.sample_background(dataset)
             events = EventList.stack([events_bkg])
 
-        events = self.event_det_coord(observation, events)
+        events = self.event_det_coords(observation, events)
         events.table["EVENT_ID"] = np.arange(len(events.table))
         events.table.meta = self.event_list_meta(dataset, observation)
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -181,7 +181,7 @@ class MapDatasetEventSampler:
         events.table["DEC"] = coords_reco["lat"] * u.deg
         return events
 
-    def event_det_coord(self, observation, events):
+    def event_det_coords(self, observation, events):
         """Add columns of detector coordinates (DETX-DETY) to the event list.
 
         Parameters

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -182,7 +182,7 @@ class MapDatasetEventSampler:
         return events
 
     def event_det_coord(self, observation, events):
-        """Add event detector coordinates to the event list.
+        """Add columns of detector coordinates (DETX-DETY) to the event list.
 
         Parameters
         ----------
@@ -196,15 +196,12 @@ class MapDatasetEventSampler:
         events : `~gammapy.data.EventList`
             Event list with columns of event detector coordinates.
         """
-        for sky in ["_TRUE", ""]:
-            sky_coord = SkyCoord(
-                events.table["RA" + sky], events.table["DEC" + sky], frame="icrs"
-            )
-            frame = SkyOffsetFrame(origin=observation.pointing_radec.icrs)
-            pseudo_fov_coord = sky_coord.transform_to(frame)
+        sky_coord = SkyCoord(events.table["RA"], events.table["DEC"], frame="icrs")
+        frame = SkyOffsetFrame(origin=observation.pointing_radec.icrs)
+        pseudo_fov_coord = sky_coord.transform_to(frame)
 
-            events.table["DETX" + sky] = pseudo_fov_coord.lon
-            events.table["DETY" + sky] = pseudo_fov_coord.lat
+        events.table["DETX"] = pseudo_fov_coord.lon
+        events.table["DETY"] = pseudo_fov_coord.lat
         return events
 
     @staticmethod

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -10,7 +10,6 @@ from gammapy.data import EventList
 from gammapy.maps import MapCoord
 from gammapy.modeling.models import BackgroundModel, ConstantTemporalModel
 from gammapy.utils.random import get_random_state
-from gammapy.utils.coordinates import sky_to_fov
 
 
 __all__ = ["MapDatasetEventSampler"]

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -172,7 +172,7 @@ def test_mde_sample_edisp(dataset):
 
 
 @requires_data()
-def test_event_det_coord(dataset):
+def test_event_det_coords(dataset):
     irfs = load_cta_irfs(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -130,6 +130,8 @@ def test_mde_sample_background(dataset):
     assert_allclose(events.table["DEC"][0], -30.870316, rtol=1e-5)
     assert events.table["DEC"].unit == "deg"
 
+    assert events.table["DEC_TRUE"][0] == events.table["DEC"][0]
+
     assert_allclose(events.table["MC_ID"][0], 0, rtol=1e-5)
 
 
@@ -167,6 +169,34 @@ def test_mde_sample_edisp(dataset):
     assert events.table["DEC_TRUE"].unit == "deg"
 
     assert_allclose(events.table["MC_ID"][0], 1, rtol=1e-5)
+
+
+@requires_data()
+def test_event_det_coord(dataset):
+    irfs = load_cta_irfs(
+        "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+    )
+    livetime = 1.0 * u.hr
+    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    obs = Observation.create(
+        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
+    )
+
+    sampler = MapDatasetEventSampler(random_state=0)
+    events = sampler.run(dataset=dataset, observation=obs)
+
+    assert len(events.table) == 374
+    assert_allclose(events.table["DETX"][0], -2.44563584, rtol=1e-5)
+    assert events.table["DETX"].unit == "deg"
+
+    assert_allclose(events.table["DETX_TRUE"][0], -2.44563584, rtol=1e-5)
+    assert events.table["DETX_TRUE"].unit == "deg"
+
+    assert_allclose(events.table["DETY"][0], 0.01414569, rtol=1e-5)
+    assert events.table["DETY"].unit == "deg"
+
+    assert_allclose(events.table["DETY_TRUE"][0], 0.01414569, rtol=1e-5)
+    assert events.table["DETY_TRUE"].unit == "deg"
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -189,14 +189,8 @@ def test_event_det_coord(dataset):
     assert_allclose(events.table["DETX"][0], -2.44563584, rtol=1e-5)
     assert events.table["DETX"].unit == "deg"
 
-    assert_allclose(events.table["DETX_TRUE"][0], -2.44563584, rtol=1e-5)
-    assert events.table["DETX_TRUE"].unit == "deg"
-
     assert_allclose(events.table["DETY"][0], 0.01414569, rtol=1e-5)
     assert events.table["DETY"].unit == "deg"
-
-    assert_allclose(events.table["DETY_TRUE"][0], 0.01414569, rtol=1e-5)
-    assert events.table["DETY_TRUE"].unit == "deg"
 
 
 @requires_data()


### PR DESCRIPTION
This PR implements the functionality `event_det_coord` in the `MapDatasetEventSampler` class. The `event_det_coord` generates two new columns defined as DETX and DETY. These represent the positions of the simulated events (source and background) in detector coordinates with respect to the center of the FOV. For now, the FOV frame rotation is not taken into account.
Such a functionality may be useful, for example, for IRF calibrations.

In addition, the PR fixes a tiny bug in `MapDatasetEventSampler` related to the generation, in the event list, of the `RA_TRUE` and `DEC_TRUE` background coordinates only. Currently, they take no-sense values (as 1e20), while I suggest they should rather be at least equal to `RA` and `DEC` coordinates.
