### PR TITLE
Send warning in case parameter value is set outside boundaries

### DIFF
--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -124,7 +124,7 @@ class Fit:
         return optimize_result
 
     def check_limits(self, strict=False):
-        "Check that all parameters are within their min/max range"""
+        """Check that all parameters are within their min/max range"""
         for par in self._parameters:
             par.check_limits(strict=strict)
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -100,6 +100,9 @@ class Fit:
         fit_result : `FitResult`
             Results
         """
+
+        self.check_limits(strict=True)
+
         if optimize_opts is None:
             optimize_opts = {}
         optimize_result = self.optimize(backend, **optimize_opts)
@@ -116,7 +119,14 @@ class Fit:
         # back or how to form the FitResult object.
         optimize_result._success = optimize_result.success and covariance_result.success
 
+        self.check_limits()
+
         return optimize_result
+
+    def check_limits(self, strict=False):
+        "Check that all parameters are within their min/max range"""
+        for par in self._parameters:
+            par.check_limits(strict=strict)
 
     def optimize(self, backend="minuit", **kwargs):
         """Run the optimization.

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -356,7 +356,7 @@ class DiskSpatialModel(SpatialModel):
     r_0 = Parameter("r_0", "1 deg", min=0)
     e = Parameter("e", 0, min=0, max=1, frozen=True)
     phi = Parameter("phi", "0 deg", frozen=True)
-    edge = Parameter("edge", "0.01 deg", frozen=True, min=0.01)
+    edge = Parameter("edge", "0.01 deg", frozen=True)
 
     @property
     def evaluation_radius(self):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -234,7 +234,9 @@ class Parameter:
                         f"Value {self.value} is outside bounds [{self.min}, {self.max}] for parameter '{self.name}'"
                     )
                 else:
-                    raise ValueError(f"Value {self.value} is outside bounds [{self.min}, {self.max}] for parameter '{self.name}'")
+                    raise ValueError(
+                        f"Value {self.value} is outside bounds [{self.min}, {self.max}] for parameter '{self.name}'"
+                    )
 
     def __repr__(self):
         return (

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -138,8 +138,7 @@ class Parameter:
     @factor.setter
     def factor(self, val):
         self._factor = float(val)
-        if self.frozen is False:
-            self.check_limits()
+        self.check_limits()
 
     @property
     def scale(self):
@@ -226,15 +225,16 @@ class Parameter:
 
     def check_limits(self, strict=False):
         """Emit a warning or error if value is outside the min/max range"""
-        if (~np.isnan(self.min) and (self.value <= self.min)) or (
-            ~np.isnan(self.max) and (self.value >= self.max)
-        ):
-            if strict is False:
-                log.warning(
-                    f"Value {self.value} is outside bounds [{self.min}, {self.max}] for parameter '{self.name}'"
-                )
-            else:
-                raise ValueError(f"Value {self.value} is outside bounds [{self.min}, {self.max}] for parameter '{self.name}'")
+        if self.frozen is False:
+            if (~np.isnan(self.min) and (self.value <= self.min)) or (
+                ~np.isnan(self.max) and (self.value >= self.max)
+            ):
+                if strict is False:
+                    log.warning(
+                        f"Value {self.value} is outside bounds [{self.min}, {self.max}] for parameter '{self.name}'"
+                    )
+                else:
+                    raise ValueError(f"Value {self.value} is outside bounds [{self.min}, {self.max}] for parameter '{self.name}'")
 
     def __repr__(self):
         return (


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
This PR solves #2917 . The value setter for the `Parameter` class is now responsible to check that:

- the value is contained in the min/max range;
- the value is different from the min/max bounds by at least 1%. This level of tolerance is a somewhat arbitrary choice.

In case either of these condition is False, a `RuntimeWarning` is sent.

I checked the sane behavior here: https://github.com/luca-giunti/share/blob/master/Parameters_ouside_bounds.ipynb
During a fit, in case MINUIT hits the min/max borders for some parameters, the user will be notified. So even if the outcome of the fit is `success=True`, it will be clear that something went wrong. This can be seen in cell [22] of https://github.com/luca-giunti/share/blob/master/analysis_1.ipynb .

**Dear reviewer**
#2917 can be closed as soon as this is merged.
