### PR TITLE
Add basic NormSpectralModels

### DIFF
--- a/gammapy/modeling/models/__init__.py
+++ b/gammapy/modeling/models/__init__.py
@@ -39,9 +39,9 @@ SPECTRAL_MODEL_REGISTRY = Registry(
         AbsorbedSpectralModel,
         NaimaSpectralModel,
         ScaleSpectralModel,
-        NormPowerLawSpectralModel,
-        NormLogParabolaSpectralModel,
-        NormExpCutoffPowerLawSpectralModel,
+        PowerLawNormSpectralModel,
+        LogParabolaNormSpectralModel,
+        ExpCutoffPowerLawNormSpectralModel,
     ]
 )
 """Registry of spectral model classes."""

--- a/gammapy/modeling/models/__init__.py
+++ b/gammapy/modeling/models/__init__.py
@@ -39,6 +39,9 @@ SPECTRAL_MODEL_REGISTRY = Registry(
         AbsorbedSpectralModel,
         NaimaSpectralModel,
         ScaleSpectralModel,
+        NormPowerLawSpectralModel,
+        NormLogParabolaSpectralModel,
+        NormExpCutoffPowerLawSpectralModel,
     ]
 )
 """Registry of spectral model classes."""

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -578,7 +578,7 @@ class PowerLawSpectralModel(SpectralModel):
         return reference * np.exp(cov_index_ampl / (amplitude * index_err ** 2))
 
 
-class NormPowerLawSpectralModel(SpectralModel):
+class PowerLawNormSpectralModel(SpectralModel):
     r"""Spectral power-law model with normalized amplitude parameter.
 
     Parameters
@@ -599,7 +599,7 @@ class NormPowerLawSpectralModel(SpectralModel):
 
     """
 
-    tag = ["NormPowerLawSpectralModel", "norm-pl"]
+    tag = ["PowerLawNormSpectralModel", "pl-norm"]
     tilt = Parameter("tilt", 2.0)
     norm = Parameter("norm", 1, unit="")
     reference = Parameter("reference", "1 TeV", frozen=True)
@@ -897,7 +897,7 @@ class ExpCutoffPowerLawSpectralModel(SpectralModel):
             return np.power((2 - index) / alpha, 1 / alpha) / lambda_
 
 
-class NormExpCutoffPowerLawSpectralModel(SpectralModel):
+class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
     r"""Norm spectral exponential cutoff power-law model.
 
     Parameters
@@ -917,7 +917,7 @@ class NormExpCutoffPowerLawSpectralModel(SpectralModel):
     ExpCutoffPowerLawSpectralModel:
         Spectral exponential cutoff power-law model
     """
-    tag = ["NormExpCutoffPowerLawSpectralModel", "norm-ecpl"]
+    tag = ["ExpCutoffPowerLawNormSpectralModel", "ecpl-norm"]
 
     index = Parameter("index", 1.5)
     norm = Parameter("norm", 1, unit="")
@@ -1098,7 +1098,7 @@ class LogParabolaSpectralModel(SpectralModel):
         return reference * np.exp((2 - alpha) / (2 * beta))
 
 
-class NormLogParabolaSpectralModel(SpectralModel):
+class LogParabolaNormSpectralModel(SpectralModel):
     r"""Norm spectral log parabola model.
 
     Parameters
@@ -1116,7 +1116,7 @@ class NormLogParabolaSpectralModel(SpectralModel):
     LogParabolaSpectralModel:
         Spectral log parabola model
     """
-    tag = ["NormLogParabolaSpectralModel", "norm-lp"]
+    tag = ["LogParabolaNormSpectralModel", "lp-norm"]
     norm = Parameter("norm", 1, unit="")
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 2)

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -182,12 +182,15 @@ def make_all_models():
         operator=np.add,
     )
     yield Model.create("PowerLawSpectralModel", "spectral")
+    yield Model.create("NormPowerLawSpectralModel", "spectral")
     yield Model.create("PowerLaw2SpectralModel", "spectral")
     yield Model.create("ExpCutoffPowerLawSpectralModel", "spectral")
