### PR TITLE
Add meta_table to MapDataset

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -64,6 +64,9 @@ class MapDataset(Dataset):
         Mask defining the safe data range.
     gti : `~gammapy.data.GTI`
         GTI of the observation or union of GTI if it is a stacked observation
+    meta_table : `~astropy.table.Table`
+        Table listing informations on observations used to create the dataset.
+        One line per observation for stacked datasets.
     """
 
     stat_type = "cash"
@@ -82,6 +85,7 @@ class MapDataset(Dataset):
         use_cache=True,
         mask_safe=None,
         gti=None,
+        meta_table=None,
     ):
         if mask_fit is not None and mask_fit.data.dtype != np.dtype("bool"):
             raise ValueError("mask data must have dtype bool")
@@ -101,6 +105,7 @@ class MapDataset(Dataset):
         self.models = models
         self.gti = gti
         self.use_cache = use_cache
+        self.meta_table = meta_table
 
         # check whether a reference geom is defined
         _ = self._geom
@@ -344,6 +349,7 @@ class MapDataset(Dataset):
         binsz_irf=None,
         reference_time="2000-01-01",
         name=None,
+        meta_table=None,
         **kwargs,
     ):
         """Create a MapDataset object with zero filled maps.
@@ -365,6 +371,9 @@ class MapDataset(Dataset):
             the reference time to use in GTI definition
         name : str
             Name of the returned dataset.
+        meta_table : `~astropy.table.Table`
+            Table listing informations on observations used to create the dataset.
+            One line per observation for stacked datasets.
 
         Returns
         -------
@@ -1113,6 +1122,9 @@ class MapDatasetOnOff(MapDataset):
         Mask defining the safe data range.
     gti : `~gammapy.data.GTI`
         GTI of the observation or union of GTI if it is a stacked observation
+    meta_table : `~astropy.table.Table`
+        Table listing informations on observations used to create the dataset.
+        One line per observation for stacked datasets.
     name : str
         Name of the dataset.
 
@@ -1136,6 +1148,7 @@ class MapDatasetOnOff(MapDataset):
         evaluation_mode="local",
         mask_safe=None,
         gti=None,
+        meta_table=None,
     ):
         if mask_fit is not None and mask_fit.dtype != np.dtype("bool"):
             raise ValueError("mask data must have dtype bool")
@@ -1165,6 +1178,7 @@ class MapDatasetOnOff(MapDataset):
         self.models = models
         self.mask_safe = mask_safe
         self.gti = gti
+        self.meta_table = meta_table
 
     def __str__(self):
         str_ = super().__str__()

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -226,7 +226,8 @@ class MapDatasetMaker:
             exposure_map=exposure,
         )
 
-    def make_meta_table(self, observation):
+    @staticmethod
+    def make_meta_table(observation):
         """Make info meta table.
 
         Parameters

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -228,7 +228,7 @@ class MapDatasetMaker:
 
     def make_meta_table(self, observation):
         """Make info meta table.
-        
+
         Parameters
         ----------
         observation : `~gammapy.data.Observation`

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
+from astropy.table import Table
+import astropy.units as u
 from gammapy.datasets import MapDataset
 from gammapy.irf import EnergyDependentMultiGaussPSF
 from gammapy.maps import Map
@@ -224,6 +226,32 @@ class MapDatasetMaker:
             exposure_map=exposure,
         )
 
+    def make_meta_table(self, observation):
+        """Make info meta table.
+        
+        Parameters
+        ----------
+        observation : `~gammapy.data.Observation`
+            Observation
+        
+        Returns
+        -------
+        info_table: `~astropy.table.Table`
+        """
+        info_table = Table()
+        info_table["TELESCOP"] = [observation.aeff.meta["TELESCOP"]]
+        info_table["INSTRUME"] = [observation.aeff.meta["INSTRUME"]]
+        info_table["NAME"] = [observation.aeff.meta["CBD10001"][5:-1]]
+        info_table["OBS_ID"] = [observation.obs_id]
+        #        NOT WORK YET
+        #        info_table['AZ'] = [observation.pointing_altaz.az]
+        #        info_table['ALT'] = [observation.pointing_altaz.alt]
+
+        info_table["RA_PNT"] = [observation.pointing_radec.icrs.ra.deg] * u.deg
+        info_table["DEC_PNT"] = [observation.pointing_radec.icrs.dec.deg] * u.deg
+
+        return info_table
+
     def run(self, dataset, observation):
         """Make map dataset.
 
@@ -240,6 +268,7 @@ class MapDatasetMaker:
             Map dataset.
         """
         kwargs = {"gti": observation.gti}
+        kwargs["obs_info"] = self.make_meta_table(observation)
 
         mask_safe = Map.from_geom(dataset.counts.geom, dtype=bool)
         mask_safe.data |= True

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -236,21 +236,21 @@ class MapDatasetMaker:
         
         Returns
         -------
