### PR TITLE
Add more template spectral model corrections

### DIFF
--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -317,7 +317,7 @@ def test_analysis_3d():
     analysis.get_flux_points()
 
     assert len(analysis.datasets) == 1
-    assert len(analysis.fit_result.parameters) == 8
+    assert len(analysis.fit_result.parameters) == 11
     res = analysis.fit_result.parameters
     assert res["amplitude"].unit == "cm-2 s-1 TeV-1"
     assert len(analysis.flux_points.data.table) == 2

--- a/gammapy/datasets/tests/test_io.py
+++ b/gammapy/datasets/tests/test_io.py
@@ -59,7 +59,7 @@ def test_datasets_to_io(tmp_path):
         tmp_path, "written_datasets.yaml", "written_models.yaml"
     )
 
-    assert len(datasets.parameters) == 21
+    assert len(datasets.parameters) == 30
 
     assert len(datasets_read) == 2
     dataset0 = datasets_read[0]

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -418,8 +418,8 @@ def test_map_fit(sky_model, geom, geom_etrue):
     assert_allclose(pars[8].error, 0.015811, rtol=1e-2)
 
     # background norm 2
-    assert_allclose(pars[11].value, 1, rtol=1e-2)
-    assert_allclose(pars[11].error, 0.02147, rtol=1e-2)
+    assert_allclose(pars[14].value, 1, rtol=1e-2)
+    assert_allclose(pars[14].error, 0.02147, rtol=1e-2)
 
     # test mask_safe evaluation
     mask_safe = geom.energy_mask(emin=1 * u.TeV)

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -431,9 +431,17 @@ def test_TemplateSpectralModel_evaluate_tiny():
     values = np.array([4.39150790e-38, 1.96639562e-38, 8.80497507e-39, 3.94262401e-39])
 
     model = TemplateSpectralModel(
-        energy=energy, values=values * u.Unit("MeV-1 s-1 sr-1")
+        energy=energy * u.TeV, values=values * u.Unit("MeV-1 s-1 sr-1")
     )
