### PR TITLE
Adapt SpectrumDataset to use background_model instead of background

### DIFF
--- a/docs/tutorials/cta_sensitivity.ipynb
+++ b/docs/tutorials/cta_sensitivity.ipynb
@@ -78,7 +78,9 @@
     "region = CircleSkyRegion(center=center, radius=0.1 * u.deg)\n",
     "\n",
     "e_reco = MapAxis.from_energy_bounds(\"0.03 TeV\", \"30 TeV\", nbin=20)\n",
-    "e_true = MapAxis.from_energy_bounds(\"0.01 TeV\", \"100 TeV\", nbin=100, name=\"energy_true\")\n",
+    "e_true = MapAxis.from_energy_bounds(\n",
+    "    \"0.01 TeV\", \"100 TeV\", nbin=100, name=\"energy_true\"\n",
+    ")\n",
     "\n",
     "empty_dataset = SpectrumDataset.create(\n",
     "    e_reco=e_reco, e_true=e_true, region=region\n",
@@ -143,7 +145,7 @@
     "    energy=e_reco.center, theta=0.5 * u.deg, fraction=containment\n",
     ")[0]\n",
     "factor = (1 - np.cos(on_radii)) / (1 - np.cos(region.radius))\n",
-    "dataset.background.data *= factor.value.reshape((-1, 1, 1))"
+    "dataset.background_model.map *= factor.value.reshape((-1, 1, 1))"
    ]
   },
   {
@@ -283,6 +285,20 @@
     "* Also compute the sensitivity for a 20 hour observation\n",
     "* Compare how the sensitivity differs between 5 and 20 hours by plotting the ratio as a function of energy."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/tutorials/spectrum_simulation.ipynb
+++ b/docs/tutorials/spectrum_simulation.ipynb
@@ -192,7 +192,7 @@
     "dataset_onoff = SpectrumDatasetOnOff.from_spectrum_dataset(\n",
     "    dataset=dataset, acceptance=1, acceptance_off=5\n",
     ")\n",
-    "dataset_onoff.fake(background_model=dataset.background)\n",
+    "dataset_onoff.fake(background_model=dataset.background_model)\n",
     "print(dataset_onoff)"
    ]
   },
@@ -215,7 +215,9 @@
     "datasets = Datasets()\n",
     "\n",
     "for idx in range(n_obs):\n",
-    "    dataset_onoff.fake(random_state=idx, background_model=dataset.background)\n",
+    "    dataset_onoff.fake(\n",
+    "        random_state=idx, background_model=dataset.background_model\n",
+    "    )\n",
     "    datasets.append(dataset_onoff.copy(name=f\"obs-{idx}\"))"
    ]
   },

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from pathlib import Path
 import numpy as np
+import logging
 from astropy import units as u
 from astropy.io import fits
 from astropy.table import Table
@@ -13,9 +14,12 @@ from gammapy.stats import CashCountsStatistic, WStatCountsStatistic, cash, wstat
 from gammapy.utils.random import get_random_state
 from gammapy.utils.scripts import make_name, make_path
 from gammapy.utils.table import hstack_columns
+from gammapy.modeling.models import BackgroundModel
 from .map import MapEvaluator
 
 __all__ = ["SpectrumDatasetOnOff", "SpectrumDataset"]
+
+log = logging.getLogger(__name__)
 
 
 class SpectrumDataset(Dataset):
@@ -66,7 +70,6 @@ class SpectrumDataset(Dataset):
         livetime=None,
         aeff=None,
         edisp=None,
-        background=None,
         mask_safe=None,
         mask_fit=None,
         name=None,
@@ -86,7 +89,7 @@ class SpectrumDataset(Dataset):
         self.mask_fit = mask_fit
         self.aeff = aeff
         self.edisp = edisp
-        self.background = background
+        self._background_model = None
         self.mask_safe = mask_safe
         self.gti = gti
         self.meta_table = meta_table
@@ -126,16 +129,14 @@ class SpectrumDataset(Dataset):
             str_ += "\t{:32}: {:.2f}\n\n".format("Total off counts", counts_off)
 
         background = np.nan
-        if getattr(self, "background", None) is not None:
-            background = np.sum(self.background.data)
-            str_ += "\t{:32}: {:.2f}\n\n".format("Total background counts", background)
+        if self.background_model is not None:
+            background = np.sum(self.background_model.evaluate().data)
+        str_ += "\t{:32}: {:.2f}\n\n".format("Total background counts", background)
 
         aeff_min, aeff_max, aeff_unit = np.nan, np.nan, ""
         if self.aeff is not None:
             try:
