### PR TITLE
Use norm parameter in TSMapEstimator

### DIFF
--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -158,10 +158,7 @@ def test_compute_ts_map_downsampled(input_dataset):
 @requires_data()
 def test_large_kernel(input_dataset):
     """Minimal test of compute_ts_image"""
-    spatial_model = GaussianSpatialModel(sigma="4 deg")
-    spectral_model = PowerLawSpectralModel(index=2)
-    model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
-    ts_estimator = TSMapEstimator(model=model, kernel_width="4 deg")
+    ts_estimator = TSMapEstimator(kernel_width="4 deg")
 
     with pytest.raises(ValueError):
         ts_estimator.run(input_dataset)

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -425,10 +425,8 @@ class SimpleMapDataset:
         Kernel array
 
     """
-    FLUX_FACTOR = 1e-12
-
     def __init__(self, model, counts, background, x_guess):
-        self.model = model * self.FLUX_FACTOR
+        self.model = model
         self.counts = counts
         self.background = background
         self.x_guess = x_guess
@@ -481,6 +479,8 @@ class BrentqFluxEstimator(Estimator):
     """Single parameter flux estimator"""
     _available_selection_optional = ["errn-errp", "ul"]
     tag = "BrentqFluxEstimator"
+
+    FLUX_FACTOR = 1e-12
 
     def __init__(self, rtol, n_sigma, n_sigma_ul, selection_optional=None, max_niter=20, ts_threshold=None):
         self.rtol = rtol
@@ -604,7 +604,7 @@ class BrentqFluxEstimator(Estimator):
         """"""
         if self.ts_threshold is not None:
             flux = dataset.x_guess
-            stat = dataset.stat_sum(norm=flux / dataset.FLUX_FACTOR)
+            stat = dataset.stat_sum(norm=flux / self.FLUX_FACTOR)
             stat_null = dataset.stat_sum(norm=0)
             ts = (stat_null - stat) * np.sign(flux)
             if ts < self.ts_threshold:
@@ -659,7 +659,7 @@ def _ts_value(
         counts=counts,
         background=background,
         exposure=exposure,
-        kernel=kernel,
+        kernel=kernel * flux_estimator.FLUX_FACTOR,
         position=position,
         flux=flux
     )

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -447,20 +447,20 @@ class SimpleMapDataset:
         Kernel array
 
     """
-    FLUX_FACTOR = 1e-12
-
     def __init__(self, model, counts, background, x_guess):
         self.model = model
         self.counts = counts
         self.background = background
         self.x_guess = x_guess
+        self.FLUX_FACTOR = 1e-12
 
     @lazyproperty
     def x_bounds(self):
         """Bounds for x"""
-        return amplitude_bounds_cython(
+        x_min, x_max, x_min_total = amplitude_bounds_cython(
             self.counts.ravel(), self.background.ravel(), self.model.ravel()
         )
+        return x_min / self.FLUX_FACTOR, x_max / self.FLUX_FACTOR, x_min_total / self.FLUX_FACTOR
 
     def npred(self, x):
         """Predicted number of counts"""
@@ -475,8 +475,8 @@ class SimpleMapDataset:
     def stat_derivative(self, x):
         """Stat derivative"""
         return f_cash_root_cython(
-            x, self.counts.ravel(), self.background.ravel(), self.model.ravel()
-        )
+            x * self.FLUX_FACTOR, self.counts.ravel(), self.background.ravel(), self.model.ravel()
+        ) * self.FLUX_FACTOR
 
     def stat_2nd_derivative(self, x):
         """Stat 2nd derivative"""

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -227,6 +227,8 @@ class TSMapEstimator(Estimator):
         flux = model.spectral_model.integral(
             emin=energy.min(), emax=energy.max()
         )
+
+        self._flux_estimator.flux_ref = flux.to_value("cm-2 s-1")
         dataset.models = [model]
         npred = dataset.npred()
         dataset.models = models
@@ -503,9 +505,9 @@ class BrentqFluxEstimator(Estimator):
                 warnings.simplefilter("ignore")
                 try:
                     result_fit = scipy.optimize.brentq(
-                        dataset.stat_derivative,
-                        norm_min,
-                        norm_max,
+                        f=dataset.stat_derivative,
+                        a=norm_min,
+                        b=norm_max,
                         maxiter=self.max_niter,
                         full_output=True,
                         rtol=self.rtol,

--- a/gammapy/stats/fit_statistics_cython.pyx
+++ b/gammapy/stats/fit_statistics_cython.pyx
@@ -68,7 +68,7 @@ def f_cash_root_cython(np.float_t x, np.ndarray[np.float_t, ndim=1] counts,
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
-def amplitude_bounds_cython(np.ndarray[np.float_t, ndim=1] counts,
+def norm_bounds_cython(np.ndarray[np.float_t, ndim=1] counts,
                             np.ndarray[np.float_t, ndim=1] background,
                             np.ndarray[np.float_t, ndim=1] model):
     """Compute bounds for the root of `_f_cash_root_cython`.

--- a/gammapy/stats/fit_statistics_cython.pyx
+++ b/gammapy/stats/fit_statistics_cython.pyx
@@ -4,9 +4,6 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
-cdef np.float_t FLUX_FACTOR = 1e-12
-
-
 cdef extern from "math.h":
     float log(float x)
 
@@ -59,15 +56,14 @@ def f_cash_root_cython(np.float_t x, np.ndarray[np.float_t, ndim=1] counts,
     for i in range(ni):
         if model[i] > 0:
             if counts[i] > 0:
-                sum += model[i] * (1 - counts[i] / (x * model[i]
-                                                          * FLUX_FACTOR + background[i]))
+                sum += model[i] * (1 - counts[i] / (x * model[i] + background[i]))
             else:
                 sum += model[i]
 
-    # 2 * FLUX_FACTOR is required to maintain the correct normalization of the
+    # 2 is required to maintain the correct normalization of the
     # derivative of the likelihood function. It doesn't change the result of
     # the fit.
-    return 2 * FLUX_FACTOR * sum
+    return 2 * sum
 
 
 @cython.cdivision(True)
@@ -105,4 +101,4 @@ def amplitude_bounds_cython(np.ndarray[np.float_t, ndim=1] counts,
                 sn_min_total = sn
     b_min = c_min / s_model - sn_min
     b_max = s_counts / s_model - sn_min
-    return b_min / FLUX_FACTOR, b_max / FLUX_FACTOR, -sn_min_total / FLUX_FACTOR
+    return b_min, b_max, -sn_min_total


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request refactors the `TSMapEstimator` to use a `norm` parameter instead of `FLUX_FACTOR`

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
