### PR TITLE
Fix evaluators cache

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -246,13 +246,14 @@ class MapDataset(Dataset):
 
         if self.models:
             for model in self.models:
-                evaluator = self._evaluators.get(model.name)
+                model_id = hex(id(model))
+                evaluator = self._evaluators.get(model_id)
 
                 if evaluator is None:
                     evaluator = MapEvaluator(
                         model=model, evaluation_mode=self.evaluation_mode, gti=self.gti
                     )
-                    self._evaluators[model.name] = evaluator
+                    self._evaluators[model_id] = evaluator
 
                 # if the model component drifts out of its support the evaluator has
                 # has to be updated

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -214,15 +214,13 @@ class MapDataset(Dataset):
         """Model evaluators"""
 
         if self.models:
-            hex_ids = []
             for model in self.models:
-                evaluator = self._evaluators.get(model.hex_id)
-                hex_ids.append(model.hex_id)
+                evaluator = self._evaluators.get(model)
                 if evaluator is None:
                     evaluator = MapEvaluator(
                         model=model, evaluation_mode=self.evaluation_mode, gti=self.gti
                     )
-                    self._evaluators[model.hex_id] = evaluator
+                    self._evaluators[model] = evaluator
 
                 # if the model component drifts out of its support the evaluator has
                 # has to be updated
@@ -231,7 +229,7 @@ class MapDataset(Dataset):
 
         keys = list(self._evaluators.keys())
         for key in keys:
-            if key not in hex_ids:
+            if key not in self.models:
                 del self._evaluators[key]
 
         return self._evaluators
@@ -262,9 +260,9 @@ class MapDataset(Dataset):
         """Predicted source and background counts (`~gammapy.maps.Map`)."""
         npred_total = Map.from_geom(self._geom, dtype=float)
 
-        for _, evaluator in self.evaluators.items():
-            if evaluator.contributes:
-                npred = evaluator.compute_npred()
+        for key in self.evaluators:
+            if self.evaluators[key].contributes:
+                npred = self.evaluators[key].compute_npred()
                 npred_total.stack(npred)
 
         return npred_total

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -214,21 +214,25 @@ class MapDataset(Dataset):
         """Model evaluators"""
 
         if self.models:
+            hex_ids = []
             for model in self.models:
-                model_id = hex(id(model))
-                evaluator = self._evaluators.get(model_id)
-
+                evaluator = self._evaluators.get(model.hex_id)
+                hex_ids.append(model.hex_id)
                 if evaluator is None:
                     evaluator = MapEvaluator(
                         model=model, evaluation_mode=self.evaluation_mode, gti=self.gti
                     )
-                    self._evaluators[model_id] = evaluator
+                    self._evaluators[model.hex_id] = evaluator
 
                 # if the model component drifts out of its support the evaluator has
                 # has to be updated
-
                 if evaluator.needs_update:
                     evaluator.update(self.exposure, self.psf, self.edisp, self._geom)
+
+        keys = list(self._evaluators.keys())
+        for key in keys:
+            if key not in hex_ids:
+                del self._evaluators[key]
 
         return self._evaluators
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -72,7 +72,7 @@ class MapDatasetEventSampler:
             if isinstance(model, BackgroundModel):
                 continue
 
-            evaluator = dataset.evaluators.get(model.name)
+            evaluator = dataset.evaluators.get(hex(id(model)))
 
             evaluator = copy.deepcopy(evaluator)
             evaluator.model.apply_irf["psf"] = False

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -67,7 +67,6 @@ class MapDatasetEventSampler:
             Event list
         """
         events_all = []
-        _ = dataset.npred() # update evaluators
         for idx, model in enumerate(dataset.models):
             if isinstance(model, BackgroundModel):
                 continue

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -71,7 +71,7 @@ class MapDatasetEventSampler:
             if isinstance(model, BackgroundModel):
                 continue
 
-            evaluator = dataset.evaluators.get(hex(id(model)))
+            evaluator = dataset.evaluators.get(model)
 
             evaluator = copy.deepcopy(evaluator)
             evaluator.model.apply_irf["psf"] = False

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -67,7 +67,7 @@ class MapDatasetEventSampler:
             Event list
         """
         events_all = []
-
+        _ = dataset.npred() # update evaluators
         for idx, model in enumerate(dataset.models):
             if isinstance(model, BackgroundModel):
                 continue

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -181,9 +181,10 @@ class SpectrumDataset(Dataset):
         """Model evaluators"""
 
         if self.models:
+            hex_ids = []
             for model in self.models:
-                model_id = hex(id(model))
-                evaluator = self._evaluators.get(model_id)
+                evaluator = self._evaluators.get(model.hex_id)
+                hex_ids.append(model.hex_id)
 
                 if evaluator is None:
                     evaluator = MapEvaluator(
@@ -192,7 +193,12 @@ class SpectrumDataset(Dataset):
                         edisp=self.edisp,
                         gti=self.gti,
                     )
