### PR TITLE
Allow custom spectral models corrections for BackgroundModel

### DIFF
--- a/docs/tutorials/analysis_2.ipynb
+++ b/docs/tutorials/analysis_2.ipynb
@@ -261,7 +261,7 @@
     "    # fit background model\n",
     "    dataset = maker_fov.run(dataset)\n",
     "    print(\n",
-    "        f\"Background norm obs {obs.obs_id}: {dataset.background_model.norm.value:.2f}\"\n",
+    "        f\"Background norm obs {obs.obs_id}: {dataset.background_model.spectral_model.norm.value:.2f}\"\n",
     "    )\n",
     "    # The resulting dataset cutout is stacked onto the final one\n",
     "    stacked.stack(dataset)"
@@ -588,7 +588,25 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
@@ -616,7 +634,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0.0,
+       "index": 0,
        "layout": "IPY_MODEL_a517c2af0a5e486a9159bd8012d32fac",
        "orientation": "horizontal",
        "readout": true,
@@ -848,7 +866,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0.0,
+       "index": 0,
        "layout": "IPY_MODEL_a1e366163a044038a7ecece700881580",
        "style": "IPY_MODEL_c3f3ea0bc74849ddbac907b638cd3d40"
       }
@@ -930,8 +948,8 @@
       }
      }
     },
-    "version_major": 2.0,
-    "version_minor": 0.0
+    "version_major": 2,
+    "version_minor": 0
    }
   }
  },

--- a/docs/tutorials/analysis_3d.ipynb
+++ b/docs/tutorials/analysis_3d.ipynb
@@ -543,7 +543,7 @@
     "model_joint = model.copy(name=\"source-joint\")\n",
     "for dataset in analysis_joint.datasets:\n",
     "    dataset.models.append(model_joint)\n",
-    "    dataset.background_model.norm.value = 1.1"
+    "    dataset.background_model.spectral_model.norm.value = 1.1"
    ]
   },
   {
@@ -610,7 +610,7 @@
    "outputs": [],
    "source": [
     "for dataset in analysis_joint.datasets:\n",
-    "    print(dataset.background_model.norm.value)"
+    "    print(dataset.background_model.spectral_model.norm.value)"
    ]
   },
   {

--- a/docs/tutorials/analysis_3d.ipynb
+++ b/docs/tutorials/analysis_3d.ipynb
@@ -311,7 +311,7 @@
     ")\n",
     "\n",
     "dataset_stacked.models.append(model)\n",
-    "dataset_stacked.background_model.norm.value = 1.3"
+    "dataset_stacked.background_model.spectral_model.norm.value = 1.3"
    ]
   },
   {
@@ -740,7 +740,25 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
   },
   "nbsphinx": {
    "orphan": true
@@ -802,7 +820,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 1.0,
+       "index": 1,
        "layout": "IPY_MODEL_90f3435bb1694269b8e787efc8dc0a26",
        "style": "IPY_MODEL_20c37ca6d6d5485fafdbd4ce12825a84"
       }
@@ -964,7 +982,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0.0,
+       "index": 0,
        "layout": "IPY_MODEL_c49288d19d1e44329918ae6e184252a3",
        "orientation": "horizontal",
        "readout": true,
@@ -1018,7 +1036,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0.0,
+       "index": 0,
        "layout": "IPY_MODEL_3941f1865c024123bb6eeb52f656716d",
        "orientation": "horizontal",
        "readout": true,
@@ -1046,7 +1064,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 1.0,
+       "index": 1,
        "layout": "IPY_MODEL_e195da0534a1499ba0d3c97ff936049f",
        "style": "IPY_MODEL_f1e84267c722485fae35984cdd520ab0"
       }
@@ -1433,8 +1451,8 @@
       }
      }
     },
-    "version_major": 2.0,
-    "version_minor": 0.0
+    "version_major": 2,
+    "version_minor": 0
    }
   }
  },