-                aeff_min = np.min(
-                    self.aeff.data[self.aeff.data > 0]
-                )
+                aeff_min = np.min(self.aeff.data[self.aeff.data > 0])
             except ValueError:
                 aeff_min = 0
             aeff_max = np.max(self.aeff.data)
@@ -195,10 +196,7 @@ class SpectrumDataset(Dataset):
 
                 if evaluator is None:
                     evaluator = MapEvaluator(
-                        model=model,
-                        exposure=self.exposure,
-                        edisp=edisp,
-                        gti=self.gti,
+                        model=model, exposure=self.exposure, edisp=edisp, gti=self.gti,
                     )
                     self._evaluators[model] = evaluator
 
@@ -214,13 +212,26 @@ class SpectrumDataset(Dataset):
         """Models (`gammapy.modeling.models.Models`)."""
         return ProperModels(self)
 
+    @property
+    def background_model(self):
+        return self._background_model
+
     @models.setter
     def models(self, models):
         if models is None:
             self._models = None
         else:
             self._models = Models(models)
-        # reset evaluators
+
+        # TODO: clean this up (probably by removing)
+        for model in self.models:
+            if isinstance(model, BackgroundModel):
+                if model.datasets_names is not None:
+                    if self.name in model.datasets_names:
+                        self._background_model = model
+                        break
+        else:
+            log.warning(f"No background model defined for dataset {self.name}")
         self._evaluators = {}
 
     @property
@@ -254,10 +265,12 @@ class SpectrumDataset(Dataset):
         """Main analysis geometry"""
         if self.counts is not None:
             return self.counts.geom
+        elif self.background_model is not None:
+            return self.background_model.map.geom
         elif self.background is not None:
             return self.background.geom
         else:
-            raise ValueError("Either 'counts', 'background' must be defined.")
+            raise ValueError("Either 'counts', 'background_model' must be defined.")
 
     @property
     def data_shape(self):
@@ -270,8 +283,8 @@ class SpectrumDataset(Dataset):
         if self.edisp is not None:
             return self.edisp.get_edisp_kernel()
 
-    def npred_sig(self):
-        """Predicted counts from source model (`RegionNDMap`)."""
+    def npred(self):
+        """Predicted counts from source and background model (`RegionNDMap`)."""
         npred_total = RegionNDMap.from_geom(self._geom)
 
         for evaluator in self.evaluators.values():
@@ -280,23 +293,13 @@ class SpectrumDataset(Dataset):
 
         return npred_total
 
-    def npred(self):
-        """Return npred map (model + background)"""
-        npred = self.npred_sig()
-
-        if self.background:
-            npred += self.background
-
-        return npred
-
     def stat_array(self):
         """Likelihood per bin given the current model parameters"""
         return cash(n_on=self.counts.data, mu_on=self.npred().data)
 
     @property
     def excess(self):
-        """Excess (counts - alpha * counts_off)"""
-        return self.counts - self.background
+        return self.counts - self.background_model.evaluate()
 
     @property
     def exposure(self):
@@ -385,7 +388,12 @@ class SpectrumDataset(Dataset):
             label="Measured excess",
             yerr=np.sqrt(np.abs(self.excess.data.flatten())),
         )
-        self.npred_sig().plot_hist(ax=ax, label="Predicted excess")
+        if self.background_model:
+            pred_excess = self.npred() - self.background_model.evaluate()
+        elif self.background:
+            pred_excess = self.npred() - self.background
+
+        pred_excess.plot_hist(ax=ax, label="Predicted excess")
 
         ax.legend(numpoints=1)
         ax.set_title("")
@@ -488,8 +496,12 @@ class SpectrumDataset(Dataset):
         if region is None:
             region = "icrs;circle(0, 0, 1)"
 
+        name = make_name(name)
         counts = RegionNDMap.create(region=region, axes=[e_reco])
         background = RegionNDMap.create(region=region, axes=[e_reco])
+        models = Models(
+            [BackgroundModel(background, name=name + "-bkg", datasets_names=[name])]
+        )
         aeff = RegionNDMap.create(region=region, axes=[e_true], unit="cm2")
         edisp = EDispKernelMap.from_diagonal_response(e_reco, e_true, counts.geom)
         mask_safe = RegionNDMap.from_geom(counts.geom, dtype="bool")
@@ -501,9 +513,9 @@ class SpectrumDataset(Dataset):
             aeff=aeff,
             edisp=edisp,
             mask_safe=mask_safe,
-            background=background,
             livetime=livetime,
             gti=gti,
+            models=models,
             name=name,
         )
 
