### PR TITLE
Rename LightCurveEstimator energy_range to e_edges

### DIFF
--- a/docs/tutorials/light_curve.ipynb
+++ b/docs/tutorials/light_curve.ipynb
@@ -248,7 +248,7 @@
    "outputs": [],
    "source": [
     "lc_maker_3d = LightCurveEstimator(\n",
-    "    energy_range=[1, 10] * u.TeV, source=\"crab\", reoptimize=False\n",
+    "    e_edges=[1, 10] * u.TeV, source=\"crab\", reoptimize=False\n",
     ")\n",
     "lc_3d = lc_maker_3d.run(analysis_3d.datasets)"
    ]
@@ -431,7 +431,7 @@
    "outputs": [],
    "source": [
     "lc_maker_1d = LightCurveEstimator(\n",
-    "    energy_range=[1, 10] * u.TeV, source=\"crab\", reoptimize=False\n",
+    "    e_edges=[1, 10] * u.TeV, source=\"crab\", reoptimize=False\n",
     ")\n",
     "lc_1d = lc_maker_1d.run(analysis_1d.datasets)"
    ]
@@ -494,7 +494,7 @@
    "outputs": [],
    "source": [
     "lc_maker_1d = LightCurveEstimator(\n",
-    "    energy_range=[1, 10] * u.TeV,\n",
+    "    e_edges=[1, 10] * u.TeV,\n",
     "    time_intervals=time_intervals,\n",
     "    source=\"crab\",\n",
     "    reoptimize=False,\n",

--- a/docs/tutorials/light_curve_flare.ipynb
+++ b/docs/tutorials/light_curve_flare.ipynb
@@ -337,7 +337,7 @@
    "outputs": [],
    "source": [
     "lc_maker_1d = LightCurveEstimator(\n",
-    "    energy_range=[0.7, 20] * u.TeV, source=\"pks2155\"\n",
+    "    e_edges=[0.7, 20] * u.TeV, source=\"pks2155\"\n",
     ")"
    ]
   },

--- a/docs/tutorials/light_curve_simulation.ipynb
+++ b/docs/tutorials/light_curve_simulation.ipynb
@@ -287,7 +287,7 @@
    "source": [
     "%%time\n",
     "lc_maker_1d = LightCurveEstimator(\n",
-    "    energy_range=[energy_axis.edges[0], energy_axis.edges[-1]],\n",
+    "    e_edges=[energy_axis.edges[0], energy_axis.edges[-1]],\n",
     "    source=\"model-fit\",\n",
     "    reoptimize=False,\n",
     ")\n",

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -320,6 +320,7 @@ class SpectrumDataset(Dataset):
         self.counts = npred
 
     @property
+    # TODO: make this a method to support different methods?
     def energy_range(self):
         """Energy range defined by the safe mask"""
         energy = self._energy_axis.edges

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -187,7 +187,7 @@ def test_lightcurve_estimator_spectrum_datasets():
     ]
 
     estimator = LightCurveEstimator(
-        energy_range=[1, 30] * u.TeV, norm_n_values=3, time_intervals=time_intervals
+        e_edges=[1, 30] * u.TeV, norm_n_values=3, time_intervals=time_intervals
     )
     lightcurve = estimator.run(datasets)
     assert_allclose(lightcurve.table["time_min"], [55197.0, 55197.041667])
@@ -235,7 +235,7 @@ def test_lightcurve_estimator_spectrum_datasets_withmaskfit():
 
     selection = ["scan"]
     estimator = LightCurveEstimator(
-        energy_range=[1, 30] * u.TeV,
+        e_edges=[1, 30] * u.TeV,
         norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional=selection,
@@ -254,7 +254,7 @@ def test_lightcurve_estimator_spectrum_datasets_default():
     datasets = get_spectrum_datasets()
     selection = ["scan"]
     estimator = LightCurveEstimator(
-        energy_range=[1, 30] * u.TeV, norm_n_values=3, selection_optional=selection
+        e_edges=[1, 30] * u.TeV, norm_n_values=3, selection_optional=selection
     )
     lightcurve = estimator.run(datasets)
     assert_allclose(lightcurve.table["time_min"], [55197.0, 55197.041667])
@@ -273,7 +273,7 @@ def test_lightcurve_estimator_spectrum_datasets_notordered():
         Time(["2010-01-01T00:00:00", "2010-01-01T01:00:00"]),
     ]
     estimator = LightCurveEstimator(
-        energy_range=[1, 100] * u.TeV,
+        e_edges=[1, 100] * u.TeV,
         norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional=["scan"],
@@ -291,7 +291,7 @@ def test_lightcurve_estimator_spectrum_datasets_largerbin():
     datasets = get_spectrum_datasets()
     time_intervals = [Time(["2010-01-01T00:00:00", "2010-01-01T02:00:00"])]
     estimator = LightCurveEstimator(
-        energy_range=[1, 30] * u.TeV,
+        e_edges=[1, 30] * u.TeV,
         norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional=["scan"],
@@ -340,7 +340,7 @@ def test_lightcurve_estimator_spectrum_datasets_gti_not_include_in_time_interval
         Time(["2010-01-01T01:00:00", "2010-01-01T01:05:00"]),
     ]
     estimator = LightCurveEstimator(
-        energy_range=[1, 30] * u.TeV,
+        e_edges=[1, 30] * u.TeV,
         norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional=["scan"],
@@ -379,7 +379,7 @@ def test_lightcurve_estimator_map_datasets():
         Time(["2010-01-01T01:00:00", "2010-01-01T02:00:00"]),
     ]
     estimator = LightCurveEstimator(
-        energy_range=[1, 100] * u.TeV,
+        e_edges=[1, 100] * u.TeV,
         source="test_source",
         time_intervals=time_intervals,
         selection_optional=["scan"],
@@ -404,7 +404,7 @@ def test_lightcurve_estimator_map_datasets():
 
     time_intervals2 = [Time(["2010-01-01T00:00:00", "2010-01-01T02:00:00"])]
     estimator2 = LightCurveEstimator(
-        energy_range=[1, 100] * u.TeV,
+        e_edges=[1, 100] * u.TeV,
         source="test_source",
         time_intervals=time_intervals2,
         selection_optional=["scan"],


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request rename the `energy_range` argument of the `LightCurveEstimator` to `e_edges` for consistency with other estimators. So far only one energy bin is supported, this can be easily changed in follow up PRs.

<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