--- a/docs/tutorials/fermi_lat.ipynb
+++ b/docs/tutorials/fermi_lat.ipynb
@@ -581,10 +581,8 @@
     "# pre-compute iso model\n",
     "evaluator = MapEvaluator(diffuse_iso)\n",
     "evaluator.update(exposure=exposure, psf=psf, edisp=edisp, geom=counts.geom)\n",
-    "diffuse_iso = BackgroundModel(\n",
-    "    evaluator.compute_npred(), name=\"bkg-iso\", norm=3.3\n",
-    ")\n",
-    "\n",
+    "diffuse_iso = BackgroundModel(evaluator.compute_npred(), name=\"bkg-iso\")\n",
+    "diffuse_iso.spectral_model.norm.value = 3.3\n",
     "# pre-compute diffuse model\n",
     "evaluator = MapEvaluator(diffuse_gal)\n",
     "evaluator.update(exposure=exposure, psf=psf, edisp=edisp, geom=counts.geom)\n",
@@ -705,7 +703,25 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
   },
   "toc": {
    "base_numbering": 1,

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -339,10 +339,16 @@ def test_analysis_3d_joint_datasets():
     analysis.get_observations()
     analysis.get_datasets()
     assert len(analysis.datasets) == 2
-    assert_allclose(analysis.datasets[0].background_model.spectral_model.norm.value, 1.031743694988066)
-    assert_allclose(analysis.datasets[0].background_model.spectral_model.tilt.value, 0.0)
     assert_allclose(
-        analysis.datasets[1].background_model.spectral_model.norm.value, 0.9776349021876344
+        analysis.datasets[0].background_model.spectral_model.norm.value,
+        1.031743694988066,
+    )
+    assert_allclose(
+        analysis.datasets[0].background_model.spectral_model.tilt.value, 0.0
+    )
+    assert_allclose(
+        analysis.datasets[1].background_model.spectral_model.norm.value,
+        0.9776349021876344,
     )
 
 

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -314,7 +314,7 @@ def test_analysis_3d():
     analysis.get_observations()
     analysis.get_datasets()
     analysis.read_models(MODEL_FILE)
-    analysis.datasets["stacked"].background_model.tilt.frozen = False
+    analysis.datasets["stacked"].background_model.spectral_model.tilt.frozen = False
     analysis.run_fit()
     analysis.get_flux_points()
 
@@ -339,10 +339,10 @@ def test_analysis_3d_joint_datasets():
     analysis.get_observations()
     analysis.get_datasets()
     assert len(analysis.datasets) == 2
-    assert_allclose(analysis.datasets[0].background_model.norm.value, 1.031743694988066)
-    assert_allclose(analysis.datasets[0].background_model.tilt.value, 0.0)
+    assert_allclose(analysis.datasets[0].background_model.spectral_model.norm.value, 1.031743694988066)
+    assert_allclose(analysis.datasets[0].background_model.spectral_model.tilt.value, 0.0)
     assert_allclose(
-        analysis.datasets[1].background_model.norm.value, 0.9776349021876344
+        analysis.datasets[1].background_model.spectral_model.norm.value, 0.9776349021876344
     )
 
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1063,7 +1063,7 @@ class MapDataset(Dataset):
         if self.background_model is not None:
             bkg = self.background_model.evaluate().get_spectrum(on_region, np.sum)
             bkg_model = BackgroundModel(bkg, name=name + "-bkg", datasets_names=[name])
-            bkg_model.norm.frozen = True
+            bkg_model.spectral_model.norm.frozen = True
             kwargs["models"] = Models([bkg_model])
 
         if self.exposure is not None:

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1933,7 +1933,7 @@ class MapDatasetOnOff(MapDataset):
             Sliced map object.
         """
         kwargs = {"name": name}
-        dataset = super().slice_by_idx(slices,name)
+        dataset = super().slice_by_idx(slices, name)
 
         if self.counts_off is not None:
             kwargs["counts_off"] = self.counts_off.slice_by_idx(slices=slices)
@@ -1945,6 +1945,7 @@ class MapDatasetOnOff(MapDataset):
             kwargs["acceptance_off"] = self.acceptance_off.slice_by_idx(slices=slices)
 
         return self.from_map_dataset(dataset, **kwargs)
+
 
 class MapEvaluator:
     """Sky model evaluation on maps.

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -700,7 +700,7 @@ class SpectrumDataset(Dataset):
         if self.background_model is not None:
             m = self.background_model.evaluate().slice_by_idx(slices=slices)
             bkg_model = BackgroundModel(map=m, datasets_names=[name])
-            bkg_model.norm.frozen = True
+            bkg_model.spectral_model.norm.frozen = True
             kwargs["models"] = bkg_model
 
         if self.edisp is not None:

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -388,7 +388,7 @@ def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
 @requires_data()
 def test_map_fit(sky_model, geom, geom_etrue):
     dataset_1 = get_map_dataset(sky_model, geom, geom_etrue, name="test-1")
-    dataset_1.background_model.norm.value = 0.5
+    dataset_1.background_model.spectral_model.norm.value = 0.5
     dataset_1.counts = dataset_1.npred()
 
     dataset_2 = get_map_dataset(sky_model, geom, geom_etrue, name="test-2")
@@ -397,8 +397,8 @@ def test_map_fit(sky_model, geom, geom_etrue):
 
     sky_model.parameters["sigma"].frozen = True
 
-    dataset_1.background_model.norm.value = 0.49
-    dataset_2.background_model.norm.value = 0.99
+    dataset_1.background_model.spectral_model.norm.value = 0.49
+    dataset_2.background_model.spectral_model.norm.value = 0.99
 
     fit = Fit([dataset_1, dataset_2])
     result = fit.run()
@@ -456,7 +456,7 @@ def test_map_fit_one_energy_bin(sky_model, geom_image):
     dataset = get_map_dataset(sky_model, geom_image, geom_etrue)
     sky_model.spectral_model.index.value = 3.0
     sky_model.spectral_model.index.frozen = True
-    dataset.background_model.norm.value = 0.5
+    dataset.background_model.spectral_model.norm.value = 0.5
 
     dataset.counts = dataset.npred()
 

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -49,7 +49,7 @@ def spectrum_dataset():
     background = RegionNDMap.create(region="icrs;circle(0, 0, 0.1)", axes=[axis])
 
     bkg_model = BackgroundModel(background, name=name + "-bkg", datasets_names=[name])
-    bkg_model.norm.frozen = True
+    bkg_model.spectral_model.norm.frozen = True
 
     models = Models([bkg_model, model])
     aeff = RegionNDMap.create(region="icrs;circle(0, 0, 0.1)", axes=[axis_true])

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -111,4 +111,4 @@ class FoVBackgroundMaker(Maker):
             )
         else:
             scale = count_tot / bkg_tot