@@ -551,9 +563,13 @@ class SpectrumDataset(Dataset):
             self.counts *= self.mask_safe
             self.counts.stack(other.counts, weights=other.mask_safe)
 
-        if self.background is not None and self.stat_type == "cash":
-            self.background *= self.mask_safe
-            self.background.stack(other.background, weights=other.mask_safe)
+        if self.stat_type == "cash":
+            if self.background_model and other.background_model:
+                self._background_model.map *= self.mask_safe
+                self._background_model.stack(other.background_model, other.mask_safe)
+                self.models = Models([self.background_model])
+        else:
+            self.models = None
 
         if self.livetime is None or other.livetime is None:
             raise ValueError("IRF stacking requires livetime for both datasets.")
@@ -593,8 +609,8 @@ class SpectrumDataset(Dataset):
 
         if isinstance(self, SpectrumDatasetOnOff) and self.counts_off is not None:
             self.background.plot_hist(ax=ax1, label="alpha * N_off")
-        elif self.background is not None:
-            self.background.plot_hist(ax=ax1, label="background")
+        elif self.background_model is not None:
+            self.background_model.evaluate().plot_hist(ax=ax1, label="background")
 
         self.counts.plot_hist(ax=ax1, label="n_on")
 
@@ -637,10 +653,15 @@ class SpectrumDataset(Dataset):
 
         info["n_on"] = self.counts.data[mask].sum()
 
-        info["background"] = self.background.data[mask].sum()
+        if self.background_model:
+            background = self.background_model.evaluate().data[mask].sum()
+        elif self.background:
+            background = self.background.data[mask].sum()
+
+        info["background"] = background
         info["excess"] = self.excess.data[mask].sum()
         info["significance"] = CashCountsStatistic(
-            self.counts.data[mask].sum(), self.background.data[mask].sum()
+            self.counts.data[mask].sum(), background
         ).significance
 
         info["background_rate"] = info["background"] / info["livetime"]
@@ -677,8 +698,11 @@ class SpectrumDataset(Dataset):
         if self.exposure is not None:
             kwargs["aeff"] = self.aeff.slice_by_idx(slices=slices)
 
-        if self.background is not None:
-            kwargs["background"] = self.background.slice_by_idx(slices=slices)
+        if self.background_model is not None:
+            m = self.background_model.evaluate().slice_by_idx(slices=slices)
+            bkg_model = BackgroundModel(map=m, datasets_names=[name])
+            bkg_model.norm.frozen = True
+            kwargs["models"] = bkg_model
 
         if self.edisp is not None:
             kwargs["edisp"] = self.edisp.slice_by_idx(slices=slices)
@@ -784,6 +808,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         self._name = make_name(name)
         self.gti = gti
         self.models = models
+        self._background_model = None
 
         # TODO: this enforces the exposure on the edisp map, maybe better move
         #  to where the EDispKernelMap is created?
@@ -802,12 +827,23 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         str_acc = "\t{:32}: {}\n".format("Acceptance mean:", acceptance)
         str_list.insert(16, str_acc)
         str_ = "\n".join(str_list)
+
+        acceptance_off = np.nan
+        if self.acceptance_off is not None:
+            acceptance_off = np.sum(self.acceptance_off.data)
+        str_ += "\t{:32}: {:.0f} \n".format("Acceptance off", acceptance_off)
+
         return str_.expandtabs(tabsize=2)
 
     @property
     def background(self):
         """"""
         return self.alpha * self.counts_off.data
+
+    @property
+    def excess(self):
+        """counts - bkg"""
+        return self.counts - self.background
 
     @property
     def alpha(self):
@@ -832,7 +868,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
     def stat_array(self):
         """Likelihood per bin given the current model parameters"""
