### PR TITLE
Fix filename handling in read/write methods

### DIFF
--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -108,7 +108,7 @@ class FluxPointsDataset(Dataset):
 
         table["mask_fit"] = mask_fit
         table["mask_safe"] = self.mask_safe
-        table.write(filename, overwrite=overwrite, **kwargs)
+        table.write(make_path(filename), overwrite=overwrite, **kwargs)
 
     @classmethod
     def from_dict(cls, data, models, **kwargs):

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -863,7 +863,7 @@ class MapDataset(Dataset):
         overwrite : bool
             Overwrite file if it exists.
         """
-        self.to_hdulist().writeto(make_path(filename), overwrite=overwrite)
+        self.to_hdulist().writeto(str(make_path(filename)), overwrite=overwrite)
 
     @classmethod
     def _read_lazy(cls, name, filename, cache):
@@ -921,12 +921,13 @@ class MapDataset(Dataset):
         dataset : `MapDataset`
             Map dataset.
         """
+        filename = str(make_path(filename))
         name = make_name(name)
 
         if lazy:
             return cls._read_lazy(name=name, filename=filename, cache=cache)
         else:
-            with fits.open(make_path(filename), memmap=False) as hdulist:
+            with fits.open(filename, memmap=False) as hdulist:
                 return cls.from_hdulist(hdulist, name=name)
 
     @classmethod

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -869,7 +869,7 @@ class MapDataset(Dataset):
     def _read_lazy(cls, name, filename, cache):
         kwargs = {"name": name}
         try:
-            kwargs["gti"] = GTI(Table.read(filename, hdu="GTI"))
+            kwargs["gti"] = GTI.read(filename)
         except KeyError:
             pass
 
@@ -921,13 +921,12 @@ class MapDataset(Dataset):
         dataset : `MapDataset`
             Map dataset.
         """
-        filename = str(make_path(filename))
         name = make_name(name)
 
         if lazy:
             return cls._read_lazy(name=name, filename=filename, cache=cache)
         else:
-            with fits.open(filename, memmap=False) as hdulist:
+            with fits.open(str(make_path(filename)), memmap=False) as hdulist:
                 return cls.from_hdulist(hdulist, name=name)
 
     @classmethod

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -1102,7 +1102,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
             region_hdu = fits.BinTableHDU(region_table, name="REGION")
             hdulist.append(region_hdu)
 
-        hdulist.writeto(outdir / phafile, overwrite=overwrite)
+        hdulist.writeto(str(outdir / phafile), overwrite=overwrite)
 
         self.aeff.write(outdir / arffile, overwrite=overwrite, use_sherpa=use_sherpa)
 
@@ -1128,7 +1128,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
                 region_hdu = fits.BinTableHDU(region_table, name="REGION")
                 hdulist.append(region_hdu)
 
-            hdulist.writeto(outdir / bkgfile, overwrite=overwrite)
+            hdulist.writeto(str(outdir / bkgfile), overwrite=overwrite)
 
         if self.edisp is not None:
             self._edisp_kernel.write(
@@ -1178,7 +1178,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         filename = make_path(filename)
         dirname = filename.parent
 
-        with fits.open(filename, memmap=False) as hdulist:
+        with fits.open(str(filename), memmap=False) as hdulist:
             counts = RegionNDMap.from_hdulist(hdulist, format="ogip")
             acceptance = RegionNDMap.from_hdulist(
                 hdulist, format="ogip", ogip_column="BACKSCAL"
@@ -1206,7 +1206,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
         try:
             bkgfile = phafile.replace("pha", "bkg")
-            with fits.open(dirname / bkgfile, memmap=False) as hdulist:
+            with fits.open(str(dirname / bkgfile), memmap=False) as hdulist:
                 counts_off = RegionNDMap.from_hdulist(hdulist, format="ogip")
                 acceptance_off = RegionNDMap.from_hdulist(
                     hdulist, ogip_column="BACKSCAL"

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -126,7 +126,7 @@ class Background3D:
     @classmethod
     def read(cls, filename, hdu="BACKGROUND"):
         """Read from file."""
-        with fits.open(make_path(filename), memmap=False) as hdulist:
+        with fits.open(str(make_path(filename)), memmap=False) as hdulist:
             return cls.from_hdulist(hdulist, hdu=hdu)
 
     def to_table(self):
@@ -307,7 +307,7 @@ class Background2D:
     @classmethod
     def read(cls, filename, hdu="BACKGROUND"):
         """Read from file."""
-        with fits.open(make_path(filename), memmap=False) as hdulist:
+        with fits.open(str(make_path(filename)), memmap=False) as hdulist:
             return cls.from_hdulist(hdulist, hdu=hdu)
 
     def to_table(self):

--- a/gammapy/irf/edisp_kernel.py
+++ b/gammapy/irf/edisp_kernel.py
@@ -281,7 +281,7 @@ class EDispKernel:
         hdu2 : str, optional
             HDU containing the energy axis information, default, EBOUNDS
         """
-        with fits.open(make_path(filename), memmap=False) as hdulist:
+        with fits.open(str(make_path(filename)), memmap=False) as hdulist:
             return cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
 
     def to_hdulist(self, use_sherpa=False, **kwargs):
@@ -404,7 +404,7 @@ class EDispKernel:
 
     def write(self, filename, use_sherpa=False, **kwargs):
         """Write to file."""
-        filename = make_path(filename)
+        filename = str(make_path(filename))
         self.to_hdulist(use_sherpa=use_sherpa).writeto(filename, **kwargs)
 
     def get_resolution(self, e_true):

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -197,7 +197,7 @@ class EffectiveAreaTable:
     @classmethod
     def read(cls, filename, hdu="SPECRESP"):
         """Read from file."""
