### PR TITLE
Add shorter tags for models

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -184,7 +184,7 @@ class SourceCatalogObjectFermiBase(SourceCatalogObject, abc.ABC):
         lat_err = semi_major / scale_1sigma
         lon_err = semi_minor / scale_1sigma / np.cos(d["DEJ2000"])
 
-        if  "TemplateSpatialModel" not in model.tag:
+        if "TemplateSpatialModel" not in model.tag:
             model.parameters["lon_0"].error = lon_err
             model.parameters["lat_0"].error = lat_err
             model.phi_0 = phi_0
@@ -411,7 +411,7 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
         else:
             raise ValueError(f"Invalid spec_type: {spec_type!r}")
 
-        model = Model.create(tag, **pars)
+        model = Model.create(tag, "spectral", **pars)
 
         for name, value in errs.items():
             model.parameters[name].error = value
@@ -676,7 +676,7 @@ class SourceCatalogObject3FGL(SourceCatalogObjectFermiBase):
         else:
             raise ValueError(f"Invalid spec_type: {spec_type!r}")
 
-        model = Model.create(tag, **pars)
+        model = Model.create(tag, "spectral", **pars)
 
         for name, value in errs.items():
             model.parameters[name].error = value
@@ -906,7 +906,7 @@ class SourceCatalogObject2FHL(SourceCatalogObjectFermiBase):
             "index": self.data["Unc_Spectral_Index"],
         }
 
-        model = Model.create(tag, **pars)
+        model = Model.create(tag, "spectral", **pars)
 
         for name, value in errs.items():
             model.parameters[name].error = value
@@ -1079,7 +1079,7 @@ class SourceCatalogObject3FHL(SourceCatalogObjectFermiBase):
         else:
             raise ValueError(f"Invalid spec_type: {spec_type!r}")
 
-        model = Model.create(tag, **pars)
+        model = Model.create(tag, "spectral", **pars)
 
         for name, value in errs.items():
             model.parameters[name].error = value

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -184,7 +184,7 @@ class SourceCatalogObjectFermiBase(SourceCatalogObject, abc.ABC):
         lat_err = semi_major / scale_1sigma
         lon_err = semi_minor / scale_1sigma / np.cos(d["DEJ2000"])
 
-        if model.tag != "TemplateSpatialModel":
+        if  "TemplateSpatialModel" not in model.tag:
             model.parameters["lon_0"].error = lon_err
             model.parameters["lat_0"].error = lat_err
             model.phi_0 = phi_0

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -219,7 +219,7 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         else:
             raise ValueError(f"Invalid spec_type: {spec_type}")
 
-        model = Model.create(tag, **pars)
+        model = Model.create(tag, "spectral", **pars)
         for name, value in errs.items():
             model.parameters[name].error = value
 
@@ -262,7 +262,7 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         else:
             raise ValueError(f"Invalid morph_type: {morph_type!r}")
 
-        model = Model.create(tag, **pars)
+        model = Model.create(tag, "spatial", **pars)
 
         for name, value in errs.items():
             model.parameters[name].error = value

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -120,7 +120,7 @@ class SourceCatalogObject2HWC(SourceCatalogObject):
             "index": self.data[f"spec{idx}_index_err"],
         }
 
-        model = Model.create("PowerLawSpectralModel", **pars)
+        model = Model.create("PowerLawSpectralModel", "spectral", **pars)
 
         for name, value in errs.items():
             model.parameters[name].error = value
@@ -148,7 +148,7 @@ class SourceCatalogObject2HWC(SourceCatalogObject):
             "lon_0": self.data.pos_err / np.cos(self.data.glat),
         }
 
-        model = Model.create(tag, **pars)
+        model = Model.create(tag, "spatial", **pars)
 
         for name, value in errs.items():
             model.parameters[name].error = value

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -77,7 +77,7 @@ class SourceCatalogObjectHGPSComponent(SourceCatalogObject):
             "frame": "galactic",
         }
         errs = {"lon_0": d["GLON_Err"], "lat_0": d["GLAT_Err"], "sigma": d["Size_Err"]}
-        model = Model.create(tag, **pars)
+        model = Model.create(tag, "spatial", **pars)
 
         for name, value in errs.items():
             model.parameters[name].error = value
@@ -465,7 +465,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         else:
             raise ValueError(f"Invalid spec_type: {spec_type}")
 
-        model = Model.create(tag, **pars)
+        model = Model.create(tag, "spectral", **pars)
         errs["reference"] = 0 * u.TeV
 
         for name, value in errs.items():
@@ -507,7 +507,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         else:
             raise ValueError(f"Invalid spatial_type: {spatial_type}")
 
-        model = Model.create(tag, **pars)
+        model = Model.create(tag, "spatial", **pars)
         for name, value in errs.items():
             model.parameters[name].error = value
         return model

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -165,7 +165,7 @@ class TestFermi4FGLObject:
 
     def test_spatial_model(self):
         model = self.cat["4FGL J0000.3-7355"].spatial_model()
-        assert model.tag == "PointSpatialModel"
+        assert "PointSpatialModel" in model.tag
         assert model.frame == "icrs"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 0.0983)
@@ -178,7 +178,7 @@ class TestFermi4FGLObject:
         assert_allclose(model.position.dec.value, pos_err.center.dec.value)
 
         model = self.cat["4FGL J1409.1-6121e"].spatial_model()
-        assert model.tag == "DiskSpatialModel"
+        assert "DiskSpatialModel" in model.tag
         assert model.frame == "icrs"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 212.294006)