-            dataset.background_model.norm.value = scale
+            dataset.background_model.spectral_model.norm.value = scale

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -27,6 +27,7 @@ class FoVBackgroundMaker(Maker):
     exclusion_mask : `~gammapy.maps.WcsNDMap`
         Exclusion mask
     """
+
     tag = "FoVBackgroundMaker"
 
     def __init__(self, method="scale", exclusion_mask=None):

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -78,8 +78,8 @@ def test_fov_bkg_maker_scale(obs_dataset, exclusion_mask):
     test_dataset = obs_dataset.copy(name="test-fov")
     dataset = fov_bkg_maker.run(test_dataset)
 
-    assert_allclose(dataset.background_model.norm.value, 0.830789, rtol=1e-4)
-    assert_allclose(dataset.background_model.tilt.value, 0.0, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.norm.value, 0.830789, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.tilt.value, 0.0, rtol=1e-4)
 
 
 @requires_data()
@@ -90,8 +90,8 @@ def test_fov_bkg_maker_fit(obs_dataset, exclusion_mask):
     test_dataset = obs_dataset.copy(name="test-fov")
     dataset = fov_bkg_maker.run(test_dataset)
 
-    assert_allclose(dataset.background_model.norm.value, 0.830789, rtol=1e-4)
-    assert_allclose(dataset.background_model.tilt.value, 0.0, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.norm.value, 0.830789, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.tilt.value, 0.0, rtol=1e-4)
 
 
 @requires_data()
@@ -115,10 +115,10 @@ def test_fov_bkg_maker_fit_with_source_model(obs_dataset, exclusion_mask):
     # Here we check that source parameters are correctly thawed after fit.
     assert not dataset.models.parameters["index"].frozen
     assert not dataset.models.parameters["lon_0"].frozen
-    assert not dataset.background_model.norm.frozen
+    assert not dataset.background_model.spectral_model.norm.frozen
 
-    assert_allclose(dataset.background_model.norm.value, 0.830789, rtol=1e-4)
-    assert_allclose(dataset.background_model.tilt.value, 0.0, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.norm.value, 0.830789, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.tilt.value, 0.0, rtol=1e-4)
 
 
 @requires_data()
@@ -127,11 +127,11 @@ def test_fov_bkg_maker_fit_with_tilt(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
 
     test_dataset = obs_dataset.copy(name="test-fov")
-    test_dataset.background_model.tilt.frozen = False
+    test_dataset.background_model.spectral_model.tilt.frozen = False
     dataset = fov_bkg_maker.run(test_dataset)
 
-    assert_allclose(dataset.background_model.norm.value, 0.9034, rtol=1e-4)
-    assert_allclose(dataset.background_model.tilt.value, 0.0728, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.norm.value, 0.9034, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.tilt.value, 0.0728, rtol=1e-4)
 
 
 @requires_data()
@@ -144,7 +144,7 @@ def test_fov_bkg_maker_fit_fail(obs_dataset, exclusion_mask):
     test_dataset.background_model.map.data *= -1
     dataset = fov_bkg_maker.run(test_dataset)
 
-    assert_allclose(dataset.background_model.norm.value, 1, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.norm.value, 1, rtol=1e-4)
 
 
 @requires_data()
@@ -156,4 +156,4 @@ def test_fov_bkg_maker_scale_fail(obs_dataset, exclusion_mask):
     test_dataset.background_model.map.data *= -1
     dataset = fov_bkg_maker.run(test_dataset)
 
-    assert_allclose(dataset.background_model.norm.value, 1, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.norm.value, 1, rtol=1e-4)

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -78,7 +78,9 @@ def test_fov_bkg_maker_scale(obs_dataset, exclusion_mask):
     test_dataset = obs_dataset.copy(name="test-fov")
     dataset = fov_bkg_maker.run(test_dataset)
 
-    assert_allclose(dataset.background_model.spectral_model.norm.value, 0.830789, rtol=1e-4)
+    assert_allclose(
+        dataset.background_model.spectral_model.norm.value, 0.830789, rtol=1e-4
+    )
     assert_allclose(dataset.background_model.spectral_model.tilt.value, 0.0, rtol=1e-4)
 
 
@@ -90,7 +92,9 @@ def test_fov_bkg_maker_fit(obs_dataset, exclusion_mask):
     test_dataset = obs_dataset.copy(name="test-fov")
     dataset = fov_bkg_maker.run(test_dataset)
 
-    assert_allclose(dataset.background_model.spectral_model.norm.value, 0.830789, rtol=1e-4)
+    assert_allclose(
+        dataset.background_model.spectral_model.norm.value, 0.830789, rtol=1e-4
+    )
     assert_allclose(dataset.background_model.spectral_model.tilt.value, 0.0, rtol=1e-4)
 
 
@@ -117,7 +121,9 @@ def test_fov_bkg_maker_fit_with_source_model(obs_dataset, exclusion_mask):
     assert not dataset.models.parameters["lon_0"].frozen
     assert not dataset.background_model.spectral_model.norm.frozen
 
-    assert_allclose(dataset.background_model.spectral_model.norm.value, 0.830789, rtol=1e-4)
+    assert_allclose(
+        dataset.background_model.spectral_model.norm.value, 0.830789, rtol=1e-4
+    )
     assert_allclose(dataset.background_model.spectral_model.tilt.value, 0.0, rtol=1e-4)
 
 
@@ -130,8 +136,12 @@ def test_fov_bkg_maker_fit_with_tilt(obs_dataset, exclusion_mask):
     test_dataset.background_model.spectral_model.tilt.frozen = False
     dataset = fov_bkg_maker.run(test_dataset)
 
-    assert_allclose(dataset.background_model.spectral_model.norm.value, 0.901523, rtol=1e-4)
-    assert_allclose(dataset.background_model.spectral_model.tilt.value, 0.071069, rtol=1e-4)
+    assert_allclose(
+        dataset.background_model.spectral_model.norm.value, 0.901523, rtol=1e-4
+    )
+    assert_allclose(
+        dataset.background_model.spectral_model.tilt.value, 0.071069, rtol=1e-4
+    )
 
 
 @requires_data()

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -130,8 +130,8 @@ def test_fov_bkg_maker_fit_with_tilt(obs_dataset, exclusion_mask):
     test_dataset.background_model.spectral_model.tilt.frozen = False
     dataset = fov_bkg_maker.run(test_dataset)
 
-    assert_allclose(dataset.background_model.spectral_model.norm.value, 0.9034, rtol=1e-4)
-    assert_allclose(dataset.background_model.spectral_model.tilt.value, 0.0728, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.norm.value, 0.901523, rtol=1e-4)
+    assert_allclose(dataset.background_model.spectral_model.tilt.value, 0.071069, rtol=1e-4)
 
 
 @requires_data()

--- a/gammapy/makers/background/tests/test_ring.py
+++ b/gammapy/makers/background/tests/test_ring.py
@@ -139,7 +139,11 @@ def test_adaptive_ring_bkg_maker(pars, geom, observations, exclusion_mask):
     mask = dataset.mask_safe
     assert_allclose(dataset_on_off.counts_off.data[mask].sum(), pars["counts_off"])
     assert_allclose(
-        dataset_on_off.acceptance_off.data[mask].sum(), pars["acceptance_off"], rtol=1e-5
+        dataset_on_off.acceptance_off.data[mask].sum(),
+        pars["acceptance_off"],
+        rtol=1e-5,
     )
     assert_allclose(dataset_on_off.alpha.data[0][100][100], pars["alpha"], rtol=1e-5)
-    assert_allclose(dataset_on_off.exposure.data[0][100][100], pars["exposure"], rtol=1e-5)
+    assert_allclose(
+        dataset_on_off.exposure.data[0][100][100], pars["exposure"], rtol=1e-5
+    )

--- a/gammapy/makers/background/tests/test_ring.py
+++ b/gammapy/makers/background/tests/test_ring.py
@@ -139,7 +139,7 @@ def test_adaptive_ring_bkg_maker(pars, geom, observations, exclusion_mask):
     mask = dataset.mask_safe
     assert_allclose(dataset_on_off.counts_off.data[mask].sum(), pars["counts_off"])
     assert_allclose(
-        dataset_on_off.acceptance_off.data[mask].sum(), pars["acceptance_off"]
+        dataset_on_off.acceptance_off.data[mask].sum(), pars["acceptance_off"], rtol=1e-5
     )
     assert_allclose(dataset_on_off.alpha.data[0][100][100], pars["alpha"], rtol=1e-5)
     assert_allclose(dataset_on_off.exposure.data[0][100][100], pars["exposure"], rtol=1e-5)

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -200,7 +200,7 @@ class SpectrumDatasetMaker(Maker):
             bkg_model = BackgroundModel(
                 bkg, name=dataset.name + "-bkg", datasets_names=[dataset.name],
             )
-            bkg_model.norm.frozen = True
+            bkg_model.spectral_model.norm.frozen = True
             kwargs["models"] = bkg_model
 
         if "aeff" in self.selection:

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -637,12 +637,7 @@ class BackgroundModel(Model):
     map = LazyFitsData(cache=True)
 
     def __init__(
-        self,
-        map,
-        spectral_model = None,
-        name=None,
-        filename=None,
-        datasets_names=None,
+        self, map, spectral_model=None, name=None, filename=None, datasets_names=None,
     ):
         if isinstance(map, Map):
             axis = map.geom.get_axis_by_name("energy")
@@ -695,7 +690,7 @@ class BackgroundModel(Model):
         parameters = []
         parameters.append(self.spectral_model.parameters)
         return Parameters.from_stack(parameters)
-            
+
     def evaluate(self):
         """Evaluate background model.
 