-        mu_sig = self.npred_sig().data
+        mu_sig = self.npred().data
         on_stat_ = wstat(
             n_on=self.counts.data,
             n_off=self.counts_off.data,
@@ -856,13 +892,13 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         """
         random_state = get_random_state(random_state)
 
-        npred_sig = self.npred_sig()
-        npred_sig.data = random_state.poisson(npred_sig.data)
+        npred = self.npred()
+        npred.data = random_state.poisson(npred.data)
 
         npred_bkg = background_model.copy()
         npred_bkg.data = random_state.poisson(npred_bkg.data)
 
-        self.counts = npred_sig + npred_bkg
+        self.counts = npred + npred_bkg
 
         npred_off = background_model / self.alpha
         npred_off.data = random_state.poisson(npred_off.data)
@@ -1131,7 +1167,12 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
         hdulist.writeto(str(outdir / phafile), overwrite=overwrite)
 
-        self.aeff.write(outdir / arffile, overwrite=overwrite, format=hdu_format, ogip_column="SPECRESP")
+        self.aeff.write(
+            outdir / arffile,
+            overwrite=overwrite,
+            format=hdu_format,
+            ogip_column="SPECRESP",
+        )
 
         if self.counts_off is not None:
             counts_off_table = self.counts_off.to_table()
@@ -1364,9 +1405,9 @@ class SpectrumDatasetOnOff(SpectrumDataset):
             Spectrum dataset on off.
 
         """
-        if counts_off is None and dataset.background is not None:
+        if counts_off is None and dataset.background_model is not None:
             alpha = acceptance / acceptance_off
-            counts_off = dataset.background / alpha
+            counts_off = dataset.background_model.evaluate() / alpha
 
         return cls(
             models=dataset.models,
@@ -1381,7 +1422,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
             acceptance_off=acceptance_off,
             gti=dataset.gti,
             name=dataset.name,
-            meta_table=dataset.meta_table
+            meta_table=dataset.meta_table,
         )
 
     def slice_by_idx(self, slices, name=None):

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -41,8 +41,6 @@ class SpectrumDataset(Dataset):
         Effective area
     edisp : `~gammapy.irf.EDispKernelMap`
         Energy dispersion kernel.
-    background : `~gammapy.maps.RegionNDMap`
-        Background to use for the fit.
     mask_safe : `~gammapy.maps.RegionNDMap`
         Mask defining the safe data range.
     mask_fit : `~gammapy.maps.RegionNDMap`
@@ -895,12 +893,12 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         npred = self.npred()
         npred.data = random_state.poisson(npred.data)
 
-        npred_bkg = background_model.copy()
+        npred_bkg = background_model.evaluate().copy()
         npred_bkg.data = random_state.poisson(npred_bkg.data)
 
         self.counts = npred + npred_bkg
 
-        npred_off = background_model / self.alpha
+        npred_off = background_model.evaluate() / self.alpha
         npred_off.data = random_state.poisson(npred_off.data)
         self.counts_off = npred_off
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -213,16 +213,14 @@ def test_to_spectrum_dataset(sky_model, geom, geom_etrue, edisp_mode):
 
     assert np.sum(spectrum_dataset.counts.data) == 1
     assert spectrum_dataset.data_shape == (2, 1, 1)
-    assert spectrum_dataset.background.geom.axes[0].nbin == 2
+    assert spectrum_dataset.background_model.map.geom.axes[0].nbin == 2
     assert spectrum_dataset.aeff.geom.axes[0].nbin == 3
     assert spectrum_dataset.aeff.unit == "m2"
     assert spectrum_dataset.edisp.get_edisp_kernel().e_reco.nbin == 2
     assert spectrum_dataset.edisp.get_edisp_kernel().e_true.nbin == 3
     assert spectrum_dataset_corrected.aeff.unit == "m2"
     assert_allclose(spectrum_dataset.aeff.data[1], 853023.423047, rtol=1e-5)
-    assert_allclose(
-        spectrum_dataset_corrected.aeff.data[1], 559476.3357, rtol=1e-5
-    )
+    assert_allclose(spectrum_dataset_corrected.aeff.data[1], 559476.3357, rtol=1e-5)
 
 
 @requires_data()
@@ -389,15 +387,11 @@ def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
 @requires_dependency("matplotlib")
 @requires_data()
 def test_map_fit(sky_model, geom, geom_etrue):
-    dataset_1 = get_map_dataset(
-        sky_model, geom, geom_etrue, name="test-1"
-    )
+    dataset_1 = get_map_dataset(sky_model, geom, geom_etrue, name="test-1")
     dataset_1.background_model.norm.value = 0.5
     dataset_1.counts = dataset_1.npred()
 
-    dataset_2 = get_map_dataset(
-        sky_model, geom, geom_etrue, name="test-2"
-    )
+    dataset_2 = get_map_dataset(sky_model, geom, geom_etrue, name="test-2")
 
     dataset_2.counts = dataset_2.npred()
 
@@ -599,7 +593,7 @@ def test_stack(sky_model):
         mask_safe=mask1,
         name="dataset-1",
         edisp=edisp,
-        meta_table=Table({"OBS_ID": [0]})
+        meta_table=Table({"OBS_ID": [0]}),
     )
 
     bkg2 = Map.from_geom(geom)
@@ -626,7 +620,7 @@ def test_stack(sky_model):
         mask_safe=mask2,
         name="dataset-2",
         edisp=edisp,