+    yield Model.create("NormExpCutoffPowerLawSpectralModel", "spectral")
     yield Model.create("ExpCutoffPowerLaw3FGLSpectralModel", "spectral")
     yield Model.create("SuperExpCutoffPowerLaw3FGLSpectralModel", "spectral")
     yield Model.create("SuperExpCutoffPowerLaw4FGLSpectralModel", "spectral")
     yield Model.create("LogParabolaSpectralModel", "spectral")
+    yield Model.create("NormLogParabolaSpectralModel", "spectral")
     yield Model.create(
         "TemplateSpectralModel", "spectral", energy=[1, 2] * u.cm, values=[3, 4] * u.cm
     )  # TODO: add unit validation?

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -182,15 +182,15 @@ def make_all_models():
         operator=np.add,
     )
     yield Model.create("PowerLawSpectralModel", "spectral")
-    yield Model.create("NormPowerLawSpectralModel", "spectral")
+    yield Model.create("PowerLawNormSpectralModel", "spectral")
     yield Model.create("PowerLaw2SpectralModel", "spectral")
     yield Model.create("ExpCutoffPowerLawSpectralModel", "spectral")
-    yield Model.create("NormExpCutoffPowerLawSpectralModel", "spectral")
+    yield Model.create("ExpCutoffPowerLawNormSpectralModel", "spectral")
     yield Model.create("ExpCutoffPowerLaw3FGLSpectralModel", "spectral")
     yield Model.create("SuperExpCutoffPowerLaw3FGLSpectralModel", "spectral")
     yield Model.create("SuperExpCutoffPowerLaw4FGLSpectralModel", "spectral")
     yield Model.create("LogParabolaSpectralModel", "spectral")