@@ -705,7 +700,7 @@ class BackgroundModel(Model):
             Background evaluated on the Map
         """
         value = self.spectral_model(self.energy_center).value
-        back_values =  self.map.data * value
+        back_values = self.map.data * value
         return self.map.copy(data=back_values)
 
     def to_dict(self):
@@ -748,7 +743,7 @@ class BackgroundModel(Model):
 
         return cls(
             map=bkg_map,
-            spectral_model = spectral_model,
+            spectral_model=spectral_model,
             name=data["name"],
             datasets_names=data.get("datasets_names"),
             filename=data.get("filename"),

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -783,8 +783,8 @@ class BackgroundModel(Model):
         cutout_kwargs = {"position": position, "width": width, "mode": mode}
 
         bkg_map = self.map.cutout(**cutout_kwargs)
-        parameters = self.parameters.copy()
-        return self.__class__.from_parameters(parameters, map=bkg_map, name=name)
+        spectral_model = self.spectral_model.copy()
+        return self.__class__(bkg_map, spectral_model=spectral_model, name=name)
 
     def stack(self, other, weights=None):
         """Stack background model in place.
@@ -802,8 +802,8 @@ class BackgroundModel(Model):
         self.map = bkg
 
         # reset parameter values
-        self.norm.value = 1
-        self.tilt.value = 0
+        self.spectral_model.norm.value = 1
+        self.spectral_model.tilt.value = 0
 
     def __str__(self):
         str_ = self.__class__.__name__ + "\n\n"

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -11,7 +11,7 @@ from gammapy.utils.scripts import make_name, make_path
 from gammapy.utils.fits import LazyFitsData, HDULocation
 from .core import Model, Models
 from .spatial import SpatialModel
