### PR TITLE
Cache npred in MapEvaluator

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -100,6 +100,7 @@ class MapDataset(Dataset):
         self.mask_safe = mask_safe
         self.models = models
         self.gti = gti
+        self.use_cache = use_cache
 
         # check whether a reference geom is defined
         _ = self._geom
@@ -1823,9 +1824,9 @@ class MapEvaluator:
             Predicted counts on the map (in reco energy bins)
         """
 
-        pars = self.model.parameters.values
+        pars = list(self.model.parameters.values)
         npred = self._npred_cached
-        if pars != self._pars_cached:
+        if self._pars_cached != pars:
             self._pars_cached = pars
             if isinstance(self.model, BackgroundModel):
                 npred = self.model.evaluate()

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -217,13 +217,14 @@ class MapDataset(Dataset):
     def evaluators(self):
         """Model evaluators"""
 
-        if self.models:
+        models = self.models
+        if models:
             keys = list(self._evaluators.keys())
             for key in keys:
-                if key not in self.models:
+                if key not in models:
                     del self._evaluators[key]
 
-            for model in self.models:
+            for model in models:
                 evaluator = self._evaluators.get(model)
 
                 if evaluator is None:

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -1019,7 +1019,9 @@ class WcsGeom(Geom):
             return NotImplemented
 
         if not (self.is_regular and other.is_regular):
-            raise NotImplementedError("Geom comparison is not possible for irregular geometries.")
+            raise NotImplementedError(
+                "Geom comparison is not possible for irregular geometries."
+            )
 
         # check overall shape and axes compatibility
         if self.data_shape != other.data_shape:

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -257,3 +257,18 @@ def test_models_management(tmp_path):
     assert npred1b != npred1
     assert npred1b != npred0
     assert_allclose(npred1b, 2147.407023024028)
+
+    from timeit import timeit
+
+    datasets.models.remove(model1b)
+    _ = datasets.models  # auto-update models
+    newmodels = [datasets.models[0].copy() for k in range(48)]
+    datasets.models.extend(newmodels)
+
+    assert (
+        datasets[0].npred(use_cache=False).data.sum()
+        == datasets[0].npred(use_cache=True).data.sum()
+    )
+    assert timeit(lambda: datasets[0].npred(use_cache=False), number=1) > timeit(
+        lambda: datasets[0].npred(use_cache=True), number=1
+    )

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -258,17 +258,12 @@ def test_models_management(tmp_path):
     assert npred1b != npred0
     assert_allclose(npred1b, 2147.407023024028)
 
-    from timeit import timeit
-
     datasets.models.remove(model1b)
     _ = datasets.models  # auto-update models
     newmodels = [datasets.models[0].copy() for k in range(48)]
     datasets.models.extend(newmodels)
 
-    assert (
-        datasets[0].npred(use_cache=False).data.sum()
-        == datasets[0].npred(use_cache=True).data.sum()
-    )
-    assert timeit(lambda: datasets[0].npred(use_cache=False), number=1) > timeit(
-        lambda: datasets[0].npred(use_cache=True), number=1
-    )
+    datasets[0].use_cache = False
+    nocache = datasets[0].npred().data.sum()
+    datasets[0].use_cache = True
+    assert_allclose(datasets[0].npred().data.sum(), nocache)


### PR DESCRIPTION
- add caching of parameters values and npred on evaluators such as npred is not recomputed if all parameters values do not change  (used by default). 
This speed up fitting and flux points estimation in 3FHL validation by a factor of 2.