-        info_table: `~astropy.table.Table`
+        meta_table: `~astropy.table.Table`
         """
-        info_table = Table()
-        info_table["TELESCOP"] = [observation.aeff.meta["TELESCOP"]]
-        info_table["INSTRUME"] = [observation.aeff.meta["INSTRUME"]]
-        info_table["NAME"] = [observation.aeff.meta["CBD10001"][5:-1]]
-        info_table["OBS_ID"] = [observation.obs_id]
+        meta_table = Table()
+        meta_table["TELESCOP"] = [observation.aeff.meta["TELESCOP"]]
+        meta_table["INSTRUME"] = [observation.aeff.meta["INSTRUME"]]
+        meta_table["NAME"] = [observation.aeff.meta["CBD10001"][5:-1]]
+        meta_table["OBS_ID"] = [observation.obs_id]
         #        NOT WORK YET
         #        info_table['AZ'] = [observation.pointing_altaz.az]
         #        info_table['ALT'] = [observation.pointing_altaz.alt]
 
-        info_table["RA_PNT"] = [observation.pointing_radec.icrs.ra.deg] * u.deg
-        info_table["DEC_PNT"] = [observation.pointing_radec.icrs.dec.deg] * u.deg
+        meta_table["RA_PNT"] = [observation.pointing_radec.icrs.ra.deg] * u.deg
+        meta_table["DEC_PNT"] = [observation.pointing_radec.icrs.dec.deg] * u.deg
 
-        return info_table
+        return meta_table
 
     def run(self, dataset, observation):
         """Make map dataset.
@@ -268,7 +268,7 @@ class MapDatasetMaker:
             Map dataset.
         """
         kwargs = {"gti": observation.gti}
-        kwargs["obs_info"] = self.make_meta_table(observation)
+        kwargs["meta_table"] = self.make_meta_table(observation)
 
         mask_safe = Map.from_geom(dataset.counts.geom, dtype=bool)
         mask_safe.data |= True

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -241,7 +241,7 @@ class MapDatasetMaker:
         meta_table = Table()
         meta_table["TELESCOP"] = [observation.aeff.meta["TELESCOP"]]
         meta_table["INSTRUME"] = [observation.aeff.meta["INSTRUME"]]
-        meta_table["NAME"] = [observation.aeff.meta["CBD10001"][5:-1]]
+#        meta_table["NAME"] = [observation.aeff.meta["CBD10001"][5:-1]]
         meta_table["OBS_ID"] = [observation.obs_id]
         #        NOT WORK YET
         #        info_table['AZ'] = [observation.pointing_altaz.az]

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -234,7 +234,7 @@ class MapDatasetMaker:
         ----------
         observation : `~gammapy.data.Observation`
             Observation
-        
+
         Returns
         -------
         meta_table: `~astropy.table.Table`

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -202,10 +202,6 @@ def test_make_meta_table(observations):
     e_true = MapAxis.from_edges(
                                 [0.1, 0.5, 2.5, 10.0], name="energy_true", unit="TeV", interp="log"
                                 )
-        
-    reference = MapDataset.create(
-                              geom=geom_reco, energy_axis_true=e_true, binsz_irf=1.0
-                              )
 
     maker_obs = MapDatasetMaker()
     map_dataset_meta_table = maker_obs.make_meta_table(observation=observations[0])

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -198,11 +198,6 @@ def test_map_maker_obs_with_migra(observations):
 
 @requires_data()
 def test_make_meta_table(observations):
-    geom_reco = geom(ebounds=[0.1, 1, 10])
-    e_true = MapAxis.from_edges(
-                                [0.1, 0.5, 2.5, 10.0], name="energy_true", unit="TeV", interp="log"
-                                )
-
     maker_obs = MapDatasetMaker()
     map_dataset_meta_table = maker_obs.make_meta_table(observation=observations[0])
 

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -195,3 +195,21 @@ def test_map_maker_obs_with_migra(observations):
     assert isinstance(map_dataset.edisp, EDispMap)
     assert map_dataset.edisp.edisp_map.data.shape == (3, 49, 5, 10)
     assert map_dataset.edisp.exposure_map.data.shape == (3, 1, 5, 10)
+
+@requires_data()
+def test_make_meta_table(observations):
+    geom_reco = geom(ebounds=[0.1, 1, 10])
+    e_true = MapAxis.from_edges(
+                                [0.1, 0.5, 2.5, 10.0], name="energy_true", unit="TeV", interp="log"
+                                )
+        
+    reference = MapDataset.create(
+                              geom=geom_reco, energy_axis_true=e_true, binsz_irf=1.0
+                              )
+
+    maker_obs = MapDatasetMaker()
+    map_dataset_meta_table = maker_obs.make_meta_table(observation=observations[0])
+
+    assert_allclose(map_dataset_meta_table["RA_PNT"], 267.68121338)
+    assert_allclose(map_dataset_meta_table["DEC_PNT"], -29.6075)
+    assert_allclose(map_dataset_meta_table["OBS_ID"], 110380)


### PR DESCRIPTION
This PR adds an `obs-info` table to the `Datasets` (see PR #2447 and #2452). This allows to keep track of the observation info for the `MapDataset`, `SpectrumDataset` and `SpectrumDatasetOnOff`.
For now, I've added the `obs-info` property on the `MapDataset` only and I modified the `MapDatasetMaker` accordingly. In particular, in the latter, I have implemented the `make_obs_info` function that reads the observation info and store them into an `obs-info` table.
If this approach is fine, I can continue extending to `SpectrumDataset` and `SpectrumDatasetOnOff`.
It remains to understand what info we want to keep. For now, there is just a bunch of them selected as reference.