### PR TITLE
PSF-convolved spatial model caching in MapEvaluator

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1894,13 +1894,10 @@ class MapEvaluator:
         if self.model.spatial_model and not isinstance(self.geom, RegionGeom):
             spatial_pars = list(self.model.spatial_model.parameters.values)
             spatial_conv = self._spatial_conv_cached
-            if self._spatial_pars_cached != spatial_pars or self._spatial_conv_cached is None:
+            if self._spatial_pars_cached != spatial_pars or spatial_conv is None:
                 self._spatial_pars_cached = spatial_pars
-                spatial_conv = Map.from_geom(geom=self.geom, data=1)
                 geom_image = self.geom.to_image()
-                integral = self.model.spatial_model.integrate_geom(geom_image)
-                spatial_conv.data = np.ones(value.shape) * integral.data
-                spatial_conv.unit = integral.unit
+                spatial_conv = self.model.spatial_model.integrate_geom(geom_image)
                 if self.psf and self.model.apply_irf["psf"]:
                     spatial_conv = self.apply_psf(spatial_conv)
                 self._spatial_conv_cached = spatial_conv

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -13,7 +13,7 @@ from gammapy.irf.edisp_map import EDispMap, EDispKernelMap
 from gammapy.irf.psf_kernel import PSFKernel
 from gammapy.irf.psf_map import PSFMap
 from gammapy.maps import Map, MapAxis, RegionGeom
-from gammapy.modeling.models import BackgroundModel, Models, ProperModels
+from gammapy.modeling.models import BackgroundModel, Models, ProperModels, SkyDiffuseCube
 from gammapy.stats import cash, cash_sum_cython, wstat
 from gammapy.utils.random import get_random_state
 from gammapy.utils.scripts import make_name, make_path
@@ -274,6 +274,7 @@ class MapDataset(Dataset):
         for evaluator in self.evaluators.values():
             if evaluator.contributes:
                 if self.use_cache is False:
+                    evaluator._spatial_pars_cached = None
                     evaluator._pars_cached = None
                 npred = evaluator.compute_npred()
                 npred_total.stack(npred)
@@ -1705,7 +1706,9 @@ class MapEvaluator:
         self.contributes = True
         self._npred_cached = None
         self._pars_cached = None
-
+        self._spatial_pars_cached = None
+        self._spatial_conv_cached = None
+        
         if evaluation_mode not in {"local", "global"}:
             raise ValueError(f"Invalid evaluation_mode: {evaluation_mode!r}")
         self.evaluation_mode = evaluation_mode
@@ -1785,6 +1788,7 @@ class MapEvaluator:
             self.exposure = exposure
 
         self._pars_cached = None
+        self._spatial_pars_cached = None
 
     def compute_dnde(self):
         """Compute model differential flux at map pixel centers.
@@ -1848,8 +1852,9 @@ class MapEvaluator:
         if self._pars_cached != pars:
             self._pars_cached = pars
             if isinstance(self.model, BackgroundModel):
-                npred = self.model.evaluate()
-            else:
+                npred = self.model.evaluate()        
+            elif isinstance(self.model, SkyDiffuseCube):
+                #TODO: remove once SkyDiffuseCube can be a spatial model                
                 flux = self.compute_flux()
 
                 if self.model.apply_irf["exposure"]:
@@ -1860,6 +1865,44 @@ class MapEvaluator:
 
                 if self.model.apply_irf["edisp"]:
                     npred = self.apply_edisp(npred)
+            else:
+                
+                flux_conv = self._compute_flux_conv()
+                
+                if self.model.apply_irf["exposure"]:
+                    npred = self.apply_exposure(flux_conv)
 
+                if self.model.apply_irf["edisp"]:
+                    npred = self.apply_edisp(npred)
+                
             self._npred_cached = npred
         return npred
+
+    def _compute_flux_conv(self):
+        """ compute_flux with caching of psf-convolved spatial model"""
+        energy = self.geom.get_axis_by_name("energy_true").edges
+        
+        value = self.model.spectral_model.integral(
+            energy[:-1], energy[1:], intervals=True
+        ).reshape((-1, 1, 1))
+                
+        if self.model.spatial_model and not isinstance(self.geom, RegionGeom):
+            spatial_pars = list(self.model.spatial_model.parameters.values)
+            spatial_conv = self._spatial_conv_cached
+            if self._spatial_pars_cached != spatial_pars:
+                self._spatial_pars_cached = spatial_pars
+                spatial_conv = Map.from_geom(geom=self.geom, data=1)
+                geom_image = self.geom.to_image()
+                integral = self.model.spatial_model.integrate_geom(geom_image)
+                spatial_conv.data = np.ones(value.shape) * integral.data
+                spatial_conv.unit = integral.unit
+                if self.psf and self.model.apply_irf["psf"]:
+                    spatial_conv = self.apply_psf(spatial_conv)
+                self._spatial_conv_cached = spatial_conv
+            value =  value * spatial_conv.quantity
+        
+        if self.model.temporal_model:
+            integral = self.model.temporal_model.integral(self.gti.time_start, self.gti.time_stop)
+            value = value * np.sum(integral)
+        
+        return Map.from_geom(geom=self.geom, data=value.value, unit=value.unit)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -279,8 +279,8 @@ class MapDataset(Dataset):
         for evaluator in self.evaluators.values():
             if evaluator.contributes:
                 if self.use_cache is False:
-                    evaluator._spatial_pars_cached = None
-                    evaluator._pars_cached = None
+                    evaluator._spatial_conv_cached = None
+                    evaluator._npred_cached = None
                 npred = evaluator.compute_npred()
                 npred_total.stack(npred)
         return npred_total
@@ -1792,8 +1792,8 @@ class MapEvaluator:
         else:
             self.exposure = exposure
 
-        self._pars_cached = None
-        self._spatial_pars_cached = None
+        self._npred_cached = None
+        self._spatial_conv_cached = None
 
     def compute_dnde(self):
         """Compute model differential flux at map pixel centers.