-from .spectral import SpectralModel
+from .spectral import SpectralModel, PowerLawNormSpectralModel
 from .temporal import TemporalModel
 
 
@@ -635,17 +635,12 @@ class BackgroundModel(Model):
     """
 
     tag = "BackgroundModel"
-    norm = Parameter("norm", 1, unit="", min=0)
-    tilt = Parameter("tilt", 0, unit="", frozen=True)
-    reference = Parameter("reference", "1 TeV", frozen=True)
     map = LazyFitsData(cache=True)
 
     def __init__(
         self,
         map,
-        norm=norm.quantity,
-        tilt=tilt.quantity,
-        reference=reference.quantity,
+        spectral_model = None,
         name=None,
         filename=None,
         datasets_names=None,
@@ -658,18 +653,21 @@ class BackgroundModel(Model):
                 )
 
         self.map = map
-
         self._name = make_name(name)
         self.filename = filename
+
+        if spectral_model is None:
+            spectral_model = PowerLawNormSpectralModel()
+            spectral_model.tilt.frozen = True
+        self._spectral_model = spectral_model
 
         if isinstance(datasets_names, list):
             if len(datasets_names) != 1:
                 raise ValueError(
                     "Currently background models can only be assigned to one dataset."
                 )
-
         self.datasets_names = datasets_names
-        super().__init__(norm=norm, tilt=tilt, reference=reference)
+        super().__init__()
 
     @property
     def name(self):
@@ -682,6 +680,22 @@ class BackgroundModel(Model):
         energy = energy_axis.center
         return energy[:, np.newaxis, np.newaxis]
 
+    @property
+    def spectral_model(self):
+        """`~gammapy.modeling.models.SpectralModel`"""
+        return self._spectral_model
+
+    @spectral_model.setter
+    def spectral_model(self, model):
+        if not (model is None or isinstance(model, SpectralModel)):
+            raise TypeError(f"Invalid type: {model!r}")
+
+    @property
+    def parameters(self):
+        parameters = []
+        parameters.append(self.spectral_model.parameters)
+        return Parameters.from_stack(parameters)
+            
     def evaluate(self):
         """Evaluate background model.
 
