### PR TITLE
PSFMap from Gaussian 

### DIFF
--- a/gammapy/irf/psf_map.py
+++ b/gammapy/irf/psf_map.py
@@ -300,7 +300,7 @@ class PSFMap(IRFMap):
         return cls(psf_map=psf_map, exposure_map=exposure_map)
 
     @classmethod
-    def from_gauss(cls,energy, rad, sigma):
+    def from_gauss(cls, energy, rad, sigma):
         """Create all -sky PSF map from Gaussian width.
 
         This is used for testing and examples.
@@ -334,12 +334,12 @@ class PSFMap(IRFMap):
             # one width per energy
             energytable_temp = np.zeros(tableshape)*u.sr**-1
             for i in np.arange(tableshape[0]):
-                energytable_temp[i,:] = TablePSF.from_shape(shape='gauss', width=sigma[i], rad=rad).psf_value
+                energytable_temp[i, :] = TablePSF.from_shape(shape='gauss', width=sigma[i], rad=rad).psf_value
         else:
             raise AssertionError('There need to be the same number of sigma values as energies')
         energytable = EnergyDependentTablePSF(energy, rad, exposure=None, psf_value=energytable_temp)
-        psfmap = cls.from_energy_dependent_table_psf(energytable)
-        return psfmap
+        psf_map = cls.from_energy_dependent_table_psf(energytable)
+        return psf_map
 
     def to_image(self, spectrum=None, keepdims=True):
         """Reduce to a 2-D map after weighing

--- a/gammapy/irf/psf_map.py
+++ b/gammapy/irf/psf_map.py
@@ -301,7 +301,7 @@ class PSFMap(IRFMap):
 
     @classmethod
     def from_gauss(cls,energy, rad, sigma):
-        """Create PSF map from Gaussian width.
+        """Create all -sky PSF map from Gaussian width.
 
         This is used for testing and examples.
 
@@ -326,13 +326,11 @@ class PSFMap(IRFMap):
         # note: it would be straightforward to also have disk shape instead
         # of gauss
         tableshape = (energy.shape[0], rad.shape[0])
-        
         if np.size(sigma) == 1:
             # same width for all energies
             tablepsf = TablePSF.from_shape(shape='gauss', width=sigma, rad=rad)
             energytable_temp = np.tile(tablepsf.psf_value, (tableshape[0], 1))
-            print(energytable_temp.shape)
-        elif np.size(sigma) == len(energy):
+        elif np.size(sigma) == np.size(energy):
             # one width per energy
             energytable_temp = np.zeros(tableshape)*u.sr**-1
             for i in np.arange(tableshape[0]):

--- a/gammapy/irf/psf_map.py
+++ b/gammapy/irf/psf_map.py
@@ -312,9 +312,9 @@ class PSFMap(IRFMap):
         Parameters
         ----------
         energy_axis_true : `~gammapy.maps.MapAxis`
-            True energy axis. 
+            True energy axis.
         rad_axis : `~gammapy.maps.MapAxis`
-            Offset angle wrt source position axis. 
+            Offset angle wrt source position axis.
         sigma : `~astropy.coordinates.Angle`
             Gaussian width.
 

--- a/gammapy/irf/psf_map.py
+++ b/gammapy/irf/psf_map.py
@@ -6,7 +6,7 @@ from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.utils.random import InverseCDFSampler, get_random_state
 from .irf_map import IRFMap
 from .psf_kernel import PSFKernel
-from .psf_table import EnergyDependentTablePSF
+from .psf_table import EnergyDependentTablePSF,TablePSF
 
 __all__ = ["PSFMap"]
 
@@ -298,6 +298,50 @@ class PSFMap(IRFMap):
         exposure_map = Map.from_geom(geom_exposure, unit="cm2 s")
         exposure_map.quantity += data
         return cls(psf_map=psf_map, exposure_map=exposure_map)