@@ -186,7 +186,7 @@ class TestFermi4FGLObject:
         assert_allclose(p["r_0"].value, 0.7331369519233704)
 
         model = self.cat["4FGL J0617.2+2234e"].spatial_model()
-        assert model.tag == "GaussianSpatialModel"
+        assert "GaussianSpatialModel" in model.tag
         assert model.frame == "icrs"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 94.309998)
@@ -194,7 +194,7 @@ class TestFermi4FGLObject:
         assert_allclose(p["sigma"].value, 0.27)
 
         model = self.cat["4FGL J1443.0-6227e"].spatial_model()
-        assert model.tag == "TemplateSpatialModel"
+        assert "TemplateSpatialModel" in model.tag
         assert model.frame == "fk5"
         assert model.normalize is True
 
@@ -305,14 +305,14 @@ class TestFermi3FGLObject:
 
     def test_spatial_model(self):
         model = self.cat[0].spatial_model()
-        assert model.tag == "PointSpatialModel"
+        assert "PointSpatialModel" in model.tag
         assert model.frame == "icrs"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 0.0377)
         assert_allclose(p["lat_0"].value, 65.751701)
 
         model = self.cat[122].spatial_model()
-        assert model.tag == "GaussianSpatialModel"
+        assert "GaussianSpatialModel" in model.tag
         assert model.frame == "icrs"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 14.75)
@@ -320,7 +320,7 @@ class TestFermi3FGLObject:
         assert_allclose(p["sigma"].value, 1.35)
 
         model = self.cat[955].spatial_model()
-        assert model.tag == "DiskSpatialModel"
+        assert "DiskSpatialModel" in model.tag
         assert model.frame == "icrs"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 128.287201)
@@ -328,7 +328,7 @@ class TestFermi3FGLObject:
         assert_allclose(p["r_0"].value, 0.91)
 
         model = self.cat[602].spatial_model()
-        assert model.tag == "TemplateSpatialModel"
+        assert "TemplateSpatialModel" in model.tag
         assert model.frame == "fk5"
         assert model.normalize is True
 
@@ -442,7 +442,7 @@ class TestFermi2FHLObject:
 
     def test_spatial_model(self):
         model = self.cat[221].spatial_model()
-        assert model.tag == "PointSpatialModel"
+        assert "PointSpatialModel" in model.tag
         assert model.frame == "icrs"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 221.281998, rtol=1e-5)
@@ -459,7 +459,7 @@ class TestFermi2FHLObject:
         assert_allclose(model.position.dec.value, pos_err.center.dec.value)
 
         model = self.cat[97].spatial_model()
-        assert model.tag == "GaussianSpatialModel"
+        assert "GaussianSpatialModel" in model.tag
         assert model.frame == "icrs"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 94.309998, rtol=1e-5)
@@ -467,7 +467,7 @@ class TestFermi2FHLObject:
         assert_allclose(p["sigma"].value, 0.27)
 
         model = self.cat[134].spatial_model()
-        assert model.tag == "DiskSpatialModel"
+        assert "DiskSpatialModel" in model.tag
         assert model.frame == "icrs"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 125.660004, rtol=1e-5)
@@ -475,7 +475,7 @@ class TestFermi2FHLObject:
         assert_allclose(p["r_0"].value, 0.37)
 
         model = self.cat[256].spatial_model()
-        assert model.tag == "TemplateSpatialModel"
+        assert "TemplateSpatialModel" in model.tag
         assert model.frame == "fk5"
         assert model.normalize is True
         # TODO: have to check the extended template used for RX J1713,

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -174,7 +174,7 @@ class TestFluxPointsEstimator:
         fp = fpe.run(datasets)
 
         actual = fp.table["norm"].data
-        assert_allclose(actual, [0.974726, 0.96342 , 0.994251], rtol=1e-2)
+        assert_allclose(actual, [0.974726, 0.96342, 0.994251], rtol=1e-2)
 
         actual = fp.table["norm_err"].data
         assert_allclose(actual, [0.067637, 0.052022, 0.087059], rtol=3e-2)
@@ -183,7 +183,7 @@ class TestFluxPointsEstimator:
         assert_allclose(actual, [[44611, 0], [1923, 0], [282, 0]])
 
         actual = fp.table["norm_ul"].data
-        assert_allclose(actual, [1.111852, 1.07004 , 1.17829], rtol=1e-2)
+        assert_allclose(actual, [1.111852, 1.07004, 1.17829], rtol=1e-2)
 
         actual = fp.table["sqrt_ts"].data
         assert_allclose(actual, [16.681221, 28.408676, 21.91912], rtol=1e-2)
@@ -192,7 +192,7 @@ class TestFluxPointsEstimator:
         assert_allclose(actual, [0.2, 1, 5])
 
         actual = fp.table["stat_scan"][0] - fp.table["stat"][0]
-        assert_allclose(actual, [1.628746e+02, 1.416280e-01, 2.006994e+03], rtol=1e-2)
+        assert_allclose(actual, [1.628746e02, 1.416280e-01, 2.006994e03], rtol=1e-2)
 
     @staticmethod
     @requires_dependency("iminuit")

--- a/gammapy/modeling/models/__init__.py
+++ b/gammapy/modeling/models/__init__.py
@@ -53,12 +53,7 @@ TEMPORAL_MODEL_REGISTRY = Registry(
 )
 """Registry of temporal models classes."""
 
