### PR TITLE
Lazy dataset loading prototype

### DIFF
--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -80,8 +80,8 @@ class Observation:
 
     @property
     def gti(self):
-        events = self.obs_filter.filter_gti(self._gti)
-        return events
+        gti = self.obs_filter.filter_gti(self._gti)
+        return gti
 
     @staticmethod
     def _get_obs_info(pointing, deadtime_fraction):
@@ -298,7 +298,7 @@ class Observation:
                 bkg = self.bkg
 
             bkg.plot(ax=ax_bkg)
-        except IndexError:
+        except AttributeError:
             logging.warning(f"No background model found for obs {self.obs_id}.")
 
         self.psf.plot_containment_vs_energy(ax=ax_psf)

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -181,7 +181,7 @@ class Datasets(collections.abc.MutableSequence):
         return copy.deepcopy(self)
 
     @classmethod
-    def read(cls, path, filedata="_datasets.yaml", filemodel="_models.yaml"):
+    def read(cls, path, filedata="_datasets.yaml", filemodel="_models.yaml", lazy=True, cache=True):
         """De-serialize datasets from YAML and FITS files.
 
         Parameters
@@ -192,6 +192,11 @@ class Datasets(collections.abc.MutableSequence):
             file path or name of yaml datasets file
         filemodel : str
             file path or name of yaml models file
+        lazy : bool
+            Whether to lazy load data into memory
+        cache : bool
+            Whether to cache the data after loading.
+
 
         Returns
         -------
@@ -218,7 +223,9 @@ class Datasets(collections.abc.MutableSequence):
         for data in data_list["datasets"]:
             if (path / data["filename"]).exists():
                 data["filename"] = str(make_path(path / data["filename"]))
-            dataset = DATASET_REGISTRY.get_cls(data["type"]).from_dict(data, models)
+
+            dataset_cls = DATASET_REGISTRY.get_cls(data["type"])
+            dataset = dataset_cls.from_dict(data, models, lazy=lazy, cache=cache)
             datasets.append(dataset)
         return cls(datasets)
 

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -111,7 +111,7 @@ class FluxPointsDataset(Dataset):
         table.write(filename, overwrite=overwrite, **kwargs)
 
     @classmethod
-    def from_dict(cls, data, models):
+    def from_dict(cls, data, models, **kwargs):
         """Create flux point dataset from dict.
 
         Parameters

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -156,12 +156,6 @@ class MapDataset(Dataset):
         gti=None,
         meta_table=None,
     ):
-        #if mask_fit is not None and mask_fit.data.dtype != np.dtype("bool"):
-        #    raise ValueError("mask data must have dtype bool")
-
-        #if mask_safe is not None and mask_safe.data.dtype != np.dtype("bool"):
-        #    raise ValueError("mask data must have dtype bool")
-
         self._name = make_name(name)
         self._background_model = None
         self.evaluation_mode = evaluation_mode
@@ -179,9 +173,6 @@ class MapDataset(Dataset):
         self.gti = gti
         self.use_cache = use_cache
         self.meta_table = meta_table
-
-        # check whether a reference geom is defined
-        #_ = self._geom
 
     @property
     def name(self):

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -890,30 +890,25 @@ class MapDataset(Dataset):
                 cache=cache
             )
 