+
+    @classmethod
+    def from_gauss(cls,energy, rad, sigma):
+        """Create PSF map from Gaussian width.
+
+        This is used for testing and examples.
+
+        The width can be the same for all energies
+        or be an array with one value per energy node.
+        It does not depend on position.
+
+        Parameters
+        ----------
+        energy : `~astropy.units.Quantity`
+            Energy (1-dim)
+        rad : `~astropy.units.Quantity` with angle units
+            Offset angle wrt source position (1-dim)
+        sigma : `~astropy.coordinates.Angle`
+            Gaussian width.
+        Returns
+        -------
+        psf_map : `PSFMap`
+            Point spread function map.
+        """  
+
+        # note: it would be straightforward to also have disk shape instead
+        # of gauss
+        tableshape = (energy.shape[0], rad.shape[0])
+        
+        if np.size(sigma) == 1:
+            # same width for all energies
+            tablepsf = TablePSF.from_shape(shape='gauss', width=sigma, rad=rad)
+            energytable_temp = np.tile(tablepsf.psf_value, (tableshape[0], 1))
+            print(energytable_temp.shape)
+        elif np.size(sigma) == len(energy):
+            # one width per energy
+            energytable_temp = np.zeros(tableshape)*u.sr**-1
+            for i in np.arange(tableshape[0]):
+                energytable_temp[i,:] = TablePSF.from_shape(shape='gauss', width=sigma[i], rad=rad).psf_value
+        else:
+            raise AssertionError('There need to be the same number of sigma values as energies')
+        energytable = EnergyDependentTablePSF(energy, rad, exposure=None, psf_value=energytable_temp)
+        psfmap = cls.from_energy_dependent_table_psf(energytable)
+        return psfmap
 
     def to_image(self, spectrum=None, keepdims=True):
         """Reduce to a 2-D map after weighing

--- a/gammapy/irf/psf_map.py
+++ b/gammapy/irf/psf_map.py
@@ -300,7 +300,7 @@ class PSFMap(IRFMap):
         return cls(psf_map=psf_map, exposure_map=exposure_map)
 
     @classmethod
-    def from_gauss(cls, energy, rad, sigma):
+    def from_gauss(cls, energy_axis_true, rad_axis, sigma):
         """Create all -sky PSF map from Gaussian width.
 
         This is used for testing and examples.
@@ -311,20 +311,22 @@ class PSFMap(IRFMap):
 
         Parameters
         ----------
-        energy : `~astropy.units.Quantity`
-            Energy (1-dim)
-        rad : `~astropy.units.Quantity` with angle units
-            Offset angle wrt source position (1-dim)
+        energy_axis_true : `~gammapy.maps.MapAxis`
+            True energy axis. 
+        rad_axis : `~gammapy.maps.MapAxis`
+            Offset angle wrt source position axis. 
         sigma : `~astropy.coordinates.Angle`
             Gaussian width.
+
         Returns
         -------
         psf_map : `PSFMap`
             Point spread function map.
-        """  
-
+        """
         # note: it would be straightforward to also have disk shape instead
         # of gauss
+        energy = energy_axis_true.center
+        rad = rad_axis.center
         tableshape = (energy.shape[0], rad.shape[0])
         if np.size(sigma) == 1:
             # same width for all energies
@@ -333,8 +335,8 @@ class PSFMap(IRFMap):
         elif np.size(sigma) == np.size(energy):
             # one width per energy
             energytable_temp = np.zeros(tableshape)*u.sr**-1
-            for i in np.arange(tableshape[0]):
-                energytable_temp[i, :] = TablePSF.from_shape(shape='gauss', width=sigma[i], rad=rad).psf_value
+            for idx in np.arange(tableshape[0]):
+                energytable_temp[idx, :] = TablePSF.from_shape(shape='gauss', width=sigma[idx], rad=rad).psf_value
         else:
             raise AssertionError('There need to be the same number of sigma values as energies')
         energytable = EnergyDependentTablePSF(energy, rad, exposure=None, psf_value=energytable_temp)

--- a/gammapy/irf/tests/test_psf_map.py
+++ b/gammapy/irf/tests/test_psf_map.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose, assert_almost_equal
+from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.units import Unit
@@ -388,31 +388,31 @@ def test_psfmap_from_gauss():
     energy = np.logspace(-1, 2, 10)*u.TeV
     energy_axis = MapAxis.from_nodes(energy, name="energy_true", interp="log", unit="TeV")
     rad_axis = MapAxis.from_nodes(rad, name="theta", unit="deg")
-    
+
     # define sigmas starting at 0.1 in steps of 0.1 deg
     sigma = (np.arange(energy.shape[0])*0.1 +0.1)*u.deg
     
     # with energy-dependent sigma
-    psfmap = PSFMap.from_gauss(energy, rad, sigma)
+    psfmap = PSFMap.from_gauss(energy_axis, rad_axis, sigma)
     assert psfmap.psf_map.geom.axes[0] == rad_axis
     assert psfmap.psf_map.geom.axes[1] == energy_axis
     assert psfmap.psf_map.unit == Unit("sr-1")
     assert psfmap.psf_map.data.shape == (energy.shape[0], rad.shape[0], 1, 2)
     assert_allclose(
-        psfmap.get_energy_dependent_table_psf().containment_radius(1*u.TeV)[0], 
+        psfmap.get_energy_dependent_table_psf().containment_radius(1*u.TeV)[0],
         psfmap.containment_radius_map(1*u.TeV).data[0][0]*u.deg
     )