-MODEL_REGISTRY = Registry(
-    SPATIAL_MODEL_REGISTRY
-    + SPECTRAL_MODEL_REGISTRY
-    + TEMPORAL_MODEL_REGISTRY
-    + [SkyModel, SkyDiffuseCube, BackgroundModel]
-)
+MODEL_REGISTRY = Registry([SkyModel, SkyDiffuseCube, BackgroundModel])
 """Registry of model classes"""
 
 

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -121,19 +121,32 @@ class Model:
         return cls.from_parameters(parameters, **kwargs)
 
     @staticmethod
-    def create(tag, *args, **kwargs):
+    def create(tag, model_type=None, *args, **kwargs):
         """Create a model instance.
 
         Examples
         --------
         >>> from gammapy.modeling.models import Model
-        >>> spectral_model = Model.create("PowerLaw2SpectralModel", amplitude="1e-10 cm-2 s-1", index=3)
+        >>> spectral_model = Model.create("pl-2", model_type="spectral", amplitude="1e-10 cm-2 s-1", index=3)
         >>> type(spectral_model)
         gammapy.modeling.models.spectral.PowerLaw2SpectralModel
         """
-        from . import MODEL_REGISTRY
+        from . import (
+            MODEL_REGISTRY,
+            SPATIAL_MODEL_REGISTRY,
+            SPECTRAL_MODEL_REGISTRY,
+            TEMPORAL_MODEL_REGISTRY,
+        )
 
-        cls = MODEL_REGISTRY.get_cls(tag)
+        if model_type is None:
+            cls = MODEL_REGISTRY.get_cls(tag)
+        else:
+            registry = {
+                "spatial": SPATIAL_MODEL_REGISTRY,
+                "spectral": SPECTRAL_MODEL_REGISTRY,
+                "temporal": TEMPORAL_MODEL_REGISTRY,
+            }
+            cls = registry[model_type].get_cls(tag)
         return cls(*args, **kwargs)
 
     def __str__(self):

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -106,7 +106,8 @@ class Model:
 
     def to_dict(self):
         """Create dict for YAML serialisation"""
-        return {"type": self.tag, "parameters": self.parameters.to_dict()}
+        tag = self.tag[0] if isinstance(self.tag, list) else self.tag
+        return {"type": tag, "parameters": self.parameters.to_dict()}
 
     @classmethod
     def from_dict(cls, data):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -210,7 +210,7 @@ class PointSpatialModel(SpatialModel):
         Center position coordinate frame
     """
 
-    tag = ["PointSpatialModel", "PS"]
+    tag = ["PointSpatialModel", "point"]
     lon_0 = Parameter("lon_0", "0 deg")
     lat_0 = Parameter("lat_0", "0 deg", min=-90, max=90)
 
@@ -281,7 +281,7 @@ class GaussianSpatialModel(SpatialModel):
         Center position coordinate frame
     """
 
-    tag = ["GaussianSpatialModel", "GaussianSpatial"]
+    tag = ["GaussianSpatialModel", "gauss"]
 
     lon_0 = Parameter("lon_0", "0 deg")
     lat_0 = Parameter("lat_0", "0 deg", min=-90, max=90)
@@ -489,7 +489,7 @@ class ConstantSpatialModel(SpatialModel):
         Value
     """
 
-    tag = ["ConstantSpatialModel", "ConstantSpatial"]
+    tag = ["ConstantSpatialModel", "const"]
     value = Parameter("value", "1 sr-1", frozen=True)
 
     frame = "icrs"
@@ -546,7 +546,7 @@ class TemplateSpatialModel(SpatialModel):
         Default arguments are {'interp': 'linear', 'fill_value': 0}.
     """
 
