### PR TITLE
Add read/write example for exclusion masks

### DIFF
--- a/tutorials/exclusion_mask.ipynb
+++ b/tutorials/exclusion_mask.ipynb
@@ -275,7 +275,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasets = Datasets.read(\"$GAMMAPY_DATA/fermi-3fhl-crab/\",\n",
+    "datasets = Datasets.read(\n",
+    "    \"$GAMMAPY_DATA/fermi-3fhl-crab/\",\n",
     "    \"Fermi-LAT-3FHL_datasets.yaml\",\n",
     "    \"Fermi-LAT-3FHL_models.yaml\",\n",
     ")"
@@ -351,11 +352,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading and writing exclusion masks\n",
+    "\n",
+    "`gammapy.maps` cannot directly read/write maps with boolean content. Thus, for serialisation of exclusion masks, it is necessary to do an explicit type casting between boolean and int, as we show here."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# To save masks to disk\n",
+    "mask_map_int = mask_map.copy()\n",
+    "mask_map_int.data = mask_map_int.data.astype(int)\n",
+    "mask_map_int.write(\"exclusion_mask.fits\", overwrite=\"True\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To read maps from disk\n",
+    "mask_map = Map.read(\"exclusion_mask.fits\")\n",
+    "mask_map.data = mask_map.data.astype(bool)"
+   ]
   }
  ],
  "metadata": {
@@ -374,7 +400,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds an example for reading and writing of exclusion masks in the `exclusion_mask.ipynb` tutorial.