### PR TITLE
Optional exposure map for the EdispMap and PSF in the MapDataset

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -827,7 +827,10 @@ class MapDataset(Dataset):
             )
         if "EDISP" in hdulist:
             edisp_map = Map.from_hdulist(hdulist, hdu="edisp")
-            exposure_map = Map.from_hdulist(hdulist, hdu="edisp_exposure")
+            try:
+                exposure_map = Map.from_hdulist(hdulist, hdu="edisp_exposure")
+            except:
+                exposure_map = None
             if edisp_map.geom.axes[0].name == "energy":
                 kwargs["edisp"] = EDispKernelMap(edisp_map, exposure_map)
             else:

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -829,7 +829,7 @@ class MapDataset(Dataset):
             edisp_map = Map.from_hdulist(hdulist, hdu="edisp")
             try:
                 exposure_map = Map.from_hdulist(hdulist, hdu="edisp_exposure")
-            except:
+            except KeyError:
                 exposure_map = None
             if edisp_map.geom.axes[0].name == "energy":
                 kwargs["edisp"] = EDispKernelMap(edisp_map, exposure_map)
@@ -842,7 +842,10 @@ class MapDataset(Dataset):
 
         if "PSF" in hdulist:
             psf_map = Map.from_hdulist(hdulist, hdu="psf")
-            exposure_map = Map.from_hdulist(hdulist, hdu="psf_exposure")
+            try:
+                exposure_map = Map.from_hdulist(hdulist, hdu="psf_exposure")
+            except KeyError:
+                exposure_map = None
             kwargs["psf"] = PSFMap(psf_map, exposure_map)
 
         if "MASK_SAFE" in hdulist:

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -78,7 +78,7 @@ class EDispMap(IRFMap):
 
     _hdu_name = "edisp"
 
-    def __init__(self, edisp_map, exposure_map):
+    def __init__(self, edisp_map, exposure_map=None):
         if edisp_map.geom.axes[1].name.upper() != "ENERGY_TRUE":
             raise ValueError("Incorrect energy axis position in input Map")
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request makes the presence of an exposure map for the EdispKernel and PSF optional, when loading a MapDataset from a hdulist.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