@@ -690,22 +704,18 @@ class BackgroundModel(Model):
         background_map : `~gammapy.maps.Map`
             Background evaluated on the Map
         """
-        norm = self.norm.value
-        tilt = self.tilt.value
-        reference = self.reference.quantity
-        tilt_factor = np.power((self.energy_center / reference).to(""), -tilt)
-        back_values = norm * self.map.data * tilt_factor.value
+        value = self.spectral_model(self.energy_center).value
+        back_values =  self.map.data * value
         return self.map.copy(data=back_values)
 
     def to_dict(self):
         data = {}
         data["name"] = self.name
-        data.update(super().to_dict())
+        data["type"] = self.tag
+        data["spectral"] = self.spectral_model.to_dict()
 
         if self.filename is not None:
             data["filename"] = self.filename
-
-        data["parameters"] = data.pop("parameters")
 
         if self.datasets_names is not None:
             data["datasets_names"] = self.datasets_names
@@ -714,6 +724,15 @@ class BackgroundModel(Model):
 
     @classmethod
     def from_dict(cls, data):
+        from gammapy.modeling.models import SPECTRAL_MODEL_REGISTRY
+
+        spectral_data = data.get("spectral")
+        if spectral_data is not None:
+            model_class = SPECTRAL_MODEL_REGISTRY.get_cls(spectral_data["type"])
+            spectral_model = model_class.from_dict(spectral_data)
+        else:
+            spectral_model = None
+
         if "filename" in data:
             bkg_map = Map.read(data["filename"])
         elif "map" in data:
@@ -727,11 +746,9 @@ class BackgroundModel(Model):
             )
             bkg_map = Map.from_geom(geom)
 
-        parameters = Parameters.from_dict(data["parameters"])
-
-        return cls.from_parameters(
-            parameters=parameters,
+        return cls(
             map=bkg_map,
+            spectral_model = spectral_model,
             name=data["name"],
             datasets_names=data.get("datasets_names"),
             filename=data.get("filename"),

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -169,7 +169,6 @@ class SkyModel(SkyModelBase):
     def spectral_model(self, model):
         if not (model is None or isinstance(model, SpectralModel)):
             raise TypeError(f"Invalid type: {model!r}")
-
         self._spectral_model = model
 
     @property
@@ -659,7 +658,7 @@ class BackgroundModel(Model):
         if spectral_model is None:
             spectral_model = PowerLawNormSpectralModel()
             spectral_model.tilt.frozen = True
-        self._spectral_model = spectral_model
+        self.spectral_model = spectral_model
 
         if isinstance(datasets_names, list):
             if len(datasets_names) != 1:
@@ -689,6 +688,7 @@ class BackgroundModel(Model):
     def spectral_model(self, model):
         if not (model is None or isinstance(model, SpectralModel)):
             raise TypeError(f"Invalid type: {model!r}")
+        self._spectral_model = model
 
     @property
     def parameters(self):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -625,12 +625,9 @@ class BackgroundModel(Model):
     ----------
     map : `~gammapy.maps.Map`
         Background model map
-    norm : float
-        Background normalization
-    tilt : float
-        Additional tilt in the spectrum
-    reference : `~astropy.units.Quantity`
-        Reference energy of the tilt.
+    spectral_model : `~gammapy.modeling.models.SpectralModel`
+        Normalized spectral model,
+        default is `~gammapy.modeling.models.PowerLawNormSpectralModel`
     """
 
     tag = "BackgroundModel"

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -593,7 +593,7 @@ class PowerLawNormSpectralModel(SpectralModel):
     """
 
     tag = ["PowerLawNormSpectralModel", "pl-norm"]
-    tilt = Parameter("tilt", 2.0)
+    tilt = Parameter("tilt", 0)
     norm = Parameter("norm", 1, unit="")
     reference = Parameter("reference", "1 TeV", frozen=True)
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -593,8 +593,8 @@ class PowerLawNormSpectralModel(SpectralModel):
     """
 
     tag = ["PowerLawNormSpectralModel", "pl-norm"]