-        hduloc_edisp = HDULocation(
+        kwargs["edisp"] = HDULocation(
             hdu_class="edisp_kernel_map", file_dir=path.parent, file_name=path.name, hdu_name="EDISP",
             cache=cache
         )
 
-        kwargs["edisp"] = hduloc_edisp
-
-        hduloc_psf = HDULocation(
+        kwargs["psf"] = HDULocation(
             hdu_class="psf_map", file_dir=path.parent, file_name=path.name, hdu_name="PSF",
             cache=cache
         )
-
-        kwargs["psf"] = hduloc_psf
 
         hduloc = HDULocation(
             hdu_class="map", file_dir=path.parent, file_name=path.name, hdu_name="BACKGROUND",
             cache=cache
         )
 
-        model = BackgroundModel(
+        kwargs["models"] = [BackgroundModel(
             hduloc, datasets_names=[name], name=name + "-bkg"
-        )
+        )]
 
-        kwargs["models"] = [model]
         return cls(**kwargs)
 
     @classmethod

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -141,6 +141,15 @@ class MapDataset(Dataset):
     mask_fit = LazyFitsData(cache=True)
     mask_safe = LazyFitsData(cache=True)
 
+    _lazy_data_members = [
+        "counts",
+        "exposure",
+        "edisp",
+        "psf",
+        "mask_fit",
+        "mask_safe"
+    ]
+
     def __init__(
         self,
         models=None,
@@ -1357,6 +1366,12 @@ class MapDataset(Dataset):
             kwargs["mask_fit"] = self.mask_fit.slice_by_idx(slices=slices)
 
         return self.__class__(**kwargs)
+
+    def reset_data_cache(self):
+        """Reset data cache to free memory space"""
+        for name in self._lazy_data_members:
+            if self.__dict__.pop(name, False):
+                log.info(f"Clearing {name} cache for dataset {self.name}")
 
 
 class MapDatasetOnOff(MapDataset):

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -1283,7 +1283,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         self.to_ogip_files(outdir=outdir, overwrite=overwrite)
 
     @classmethod
-    def from_dict(cls, data, models):
+    def from_dict(cls, data, models, **kwargs):
         """Create flux point dataset from dict.
 
         Parameters

--- a/gammapy/estimators/tests/test_asmooth_map.py
+++ b/gammapy/estimators/tests/test_asmooth_map.py
@@ -7,6 +7,7 @@ from gammapy.datasets import Datasets, MapDatasetOnOff
 from gammapy.estimators import ASmoothMapEstimator
 from gammapy.maps import Map, WcsNDMap
 from gammapy.utils.testing import requires_data
+from gammapy.modeling.models import BackgroundModel
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
 from gammapy.estimators.flux import FluxEstimator
-from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
+from gammapy.modeling.models import PowerLawSpectralModel, SkyModel, BackgroundModel
 from gammapy.utils.testing import requires_data, requires_dependency
 
 
@@ -45,6 +45,7 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
         norm_max=2,
         reoptimize=False,
     )
+
     result = estimator.run(fermi_datasets)
 
     assert_allclose(result["norm"], 1.010983, atol=1e-3)

--- a/gammapy/irf/__init__.py
+++ b/gammapy/irf/__init__.py
@@ -26,5 +26,7 @@ IRF_REGISTRY = Registry(
         PSFKing,
         Background3D,
         Background2D,
+        PSFMap,
+        EDispKernelMap,
     ]
 )

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -325,7 +325,7 @@ class EDispKernelMap(IRFMap):
         Associated exposure map. Needs to have a consistent map geometry.
 
     """
-
+    tag = "edisp_kernel_map"
     _hdu_name = "edisp"
 
     def __init__(self, edisp_kernel_map, exposure_map):

--- a/gammapy/irf/irf_map.py
+++ b/gammapy/irf/irf_map.py
@@ -58,7 +58,7 @@ class IRFMap:
         return cls(irf_map, exposure_map)
 
     @classmethod
-    def read(cls, filename):
+    def read(cls, filename, hdu=None):
         """Read an IRF_map from file and create corresponding object"""
         with fits.open(filename, memmap=False) as hdulist:
             return cls.from_hdulist(hdulist)

--- a/gammapy/irf/irf_map.py
+++ b/gammapy/irf/irf_map.py
@@ -61,7 +61,7 @@ class IRFMap:
     def read(cls, filename, hdu=None):
         """Read an IRF_map from file and create corresponding object"""
         with fits.open(filename, memmap=False) as hdulist:
-            return cls.from_hdulist(hdulist)
+            return cls.from_hdulist(hdulist, hdu=hdu)
 
     def to_hdulist(self):
         """Convert to `~astropy.io.fits.HDUList`.

--- a/gammapy/irf/psf_map.py
+++ b/gammapy/irf/psf_map.py
@@ -65,7 +65,7 @@ class PSFMap(IRFMap):
         # Write map to disk
         psf_map.write('psf_map.fits')
     """
-
+    tag = "psf_map"
     _hdu_name = "psf"
 
     @property
@@ -157,7 +157,11 @@ class PSFMap(IRFMap):
         kernel : `~gammapy.cube.PSFKernel`
             the resulting kernel
         """
+        if position is None:
+            position = self.psf_map.geom.center_skydir
+
         table_psf = self.get_energy_dependent_table_psf(position)
+
         if max_radius is None:
             max_radius = np.max(table_psf.rad)
             min_radius_geom = np.min(geom.width) / 2.

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -101,7 +101,12 @@ class WcsNDMap(WcsMap):
 
             map_out.set_by_idx(idx[::-1], vals)
         else:
-            map_out = cls(geom=geom, meta=meta, data=hdu.data, unit=unit)
+            if "mask" in hdu.name.lower():
+                data = hdu.data.astype(bool)
+            else:
+                data = hdu.data
+
+            map_out = cls(geom=geom, meta=meta, data=data, unit=unit)
 
         return map_out
 

--- a/gammapy/modeling/iminuit.py
+++ b/gammapy/modeling/iminuit.py
@@ -163,11 +163,10 @@ def make_minuit_par_kwargs(parameters):
         max_ = None if np.isnan(par.factor_max) else par.factor_max
         kwargs[f"limit_{name}"] = (min_, max_)
 
-        if par.error == 0:
+        if par.error == 0 or np.isnan(par.error):
             error = 1
         else:
             error = par.error / par.scale
-
         kwargs[f"error_{name}"] = error
 
     return kwargs

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -78,7 +78,8 @@ class Model:
         self._check_covariance()
         for par in self.parameters:
             pars = Parameters([par])
-            covar = Covariance(pars, data=[[par.error ** 2]])
+            error = np.nan_to_num(par.error ** 2, nan=1)
+            covar = Covariance(pars, data=[[error]])
             self._covariance.set_subcovariance(covar)
 
         return self._covariance
@@ -264,7 +265,8 @@ class Models(collections.abc.MutableSequence):
         models = []
 
         for component in data["components"]:
-            model = MODEL_REGISTRY.get_cls(component["type"]).from_dict(component)
+            model_cls = MODEL_REGISTRY.get_cls(component["type"])
+            model = model_cls.from_dict(component)
             models.append(model)
 
         models = cls(models)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -8,6 +8,7 @@ from gammapy.maps import Map, MapAxis, RegionGeom, WcsGeom
 from gammapy.modeling import Covariance, Parameter, Parameters
 from gammapy.modeling.parameter import _get_parameters_str
 from gammapy.utils.scripts import make_name, make_path
+from gammapy.utils.fits import LazyFitsData, HDULocation
 from .core import Model, Models
 from .spatial import SpatialModel
 from .spectral import SpectralModel
@@ -614,6 +615,7 @@ class BackgroundModel(Model):
     norm = Parameter("norm", 1, unit="", min=0)
     tilt = Parameter("tilt", 0, unit="", frozen=True)
     reference = Parameter("reference", "1 TeV", frozen=True)
+    map = LazyFitsData(cache=True)
 
     def __init__(
         self,
@@ -625,9 +627,10 @@ class BackgroundModel(Model):
         filename=None,
         datasets_names=None,
     ):
-        axis = map.geom.get_axis_by_name("energy")
-        if axis.node_type != "edges":
-            raise ValueError('Need an integrated map, energy axis node_type="edges"')
+        if isinstance(map, Map):
+            axis = map.geom.get_axis_by_name("energy")
+            if axis.node_type != "edges":
+                raise ValueError('Need an integrated map, energy axis node_type="edges"')
 
         self.map = map
 

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -349,18 +349,18 @@ class SkyModel(SkyModelBase):
 
         str_ += "\t{:26}: {}\n".format("Datasets names", self.datasets_names)
 
-        str_ += "\t{:26}: {}\n".format("Spectral model type", self.spectral_model.tag)
+        str_ += "\t{:26}: {}\n".format("Spectral model type", self.spectral_model.__class__.__name__)
 
         if self.spatial_model is not None:
-            spatial_type = self.spatial_model.tag
+            spatial_type = self.spatial_model.__class__.__name__
         else:
-            spatial_type = "None"
+            spatial_type = ""
         str_ += "\t{:26}: {}\n".format("Spatial  model type", spatial_type)
 
         if self.temporal_model is not None:
-            temporal_type = self.temporal_model.tag
+            temporal_type = self.temporal_model.__class__.__name__
         else:
-            temporal_type = "None"
+            temporal_type = ""
         str_ += "\t{:26}: {}\n".format("Temporal model type", temporal_type)
 
         str_ += "\tParameters:\n"
@@ -811,10 +811,13 @@ def create_fermi_isotropic_diffuse_model(filename, **kwargs):
     energy = u.Quantity(vals[:, 0], "MeV", copy=False)
     values = u.Quantity(vals[:, 1], "MeV-1 s-1 cm-2", copy=False)
 
+    kwargs.setdefault("interp_kwargs", {"fill_value": None})
+
     spatial_model = ConstantSpatialModel()
     spectral_model = TemplateSpectralModel(energy=energy, values=values, **kwargs)
     return SkyModel(
         spatial_model=spatial_model,
         spectral_model=spectral_model,
         name="fermi-diffuse-iso",
+
     )

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -247,8 +247,6 @@ def test_models_management(tmp_path):
     datasets[0].models = model1
     _ = datasets.models  # auto-update models
 
-    print(datasets[0].models["gll_iem_v06_cutout"].map)
-
     npred1 = datasets[0].npred().data.sum()
     datasets.models.remove(model1)
     npred0 = datasets[0].npred().data.sum()

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -247,6 +247,8 @@ def test_models_management(tmp_path):
     datasets[0].models = model1
     _ = datasets.models  # auto-update models
 
+    print(datasets[0].models["gll_iem_v06_cutout"].map)
+
     npred1 = datasets[0].npred().data.sum()
     datasets.models.remove(model1)
     npred0 = datasets[0].npred().data.sum()

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -105,11 +105,10 @@ class LazyFitsData(object):
             # Accessed on a class, not an instance
             return self
 
-        value = instance.__dict__.get(self.name)
-        if value is not None:
-            return value
-        else:
-            hdu_loc = instance.__dict__.get(f"_{self.name}_hdu")
+        try:
+            return instance.__dict__[self.name]
+        except KeyError:
+            hdu_loc = instance.__dict__[f"_{self.name}_hdu"]
             value = hdu_loc.load()
             if self.cache:
                 instance.__dict__[self.name] = value

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -118,7 +118,7 @@ class LazyFitsData(object):
             except KeyError:
                 value = None
                 log.warning(f"HDU '{hdu_loc.hdu_name}' not found")
-            if self.cache or hdu_loc.cache:
+            if self.cache and hdu_loc.cache:
                 instance.__dict__[self.name] = value
             return value
 

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -117,7 +117,7 @@ class LazyFitsData(object):
                 value = hdu_loc.load()
             except KeyError:
                 value = None
-                log.warning(f"HDU {hdu_loc.hdu_name} not found")
+                log.warning(f"HDU '{hdu_loc.hdu_name}' not found")
             if self.cache or hdu_loc.cache:
                 instance.__dict__[self.name] = value
             return value

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -78,7 +78,6 @@ class HDULocation:
             return GTI.read(filename, hdu=hdu)
         elif hdu_class == "map":
             from gammapy.maps import Map
-
             return Map.read(filename, hdu=hdu)
         else:
             cls = IRF_REGISTRY.get_cls(hdu_class)
@@ -110,7 +109,7 @@ class LazyFitsData(object):
         if value is not None:
             return value
         else:
-            hdu_loc = instance.__dict__.get(self.name + "_hdu")
+            hdu_loc = instance.__dict__.get(f"_{self.name}_hdu")
             value = hdu_loc.load()
             if self.cache:
                 instance.__dict__[self.name] = value
@@ -118,7 +117,7 @@ class LazyFitsData(object):
 
     def __set__(self, instance, value):
         if isinstance(value, HDULocation):
-            instance.__dict__[self.name + "_hdu"] = value
+            instance.__dict__[f"_{self.name}_hdu"] = value
         else:
             instance.__dict__[self.name] = value
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a near production ready proof of concept to extend the lazy loading we have for `Observation` objects to `MapDataset`. The use-case is clearly to be able to load a large number of observations O(1e3) in to the Python session without loading the actual data. I think we should offer two options:

- Cache the data in memory, which is needed for fitting
- Don't cache the data, which is needed for stacking
- Possibly a combination e.g. for the estimation of light curves , where the data needs to be cached for the fit, but once the fit is done the data could go out of memory. So we possibly need an explicit `dataset.clear_data()` or similar.

The question is what other options do we offer? Is lazy loading always enabled? Any other potential issue you see?

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