-        filename = make_path(filename)
+        filename = str(make_path(filename))
         with fits.open(filename, memmap=False) as hdulist:
             try:
                 return cls.from_hdulist(hdulist, hdu=hdu)
@@ -239,7 +239,7 @@ class EffectiveAreaTable:
 
     def write(self, filename, use_sherpa=False, **kwargs):
         """Write to file."""
-        filename = make_path(filename)
+        filename = str(make_path(filename))
         self.to_hdulist(use_sherpa=use_sherpa).writeto(filename, **kwargs)
 
     def evaluate_fill_nan(self, **kwargs):
@@ -411,7 +411,7 @@ class EffectiveAreaTable2D:
     @classmethod
     def read(cls, filename, hdu="EFFECTIVE AREA"):
         """Read from file."""
-        with fits.open(make_path(filename), memmap=False) as hdulist:
+        with fits.open(str(make_path(filename)), memmap=False) as hdulist:
             return cls.from_hdulist(hdulist, hdu=hdu)
 
     def to_effective_area_table(self, offset, energy=None):

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -195,7 +195,7 @@ class EnergyDispersion2D:
         filename : str
             File name
         """
-        with fits.open(make_path(filename), memmap=False) as hdulist:
+        with fits.open(str(make_path(filename)), memmap=False) as hdulist:
             return cls.from_hdulist(hdulist, hdu)
 
     def to_energy_dispersion(self, offset, e_true=None, e_reco=None):

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -206,7 +206,7 @@ class PSF3D:
 
         Calls `~astropy.io.fits.HDUList.writeto`, forwarding all arguments.
         """
-        self.to_fits().writeto(filename, *args, **kwargs)
+        self.to_fits().writeto(str(make_path(filename)), *args, **kwargs)
 
     def evaluate(self, energy=None, offset=None, rad=None):
         """Interpolate PSF value at a given offset and energy.

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -107,7 +107,7 @@ class EnergyDependentMultiGaussPSF:
         filename : str
             File name
         """
-        with fits.open(make_path(filename), memmap=False) as hdulist:
+        with fits.open(str(make_path(filename)), memmap=False) as hdulist:
             return cls.from_fits(hdulist[hdu])
 
     @classmethod
@@ -199,7 +199,7 @@ class EnergyDependentMultiGaussPSF:
 
         Calls `~astropy.io.fits.HDUList.writeto`, forwarding all arguments.
         """
-        self.to_fits().writeto(filename, *args, **kwargs)
+        self.to_fits().writeto(str(make_path(filename)), *args, **kwargs)
 
     def psf_at_energy_and_theta(self, energy, theta):
         """

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -149,7 +149,7 @@ class PSFKing:
 
         Calls `~astropy.io.fits.HDUList.writeto`, forwarding all arguments.
         """
-        self.to_fits().writeto(filename, *args, **kwargs)
+        self.to_fits().writeto(str(make_path(filename)), *args, **kwargs)
 
     @staticmethod
     def evaluate_direct(r, gamma, sigma):

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -348,15 +348,15 @@ class EnergyDependentTablePSF:
         filename : str
             File name
         """
-        with fits.open(make_path(filename), memmap=False) as hdulist:
+        with fits.open(str(make_path(filename)), memmap=False) as hdulist:
             return cls.from_fits(hdulist)
 
-    def write(self, *args, **kwargs):
+    def write(self, filename, *args, **kwargs):
         """Write to FITS file.
 
         Calls `~astropy.io.fits.HDUList.writeto`, forwarding all arguments.
         """
-        self.to_fits().writeto(*args, **kwargs)
+        self.to_fits().writeto(str(make_path(filename)), *args, **kwargs)
 
     def evaluate(self, energy=None, rad=None, method="linear"):
         """Evaluate the PSF at a given energy and offset

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -327,7 +327,7 @@ class Map(abc.ABC):
             This option is only compatible with the 'gadf' format.
         """
         hdulist = self.to_hdulist(**kwargs)
-        hdulist.writeto(filename, overwrite=overwrite)
+        hdulist.writeto(make_path(filename), overwrite=overwrite)
 
     def iter_by_image(self):
         """Iterate over image planes of the map.

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -185,7 +185,7 @@ class Map(abc.ABC):
         map_out : `Map`
             Map object
         """
-        with fits.open(make_path(filename), memmap=False) as hdulist:
+        with fits.open(str(make_path(filename)), memmap=False) as hdulist:
             return Map.from_hdulist(hdulist, hdu, hdu_bands, map_type)
 
     @staticmethod
@@ -327,7 +327,7 @@ class Map(abc.ABC):
             This option is only compatible with the 'gadf' format.
         """
         hdulist = self.to_hdulist(**kwargs)
-        hdulist.writeto(make_path(filename), overwrite=overwrite)
+        hdulist.writeto(str(make_path(filename)), overwrite=overwrite)
 
     def iter_by_image(self):
         """Iterate over image planes of the map.

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -59,7 +59,7 @@ class HDULocation:
         filename = self.path(abs_path=True)
         # Here we're intentionally not calling `with fits.open`
         # because we don't want the file to remain open.
-        hdu_list = fits.open(filename, memmap=False)
+        hdu_list = fits.open(str(filename), memmap=False)
         return hdu_list[self.hdu_name]
 
     def load(self):


### PR DESCRIPTION
Wrapped `filename` in `make_path()`, as in `Map.read`, to allow for environment variables.