-    yield Model.create("NormLogParabolaSpectralModel", "spectral")
+    yield Model.create("LogParabolaNormSpectralModel", "spectral")
     yield Model.create(
         "TemplateSpectralModel", "spectral", energy=[1, 2] * u.cm, values=[3, 4] * u.cm
     )  # TODO: add unit validation?

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -12,14 +12,14 @@ from gammapy.modeling.models import (
     CompoundSpectralModel,
     ExpCutoffPowerLaw3FGLSpectralModel,
     ExpCutoffPowerLawSpectralModel,
-    NormExpCutoffPowerLawSpectralModel,
+    ExpCutoffPowerLawNormSpectralModel,
     GaussianSpectralModel,
     LogParabolaSpectralModel,
-    NormLogParabolaSpectralModel,
+    LogParabolaNormSpectralModel,
     NaimaSpectralModel,
     PowerLaw2SpectralModel,
     PowerLawSpectralModel,
-    NormPowerLawSpectralModel,
+    PowerLawNormSpectralModel,
     BrokenPowerLawSpectralModel,
     SmoothBrokenPowerLawSpectralModel,
     SuperExpCutoffPowerLaw4FGLSpectralModel,
@@ -69,7 +69,7 @@ TEST_MODELS = [
     ),
     dict(
         name="norm-powerlaw",
-        model=NormPowerLawSpectralModel(
+        model=PowerLawNormSpectralModel(
             index=2 * u.Unit(""), norm=4.0 * u.Unit(""), reference=1 * u.TeV,
         ),
         val_at_2TeV=u.Quantity(1.0, ""),
@@ -103,7 +103,7 @@ TEST_MODELS = [
     ),
     dict(
         name="norm-ecpl",
-        model=NormExpCutoffPowerLawSpectralModel(
+        model=ExpCutoffPowerLawNormSpectralModel(
             index=1.6 * u.Unit(""),
             norm=4 * u.Unit(""),
             reference=1 * u.TeV,
@@ -153,7 +153,7 @@ TEST_MODELS = [
     ),
     dict(
         name="norm-logpar",
-        model=NormLogParabolaSpectralModel(
+        model=LogParabolaNormSpectralModel(
             alpha=2.3 * u.Unit(""),
             norm=4 * u.Unit(""),
             reference=1 * u.TeV,

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -112,7 +112,6 @@ TEST_MODELS = [
         val_at_2TeV=u.Quantity(1.080321705479446, ""),
         integral_1_10TeV=u.Quantity(3.765838739678921, "TeV"),
         eflux_1_10TeV=u.Quantity(9.901735870666526, "TeV2"),
-        e_peak=4 * u.TeV,
     ),
     dict(
         name="ecpl_3fgl",
@@ -163,7 +162,6 @@ TEST_MODELS = [
         val_at_2TeV=u.Quantity(0.6387956571420305, ""),
         integral_1_10TeV=u.Quantity(2.255689748270628, "TeV"),
         eflux_1_10TeV=u.Quantity(3.9586515834989267, "TeV2"),
-        e_peak=0.74082 * u.TeV,
     ),
     dict(
         name="logpar10",

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -12,11 +12,14 @@ from gammapy.modeling.models import (
     CompoundSpectralModel,
     ExpCutoffPowerLaw3FGLSpectralModel,
     ExpCutoffPowerLawSpectralModel,
+    NormExpCutoffPowerLawSpectralModel,
     GaussianSpectralModel,
     LogParabolaSpectralModel,
+    NormLogParabolaSpectralModel,
     NaimaSpectralModel,
     PowerLaw2SpectralModel,
     PowerLawSpectralModel,
+    NormPowerLawSpectralModel,
     BrokenPowerLawSpectralModel,
     SmoothBrokenPowerLawSpectralModel,
     SuperExpCutoffPowerLaw4FGLSpectralModel,
@@ -65,6 +68,15 @@ TEST_MODELS = [
         eflux_1_10TeV=u.Quantity(9.210340371976184, "TeV cm-2 s-1"),
     ),
     dict(
+        name="norm-powerlaw",
+        model=NormPowerLawSpectralModel(
+            index=2 * u.Unit(""), norm=4.0 * u.Unit(""), reference=1 * u.TeV,
+        ),
+        val_at_2TeV=u.Quantity(1.0, ""),
+        integral_1_10TeV=u.Quantity(3.6, "TeV"),
+        eflux_1_10TeV=u.Quantity(9.210340371976184, "TeV2"),
+    ),
+    dict(
         name="powerlaw2",
         model=PowerLaw2SpectralModel(
             amplitude=u.Quantity(2.9227116204223784, "cm-2 s-1"),
@@ -87,6 +99,19 @@ TEST_MODELS = [
         val_at_2TeV=u.Quantity(1.080321705479446, "cm-2 s-1 TeV-1"),
         integral_1_10TeV=u.Quantity(3.765838739678921, "cm-2 s-1"),
         eflux_1_10TeV=u.Quantity(9.901735870666526, "TeV cm-2 s-1"),
+        e_peak=4 * u.TeV,
+    ),
+    dict(
+        name="norm-ecpl",
+        model=NormExpCutoffPowerLawSpectralModel(
+            index=1.6 * u.Unit(""),
+            norm=4 * u.Unit(""),
+            reference=1 * u.TeV,
+            lambda_=0.1 / u.TeV,
+        ),
+        val_at_2TeV=u.Quantity(1.080321705479446, ""),
+        integral_1_10TeV=u.Quantity(3.765838739678921, "TeV"),
+        eflux_1_10TeV=u.Quantity(9.901735870666526, "TeV2"),
         e_peak=4 * u.TeV,
     ),
     dict(
@@ -125,6 +150,19 @@ TEST_MODELS = [
         val_at_2TeV=u.Quantity(0.6387956571420305, "cm-2 s-1 TeV-1"),
         integral_1_10TeV=u.Quantity(2.255689748270628, "cm-2 s-1"),
         eflux_1_10TeV=u.Quantity(3.9586515834989267, "TeV cm-2 s-1"),
+        e_peak=0.74082 * u.TeV,
+    ),
+    dict(
+        name="norm-logpar",
+        model=NormLogParabolaSpectralModel(
+            alpha=2.3 * u.Unit(""),
+            norm=4 * u.Unit(""),
+            reference=1 * u.TeV,
+            beta=0.5 * u.Unit(""),
+        ),
+        val_at_2TeV=u.Quantity(0.6387956571420305, ""),
+        integral_1_10TeV=u.Quantity(2.255689748270628, "TeV"),
+        eflux_1_10TeV=u.Quantity(3.9586515834989267, "TeV2"),
         e_peak=0.74082 * u.TeV,
     ),
     dict(
@@ -253,10 +291,10 @@ TEST_MODELS.append(
 TEST_MODELS.append(
     dict(
         name="compound6",
-        model=TEST_MODELS[8]["model"] + u.Quantity(4, "cm-2 s-1 TeV-1"),
-        val_at_2TeV=TEST_MODELS[8]["val_at_2TeV"] * 2,
-        integral_1_10TeV=TEST_MODELS[8]["integral_1_10TeV"] * 2,
-        eflux_1_10TeV=TEST_MODELS[8]["eflux_1_10TeV"] * 2,
+        model=TEST_MODELS[11]["model"] + u.Quantity(4, "cm-2 s-1 TeV-1"),
+        val_at_2TeV=TEST_MODELS[11]["val_at_2TeV"] * 2,
+        integral_1_10TeV=TEST_MODELS[11]["integral_1_10TeV"] * 2,
+        eflux_1_10TeV=TEST_MODELS[11]["eflux_1_10TeV"] * 2,
     )
 )
 

--- a/gammapy/utils/integrate.py
+++ b/gammapy/utils/integrate.py
@@ -2,41 +2,7 @@
 import numpy as np
 from .interpolation import LogScale
 
-__all__ = ["evaluate_integral_pwl", "trapz_loglog"]
-
-
-def evaluate_integral_pwl(emin, emax, index, amplitude, reference):
-    """Evaluate pwl integral (static function)."""
-    val = -1 * index + 1
-
-    prefactor = amplitude * reference / val
-    upper = np.power((emax / reference), val)
-    lower = np.power((emin / reference), val)
-    integral = prefactor * (upper - lower)
-
-    mask = np.isclose(val, 0)
-
-    if mask.any():
-        integral[mask] = (amplitude * reference * np.log(emax / emin))[mask]
-
-    return integral
-
-
-def evaluate_integral_norm_pwl(emin, emax, index, norm, reference):
-    """Evaluate pwl integral (static function)."""
-    val = -1 * index + 1
-
-    prefactor = norm * reference / val
-    upper = np.power((emax / reference), val)
-    lower = np.power((emin / reference), val)
-    integral = prefactor * (upper - lower)
-
-    mask = np.isclose(val, 0)
-
-    if mask.any():
-        integral[mask] = (norm * reference * np.log(emax / emin))[mask]
-
-    return integral
+__all__ = ["trapz_loglog"]
 
 
 def trapz_loglog(y, x, axis=-1):
@@ -58,6 +24,8 @@ def trapz_loglog(y, x, axis=-1):
     trapz : float
         Definite integral as approximated by trapezoidal rule in loglog space.
     """
+    from gammapy.modeling.models import PowerLawSpectralModel as pl
+
     # see https://stackoverflow.com/a/56840428
     x, y = np.moveaxis(x, axis, 0), np.moveaxis(y, axis, 0)
 
@@ -69,6 +37,6 @@ def trapz_loglog(y, x, axis=-1):
     index = -log(vals_emin / vals_emax) / log(emin / emax)
     index[np.isnan(index)] = np.inf
 
-    return evaluate_integral_pwl(
+    return pl.evaluate_integral(
         emin=emin, emax=emax, index=index, reference=emin, amplitude=vals_emin
     )

--- a/gammapy/utils/integrate.py
+++ b/gammapy/utils/integrate.py
@@ -22,6 +22,23 @@ def evaluate_integral_pwl(emin, emax, index, amplitude, reference):
     return integral
 
 
+def evaluate_integral_norm_pwl(emin, emax, index, norm, reference):
+    """Evaluate pwl integral (static function)."""
+    val = -1 * index + 1
+
+    prefactor = norm * reference / val
+    upper = np.power((emax / reference), val)
+    lower = np.power((emin / reference), val)
+    integral = prefactor * (upper - lower)
+
+    mask = np.isclose(val, 0)
+
+    if mask.any():
+        integral[mask] = (norm * reference * np.log(emax / emin))[mask]
+
+    return integral
+
+
 def trapz_loglog(y, x, axis=-1):
     """Integrate using the composite trapezoidal rule in log-log space.
 


### PR DESCRIPTION
- add NormPowerLawSpectralModel
- add NormLogparabolaSpectralModel
- add NormExpCutoffPowerLawSpectralModel
- left a TODO about where and how to document the difference with their corresponding amplitude-based model.
- left a TODO about plot method redefinition
- more complex models will be added in separate PR