-        meta_table=Table({"OBS_ID": [1]})
+        meta_table=Table({"OBS_ID": [1]}),
     )
 
     dataset1.models.append(sky_model)
@@ -1093,15 +1087,9 @@ def test_slice_by_idx():
     )
 
     geom = WcsGeom.create(
-        skydir=(0, 0),
-        binsz=0.5,
-        width=(2, 2),
-        frame="icrs",
-        axes=[axis],
+        skydir=(0, 0), binsz=0.5, width=(2, 2), frame="icrs", axes=[axis],
     )
-    dataset = MapDataset.create(
-        geom=geom, energy_axis_true=axis_etrue, binsz_irf=0.5
-    )
+    dataset = MapDataset.create(geom=geom, energy_axis_true=axis_etrue, binsz_irf=0.5)
 
     slices = {"energy": slice(5, 10)}
     sub_dataset = dataset.slice_by_idx(slices)
@@ -1131,4 +1119,3 @@ def test_slice_by_idx():
 
     axis = sub_dataset.exposure.geom.get_axis_by_name("energy_true")
     assert_allclose(axis.edges[0].value, 0.210175, rtol=1e-5)
-

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -512,6 +512,7 @@ class TestSpectrumOnOff:
         """Test the fake dataset"""
         source_model = SkyModel(spectral_model=PowerLawSpectralModel())
         dataset = SpectrumDatasetOnOff(
+            name="test",
             counts=self.on_counts,
             counts_off=self.off_counts,
             models=source_model,
@@ -525,7 +526,10 @@ class TestSpectrumOnOff:
 
         background = RegionNDMap.from_geom(dataset.counts.geom)
         background.data += 1
-        dataset.fake(background_model=background, random_state=314)
+        background_model = BackgroundModel(
+            background, name="test-bkg", datasets_names="test"
+        )
+        dataset.fake(background_model=background_model, random_state=314)
 
         assert real_dataset.counts.data.shape == dataset.counts.data.shape
         assert real_dataset.counts_off.data.shape == dataset.counts_off.data.shape

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -17,6 +17,7 @@ from gammapy.modeling.models import (
     Models,
     PowerLawSpectralModel,
     SkyModel,
+    BackgroundModel,
 )
 from gammapy.utils.random import get_random_state
 from gammapy.utils.regions import compound_region_to_list, make_region
@@ -31,6 +32,7 @@ from gammapy.utils.time import time_ref_to_dict
 
 @pytest.fixture()
 def spectrum_dataset():
+    name = "test"
     energy = np.logspace(-1, 1, 31) * u.TeV
     livetime = 100 * u.s
 
@@ -41,12 +43,15 @@ def spectrum_dataset():
     temp_mod = ConstantTemporalModel()
 
     model = SkyModel(spectral_model=pwl, temporal_model=temp_mod, name="test-source")
-
-
     axis = MapAxis.from_edges(energy, interp="log", name="energy")
     axis_true = MapAxis.from_edges(energy, interp="log", name="energy_true")
 
     background = RegionNDMap.create(region="icrs;circle(0, 0, 0.1)", axes=[axis])
+
+    bkg_model = BackgroundModel(background, name=name + "-bkg", datasets_names=[name])
+    bkg_model.norm.frozen = True
+
+    models = Models([bkg_model, model])
     aeff = RegionNDMap.create(region="icrs;circle(0, 0, 0.1)", axes=[axis_true])
     aeff.quantity = u.Quantity("1 cm2")
     bkg_rate = np.ones(30) / u.s
@@ -58,12 +63,7 @@ def spectrum_dataset():
     gti = GTI.create(start, stop, reference_time=t_ref)
 
     dataset = SpectrumDataset(
-        models=model,
-        aeff=aeff,
-        livetime=livetime,
-        background=background,
-        name="test",
-        gti=gti,
+        models=models, aeff=aeff, livetime=livetime, name=name, gti=gti,
     )
     dataset.fake(random_state=23)
     return dataset
@@ -148,10 +148,10 @@ def test_fit(spectrum_dataset):
 
     pars = result.parameters
     assert_allclose(pars["index"].value, 2.1, rtol=1e-2)
-    assert_allclose(pars["index"].error, 0.00127, rtol=1e-2)
+    assert_allclose(pars["index"].error, 0.001206, rtol=1e-2)
 
     assert_allclose(pars["amplitude"].value, 1e5, rtol=1e-3)
-    assert_allclose(pars["amplitude"].error, 153.450, rtol=1e-2)
+    assert_allclose(pars["amplitude"].error, 139.61, rtol=1e-2)
 
 
 def test_spectrum_dataset_create():
@@ -164,10 +164,12 @@ def test_spectrum_dataset_create():
     assert empty_spectrum_dataset.name == "test"
     assert empty_spectrum_dataset.counts.data.sum() == 0
     assert empty_spectrum_dataset.data_shape[0] == 2
-    assert empty_spectrum_dataset.background.data.sum() == 0
-    assert empty_spectrum_dataset.background.geom.axes[0].nbin == 2
+    assert empty_spectrum_dataset.background_model.map.data.sum() == 0
+    assert empty_spectrum_dataset.background_model.map.geom.axes[0].nbin == 2
     assert empty_spectrum_dataset.aeff.geom.axes[0].nbin == 3
-    assert empty_spectrum_dataset.edisp.edisp_map.geom.get_axis_by_name("energy").nbin == 2
+    assert (
+        empty_spectrum_dataset.edisp.edisp_map.geom.get_axis_by_name("energy").nbin == 2
+    )
     assert empty_spectrum_dataset.livetime.value == 0
     assert len(empty_spectrum_dataset.gti.table) == 0
     assert empty_spectrum_dataset.energy_range[0] is None
@@ -178,18 +180,25 @@ def test_spectrum_dataset_stack_diagonal_safe_mask(spectrum_dataset):
     geom = spectrum_dataset.counts.geom
 
     energy = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=30)