-    assert_almost_equal(
-        psfmap.containment_radius_map(energy[3],0.68).data[0][0]/sigma[3].value, 
-         1.5095921854516636, decimal=2
+    assert_allclose(
+        psfmap.containment_radius_map(energy[3], 0.68).data[0][0]/sigma[3].value,
+          1.51, atol=1e-3
     )
-    assert_almost_equal(
-        psfmap.containment_radius_map(energy[3],0.95).data[0][0]/sigma[3].value,
-         2.4477468306808161, decimal=2
+    assert_allclose(
+        psfmap.containment_radius_map(energy[3], 0.95).data[0][0]/sigma[3].value,
+         2.45,atol=1e-3
     )
     
     # with constant sigma
-    psfmap1 = PSFMap.from_gauss(energy, rad, sigma[0])
+    psfmap1 = PSFMap.from_gauss(energy_axis, rad_axis, sigma[0])
     assert psfmap1.psf_map.geom.axes[0] == rad_axis
     assert psfmap1.psf_map.geom.axes[1] == energy_axis
     assert psfmap1.psf_map.unit == Unit("sr-1")
@@ -429,4 +429,5 @@ def test_psfmap_from_gauss():
     
     # test that it won't work with different number of sigmas and energies
     with pytest.raises(AssertionError):
-        psfmap2 = PSFMap.from_gauss(energy, rad, sigma[:3])
+        psfmap2 = PSFMap.from_gauss(energy_axis, rad_axis, sigma[:3])
+        

--- a/gammapy/irf/tests/test_psf_map.py
+++ b/gammapy/irf/tests/test_psf_map.py
@@ -408,7 +408,7 @@ def test_psfmap_from_gauss():
     )
     assert_allclose(
         psfmap.containment_radius_map(energy[3], 0.95).data[0][0]/sigma[3].value,
-         2.45,atol=1e-3
+         2.45, atol=1e-3
     )
     
     # with constant sigma
@@ -430,4 +430,3 @@ def test_psfmap_from_gauss():
     # test that it won't work with different number of sigmas and energies
     with pytest.raises(AssertionError):
         psfmap2 = PSFMap.from_gauss(energy_axis, rad_axis, sigma[:3])
-        

--- a/gammapy/irf/tests/test_psf_map.py
+++ b/gammapy/irf/tests/test_psf_map.py
@@ -384,8 +384,8 @@ def test_to_image():
     assert_allclose(psf2D.psf_map.data[0][0][12][12], 23255.41204827, rtol=1e-2)
 
 def test_psfmap_from_gauss():
-    rad = np.linspace(0,1.5,50)*u.deg
-    energy = np.logspace(-1,2,10)*u.TeV
+    rad = np.linspace(0, 1.5, 50)*u.deg
+    energy = np.logspace(-1, 2, 10)*u.TeV
     energy_axis = MapAxis.from_nodes(energy, name="energy_true", interp="log", unit="TeV")
     rad_axis = MapAxis.from_nodes(rad, name="theta", unit="deg")
     
@@ -404,11 +404,11 @@ def test_psfmap_from_gauss():
     )
     assert_almost_equal(
         psfmap.containment_radius_map(energy[3],0.68).data[0][0]/sigma[3].value, 
-        1.5095921854516636,decimal=2
+         1.5095921854516636, decimal=2
     )
     assert_almost_equal(
         psfmap.containment_radius_map(energy[3],0.95).data[0][0]/sigma[3].value,
-        2.4477468306808161,decimal=2
+         2.4477468306808161, decimal=2
     )
     
     # with constant sigma
@@ -421,11 +421,11 @@ def test_psfmap_from_gauss():
         psfmap1.get_energy_dependent_table_psf().containment_radius(1*u.TeV)[0],
          psfmap1.containment_radius_map(1*u.TeV).data[0][0]*u.deg
     )
-    
+
     # check that the PSF with the same sigma is the same
     psfvalue = psfmap.get_energy_dependent_table_psf().psf_value[0]
     psfvalue1 = psfmap1.get_energy_dependent_table_psf().psf_value[0]
-    assert_allclose(psfvalue,psfvalue1 ,atol=1e-7) 
+    assert_allclose(psfvalue, psfvalue1, atol=1e-7)
     
     # test that it won't work with different number of sigmas and energies
     with pytest.raises(AssertionError):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request creates a function `PSFMap.from_gaussian()` to create an all-sky `PSFMap` with Gaussian profiles, which is useful for tests. The shape (sigma) can depend on energy but it does not depend on position. I used existing functions to create a `TablePSF` from a Gaussian profile, extended it to an `EnergyDependentTablePSF` and then finally a `PSFMap`. Note that it would also be straightforward to have a disk profile, as that is already an option in `TablePSF.from_shape()`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
I also created a test, `test_psfmap_from_gauss()`, to make sure the behavior is the expected one.