-    tilt = Parameter("tilt", 0)
     norm = Parameter("norm", 1, unit="")
+    tilt = Parameter("tilt", 0)
     reference = Parameter("reference", "1 TeV", frozen=True)
 
     @staticmethod

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -182,20 +182,26 @@ def test_skymodel_addition(sky_model, sky_models, sky_models_2, diffuse_model):
 
 
 def test_background_model(background):
-    bkg1 = BackgroundModel(background, norm=2.0).evaluate()
-    assert_allclose(bkg1.data[0][0][0], background.data[0][0][0] * 2.0, rtol=1e-3)
-    assert_allclose(bkg1.data.sum(), background.data.sum() * 2.0, rtol=1e-3)
+    bkg1 = BackgroundModel(background)
+    bkg1.spectral_model.norm.value = 2.0
+    npred1 = bkg1.evaluate()
+    assert_allclose(npred1.data[0][0][0], background.data[0][0][0] * 2.0, rtol=1e-3)
+    assert_allclose(npred1.data.sum(), background.data.sum() * 2.0, rtol=1e-3)
 
-    bkg2 = BackgroundModel(
-        background, norm=2.0, tilt=0.2, reference="1000 GeV"
-    ).evaluate()
-    assert_allclose(bkg2.data[0][0][0], 2.254e-07, rtol=1e-3)
-    assert_allclose(bkg2.data.sum(), 7.352e-06, rtol=1e-3)
+    bkg2 = BackgroundModel(background)
+    bkg2.spectral_model.norm.value = 2.0
+    bkg2.spectral_model.tilt.value = 0.2
+    bkg2.spectral_model.reference.quantity = "1000 GeV"
+
+    npred2 = bkg2.evaluate()
+    assert_allclose(npred2.data[0][0][0], 2.254e-07, rtol=1e-3)
+    assert_allclose(npred2.data.sum(), 7.352e-06, rtol=1e-3)
 
 
 def test_background_model_io(tmpdir, background):
     filename = str(tmpdir / "test-bkg-file.fits")
-    bkg = BackgroundModel(background, norm=2.0, filename=filename)
+    bkg = BackgroundModel(background, filename=filename)
+    bkg.spectral_model.norm.value = 2.0
     bkg.map.write(filename, overwrite=True)
     bkg_dict = bkg.to_dict()
     bkg_read = bkg.from_dict(bkg_dict)

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -70,7 +70,7 @@ TEST_MODELS = [
     dict(
         name="norm-powerlaw",
         model=PowerLawNormSpectralModel(
-            index=2 * u.Unit(""), norm=4.0 * u.Unit(""), reference=1 * u.TeV,
+            tilt=2 * u.Unit(""), norm=4.0 * u.Unit(""), reference=1 * u.TeV,
         ),
         val_at_2TeV=u.Quantity(1.0, ""),
         integral_1_10TeV=u.Quantity(3.6, "TeV"),


### PR DESCRIPTION
Add spectral_model argument to BackgroundModel instead of norm and tilt arguments in order to allows more refine parametrisation. Default spectral_model is PowerLawNormSpectralModel which is equivalent to previous parametrisation. 