-    energy_true = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=30, name="energy_true")
+    energy_true = MapAxis.from_energy_bounds(
+        "0.1 TeV", "10 TeV", nbin=30, name="energy_true"
+    )
 
-    aeff = EffectiveAreaTable.from_parametrization(energy.edges, "HESS").to_region_map(geom.region)
-    edisp = EDispKernelMap.from_diagonal_response(energy, energy_true, geom=geom.to_image())
+    aeff = EffectiveAreaTable.from_parametrization(energy.edges, "HESS").to_region_map(
+        geom.region
+    )
+    edisp = EDispKernelMap.from_diagonal_response(
+        energy, energy_true, geom=geom.to_image()
+    )
     livetime = 100 * u.s
-    background = spectrum_dataset.background
+    background = spectrum_dataset.background_model.map
     spectrum_dataset1 = SpectrumDataset(
+        name="ds1",
         counts=spectrum_dataset.counts.copy(),
         livetime=livetime,
         aeff=aeff,
         edisp=edisp.copy(),
-        background=background.copy(),
+        models=BackgroundModel(background, name="ds1-bkg", datasets_names=["ds1"]),
     )
 
     livetime2 = 0.5 * livetime
@@ -202,11 +211,12 @@ def test_spectrum_dataset_stack_diagonal_safe_mask(spectrum_dataset):
     safe_mask2 = RegionNDMap.from_geom(geom=geom, data=data)
 
     spectrum_dataset2 = SpectrumDataset(
+        name="ds2",
         counts=spectrum_dataset.counts.copy(),
         livetime=livetime2,
         aeff=aeff2,
         edisp=edisp,
-        background=bkg2,
+        models=BackgroundModel(bkg2, name="ds2-bkg", datasets_names=["ds2"]),
         mask_safe=safe_mask2,
     )
     spectrum_dataset1.stack(spectrum_dataset2)
@@ -215,8 +225,10 @@ def test_spectrum_dataset_stack_diagonal_safe_mask(spectrum_dataset):
     assert_allclose(spectrum_dataset1.counts.data[1:], reference[1:] * 2)
     assert_allclose(spectrum_dataset1.counts.data[0], 141363)
     assert spectrum_dataset1.livetime == 1.5 * livetime