-    result = model.evaluate(energy, norm=1.0, tilt=0.0, reference=1 * u.TeV)
+    result = model.evaluate(
+        energy * u.TeV,
+        norm=1.0,
+        tilt=0.0,
+        reference=1 * u.TeV,
+        lambda_=0.0 / u.TeV,
+        alpha=1,
+        beta=0,
+    )
     tiny = np.finfo(np.float32).tiny
     mask = abs(values) - tiny > tiny
     np.testing.assert_allclose(

--- a/tutorials/mcmc_sampling.ipynb
+++ b/tutorials/mcmc_sampling.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,9 +102,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:gammapy.irf.background:Invalid unit found in background table! Assuming (s-1 MeV-1 sr-1)\n"
+     ]
+    }
+   ],
    "source": [
     "irfs = load_cta_irfs(\n",
     "    \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
@@ -119,15 +127,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SkyModel\n",
+      "\n",
+      "  Name                      : source\n",
+      "  Datasets names            : None\n",
+      "  Spectral model type       : ExpCutoffPowerLawSpectralModel\n",
+      "  Spatial  model type       : GaussianSpatialModel\n",
+      "  Temporal model type       : None\n",
+      "  Parameters:\n",
+      "    index                   :   2.000              \n",
+      "    amplitude               :   3.00e-12  1 / (cm2 s TeV)\n",
+      "    reference    (frozen)   :   1.000  TeV         \n",
+      "    lambda_                 :   0.050  1 / TeV     \n",
+      "    alpha        (frozen)   :   1.000              \n",
+      "    lon_0        (frozen)   :   0.000  deg         \n",
+      "    lat_0        (frozen)   :   0.000  deg         \n",
+      "    sigma        (frozen)   :   0.200  deg         \n",
+      "    e            (frozen)   :   0.000              \n",
+      "    phi          (frozen)   :   0.000  deg         \n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# Define sky model to simulate the data\n",
     "spatial_model = GaussianSpatialModel(\n",
     "    lon_0=\"0 deg\", lat_0=\"0 deg\", sigma=\"0.2 deg\", frame=\"galactic\"\n",
     ")\n",
-    "\n",
     "spectral_model = ExpCutoffPowerLawSpectralModel(\n",
     "    index=2,\n",
     "    amplitude=\"3e-12 cm-2 s-1 TeV-1\",\n",
@@ -138,12 +172,12 @@
     "sky_model_simu = SkyModel(\n",
     "    spatial_model=spatial_model, spectral_model=spectral_model, name=\"source\"\n",
     ")\n",
-    "print(sky_model_simu)"
+    "print(sky_model_simu)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,16 +198,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAVEAAAEMCAYAAAB9ZoVrAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAgAElEQVR4nO29e7yVVbX///5wFURFxQsKBiVGSIaoaGpGXhL7mnjMyijR7GiWWnrqeD0/L6csLbuZlZmhYpGikhLHvKWkhkqACqiYpCiYl1BRFEGB8fvjeZYs1jPmZu3L2nuvvcf79VqvvdZY43nWfC57rrnmZ44xZGYEQRAETaNLWzcgCIKgnolONAiCoBlEJxoEQdAMohMNgiBoBtGJBkEQNIPoRIMgCJpBq3aikiZIelnS/DLbdpLulnSLpD65raek6yUtlPSQpEFl/mfl9iclHVxmX9SKhxIEQQC0/kj0amBMhe0bwCnAlcCXcttXgNfMbEfgJ8DFAJKGAUcBO+f7+aWkro1pgKRrm9r49kwcV/3RUY+tox5XilbtRM3sXuDVCnNXYG3+UG4bC1yTP78ROECScvt1ZrbKzJ4BFgKjcr9/V9mMI5rY/PZOHFf90VGPraMel0u3tm4AcBlwLfA6MC63bQ8sBjCz1ZJeB7bM7Q+Wbbskt2Fme7RWg4MgCEq0eSdqZs8C+1WY5bk2YG+Q/OfFEfmOe++w5ZbrbZPawSY9irYuibH7KyuLtj5ea4GVzgem2uDNVaxxbBv16MG2FccF4BwCPRPt6tnT+SzvwxJ42wO8+WbR1qt3dfvcrHcPBjnH1Wcj33+Zcx16Ja6Zdy3fXZ3wrXJ7gNVri7YVjl+fHj0Y0q94bHL226uX/1lrnc96Z5Xvu9S5ln19V7o5N57XLoC33q3wk5D0VplpipkdnfgolzFjxtjSpUur8p09e/btZlY5TdhqtHknmmAJMBBYIqkbsBnZNEDJXmIA8K8N7Sy/gEcDbCnZvq+uP6Pg/N8BcMyIom2LLXzfk+8u2sYl/tFnOB/4btEEwDaO7SXH9k+AVytnSmA3x/cjiXaN2rloe/nlRMO87Uf59okTi7ZD965+v1dOKx7XuP193+851+HAPr6vdy0XPOf7en1+30QP9Oyyou12x++0jYC3ise26aZF3wP39T/rjTeKtjlzfN8TnQmvr/quDN6uaEt98U1ZuP7rLYYP59F58zZO7Loqli5dyqxZs6ryldSvOZ/VXNrrEqepwDH58yOBuy3LlDIVOCpX7wcDQ4CZbdTGIAhqytoqH21Lq45EJf0BGA30k7QEOM/Mfuu4/ha4VtJCshHoUQBm9pikycDjwGrgJDNrxA/OIAjqAyP7F2//tGonamZfqNJvJfDZxHsXAhe2ZLuCIGiPtP0osxra65xozdh2czj7gPVtv77R973skaLtc85cEcDhjm3rrX3fEc68W/fEldje+bx5iXk7D2/d16uJSWBnSpWdh/u+y525uO85c5/gzzlPnOb7ev82Q525xyucuU+A0c587wJH2AIY6czxpaaAPWFoqDP3CfCEY/upMwf84ouJD3M4apJvv8jZ7zMJleAC5x57NTHYu8fZR2pB9siK/T6d8GscRnSiQRAEzSI60SAIgiYSI9EgCIJmEp1oEARBEwl1PgiCoJnESLRd8vxrcE6FGr9fIqJlR0/NdBRsgN6OKnxiQkX/X8d36FDf11sh0N3xOy0RAXTXjKItpUDfNb9o8yJiAO51ju2AHX3fXy8s2g5PqP4DBhRt06cXbVv5m7skArS40zkRH0n4LnFszqkFYIxzP3lRRCsSqyQWOLbDEp+1aFHR9pHEvTTD2fFx3rIS4E/O6okViYFhr4oTnIgqbiQxJxoEQdBMohMNgiBoIjESDYIgaCYhLAVBEDSRGIm2W7oBlRnQVie+8P7mhAsen0j3dp+TS2pSQjy5zRFw/uUISABeBjQvXeTcuf72Xrjifjv4vp5o1t1LSAoc56Si89LQAYxzwl+nOecA4AOO+PF8IwYkKx2xpjGpDj2hBmAjZydjEkLafOfYdtu9aLszkenNE/6OdrYHuNDZx6hE2OceTntXeDcI8JJzzhOXl4Mr/k82mOC3auqjE22vqfCCIOjUlEaizU+FJ2mgpHskPSHpMUnfrHj/25KslJdUGZfmBTHnShrZ0P473Ug0CIJ6ocVGoquBb5nZHEmbALMl3Wlmj0saCBwElC/aO4QsV/EQYE/gV/lflxiJBkHQTmmZkaiZvWBmc/Lny8kSbW2fv/0T4HTWn4UYC0y0jAeBvpL6p/YfI9EgCNohjQr77CepfHb4CjO7wnOUNAjYFXhI0mHA82b2aFZM+D3eK5SZUyqI+YK3z+hEgyBohzRKnV9qZgnpbR2S+gA3AaeS9dDnAJ/0XBMNcul0nWivLjC8IhlvKmmvF155daKi0ygn1G96QoH21OJErudkOGglKZXVKx6XKmT21ROLtoMu8X1PeKdo29V3ZbojNyfyVfOkM/h4xfH7cGJ7rz5kKjwTZ0VE6jr897eLth8lzo23emJP5zrcklDnJ4wv2n6eSHg93jmRqVDdeU747YcS99doZ2VJv8T9/HjF6/aozkvqTtaB/t7Mpkj6MDAYKI1CBwBzJI2ikQUxY040CIJ2Soup8yKr2/aEmf0YwMzmmdnWZjbIzAaRdZwjzexFsoKY43OVfi/gdTNzf8pDJxyJBkFQD7ToYvt9yEqmz5NU+v1xtpndmvC/FfgUsJBsqfWXG9p5dKJBELRDWi6fqJndzwaSS+Wj0dJzA06qdv/RiQZB0E6pj4ilTteJ9uoFu+yyvu3AhMpx881FWyKdKG844tRXj/R9P+5UF/1UYr9dnDBIT2yakchdOtOxJyI5OcARSg4ompKf56QCBWCkk9AzVUW0/7ZF2113FW29nUqdAH0cge+5xLk50DmPS7zEocBVE4q2+31XfjmuaPvmL4u2zyTOweTJRdtBiXDjpY6S9nIiYex2TtXUGQnVbaZzo192qu/788vWf/2k79YEohMNgiBoIpGAJAiCoJlEJxoEQdBEYiQaBEHQTCIpcxAEQROJkWi75d9vwa8qFMn/9qJnKYazAQxK7NdT7f+dUEnPr8wKDVyakP33dxIoe1UbU9UvP/T+om3m076v0yz2dBIXgx9aeG5iv885ca4/8EpaArc7oZBfGlPd5wNMc9TmcYnQxnedgU4qBHi4o2wf5p0w/MTORzvq+nGJEOITHNs7TpgtwCTnnB+WWG2ywLkfd0wcg7dIYWIi9LR2RCcaBEHQRGIkGgRB0EyiEw2CIGgG0YkGQRA0kZaLna81na4T7dMF9qkIGTz7Dt93nJNcMpW3cwtngj6Vt9PzPTnxpbsoEbJYSe/ElVy2rGjbJZE0c08nlDJV/bKLk0TxO4nql9s4QsfXE+GG3i5uua1oG5KoWOpVtByZKDPmXcvHnZyb4FcR3T4R5+pVXn3FEawSUZ+869gOPdT39SrVpu7RvZ37LnV9PS3OCwUF+GSFeKkGU31US8yJBkEQNJPoRIMgCJpBdKJBEARNJH7OB0EQNIMQloIgCJpJjETbJa+uhckVSul/JtTqe5z6fl0T+/3pl4q2SZN83x0dBfmyu31fL/fwZ5zisG8lwhVffLFo8xRdgL86yvSYlITsMGiQb7/fyV58rhOOCvCqowAvd45tjBMKCnCRU238LwnFfdzeRdtuieOd6VS6XJjY74mOku6dg62clRPgFzc/+bu+71AnHHXffX3f6dOLNm/VAcAoZ/VDaqXIvyr/TxKrNBpH/JwPgiBoJtGJBkEQNIPoRIMgCJpI/fycd+JOgiAI2pqSOl/No2EkDZR0j6QnJD0m6Zu5/YeSFkiaK+mPkvqWbXOWpIWSnpR0cIP7z0osdx4GdJGd0nN92/TE5Pp3HYFg6rTEfh1xaoojTIFfAPt9viv7OJP0ngC0X0Ko2Wuvoi0liHhVRKdM8X0XOWJP6nYe6ZybZxLn5mvHFW1eGOMNTsVUgCHO+UqFNnr8NXEvjHP2+3YivHJu4tgqOTCRq9UT0pYn8qfOdHKEDnWqqwKccWbRdsH5vu/rjm2e70qlPnfL8OE8Mm9es4I/d999oM2adVpVvtK3ZpuZI7eW3ld/oL+ZzZG0CTAbOJysQO3dZrZa0sUAZnaGpGHAH4BRwHbAXcBOZrbG23+MRIMgaKesrfLRMGb2gpnNyZ8vB54AtjezO8ys9N3/IOuqfo8FrjOzVWb2DLCQrEN1afVOVNKYfIi8UNKZuW1nSQ9IukZSl9z2nXyY/YikOyRtl9sl6dJ8+7mSRub2QZKmt/bxBEFQC0pzolV1ov0kzSp7eMUBgKyfAHYFHqp46zjgz/nz7YHFZe8tyW0urdqJSuoK/AI4BBgGfCEfOv8XcBgwCygV6/ihme1iZiOAacC5uf0QYEj+OAH4VesdQRAErUfVnehSM9u97OGsFgZJfYCbgFPN7I0y+zlks1G/L5mczZPznq2tzo8CFprZ0wCSriMbOndl3VePAMoPEtiYdQcxFpho2WTug5L65nMea/BLHQVBUHe0rDovqTtZB/p7M5tSZj8GOBQ4wNYJREuAgWWbDwCSM92t/XM+NUz+GfB/wEeB97J7SrpQ0mLgi6wbibr7MLPFZnZEDdseBEGr0mLqvIDfAk+Y2Y/L7GOAM4DDzKxcJpwKHCWpp6TBZL96E2UFW38k6g6TzexhYE/njXOAcySdBZwMnJfaR4MfKl0LHAHQi2KVR0+FB/izkwzYU+EBejnxmScm1NetnSTFXvJk8BP8jnS2/3Oi0ua9jj0h3jLbSSL9oUSlzOedMMhUsmcvzPWJxPf6JRN8eyXvd8IdwT+3Vycqi569f9H2aCL8trvzn7JJoqrm6U5I6vec40qFXJozAJuSqBzrFetckNjvxRcVbamx3uedY3jN+X8AWF7x+rnFi5H0VplpipkdnfioBC06Et0HOBqYJ+mR3HY2cCnQE7gz62d50MxONLPHJE0mK/i7GjgppcxD63eijRomlzGJbKR6XlP2kV/AowG2lzrXmq4gaGV2GDiQV5ct27jZO1rbMp2omd2PP/i6tYFtLgQurGb/rf1z/u/AEEmDJfUAjiIbOheQNKTs5WFAaTwxFRifq/R7Aa+bmZezIQiCesUs60SrebQxrToSzRe1ngzcTiYmTTCzxxLuF0n6INmY/lngxNx+K/ApsrVbK4Av17bVQRC0Ce2gg6yGVo+dN7NbaWAYXeb3mYTdgJNaul1BELQjzIriRTul0yUg2WwzOORj69umJUI5l3rbJybtJzqzsglNhrcc24XjfV9PlHnwwaJtt0QI4vNOCOE+iZyZbzvH5lUmBfi4I5rNeKRoAzjeWfo83xGmALo5d6TXho37+Nt7Ia3nJ3KPeuGgFzthp+DnYP3eRN/3Ruc8OB/F5gnB6xNOntM9EsLhWOfYrk8IQB6JJrCFc48NSvhWhgtPb5Fqn/gKWzuk03WiQRDUAaU50TogOtEgCNon0YkGQRA0ESM60SAIgqYTP+fbLc+/Dv9TISQlgkEKeRIBZiai873aXJ/zdgBcOaNoe+zxRCMcbmxEFNK+jigzPSHqeBFHd97r+x7vCGGPJIQljxGJaK7NnfYOHzOwYLv45MVFR/ycqNslIqmudASYJUt8395ORJoXOQbwuHNDHe4IYZ6IBnC/c398KJEv1hPYPpQ43uGOoDj/jqIN/JymqSU1qyrUqbWNKG6YJNT5IAiCZhIj0SAIgiZi1M0Sp6rCPiW9T9KB+fNeeYr9IAiCGlE/YZ8b7EQlHQ/cCPw6Nw0Abq5lo4IgCDpMJ0oWYrkP8AaAmT0FJKbUgyAIWoAOloBklZm9k+fbQ1I3NpC/sz0zoC9cNHp92+KEIjtjVtG2YyKP5TQnH+hGCcm8Mv8iwO3OZ4GfctYL1Ts6cSXfeado6+67cq8TuuqtOgB41VmlcN7Uka7vd48oJio9JhHm+rpT1XLxjKISf+KJRT+AN5ztf5DIUXrcJ4u2LolhhZfX9V+JBIyjHCV9prOiYnRCxf7muZsVbL/7pVd/089zmqo2OsexpzqAFc6Nd0Tifq4MTb6tJcI+DT/Wth1STSf6V0lnA70kHQR8HfhTbZsVBEHnxmBN248yq6Gan/NnAv8mKzv9VbLlYv9Ty0YFQdDJKUUsdYSf82a2FvhN/giCIGgFrG6WOCU7UUnzaGDu08x2qUmLgiAIoF2MMqtB66qEVrwhvS9/WkqAfG3+94vACjP73xq3rSZsI9kXK2zFafyMDziqypaJ/JpXO7UAeyT2+wMnv+bkyb7vppsWbQueK9pGJpKXesKSt0+AvZ0w1eeczwJ44cWi7S0nVBBghx2KtpRm4LWh69mnF2zzx//A3f6fTj7RscclLtqbxQZ/7WznhAGnO0LYbxL5RAc7YZdeIcNeCaFmphOW62wOQF9H6Nyyn+/7uHNuUjzg2AYlfCt3+/rw4cydN69Z8tLuw/rarN/tV5WvdvvTbDPbvTmf1xySI1EzexZA0j5mtk/ZW2dK+htQl51oEAR1Qp2MRKsRljaWtG/phaS9geZX8guCIEhhuTpfzWMDSBoo6R5JT0h6TNI3c/sWku6U9FT+d/PcLkmXSlooaa4kf+1eTjVLnL4CTJBU+tW7DEgUUQiCIGghWm4kuhr4lpnNyUPWZ0u6EzgW+IuZXSTpTLKVSGcAhwBD8seewK/yvy7VqPOzgY9I2pRsDtVf9RsEQdBStGB5kLyk+gv58+WSngC2B8YCo3O3a4DpZJ3oWGBiXhTzQUl9JfVPlWbfYCcq6dyK16WGxZxoEAS1owZLnCQNAnYFHgK2KXWMZvaCpFI4+/ZAeZjcktzWtE6U9YtTbgQcCjzRmIa3J7oClSmoPBUe/JA6r0IkZGe4kl0TiXQvv6Jo2zeRwNljnqOYe1VBwa9+Ofann3B9x42+p2A7+0h/v54S//nbvuw7L3ESKM/w9F9g9OiibcXbBZOXYBhg+Mjimoh/L/AzaW81rChjn3qUV+MVfj+paPu73wS2dEJPvRURlyWSY58+qmj7H2f1B8AFznVfk1j54PUAm/uuHODc+4cf7vtWJuP+cYuEfVpjwj77SSoPnL7CzAr/ZZL6ADcBp5rZG6UBoYP3RnK5ZzU/539U0ZBLgKkb2i4IgqBZVP9zfumGljhJ6k7Wgf7ezKbk5pdKP9Ml9WddkYslQHk5hQFAIiNBlflEK+gNJMZYQRAELUALZnFSNuT8LfCEmf247K2pwDH582OAW8rs43OVfi/g9dR8KFQ3J1oeudQV2Ar4zgZbHgRB0BxaTp3fBzgamCepNPlwNnARMFnSV4DngM/m790KfIosjmAFkJinyqhmTvTQsuergZfMrD5yVAVBUJ8YLZbFyczux5/nBDjA8TfWRWpukGo60e+a2dHlBknXVtrqhbfJ0lGVs2PiWg0aVLRd6SXzBD7s2BY6OSRxPh9g5Arf9yGnguZXjyra7k1U5fTCDa8/sSggAQxrhJD2+ROcYNnHH/Odt+1ftP13YnHHP50DvuLXRdvJp/jbzyomZt1q06dc1/nTiyLSa4lqrl6477kJcevPdxdtXmXQrRP3kledtJiRNWN2Ig+txzhHvEwJdJMcIe1nN/q+lfrY6pao9omlFbJ2RjWd6M7lL/KkzLvVpjlBEAS06DrRWpMUliSdJWk5sIukN/LHcuAl1k3ABkEQ1IY6ySea7ETN7PtmtgnwQzPbNH9sYmZbmtlZrdjGIAg6I3XSiTaUT3SomS0AbvAC8M0sNU0TBEHQPOro53xDc6L/BZwA/Mh5z4D9a9KiIAgCqJsaSw3lEy2lDj7EzFaWvycpkU62/bOarGBUOQ8nVPSVK4s2J6IPgO37FG2jnPA9gNGO6HhbQl1PiMUF+juKboquiUmcL44r2jylGOCem4t5aD4xJZHoZmUxbJPXEtmeP7Bz0XaWV66zMng3Z4eXirZ3Vrmuw0cV2/XM/LccT/jYqU42tMp4x5x//av4zz/fCfH8dCJU17vvLk3klZ7k3CApcXzqjKIttfqit7OqY5dElvGVFW1wCqM2nsaFfbYp1UQsOafetQVBELQctra6RxvT0JzotmR5NXpJ2pV1i1U3JV2tIAiCoPl0kDnRg8mSlg4AyuNNl5OFTAVBENSOeu9Ezewa4BpJnzGzm1qxTUEQdHY6yEgUADO7SdL/I4tc2qjMXpdJmd+3OVx58Pq2Zct83ytvK9pS8xgTnfyaC5zwP4BDRxRtAxLCwcWnFqetH7i/eHOlxKLZjViI1s25G1LCklsxNFUadKaTDPOr30u1wrEd7NgSJ2yoc8A9evq+q9cUTAtufNR1ffWK4n4nT/N3613L1x1F8oGEajjIyQE7xKmYCnCU08/stJPv+23nMgxItGGoUz32Ll9Ho3K3ibPdeDpKJyrpcrK+4xPAlcCRFM9bEARBy2EG73YcdX5vMxsPvGZmFwAfZf2EpUEQBC2LUf8RS2WUFtOtkLQd8AowuHZNCoIgsHaxfKkaqulEp0nqC/yQLCOXAb+paauCIAjawSizGqoRlkpZ7G+SNI1MXHKmnYMgCFqI0s/5OqCakeh7mNkqYJWkG4CEXti+WfIanH7d+rZxia+ERY5tdGK/ezsJbxckku4ud5T8JQmV9M/TijfSZEfW2zuhont5bc+b6oQwAvf9tHopf7dDnUTLO37Ad97VKxPpyfsAgxybE2/4yqn+5ls6oaepimA7FG/hQ7x4R+CFKcXqpKMTYb37O1klLrqoaNvNCRUGmO3cH+MSn/VrJ1HyIwnZ92QnMfTMl4s2AJx790tjfNctKlaxtEyezI4V9unREkVRN/wh0hhJT0paKOnM3DZY0kOSnpJ0vaQeuf18Sce2RruCIKgxZlkCkmoebUxTO9FkDeaWQlJX4BfAIcAw4AuShgEXAz8xsyHAa8BXat2WIAjagHpX5yX9Cb+zFLBlzVq0jlHAQjN7Om/PdcBYshR8pXxD1wDnA78C3mTdSoIgCOqZDjInekkT32sptgcWl71eAuwJLCurNrok98PMWqNNQRC0Ch1giZOZ/bU1G+Lgzbt2dWwbnFqQdC1wBMDGXeCzFULDO+/4241zpLNJicjG7RYVbakv0nedz1tcNAHwj38UbY1R9N7viSpzfAHpZUdk6Dmgn79jL1nqq6/5vpsMcIxO3k8AXnBsTubFLU9PbP/7osmpAArACqfE6ove50P/4cVYzuee89VA7/Qe5VRoveS6og1giGP770SlzQMdceptJx8pwFPO9T0gkdPUu0cvd8KgIRvJlPPs4sVIKk/MOqVJ1YFbaCQqaQJZ6feXzWx4bhsBXE622mg18HUzmylJwM/I6s6vAI7dUBWPps6JtgZLWD8yagDwHNA3rzhasv1rQzsys6PNbGMz23jr7i3f0CAI1rHDwIGU/t/yR+M7UIM1q62qRxVcDVSuLfgBcIGZjQDOzV9DpsEMyR8nkE0VNkh77kT/DgzJ1fgewFHAVOAesvh9gGOIyqNB0OEwg7VrqntseF92L8UiEca6dXabsW4wNhaYaBkPkg3anPV862jUOtHWxMxWSzoZuJ3sZ/wEM3tM0hnAdZK+CzwM/LYt2xkEQW1YW/0aoH6SyudsrjCzKzawzanA7ZIuIRtMllZ6e1rM9vjzTEB1WZzuBD5rZsvy15sD15mZl5+sRTGzW4FbK2xPkyn3QRB0UBopzi81s90b+RFfA07LU31+jmwwdiC+FtNgd17NSLRfqQMFMLPXJDmxD/WBBN0rjnqLRGrKVc7k+neH+b5eyswTT/R9L3CiV1L8y8l1OsqpRLbQyUEJMMaLMum9seu7995+kTaPNVOKsyhd9/2o7/y+Fx3jlxJ7LkYGwT+LJrvS39yJclk15f9c155bOOdh9buu7y2TizfDG4mqhfOdwoefO7Roe8XfnPFOxNOXtvV9r59ctD2fCPQZ2tfxrVSFcrwIvBQ7VohT31xa/bZJrLqf6s3gGOCb+fMbyNJ8gq/FNKi7VDMnulbSe4KwpPfRCovtgyDo3NR4rf2/gI/nz/cHnsqfTwXGK2Mv4HUzS/6Uh+pGoucA90sqLXnaj0y1CoIgqAlmbuGBJiHpD2RpL/pJWgKcBxwP/Cxf6bOSdX3arWTLmxaSLXH68ob2X00Wp9skjQT2IpsvOM3MWmLAHgRB4NKSAUtm9oXEW7s5vgac1Jj9NxT2OdTMFuQdKKybF9hB0g4bWoAaBEHQZGo/J9piNDQS/S+yIe6PnPeMbB4hCIKgxTEatcSpTVE2em3AQdrIzFZuyFYvbC3Z5ytsqQqe8xzbf+/n+77qRADOne/7evrvsET43aJFRdsKR339SCInqhfZOMCLwqSosgJslViH0WcLJ8dnt0Q42H4fK9oGDfJ9vRyS23/EcfQigMHNQfNs4kJcfVXR1s8Pc330ruIM1gcS12y5o9rffHPR5uUdBbjBCfF8NqG4ewtLUpVjvWquI/3UssydW7Qdf6a/41O+sf7Nf9/w4Twyb16z0mV+ZCvZbZ+pzne7XzO7CUucWoxq1HkncNm1BUEQtAhm2Wqzah5tTUNzotuSrdTvJWlX1i1C3ZT04C0IgqBFqJef8w3NiR4MHEu22PRHrOtE3wDOrm2zgiDozNRROtEGU+FdA1wj6TNmdlMrtikIgs6OdYBOtIzdJP2lInb+W2b2P7VtWm3YtBcc+MH1bV7hOIBXnVDKyff6viOdQnE7JgqkedrFi15kJLCNI+x4qTxnJGapPd/HH/d9PaHj7rt934O+7mQ19dQ1gGWv+3aP6dOLti9+rWi7xlcdVi1YVLD1/H4iznbfouC16q77XFcvrDdR084NwfVCRO9N3Esfd8TLPyauwxYbFW19EgXw7nRy4XZzBCSAXs6x3Xezf30r04z28nfZaOpliVM1wtIhlbHzZCv6gyAIakJpiVM1j7ammpFoV0k983LJSOoF9Kxts4Ig6MyU1Pl6oJpO9HfAXyRdRfYFcRxZgbggCILa0JHmRM3sB5LmAQeQKfTfMbPba96yIAg6Ne3hp3o1VJXZ3sz+DPy5xm0JgiAA8vIgHWUkmufU+znwIaAHWbzdW2a2aYMbtlNWr4OL0e4AABy2SURBVC5WtXwmkXLVy3OcOugxjoq+dSJk0lPSvWhHgJVOcO2CBdVvP3la0Xb4J33f+YnoSJc3iwmc17zsq7ddBzixp9P8RMls55SzeW1iwfTM3YvczQeP2Kxo/Mn3Xd+nZhVXDaQSdA93EmGn/smnO0r+6ScXbZde5m//Z+d+9CqAAixy7o9FiYq0ezpJmZck7n3vSr6WWHxxUcW5ubBZAZ/r6DCdKHAZWZG4G4DdgfFAImo4CIKg+VgHyeL0Hma2UFJXM1sDXCUpYueDIKgpLZWUudZU04muyEsWPyLpB2RV7/wiPUEQBC1APY1Eq1lsfzTZPOjJwFtkRZyqTFIVBEHQNGpcY6nFqGaJ07P507eBC2rbnNqz4l2YWzGZfu7Xfd/+1xVtkxOT6399pGg77kjfd9y4ou1GJ4ckwEuOcDDNEZac6L/ss5wQwh5OKlDwQxM9EQvgIMfWtUfiOzmlenl4lUgnF0tavuNUYk2SyF06pMfzBds3T/Yr3xzkZKtMiVDHHVW0nemISKlrdpAjSFaKoSXGONc3FU7qXYZdHMEMoKfTuC/OKtoArqtUSJyUro2lnpIyN5QKbx4NVPU0s11q0qIgCIIOssTJqZQdBEFQezpE2GfZz/ggCIJWp15+zm9QWJK0l6S/S3pT0juS1khyZs+CIAhahlJS5pYQliRNkPSypPkV9lMkPSnpsXzlUcl+lqSF+XsHb2j/sdg+CIL2R8sucbqarB97L/RN0ieAscAuZrZK0ta5fRhZf7czsB1wl6Sd8jXyLp1usX3PLjCoIuHspEm+74xlRdu4RCjniBFF27kJxX1PR/lMhYju6oTqPf100bZbotahp+renFBv93C+Gg8/3Pf999wXCrZlzvkCeHLqYwXbZon42ZUrFxdsBx1aXE6QWjWwcmUxlHP6/z7q+noJq/dLqNWzHWX6Gec6gJ8U+Qjns6Y64aEAc5xrllLyvQTQqcHZm07y8ZTqv5Hzgacm9ntfxXGsTZzDxtJSwpKZ3StpUIX5a8BFpRSfZlY6E2OB63L7M5IWAqOAB1L7r2ad6HqL7SWdRiy2D4KghliVCZnzedN+kmaVPU6o4iN2Aj4m6SFJf5W0R27fHij/Jl+S25JUMxI9mqyzPRk4jVhsHwRBjTEatbx4aRPqzncDNgf2AvYAJkt6P+sKclY2p8EdNUiZSr+SDrDYPgiCOqD2YZ9LgClmZsBMSWuBfrl9YJnfACCR6yoj+XNe0lhJJ5W9fkjS0/kjEYsTBEHQMtS4xtLNwP4AknYiS/O5FJgKHCWpp6TBZFkIE7PXGQ2NRE8nU6lK9CQb9m4MXAUkZJP2zRtr4S8VE+wfSPgucmwjR/q+XjXI4x0xAWCpE1noiUXghxZ6tq6Jr8MdnKKcjyZEmeXOwrUJE3zfzzhfo1smwiA9wWm3xHl0hQ4nxnPThDDlRXimBK+f31G0eTk3Ad7vVG7day/f98EHizZPABrlXBuAG5x8oJ9N+HrnwctBC75YdGgipObmm4u2RJrSpOjVHFoyKbOkPwCjyeZOlwDnAROACfmyp3eAY/JR6WOSJgOPA6uBkxpS5qHhTrSHmZVPsN5vZq8Ar0gKYSkIgprSUj/nzewLibe+lPC/ELiw2v031IluXrHj8tzcW1X7AUEQBI3FrH7yiTa0xOkhScdXGiV9lQ3MEQRBEDSHloxYqjUNjURPA26WNA6Yk9t2I5sbTSzBDoIgaAE6QhanfAX/3pL2JwuBAvg/M7u7VVoWBEGnpl4y2ysTpDoPI7aW3fnZ9W0Ti8UkAV8FT1VS9MwfSHxF/dNZRDwqEfZ5p6NWv+b4DfA3x4lAZHyi2udzzkH8v4R6+wsnyXBq5cIqJ4FyKmRysKOCT3JCLg9x/MBX94cN830P+fqggu28Yxe5vp7gveN2/n77O/bfOMeQUrW9W+GwvX3fl5zjfcgrUwsUU1CnQw8PHVq0vZtY/P5KxWqTqwcM5+F585pV8/N93WVn96vO98QXmd2ExfYtRlWx80EQBK1NvaTCi040CIJ2R4dIyhwEQdCW1L2wFARB0FZ0iEJ1HZU334QZFdlQDx7j+97n5N1Mhb695Ni+lVgI9vCcoi0V9rncsXki0ghPQQKed3JIpsIg5zjhoKk8p0Md4WFyIsvsKEdo8XJuAtznCDBeKGaigCebO2KgF3IJcNW5iwq21MJpTwTywigB1jgCzM5FE3s6OWgB5s0v2jwBCeA1p/rs2YlEcJ6AOiMRIjrDuReKNVczKi/vmpTK2RjqaIlTNflEWwRlXJqn3Z8raWTZe6dJmiPp8/nrjSTNlPRonrr/gjLfwXkylKckXZ/nOkXS+ZKOba3jCYKgdhjZEqdqHm1Nq3WiwCFkGVGGACcAvwKQ1IcssckooFSRfRWwv5l9BBgBjJFUSvdwMfATMxtCttrnK612BEEQtA5WPxFLrdmJjgUmWsaDQF9J/VmXBPW9GZDcp/RDtHv+MEkiS19VyiB1Deuip94E3q7xMQRB0AqYZUmZq3m0Na3Zibpp981sOTAPmAVcX3pTUldJjwAvA3ea2UPAlsAyM1tdvg8AM7vEzK4nCIIOQYxEiyTT7pvZ981sVzN7r2Scma0xsxFkOsooScMb2keDHyxdK+ktSW+95ETPBEHQcixevJjS/1v+uLax++goCUiaTZ4Zv5QJ6u80Mu0+gJktkzQdGAP8iGwaoFs+Gq12H0eT1YpiG8nufmT993v3djbCr+A5NKFmTneU/FMSaas9wXvfRELjwxzbXEeRTR3D+5wr/OKLvu8RziqFC27zfU9xEk6nbqYdnSqiixb5vts5Svx1zmqChYkMDqOdSpPdEg378unFuMIfnelkzMZPfnxHYkWFF5H6Icc44ZGiDTIRoJJeiZUAbzv2n1/h+3ocmQiflTe8Sqxy2KFipcXvBg7k4WXLmp1zuB30j1VR05Gomf3CzEbkI8qbgfG5Sr8X8LqZFevuApK2ktQ3f94LOBBYkGeevgco5VU/BrillscQBEHbsLbKR1vTmutEbwU+RfZ9tgL4cgO+/YFrJHUl6+gnm9m0/L0zgOskfRd4GPht7ZocBEFbYGS1OeqBVutE81HkSRt0zHznArsm3nuabDlUEAQdFKN9jDKrodNFLAVBUB9EJ9pO2WJTGFeRm9EpJgn4a9BSoX6eupWImMRLTvO4IxYB7OLsxNOQUlUbf+VU6xyQCMub4ohIByTCM6c6BWI+t5/vu5VzDN9zhDjwb0hHK3LPAfgi0phEWO9VPyiKSM85YbIAGzv2/RMVOG9zYoMXOCLUoYl8pPc4N9OOK3zfJxzf/9jf9/XEsdsSwuGBBxZt7yb+TyZXHG9LdX710om25hKnIAiCqij9nG8JYUnSBEkv5+WRK9/7tiST1C9/nQxPTxGdaBAE7ZIWVOevJlsiuR6SBgIHsX5eITc8vSGiEw2CoN1RUuereWxwX2b3At6E2U+A01k/YCcVnp4kOtEgCNoljRiJ9pM0q+yRSAa4DkmHAc+b2aMVb7nh6Q3tq9MJS6++AZMqJtP385QL4O1EdFK1/GeiuNirznfiFCd/I/j5PFc4IkMqAmiYEy30NydfJcBgJ2pq90T5r6/uUrRd5YhYAC84x3tRQgi7aVrR9jFnQdv3HGELACcKaE4iMqi3IxLu7eRJBV+USUVCDXOEJa/oYYoznDy0N9/s+3Z3bI8kjneOcx1SxfKmTy/aFiVEt50qXrsRNI2kkUucljamUJ2k3sA5gFeysdGh5Z2uEw2CoD6ooTr/AWAw8GiWGI4BwBxJo8hGno0KT4+f80EQtDtaUp0v7NtsnpltbWaDzGwQWcc50sxeBKZSZXh6iehEgyBol7TgEqc/AA8AH5S0RFJDidxvBZ4mC0//DfD1De0/fs4HQdDuaMnYeTP7wgbeH1T2vOrw9BLRiQZB0C6pl4il6ESB6Qm12kuf+KmEyjreCbWb41T1BNiymMaSUYnwyiVLijYvbDNV0dILefxtwneNo96+k6jgOd85Zw8kQlc/4YQ33nWX77uZIxfPnVu0pW7c4U5+zEmJvJ/fcFYY3JdQ/bd0rs8uzvYAOzjhoG+8UbSlFHtvJcAHnFUW4Ff7TF2HrRxbqoLn5xwl3inECkDVsngjiAQkQRAEzSQ60SAIgmYQnWgQBEETiaTMQRAEzSDmRNsxPbrADhXJKL3ciQCXOKF2UxKT9msdEalLI1bhpkSGN50J/lucENFDEgXHznaKliU0CrZy7oY3EqF+XjjqwKIJgPlOvIdTjw6AbZ39ejlcRzmhleAXxRuQEJZudUSkQQmB74NOOKgn+gHcnGhbJXskzq33WZboUbw8si9M9H23cU764U4RQPCvT+q+2bPijb95gZNNIDrRIAiCJhIj0SAIgmYSnWgQBEEziE40CIKgiYQ6HwRB0AxiTrQd0707bLPt+rafJhLe7u0oxVNe9n332qto88L/wFfM905Ufhw3rmi767Ki7d6EAn2AI6n+MxH2ub3ThmHDfN/77y/aEgUp2cXZ70cTCasn3Vi0fdpJneutWgDo7ZQBPXu87+uFni5JZI70wiu9lQDA+hV7crzkx5s54Z0Av3HOwfDE/XGmo8SPG+H7DnVU/xnX+b49HNvwRAbnhyrup7WJJOeNJTrRIAiCZhCdaBAEQROJn/NBEATNJDrRIAiCJhLqfDvmzVXFifCUINLHCQEcmhCWtnMm/o9zBCSAK44r2q5MVMo8zhGRHL2LV/zNed4JTUyFmHo5L1NVREePLtpS1S+9ypGegATwlmNb5oQmpnJmDnfsqdylq53/0pEJUeZkp4LmoISYd7hz3/RwlJq1iaHWDs72ExKC13jnZpiRqPZ5gBPe/P8d6fveflvR9kpCzKu8PA2WxmwEMRINgiBoIjEnGgRB0EyiEw2CIGgiMRINgiBoJvUiLEXd+SAI2h2lkWgL1Z2fIOllSfPLbD+UtEDSXEl/lNS37L2zJC2U9KSkgze4/6zMcudha8k+X2HbJjEe/6PzVZjI34wn2n9ulO/7j38kduJwnaNMOwU86Zo4hiedY3gn8Vmfc8L1nnASQIMfsphSm73qld9LJC6+1DlnU5zkyWMTJSYfcZTpPRPXob+zouLixKoBL+H04EQo5gpnuceNznX8aiJs1AvLTXUWdzi2VDSqdwy9E/fNCGeVwu2Jcp+Viz1uGT6cR+bNa1Zq5o0kSyX5rmQhzDazZNFRSfsBbwITzWx4bvskcLeZrZZ0MYCZnSFpGPAHYBSwHXAXsJOZrUntP0aiQRC0O1pyJGpm9wKvVtjuMLPSEONBoFSIfCxwnZmtMrNnyCqnJ76GM6ITDYKgXdKITrSfpFlljxMa+VHHAX/On28PLC57b0luSxLCUhAE7ZJGqPNLG/o53xCSziHTsH5fMjluDc55RicaBEG7ozXCPiUdAxwKHGDrxKElrD99PABIxItldLpOtHcPGFmRTzQVBtndEVUeXen7PurY9k5Ug5zviAwDiiYAjnPEi4XOJX03ccd52seHE8rDQkfQWJPY71QnvPLDvivvc2yJU05fp8zkjk4ey8fmF23gC2mbJcSxOU6F1pQo47Xre4l/LU/480SSvybyug51wj4XJEIuP+F9lhcXDCxy1M/bE9e3l3POUtfs3orXLSFV13qdqKQxwBnAx82sXAqcCkyS9GOyf58hgCNtrqPTdaJBENQHLdWJSvoDMJps7nQJcB5wFtATuFMSwINmdqKZPSZpMvA42WD4pIaUeYhONAiCdkpLdaJm9gXH/NsG/C8ELqx2/9GJBkHQ7oiwzyAIgmYSnWgQBEETiaTM7RkrJuNdnlA+t3ZUzt0SyYDXOPvo5VSeBNjEsTk5cAGY7Ei9XpLj+YkEwccdVbTdfbfv6x2vl7gY4EDnPKSSMnv7OCJROXLGjKLtdWdFxGaJ7c91qqNOmeL7enzSqSwK/jF8pVKWzvlwldUu5ySSJ48cWbTdlvgsb1XHpETicG/lwcd8V3bZpWhLJeg+e9D6r89YnthpI6mXkWirRSxJGirpAUmrJH274r2jJM2RdGqZbTdJ8/JEAJcql9AkbSHpTklP5X83z+3HSjq/tY4nCILa0ZJhn7WmNcM+XwW+AVzivHcUsAewl6TSKrlfASeQrdMawrrld2cCfzGzIcBf8tdBEHQwohOtwMxeNrO/A+86b5dCrQyQpP7Apmb2QB5JMBE4PPcZC1yTP7+mzP42WaaWIAjqnHoaibaXOdEpwCzgd2a2XNIHycKvSpQnAdjGzF4AMLMXJG2dP7++mg/q1qs3/T48dD1bz8T82mqnu+/mFHMDGOykP9sikctrgJMa7oO+K92dcJ8tdi7atnciagB6Di7a+jnzXQA9nWJqaxLLjLs756FrV9/XI7Vfbx89nXPbp6e/fc9BRds2u1bdLDZOhCx57d02Mfe3WSrsqYL+iSFMn52KtiGJ4UF/x+ZsDvhRU/0Svps4N2Q/bzIf2KQiLE5zvHFS46kXYanV84nm85Zvmpn3s77kswfwfTM7MH/9MeB0M/u0pGVmVp5A9TUz23wDn3ktcARAly5deu+6ayP+q+qEZ555hsGDnR6zzumoxwUd99gefvhh1q5dW/7VN8XMjm7MPiTdRrqPr2SpmXnRtq1CTUeikk4Cjs9ffsrMGgzkL2MJ6wuP5UkAXpLUPx+F9sfPh7we+QU8Om/TW7Nmzdq4ynbUDZLeeuWVV+K46oiOemyS3jKzZh1XW3aKjaWmc6Jm9gszG5E/qu1AyX+uL5e0V67Kjwduyd+eChyTPz+mzB4EQdDqtNrPeUnbks17bko2H/wmMMzM3FlGSbsDVwO9yBKmnmJmJmlLYDKwA/Ac8FkzS6zedPfb7G/J9kgcV/3RUY+tox5XilYTlszsRdIZ3zz/WUBh2bKZvQIc0IymNGLpdV0Rx1V/dNRj66jH5dLpCtUFQRC0JFFjKQiCoBlEJxoEQdAM6roTlTRB0suS5pfZtpN0t6RbSiGkknpKuj6Pw39I0qAy/7Ny+5OSDi6zL2rFQykgaUzepoWSzsxtO+f5B66R1CW3fUfSXEmPSLpD0na5XXnOgYX5+yNz+yBJ09vswBIkjndwfr2eyq9fj9x+vqRj26idG0maKelRSY9JuiC3Xy3pmfw6PCJpRG7fXNIf82swU9Lwsn15OSNuK9v35ZK65vZ2lzOiXq5ZzTGzun0A+wEjgflltouAnYFPAyfmtq8Dl+fPjwKuz58PIyuP1BMYDPwT6Jq/t6gNj6tr3pb3Az3yNg4jy8a9FXAKMCb33bRsu2+UHeenyFY1CNgLeCi3DwKmt/W1q/J4JwNH5T6XA1/Ln58PHNtGbRXQJ3/eHXgoP79XA0c6/j8EzsufDyXL+1B67+b82K8r2+emZZ9zU9nx/wA4M39+JnBx/vxY4Py4Zm33qOuRqJndS5bYpJyurAurLcXkl8fb3wgckK8/HQtcZ2arzOwZYCEwKvf7dy3bvgFGAQvN7Gkze4fsn2ws2bGVwooFYOsvEduYdXXCxgITLeNBoG8enLCG4jlra1LHuz/Z9YL18yS8SZYrodXJz2cpCLN7/mhInR1GligHM1sADJK0Tf7eejkjcp/S9exG1jmVX8/2lDOibq5ZranrTjTBZcCvgROB3+W27YHFAGa2Gngd2LLcnvNejL6Z7dFK7fVItetnwP8BHwXuKL0p6UJJi4EvAuc2tA8zW2xmR9Sw7U0hdbzL8utVbsPMLrEqcyXUAkldJT1CFi13p5k9lL91Yf6z/SeSStH9j5KHHEsaRVb8tLTUr5QzYpaZLS/b/+35vpezrkNaL2cE8F7OCGsghLqG1NU1qyUdrhM1s2fNbD8z+3TZjSnPtQF7W+O2y8weNrM9zexLVlaB0MzOMbOBwO+BkxvaRw3a2hJ4bfXSmbSL9pvZGjMbQdYZjsrnOc8i+7m+B1l14TNy94uAzfNO9xTgYfLcGmZ2jZntamY/qtj/wWS5RXqSjezaI3V1zWpJh+tEEywhT2IjqRuwGdlP2vfsOeUx+m1JU9s1CfhMM/fRFnhtfY5sCqJbma1dtd/MlgHTyeanX8h/6q8CriKfFjKzN8zsy3mnO55sTvuZKva9kizEeWxueimfjkFV5oyoMXV5zWpBZ+lEy+PtjwTutmy2eypwVK7eDyZL/jyzjdpYzt+BIbnS2YNMDJvqOUoaUvbyMGBB/nwqMD5X6fcCXi/9HGyHpI73HrLrBe0kT4KkrST1zZ/3Ag4EFpR1cCKbB5yfv+5bUqiB/wTutXSoc5+y/XQjEwfLr2d7yhlRN9es5rS1stWcB/AH4AWyRM9LgK8k/DYCbiATjmYC7y977xwylfFJ4JC2Pqaydn0K+EfetnMa8LuJ7B92LvAnsnlPyH5u/SLffh6we1sfU2OPl0z5nZlftxuAnu2gnbuQ/SSfm5/3c3P73fl5nk82F19S2z8KPEXWGU4BNm9g39uQdU5zgceAnwPd8ve2JBOonsr/btEOzkVdXLNaPyLsMwiCoBl0lp/zQRAENSE60SAIgmYQnWgQBEEziE40CIKgGUQnGgRB0AyiEw2CIGgG0Yl2IiRtI2mSpKclzc7T6v3HBrYZpLJUg438vGNLqfny11dKGlbltqMlTWvK51aLpBn530GSxjVh+2MlXdbyLQvqiehEOwl5JM3NZBEz7zez3ciiTKque9UEjgXe60TN7D/N7PEafl6jMLO986eDgEZ3okEA0Yl2JvYH3jGzy0sGy5K1/BzeG43dlycJniNp78odNOQj6XRJ8/KEwhdJOhLYHfh9nqS4l6Tpyqq4lhL6zsn9/1LtQUg6QNLD+WdNKGVLkrRI0gX5PudJGprbt8qTGM+R9GtJz0rql79XSiF3EfCxvJ2nVY4wJU2TNDp//mVJ/5D0V2CfMp+tJN0k6e/54733gg5OW4dMxaN1HmQJm3/SwPu9gY3y50PI0rNBNkqbvwGfQ4AZQO/89Rb53+mUhZuWXpMl4VgMDC73r2jPaGBahW2jfLud8tcTgVPz54vIympDloT7yvz5ZcBZ+fMxZFmF+uWv3/Q+i2wEfVnZ62m5T3+yJBtbkeX6/FvJjyz5y7758x2AJ9r6msejdR6tVjI5aF9I+gWwL9nodA+y5MKXKStrsQbYydks5XMgcJWZrQAwsw0lfd6LbFrhmSr9S3wQeMbM/pG/vgY4Cfhp/rpUqnc2eQ7P/Bj/I/+c2yS9VuVneexJVhXg3wCSrmf9czAsmzUBYFNJm1hZntCgYxKdaOfhMdalycPMTsp/1s7KTacBLwEfIZvmWensI+UjGpc3srH+5ds1xKr87xrW3dsb2sZjNetPdW1U9jzV7i7AR82sQ2ZvD9LEnGjn4W5gI0lfK7P1Lnu+GfCCma0FjsZPsJvyuQM4TlJvyIqq5fblwCbOfh4APp6nHyz33xCl8ho75q+PBv66gW3uBz6Xf84ngc0dn8p2LgJGSOoiaSDrSsY8BIyWtKWk7sBny7a5g3UJsclH60EnIDrRToKZGVmey48rq0o5k+zncCkD+y+BYyQ9SPYT9S1nN66Pmd1GlktylrIM7t/O/a8GLi8JS2Vt+TdwAjBF0qNAqmzEAZKWlB7ArsCXgRskzSOrNXV5YtsSFwCflDSHbO72BbJOs5y5wOpc5DqNbK7zGbLUdpcAc/J2v0BWcO0B4K6SPecbwO7KyoM8TlaeJugERCq8oEOTq/drzGy1pI8Cv7Isy3wQtAgxJxp0dHYAJkvqArwDHN/G7Qk6GDESDYIgaAYxJxoEQdAMohMNgiBoBtGJBkEQNIPoRIMgCJpBdKJBEATN4P8HLRHc0rGhTLMAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "dataset.counts.sum_over_axes().plot(add_cbar=True);"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,52 +259,138 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MapDataset\n",
+      "----------\n",
+      "\n",
+      "  Name                            : dataset-mcmc \n",
+      "\n",
+      "  Total counts                    : 247566 \n",
+      "  Total predicted counts          : 247649.00\n",
+      "  Total background counts         : 238665.45\n",
+      "\n",
+      "  Exposure min                    : 9.42e+09 m2 s\n",
+      "  Exposure max                    : 3.67e+11 m2 s\n",
+      "\n",
+      "  Number of total bins            : 46400 \n",
+      "  Number of fit bins              : 46400 \n",
+      "\n",
+      "  Fit statistic type              : cash\n",
+      "  Fit statistic value (-2 log(L)) : -938958.09\n",
+      "\n",
+      "  Number of models                : 2 \n",
+      "  Number of parameters            : 16\n",
+      "  Number of free parameters       : 7\n",
+      "\n",
+      "  Component 0: BackgroundModel\n",
+      "  \n",
+      "    Name                      : dataset-mcmc-bkg\n",
+      "    Datasets names            : ['dataset-mcmc']\n",
+      "    Parameters:\n",
+      "      norm                    :   1.000              \n",
+      "      tilt         (frozen)   :   0.000              \n",
+      "      reference    (frozen)   :   1.000  TeV         \n",
+      "      lambda_      (frozen)   :   0.000  1 / TeV     \n",
+      "      alpha        (frozen)   :   1.000              \n",
+      "      beta         (frozen)   :   0.000              \n",
+      "  \n",
+      "  Component 1: SkyModel\n",
+      "  \n",
+      "    Name                      : source\n",
+      "    Datasets names            : None\n",
+      "    Spectral model type       : ExpCutoffPowerLawSpectralModel\n",
+      "    Spatial  model type       : GaussianSpatialModel\n",
+      "    Temporal model type       : None\n",
+      "    Parameters:\n",
+      "      index                   :   2.000              \n",
+      "      amplitude               :   3.00e-12  1 / (cm2 s TeV)\n",
+      "      reference    (frozen)   :   1.000  TeV         \n",
+      "      lambda_                 :   0.050  1 / TeV     \n",
+      "      alpha        (frozen)   :   1.000              \n",
+      "      lon_0                   :   0.000  deg         \n",
+      "      lat_0                   :   0.000  deg         \n",
+      "      sigma                   :   0.200  deg         \n",
+      "      e            (frozen)   :   0.000              \n",
+      "      phi          (frozen)   :   0.000  deg         \n",
+      "  \n",
+      "  \n"
+     ]
+    }
+   ],
    "source": [
     "print(dataset)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ProperModels\n",
+      "\n",
+      "Component 0: BackgroundModel\n",
+      "\n",
+      "  Name                      : dataset-mcmc-bkg\n",
+      "  Datasets names            : ['dataset-mcmc']\n",
+      "  Parameters:\n",
+      "    norm         (frozen)   :   1.000              \n",
+      "    tilt         (frozen)   :   0.000              \n",
+      "    reference    (frozen)   :   1.000  TeV         \n",
+      "    lambda_                 :   0.050  1 / TeV     \n",
+      "    alpha        (frozen)   :   1.000              \n",
+      "    beta         (frozen)   :   0.000              \n",
+      "\n",
+      "Component 1: SkyModel\n",
+      "\n",
+      "  Name                      : source\n",
+      "  Datasets names            : None\n",
+      "  Spectral model type       : ExpCutoffPowerLawSpectralModel\n",
+      "  Spatial  model type       : GaussianSpatialModel\n",
+      "  Temporal model type       : None\n",
+      "  Parameters:\n",
+      "    index                   :   2.000              \n",
+      "    amplitude               :   3.20e-12  1 / (cm2 s TeV)\n",
+      "    reference    (frozen)   :   1.000  TeV         \n",
+      "    lambda_                 :   0.050  1 / TeV     \n",
+      "    alpha        (frozen)   :   1.000              \n",
+      "    lon_0        (frozen)   :   0.000  deg         \n",
+      "    lat_0        (frozen)   :   0.000  deg         \n",
+      "    sigma        (frozen)   :   0.200  deg         \n",
+      "    e            (frozen)   :   0.000              \n",
+      "    phi          (frozen)   :   0.000  deg         \n",
+      "\n",
+      "\n",
+      "stat = -938545.7260836291\n"
+     ]
+    }
+   ],
    "source": [
-    "# Define the free parameters and min, max values\n",
-    "parameters = dataset.models.parameters\n",
+    "# Define the min, max and frozen parameters \n",
+    "dataset.background_model.parameters.freeze_all()\n",
+    "spatial_model.parameters.freeze_all()\n",
     "\n",
-    "parameters[\"sigma\"].frozen = True\n",
-    "parameters[\"lon_0\"].frozen = True\n",
-    "parameters[\"lat_0\"].frozen = True\n",
-    "parameters[\"amplitude\"].frozen = False\n",
-    "parameters[\"index\"].frozen = False\n",
-    "parameters[\"lambda_\"].frozen = False\n",
-    "\n",
-    "\n",
-    "parameters[\"norm\"].frozen = True\n",
-    "parameters[\"tilt\"].frozen = True\n",
-    "\n",
-    "parameters[\"norm\"].min = 0.5\n",
-    "parameters[\"norm\"].max = 2\n",
-    "\n",
-    "parameters[\"index\"].min = 1\n",
-    "parameters[\"index\"].max = 5\n",
-    "parameters[\"lambda_\"].min = 1e-3\n",
-    "parameters[\"lambda_\"].max = 1\n",
-    "\n",
-    "parameters[\"amplitude\"].min = 0.01 * parameters[\"amplitude\"].value\n",
-    "parameters[\"amplitude\"].max = 100 * parameters[\"amplitude\"].value\n",
-    "\n",
-    "parameters[\"sigma\"].min = 0.05\n",
-    "parameters[\"sigma\"].max = 1\n",
+    "spectral_model.amplitude.min = 0.01 * spectral_model.amplitude.value\n",
+    "spectral_model.amplitude.max = 100 * spectral_model.amplitude.value\n",
+    "spectral_model.index.min = 1\n",
+    "spectral_model.index.max = 5\n",
+    "spectral_model.lambda_.min = 1e-3\n",
+    "spectral_model.lambda_.max = 1\n",
     "\n",
     "# Setting amplitude init values a bit offset to see evolution\n",
     "# Here starting close to the real value\n",
-    "parameters[\"index\"].value = 2.0\n",
-    "parameters[\"amplitude\"].value = 3.2e-12\n",
-    "parameters[\"lambda_\"].value = 0.05\n",
+    "spectral_model.amplitude.value = 3.2e-12\n",
+    "spectral_model.index.value = 2.0\n",
+    "spectral_model.lambda_.value = 0.05\n",
     "\n",
     "print(dataset.models)\n",
     "print(\"stat =\", dataset.stat_sum())"
@@ -265,14 +398,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:gammapy.modeling.sampling:Missing prior for parameter: lambda_.\n",
+      "MCMC will likely fail!\n",
+      "INFO:gammapy.modeling.sampling:Free parameters: ['lambda_', 'index', 'amplitude', 'lambda_']\n",
+      "INFO:gammapy.modeling.sampling:Starting MCMC sampling: nwalkers=8, nrun=150\n",
+      "/anaconda3/envs/gpy-dev/lib/python3.7/site-packages/emcee/ensemble.py:335: RuntimeWarning: invalid value encountered in subtract\n",
+      "  lnpdiff = (self.dim - 1.) * np.log(zz) + newlnprob - lnprob0\n",
+      "/anaconda3/envs/gpy-dev/lib/python3.7/site-packages/emcee/ensemble.py:336: RuntimeWarning: invalid value encountered in greater\n",
+      "  accept = (lnpdiff > np.log(self._random.rand(len(lnpdiff))))\n",
+      "INFO:gammapy.modeling.sampling:   0%\n",
+      "INFO:gammapy.modeling.sampling:  50%\n",
+      "INFO:gammapy.modeling.sampling:100% => sampling completed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 34.1 s, sys: 495 ms, total: 34.6 s\n",
+      "Wall time: 35.2 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Now let's define a function to init parameters and run the MCMC with emcee\n",
     "# Depending on your number of walkers, Nrun and dimensionality, this can take a while (> minutes)\n",
-    "sampler = run_mcmc(dataset, nwalkers=9, nrun=150)  # to speedup the notebook\n",
+    "sampler = run_mcmc(dataset, nwalkers=6, nrun=150)  # to speedup the notebook\n",
     "# sampler=run_mcmc(dataset,nwalkers=12,nrun=1000) # more accurate contours"
    ]
   },
