### PR TITLE
Modify EdispKernel constructor to work with MapAxis

### DIFF
--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -151,13 +151,7 @@ class EDispMap(IRFMap):
             integral = np.diff(np.clip(f(migra), a_min=0, a_max=1))
             data.append(integral)
 
-        return EDispKernel(
-            e_true_lo=energy_axis_true.edges[:-1],
-            e_true_hi=energy_axis_true.edges[1:],
-            e_reco_lo=energy_axis.edges[:-1],
-            e_reco_hi=energy_axis.edges[1:],
-            data=data,
-        )
+        return EDispKernel(e_true=energy_axis_true, e_reco=energy_axis, data=data)
 
     @classmethod
     def from_geom(cls, geom):
@@ -420,13 +414,7 @@ class EDispKernelMap(IRFMap):
 
             data = self.edisp_map.get_by_coord(coords)
 
-        return EDispKernel(
-            e_true_lo=energy_true_axis.edges[:-1],
-            e_true_hi=energy_true_axis.edges[1:],
-            e_reco_lo=energy_axis.edges[:-1],
-            e_reco_hi=energy_axis.edges[1:],
-            data=data,
-        )
+        return EDispKernel(e_true=energy_true_axis, e_reco=energy_axis, data=data)
 
     @classmethod
     def from_diagonal_response(cls, energy_axis, energy_axis_true, geom=None):

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -231,7 +231,7 @@ class EnergyDispersion2D:
         e_lo, e_hi = e_true[:-1], e_true[1:]
         ereco_lo, ereco_hi = (e_reco[:-1], e_reco[1:])
 
-        return EDispKernel(
+        return EDispKernel.from_energy_lo_hi(
             e_true_lo=e_lo,
             e_true_hi=e_hi,
             e_reco_lo=ereco_lo,


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the `EDispKernel` to work with `MapAxis` to provide energies. The `energy_lo` and `energy_hi` arguments follow the serialization scheme but not the internal storage which relies on a contiguous axes described by a `MapAxis`. For API consistency `MapAxis` seems a more reasonable choice.

Note that all `gammapy.irf` classes use `Quantity` axes, which could/should be replaced in the future with `MapAxis`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