-                    self._evaluators[model_id] = evaluator
+                    self._evaluators[model.hex_id] = evaluator
+
+        keys = list(self._evaluators.keys())
+        for key in keys:
+            if key not in hex_ids:
+                del self._evaluators[key]
 
         return self._evaluators
 

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -246,7 +246,8 @@ class SpectrumDataset(Dataset):
 
         if self.models:
             for model in self.models:
-                evaluator = self._evaluators.get(model.name)
+                model_id = hex(id(model))
+                evaluator = self._evaluators.get(model_id)
 
                 if evaluator is None:
                     evaluator = MapEvaluator(
@@ -255,7 +256,7 @@ class SpectrumDataset(Dataset):
                         edisp=self.edisp,
                         gti=self.gti,
                     )
-                    self._evaluators[model.name] = evaluator
+                    self._evaluators[model_id] = evaluator
 
                 npred = evaluator.compute_npred()
                 npred_total.stack(npred)
@@ -459,7 +460,9 @@ class SpectrumDataset(Dataset):
         background = RegionNDMap.create(region=region, axes=[e_reco])
 
         aeff = EffectiveAreaTable(
-            e_true.edges[:-1], e_true.edges[1:], np.zeros(e_true.edges[:-1].shape) * u.m ** 2
+            e_true.edges[:-1],
+            e_true.edges[1:],
+            np.zeros(e_true.edges[:-1].shape) * u.m ** 2,
         )
         edisp = EDispKernel.from_diagonal_response(e_true.edges, e_reco.edges)
         mask_safe = RegionNDMap.from_geom(counts.geom, dtype="bool")

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -181,10 +181,8 @@ class SpectrumDataset(Dataset):
         """Model evaluators"""
 
         if self.models:
-            hex_ids = []
             for model in self.models:
-                evaluator = self._evaluators.get(model.hex_id)
-                hex_ids.append(model.hex_id)
+                evaluator = self._evaluators.get(model)
 
                 if evaluator is None:
                     evaluator = MapEvaluator(
@@ -193,11 +191,11 @@ class SpectrumDataset(Dataset):
                         edisp=self.edisp,
                         gti=self.gti,
                     )
-                    self._evaluators[model.hex_id] = evaluator
+                    self._evaluators[model] = evaluator
 
         keys = list(self._evaluators.keys())
         for key in keys:
-            if key not in hex_ids:
+            if key not in self.models:
                 del self._evaluators[key]
 
         return self._evaluators
@@ -261,8 +259,8 @@ class SpectrumDataset(Dataset):
         """Predicted counts from source model (`RegionNDMap`)."""
         npred_total = RegionNDMap.from_geom(self._geom)
 
-        for _, evaluator in self.evaluators.items():
-            npred = evaluator.compute_npred()
+        for key in self.evaluators:
+            npred = self.evaluators[key].compute_npred()
             npred_total.stack(npred)
 
         return npred_total

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -261,7 +261,7 @@ class SpectrumDataset(Dataset):
         """Predicted counts from source model (`RegionNDMap`)."""
         npred_total = RegionNDMap.from_geom(self._geom)
 
-        for key, evaluator in self.evaluators.items():
+        for _, evaluator in self.evaluators.items():
             npred = evaluator.compute_npred()
             npred_total.stack(npred)
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -397,7 +397,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
 
     dataset_1.models[0].spatial_model.lon_0.value = 150
     dataset_1.npred()
-    assert not dataset_1._evaluators[hex(id(dataset_1.models[0]))].contributes
+    assert not dataset_1._evaluators[dataset_1.models[0]].contributes
 
     with mpl_plot_check():
         dataset_1.plot_residuals()

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -397,7 +397,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
 
     dataset_1.models[0].spatial_model.lon_0.value = 150
     dataset_1.npred()
-    assert not dataset_1._evaluators[dataset_1.models[0].name].contributes
+    assert not dataset_1._evaluators[hex(id(dataset_1.models[0]))].contributes
 
     with mpl_plot_check():
         dataset_1.plot_residuals()

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -154,7 +154,9 @@ def test_fit(spectrum_dataset):
 
 def test_spectrum_dataset_create():
     e_reco = MapAxis.from_edges(u.Quantity([0.1, 1, 10.0], "TeV"), name="energy")
-    e_true = MapAxis.from_edges(u.Quantity([0.05, 0.5, 5, 20.0], "TeV"), name="energy_true")
+    e_true = MapAxis.from_edges(
+        u.Quantity([0.05, 0.5, 5, 20.0], "TeV"), name="energy_true"
+    )
     empty_spectrum_dataset = SpectrumDataset.create(e_reco, e_true, name="test")
 
     assert empty_spectrum_dataset.name == "test"
@@ -331,7 +333,9 @@ class TestSpectrumOnOff:
 
     def test_spectrumdatasetonoff_create(self):
         e_reco = MapAxis.from_edges(u.Quantity([0.1, 1, 10.0], "TeV"), name="energy")
