### PR TITLE
Add comparators on Map

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1026,5 +1026,8 @@ class Map(abc.ABC):
     def __eq__(self, other):
         return self._arithmetics(np.equal, other, copy=True)
 
+    def __ne__(self, other):
+        return self._arithmetics(np.not_equal, other, copy=True)
+
     def __array__(self):
         return self.data

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1011,5 +1011,20 @@ class Map(abc.ABC):
     def __itruediv__(self, other):
         return self._arithmetics(np.true_divide, other, copy=False)
 
+    def __le__(self, other):
+        return self._arithmetics(np.less_equal, other, copy=True)
+
+    def __lt__(self, other):
+        return self._arithmetics(np.less, other, copy=True)
+
+    def __ge__(self, other):
+        return self._arithmetics(np.greater_equal, other, copy=True)
+
+    def __gt__(self, other):
+        return self._arithmetics(np.greater, other, copy=True)
+
+    def __eq__(self, other):
+        return self._arithmetics(np.equal, other, copy=True)
+
     def __array__(self):
         return self.data

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -292,6 +292,22 @@ def test_map_arithmetics(map_type):
     assert m1.unit == u.Unit("")
     assert_allclose(m1.data, 4)
 
+    lt_m2 = m2 < 1.5*u.m**2
+    assert lt_m2.data.dtype == bool
+    assert_allclose(lt_m2, True)
+
+    le_m2 = m2 <= 10000*u.cm**2
+    assert_allclose(le_m2, True)
+
+    gt_m2 = m2 > 15000*u.cm**2
+    assert_allclose(gt_m2, False)
+
+    ge_m2 = m2 >= m2
+    assert_allclose(ge_m2, True)
+
+    eq_m2 = m2 == 500*u.cm**2
+    assert_allclose(eq_m2, False)
+
 
 def test_arithmetics_inconsistent_geom():
     m_wcs = Map.create(binsz=0.1, width=1.0)

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -308,6 +308,8 @@ def test_map_arithmetics(map_type):
     eq_m2 = m2 == 500*u.cm**2
     assert_allclose(eq_m2, False)
 
+    ne_m2 = m2 != 500*u.cm**2
+    assert_allclose(ne_m2, True)
 
 def test_arithmetics_inconsistent_geom():
     m_wcs = Map.create(binsz=0.1, width=1.0)

--- a/tutorials/exclusion_mask.ipynb
+++ b/tutorials/exclusion_mask.ipynb
@@ -318,7 +318,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we copy the significance map for our mask and apply a threshold of 5 sigma to remove pixels."
+    "Finally, we create the mask map by applying a threshold of 5 sigma to remove pixels."
    ]
   },
   {
@@ -327,8 +327,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask_map_significance = result[\"significance\"].copy()\n",
-    "mask_map_significance.data = mask_map_significance.data < 5.0"
+    "mask_map_significance = result[\"significance\"] < 5.0"
    ]
   },
   {


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request extends the `Map` arithmetic to comparators. Now making `(a<=b)` will return a `Map` with `dtype=bool` with element-wise comparison. 
Boolean operation can then be applied with usual map arithmetics.


This follows discussion in issue #2869  .

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
