### PR TITLE
Adapt `ExcessMapEstimator` to optionally apply mask_fit 

### DIFF
--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -92,11 +92,12 @@ class ExcessMapEstimator(Estimator):
     tag = "ExcessMapEstimator"
     available_selection = ["errn-errp", "ul"]
 
-    def __init__(self,
+    def __init__(
+        self,
         correlation_radius="0.1 deg",
         n_sigma=1,
         n_sigma_ul=3,
-        selection='all',
+        selection="all",
         apply_mask_fit=False,
         return_image=False,
     ):

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -26,7 +26,7 @@ def convolved_map_dataset_counts_statistics(
 
     mask = np.ones(dataset.data_shape, dtype=bool)
     if dataset.mask_safe:
-        mask = dataset.mask_safe
+        mask *= dataset.mask_safe
     if apply_mask_fit:
         mask *= dataset.mask_fit
 

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -122,6 +122,11 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
     assert_allclose(result["errn"].data[0, 10, 10], -12.396716, atol=1e-3)
     assert_allclose(result["ul"].data[0, 10, 10], 122.240837, atol=1e-3)
 
+    estimator_image = ExcessMapEstimator(0.1 * u.deg, return_image=True)
+    result_image = estimator_image.run(simple_dataset)
+    assert result_image["counts"].data.shape == (20, 20)
+    assert_allclose(result_image["significance"].data[10, 10], 7.910732, atol=1e-5)
+
 
 def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     estimator = ExcessMapEstimator(0.11 * u.deg, selection=None)
@@ -131,6 +136,26 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     assert_allclose(result["excess"].data[0, 10, 10], 97)
     assert_allclose(result["background"].data[0, 10, 10], 97)
     assert_allclose(result["significance"].data[0, 10, 10], 5.741116, atol=1e-5)
+
+    estimator_image = ExcessMapEstimator(0.11 * u.deg, return_image=True)
+    result_image = estimator_image.run(simple_dataset_on_off)
+    assert result_image["counts"].data.shape == (20, 20)
+    assert_allclose(result_image["significance"].data[10, 10], 5.741116, atol=1e-3)
+
+    mask_fit = Map.from_geom(
+        simple_dataset_on_off._geom,
+        data=np.ones(simple_dataset_on_off.counts.data.shape, dtype=bool),
+    )
+    mask_fit.data[:, :, 10] = False
+    mask_fit.data[:, 10, :] = False
+    simple_dataset_on_off.mask_fit = mask_fit
+    estimator_image = ExcessMapEstimator(
+        0.11 * u.deg, apply_mask_fit=True, return_image=True
+    )
+    result_image = estimator_image.run(simple_dataset_on_off)
+    assert result_image["counts"].data.shape == (20, 20)
+    assert_allclose(result_image["significance"].data[10, 10], 5.08179, atol=1e-3)
+
 
 def test_incorrect_selection():
     with pytest.raises(ValueError):

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -104,10 +104,6 @@ def test_compute_lima_on_off_image():
     assert_allclose(actual, desired, atol=0.2)
 
 
-def test_significance_map_estimator_incorrect_dataset():
-    with pytest.raises(ValueError):
-        ExcessMapEstimator("bad")
-
 
 def test_significance_map_estimator_map_dataset(simple_dataset):
     estimator = ExcessMapEstimator(0.1 * u.deg)
@@ -126,6 +122,9 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
     result_image = estimator_image.run(simple_dataset)
     assert result_image["counts"].data.shape == (20, 20)
     assert_allclose(result_image["significance"].data[10, 10], 7.910732, atol=1e-5)
+    result_image = estimator_image.run(simple_dataset)
+    assert result_image["counts"].data.shape == (1, 20, 20)
+    assert_allclose(result_image["significance"].data[0, 10, 10], 7.910732, atol=1e-5)
 
 
 def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
@@ -141,6 +140,9 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     result_image = estimator_image.run(simple_dataset_on_off)
     assert result_image["counts"].data.shape == (20, 20)
     assert_allclose(result_image["significance"].data[10, 10], 5.741116, atol=1e-3)
+    result_image = estimator_image.run(simple_dataset_on_off)
+    assert result_image["counts"].data.shape == (1, 20, 20)
+    assert_allclose(result_image["significance"].data[0, 10, 10], 5.741116, atol=1e-3)
 
     mask_fit = Map.from_geom(
         simple_dataset_on_off._geom,
@@ -155,6 +157,9 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     result_image = estimator_image.run(simple_dataset_on_off)
     assert result_image["counts"].data.shape == (20, 20)
     assert_allclose(result_image["significance"].data[10, 10], 5.08179, atol=1e-3)
+    result_image = estimator_image.run(simple_dataset_on_off)
+    assert result_image["counts"].data.shape == (1, 20, 20)
+    assert_allclose(result_image["significance"].data[0, 10, 10], 5.08179, atol=1e-3)
 
 
 def test_incorrect_selection():
@@ -167,3 +172,8 @@ def test_incorrect_selection():
     estimator = ExcessMapEstimator(0.11 * u.deg)
     with pytest.raises(ValueError):
         estimator.selection = "bad"
+
+def test_significance_map_estimator_incorrect_dataset():
+    with pytest.raises(ValueError):
+        ExcessMapEstimator("bad")
+

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -104,7 +104,6 @@ def test_compute_lima_on_off_image():
     assert_allclose(actual, desired, atol=0.2)
 
 
-
 def test_significance_map_estimator_map_dataset(simple_dataset):
     estimator = ExcessMapEstimator(0.1 * u.deg)
     result = estimator.run(simple_dataset)
@@ -119,9 +118,6 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
     assert_allclose(result["ul"].data[0, 10, 10], 122.240837, atol=1e-3)
 
     estimator_image = ExcessMapEstimator(0.1 * u.deg, return_image=True)
-    result_image = estimator_image.run(simple_dataset)
-    assert result_image["counts"].data.shape == (20, 20)
-    assert_allclose(result_image["significance"].data[10, 10], 7.910732, atol=1e-5)
     result_image = estimator_image.run(simple_dataset)
     assert result_image["counts"].data.shape == (1, 20, 20)
     assert_allclose(result_image["significance"].data[0, 10, 10], 7.910732, atol=1e-5)
@@ -138,9 +134,6 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
 
     estimator_image = ExcessMapEstimator(0.11 * u.deg, return_image=True)
     result_image = estimator_image.run(simple_dataset_on_off)
-    assert result_image["counts"].data.shape == (20, 20)
-    assert_allclose(result_image["significance"].data[10, 10], 5.741116, atol=1e-3)
-    result_image = estimator_image.run(simple_dataset_on_off)
     assert result_image["counts"].data.shape == (1, 20, 20)
     assert_allclose(result_image["significance"].data[0, 10, 10], 5.741116, atol=1e-3)
 
@@ -154,9 +147,6 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     estimator_image = ExcessMapEstimator(
         0.11 * u.deg, apply_mask_fit=True, return_image=True
     )
-    result_image = estimator_image.run(simple_dataset_on_off)
-    assert result_image["counts"].data.shape == (20, 20)
-    assert_allclose(result_image["significance"].data[10, 10], 5.08179, atol=1e-3)
     result_image = estimator_image.run(simple_dataset_on_off)
     assert result_image["counts"].data.shape == (1, 20, 20)
     assert_allclose(result_image["significance"].data[0, 10, 10], 5.08179, atol=1e-3)
@@ -173,7 +163,7 @@ def test_incorrect_selection():
     with pytest.raises(ValueError):
         estimator.selection = "bad"
 
+
 def test_significance_map_estimator_incorrect_dataset():
     with pytest.raises(ValueError):
         ExcessMapEstimator("bad")
-

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -23,7 +23,7 @@ def simple_dataset():
     axis = MapAxis.from_energy_bounds(0.1, 10, 1, unit="TeV")
     geom = WcsGeom.create(npix=20, binsz=0.02, axes=[axis])
     dataset = MapDataset.create(geom)
-    dataset.mask_safe += 1
+    dataset.mask_safe += np.ones(dataset.data_shape, dtype=bool)
     dataset.counts += 2
     dataset.background_model.map += 1
     return dataset
@@ -34,7 +34,7 @@ def simple_dataset_on_off():
     axis = MapAxis.from_energy_bounds(0.1, 10, 1, unit="TeV")
     geom = WcsGeom.create(npix=20, binsz=0.02, axes=[axis])
     dataset = MapDatasetOnOff.create(geom)
-    dataset.mask_safe += 1
+    dataset.mask_safe += np.ones(dataset.data_shape, dtype=bool)
     dataset.counts += 2
     dataset.counts_off += 1
     dataset.acceptance += 1


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adapts the `ExcessMapEstimator` to optionally apply a mask_fit and directly return excess 2D images from a 3D dataset.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

Here, I apply the masks before doing the convolution. @luca-giunti once mentioned that this can sometimes lead to artefacts along the edge of the mask, but we have to test under which circumstances this can happen.