@@ -291,11 +450,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'sampler' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-12-193135234a28>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mplot_trace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msampler\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdataset\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'sampler' is not defined"
+     ]
+    }
+   ],
    "source": [
     "plot_trace(sampler, dataset)"
    ]

--- a/tutorials/mcmc_sampling.ipynb
+++ b/tutorials/mcmc_sampling.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,17 +102,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:gammapy.irf.background:Invalid unit found in background table! Assuming (s-1 MeV-1 sr-1)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "irfs = load_cta_irfs(\n",
     "    \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
@@ -127,36 +119,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SkyModel\n",
-      "\n",
-      "  Name                      : source\n",
-      "  Datasets names            : None\n",
-      "  Spectral model type       : ExpCutoffPowerLawSpectralModel\n",
-      "  Spatial  model type       : GaussianSpatialModel\n",
-      "  Temporal model type       : None\n",
-      "  Parameters:\n",
-      "    index                   :   2.000              \n",
-      "    amplitude               :   3.00e-12  1 / (cm2 s TeV)\n",
-      "    reference    (frozen)   :   1.000  TeV         \n",
-      "    lambda_                 :   0.050  1 / TeV     \n",
-      "    alpha        (frozen)   :   1.000              \n",
-      "    lon_0        (frozen)   :   0.000  deg         \n",
-      "    lat_0        (frozen)   :   0.000  deg         \n",
-      "    sigma        (frozen)   :   0.200  deg         \n",
-      "    e            (frozen)   :   0.000              \n",
-      "    phi          (frozen)   :   0.000  deg         \n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define sky model to simulate the data\n",
     "spatial_model = GaussianSpatialModel(\n",
