### PR TITLE
Fix plot_spectrum_datasets_off_regions and make customization more flexible

### DIFF
--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -3,7 +3,7 @@ import numpy as np
 __all__ = ["plot_spectrum_datasets_off_regions", "plot_contour_line"]
 
 
-def plot_spectrum_datasets_off_regions(datasets, ax=None, legend=None, legend_kw={}, **kwargs):
+def plot_spectrum_datasets_off_regions(datasets, ax=None, legend=None, legend_kwargs=None, **kwargs):
     """Plot the off regions of spectrum datasets.
 
     Parameters
@@ -16,7 +16,7 @@ def plot_spectrum_datasets_off_regions(datasets, ax=None, legend=None, legend_kw
     legend : bool
         Whether to add/display the labels of the off regions in a legend. By default True if
         ``len(datasets) <= 10``.
-    legend_kw : dict
+    legend_kwargs : dict
         Keyword arguments used in `matplotlib.axes.Axes.legend`. The ``handler_map`` cannot be
         overridden.
     **kwargs : dict
@@ -52,10 +52,10 @@ def plot_spectrum_datasets_off_regions(datasets, ax=None, legend=None, legend_kw
 
     Plot that uses a modified `~matplotlib.rcParams`, has two legend columns, static and
     dynamic colors, but only shows labels for ``datasets1`` and ``datasets2``. Note that
-    ``legend_kw`` only applies if it's given in the last function call with ``legend=True``:
+    ``legend_kwargs`` only applies if it's given in the last function call with ``legend=True``:
     >>> plt.rc('legend', columnspacing=1, fontsize=9)
     >>> plot_spectrum_datasets_off_regions(datasets1, ax, legend=True, edgecolor='cyan')
-    >>> plot_spectrum_datasets_off_regions(datasets2, ax, legend=True, legend_kw=dict(ncol=2))
+    >>> plot_spectrum_datasets_off_regions(datasets2, ax, legend=True, legend_kwargs=dict(ncol=2))
     >>> plot_spectrum_datasets_off_regions(datasets3, ax, legend=False, edgecolor='magenta')
     """
     import matplotlib.pyplot as plt
@@ -64,6 +64,7 @@ def plot_spectrum_datasets_off_regions(datasets, ax=None, legend=None, legend_kw
 
     ax = ax or plt.gca(projection=datasets[0].counts_off.geom.wcs)
     legend = legend or legend is None and len(datasets) <= 10
+    legend_kwargs = legend_kwargs or {}
     handles, labels = [], []
 
     kwargs.setdefault("facecolor", "none")
@@ -97,9 +98,9 @@ def plot_spectrum_datasets_off_regions(datasets, ax=None, legend=None, legend_kw
             return CirclePolygon((radius - xdescent, height / 2 - ydescent), radius)
         patch_handler = HandlerPatch(patch_func)
 
-        legend_kw.setdefault("handletextpad", 0.5)
-        legend_kw["handler_map"] = {Patch: patch_handler, tuple: tuple_handler}
-        ax.legend(handles, labels, **legend_kw)
+        legend_kwargs.setdefault("handletextpad", 0.5)
+        legend_kwargs["handler_map"] = {Patch: patch_handler, tuple: tuple_handler}
+        ax.legend(handles, labels, **legend_kwargs)
 
 
 def plot_contour_line(ax, x, y, **kwargs):

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -8,30 +8,30 @@ def plot_spectrum_datasets_off_regions(datasets, ax=None, legend=None, **kwargs)
 
     Parameters
     ----------
-    datasets : list of `SpectrumDatasetOnOff`
+    datasets : `Datasets` of or list of `SpectrumDatasetOnOff`
         List of spectrum on-off datasets.
     ax : `~`
         .
     legend : bool
-        Whether to display the legend. By default True if `len(datasets) <= 10`.
-    kwargs : dict
-        Keyword arguments used in `~gammapy.maps.RegionNDMap.plot_region`.
-        Can contain a `cycler.Cycler` in a `prop_cycle` item.
+        Whether to display the legend. By default True if ``len(datasets) <= 10``.
+    **kwargs : dict
+        Keyword arguments used in `gammapy.maps.RegionNDMap.plot_region`.
+        Can contain a `~cycler.Cycler` in a ``prop_cycle`` item.
 
     Notes
     -----
-    Properties from the `prop_cycle` have maximum priority except `edgecolor`.
-    `edgecolor` is selected from the sources below in this order:
-        `kwargs["edgecolor"]`
-        `kwargs["prop_cycle"]`
-        `~matplotlib.RcParams["axes.prop_cycle"]`
-        `~matplotlib.RcParams["patch.edgecolor"]`
-    `~matplotlib.RcParams["patch.facecolor"]` is never used.
+    Properties from the ``prop_cycle`` have maximum priority, except ``color``.
+    ``edgecolor``/``color`` is selected from the sources below in this order:
+        ``kwargs["edgecolor"]``
+        ``kwargs["prop_cycle"]``
+        ``matplotlib.rcParams["axes.prop_cycle"]``
+        ``matplotlib.rcParams["patch.edgecolor"]``
+    ``matplotlib.rcParams["patch.facecolor"]`` is never used.
 
     Examples
     --------
     >>> plot_spectrum_datasets_off_regions(datasets, ax, legend=False, lw=2.5)
-    >>> plot_spectrum_datasets_off_regions(datasets, ax, alpha=.3, facecolor='k')
+    >>> plot_spectrum_datasets_off_regions(datasets, ax, alpha=0.3, facecolor='k')
     >>> plot_spectrum_datasets_off_regions(
             datasets, ax, ls='--', prop_cycle=plt.cycler('color', list('rgb'))
         )
@@ -52,7 +52,7 @@ def plot_spectrum_datasets_off_regions(datasets, ax=None, legend=None, **kwargs)
     plot_kwargs = kwargs.copy()
 
     for props, dataset in zip(prop_cycle(), datasets):
-        props = props.copy()	# not sure why this is necessary
+        props = props.copy()
         color = props.pop("color", plt.rcParams["patch.edgecolor"])
         plot_kwargs["edgecolor"] = kwargs.get("edgecolor", color)
         plot_kwargs.update(props)


### PR DESCRIPTION
**Description**
This pull request aims to solve issue #2919. It cycles through `prop_cycle` exposing the dynamic properties. These have priority over the static properties passed to `plot_kwargs` before the loop. This implementation aims to allow the user to freely customize the plot. The only exception is `facecolor` which cannot be read from `rcParams`. The legend can be toggled and has an appropriate default. I also inverted the order of the `ax` attribution as it was raising compatibility errors for me in the master branch and because it makes more sense for the _override_ to come first.

**Dear reviewer**
I would like to know if `Axes` other than WCS are/should be supported here and, if yes, what would be the most generic/appropriate `Axes` object name to put on lines 13-14. Is the rest of the documentaion perfect?