-    tag = ["TemplateSpatialModel", "TemplateSpatial"]
+    tag = ["TemplateSpatialModel", "template"]
     norm = Parameter("norm", 1)
 
     def __init__(

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -210,7 +210,7 @@ class PointSpatialModel(SpatialModel):
         Center position coordinate frame
     """
 
-    tag = "PointSpatialModel"
+    tag = ["PointSpatialModel", "PS"]
     lon_0 = Parameter("lon_0", "0 deg")
     lat_0 = Parameter("lat_0", "0 deg", min=-90, max=90)
 
@@ -281,7 +281,7 @@ class GaussianSpatialModel(SpatialModel):
         Center position coordinate frame
     """
 
-    tag = "GaussianSpatialModel"
+    tag = ["GaussianSpatialModel", "GaussianSpatial"]
 
     lon_0 = Parameter("lon_0", "0 deg")
     lat_0 = Parameter("lat_0", "0 deg", min=-90, max=90)
@@ -350,7 +350,7 @@ class DiskSpatialModel(SpatialModel):
         Center position coordinate frame
     """
 
-    tag = "DiskSpatialModel"
+    tag = ["DiskSpatialModel", "disk"]
     lon_0 = Parameter("lon_0", "0 deg")
     lat_0 = Parameter("lat_0", "0 deg", min=-90, max=90)
     r_0 = Parameter("r_0", "1 deg", min=0)
@@ -436,7 +436,7 @@ class ShellSpatialModel(SpatialModel):
         Center position coordinate frame
     """
 
-    tag = "ShellSpatialModel"
+    tag = ["ShellSpatialModel", "shell"]
     lon_0 = Parameter("lon_0", "0 deg")
     lat_0 = Parameter("lat_0", "0 deg", min=-90, max=90)
     radius = Parameter("radius", "1 deg")
@@ -489,7 +489,7 @@ class ConstantSpatialModel(SpatialModel):
         Value
     """
 
-    tag = "ConstantSpatialModel"
+    tag = ["ConstantSpatialModel", "ConstantSpatial"]
     value = Parameter("value", "1 sr-1", frozen=True)
 
     frame = "icrs"
@@ -546,7 +546,7 @@ class TemplateSpatialModel(SpatialModel):
         Default arguments are {'interp': 'linear', 'fill_value': 0}.
     """
 
-    tag = "TemplateSpatialModel"
+    tag = ["TemplateSpatialModel", "TemplateSpatial"]
     norm = Parameter("norm", 1)
 
     def __init__(

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -389,7 +389,7 @@ class ConstantSpectralModel(SpectralModel):
         :math:`k`
     """
 
-    tag = "ConstantSpectralModel"
+    tag = ["ConstantSpectralModel", "ConstantSpectral"]
     const = Parameter("const", "1e-12 cm-2 s-1 TeV-1")
 
     @staticmethod
@@ -404,7 +404,7 @@ class CompoundSpectralModel(SpectralModel):
     For more information see :ref:`compound-spectral-model`.
     """
 
-    tag = "CompoundSpectralModel"
+    tag = ["CompoundSpectralModel", "CompoundSpectral"]
 
     def __init__(self, model1, model2, operator):
         self.model1 = model1
@@ -452,7 +452,7 @@ class PowerLawSpectralModel(SpectralModel):
         :math:`E_0`
     """
 
-    tag = "PowerLawSpectralModel"
+    tag = ["PowerLawSpectralModel", "PL"]
     index = Parameter("index", 2.0)
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
     reference = Parameter("reference", "1 TeV", frozen=True)
@@ -561,7 +561,7 @@ class PowerLaw2SpectralModel(SpectralModel):
         Upper energy limit :math:`E_{0, max}`.
     """
 
-    tag = "PowerLaw2SpectralModel"
+    tag = ["PowerLaw2SpectralModel", "PL2"]
 
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1")
     index = Parameter("index", 2)
@@ -675,7 +675,7 @@ class SmoothBrokenPowerLawSpectralModel(SpectralModel):
         :math:`\beta`
     """
 
-    tag = "SmoothBrokenPowerLawSpectralModel"
+    tag = ["SmoothBrokenPowerLawSpectralModel", "SBPL"]
     index1 = Parameter("index1", 2.0)
     index2 = Parameter("index2", 2.0)
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
@@ -711,7 +711,7 @@ class ExpCutoffPowerLawSpectralModel(SpectralModel):
         :math:`\alpha`
     """
 
-    tag = "ExpCutoffPowerLawSpectralModel"
+    tag = ["ExpCutoffPowerLawSpectralModel", "ECPL"]
 
     index = Parameter("index", 1.5)
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
@@ -764,7 +764,7 @@ class ExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
         :math:`E_{C}`
     """
 
-    tag = "ExpCutoffPowerLaw3FGLSpectralModel"
+    tag = ["ExpCutoffPowerLaw3FGLSpectralModel", "ECPL3FGL"]
     index = Parameter("index", 1.5)
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
     reference = Parameter("reference", "1 TeV", frozen=True)
@@ -803,7 +803,7 @@ class SuperExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
         :math:`E_{C}`
     """
 
-    tag = "SuperExpCutoffPowerLaw3FGLSpectralModel"
+    tag = ["SuperExpCutoffPowerLaw3FGLSpectralModel", "SECPL3FGL"]
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
     reference = Parameter("reference", "1 TeV", frozen=True)
     ecut = Parameter("ecut", "10 TeV")
@@ -838,7 +838,7 @@ class SuperExpCutoffPowerLaw4FGLSpectralModel(SpectralModel):
         internally assumes unit of :math:`[E_0]` power :math:`-\Gamma_2`
     """
 
-    tag = "SuperExpCutoffPowerLaw4FGLSpectralModel"
+    tag = ["SuperExpCutoffPowerLaw4FGLSpectralModel", "SECPL4FGL"]
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
     reference = Parameter("reference", "1 TeV", frozen=True)
     expfactor = Parameter("expfactor", "1e-2")
@@ -874,7 +874,7 @@ class LogParabolaSpectralModel(SpectralModel):
         :math:`\beta`
     """
 
-    tag = "LogParabolaSpectralModel"
+    tag = ["LogParabolaSpectralModel", "LP", "logpar"]
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 2)
@@ -931,7 +931,7 @@ class TemplateSpectralModel(SpectralModel):
         Meta information, meta['filename'] will be used for serialization
     """
 
-    tag = "TemplateSpectralModel"
+    tag = ["TemplateSpectralModel", "TemplateSpectral"]
     norm = Parameter("norm", 1, unit="")
     tilt = Parameter("tilt", 0, unit="", frozen=True)
     reference = Parameter("reference", "1 TeV", frozen=True)
@@ -1017,7 +1017,7 @@ class TemplateSpectralModel(SpectralModel):
 
     def to_dict(self):
         return {
-            "type": self.tag,
+            "type": self.tag[0],
             "parameters": self.parameters.to_dict(),
             "energy": {
                 "data": self.energy.data.tolist(),
@@ -1048,7 +1048,7 @@ class ScaleSpectralModel(SpectralModel):
         Multiplicative norm factor for the model value.
     """
 
-    tag = "ScaleSpectralModel"
+    tag = ["ScaleSpectralModel", "ScaleSpectral"]
     norm = Parameter("norm", 1, unit="")
 
     def __init__(self, model, norm=norm.quantity):
@@ -1351,7 +1351,7 @@ class NaimaSpectralModel(SpectralModel):
         for now this is used  only for synchrotron self-compton model
     """
 
-    tag = "NaimaSpectralModel"
+    tag = ["NaimaSpectralModel", "NaimaSpectral"]
 
     def __init__(
         self, radiative_model, distance=1.0 * u.kpc, seed=None, nested_models=None
@@ -1495,7 +1495,7 @@ class GaussianSpectralModel(SpectralModel):
         :math:`\sigma`
     """
 
-    tag = "GaussianSpectralModel"
+    tag = ["GaussianSpectralModel", "GaussianSpectral"]
     norm = Parameter("norm", 1e-12 * u.Unit("cm-2 s-1"))
     mean = Parameter("mean", 1 * u.TeV)
     sigma = Parameter("sigma", 2 * u.TeV)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -389,7 +389,7 @@ class ConstantSpectralModel(SpectralModel):
         :math:`k`
     """
 
-    tag = ["ConstantSpectralModel", "ConstantSpectral"]
+    tag = ["ConstantSpectralModel", "const"]
     const = Parameter("const", "1e-12 cm-2 s-1 TeV-1")
 
     @staticmethod
@@ -404,7 +404,7 @@ class CompoundSpectralModel(SpectralModel):
     For more information see :ref:`compound-spectral-model`.
     """
 
-    tag = ["CompoundSpectralModel", "CompoundSpectral"]
+    tag = ["CompoundSpectralModel", "compound"]
 
     def __init__(self, model1, model2, operator):
         self.model1 = model1
@@ -452,7 +452,7 @@ class PowerLawSpectralModel(SpectralModel):
         :math:`E_0`
     """
 
-    tag = ["PowerLawSpectralModel", "PL"]
+    tag = ["PowerLawSpectralModel", "pl"]
     index = Parameter("index", 2.0)
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
     reference = Parameter("reference", "1 TeV", frozen=True)
@@ -561,7 +561,7 @@ class PowerLaw2SpectralModel(SpectralModel):
         Upper energy limit :math:`E_{0, max}`.
     """
 
-    tag = ["PowerLaw2SpectralModel", "PL2"]
+    tag = ["PowerLaw2SpectralModel", "pl-2"]
 
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1")
     index = Parameter("index", 2)
@@ -675,7 +675,7 @@ class SmoothBrokenPowerLawSpectralModel(SpectralModel):
         :math:`\beta`
     """
 
-    tag = ["SmoothBrokenPowerLawSpectralModel", "SBPL"]
+    tag = ["SmoothBrokenPowerLawSpectralModel", "sbpl"]
     index1 = Parameter("index1", 2.0)
     index2 = Parameter("index2", 2.0)
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
@@ -711,7 +711,7 @@ class ExpCutoffPowerLawSpectralModel(SpectralModel):
         :math:`\alpha`
     """
 
-    tag = ["ExpCutoffPowerLawSpectralModel", "ECPL"]
+    tag = ["ExpCutoffPowerLawSpectralModel", "ecpl"]
 
     index = Parameter("index", 1.5)
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
@@ -764,7 +764,7 @@ class ExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
         :math:`E_{C}`
     """
 
-    tag = ["ExpCutoffPowerLaw3FGLSpectralModel", "ECPL3FGL"]
+    tag = ["ExpCutoffPowerLaw3FGLSpectralModel", "ecpl-3fgl"]
     index = Parameter("index", 1.5)
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
     reference = Parameter("reference", "1 TeV", frozen=True)
@@ -803,7 +803,7 @@ class SuperExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
         :math:`E_{C}`
     """
 
-    tag = ["SuperExpCutoffPowerLaw3FGLSpectralModel", "SECPL3FGL"]
+    tag = ["SuperExpCutoffPowerLaw3FGLSpectralModel", "secpl-3fgl"]
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
     reference = Parameter("reference", "1 TeV", frozen=True)
     ecut = Parameter("ecut", "10 TeV")
@@ -838,7 +838,7 @@ class SuperExpCutoffPowerLaw4FGLSpectralModel(SpectralModel):
         internally assumes unit of :math:`[E_0]` power :math:`-\Gamma_2`
     """
 
-    tag = ["SuperExpCutoffPowerLaw4FGLSpectralModel", "SECPL4FGL"]
+    tag = ["SuperExpCutoffPowerLaw4FGLSpectralModel", "secpl-4fgl"]
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
     reference = Parameter("reference", "1 TeV", frozen=True)
     expfactor = Parameter("expfactor", "1e-2")
@@ -874,7 +874,7 @@ class LogParabolaSpectralModel(SpectralModel):
         :math:`\beta`
     """
 
-    tag = ["LogParabolaSpectralModel", "LP", "logpar"]
+    tag = ["LogParabolaSpectralModel", "lp"]
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 2)
@@ -931,7 +931,7 @@ class TemplateSpectralModel(SpectralModel):
         Meta information, meta['filename'] will be used for serialization
     """
 
-    tag = ["TemplateSpectralModel", "TemplateSpectral"]
+    tag = ["TemplateSpectralModel", "template"]
     norm = Parameter("norm", 1, unit="")
     tilt = Parameter("tilt", 0, unit="", frozen=True)
     reference = Parameter("reference", "1 TeV", frozen=True)
@@ -1048,7 +1048,7 @@ class ScaleSpectralModel(SpectralModel):
         Multiplicative norm factor for the model value.
     """
 