@@ -177,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,29 +163,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAVEAAAEMCAYAAAB9ZoVrAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAgAElEQVR4nO29e7yVVbX///5wFURFxQsKBiVGSIaoaGpGXhL7mnjMyijR7GiWWnrqeD0/L6csLbuZlZmhYpGikhLHvKWkhkqACqiYpCiYl1BRFEGB8fvjeZYs1jPmZu3L2nuvvcf79VqvvdZY43nWfC57rrnmZ44xZGYEQRAETaNLWzcgCIKgnolONAiCoBlEJxoEQdAMohMNgiBoBtGJBkEQNIPoRIMgCJpBq3aikiZIelnS/DLbdpLulnSLpD65raek6yUtlPSQpEFl/mfl9iclHVxmX9SKhxIEQQC0/kj0amBMhe0bwCnAlcCXcttXgNfMbEfgJ8DFAJKGAUcBO+f7+aWkro1pgKRrm9r49kwcV/3RUY+tox5XilbtRM3sXuDVCnNXYG3+UG4bC1yTP78ROECScvt1ZrbKzJ4BFgKjcr9/V9mMI5rY/PZOHFf90VGPraMel0u3tm4AcBlwLfA6MC63bQ8sBjCz1ZJeB7bM7Q+Wbbskt2Fme7RWg4MgCEq0eSdqZs8C+1WY5bk2YG+Q/OfFEfmOe++w5ZbrbZPawSY9irYuibH7KyuLtj5ea4GVzgem2uDNVaxxbBv16MG2FccF4BwCPRPt6tnT+SzvwxJ42wO8+WbR1qt3dfvcrHcPBjnH1Wcj33+Zcx16Ja6Zdy3fXZ3wrXJ7gNVri7YVjl+fHj0Y0q94bHL226uX/1lrnc96Z5Xvu9S5ln19V7o5N57XLoC33q3wk5D0VplpipkdnfgolzFjxtjSpUur8p09e/btZlY5TdhqtHknmmAJMBBYIqkbsBnZNEDJXmIA8K8N7Sy/gEcDbCnZvq+uP6Pg/N8BcMyIom2LLXzfk+8u2sYl/tFnOB/4btEEwDaO7SXH9k+AVytnSmA3x/cjiXaN2rloe/nlRMO87Uf59okTi7ZD965+v1dOKx7XuP193+851+HAPr6vdy0XPOf7en1+30QP9Oyyou12x++0jYC3ise26aZF3wP39T/rjTeKtjlzfN8TnQmvr/quDN6uaEt98U1ZuP7rLYYP59F58zZO7Loqli5dyqxZs6ryldSvOZ/VXNrrEqepwDH58yOBuy3LlDIVOCpX7wcDQ4CZbdTGIAhqytoqH21Lq45EJf0BGA30k7QEOM/Mfuu4/ha4VtJCshHoUQBm9pikycDjwGrgJDNrxA/OIAjqAyP7F2//tGonamZfqNJvJfDZxHsXAhe2ZLuCIGiPtP0osxra65xozdh2czj7gPVtv77R973skaLtc85cEcDhjm3rrX3fEc68W/fEldje+bx5iXk7D2/d16uJSWBnSpWdh/u+y525uO85c5/gzzlPnOb7ev82Q525xyucuU+A0c587wJH2AIY6czxpaaAPWFoqDP3CfCEY/upMwf84ouJD3M4apJvv8jZ7zMJleAC5x57NTHYu8fZR2pB9siK/T6d8GscRnSiQRAEzSI60SAIgiYSI9EgCIJmEp1oEARBEwl1PgiCoJnESLRd8vxrcE6FGr9fIqJlR0/NdBRsgN6OKnxiQkX/X8d36FDf11sh0N3xOy0RAXTXjKItpUDfNb9o8yJiAO51ju2AHX3fXy8s2g5PqP4DBhRt06cXbVv5m7skArS40zkRH0n4LnFszqkFYIxzP3lRRCsSqyQWOLbDEp+1aFHR9pHEvTTD2fFx3rIS4E/O6okViYFhr4oTnIgqbiQxJxoEQdBMohMNgiBoIjESDYIgaCYhLAVBEDSRGIm2W7oBlRnQVie+8P7mhAsen0j3dp+TS2pSQjy5zRFw/uUISABeBjQvXeTcuf72Xrjifjv4vp5o1t1LSAoc56Si89LQAYxzwl+nOecA4AOO+PF8IwYkKx2xpjGpDj2hBmAjZydjEkLafOfYdtu9aLszkenNE/6OdrYHuNDZx6hE2OceTntXeDcI8JJzzhOXl4Mr/k82mOC3auqjE22vqfCCIOjUlEaizU+FJ2mgpHskPSHpMUnfrHj/25KslJdUGZfmBTHnShrZ0P473Ug0CIJ6ocVGoquBb5nZHEmbALMl3Wlmj0saCBwElC/aO4QsV/EQYE/gV/lflxiJBkHQTmmZkaiZvWBmc/Lny8kSbW2fv/0T4HTWn4UYC0y0jAeBvpL6p/YfI9EgCNohjQr77CepfHb4CjO7wnOUNAjYFXhI0mHA82b2aFZM+D3eK5SZUyqI+YK3z+hEgyBohzRKnV9qZgnpbR2S+gA3AaeS9dDnAJ/0XBMNcul0nWivLjC8IhlvKmmvF155daKi0ygn1G96QoH21OJErudkOGglKZXVKx6XKmT21ROLtoMu8X1PeKdo29V3ZbojNyfyVfOkM/h4xfH7cGJ7rz5kKjwTZ0VE6jr897eLth8lzo23emJP5zrcklDnJ4wv2n6eSHg93jmRqVDdeU747YcS99doZ2VJv8T9/HjF6/aozkvqTtaB/t7Mpkj6MDAYKI1CBwBzJI2ikQUxY040CIJ2Soup8yKr2/aEmf0YwMzmmdnWZjbIzAaRdZwjzexFsoKY43OVfi/gdTNzf8pDJxyJBkFQD7ToYvt9yEqmz5NU+v1xtpndmvC/FfgUsJBsqfWXG9p5dKJBELRDWi6fqJndzwaSS+Wj0dJzA06qdv/RiQZB0E6pj4ilTteJ9uoFu+yyvu3AhMpx881FWyKdKG844tRXj/R9P+5UF/1UYr9dnDBIT2yakchdOtOxJyI5OcARSg4ompKf56QCBWCkk9AzVUW0/7ZF2113FW29nUqdAH0cge+5xLk50DmPS7zEocBVE4q2+31XfjmuaPvmL4u2zyTOweTJRdtBiXDjpY6S9nIiYex2TtXUGQnVbaZzo192qu/788vWf/2k79YEohMNgiBoIpGAJAiCoJlEJxoEQdBEYiQaBEHQTCIpcxAEQROJkWi75d9vwa8qFMn/9qJnKYazAQxK7NdT7f+dUEnPr8wKDVyakP33dxIoe1UbU9UvP/T+om3m076v0yz2dBIXgx9aeG5iv885ca4/8EpaArc7oZBfGlPd5wNMc9TmcYnQxnedgU4qBHi4o2wf5p0w/MTORzvq+nGJEOITHNs7TpgtwCTnnB+WWG2ywLkfd0wcg7dIYWIi9LR2RCcaBEHQRGIkGgRB0EyiEw2CIGgG0YkGQRA0kZaLna81na4T7dMF9qkIGTz7Dt93nJNcMpW3cwtngj6Vt9PzPTnxpbsoEbJYSe/ElVy2rGjbJZE0c08nlDJV/bKLk0TxO4nql9s4QsfXE+GG3i5uua1oG5KoWOpVtByZKDPmXcvHnZyb4FcR3T4R5+pVXn3FEawSUZ+869gOPdT39SrVpu7RvZ37LnV9PS3OCwUF+GSFeKkGU31US8yJBkEQNJPoRIMgCJpBdKJBEARNJH7OB0EQNIMQloIgCJpJjETbJa+uhckVSul/JtTqe5z6fl0T+/3pl4q2SZN83x0dBfmyu31fL/fwZ5zisG8lwhVffLFo8xRdgL86yvSYlITsMGiQb7/fyV58rhOOCvCqowAvd45tjBMKCnCRU238LwnFfdzeRdtuieOd6VS6XJjY74mOku6dg62clRPgFzc/+bu+71AnHHXffX3f6dOLNm/VAcAoZ/VDaqXIvyr/TxKrNBpH/JwPgiBoJtGJBkEQNIPoRIMgCJpI/fycd+JOgiAI2pqSOl/No2EkDZR0j6QnJD0m6Zu5/YeSFkiaK+mPkvqWbXOWpIWSnpR0cIP7z0osdx4GdJGd0nN92/TE5Pp3HYFg6rTEfh1xaoojTIFfAPt9viv7OJP0ngC0X0Ko2Wuvoi0liHhVRKdM8X0XOWJP6nYe6ZybZxLn5mvHFW1eGOMNTsVUgCHO+UqFNnr8NXEvjHP2+3YivHJu4tgqOTCRq9UT0pYn8qfOdHKEDnWqqwKccWbRdsH5vu/rjm2e70qlPnfL8OE8Mm9es4I/d999oM2adVpVvtK3ZpuZI7eW3ld/oL+ZzZG0CTAbOJysQO3dZrZa0sUAZnaGpGHAH4BRwHbAXcBOZrbG23+MRIMgaKesrfLRMGb2gpnNyZ8vB54AtjezO8ys9N3/IOuqfo8FrjOzVWb2DLCQrEN1afVOVNKYfIi8UNKZuW1nSQ9IukZSl9z2nXyY/YikOyRtl9sl6dJ8+7mSRub2QZKmt/bxBEFQC0pzolV1ov0kzSp7eMUBgKyfAHYFHqp46zjgz/nz7YHFZe8tyW0urdqJSuoK/AI4BBgGfCEfOv8XcBgwCygV6/ihme1iZiOAacC5uf0QYEj+OAH4VesdQRAErUfVnehSM9u97OGsFgZJfYCbgFPN7I0y+zlks1G/L5mczZPznq2tzo8CFprZ0wCSriMbOndl3VePAMoPEtiYdQcxFpho2WTug5L65nMea/BLHQVBUHe0rDovqTtZB/p7M5tSZj8GOBQ4wNYJREuAgWWbDwCSM92t/XM+NUz+GfB/wEeB97J7SrpQ0mLgi6wbibr7MLPFZnZEDdseBEGr0mLqvIDfAk+Y2Y/L7GOAM4DDzKxcJpwKHCWpp6TBZL96E2UFW38k6g6TzexhYE/njXOAcySdBZwMnJfaR4MfKl0LHAHQi2KVR0+FB/izkwzYU+EBejnxmScm1NetnSTFXvJk8BP8jnS2/3Oi0ua9jj0h3jLbSSL9oUSlzOedMMhUsmcvzPWJxPf6JRN8eyXvd8IdwT+3Vycqi569f9H2aCL8trvzn7JJoqrm6U5I6vec40qFXJozAJuSqBzrFetckNjvxRcVbamx3uedY3jN+X8AWF7x+rnFi5H0VplpipkdnfioBC06Et0HOBqYJ+mR3HY2cCnQE7gz62d50MxONLPHJE0mK/i7GjgppcxD63eijRomlzGJbKR6XlP2kV/AowG2lzrXmq4gaGV2GDiQV5ct27jZO1rbMp2omd2PP/i6tYFtLgQurGb/rf1z/u/AEEmDJfUAjiIbOheQNKTs5WFAaTwxFRifq/R7Aa+bmZezIQiCesUs60SrebQxrToSzRe1ngzcTiYmTTCzxxLuF0n6INmY/lngxNx+K/ApsrVbK4Av17bVQRC0Ce2gg6yGVo+dN7NbaWAYXeb3mYTdgJNaul1BELQjzIriRTul0yUg2WwzOORj69umJUI5l3rbJybtJzqzsglNhrcc24XjfV9PlHnwwaJtt0QI4vNOCOE+iZyZbzvH5lUmBfi4I5rNeKRoAzjeWfo83xGmALo5d6TXho37+Nt7Ia3nJ3KPeuGgFzthp+DnYP3eRN/3Ruc8OB/F5gnB6xNOntM9EsLhWOfYrk8IQB6JJrCFc48NSvhWhgtPb5Fqn/gKWzuk03WiQRDUAaU50TogOtEgCNon0YkGQRA0ESM60SAIgqYTP+fbLc+/Dv9TISQlgkEKeRIBZiai873aXJ/zdgBcOaNoe+zxRCMcbmxEFNK+jigzPSHqeBFHd97r+x7vCGGPJIQljxGJaK7NnfYOHzOwYLv45MVFR/ycqNslIqmudASYJUt8395ORJoXOQbwuHNDHe4IYZ6IBnC/c398KJEv1hPYPpQ43uGOoDj/jqIN/JymqSU1qyrUqbWNKG6YJNT5IAiCZhIj0SAIgiZi1M0Sp6rCPiW9T9KB+fNeeYr9IAiCGlE/YZ8b7EQlHQ/cCPw6Nw0Abq5lo4IgCDpMJ0oWYrkP8AaAmT0FJKbUgyAIWoAOloBklZm9k+fbQ1I3NpC/sz0zoC9cNHp92+KEIjtjVtG2YyKP5TQnH+hGCcm8Mv8iwO3OZ4GfctYL1Ts6cSXfeado6+67cq8TuuqtOgB41VmlcN7Uka7vd48oJio9JhHm+rpT1XLxjKISf+KJRT+AN5ztf5DIUXrcJ4u2LolhhZfX9V+JBIyjHCV9prOiYnRCxf7muZsVbL/7pVd/089zmqo2OsexpzqAFc6Nd0Tifq4MTb6tJcI+DT/Wth1STSf6V0lnA70kHQR8HfhTbZsVBEHnxmBN248yq6Gan/NnAv8mKzv9VbLlYv9Ty0YFQdDJKUUsdYSf82a2FvhN/giCIGgFrG6WOCU7UUnzaGDu08x2qUmLgiAIoF2MMqtB66qEVrwhvS9/WkqAfG3+94vACjP73xq3rSZsI9kXK2zFafyMDziqypaJ/JpXO7UAeyT2+wMnv+bkyb7vppsWbQueK9pGJpKXesKSt0+AvZ0w1eeczwJ44cWi7S0nVBBghx2KtpRm4LWh69mnF2zzx//A3f6fTj7RscclLtqbxQZ/7WznhAGnO0LYbxL5RAc7YZdeIcNeCaFmphOW62wOQF9H6Nyyn+/7uHNuUjzg2AYlfCt3+/rw4cydN69Z8tLuw/rarN/tV5WvdvvTbDPbvTmf1xySI1EzexZA0j5mtk/ZW2dK+htQl51oEAR1Qp2MRKsRljaWtG/phaS9geZX8guCIEhhuTpfzWMDSBoo6R5JT0h6TNI3c/sWku6U9FT+d/PcLkmXSlooaa4kf+1eTjVLnL4CTJBU+tW7DEgUUQiCIGghWm4kuhr4lpnNyUPWZ0u6EzgW+IuZXSTpTLKVSGcAhwBD8seewK/yvy7VqPOzgY9I2pRsDtVf9RsEQdBStGB5kLyk+gv58+WSngC2B8YCo3O3a4DpZJ3oWGBiXhTzQUl9JfVPlWbfYCcq6dyK16WGxZxoEAS1owZLnCQNAnYFHgK2KXWMZvaCpFI4+/ZAeZjcktzWtE6U9YtTbgQcCjzRmIa3J7oClSmoPBUe/JA6r0IkZGe4kl0TiXQvv6Jo2zeRwNljnqOYe1VBwa9+Ofann3B9x42+p2A7+0h/v54S//nbvuw7L3ESKM/w9F9g9OiibcXbBZOXYBhg+Mjimoh/L/AzaW81rChjn3qUV+MVfj+paPu73wS2dEJPvRURlyWSY58+qmj7H2f1B8AFznVfk1j54PUAm/uuHODc+4cf7vtWJuP+cYuEfVpjwj77SSoPnL7CzAr/ZZL6ADcBp5rZG6UBoYP3RnK5ZzU/539U0ZBLgKkb2i4IgqBZVP9zfumGljhJ6k7Wgf7ezKbk5pdKP9Ml9WddkYslQHk5hQFAIiNBlflEK+gNJMZYQRAELUALZnFSNuT8LfCEmf247K2pwDH582OAW8rs43OVfi/g9dR8KFQ3J1oeudQV2Ar4zgZbHgRB0BxaTp3fBzgamCepNPlwNnARMFnSV4DngM/m790KfIosjmAFkJinyqhmTvTQsuergZfMrD5yVAVBUJ8YLZbFyczux5/nBDjA8TfWRWpukGo60e+a2dHlBknXVtrqhbfJ0lGVs2PiWg0aVLRd6SXzBD7s2BY6OSRxPh9g5Arf9yGnguZXjyra7k1U5fTCDa8/sSggAQxrhJD2+ROcYNnHH/Odt+1ftP13YnHHP50DvuLXRdvJp/jbzyomZt1q06dc1/nTiyLSa4lqrl6477kJcevPdxdtXmXQrRP3kledtJiRNWN2Ig+txzhHvEwJdJMcIe1nN/q+lfrY6pao9omlFbJ2RjWd6M7lL/KkzLvVpjlBEAS06DrRWpMUliSdJWk5sIukN/LHcuAl1k3ABkEQ1IY6ySea7ETN7PtmtgnwQzPbNH9sYmZbmtlZrdjGIAg6I3XSiTaUT3SomS0AbvAC8M0sNU0TBEHQPOro53xDc6L/BZwA/Mh5z4D9a9KiIAgCqJsaSw3lEy2lDj7EzFaWvycpkU62/bOarGBUOQ8nVPSVK4s2J6IPgO37FG2jnPA9gNGO6HhbQl1PiMUF+juKboquiUmcL44r2jylGOCem4t5aD4xJZHoZmUxbJPXEtmeP7Bz0XaWV66zMng3Z4eXirZ3Vrmuw0cV2/XM/LccT/jYqU42tMp4x5x//av4zz/fCfH8dCJU17vvLk3klZ7k3CApcXzqjKIttfqit7OqY5dElvGVFW1wCqM2nsaFfbYp1UQsOafetQVBELQctra6RxvT0JzotmR5NXpJ2pV1i1U3JV2tIAiCoPl0kDnRg8mSlg4AyuNNl5OFTAVBENSOeu9Ezewa4BpJnzGzm1qxTUEQdHY6yEgUADO7SdL/I4tc2qjMXpdJmd+3OVx58Pq2Zct83ytvK9pS8xgTnfyaC5zwP4BDRxRtAxLCwcWnFqetH7i/eHOlxKLZjViI1s25G1LCklsxNFUadKaTDPOr30u1wrEd7NgSJ2yoc8A9evq+q9cUTAtufNR1ffWK4n4nT/N3613L1x1F8oGEajjIyQE7xKmYCnCU08/stJPv+23nMgxItGGoUz32Ll9Ho3K3ibPdeDpKJyrpcrK+4xPAlcCRFM9bEARBy2EG73YcdX5vMxsPvGZmFwAfZf2EpUEQBC2LUf8RS2WUFtOtkLQd8AowuHZNCoIgsHaxfKkaqulEp0nqC/yQLCOXAb+paauCIAjawSizGqoRlkpZ7G+SNI1MXHKmnYMgCFqI0s/5OqCakeh7mNkqYJWkG4CEXti+WfIanH7d+rZxia+ERY5tdGK/ezsJbxckku4ud5T8JQmV9M/TijfSZEfW2zuhont5bc+b6oQwAvf9tHopf7dDnUTLO37Ad97VKxPpyfsAgxybE2/4yqn+5ls6oaepimA7FG/hQ7x4R+CFKcXqpKMTYb37O1klLrqoaNvNCRUGmO3cH+MSn/VrJ1HyIwnZ92QnMfTMl4s2AJx790tjfNctKlaxtEyezI4V9unREkVRN/wh0hhJT0paKOnM3DZY0kOSnpJ0vaQeuf18Sce2RruCIKgxZlkCkmoebUxTO9FkDeaWQlJX4BfAIcAw4AuShgEXAz8xsyHAa8BXat2WIAjagHpX5yX9Cb+zFLBlzVq0jlHAQjN7Om/PdcBYshR8pXxD1wDnA78C3mTdSoIgCOqZDjInekkT32sptgcWl71eAuwJLCurNrok98PMWqNNQRC0Ch1giZOZ/bU1G+Lgzbt2dWwbnFqQdC1wBMDGXeCzFULDO+/4241zpLNJicjG7RYVbakv0nedz1tcNAHwj38UbY1R9N7viSpzfAHpZUdk6Dmgn79jL1nqq6/5vpsMcIxO3k8AXnBsTubFLU9PbP/7osmpAArACqfE6ove50P/4cVYzuee89VA7/Qe5VRoveS6og1giGP770SlzQMdceptJx8pwFPO9T0gkdPUu0cvd8KgIRvJlPPs4sVIKk/MOqVJ1YFbaCQqaQJZ6feXzWx4bhsBXE622mg18HUzmylJwM/I6s6vAI7dUBWPps6JtgZLWD8yagDwHNA3rzhasv1rQzsys6PNbGMz23jr7i3f0CAI1rHDwIGU/t/yR+M7UIM1q62qRxVcDVSuLfgBcIGZjQDOzV9DpsEMyR8nkE0VNkh77kT/DgzJ1fgewFHAVOAesvh9gGOIyqNB0OEwg7VrqntseF92L8UiEca6dXabsW4wNhaYaBkPkg3anPV862jUOtHWxMxWSzoZuJ3sZ/wEM3tM0hnAdZK+CzwM/LYt2xkEQW1YW/0aoH6SyudsrjCzKzawzanA7ZIuIRtMllZ6e1rM9vjzTEB1WZzuBD5rZsvy15sD15mZl5+sRTGzW4FbK2xPkyn3QRB0UBopzi81s90b+RFfA07LU31+jmwwdiC+FtNgd17NSLRfqQMFMLPXJDmxD/WBBN0rjnqLRGrKVc7k+neH+b5eyswTT/R9L3CiV1L8y8l1OsqpRLbQyUEJMMaLMum9seu7995+kTaPNVOKsyhd9/2o7/y+Fx3jlxJ7LkYGwT+LJrvS39yJclk15f9c155bOOdh9buu7y2TizfDG4mqhfOdwoefO7Roe8XfnPFOxNOXtvV9r59ctD2fCPQZ2tfxrVSFcrwIvBQ7VohT31xa/bZJrLqf6s3gGOCb+fMbyNJ8gq/FNKi7VDMnulbSe4KwpPfRCovtgyDo3NR4rf2/gI/nz/cHnsqfTwXGK2Mv4HUzS/6Uh+pGoucA90sqLXnaj0y1CoIgqAlmbuGBJiHpD2RpL/pJWgKcBxwP/Cxf6bOSdX3arWTLmxaSLXH68ob2X00Wp9skjQT2IpsvOM3MWmLAHgRB4NKSAUtm9oXEW7s5vgac1Jj9NxT2OdTMFuQdKKybF9hB0g4bWoAaBEHQZGo/J9piNDQS/S+yIe6PnPeMbB4hCIKgxTEatcSpTVE2em3AQdrIzFZuyFYvbC3Z5ytsqQqe8xzbf+/n+77qRADOne/7evrvsET43aJFRdsKR339SCInqhfZOMCLwqSosgJslViH0WcLJ8dnt0Q42H4fK9oGDfJ9vRyS23/EcfQigMHNQfNs4kJcfVXR1s8Pc330ruIM1gcS12y5o9rffHPR5uUdBbjBCfF8NqG4ewtLUpVjvWquI/3UssydW7Qdf6a/41O+sf7Nf9/w4Twyb16z0mV+ZCvZbZ+pzne7XzO7CUucWoxq1HkncNm1BUEQtAhm2Wqzah5tTUNzotuSrdTvJWlX1i1C3ZT04C0IgqBFqJef8w3NiR4MHEu22PRHrOtE3wDOrm2zgiDozNRROtEGU+FdA1wj6TNmdlMrtikIgs6OdYBOtIzdJP2lInb+W2b2P7VtWm3YtBcc+MH1bV7hOIBXnVDKyff6viOdQnE7JgqkedrFi15kJLCNI+x4qTxnJGapPd/HH/d9PaHj7rt934O+7mQ19dQ1gGWv+3aP6dOLti9+rWi7xlcdVi1YVLD1/H4iznbfouC16q77XFcvrDdR084NwfVCRO9N3Esfd8TLPyauwxYbFW19EgXw7nRy4XZzBCSAXs6x3Xezf30r04z28nfZaOpliVM1wtIhlbHzZCv6gyAIakJpiVM1j7ammpFoV0k983LJSOoF9Kxts4Ig6MyU1Pl6oJpO9HfAXyRdRfYFcRxZgbggCILa0JHmRM3sB5LmAQeQKfTfMbPba96yIAg6Ne3hp3o1VJXZ3sz+DPy5xm0JgiAA8vIgHWUkmufU+znwIaAHWbzdW2a2aYMbtlNWr4OL0e4AABy2SURBVC5WtXwmkXLVy3OcOugxjoq+dSJk0lPSvWhHgJVOcO2CBdVvP3la0Xb4J33f+YnoSJc3iwmc17zsq7ddBzixp9P8RMls55SzeW1iwfTM3YvczQeP2Kxo/Mn3Xd+nZhVXDaQSdA93EmGn/smnO0r+6ScXbZde5m//Z+d+9CqAAixy7o9FiYq0ezpJmZck7n3vSr6WWHxxUcW5ubBZAZ/r6DCdKHAZWZG4G4DdgfFAImo4CIKg+VgHyeL0Hma2UFJXM1sDXCUpYueDIKgpLZWUudZU04muyEsWPyLpB2RV7/wiPUEQBC1APY1Eq1lsfzTZPOjJwFtkRZyqTFIVBEHQNGpcY6nFqGaJ07P507eBC2rbnNqz4l2YWzGZfu7Xfd/+1xVtkxOT6399pGg77kjfd9y4ou1GJ4ckwEuOcDDNEZac6L/ss5wQwh5OKlDwQxM9EQvgIMfWtUfiOzmlenl4lUgnF0tavuNUYk2SyF06pMfzBds3T/Yr3xzkZKtMiVDHHVW0nemISKlrdpAjSFaKoSXGONc3FU7qXYZdHMEMoKfTuC/OKtoArqtUSJyUro2lnpIyN5QKbx4NVPU0s11q0qIgCIIOssTJqZQdBEFQezpE2GfZz/ggCIJWp15+zm9QWJK0l6S/S3pT0juS1khyZs+CIAhahlJS5pYQliRNkPSypPkV9lMkPSnpsXzlUcl+lqSF+XsHb2j/sdg+CIL2R8sucbqarB97L/RN0ieAscAuZrZK0ta5fRhZf7czsB1wl6Sd8jXyLp1usX3PLjCoIuHspEm+74xlRdu4RCjniBFF27kJxX1PR/lMhYju6oTqPf100bZbotahp+renFBv93C+Gg8/3Pf999wXCrZlzvkCeHLqYwXbZon42ZUrFxdsBx1aXE6QWjWwcmUxlHP6/z7q+noJq/dLqNWzHWX6Gec6gJ8U+Qjns6Y64aEAc5xrllLyvQTQqcHZm07y8ZTqv5Hzgacm9ntfxXGsTZzDxtJSwpKZ3StpUIX5a8BFpRSfZlY6E2OB63L7M5IWAqOAB1L7r2ad6HqL7SWdRiy2D4KghliVCZnzedN+kmaVPU6o4iN2Aj4m6SFJf5W0R27fHij/Jl+S25JUMxI9mqyzPRk4jVhsHwRBjTEatbx4aRPqzncDNgf2AvYAJkt6P+sKclY2p8EdNUiZSr+SDrDYPgiCOqD2YZ9LgClmZsBMSWuBfrl9YJnfACCR6yoj+XNe0lhJJ5W9fkjS0/kjEYsTBEHQMtS4xtLNwP4AknYiS/O5FJgKHCWpp6TBZFkIE7PXGQ2NRE8nU6lK9CQb9m4MXAUkZJP2zRtr4S8VE+wfSPgucmwjR/q+XjXI4x0xAWCpE1noiUXghxZ6tq6Jr8MdnKKcjyZEmeXOwrUJE3zfzzhfo1smwiA9wWm3xHl0hQ4nxnPThDDlRXimBK+f31G0eTk3Ad7vVG7day/f98EHizZPABrlXBuAG5x8oJ9N+HrnwctBC75YdGgipObmm4u2RJrSpOjVHFoyKbOkPwCjyeZOlwDnAROACfmyp3eAY/JR6WOSJgOPA6uBkxpS5qHhTrSHmZVPsN5vZq8Ar0gKYSkIgprSUj/nzewLibe+lPC/ELiw2v031IluXrHj8tzcW1X7AUEQBI3FrH7yiTa0xOkhScdXGiV9lQ3MEQRBEDSHloxYqjUNjURPA26WNA6Yk9t2I5sbTSzBDoIgaAE6QhanfAX/3pL2JwuBAvg/M7u7VVoWBEGnpl4y2ysTpDoPI7aW3fnZ9W0Ti8UkAV8FT1VS9MwfSHxF/dNZRDwqEfZ5p6NWv+b4DfA3x4lAZHyi2udzzkH8v4R6+wsnyXBq5cIqJ4FyKmRysKOCT3JCLg9x/MBX94cN830P+fqggu28Yxe5vp7gveN2/n77O/bfOMeQUrW9W+GwvX3fl5zjfcgrUwsUU1CnQw8PHVq0vZtY/P5KxWqTqwcM5+F585pV8/N93WVn96vO98QXmd2ExfYtRlWx80EQBK1NvaTCi040CIJ2R4dIyhwEQdCW1L2wFARB0FZ0iEJ1HZU334QZFdlQDx7j+97n5N1Mhb695Ni+lVgI9vCcoi0V9rncsXki0ghPQQKed3JIpsIg5zjhoKk8p0Md4WFyIsvsKEdo8XJuAtznCDBeKGaigCebO2KgF3IJcNW5iwq21MJpTwTywigB1jgCzM5FE3s6OWgB5s0v2jwBCeA1p/rs2YlEcJ6AOiMRIjrDuReKNVczKi/vmpTK2RjqaIlTNflEWwRlXJqn3Z8raWTZe6dJmiPp8/nrjSTNlPRonrr/gjLfwXkylKckXZ/nOkXS+ZKOba3jCYKgdhjZEqdqHm1Nq3WiwCFkGVGGACcAvwKQ1IcssckooFSRfRWwv5l9BBgBjJFUSvdwMfATMxtCttrnK612BEEQtA5WPxFLrdmJjgUmWsaDQF9J/VmXBPW9GZDcp/RDtHv+MEkiS19VyiB1Deuip94E3q7xMQRB0AqYZUmZq3m0Na3Zibpp981sOTAPmAVcX3pTUldJjwAvA3ea2UPAlsAyM1tdvg8AM7vEzK4nCIIOQYxEiyTT7pvZ981sVzN7r2Scma0xsxFkOsooScMb2keDHyxdK+ktSW+95ETPBEHQcixevJjS/1v+uLax++goCUiaTZ4Zv5QJ6u80Mu0+gJktkzQdGAP8iGwaoFs+Gq12H0eT1YpiG8nufmT993v3djbCr+A5NKFmTneU/FMSaas9wXvfRELjwxzbXEeRTR3D+5wr/OKLvu8RziqFC27zfU9xEk6nbqYdnSqiixb5vts5Svx1zmqChYkMDqOdSpPdEg378unFuMIfnelkzMZPfnxHYkWFF5H6Icc44ZGiDTIRoJJeiZUAbzv2n1/h+3ocmQiflTe8Sqxy2KFipcXvBg7k4WXLmp1zuB30j1VR05Gomf3CzEbkI8qbgfG5Sr8X8LqZFevuApK2ktQ3f94LOBBYkGeevgco5VU/BrillscQBEHbsLbKR1vTmutEbwU+RfZ9tgL4cgO+/YFrJHUl6+gnm9m0/L0zgOskfRd4GPht7ZocBEFbYGS1OeqBVutE81HkSRt0zHznArsm3nuabDlUEAQdFKN9jDKrodNFLAVBUB9EJ9pO2WJTGFeRm9EpJgn4a9BSoX6eupWImMRLTvO4IxYB7OLsxNOQUlUbf+VU6xyQCMub4ohIByTCM6c6BWI+t5/vu5VzDN9zhDjwb0hHK3LPAfgi0phEWO9VPyiKSM85YbIAGzv2/RMVOG9zYoMXOCLUoYl8pPc4N9OOK3zfJxzf/9jf9/XEsdsSwuGBBxZt7yb+TyZXHG9LdX710om25hKnIAiCqij9nG8JYUnSBEkv5+WRK9/7tiST1C9/nQxPTxGdaBAE7ZIWVOevJlsiuR6SBgIHsX5eITc8vSGiEw2CoN1RUuereWxwX2b3At6E2U+A01k/YCcVnp4kOtEgCNoljRiJ9pM0q+yRSAa4DkmHAc+b2aMVb7nh6Q3tq9MJS6++AZMqJtP385QL4O1EdFK1/GeiuNirznfiFCd/I/j5PFc4IkMqAmiYEy30NydfJcBgJ2pq90T5r6/uUrRd5YhYAC84x3tRQgi7aVrR9jFnQdv3HGELACcKaE4iMqi3IxLu7eRJBV+USUVCDXOEJa/oYYoznDy0N9/s+3Z3bI8kjneOcx1SxfKmTy/aFiVEt50qXrsRNI2kkUucljamUJ2k3sA5gFeysdGh5Z2uEw2CoD6ooTr/AWAw8GiWGI4BwBxJo8hGno0KT4+f80EQtDtaUp0v7NtsnpltbWaDzGwQWcc50sxeBKZSZXh6iehEgyBol7TgEqc/AA8AH5S0RFJDidxvBZ4mC0//DfD1De0/fs4HQdDuaMnYeTP7wgbeH1T2vOrw9BLRiQZB0C6pl4il6ESB6Qm12kuf+KmEyjreCbWb41T1BNiymMaSUYnwyiVLijYvbDNV0dILefxtwneNo96+k6jgOd85Zw8kQlc/4YQ33nWX77uZIxfPnVu0pW7c4U5+zEmJvJ/fcFYY3JdQ/bd0rs8uzvYAOzjhoG+8UbSlFHtvJcAHnFUW4Ff7TF2HrRxbqoLn5xwl3inECkDVsngjiAQkQRAEzSQ60SAIgmYQnWgQBEETiaTMQRAEzSDmRNsxPbrADhXJKL3ciQCXOKF2UxKT9msdEalLI1bhpkSGN50J/lucENFDEgXHznaKliU0CrZy7oY3EqF+XjjqwKIJgPlOvIdTjw6AbZ39ejlcRzmhleAXxRuQEJZudUSkQQmB74NOOKgn+gHcnGhbJXskzq33WZboUbw8si9M9H23cU764U4RQPCvT+q+2bPijb95gZNNIDrRIAiCJhIj0SAIgmYSnWgQBEEziE40CIKgiYQ6HwRB0AxiTrQd0707bLPt+rafJhLe7u0oxVNe9n332qto88L/wFfM905Ufhw3rmi767Ki7d6EAn2AI6n+MxH2ub3ThmHDfN/77y/aEgUp2cXZ70cTCasn3Vi0fdpJneutWgDo7ZQBPXu87+uFni5JZI70wiu9lQDA+hV7crzkx5s54Z0Av3HOwfDE/XGmo8SPG+H7DnVU/xnX+b49HNvwRAbnhyrup7WJJOeNJTrRIAiCZhCdaBAEQROJn/NBEATNJDrRIAiCJhLqfDvmzVXFifCUINLHCQEcmhCWtnMm/o9zBCSAK44r2q5MVMo8zhGRHL2LV/zNed4JTUyFmHo5L1NVREePLtpS1S+9ypGegATwlmNb5oQmpnJmDnfsqdylq53/0pEJUeZkp4LmoISYd7hz3/RwlJq1iaHWDs72ExKC13jnZpiRqPZ5gBPe/P8d6fveflvR9kpCzKu8PA2WxmwEMRINgiBoIjEnGgRB0EyiEw2CIGgiMRINgiBoJvUiLEXd+SAI2h2lkWgL1Z2fIOllSfPLbD+UtEDSXEl/lNS37L2zJC2U9KSkgze4/6zMcudha8k+X2HbJjEe/6PzVZjI34wn2n9ulO/7j38kduJwnaNMOwU86Zo4hiedY3gn8Vmfc8L1nnASQIMfsphSm73qld9LJC6+1DlnU5zkyWMTJSYfcZTpPRPXob+zouLixKoBL+H04EQo5gpnuceNznX8aiJs1AvLTXUWdzi2VDSqdwy9E/fNCGeVwu2Jcp+Viz1uGT6cR+bNa1Zq5o0kSyX5rmQhzDazZNFRSfsBbwITzWx4bvskcLeZrZZ0MYCZnSFpGPAHYBSwHXAXsJOZrUntP0aiQRC0O1pyJGpm9wKvVtjuMLPSEONBoFSIfCxwnZmtMrNnyCqnJ76GM6ITDYKgXdKITrSfpFlljxMa+VHHAX/On28PLC57b0luSxLCUhAE7ZJGqPNLG/o53xCSziHTsH5fMjluDc55RicaBEG7ozXCPiUdAxwKHGDrxKElrD99PABIxItldLpOtHcPGFmRTzQVBtndEVUeXen7PurY9k5Ug5zviAwDiiYAjnPEi4XOJX03ccd52seHE8rDQkfQWJPY71QnvPLDvivvc2yJU05fp8zkjk4ey8fmF23gC2mbJcSxOU6F1pQo47Xre4l/LU/480SSvybyug51wj4XJEIuP+F9lhcXDCxy1M/bE9e3l3POUtfs3orXLSFV13qdqKQxwBnAx82sXAqcCkyS9GOyf58hgCNtrqPTdaJBENQHLdWJSvoDMJps7nQJcB5wFtATuFMSwINmdqKZPSZpMvA42WD4pIaUeYhONAiCdkpLdaJm9gXH/NsG/C8ELqx2/9GJBkHQ7oiwzyAIgmYSnWgQBEETiaTM7RkrJuNdnlA+t3ZUzt0SyYDXOPvo5VSeBNjEsTk5cAGY7Ei9XpLj+YkEwccdVbTdfbfv6x2vl7gY4EDnPKSSMnv7OCJROXLGjKLtdWdFxGaJ7c91qqNOmeL7enzSqSwK/jF8pVKWzvlwldUu5ySSJ48cWbTdlvgsb1XHpETicG/lwcd8V3bZpWhLJeg+e9D6r89YnthpI6mXkWirRSxJGirpAUmrJH274r2jJM2RdGqZbTdJ8/JEAJcql9AkbSHpTklP5X83z+3HSjq/tY4nCILa0ZJhn7WmNcM+XwW+AVzivHcUsAewl6TSKrlfASeQrdMawrrld2cCfzGzIcBf8tdBEHQwohOtwMxeNrO/A+86b5dCrQyQpP7Apmb2QB5JMBE4PPcZC1yTP7+mzP42WaaWIAjqnHoaibaXOdEpwCzgd2a2XNIHycKvSpQnAdjGzF4AMLMXJG2dP7++mg/q1qs3/T48dD1bz8T82mqnu+/mFHMDGOykP9sikctrgJMa7oO+K92dcJ8tdi7atnciagB6Di7a+jnzXQA9nWJqaxLLjLs756FrV9/XI7Vfbx89nXPbp6e/fc9BRds2u1bdLDZOhCx57d02Mfe3WSrsqYL+iSFMn52KtiGJ4UF/x+ZsDvhRU/0Svps4N2Q/bzIf2KQiLE5zvHFS46kXYanV84nm85Zvmpn3s77kswfwfTM7MH/9MeB0M/u0pGVmVp5A9TUz23wDn3ktcARAly5deu+6ayP+q+qEZ555hsGDnR6zzumoxwUd99gefvhh1q5dW/7VN8XMjm7MPiTdRrqPr2SpmXnRtq1CTUeikk4Cjs9ffsrMGgzkL2MJ6wuP5UkAXpLUPx+F9sfPh7we+QU8Om/TW7Nmzdq4ynbUDZLeeuWVV+K46oiOemyS3jKzZh1XW3aKjaWmc6Jm9gszG5E/qu1AyX+uL5e0V67Kjwduyd+eChyTPz+mzB4EQdDqtNrPeUnbks17bko2H/wmMMzM3FlGSbsDVwO9yBKmnmJmJmlLYDKwA/Ac8FkzS6zedPfb7G/J9kgcV/3RUY+tox5XilYTlszsRdIZ3zz/WUBh2bKZvQIc0IymNGLpdV0Rx1V/dNRj66jH5dLpCtUFQRC0JFFjKQiCoBlEJxoEQdAM6roTlTRB0suS5pfZtpN0t6RbSiGkknpKuj6Pw39I0qAy/7Ny+5OSDi6zL2rFQykgaUzepoWSzsxtO+f5B66R1CW3fUfSXEmPSLpD0na5XXnOgYX5+yNz+yBJ09vswBIkjndwfr2eyq9fj9x+vqRj26idG0maKelRSY9JuiC3Xy3pmfw6PCJpRG7fXNIf82swU9Lwsn15OSNuK9v35ZK65vZ2lzOiXq5ZzTGzun0A+wEjgflltouAnYFPAyfmtq8Dl+fPjwKuz58PIyuP1BMYDPwT6Jq/t6gNj6tr3pb3Az3yNg4jy8a9FXAKMCb33bRsu2+UHeenyFY1CNgLeCi3DwKmt/W1q/J4JwNH5T6XA1/Ln58PHNtGbRXQJ3/eHXgoP79XA0c6/j8EzsufDyXL+1B67+b82K8r2+emZZ9zU9nx/wA4M39+JnBx/vxY4Py4Zm33qOuRqJndS5bYpJyurAurLcXkl8fb3wgckK8/HQtcZ2arzOwZYCEwKvf7dy3bvgFGAQvN7Gkze4fsn2ws2bGVwooFYOsvEduYdXXCxgITLeNBoG8enLCG4jlra1LHuz/Z9YL18yS8SZYrodXJz2cpCLN7/mhInR1GligHM1sADJK0Tf7eejkjcp/S9exG1jmVX8/2lDOibq5ZranrTjTBZcCvgROB3+W27YHFAGa2Gngd2LLcnvNejL6Z7dFK7fVItetnwP8BHwXuKL0p6UJJi4EvAuc2tA8zW2xmR9Sw7U0hdbzL8utVbsPMLrEqcyXUAkldJT1CFi13p5k9lL91Yf6z/SeSStH9j5KHHEsaRVb8tLTUr5QzYpaZLS/b/+35vpezrkNaL2cE8F7OCGsghLqG1NU1qyUdrhM1s2fNbD8z+3TZjSnPtQF7W+O2y8weNrM9zexLVlaB0MzOMbOBwO+BkxvaRw3a2hJ4bfXSmbSL9pvZGjMbQdYZjsrnOc8i+7m+B1l14TNy94uAzfNO9xTgYfLcGmZ2jZntamY/qtj/wWS5RXqSjezaI3V1zWpJh+tEEywhT2IjqRuwGdlP2vfsOeUx+m1JU9s1CfhMM/fRFnhtfY5sCqJbma1dtd/MlgHTyeanX8h/6q8CriKfFjKzN8zsy3mnO55sTvuZKva9kizEeWxueimfjkFV5oyoMXV5zWpBZ+lEy+PtjwTutmy2eypwVK7eDyZL/jyzjdpYzt+BIbnS2YNMDJvqOUoaUvbyMGBB/nwqMD5X6fcCXi/9HGyHpI73HrLrBe0kT4KkrST1zZ/3Ag4EFpR1cCKbB5yfv+5bUqiB/wTutXSoc5+y/XQjEwfLr2d7yhlRN9es5rS1stWcB/AH4AWyRM9LgK8k/DYCbiATjmYC7y977xwylfFJ4JC2Pqaydn0K+EfetnMa8LuJ7B92LvAnsnlPyH5u/SLffh6we1sfU2OPl0z5nZlftxuAnu2gnbuQ/SSfm5/3c3P73fl5nk82F19S2z8KPEXWGU4BNm9g39uQdU5zgceAnwPd8ve2JBOonsr/btEOzkVdXLNaPyLsMwiCoBl0lp/zQRAENSE60SAIgmYQnWgQBEEziE40CIKgGUQnGgRB0AyiEw2CIGgG0Yl2IiRtI2mSpKclzc7T6v3HBrYZpLJUg438vGNLqfny11dKGlbltqMlTWvK51aLpBn530GSxjVh+2MlXdbyLQvqiehEOwl5JM3NZBEz7zez3ciiTKque9UEjgXe60TN7D/N7PEafl6jMLO986eDgEZ3okEA0Yl2JvYH3jGzy0sGy5K1/BzeG43dlycJniNp78odNOQj6XRJ8/KEwhdJOhLYHfh9nqS4l6Tpyqq4lhL6zsn9/1LtQUg6QNLD+WdNKGVLkrRI0gX5PudJGprbt8qTGM+R9GtJz0rql79XSiF3EfCxvJ2nVY4wJU2TNDp//mVJ/5D0V2CfMp+tJN0k6e/54733gg5OW4dMxaN1HmQJm3/SwPu9gY3y50PI0rNBNkqbvwGfQ4AZQO/89Rb53+mUhZuWXpMl4VgMDC73r2jPaGBahW2jfLud8tcTgVPz54vIympDloT7yvz5ZcBZ+fMxZFmF+uWv3/Q+i2wEfVnZ62m5T3+yJBtbkeX6/FvJjyz5y7758x2AJ9r6msejdR6tVjI5aF9I+gWwL9nodA+y5MKXKStrsQbYydks5XMgcJWZrQAwsw0lfd6LbFrhmSr9S3wQeMbM/pG/vgY4Cfhp/rpUqnc2eQ7P/Bj/I/+c2yS9VuVneexJVhXg3wCSrmf9czAsmzUBYFNJm1hZntCgYxKdaOfhMdalycPMTsp/1s7KTacBLwEfIZvmWensI+UjGpc3srH+5ds1xKr87xrW3dsb2sZjNetPdW1U9jzV7i7AR82sQ2ZvD9LEnGjn4W5gI0lfK7P1Lnu+GfCCma0FjsZPsJvyuQM4TlJvyIqq5fblwCbOfh4APp6nHyz33xCl8ho75q+PBv66gW3uBz6Xf84ngc0dn8p2LgJGSOoiaSDrSsY8BIyWtKWk7sBny7a5g3UJsclH60EnIDrRToKZGVmey48rq0o5k+zncCkD+y+BYyQ9SPYT9S1nN66Pmd1GlktylrIM7t/O/a8GLi8JS2Vt+TdwAjBF0qNAqmzEAZKWlB7ArsCXgRskzSOrNXV5YtsSFwCflDSHbO72BbJOs5y5wOpc5DqNbK7zGbLUdpcAc/J2v0BWcO0B4K6SPecbwO7KyoM8TlaeJugERCq8oEOTq/drzGy1pI8Cv7Isy3wQtAgxJxp0dHYAJkvqArwDHN/G7Qk6GDESDYIgaAYxJxoEQdAMohMNgiBoBtGJBkEQNIPoRIMgCJpBdKJBEATN4P8HLRHc0rGhTLMAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 2 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "dataset.counts.sum_over_axes().plot(add_cbar=True);"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,121 +211,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MapDataset\n",
-      "----------\n",
-      "\n",
-      "  Name                            : dataset-mcmc \n",
-      "\n",
-      "  Total counts                    : 247566 \n",
-      "  Total predicted counts          : 247649.00\n",
-      "  Total background counts         : 238665.45\n",
-      "\n",
-      "  Exposure min                    : 9.42e+09 m2 s\n",
-      "  Exposure max                    : 3.67e+11 m2 s\n",
-      "\n",
-      "  Number of total bins            : 46400 \n",
-      "  Number of fit bins              : 46400 \n",
-      "\n",
-      "  Fit statistic type              : cash\n",
-      "  Fit statistic value (-2 log(L)) : -938958.09\n",
-      "\n",
-      "  Number of models                : 2 \n",
-      "  Number of parameters            : 16\n",
-      "  Number of free parameters       : 7\n",
-      "\n",
-      "  Component 0: BackgroundModel\n",
-      "  \n",
-      "    Name                      : dataset-mcmc-bkg\n",
-      "    Datasets names            : ['dataset-mcmc']\n",
-      "    Parameters:\n",
-      "      norm                    :   1.000              \n",
-      "      tilt         (frozen)   :   0.000              \n",
-      "      reference    (frozen)   :   1.000  TeV         \n",
-      "      lambda_      (frozen)   :   0.000  1 / TeV     \n",
-      "      alpha        (frozen)   :   1.000              \n",
-      "      beta         (frozen)   :   0.000              \n",
-      "  \n",
-      "  Component 1: SkyModel\n",
-      "  \n",
-      "    Name                      : source\n",
-      "    Datasets names            : None\n",
-      "    Spectral model type       : ExpCutoffPowerLawSpectralModel\n",
-      "    Spatial  model type       : GaussianSpatialModel\n",
-      "    Temporal model type       : None\n",
-      "    Parameters:\n",
-      "      index                   :   2.000              \n",
-      "      amplitude               :   3.00e-12  1 / (cm2 s TeV)\n",
-      "      reference    (frozen)   :   1.000  TeV         \n",
-      "      lambda_                 :   0.050  1 / TeV     \n",
-      "      alpha        (frozen)   :   1.000              \n",
-      "      lon_0                   :   0.000  deg         \n",
-      "      lat_0                   :   0.000  deg         \n",
-      "      sigma                   :   0.200  deg         \n",
-      "      e            (frozen)   :   0.000              \n",
-      "      phi          (frozen)   :   0.000  deg         \n",
-      "  \n",
-      "  \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(dataset)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ProperModels\n",
-      "\n",
-      "Component 0: BackgroundModel\n",
-      "\n",
-      "  Name                      : dataset-mcmc-bkg\n",
-      "  Datasets names            : ['dataset-mcmc']\n",
-      "  Parameters:\n",
-      "    norm         (frozen)   :   1.000              \n",
-      "    tilt         (frozen)   :   0.000              \n",
-      "    reference    (frozen)   :   1.000  TeV         \n",
-      "    lambda_                 :   0.050  1 / TeV     \n",
-      "    alpha        (frozen)   :   1.000              \n",
-      "    beta         (frozen)   :   0.000              \n",
-      "\n",
-      "Component 1: SkyModel\n",
-      "\n",
-      "  Name                      : source\n",
-      "  Datasets names            : None\n",
-      "  Spectral model type       : ExpCutoffPowerLawSpectralModel\n",
-      "  Spatial  model type       : GaussianSpatialModel\n",
-      "  Temporal model type       : None\n",
-      "  Parameters:\n",
-      "    index                   :   2.000              \n",
-      "    amplitude               :   3.20e-12  1 / (cm2 s TeV)\n",
-      "    reference    (frozen)   :   1.000  TeV         \n",
-      "    lambda_                 :   0.050  1 / TeV     \n",
-      "    alpha        (frozen)   :   1.000              \n",
-      "    lon_0        (frozen)   :   0.000  deg         \n",
-      "    lat_0        (frozen)   :   0.000  deg         \n",
-      "    sigma        (frozen)   :   0.200  deg         \n",
-      "    e            (frozen)   :   0.000              \n",
-      "    phi          (frozen)   :   0.000  deg         \n",
-      "\n",
-      "\n",
-      "stat = -938545.7260836291\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define the min, max and frozen parameters \n",
     "dataset.background_model.parameters.freeze_all()\n",
