### PR TITLE
Add an option to avoid saving Covariance to file

### DIFF
--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -222,7 +222,7 @@ class Datasets(collections.abc.MutableSequence):
             datasets.append(dataset)
         return cls(datasets)
 
-    def write(self, path, prefix="", overwrite=False, save_covariance=True):
+    def write(self, path, prefix="", overwrite=False, write_covariance=True):
         """Serialize datasets to YAML and FITS files.
 
         Parameters

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -233,6 +233,8 @@ class Datasets(collections.abc.MutableSequence):
             common prefix of file names
         overwrite : bool
             overwrite datasets FITS files
+        save_covariance : bool
+            save covariance or not
         """
 
         path = make_path(path).resolve()

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -244,7 +244,11 @@ class Datasets(collections.abc.MutableSequence):
         datasets_dict = {"datasets": datasets_dictlist}
 
         write_yaml(datasets_dict, path / f"{prefix}_datasets.yaml", sort_keys=False)
-        self.models.write(path / f"{prefix}_models.yaml", overwrite=overwrite, save_covariance=save_covariance)
+        self.models.write(
+            path / f"{prefix}_models.yaml",
+            overwrite=overwrite,
+            save_covariance=save_covariance,
+        )
 
     def stack_reduce(self, name=None):
         """Reduce the Datasets to a unique Dataset by stacking them together.

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -222,7 +222,7 @@ class Datasets(collections.abc.MutableSequence):
             datasets.append(dataset)
         return cls(datasets)
 
-    def write(self, path, prefix="", overwrite=False):
+    def write(self, path, prefix="", overwrite=False, save_covariance=True):
         """Serialize datasets to YAML and FITS files.
 
         Parameters
@@ -244,7 +244,7 @@ class Datasets(collections.abc.MutableSequence):
         datasets_dict = {"datasets": datasets_dictlist}
 
         write_yaml(datasets_dict, path / f"{prefix}_datasets.yaml", sort_keys=False)
-        self.models.write(path / f"{prefix}_models.yaml", overwrite=overwrite)
+        self.models.write(path / f"{prefix}_models.yaml", overwrite=overwrite, save_covariance=save_covariance)
 
     def stack_reduce(self, name=None):
         """Reduce the Datasets to a unique Dataset by stacking them together.

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -287,7 +287,11 @@ class Models(collections.abc.MutableSequence):
         if path.exists() and not overwrite:
             raise IOError(f"File exists already: {path}")
 
-        if save_covariance and self.covariance is not None and len(self.parameters) != 0:
+        if (
+            save_covariance
+            and self.covariance is not None
+            and len(self.parameters) != 0
+        ):
             filecovar = path.stem + "_covariance.dat"
             kwargs = dict(
                 format="ascii.fixed_width", delimiter="|", overwrite=overwrite

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -278,7 +278,7 @@ class Models(collections.abc.MutableSequence):
                 shared_register = _set_link(shared_register, model)
         return models
 
-    def write(self, path, overwrite=False, save_covariance=True):
+    def write(self, path, overwrite=False, write_covariance=True):
         """Write to YAML file.
 
         Parameters

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -279,7 +279,18 @@ class Models(collections.abc.MutableSequence):
         return models
 
     def write(self, path, overwrite=False, save_covariance=True):
-        """Write to YAML file."""
+        """Write to YAML file.
+        
+        Parameters
+        ----------
+        path : `pathlib.Path`
+            path to write files
+        overwrite : bool
+            overwrite datasets FITS files
+        save_covariance : bool
+            save covariance or not
+        """
+
         base_path, _ = split(path)
         path = make_path(path)
         base_path = make_path(base_path)

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -280,7 +280,7 @@ class Models(collections.abc.MutableSequence):
 
     def write(self, path, overwrite=False, save_covariance=True):
         """Write to YAML file.
-        
+
         Parameters
         ----------
         path : `pathlib.Path`

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -286,7 +286,7 @@ class Models(collections.abc.MutableSequence):
         path : `pathlib.Path`
             path to write files
         overwrite : bool
-            overwrite datasets FITS files
+            overwrite files
         save_covariance : bool
             save covariance or not
         """

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -278,7 +278,7 @@ class Models(collections.abc.MutableSequence):
                 shared_register = _set_link(shared_register, model)
         return models
 
-    def write(self, path, overwrite=False):
+    def write(self, path, overwrite=False, save_covariance=True):
         """Write to YAML file."""
         base_path, _ = split(path)
         path = make_path(path)
@@ -287,7 +287,7 @@ class Models(collections.abc.MutableSequence):
         if path.exists() and not overwrite:
             raise IOError(f"File exists already: {path}")
 
-        if self.covariance is not None and len(self.parameters) != 0:
+        if save_covariance and self.covariance is not None and len(self.parameters) != 0:
             filecovar = path.stem + "_covariance.dat"
             kwargs = dict(
                 format="ascii.fixed_width", delimiter="|", overwrite=overwrite


### PR DESCRIPTION
This PR introduces a "save_covariance" option (True by default) in Models.write() and Datasets.write() so ones can decide to save or not  the covariance file.