### PR TITLE
Add check for regular geom for geom.__eq__ 

### DIFF
--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -451,6 +451,14 @@ def test_wcs_geom_equal(npix, binsz, frame, proj, skypos, axes, result):
     assert (geom0 == geom1) is result
     assert (geom0 != geom1) is not result
 
+def test_irregular_geom_equality():
+    axis = MapAxis.from_bounds(1,3,10, name="axis", unit="")
+    geom0 = WcsGeom.create(skydir=(0,0), npix=10, binsz=0.1, axes=[axis])
+    binsizes = np.ones((10))*0.1
+    geom1 = WcsGeom.create(skydir=(0,0), npix=10, binsz=binsizes, axes=[axis])
+
+    with pytest.raises(NotImplementedError):
+        geom0 == geom1
 
 @pytest.mark.parametrize("node_type", ["edges", "center"])
 @pytest.mark.parametrize("interp", ["log", "lin", "sqrt"])

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -1018,6 +1018,9 @@ class WcsGeom(Geom):
         if not isinstance(other, self.__class__):
             return NotImplemented
 
+        if not (self.is_regular and other.is_regular):
+            raise NotImplementedError("Geom comparison is not possible for irregular geometries.")
+
         # check overall shape and axes compatibility
         if self.data_shape != other.data_shape:
             return False


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects a bug that can appear when one compares two geometries with non regular structures. The comparison should not be possible for now. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