-    assert_allclose(spectrum_dataset1.background.data[1:], 3 * background.data[1:])
-    assert_allclose(spectrum_dataset1.background.data[0], background.data[0])
+    assert_allclose(
+        spectrum_dataset1.background_model.map.data[1:], 3 * background.data[1:]
+    )
+    assert_allclose(spectrum_dataset1.background_model.map.data[0], background.data[0])
     assert_allclose(
         spectrum_dataset1.aeff.quantity.to_value("m2"),
         4.0 / 3 * aeff.quantity.to_value("m2"),
@@ -231,12 +243,13 @@ def test_spectrum_dataset_stack_diagonal_safe_mask(spectrum_dataset):
 def test_spectrum_dataset_stack_nondiagonal_no_bkg(spectrum_dataset):
     energy = spectrum_dataset.counts.geom.axes[0]
 
-
     geom = spectrum_dataset.counts.geom.to_image()
     edisp1 = EDispKernelMap.from_gauss(energy, energy, 0.1, 0, geom=geom)
     edisp1.exposure_map.data += 1
 
-    aeff = EffectiveAreaTable.from_parametrization(energy.edges, "HESS").to_region_map(geom.region)
+    aeff = EffectiveAreaTable.from_parametrization(energy.edges, "HESS").to_region_map(
+        geom.region
+    )
 
     livetime = 100 * u.s
     spectrum_dataset1 = SpectrumDataset(
@@ -244,7 +257,7 @@ def test_spectrum_dataset_stack_nondiagonal_no_bkg(spectrum_dataset):
         livetime=livetime,
         aeff=aeff,
         edisp=edisp1,
-        meta_table=Table({"OBS_ID": [0]})
+        meta_table=Table({"OBS_ID": [0]}),
     )
 
     livetime2 = livetime
@@ -256,13 +269,13 @@ def test_spectrum_dataset_stack_nondiagonal_no_bkg(spectrum_dataset):
         livetime=livetime2,
         aeff=aeff2,
         edisp=edisp2,
-        meta_table=Table({"OBS_ID": [1]})
+        meta_table=Table({"OBS_ID": [1]}),
     )
     spectrum_dataset1.stack(spectrum_dataset2)
 
     assert_allclose(spectrum_dataset1.meta_table["OBS_ID"][0], [0, 1])
 
-    assert spectrum_dataset1.background is None
+    assert spectrum_dataset1.background_model is None
     assert spectrum_dataset1.livetime == 2 * livetime
     assert_allclose(
         spectrum_dataset1.aeff.quantity.to_value("m2"), aeff.quantity.to_value("m2")
@@ -339,7 +352,8 @@ class TestSpectrumOnOff:
         acceptance_off.data += 10
 
         self.edisp = EDispKernelMap.from_diagonal_response(
-            self.e_reco, self.e_true, self.on_counts.geom)
+            self.e_reco, self.e_true, self.on_counts.geom
+        )
 
         self.dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
@@ -386,7 +400,11 @@ class TestSpectrumOnOff:
         model = SkyModel(spectral_model=ConstantSpectralModel(const=const))
         livetime = 1 * u.s
 
-        aeff = RegionNDMap.create(region=self.on_region, unit="cm2", axes=[self.e_reco.copy(name="energy_true")])
+        aeff = RegionNDMap.create(
+            region=self.on_region,
+            unit="cm2",
+            axes=[self.e_reco.copy(name="energy_true")],
+        )
         aeff.data += 1
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
@@ -399,7 +417,7 @@ class TestSpectrumOnOff:
         energy = aeff.geom.axes[0].edges
         expected = aeff.data[0] * (energy[-1] - energy[0]) * const * livetime
 
-        assert_allclose(dataset.npred_sig().data.sum(), expected.value)
+        assert_allclose(dataset.npred().data.sum(), expected.value)
 
     @requires_dependency("matplotlib")
     def test_peek(self):
@@ -883,7 +901,9 @@ class TestFit:
         self.src = RegionNDMap.from_geom(geom=geom, data=source_counts)
 
         self.src.livetime = 1 * u.s
-        self.aeff = EffectiveAreaTable.from_constant(energy, "1 cm2").to_region_map(region=None)
+        self.aeff = EffectiveAreaTable.from_constant(energy, "1 cm2").to_region_map(
+            region=None
+        )
 
         npred_bkg = bkg_model.integral(energy[:-1], energy[1:]).value
 

--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -81,7 +81,12 @@ class ExcessProfileEstimator(Estimator):
     _available_selection_optional = ["errn-errp", "ul", "scan"]
 
     def __init__(
-        self, regions, spectrum=None, n_sigma=1.0, n_sigma_ul=3.0, selection_optional="all"
+        self,
+        regions,
+        spectrum=None,
+        n_sigma=1.0,
+        n_sigma_ul=3.0,
+        selection_optional="all",
     ):
         self.regions = regions
         self.n_sigma = n_sigma
@@ -119,13 +124,15 @@ class ExcessProfileEstimator(Estimator):
 
         for idx, region in enumerate(self.regions):
             if isinstance(region, CircleAnnulusSkyRegion):
-                distance = (region.inner_radius + region.outer_radius) / 2.
+                distance = (region.inner_radius + region.outer_radius) / 2.0
             else:
                 distance = center.separation(region.center)
 
             distances.append(distance)
 