@@ -398,35 +247,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:gammapy.modeling.sampling:Missing prior for parameter: lambda_.\n",
-      "MCMC will likely fail!\n",
-      "INFO:gammapy.modeling.sampling:Free parameters: ['lambda_', 'index', 'amplitude', 'lambda_']\n",
-      "INFO:gammapy.modeling.sampling:Starting MCMC sampling: nwalkers=8, nrun=150\n",
-      "/anaconda3/envs/gpy-dev/lib/python3.7/site-packages/emcee/ensemble.py:335: RuntimeWarning: invalid value encountered in subtract\n",
-      "  lnpdiff = (self.dim - 1.) * np.log(zz) + newlnprob - lnprob0\n",
-      "/anaconda3/envs/gpy-dev/lib/python3.7/site-packages/emcee/ensemble.py:336: RuntimeWarning: invalid value encountered in greater\n",
-      "  accept = (lnpdiff > np.log(self._random.rand(len(lnpdiff))))\n",
-      "INFO:gammapy.modeling.sampling:   0%\n",
-      "INFO:gammapy.modeling.sampling:  50%\n",
-      "INFO:gammapy.modeling.sampling:100% => sampling completed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 34.1 s, sys: 495 ms, total: 34.6 s\n",
-      "Wall time: 35.2 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# Now let's define a function to init parameters and run the MCMC with emcee\n",
@@ -450,23 +273,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'sampler' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-12-193135234a28>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mplot_trace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msampler\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdataset\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m: name 'sampler' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "plot_trace(sampler, dataset)"
    ]

--- a/tutorials/mcmc_sampling.ipynb
+++ b/tutorials/mcmc_sampling.ipynb
@@ -272,7 +272,7 @@
     "%%time\n",
     "# Now let's define a function to init parameters and run the MCMC with emcee\n",
     "# Depending on your number of walkers, Nrun and dimensionality, this can take a while (> minutes)\n",
-    "sampler = run_mcmc(dataset, nwalkers=6, nrun=150)  # to speedup the notebook\n",
+    "sampler = run_mcmc(dataset, nwalkers=9, nrun=150)  # to speedup the notebook\n",
     "# sampler=run_mcmc(dataset,nwalkers=12,nrun=1000) # more accurate contours"
    ]
   },
@@ -423,7 +423,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add optional log-parabola and exponential cut-off corrections  to TemplateSpectralModel, SkyDiffuseCube and background model.
Allows more flexibility in the models re-optimisation for example it could be useful if they are extrapolated in the fitting range.

Maybe adding a similar all-in one spectral model could be useful for classification and automatise decisions on the optimal shape, no ?

I will add more test and update the docstring in additional commits if there is no objection on the basic idea.