@@ -1854,7 +1854,7 @@ class MapEvaluator:
 
         pars = list(self.model.parameters.values)
         npred = self._npred_cached
-        if self._pars_cached != pars:
+        if self._pars_cached != pars or self._npred_cached is None:
             self._pars_cached = pars
             if isinstance(self.model, BackgroundModel):
                 npred = self.model.evaluate()
@@ -1894,7 +1894,7 @@ class MapEvaluator:
         if self.model.spatial_model and not isinstance(self.geom, RegionGeom):
             spatial_pars = list(self.model.spatial_model.parameters.values)
             spatial_conv = self._spatial_conv_cached
-            if self._spatial_pars_cached != spatial_pars:
+            if self._spatial_pars_cached != spatial_pars or self._spatial_conv_cached is None:
                 self._spatial_pars_cached = spatial_pars
                 spatial_conv = Map.from_geom(geom=self.geom, data=1)
                 geom_image = self.geom.to_image()

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -167,7 +167,7 @@ def test_fake(sky_model, geom, geom_etrue):
     dataset.fake(314)
 
     assert real_dataset.counts.data.shape == dataset.counts.data.shape
-    assert_allclose(real_dataset.counts.data.sum(), 9525.755807)
+    assert_allclose(real_dataset.counts.data.sum(), 9525.299054, rtol=1e-5)
     assert_allclose(dataset.counts.data.sum(), 9723)
 
 
@@ -431,7 +431,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
     dataset_2.mask_safe = Map.from_geom(geom, data=mask_safe)
 
     stat = fit.datasets.stat_sum()
-    assert_allclose(stat, 14824.282955)
+    assert_allclose(stat, 14824.173099, rtol=1e-5)
 
     # test model evaluation outside image
 

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -48,7 +48,7 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
     result = estimator.run(fermi_datasets)
 
     assert_allclose(result["norm"], 0.970614, atol=1e-3)
-    assert_allclose(result["ts"], 29695.720611, atol=1e-3)
+    assert_allclose(result["ts"], 29695.689216, atol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
     assert_allclose(result["norm_errn"], 0.0199, atol=1e-3)
     assert_allclose(result["norm_errp"], 0.0199, atol=1e-3)
@@ -64,7 +64,7 @@ def test_flux_estimator_fermi_with_reoptimization(fermi_datasets):
     result = estimator.run(fermi_datasets, steps=["err", "ts"])
 
     assert_allclose(result["norm"], 0.970614, atol=1e-3)
-    assert_allclose(result["ts"], 13005.903067, atol=1e-3)
+    assert_allclose(result["ts"], 13005.871662, atol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
 
 

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -256,7 +256,7 @@ def test_models_management(tmp_path):
     npred1b = datasets[0].npred().data.sum()
     assert npred1b != npred1
     assert npred1b != npred0
-    assert_allclose(npred1b, 2147.407023024028)
+    assert_allclose(npred1b, 2147.252952, rtol=1e-5)
 
     datasets.models.remove(model1b)
     _ = datasets.models  # auto-update models


### PR DESCRIPTION
Implement caching of PSF-convolved spatial model in MapEvaluator.
(speed up 3FHL validation fit and flux points computation by a factor of about two)