### PR TITLE
Add theta squared plot example

### DIFF
--- a/docs/tutorials/hess.ipynb
+++ b/docs/tutorials/hess.ipynb
@@ -31,7 +31,10 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "import numpy as np\n",
+    "import astropy.units as u"
    ]
   },
   {
@@ -40,7 +43,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gammapy.data import DataStore"
+    "from gammapy.data import DataStore\n",
+    "from gammapy.maps import MapAxis\n",
+    "from gammapy.makers.utils import make_theta_squared_table\n",
+    "from gammapy.visualization import plot_theta2_distribution"
    ]
   },
   {
@@ -76,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obs = data_store.obs(20136)"
+    "obs = data_store.obs(23523)"
    ]
   },
   {
@@ -119,10 +125,69 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Make the theta2 distribution\n",
+    "Compute theta2 distribution from the event list:\n",
+    "    - ON counts: theta2 distribution from a target position (here the Crab)\n",
+    "    - OFF counts: theta2 distribution from a mirror position radially symmetric from the target position\n",
+    "    - alpha: normalisation between the ON and OFF acceptance, assume to be one for the moment  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### For one single observation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "position = SkyCoord(ra=83.63, dec=22.01, unit=\"deg\", frame=\"icrs\")\n",
+    "theta2_bins = MapAxis.from_bounds(0, 0.2, nbin=50, interp=\"lin\", unit=\"deg2\")\n",
+    "theta2_table = make_theta_squared_table(observation_list = [obs],on_position = position, theta2_axis = theta2_bins)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "plot_theta2_distribution(theta2_distribution_table = theta2_table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### For a set of observations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs_ids=[23523, 23526]\n",
+    "list_observation = [data_store.obs(obs_id) for obs_id in obs_ids]\n",
+    "theta2_table = make_theta_squared_table(observation_list = list_observation,on_position = position, theta2_axis = theta2_bins)\n",
+    "plot_theta2_distribution(theta2_distribution_table = theta2_table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Exercises\n",
     "\n",
     "- Find the `OBS_ID` for the runs of the Crab nebula\n",
-    "- Compute the expected number of background events in the whole FOV for `OBS_ID=20136` in the 1 TeV to 3 TeV energy band, from the background IRF."
+    "- Compute the expected number of background events in the whole FOV for `OBS_ID=23523` in the 1 TeV to 3 TeV energy band, from the background IRF."
    ]
   },
   {

--- a/docs/tutorials/hess.ipynb
+++ b/docs/tutorials/hess.ipynb
@@ -46,7 +46,7 @@
     "from gammapy.data import DataStore\n",
     "from gammapy.maps import MapAxis\n",
     "from gammapy.makers.utils import make_theta_squared_table\n",
-    "from gammapy.visualization import plot_theta2_distribution"
+    "from gammapy.visualization import plot_theta_squared_table"
    ]
   },
   {
@@ -125,18 +125,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make the theta2 distribution\n",
-    "Compute theta2 distribution from the event list:\n",
-    "    - ON counts: theta2 distribution from a target position (here the Crab)\n",
-    "    - OFF counts: theta2 distribution from a mirror position radially symmetric from the target position\n",
-    "    - alpha: normalisation between the ON and OFF acceptance, assume to be one for the moment  "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### For one single observation"
+    "## Theta sqared event distribution\n",
+    "As a quick look plot it can be helpful to plot the quadratic offset (theta squared) distribution of the events. "
    ]
   },
   {
@@ -146,8 +136,14 @@
    "outputs": [],
    "source": [
     "position = SkyCoord(ra=83.63, dec=22.01, unit=\"deg\", frame=\"icrs\")\n",
-    "theta2_bins = MapAxis.from_bounds(0, 0.2, nbin=50, interp=\"lin\", unit=\"deg2\")\n",
-    "theta2_table = make_theta_squared_table(observation_list = [obs],on_position = position, theta2_axis = theta2_bins)"
+    "theta2_axis = MapAxis.from_bounds(0, 0.2, nbin=20, interp=\"lin\", unit=\"deg2\")\n",
+    "\n",
+    "observations = data_store.get_observations([23523, 23526])\n",
+    "theta2_table = make_theta_squared_table(\n",
+    "    observations=observations,\n",
+    "    position=position,\n",
+    "    theta_squared_axis=theta2_axis\n",
+    ")"
    ]
   },
   {
@@ -158,26 +154,8 @@
    },
    "outputs": [],
    "source": [
-    "plot_theta2_distribution(theta2_distribution_table = theta2_table)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### For a set of observations"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "obs_ids=[23523, 23526]\n",
-    "list_observation = [data_store.obs(obs_id) for obs_id in obs_ids]\n",
-    "theta2_table = make_theta_squared_table(observation_list = list_observation,on_position = position, theta2_axis = theta2_bins)\n",
-    "plot_theta2_distribution(theta2_distribution_table = theta2_table)"
+    "plt.figure(figsize=(10, 5))\n",
+    "plot_theta_squared_table(theta2_table)"
    ]
   },
   {

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -304,9 +304,9 @@ class TestTheta2Table:
         # On theta2 distribution compute from (0,0) in ra/dec.
         # OFF theta2 distribution from the mirror position at (0,1) in ra/dec.
         position = SkyCoord(ra=0, dec=0, unit="deg", frame="icrs")
-        bins = MapAxis.from_bounds(0, 0.2, nbin=4, interp="lin", unit="deg2")
-        theta2_table = make_theta_squared_table(observation_list=[self.observation],
-                                                on_position=position, theta2_axis=bins
+        axis = MapAxis.from_bounds(0, 0.2, nbin=4, interp="lin", unit="deg2")
+        theta2_table = make_theta_squared_table(observations=[self.observation],
+                                                position=position, theta_squared_axis=axis
                                                 )
         theta2_lo = [0, 0.05, 0.1, 0.15]
         theta2_hi = [0.05, 0.1, 0.15, 0.2]
@@ -326,20 +326,18 @@ class TestTheta2Table:
         assert_allclose(theta2_table["alpha"], alpha)
         assert_allclose(theta2_table.meta["ON_RA"], 0 * u.deg)
         assert_allclose(theta2_table.meta["ON_DEC"], 0 * u.deg)
-        assert_allclose(theta2_table.meta["OFF_RA"], 0 * u.deg)
-        assert_allclose(theta2_table.meta["OFF_DEC"], 1 * u.deg)
 
         # Taking the off position as the on one
         off_position = position
-        theta2_table2 = make_theta_squared_table(observation_list=[self.observation],
-                                                 on_position=position, theta2_axis=bins, off_position=off_position
+        theta2_table2 = make_theta_squared_table(observations=[self.observation],
+                                                 position=position, theta_squared_axis=axis, position_off=off_position
                                                  )
 
         assert_allclose(theta2_table2["counts_off"], theta2_table["counts"])
 
         # Test for two observations, here identical
-        theta2_table_two_obs = make_theta_squared_table(observation_list=[self.observation, self.observation],
-                                                        on_position=position, theta2_axis=bins
+        theta2_table_two_obs = make_theta_squared_table(observations=[self.observation, self.observation],
+                                                        position=position, theta_squared_axis=axis
                                                         )
         on_counts_two_obs = [4, 0, 0, 0]
         off_counts_two_obs = [2, 0, 0, 0]

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -5,6 +5,7 @@ from astropy.coordinates import Angle
 from astropy.table import Table
 from gammapy.data import FixedPointingInfo
 from gammapy.irf import EDispMap, PSFMap
+from gammapy.stats import WStatCountsStatistic
 from gammapy.maps import Map, WcsNDMap
 from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.utils.coordinates import sky_to_fov
@@ -302,86 +303,89 @@ def make_edisp_kernel_map(edisp, pointing, geom, exposure_map=None):
     return edisp_map.to_edisp_kernel_map(geom.get_axis_by_name("energy"))
 
 
-def make_theta_squared_table(observation_list, on_position, theta2_axis, off_position=None):
-    """ Compute the OFF and ON theta2 distribution in the same FOV for a list of `Observation`
-    from a given theta2 binning.
+def make_theta_squared_table(observations, theta_squared_axis, position, position_off=None):
+    """Make theta squared distribution in the same FoV for a list of `Observation`
+    objects.
 
-    The ON theta2 profile is computed from a given distribution, on_position. By default, the OFF theta2 profile
-    is extracted from a mirror position radially symmetric in the FOV to pos_on.
+    The ON theta2 profile is computed from a given distribution, on_position.
+    By default, the OFF theta2 profile is extracted from a mirror position
+    radially symmetric in the FOV to pos_on.
 
-    The ON and OFF regions are assumed to be of the same size, so the normalisation factor between both region
-    alpha=1.
+    The ON and OFF regions are assumed to be of the same size, so the normalisation
+    factor between both region alpha = 1.
 
     Parameters
     ----------
-    observation_list: `~gammapy.data.Observations`
-        List of observation
-    on_position : `~astropy.coordinates.SkyCoord`
-        position from which the ON theta^2 distribution is computed
-    theta2_axis : theta2_axis: `~gammapy.maps.geom.MapAxis`
-        Array of edges of the theta2 bin used to compute the distribution
-    off_position : `astropy.coordinates.SkyCoord`
-        position from which the OFF theta^2 distribution is computed. Default: reflected position w.r.t.
-        to the pointing position
+    observations: `~gammapy.data.Observations`
+        List of observations
+    theta_squared_axis : `~gammapy.maps.geom.MapAxis`
+        Axis of edges of the theta2 bin used to compute the distribution
+    position : `~astropy.coordinates.SkyCoord`
+        Position from which the on theta^2 distribution is computed
+    position_off : `astropy.coordinates.SkyCoord`
+        Position from which the OFF theta^2 distribution is computed.
+        Default: reflected position w.r.t. to the pointing position
+
     Returns
     -------
     table : `~astropy.table.Table`
-        Table containing the ON counts, the OFF counts, the acceptance, the off acceptance and the alpha (normalisation
-        between ON and OFF) for each theta2 bin
+        Table containing the on counts, the off counts, acceptance, off acceptance and alpha
+        for each theta squared bin.
     """
-    if not theta2_axis.edges.unit.is_equivalent("deg2"):
+    if not theta_squared_axis.edges.unit.is_equivalent("deg2"):
         raise ValueError("The theta2 axis should be equivalent to deg2")
 
-    on_counts_tot = np.zeros_like(theta2_axis.center.value)
-    off_counts_tot = np.zeros_like(theta2_axis.center.value)
-    acceptance_tot = np.zeros_like(theta2_axis.center.value)
-    acceptance_off_tot = np.zeros_like(theta2_axis.center.value)
-    alpha_tot = np.zeros_like(theta2_axis.center.value)
+    table = Table()
+
+    table["theta2_min"] = theta_squared_axis.edges[:-1]
+    table["theta2_max"] = theta_squared_axis.edges[1:]
+    table["counts"] = 0
+    table["counts_off"] = 0
+    table["acceptance"] = 0.
+    table["acceptance_off"] = 0.
+
+    alpha_tot = np.zeros(len(table))
     livetime_tot = 0
-    for observation in observation_list:
-        # Angular distance of the events from the given ON position
-        separation_on = on_position.separation(observation.events.radec)
-        if not off_position:
+
+    for observation in observations:
+        separation = position.separation(observation.events.radec)
+        counts, _ = np.histogram(separation ** 2, theta_squared_axis.edges)
+        table["counts"] += counts
+
+        if not position_off:
             # Estimate the position of the mirror position
-            pos_angle = observation.pointing_radec.position_angle(on_position)
-            sep_angle = observation.pointing_radec.separation(on_position)
-            off_position = observation.pointing_radec.directional_offset_by(
+            pos_angle = observation.pointing_radec.position_angle(position)
+            sep_angle = observation.pointing_radec.separation(position)
+            position_off = observation.pointing_radec.directional_offset_by(
                 pos_angle + Angle(np.pi, "rad"), sep_angle
             )
+
         # Angular distance of the events from the mirror position
-        separation_off = off_position.separation(observation.events.radec)
+        separation_off = position_off.separation(observation.events.radec)
 
         # Extract the ON and OFF theta2 distribution from the two positions.
-        on_cnts, _ = np.histogram(separation_on ** 2, theta2_axis.edges)
-        off_cnts, _ = np.histogram(separation_off ** 2, theta2_axis.edges)
-        on_counts_tot += on_cnts
-        off_counts_tot += off_cnts
+        counts_off, _ = np.histogram(separation_off ** 2, theta_squared_axis.edges)
+        table["counts_off"] += counts_off
 
         # Normalisation between ON and OFF is one
-        acceptance = np.ones_like(theta2_axis.center.value)
-        acceptance_off = np.ones_like(theta2_axis.center.value)
-        acceptance_tot += acceptance
-        acceptance_off_tot += acceptance_off
+        acceptance = np.ones(theta_squared_axis.nbin)
+        acceptance_off = np.ones(theta_squared_axis.nbin)
+
+        table["acceptance"] += acceptance
+        table["acceptance_off"] += acceptance_off
         alpha = acceptance / acceptance_off
-        alpha_tot += alpha * observation.observation_live_time_duration.value
-        livetime_tot += observation.observation_live_time_duration.value
+        alpha_tot += alpha * observation.observation_live_time_duration.to_value("s")
+        livetime_tot += observation.observation_live_time_duration.to_value("s")
 
     alpha_tot /= livetime_tot
+    table["alpha"] = alpha_tot
 
-    table = Table(
-        {
-            "theta2_min": theta2_axis.edges[0:-1],
-            "theta2_max": theta2_axis.edges[1:],
-            "counts": on_counts_tot,
-            "counts_off": off_counts_tot,
-            "acceptance": acceptance_tot,
-            "acceptance_off": acceptance_off_tot,
-            "alpha": alpha_tot,
-        }
-    )
+    stat = WStatCountsStatistic(table["counts"], table["counts_off"], table["alpha"])
+    table["excess"] = stat.excess
+    table["sqrt_ts"] = stat.significance
+    table["excess_errn"] = stat.compute_errn()
+    table["excess_errp"] = stat.compute_errp()
 
-    table.meta["ON_RA"] = on_position.icrs.ra
-    table.meta["ON_DEC"] = on_position.icrs.dec
-    table.meta["OFF_RA"] = off_position.icrs.ra
-    table.meta["OFF_DEC"] = off_position.icrs.dec
+    table.meta["ON_RA"] = position.icrs.ra
+    table.meta["ON_DEC"] = position.icrs.dec
     return table

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -1,17 +1,49 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
+from gammapy.maps import MapAxis
+from gammapy.maps.utils import edges_from_lo_hi
 from gammapy.utils.testing import mpl_plot_check, requires_dependency
 from gammapy.visualization import plot_contour_line
+from gammapy.visualization import plot_theta2_distribution
+import astropy.units as u
+from astropy.table import Table
 
 
 @requires_dependency("matplotlib")
 def test_map_panel_plotter():
     import matplotlib.pyplot as plt
 
-    t = np.linspace(0., 6.1, 10)
+    t = np.linspace(0.0, 6.1, 10)
     x = np.cos(t)
     y = np.sin(t)
 
     ax = plt.subplot(111)
     with mpl_plot_check():
         plot_contour_line(ax, x, y)
+
+
+@requires_dependency("matplotlib")
+def test_plot_theta2_distribution():
+    theta2_lo = [0, 0.05, 0.1, 0.15] * u.deg ** 2
+    theta2_hi = [0.05, 0.1, 0.15, 0.2] * u.deg ** 2
+    theta2_edges = edges_from_lo_hi(theta2_lo, theta2_hi)
+    theta2_axis = MapAxis.from_edges(
+        theta2_edges, interp="lin", name="offset", unit=theta2_edges.unit
+    )
+    on_cnts = [2, 0, 0, 0]
+    off_cnts = [1, 0, 0, 0]
+    acceptance = [1, 1, 1, 1]
+    acceptance_off = [1, 1, 1, 1]
+    alpha = [1, 1, 1, 1]
+    theta2_distribution_table = Table(
+        {
+            "theta2_min": theta2_lo,
+            "theta2_max": theta2_hi,
+            "counts": on_cnts,
+            "counts_off": off_cnts,
+            "acceptance": acceptance,
+            "acceptance_off": acceptance_off,
+            "alpha": alpha,
+        }
+    )
+    plot_theta2_distribution(theta2_distribution_table=theta2_distribution_table)

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -1,6 +1,8 @@
 import numpy as np
+from gammapy.maps import MapAxis
+from gammapy.maps.utils import edges_from_lo_hi
 
-__all__ = ["plot_spectrum_datasets_off_regions", "plot_contour_line"]
+__all__ = ["plot_spectrum_datasets_off_regions", "plot_contour_line", "plot_theta2_distribution"]
 
 
 def plot_spectrum_datasets_off_regions(datasets, ax=None, legend=None, legend_kwargs=None, **kwargs):
@@ -90,12 +92,13 @@ def plot_spectrum_datasets_off_regions(datasets, ax=None, legend=None, legend_kw
             handles = legend.legendHandles + handles
             labels = [text.get_text() for text in legend.texts] + labels
 
-        handles = [(handle,handle) for handle in handles]
+        handles = [(handle, handle) for handle in handles]
         tuple_handler = HandlerTuple(ndivide=None, pad=0)
 
         def patch_func(legend, orig_handle, xdescent, ydescent, width, height, fontsize):
             radius = width / 2
             return CirclePolygon((radius - xdescent, height / 2 - ydescent), radius)
+
         patch_handler = HandlerPatch(patch_func)
 
         legend_kwargs.setdefault("handletextpad", 0.5)
@@ -134,3 +137,41 @@ def plot_contour_line(ax, x, y, **kwargs):
 
     ax.plot(out[:, 0], out[:, 1], "-", color=color, **kwargs)
     ax.plot(xf, yf, linestyle='', marker=marker, color=color)
+
+
+def plot_theta2_distribution(theta2_distribution_table):
+    """Plot the theta2 distribution of ON, OFF counts, excess and signifiance in each theta2bin.
+    Take the table containing the ON counts, the OFF counts, the acceptance, the off acceptance and the alpha
+    (normalisation between ON and OFF) for each theta2 bin
+    Parameters
+    ----------
+    theta2_distribution_table : `~astropy.table.Table`
+        required column: theta2_min, theta2_max, counts, counts_off and alpha
+    """
+    from gammapy.stats import WStatCountsStatistic
+    import matplotlib.pyplot as plt
+
+    theta2_edges = edges_from_lo_hi(theta2_distribution_table["theta2_min"], theta2_distribution_table["theta2_max"])
+    theta2_axis = MapAxis.from_edges(theta2_edges, interp="lin", name="offset", unit=theta2_edges.unit)
+    on_counts = theta2_distribution_table["counts"]
+    off_counts = theta2_distribution_table["counts_off"]
+    alpha = theta2_distribution_table["alpha"]
+
+    stat = WStatCountsStatistic(on_counts, off_counts, alpha)
+
+    plt.figure()
+    ax0 = plt.subplot(2, 1, 1)
+    ax0.errorbar(theta2_axis.center.value, stat.n_on, yerr=np.sqrt(stat.n_on), fmt="+", linestyle='None', label=" ON")
+    ax0.errorbar(theta2_axis.center.value, stat.n_off, yerr=np.sqrt(stat.n_off), fmt="+", linestyle='None',
+                 label=" OFF")
+    ax0.errorbar(theta2_axis.center.value, stat.excess, yerr=[-stat.compute_errn(), stat.compute_errp()], fmt="+",
+                 linestyle='None', label="Excess")
+    ax0.set_ylabel("counts")
+    ax0.set_xticks([])
+    ax0.set_xlabel('')
+    ax0.legend()
+    ax1 = plt.subplot(2, 1, 2)
+    ax1.plot(theta2_axis.center, stat.significance, marker="+", linestyle='None')
+    ax1.set_xlabel("Theta2 (" + str(theta2_axis.center.to("deg2").unit) + ")")
+    ax1.set_ylabel("significance")
+    ax1.legend()


### PR DESCRIPTION
This PR allow to perform the basic theta2 plot for ON and OFF event in the same FOV.
Add a method in the event list that return a Table containing the theta2 bins and the ON and OFF counts.
Rename the notebook HESS analysis in explore_DL3_data_theta2_plot and inside the notebook shows a basic example to do the theta2 plot of the ON, OFF and excess with the associated errors and the significance in each theta2 bin.

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request ...

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
