### PR TITLE
Adding unit test for the mcmc sampling

### DIFF
--- a/gammapy/modeling/tests/test_sampling.py
+++ b/gammapy/modeling/tests/test_sampling.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import pytest
 from gammapy.datasets import Datasets
 from gammapy.modeling.sampling import run_mcmc, ln_uniform_prior
 import numpy as np
-#@pytest.fixture
+from gammapy.utils.testing import requires_dependency
+
 def get_datasets():
     dataset = Datasets.read("$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml",
                             "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml")
@@ -35,9 +35,10 @@ def test_lnprob():
     parameters["amplitude"].value = 1000
     assert ln_uniform_prior(dataset) == -np.inf
 
+@requires_dependency("emcee")
 def test_runmcmc():
     #Running a small MCMC on pregenerated datasets
     dataset = get_datasets()
-    sampler = run_mcmc(dataset, nwalkers=6, nrun=10)  # to speedup the test
+    run_mcmc(dataset, nwalkers=6, nrun=10)  # to speedup the test
 
 

--- a/gammapy/modeling/tests/test_sampling.py
+++ b/gammapy/modeling/tests/test_sampling.py
@@ -45,6 +45,5 @@ def test_runmcmc(dataset):
     import emcee
 
     sampler = run_mcmc(dataset, nwalkers=6, nrun=10)  # to speedup the test
-    assert type(sampler) is emcee.ensemble.EnsembleSampler
-
+    assert isinstance(sampler, emcee.ensemble.EnsembleSampler)
 

--- a/gammapy/modeling/tests/test_sampling.py
+++ b/gammapy/modeling/tests/test_sampling.py
@@ -1,0 +1,43 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+from gammapy.datasets import Datasets
+from gammapy.modeling.sampling import run_mcmc, ln_uniform_prior
+import numpy as np
+#@pytest.fixture
+def get_datasets():
+    dataset = Datasets.read("$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml",
+                            "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml")
+
+    # Define the free parameters and min, max values
+    parameters = dataset.models.parameters
+    parameters["lon_0"].frozen = False
+    parameters["lat_0"].frozen = False
+    parameters["norm"].frozen = True
+    parameters["alpha"].frozen = True
+    parameters["beta"].frozen = True
+    parameters["lat_0"].min = -90
+    parameters["lat_0"].max = 90
+    parameters["lon_0"].min = 0
+    parameters["lon_0"].max = 360
+    parameters["amplitude"].min = 0.01 * parameters["amplitude"].value
+    parameters["amplitude"].max = 100 * parameters["amplitude"].value
+
+    return dataset
+
+def test_lnprob():
+    #Testing priors
+    dataset = get_datasets()
+    parameters = dataset.models.parameters
+
+    #paramater is within min, max boundaries
+    assert ln_uniform_prior(dataset) == 0.0
+    # Setting amplitude outside min, max values
+    parameters["amplitude"].value = 1000
+    assert ln_uniform_prior(dataset) == -np.inf
+
+def test_runmcmc():
+    #Running a small MCMC on pregenerated datasets
+    dataset = get_datasets()
+    sampler = run_mcmc(dataset, nwalkers=6, nrun=10)  # to speedup the test
+
+


### PR DESCRIPTION

**Description**

This pull request adds unit tests for the sampling MCMC.
With few runs for the MCMC, the full tests take only 3sec

Minor question:
I tried to use pytest fixture to avoid having to load the datasets in each test but this didn't work as I expected. Can I use fixture here to load the dataset for all functions here ?