### PR TITLE
removed at_least1d for wstat

### DIFF
--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -143,10 +143,10 @@ def wstat(n_on, n_off, alpha, mu_sig, mu_bkg=None, extra_terms=True):
     # t_b * m_b = mu_bkg
     # t_s / t_b = alpha
 
-    n_on = np.atleast_1d(np.asanyarray(n_on, dtype=np.float64))
-    n_off = np.atleast_1d(np.asanyarray(n_off, dtype=np.float64))
-    alpha = np.atleast_1d(np.asanyarray(alpha, dtype=np.float64))
-    mu_sig = np.atleast_1d(np.asanyarray(mu_sig, dtype=np.float64))
+    n_on = np.asanyarray(n_on, dtype=np.float64)
+    n_off = np.asanyarray(n_off, dtype=np.float64)
+    alpha = np.asanyarray(alpha, dtype=np.float64)
+    mu_sig = np.asanyarray(mu_sig, dtype=np.float64)
 
     if mu_bkg is None:
         mu_bkg = get_wstat_mu_bkg(n_on, n_off, alpha, mu_sig)
@@ -186,10 +186,10 @@ def get_wstat_mu_bkg(n_on, n_off, alpha, mu_sig):
 
     See :ref:`wstat`.
     """
-    n_on = np.atleast_1d(np.asanyarray(n_on, dtype=np.float64))
-    n_off = np.atleast_1d(np.asanyarray(n_off, dtype=np.float64))
-    alpha = np.atleast_1d(np.asanyarray(alpha, dtype=np.float64))
-    mu_sig = np.atleast_1d(np.asanyarray(mu_sig, dtype=np.float64))
+    n_on = np.asanyarray(n_on, dtype=np.float64)
+    n_off = np.asanyarray(n_off, dtype=np.float64)
+    alpha = np.asanyarray(alpha, dtype=np.float64)
+    mu_sig = np.asanyarray(mu_sig, dtype=np.float64)
 
     # NOTE: Corner cases in the docs are all handled correcty by this formula
     C = alpha * (n_on + n_off) - (1 + alpha) * mu_sig


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request ensures `cash` and `wstat` have similar return types. Currently `wstat` is enforcing 1D arrays with `np.at_least1d` whereas `cash` does not. This is removed now.
This should simplify code in PR #2923 .

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
