### PR TITLE
Add possiblity to plot Map with non-spatial axes of size 1

### DIFF
--- a/docs/tutorials/cta_data_analysis.ipynb
+++ b/docs/tutorials/cta_data_analysis.ipynb
@@ -235,9 +235,9 @@
     "dataset_image = stacked.to_image()\n",
     "\n",
     "images = {\n",
-    "    \"counts\": dataset_image.counts.get_image_by_idx((0,)),\n",
-    "    \"exposure\": dataset_image.exposure.get_image_by_idx((0,)),\n",
-    "    \"background\": dataset_image.background_model.map.get_image_by_idx((0,)),\n",
+    "    \"counts\": dataset_image.counts,\n",
+    "    \"exposure\": dataset_image.exposure,\n",
+    "    \"background\": dataset_image.background_model.map,\n",
     "}\n",
     "\n",
     "images[\"excess\"] = images[\"counts\"] - images[\"background\"]"

--- a/docs/tutorials/ring_background.ipynb
+++ b/docs/tutorials/ring_background.ipynb
@@ -323,10 +323,10 @@
     "ax2 = plt.subplot(222, projection=excess_map.geom.wcs)\n",
     "\n",
     "ax1.set_title(\"Significance map\")\n",
-    "significance_map.get_image_by_idx((0,)).plot(ax=ax1, add_cbar=True)\n",
+    "significance_map.plot(ax=ax1, add_cbar=True)\n",
     "\n",
     "ax2.set_title(\"Excess map\")\n",
-    "excess_map.get_image_by_idx((0,)).plot(ax=ax2, add_cbar=True)"
+    "excess_map.plot(ax=ax2, add_cbar=True)"
    ]
   },
   {

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1590,10 +1590,21 @@ class Geom(abc.ABC):
 
     @property
     def is_image(self):
-        """Whether the geom is equivalent to an image without extra dimensions."""
+        """Whether the geom is an image without extra dimensions."""
         if self.axes is None:
             return True
         return len(self.axes) == 0
+
+    @property
+    def is_flat(self):
+        """Whether the geom non spatial axes have length 1, i.e. if the geom is equivalent to an image."""
+        if self.is_image:
+            return True
+        else:
+            valid = True
+            for axis in self.axes:
+                valid = valid and (axis.nbin == 1)
+            return valid
 
     def get_axis_by_name(self, name):
         """Get an axis by name (case in-sensitive).

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -528,7 +528,8 @@ def test_convolve_pixel_scale_error():
 
 @requires_dependency("matplotlib")
 def test_plot():
-    m = WcsNDMap.create(binsz=0.1 * u.deg, width=1 * u.deg)
+    axis = MapAxis([0,1], node_type='edges')
+    m = WcsNDMap.create(binsz=0.1 * u.deg, width=1 * u.deg, axes=[axis])
     with mpl_plot_check():
         m.plot(add_cbar=True)
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -375,7 +375,7 @@ class WcsNDMap(WcsMap):
         from astropy.visualization import simple_norm
         from astropy.visualization.wcsaxes.frame import EllipticalFrame
 
-        if not self.geom.is_image:
+        if not self.geom.is_flat:
             raise TypeError("Use .plot_interactive() for Map dimension > 2")
 
         if fig is None:
@@ -389,7 +389,7 @@ class WcsNDMap(WcsMap):
             else:
                 ax = fig.add_subplot(1, 1, 1, projection=self.geom.wcs)
 
-        data = self.data.astype(float)
+        data = np.squeeze(self.data.astype(float))
 
         kwargs.setdefault("interpolation", "nearest")
         kwargs.setdefault("origin", "lower")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the behavior of `WcsNDMap.plot()` to allow for plotting of maps with 1 energy axis and only one bin. Since this is the default format we impose on datasets, we shouldn't force the user to do `datasets.counts.sum_over_axis().plot()` for datasets with only one energy bin.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