-    tag = ["ScaleSpectralModel", "ScaleSpectral"]
+    tag = ["ScaleSpectralModel", "scale"]
     norm = Parameter("norm", 1, unit="")
 
     def __init__(self, model, norm=norm.quantity):
@@ -1250,7 +1250,7 @@ class AbsorbedSpectralModel(SpectralModel):
         Norm of the EBL model
     """
 
-    tag = "AbsorbedSpectralModel"
+    tag = ["AbsorbedSpectralModel", "ebl-absorption"]
     alpha_norm = Parameter("alpha_norm", 1.0, frozen=True)
     redshift = Parameter("redshift", 0.1, frozen=True)
 
@@ -1351,7 +1351,7 @@ class NaimaSpectralModel(SpectralModel):
         for now this is used  only for synchrotron self-compton model
     """
 
-    tag = ["NaimaSpectralModel", "NaimaSpectral"]
+    tag = ["NaimaSpectralModel", "naima"]
 
     def __init__(
         self, radiative_model, distance=1.0 * u.kpc, seed=None, nested_models=None
@@ -1495,7 +1495,7 @@ class GaussianSpectralModel(SpectralModel):
         :math:`\sigma`
     """
 
-    tag = ["GaussianSpectralModel", "GaussianSpectral"]
+    tag = ["GaussianSpectralModel", "gauss"]
     norm = Parameter("norm", 1e-12 * u.Unit("cm-2 s-1"))
     mean = Parameter("mean", 1 * u.TeV)
     sigma = Parameter("sigma", 2 * u.TeV)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -637,7 +637,7 @@ class BrokenPowerLawSpectralModel(SpectralModel):
         :math:`E_{break}`
     """
 
-    tag = "BrokenPowerLawSpectralModel"
+    tag = ["BrokenPowerLawSpectralModel", "bpl"]
     index1 = Parameter("index1", 2.0)
     index2 = Parameter("index2", 2.0)
     amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -54,7 +54,7 @@ class TemporalModel(Model):
 class ConstantTemporalModel(TemporalModel):
     """Constant temporal model."""
 
-    tag = "ConstantTemporalModel"
+    tag = ["ConstantTemporalModel", "const"]
 
     @staticmethod
     def evaluate(time):
@@ -125,7 +125,7 @@ class ExpDecayTemporalModel(TemporalModel):
         The reference time in mjd
     """
 
-    tag = "ExpDecayTemporalModel"
+    tag = ["ExpDecayTemporalModel", "exp-decay"]
 
     t0 = Parameter("t0", "1 d", frozen=False)
     _t_ref_default = Time("2000-01-01")
@@ -169,7 +169,7 @@ class GaussianTemporalModel(TemporalModel):
         Width of the gaussian profile.
     """
 
-    tag = "GaussianTemporalModel"
+    tag = ["GaussianTemporalModel", "gauss"]
 
     _t_ref_default = Time("2000-01-01")
     t_ref = Parameter("t_ref", _t_ref_default.mjd, unit="day", frozen=False)
@@ -253,7 +253,7 @@ class LightCurveTemplateTemporalModel(TemporalModel):
     >>> light_curve.mean_norm_in_time_interval(46300, 46301)
     """
 
-    tag = "LightCurveTemplateTemporalModel"
+    tag = ["LightCurveTemplateTemporalModel", "template"]
 
     def __init__(self, table, filename=None):
         self.table = table
@@ -398,4 +398,4 @@ class LightCurveTemplateTemporalModel(TemporalModel):
 
     def to_dict(self, overwrite=False):
         """Create dict for YAML serilisation"""
-        return {"type": self.tag, "filename": self.filename}
+        return {"type": self.tag[0], "filename": self.filename}

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -141,7 +141,7 @@ def test_model_create():
     spectral_model = Model.create(
         "PowerLaw2SpectralModel", amplitude="1e-10 cm-2 s-1", index=3
     )
-    assert spectral_model.tag == "PowerLaw2SpectralModel"
+    assert "PowerLaw2SpectralModel" in spectral_model.tag
     assert_allclose(spectral_model.index.value, 3)
 
 

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -139,7 +139,7 @@ def test_model_copy():
 
 def test_model_create():
     spectral_model = Model.create(
-        "PowerLaw2SpectralModel", amplitude="1e-10 cm-2 s-1", index=3
+        "pl-2", model_type="spectral", amplitude="1e-10 cm-2 s-1", index=3
     )
     assert "PowerLaw2SpectralModel" in spectral_model.tag
     assert_allclose(spectral_model.index.value, 3)

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -222,3 +222,7 @@ def test_missing_parameters():
     models = Models.read(filename)
     assert models["source1"].spatial_model.e in models.parameters
     assert len(models["source1"].spatial_model.parameters) == 6
+
+
+def test_registries_print():
+    print(MODEL_REGISTRY)

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -31,8 +31,8 @@ def test_dict_to_skymodels():
     assert model0.name == "background_irf"
 
     model0 = models[1]
-    assert model0.spectral_model.tag == "ExpCutoffPowerLawSpectralModel"
-    assert model0.spatial_model.tag == "PointSpatialModel"
+    assert "ExpCutoffPowerLawSpectralModel" in model0.spectral_model.tag
+    assert "PointSpatialModel" in model0.spatial_model.tag
 
     pars0 = model0.parameters
     assert pars0["index"].value == 2.1
@@ -59,9 +59,11 @@ def test_dict_to_skymodels():
     assert np.isnan(pars0["lambda_"].max)
 
     model1 = models[2]
-    assert model1.spectral_model.tag == "PowerLawSpectralModel"
-    assert model1.spatial_model.tag == "DiskSpatialModel"
-    assert model1.temporal_model.tag == "LightCurveTemplateTemporalModel"
+    assert "PL" in model1.spectral_model.tag
+    assert "PowerLawSpectralModel" in model1.spectral_model.tag
+    assert "DiskSpatialModel" in model1.spatial_model.tag
+    assert "disk" in model1.spatial_model.tag
+    assert "LightCurveTemplateTemporalModel" in model1.temporal_model.tag
 
     pars1 = model1.parameters
     assert pars1["index"].value == 2.2
@@ -82,8 +84,8 @@ def test_dict_to_skymodels():
     )
     assert model2.spectral_model.values.unit == "1 / (cm2 MeV s sr)"
 
-    assert model2.spectral_model.tag == "TemplateSpectralModel"
-    assert model2.spatial_model.tag == "TemplateSpatialModel"
+    assert "TemplateSpectralModel" in model2.spectral_model.tag
+    assert "TemplateSpatialModel" in model2.spatial_model.tag
 
     assert model2.spatial_model.parameters["norm"].value == 1.0
     assert not model2.spatial_model.normalize
@@ -129,7 +131,7 @@ def test_absorption_io(tmp_path):
     assert new_model.redshift.value == 0.5
     assert new_model.alpha_norm.name == "alpha_norm"
     assert new_model.alpha_norm.value == 1
-    assert new_model.spectral_model.tag == "PowerLawSpectralModel"
+    assert "PowerLawSpectralModel" in new_model.spectral_model.tag
     assert_allclose(new_model.absorption.energy, dominguez.energy)
     assert_allclose(new_model.absorption.param, dominguez.param)
     assert len(new_model.parameters) == 5
@@ -202,12 +204,16 @@ def make_all_models():
 
 @pytest.mark.parametrize("model_class", MODEL_REGISTRY)
 def test_all_model_classes(model_class):
-    assert model_class.tag == model_class.__name__
+    if isinstance(model_class.tag, list):
+        assert model_class.tag[0] == model_class.__name__
+    else:
+        assert model_class.tag == model_class.__name__
 
 
 @pytest.mark.parametrize("model", make_all_models())
 def test_all_model_instances(model):
-    assert model.tag == model.__class__.__name__
+    tag = model.tag[0] if isinstance(model.tag, list) else model.tag
+    assert tag == model.__class__.__name__
 
 
 @requires_data()

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -59,7 +59,7 @@ def test_dict_to_skymodels():
     assert np.isnan(pars0["lambda_"].max)
 
     model1 = models[2]
-    assert "PL" in model1.spectral_model.tag
+    assert "pl" in model1.spectral_model.tag
     assert "PowerLawSpectralModel" in model1.spectral_model.tag
     assert "DiskSpatialModel" in model1.spatial_model.tag
     assert "disk" in model1.spatial_model.tag
@@ -116,7 +116,7 @@ def test_sky_models_io(tmp_path):
 def test_absorption_io(tmp_path):
     dominguez = Absorption.read_builtin("dominguez")
     model = AbsorbedSpectralModel(
-        spectral_model=Model.create("PowerLawSpectralModel"),
+        spectral_model=Model.create("pl", "spectral"),
         absorption=dominguez,
         redshift=0.5,
     )
@@ -142,7 +142,7 @@ def test_absorption_io(tmp_path):
         u.Quantity(np.ones((2, 3)), ""),
     )
     model = AbsorbedSpectralModel(
-        spectral_model=Model.create("PowerLawSpectralModel"),
+        spectral_model=Model.create("PowerLawSpectralModel", "spectral"),
         absorption=test_absorption,
         redshift=0.5,
     )
@@ -158,39 +158,44 @@ def test_absorption_io(tmp_path):
 
 def make_all_models():
     """Make an instance of each model, for testing."""
-    yield Model.create("ConstantSpatialModel")
+    yield Model.create("ConstantSpatialModel", "spatial")
     map_constantmodel = Map.create(npix=(10, 20), unit="sr-1")
-    yield Model.create("TemplateSpatialModel", map=map_constantmodel)
-    yield Model.create("DiskSpatialModel", lon_0="1 deg", lat_0="2 deg", r_0="3 deg")
+    yield Model.create("TemplateSpatialModel", "spatial", map=map_constantmodel)
     yield Model.create(
-        "GaussianSpatialModel", lon_0="1 deg", lat_0="2 deg", sigma="3 deg"
+        "DiskSpatialModel", "spatial", lon_0="1 deg", lat_0="2 deg", r_0="3 deg"
     )
-    yield Model.create("PointSpatialModel", lon_0="1 deg", lat_0="2 deg")
+    yield Model.create("gauss", "spatial", lon_0="1 deg", lat_0="2 deg", sigma="3 deg")
+    yield Model.create("PointSpatialModel", "spatial", lon_0="1 deg", lat_0="2 deg")
     yield Model.create(
-        "ShellSpatialModel", lon_0="1 deg", lat_0="2 deg", radius="3 deg", width="4 deg"
+        "ShellSpatialModel",
+        "spatial",
+        lon_0="1 deg",
+        lat_0="2 deg",
+        radius="3 deg",
+        width="4 deg",
     )
-    yield Model.create("ConstantSpectralModel", const="99 cm-2 s-1 TeV-1")
+    yield Model.create("ConstantSpectralModel", "spectral", const="99 cm-2 s-1 TeV-1")
     # TODO: yield Model.create("CompoundSpectralModel")
-    yield Model.create("PowerLawSpectralModel")
-    yield Model.create("PowerLaw2SpectralModel")
-    yield Model.create("ExpCutoffPowerLawSpectralModel")
-    yield Model.create("ExpCutoffPowerLaw3FGLSpectralModel")
-    yield Model.create("SuperExpCutoffPowerLaw3FGLSpectralModel")
-    yield Model.create("SuperExpCutoffPowerLaw4FGLSpectralModel")
-    yield Model.create("LogParabolaSpectralModel")
+    yield Model.create("PowerLawSpectralModel", "spectral")
+    yield Model.create("PowerLaw2SpectralModel", "spectral")
+    yield Model.create("ExpCutoffPowerLawSpectralModel", "spectral")
+    yield Model.create("ExpCutoffPowerLaw3FGLSpectralModel", "spectral")
+    yield Model.create("SuperExpCutoffPowerLaw3FGLSpectralModel", "spectral")
+    yield Model.create("SuperExpCutoffPowerLaw4FGLSpectralModel", "spectral")
+    yield Model.create("LogParabolaSpectralModel", "spectral")
     yield Model.create(
-        "TemplateSpectralModel", energy=[1, 2] * u.cm, values=[3, 4] * u.cm
+        "TemplateSpectralModel", "spectral", energy=[1, 2] * u.cm, values=[3, 4] * u.cm
     )  # TODO: add unit validation?
-    yield Model.create("GaussianSpectralModel")
+    yield Model.create("GaussianSpectralModel", "spectral")
     # TODO: yield Model.create("AbsorbedSpectralModel")
     # TODO: yield Model.create("NaimaSpectralModel")
     # TODO: yield Model.create("ScaleSpectralModel")
-    yield Model.create("ConstantTemporalModel")
-    yield Model.create("LightCurveTemplateTemporalModel", Table())
+    yield Model.create("ConstantTemporalModel", "temporal")
+    yield Model.create("LightCurveTemplateTemporalModel", "temporal", Table())
     yield Model.create(
         "SkyModel",
-        spatial_model=Model.create("ConstantSpatialModel"),
-        spectral_model=Model.create("PowerLawSpectralModel"),
+        spatial_model=Model.create("ConstantSpatialModel", "spatial"),
+        spectral_model=Model.create("PowerLawSpectralModel", "spectral"),
     )
     m1 = Map.create(
         npix=(10, 20, 30), axes=[MapAxis.from_nodes([1, 2] * u.TeV, name="energy")]

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -205,7 +205,7 @@ def test_with_skymodel(light_curve):
     sky_model = SkyModel(
         spectral_model=PowerLawSpectralModel(), temporal_model=light_curve
     )
-    assert sky_model.temporal_model.tag == "LightCurveTemplateTemporalModel"
+    assert "LightCurveTemplateTemporalModel" in sky_model.temporal_model.tag
 
     out = sky_model.to_dict()
     assert "temporal" in out

--- a/gammapy/utils/registry.py
+++ b/gammapy/utils/registry.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 __all__ = ["Registry"]
 
 
@@ -8,15 +7,15 @@ class Registry(list):
 
     def get_cls(self, tag):
         for cls in self:
-            if hasattr(cls, "tag") and cls.tag == tag:
+            if hasattr(cls, "tag") and tag in cls.tag:
                 return cls
         raise KeyError(f"No model found with tag: {tag!r}")
 
     def __str__(self):
         info = "Registry\n"
         info += "--------\n\n"
-
-        len_max = max([len(_.tag) for _ in self])
+        tags = [_.tag[0] if isinstance(_.tag, list) else _.tag for _ in self]
+        len_max = max([len(tag) for tag in tags])
 
         for item in self:
             info += f"\t{item.tag:{len_max}s}: {item.__name__}\n"

--- a/gammapy/utils/registry.py
+++ b/gammapy/utils/registry.py
@@ -16,7 +16,7 @@ class Registry(list):
         info += "--------\n\n"
         len_max = max([len(_.__name__) for _ in self])
 
-        for k, item in enumerate(self):
+        for item in self:
             info += f"{item.__name__:{len_max}s}: {item.tag} \n"
 
         return info.expandtabs(tabsize=2)

--- a/gammapy/utils/registry.py
+++ b/gammapy/utils/registry.py
@@ -14,10 +14,9 @@ class Registry(list):
     def __str__(self):
         info = "Registry\n"
         info += "--------\n\n"
-        tags = [_.tag[0] if isinstance(_.tag, list) else _.tag for _ in self]
-        len_max = max([len(tag) for tag in tags])
+        len_max = max([len(_.__name__) for _ in self])
 
-        for item in self:
-            info += f"\t{item.tag:{len_max}s}: {item.__name__}\n"
+        for k, item in enumerate(self):
+            info += f"{item.__name__:{len_max}s}: {item.tag} \n"
 
         return info.expandtabs(tabsize=2)


### PR DESCRIPTION
Redefine most of models tags with a list including shorter aliases to be used with model.create(tag) and in YAML serialization. By default the tag returned in model.to_dict() is the 0th tag which is also the class name. 