### PR TITLE
Modified required columns for likelihood SED type

### DIFF
--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -870,12 +870,9 @@ class FluxPointsEstimator(FluxEstimator):
 
         table = table_from_row_data(rows=rows, meta={"SED_TYPE": "likelihood"})
 
-        flux_points = FluxPoints(table)
-        if "norm-scan" not in self.selection:
-            return flux_points.to_sed_type("dnde")
-        else:
-            return flux_points
-        
+        #TODO: this should be changed once likelihood is fully supported
+        return FluxPoints(table).to_sed_type("dnde")
+
     @staticmethod
     def _get_energy_range(dataset, e_min, e_max):
         """Round e_min and e_max to grid"""

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -28,8 +28,6 @@ REQUIRED_COLUMNS = {
         "e_ref",
         "ref_dnde",
         "norm",
-        "norm_scan",
-        "stat_scan",
     ],
 }
 
@@ -38,6 +36,7 @@ OPTIONAL_COLUMNS = {
     "e2dnde": ["e2dnde_err", "e2dnde_errp", "e2dnde_errn", "e2dnde_ul", "is_ul"],
     "flux": ["flux_err", "flux_errp", "flux_errn", "flux_ul", "is_ul"],
     "eflux": ["eflux_err", "eflux_errp", "eflux_errn", "eflux_ul", "is_ul"],
+    "likelihood": ["norm_scan", "stat_scan"],
 }
 
 DEFAULT_UNIT = {
@@ -870,8 +869,13 @@ class FluxPointsEstimator(FluxEstimator):
             rows.append(row)
 
         table = table_from_row_data(rows=rows, meta={"SED_TYPE": "likelihood"})
-        return FluxPoints(table).to_sed_type("dnde")
 
+        flux_points = FluxPoints(table)
+        if "norm-scan" not in self.selection:
+            return flux_points.to_sed_type("dnde")
+        else:
+            return flux_points
+        
     @staticmethod
     def _get_energy_range(dataset, e_min, e_max):
         """Round e_min and e_max to grid"""

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -234,6 +234,17 @@ class TestFluxPointsEstimator:
         actual = fp.table["stat_scan"][0] - fp.table["stat"][0]
         assert_allclose(actual, 0.480491, rtol=1e-2)
 
+    @staticmethod
+    @requires_dependency("iminuit")
+    @requires_data()
+    def test_flux_points_estimator_no_norm_scan(fpe_pwl):
+        datasets, fpe = fpe_pwl
+        fpe.selection = None
+
+        fp = fpe.run(datasets)
+
+        assert fp.sed_type == "dnde"
+        assert "norm_scan" not in fp.table.colnames
 
 def test_no_likelihood_contribution():
     dataset = simulate_spectrum_dataset(
@@ -277,3 +288,4 @@ def test_mask_shape():
     fp = fpe.run([dataset_2, dataset_1])
 
     assert_allclose(fp.table["counts"], 0)
+


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies the required columns on the `Likelihood` SED type. The `norm-scan` and `stat-scan` columns are now optional. This allows the estimator to run even without asking for the likelihood scan. In this case the SED type return is `dnde`. The code has been modified to return a `likelihood` type in the general case.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