-        return MapAxis.from_nodes(u.Quantity(distances, "deg"), name="projected distance")
+        return MapAxis.from_nodes(
+            u.Quantity(distances, "deg"), name="projected distance"
+        )
 
     def make_prof(self, sp_datasets):
         """ Utility to make the profile in each region
@@ -197,7 +204,7 @@ class ExcessProfileEstimator(Estimator):
             if "ul" in self.selection_optional:
                 result["ul"] = stats.compute_upper_limit(self.n_sigma_ul)
 
-            npred = spds.npred_sig().data[mask][:, 0, 0]
+            npred = spds.npred().data[mask][:, 0, 0]
             e_reco_lo = e_reco[:-1]
             e_reco_hi = e_reco[1:]
             flux = (

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -15,6 +15,7 @@ from gammapy.modeling.models import (
     GaussianSpatialModel,
     PowerLawSpectralModel,
     SkyModel,
+    BackgroundModel,
 )
 from gammapy.utils.testing import requires_data, requires_dependency
 
@@ -43,6 +44,7 @@ def simulate_spectrum_dataset(model, random_state=0):
     )
 
     dataset = SpectrumDatasetOnOff(
+        name="test_onoff",
         aeff=aeff,
         livetime=100 * u.h,
         acceptance=acceptance,
@@ -53,7 +55,10 @@ def simulate_spectrum_dataset(model, random_state=0):
     bkg_npred = dataset.npred()
 
     dataset.models = model
-    dataset.fake(random_state=random_state, background_model=bkg_npred)
+    dataset.fake(
+        random_state=random_state,
+        background_model=BackgroundModel(bkg_npred, datasets_names="test_onoff"),
+    )
     return dataset
 
 

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -39,14 +39,18 @@ def simulate_spectrum_dataset(model, random_state=0):
     edisp = EDispKernelMap.from_diagonal_response(
         energy_axis=energy_axis,
         energy_axis_true=energy_axis.copy(name="energy_true"),
-        geom=geom
+        geom=geom,
     )
 
     dataset = SpectrumDatasetOnOff(
-        aeff=aeff, livetime=100 * u.h, acceptance=acceptance, acceptance_off=5, edisp=edisp
+        aeff=aeff,
+        livetime=100 * u.h,
+        acceptance=acceptance,
+        acceptance_off=5,
+        edisp=edisp,
     )
     dataset.models = bkg_model
-    bkg_npred = dataset.npred_sig()
+    bkg_npred = dataset.npred()
 
     dataset.models = model
     dataset.fake(random_state=random_state, background_model=bkg_npred)
@@ -300,4 +304,3 @@ def test_mask_shape():
     fp = fpe.run([dataset_2, dataset_1])
 
     assert_allclose(fp.table["counts"], 0)
-

--- a/gammapy/estimators/tests/test_sensitivity.py
+++ b/gammapy/estimators/tests/test_sensitivity.py
@@ -6,6 +6,7 @@ from gammapy.datasets import SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.estimators import SensitivityEstimator
 from gammapy.irf import EDispKernelMap, EffectiveAreaTable
 from gammapy.maps import MapAxis, RegionNDMap
+from gammapy.modeling.models import BackgroundModel
 
 
 @pytest.fixture()
@@ -21,7 +22,13 @@ def spectrum_dataset():
     )
     aeff = RegionNDMap.create(region="icrs;circle(0, 0, 0.1)", axes=[e_true], unit="m2")
     aeff.data += 1e6
-    return SpectrumDataset(aeff=aeff, livetime="1h", edisp=edisp, background=background)
+    return SpectrumDataset(
+        name="test",
+        aeff=aeff,
+        livetime="1h",
+        edisp=edisp,
+        models=BackgroundModel(background, name="test-bkg", datasets_names="test"),
+    )
 
 
 def test_cta_sensitivity_estimator(spectrum_dataset):

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -37,6 +37,7 @@ class SafeMaskMaker(Maker):
     offset_max : str or `~astropy.units.Quantity`
         Maximum offset cut.
     """
+
     tag = "SafeMaskMaker"
     available_methods = {
         "aeff-default",
@@ -194,7 +195,7 @@ class SafeMaskMaker(Maker):
         if isinstance(dataset, MapDataset):
             background_spectrum = dataset.background_model.map.get_spectrum()
         else:
-            background_spectrum = dataset.background
+            background_spectrum = dataset.background_model.map
 
         idx = np.argmax(background_spectrum.data, axis=0)
         energy_axis = geom.get_axis_by_name("energy")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request cleans up `SpectrumDataset` to use a `background_model` instead of a fixed `background`.
I think having a `background_model` also makes comparisons with `wstat` fitting easier.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

I have tried to match the `MapDataset` API, so removed `SpectrumDataset.background`.  `SpectrumDatasetOnOff.background` still exists. I do not know if it might be good to have a `background` property which simply returns `self.background_model.evaluate()`.