-        e_true = MapAxis.from_edges(u.Quantity([0.05, 0.5, 5, 20.0], "TeV"),  name="energy_true")
+        e_true = MapAxis.from_edges(
+            u.Quantity([0.05, 0.5, 5, 20.0], "TeV"), name="energy_true"
+        )
         empty_dataset = SpectrumDatasetOnOff.create(e_reco, e_true)
 
         assert empty_dataset.counts.data.sum() == 0
@@ -817,7 +821,7 @@ def test_spectrum_dataset_on_off_to_yaml(tmpdir):
 
 
 def test_stack_no_livetime():
-    e_reco = MapAxis.from_energy_bounds(1,10, 3, name="energy", unit='TeV')
+    e_reco = MapAxis.from_energy_bounds(1, 10, 3, name="energy", unit="TeV")
     dataset_1 = SpectrumDataset.create(e_reco=e_reco)
     dataset_1.livetime = None
     dataset_2 = dataset_1.copy()

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -501,6 +501,8 @@ class ProperModels(Models):
             if key in d.models.names:
                 datasets_names = d.models[key].datasets_names
                 if datasets_names is None or d.name in datasets_names:
+                    prev_id = hex(id(d.models[key]))
+                    d._evaluators[prev_id] = None
                     d._models.remove(key)
 
     def __setitem__(self, key, model):
@@ -509,7 +511,10 @@ class ProperModels(Models):
         for d in self._datasets:
             if model not in d._models:
                 if isinstance(model, (SkyModel, SkyDiffuseCube)):
+                    prev_id = hex(id(d.models[key]))
+                    d._evaluators[prev_id] = None
                     d._models[key] = model
+
                 else:
                     raise TypeError(f"Invalid type: {model!r}")
             if (

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -51,10 +51,6 @@ class Model:
             [_ for _ in cls.__dict__.values() if isinstance(_, Parameter)]
         )
 
-    @property
-    def hex_id(self):
-        return hex(id(self))
-
     @classmethod
     def from_parameters(cls, parameters, **kwargs):
         """Create model from parameter list

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -502,7 +502,7 @@ class ProperModels(Models):
                 datasets_names = d.models[key].datasets_names
                 if datasets_names is None or d.name in datasets_names:
                     prev_id = hex(id(d.models[key]))
-                    d._evaluators[prev_id] = None
+                    del d.evaluators[prev_id]
                     d._models.remove(key)
 
     def __setitem__(self, key, model):
@@ -512,7 +512,7 @@ class ProperModels(Models):
             if model not in d._models:
                 if isinstance(model, (SkyModel, SkyDiffuseCube)):
                     prev_id = hex(id(d.models[key]))
-                    d._evaluators[prev_id] = None
+                    del d.evaluators[prev_id]
                     d._models[key] = model
 
                 else:

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -51,6 +51,10 @@ class Model:
             [_ for _ in cls.__dict__.values() if isinstance(_, Parameter)]
         )
 
+    @property
+    def hex_id(self):
+        return hex(id(self))
+
     @classmethod
     def from_parameters(cls, parameters, **kwargs):
         """Create model from parameter list
@@ -501,8 +505,6 @@ class ProperModels(Models):
             if key in d.models.names:
                 datasets_names = d.models[key].datasets_names
                 if datasets_names is None or d.name in datasets_names:
-                    prev_id = hex(id(d.models[key]))
-                    del d.evaluators[prev_id]
                     d._models.remove(key)
 
     def __setitem__(self, key, model):
@@ -511,8 +513,6 @@ class ProperModels(Models):
         for d in self._datasets:
             if model not in d._models:
                 if isinstance(model, (SkyModel, SkyDiffuseCube)):
-                    prev_id = hex(id(d.models[key]))
-                    del d.evaluators[prev_id]
                     d._models[key] = model
 
                 else:

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -186,6 +186,9 @@ def test_models_management(tmp_path):
     model2 = datasets.models[0].copy(name="model2", datasets_names=[datasets[1].name])
     model3 = datasets.models[0].copy(name="model3", datasets_names=[datasets[0].name])
 
+    model1b = datasets.models[0].copy(name="model1", datasets_names=None)
+    model1b.spectral_model.amplitude.value *= 2
+
     names0 = datasets[0].models.names
     names1 = datasets[1].models.names
 
@@ -245,3 +248,12 @@ def test_models_management(tmp_path):
     _ = datasets.models  # auto-update models
     assert datasets[0].models.names == ["model1", "gll_iem_v06_cutout"]
     # the consistency check added diffuse model contained in the global model
+
+    npred1 = datasets[0].npred().data.sum()
+    datasets.models.remove(model1)
+    npred0 = datasets[0].npred().data.sum()
+    datasets.models.append(model1b)
+    npred1b = datasets[0].npred().data.sum()
+    assert npred1b != npred1
+    assert npred1b != npred0
+    assert_allclose(npred1b, 2147.407023024028)


### PR DESCRIPTION
- Evaluators dict key are now model.hex_id instead of .name as suggested in #2904 
- Automatically clear the evaluators of the removed models
- Move evaluators set up from .npred() to .evaluators() property
 Resolve #2904