### PR TITLE
Clean up estimators

### DIFF
--- a/docs/tutorials/detect.ipynb
+++ b/docs/tutorials/detect.ipynb
@@ -172,7 +172,7 @@
    "source": [
     "%%time\n",
     "estimator = TSMapEstimator(model, kernel_width=\"0.4 deg\")\n",
-    "images = estimator.run(dataset)"
+    "images = estimator.run(dataset, steps=[\"ts\"])"
    ]
   },
   {

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -131,7 +131,7 @@ class ExcessMapEstimator(Estimator):
             result.update({"ts": tsmap, "significance": significance})
 
         if "err" in steps:
-            err = Map.from_geom(geom, data=counts_stat.error)
+            err = Map.from_geom(geom, data=counts_stat.error*self.n_sigma)
             result.update({"err": err})
 
         if "errn-errp" in steps:

--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -178,7 +178,7 @@ class ExcessProfileEstimator(Estimator):
                 result["sqrt_ts"] = stats.significance
 
             if "err" in steps:
-                result["err"] = stats.error
+                result["err"] = stats.error * self.n_sigma
 
             if "errn-errp" in steps:
                 result["errn"] = stats.compute_errn(self.n_sigma)

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -120,7 +120,7 @@ class FluxEstimator(ParameterEstimator):
             steps.remove("norm-err")
             steps.append("err")
         if steps == "all":
-            steps = ["err", "ts", "errp-errn", "ul", "scan"]
+            steps = ["err", "ts", "errn-errp", "ul", "scan"]
         return steps
 
     def run(self, datasets, steps="all"):
@@ -192,7 +192,7 @@ class FluxEstimator(ParameterEstimator):
             result.update({"norm_err": np.nan})
         if "ts" in steps:
             result.update({"sqrt_ts": np.nan, "ts": np.nan, "null_value": np.nan})
-        if "errp-errn" in steps:
+        if "errn-errp" in steps:
             result.update({"norm_errp": np.nan, "norm_errn": np.nan})
         if "ul" in steps:
             result.update({"norm_ul": np.nan})

--- a/gammapy/estimators/parameter_estimator.py
+++ b/gammapy/estimators/parameter_estimator.py
@@ -142,7 +142,7 @@ class ParameterEstimator(Estimator):
                 self._freeze_parameters(parameter)
 
             if steps == "all":
-                steps = ["err", "ts", "errp-errn", "ul", "scan"]
+                steps = ["err", "ts", "errn-errp", "ul", "scan"]
 
             result = self._find_best_fit(parameter)
             TS1 = result["stat"]
@@ -154,7 +154,7 @@ class ParameterEstimator(Estimator):
                 value_err = res.parameters[parameter].error*self.n_sigma
                 result.update({f"{parameter.name}_err": value_err})
 
-            if "errp-errn" in steps:
+            if "errn-errp" in steps:
                 res = self.fit.confidence(parameter=parameter, sigma=self.n_sigma)
                 result.update(
                     {

--- a/gammapy/estimators/parameter_estimator.py
+++ b/gammapy/estimators/parameter_estimator.py
@@ -151,7 +151,7 @@ class ParameterEstimator(Estimator):
 
             if "err" in steps:
                 res = self.fit.covariance()
-                value_err = res.parameters[parameter].error
+                value_err = res.parameters[parameter].error*self.n_sigma
                 result.update({f"{parameter.name}_err": value_err})
 
             if "errp-errn" in steps:

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -73,7 +73,7 @@ def test_flux_estimator_fermi_with_reoptimization(fermi_datasets):
 @requires_dependency("iminuit")
 def test_flux_estimator_1d(hess_datasets):
     estimator = FluxEstimator(source="Crab", energy_range=[1, 10] * u.TeV)
-    result = estimator.run(hess_datasets, steps=["err", "ts", "errp-errn", "ul"])
+    result = estimator.run(hess_datasets, steps=["err", "ts", "errn-errp", "ul"])
 
     assert_allclose(result["norm"], 1.176789, atol=1e-3)
     assert_allclose(result["ts"], 693.111777, atol=1e-3)

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -165,8 +165,6 @@ def test_compute_ts_map_downsampled(input_dataset):
         model=model,
         downsampling_factor=2,
         method="root brentq",
-        error_method="conf",
-        ul_method="conf",
         kernel_width="1 deg",
     )
     result = ts_estimator.run(input_dataset)
@@ -201,5 +199,3 @@ def test_incorrect_method():
     model = GaussianSpatialModel(sigma="0.2 deg")
     with pytest.raises(ValueError):
         TSMapEstimator(model, method="bad")
-    with pytest.raises(ValueError):
-        TSMapEstimator(model, error_method="bad")

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -91,7 +91,7 @@ def test_compute_ts_map(input_dataset):
     spatial_model = GaussianSpatialModel(sigma="0.1 deg")
     spectral_model = PowerLawSpectralModel(index=2)
     model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
-    ts_estimator = TSMapEstimator(model=model, threshold=None, kernel_width="1 deg")
+    ts_estimator = TSMapEstimator(model=model, threshold=1, kernel_width="1 deg")
     result = ts_estimator.run(input_dataset, steps=["ts", "err"])
 
     assert_allclose(result["ts"].data[99, 99], 1704.23, rtol=1e-2)

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -91,19 +91,16 @@ def test_compute_ts_map(input_dataset):
     spatial_model = GaussianSpatialModel(sigma="0.1 deg")
     spectral_model = PowerLawSpectralModel(index=2)
     model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
-    ts_estimator = TSMapEstimator(model=model, threshold=1, kernel_width="1 deg")
-    result = ts_estimator.run(input_dataset)
+    ts_estimator = TSMapEstimator(model=model, threshold=None, kernel_width="1 deg")
+    result = ts_estimator.run(input_dataset, steps=["ts", "err"])
 
     assert_allclose(result["ts"].data[99, 99], 1704.23, rtol=1e-2)
     assert_allclose(result["niter"].data[99, 99], 9)
     assert_allclose(result["flux"].data[99, 99], 1.02e-09, rtol=1e-2)
-    print(np.where(~np.isnan(result["flux_err"].data)))
     assert_allclose(result["flux_err"].data[99, 99], 3.84e-11, rtol=1e-2)
-    assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
 
     assert result["flux"].unit == u.Unit("cm-2s-1")
     assert result["flux_err"].unit == u.Unit("cm-2s-1")
-    assert result["flux_ul"].unit == u.Unit("cm-2s-1")
 
     # Check mask is correctly taken into account
     assert np.isnan(result["ts"].data[30, 40])
@@ -118,6 +115,8 @@ def test_compute_ts_map_psf(fermi_dataset):
     assert_allclose(result["niter"].data[29, 29], 7)
     assert_allclose(result["flux"].data[29, 29], 1.419909e-09, rtol=1e-2)
     assert_allclose(result["flux_err"].data[29, 29], 8.245766e-11, rtol=1e-2)
+    assert_allclose(result["flux_errp"].data[29, 29], 8.358404e-11, rtol=1e-2)
+    assert_allclose(result["flux_errn"].data[29, 29], 8.129863e-11, rtol=1e-2)
     assert_allclose(result["flux_ul"].data[29, 29], 1.584825e-09, rtol=1e-2)
     assert result["flux"].unit == u.Unit("cm-2s-1")
     assert result["flux_err"].unit == u.Unit("cm-2s-1")

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -92,8 +92,6 @@ class TSMapEstimator(Estimator):
         Width of the kernel to use: the kernel will be truncated at this size
     n_sigma : int
         Number of sigma for flux error. Default is 1.
-    ul_method : ['covar', 'conf']
-        Upper limit estimation method.
     n_sigma_ul : int
         Number of sigma for flux upper limits. Default is 2.
     downsampling_factor : int
@@ -133,7 +131,6 @@ class TSMapEstimator(Estimator):
         kernel_width="0.2 deg",
         downsampling_factor=None,
         n_sigma=1,
-        ul_method="covar",
         n_sigma_ul=2,
         threshold=None,
         rtol=0.001,
@@ -151,7 +148,6 @@ class TSMapEstimator(Estimator):
 
         self.parameters = {
             "n_sigma": n_sigma,
-            "ul_method": ul_method,
             "n_sigma_ul": n_sigma_ul,
             "threshold": threshold,
             "rtol": rtol,


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a further clean up of estimators.

`steps` names are unified between the various estimators ('ts', 'err', 'earn-errp','ul'). 
The TS map estimator is simplified (removed newton and least square methods) and unified (added asymmetric errors). 
Also the `n_sigma` factor is applied also to covariance error estimates to make sure asymmetric and symmetric errors are consistent.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
