### PR TITLE
Add meta_table to SpectrumDataset

### DIFF
--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -50,6 +50,9 @@ class SpectrumDataset(Dataset):
         Dataset name.
     gti : `~gammapy.data.GTI`
         GTI of the observation or union of GTI if it is a stacked observation
+    meta_table : `~astropy.table.Table`
+        Table listing informations on observations used to create the dataset.
+        One line per observation for stacked datasets.
 
     See Also
     --------
@@ -71,6 +74,7 @@ class SpectrumDataset(Dataset):
         mask_fit=None,
         name=None,
         gti=None,
+        meta_table=None,
     ):
 
         if mask_fit is not None and mask_fit.dtype != np.dtype("bool"):
@@ -88,6 +92,7 @@ class SpectrumDataset(Dataset):
         self.background = background
         self.mask_safe = mask_safe
         self.gti = gti
+        self.meta_table = meta_table
 
         self._name = make_name(name)
         self.models = models
@@ -431,7 +436,8 @@ class SpectrumDataset(Dataset):
 
     @classmethod
     def create(
-        cls, e_reco, e_true=None, region=None, reference_time="2000-01-01", name=None
+        cls, e_reco, e_true=None, region=None, reference_time="2000-01-01", name=None,
+        meta_table=None
     ):
         """Creates empty spectrum dataset.
 
@@ -451,6 +457,9 @@ class SpectrumDataset(Dataset):
             Region to define the dataset for.
         reference_time : `~astropy.time.Time`
             reference time of the dataset, Default is "2000-01-01"
+        meta_table : `~astropy.table.Table`
+            Table listing informations on observations used to create the dataset.
+            One line per observation for stacked datasets.
         """
         if e_true is None:
             e_true = e_reco.copy(name="energy_true")
@@ -667,6 +676,9 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         Name of the dataset.
     gti : `~gammapy.data.GTI`
         GTI of the observation or union of GTI if it is a stacked observation
+    meta_table : `~astropy.table.Table`
+        Table listing informations on observations used to create the dataset.
+        One line per observation for stacked datasets.
 
     See Also
     --------
@@ -690,6 +702,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         acceptance_off=None,
         name=None,
         gti=None,
+        meta_table=None,
     ):
 
         self.counts = counts
@@ -703,6 +716,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         self.aeff = aeff
         self.edisp = edisp
         self.mask_safe = mask_safe
+        self.meta_table = meta_table
 
         if np.isscalar(acceptance):
             data = np.ones(self._geom.data_shape) * acceptance
@@ -801,7 +815,8 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
     @classmethod
     def create(
-        cls, e_reco, e_true=None, region=None, reference_time="2000-01-01", name=None
+        cls, e_reco, e_true=None, region=None, reference_time="2000-01-01", name=None,
+        meta_table=None
     ):
         """Create empty SpectrumDatasetOnOff.
 
@@ -821,6 +836,9 @@ class SpectrumDatasetOnOff(SpectrumDataset):
             Region to define the dataset for.
         reference_time : `~astropy.time.Time`
             reference time of the dataset, Default is "2000-01-01"
+        meta_table : `~astropy.table.Table`
+            Table listing informations on observations used to create the dataset.
+            One line per observation for stacked datasets.
         """
         dataset = super().create(
             e_reco=e_reco,

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -144,7 +144,8 @@ class SpectrumDatasetMaker:
             offset, e_reco=energy_axis.edges, e_true=energy_axis_true.edges
         )
 
-    def make_meta_table(self, observation):
+    @staticmethod
+    def make_meta_table(observation):
         """Make info meta table.
 
         Parameters

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -147,6 +147,20 @@ def test_safe_mask_maker_dc1(spectrum_dataset_gc, observations_cta_dc1):
     assert_allclose(dataset.energy_range[0].value, 3.162278, rtol=1e-3)
     assert dataset.energy_range[0].unit == "TeV"
 
+@requires_data()
+def test_make_meta_table(observations_hess_dl3):
+#    pos = SkyCoord(0.0, 0.0, unit="deg", frame="galactic")
+#    geom = WcsGeom.create(skydir=pos, binsz=0.02, width=10.0)
+#    e_true = MapAxis.from_edges(
+#                                [0.1, 0.5, 2.5, 10.0], name="energy_true", unit="TeV", interp="log"
+#                                )
+
+    maker_obs = SpectrumDatasetMaker()
+    map_spectrumdataset_meta_table = maker_obs.make_meta_table(observation=observations_hess_dl3[0])
+    
+    assert_allclose(map_spectrumdataset_meta_table["RA_PNT"], 83.63333129882812)
+    assert_allclose(map_spectrumdataset_meta_table["DEC_PNT"], 21.51444435119629)
+    assert_allclose(map_spectrumdataset_meta_table["OBS_ID"], 23523)
 
 @requires_data()
 class TestSpectrumMakerChain:

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -149,15 +149,9 @@ def test_safe_mask_maker_dc1(spectrum_dataset_gc, observations_cta_dc1):
 
 @requires_data()
 def test_make_meta_table(observations_hess_dl3):
-#    pos = SkyCoord(0.0, 0.0, unit="deg", frame="galactic")
-#    geom = WcsGeom.create(skydir=pos, binsz=0.02, width=10.0)
-#    e_true = MapAxis.from_edges(
-#                                [0.1, 0.5, 2.5, 10.0], name="energy_true", unit="TeV", interp="log"
-#                                )
-
     maker_obs = SpectrumDatasetMaker()
     map_spectrumdataset_meta_table = maker_obs.make_meta_table(observation=observations_hess_dl3[0])
-    
+
     assert_allclose(map_spectrumdataset_meta_table["RA_PNT"], 83.63333129882812)
     assert_allclose(map_spectrumdataset_meta_table["DEC_PNT"], 21.51444435119629)
     assert_allclose(map_spectrumdataset_meta_table["OBS_ID"], 23523)


### PR DESCRIPTION
This PR adds an meta table object to the `SpectrumDataset` and `SpectrumDatasetONOFF`. 
For now, I've added these obs-info property: ObsID, TELESCOP, INSTRUME, RA_PNT, DEC_PNT.