### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ show-response = 1
 minversion = 3.0
 norecursedirs = build dev examples tutorials docs/_build gammapy/extern
 #doctest_plus = enabled
-addopts = -p no:warnings --remote-data=any
+addopts = -p no:warnings --remote-data=any --doctest-ignore-import-errors
 remote_data_strict = True
 
 [coverage:run]


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.