### PR TITLE
Interpolation in makers map

### DIFF
--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -13,7 +13,6 @@ from .utils import (
     make_map_background_irf,
     make_map_exposure_true_energy,
     make_psf_map,
-    interpolate_map_IRF,
     interpolate_edisp_kernel_map,
     interpolate_psf_map,
 )
@@ -89,8 +88,7 @@ class MapDatasetMaker(Maker):
             Exposure map.
         """
         if isinstance(observation.aeff, Map):
-            return interpolate_map_IRF(
-                map_IRF=observation.aeff,
+            return observation.aeff.interp_to_geom(
                 geom=geom,
             )
         return make_map_exposure_true_energy(
@@ -139,8 +137,7 @@ class MapDatasetMaker(Maker):
             Background map.
         """
         if isinstance(observation.bkg, Map):
-            return interpolate_map_IRF(
-                map_IRF=observation.bkg,
+            return observation.bkg.interp_to_geom(
                 geom=geom,
             )
         bkg_coordsys = observation.bkg.meta.get("FOVALIGN", "RADEC")

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -89,7 +89,7 @@ class MapDatasetMaker(Maker):
         """
         if isinstance(observation.aeff, Map):
             return interpolate_map_IRF(
-                aeff=observation.aeff,
+                map_IRF=observation.aeff,
                 geom=geom,
             )
         else:
@@ -140,7 +140,7 @@ class MapDatasetMaker(Maker):
         """
         if isinstance(observation.bkg, Map):
             return interpolate_map_IRF(
-                aeff=observation.bkg,
+                map_IRF=observation.bkg,
                 geom=geom,
             )
         else:

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -14,6 +14,7 @@ from .utils import (
     make_map_exposure_true_energy,
     make_map_exposure_from_map,
     make_psf_map,
+    interpolate_map_IRF,
 )
 
 __all__ = ["MapDatasetMaker"]
@@ -87,7 +88,7 @@ class MapDatasetMaker(Maker):
             Exposure map.
         """
         if isinstance(observation.aeff, Map):
-            return make_map_exposure_from_map(
+            return interpolate_map_IRF(
                 aeff=observation.aeff,
                 geom=geom,
             )

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -12,7 +12,6 @@ from .utils import (
     make_edisp_kernel_map,
     make_map_background_irf,
     make_map_exposure_true_energy,
-    make_map_exposure_from_map,
     make_psf_map,
     interpolate_map_IRF,
 )

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -204,7 +204,7 @@ class MapDatasetMaker(Maker):
             EdispKernel map.
         """
 
-        if isinstance(observation.edisp,EDispKernelMap):
+        if isinstance(observation.edisp, EDispKernelMap):
             exposure_map = None
             return interpolate_edisp_kernel_map(
                 edisp=observation.edisp, 

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -13,8 +13,6 @@ from .utils import (
     make_map_background_irf,
     make_map_exposure_true_energy,
     make_psf_map,
-    interpolate_edisp_kernel_map,
-    interpolate_psf_map,
 )
 
 __all__ = ["MapDatasetMaker"]
@@ -200,9 +198,11 @@ class MapDatasetMaker(Maker):
             EdispKernel map.
         """
         if isinstance(observation.edisp, EDispKernelMap):
-            return interpolate_edisp_kernel_map(
-                edisp=observation.edisp,
-                geom=geom,
+            exposure = None
+            interp_map = observation.edisp.edisp_map.interp_to_geom(geom)
+            return EDispKernelMap(
+                edisp_kernel_map = interp_map,
+                exposure_map = exposure
                 )
         exposure = self.make_exposure_irf(geom.squash(axis="energy"), observation)
 
@@ -230,10 +230,10 @@ class MapDatasetMaker(Maker):
         """
         psf = observation.psf
         if isinstance(psf, PSFMap):
-            return interpolate_psf_map(
-                psf=psf,
-                geom=geom,
+            return PSFMap(
+                psf.psf_map.interp_to_geom(geom)
                 )
+
         if isinstance(psf, EnergyDependentMultiGaussPSF):
             rad_axis = geom.get_axis_by_name("theta")
             psf = psf.to_psf3d(rad=rad_axis.center)

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -12,6 +12,7 @@ from .utils import (
     make_edisp_kernel_map,
     make_map_background_irf,
     make_map_exposure_true_energy,
+    make_map_exposure_from_map,
     make_psf_map,
 )
 
@@ -85,12 +86,18 @@ class MapDatasetMaker(Maker):
         exposure : `~gammapy.maps.Map`
             Exposure map.
         """
-        return make_map_exposure_true_energy(
-            pointing=observation.pointing_radec,
-            livetime=observation.observation_live_time_duration,
-            aeff=observation.aeff,
-            geom=geom,
-        )
+        if isinstance(observation.aeff, Map):
+            return make_map_exposure_from_map(
+                aeff=observation.aeff,
+                geom=geom,
+            )
+        else:
+            return make_map_exposure_true_energy(
+                pointing=observation.pointing_radec,
+                livetime=observation.observation_live_time_duration,
+                aeff=observation.aeff,
+                geom=geom,
+            )
 
     @staticmethod
     def make_exposure_irf(geom, observation):

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -3,7 +3,7 @@ import logging
 from astropy.table import Table
 import astropy.units as u
 from gammapy.datasets import MapDataset
-from gammapy.irf import EnergyDependentMultiGaussPSF
+from gammapy.irf import EnergyDependentMultiGaussPSF,EDispKernelMap
 from gammapy.maps import Map
 from gammapy.modeling.models import BackgroundModel
 from .core import Maker
@@ -14,6 +14,7 @@ from .utils import (
     make_map_exposure_true_energy,
     make_psf_map,
     interpolate_map_IRF,
+    interpolate_edisp_kernel_map,
 )
 
 __all__ = ["MapDatasetMaker"]
@@ -202,14 +203,22 @@ class MapDatasetMaker(Maker):
         edisp : `~gammapy.cube.EDispKernelMap`
             EdispKernel map.
         """
-        exposure = self.make_exposure_irf(geom.squash(axis="energy"), observation)
 
-        return make_edisp_kernel_map(
-            edisp=observation.edisp,
-            pointing=observation.pointing_radec,
-            geom=geom,
-            exposure_map=exposure,
-        )
+        if isinstance(observation.edisp,EDispKernelMap):
+            exposure_map = None
+            return interpolate_edisp_kernel_map(
+                edisp=observation.edisp, 
+                geom=geom, 
+                exposure_map=exposure_map)
+        else:
+            exposure = self.make_exposure_irf(geom.squash(axis="energy"), observation)
+
+            return make_edisp_kernel_map(
+                edisp=observation.edisp,
+                pointing=observation.pointing_radec,
+                geom=geom,
+                exposure_map=exposure,
+            )
 
     def make_psf(self, geom, observation):
         """Make psf map.

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -138,25 +138,31 @@ class MapDatasetMaker(Maker):
         background : `~gammapy.maps.Map`
             Background map.
         """
-        bkg_coordsys = observation.bkg.meta.get("FOVALIGN", "RADEC")
-
-        if bkg_coordsys == "ALTAZ":
-            pointing = observation.fixed_pointing_info
-        elif bkg_coordsys == "RADEC":
-            pointing = observation.pointing_radec
-        else:
-            raise ValueError(
-                f"Invalid background coordinate system: {bkg_coordsys!r}\n"
-                "Options: ALTAZ, RADEC"
+        if isinstance(observation.bkg, Map):
+            return interpolate_map_IRF(
+                aeff=observation.bkg,
+                geom=geom,
             )
+        else:
+            bkg_coordsys = observation.bkg.meta.get("FOVALIGN", "RADEC")
 
-        return make_map_background_irf(
-            pointing=pointing,
-            ontime=observation.observation_time_duration,
-            bkg=observation.bkg,
-            geom=geom,
-            oversampling=self.background_oversampling,
-        )
+            if bkg_coordsys == "ALTAZ":
+                pointing = observation.fixed_pointing_info
+            elif bkg_coordsys == "RADEC":
+                pointing = observation.pointing_radec
+            else:
+                raise ValueError(
+                    f"Invalid background coordinate system: {bkg_coordsys!r}\n"
+                    "Options: ALTAZ, RADEC"
+                )
+
+            return make_map_background_irf(
+                pointing=pointing,
+                ontime=observation.observation_time_duration,
+                bkg=observation.bkg,
+                geom=geom,
+                oversampling=self.background_oversampling,
+            )
 
     def make_edisp(self, geom, observation):
         """Make energy dispersion map.

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -202,7 +202,6 @@ class MapDatasetMaker(Maker):
         edisp : `~gammapy.cube.EDispKernelMap`
             EdispKernel map.
         """
-
         if isinstance(observation.edisp, EDispKernelMap):
             return interpolate_edisp_kernel_map(
                 edisp=observation.edisp,

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -438,9 +438,9 @@ def test_interpolate_mapdataset():
         atol=1e-3)
 
     #test edispmap
-    psfmatrix_preinterp = edispmap.get_edisp_kernel(SkyCoord("0 deg", "0 deg")).pdf_matrix
-    psfmatrix_postinterp = dataset.edisp.get_edisp_kernel(SkyCoord("0 deg", "0 deg")).pdf_matrix
-    assert_allclose(psfmatrix_preinterp, psfmatrix_postinterp, atol=1e-7)
+    pdfmatrix_preinterp = edispmap.get_edisp_kernel(SkyCoord("0 deg", "0 deg")).pdf_matrix
+    pdfmatrix_postinterp = dataset.edisp.get_edisp_kernel(SkyCoord("0 deg", "0 deg")).pdf_matrix
+    assert_allclose(pdfmatrix_preinterp, pdfmatrix_postinterp, atol=1e-7)
 
     #test psfmap
     geom_psf = geom_target.drop('energy').to_cube([energy_true])

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -1,13 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_almost_equal
 import numpy as np
 import astropy.units as u
+from astropy.table import Table
+from astropy.time import Time
 from regions import PointSkyRegion
 from astropy.coordinates import SkyCoord
-from gammapy.data import DataStore
+from gammapy.data import DataStore, EventList, GTI, Observation
 from gammapy.datasets import MapDataset
-from gammapy.irf import EDispMap, EDispKernelMap
+from gammapy.irf import EDispMap, EDispKernelMap, PSFMap
 from gammapy.makers import MapDatasetMaker, SafeMaskMaker
 from gammapy.maps import Map, MapAxis, WcsGeom, RegionGeom
 from gammapy.utils.testing import requires_data
@@ -340,3 +342,100 @@ def test_make_mean_psf(data_store):
 
     assert not np.isnan(psf.psf_value.value).any()
     assert_allclose(psf.psf_value.value[22, 22], 12206.167892)
+
+def test_interpolate_mapdataset():
+    energy = MapAxis.from_energy_bounds("1 TeV", "300 TeV", nbin=5, name="energy")
+    energy_true = MapAxis.from_nodes(np.logspace(-1, 3, 20), name="energy_true", interp="log", unit="TeV")
+
+    # make dummy map IRFs
+    geom_allsky = WcsGeom.create(npix=(5, 3), proj="CAR", binsz=60, axes=[energy], skydir=(0, 0))
+    geom_allsky_true = geom_allsky.drop('energy').to_cube([energy_true])
+    
+    #background
+    value = 30
+    bkg_map = Map.from_geom(geom_allsky, unit="")
+    bkg_map.data = value*np.ones(bkg_map.data.shape)
+    
+    #effective area - with a gradient that also depends on energy
+    aeff_map = Map.from_geom(geom_allsky_true, unit="cm2 s")
+    ra_arr = np.arange(aeff_map.data.shape[1])
+    dec_arr = np.arange(aeff_map.data.shape[2])
+    for i in np.arange(aeff_map.data.shape[0]):
+        aeff_map.data[i, :, :] = (i+1)*10*np.meshgrid(dec_arr, ra_arr)[0]+10*np.meshgrid(dec_arr, ra_arr)[1]+10
+    aeff_map.meta["TELESCOP"] = "HAWC"
+
+    #psf map
+    width = 0.2*u.deg
+    psfMap = PSFMap.from_gauss(energy.center, np.linspace(0, 2, 50)*u.deg, width)
+    
+    #edispmap
+    edispmap = EDispKernelMap.from_gauss(energy, energy_true, sigma=0.1, bias=0.0, geom=geom_allsky)
+    
+    #events and gti
+    nr_ev = 10
+    ev_t = Table()
+    gti_t = Table()
+    
+    ev_t['EVENT_ID'] = np.arange(nr_ev)
+    ev_t['TIME'] = nr_ev*[Time('2011-01-01 00:00:00', scale='utc', format='iso')]
+    ev_t['RA'] = np.linspace(-1, 1, nr_ev)*u.deg
+    ev_t['DEC'] = np.linspace(-1, 1, nr_ev)*u.deg
+    ev_t['ENERGY'] = np.logspace(0, 2, nr_ev)*u.TeV
+
+    gti_t['START'] = [Time('2010-12-31 00:00:00', scale='utc', format='iso')]
+    gti_t['STOP'] = [Time('2011-01-02 00:00:00', scale='utc', format='iso')]
+    
+    events = EventList(ev_t)
+    gti = GTI(gti_t)
+    
+    #define observation
+    obs = Observation(obs_id=0,
+        obs_info={},
+        gti=gti,
+        aeff=aeff_map,
+        edisp=edispmap,
+        psf=psfMap,
+        bkg=bkg_map,
+        events=events,
+        obs_filter=None,
+    )
+    
+    #define analysis geometry
+    geom_target = WcsGeom.create(
+        skydir=(0, 0),
+        width=(10, 10),
+        binsz=0.1*u.deg,
+        axes=[energy]
+    )
+    
+    maker = MapDatasetMaker(selection=["exposure", "counts", "background", "edisp", "psf"])
+    dataset = MapDataset.create(geom=geom_target, energy_axis_true=energy_true, name="test")
+    dataset = maker.run(dataset, obs)
+    
+    # test counts
+    assert dataset.counts.data.sum() == nr_ev
+    
+    #test background
+    coords_bg = {
+    'skycoord' : SkyCoord("0 deg", "0 deg"),
+    'energy' : energy.center[0]
+    }
+    assert_almost_equal(dataset.background_model.evaluate().get_by_coord(coords_bg)[0], value, decimal=7)
+    
+    #test effective area
+    coords_aeff = {
+    'skycoord' : SkyCoord("0 deg", "0 deg"),
+    'energy_true' : energy_true.center[0]
+    }
+    assert_almost_equal(aeff_map.get_by_coord(coords_aeff)[0]/dataset.exposure.get_by_coord(coords_aeff)[0], 1, decimal=3)
+    
+    #test edispmap
+    psfmatrix_preinterp = edispmap.get_edisp_kernel(SkyCoord("0 deg", "0 deg")).pdf_matrix
+    psfmatrix_postinterp = dataset.edisp.get_edisp_kernel(SkyCoord("0 deg", "0 deg")).pdf_matrix
+    assert_allclose(psfmatrix_preinterp, psfmatrix_postinterp, atol=1e-7)
+    
+    #test psfmap
+    geom_psf = geom_target.drop('energy').to_cube([energy_true])
+    psfkernel_preinterp = psfMap.get_psf_kernel(SkyCoord("0 deg", "0 deg"), geom_psf, max_radius=2*u.deg).data
+    psfkernel_postinterp = dataset.psf.get_psf_kernel(SkyCoord("0 deg", "0 deg"), geom_psf, max_radius=2*u.deg).data
+    assert_allclose(psfkernel_preinterp, psfkernel_postinterp, atol=1e-4)

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -4,7 +4,7 @@ from astropy.coordinates import SkyOffsetFrame
 from astropy.coordinates import Angle
 from astropy.table import Table
 from gammapy.data import FixedPointingInfo
-from gammapy.irf import EDispMap, PSFMap
+from gammapy.irf import EDispMap, PSFMap,EDispKernelMap
 from gammapy.stats import WStatCountsStatistic
 from gammapy.maps import Map, WcsNDMap
 from gammapy.modeling.models import PowerLawSpectralModel

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -16,7 +16,6 @@ __all__ = [
     "make_edisp_kernel_map",
     "make_psf_map",
     "make_map_exposure_true_energy",
-    "make_map_exposure_from_map",
     "make_theta_squared_table",
     "interpolate_map_IRF",
     "interpolate_edisp_kernel_map",
@@ -63,30 +62,6 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
         geom=geom, data=exposure.value.reshape(geom.data_shape), unit=exposure.unit
     )
 
-def make_map_exposure_from_map(aeff, geom):
-    """Compute exposure map for a given geom from an input
-        all-sky map.
-
-    This map has a true energy axis, the exposure is not combined
-    with energy dispersion.
-
-    Parameters
-    ----------
-    aeff : `~gammapy.maps.Map`
-        Effective area
-    geom : `~gammapy.maps.WcsGeom`
-        Map geometry (must have an energy axis)
-
-    Returns
-    -------
-    map : `~gammapy.maps.WcsNDMap`
-        Exposure map
-    """
-    coords = geom.get_coord()
-    exposure = Map.from_geom(geom, unit=aeff.unit)
-    values = aeff.interp_by_coord(coords)
-    exposure.data = values
-    return exposure
 
 def interpolate_map_IRF(map_IRF, geom):
     """Compute IRF map for a given geom from an input

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -66,6 +66,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
 def interpolate_map_IRF(map_IRF, geom):
     """Compute IRF map for a given geom from an input
         all-sky map.
+
     Parameters
     ----------
     map_IRF : `~gammapy.maps.Map`
@@ -242,7 +243,7 @@ def make_psf_map(psf, pointing, geom, exposure_map=None):
     psfmap = Map.from_geom(geom, data=data, unit="sr-1")
     return PSFMap(psfmap, exposure_map)
 
-def interpolate_psf_map(psf, geom, exposure_map=None):
+def interpolate_psf_map(psf, geom):
     """Interpolate an all-sky psf map to the analysis geometry
 
     Expected axes : rad and true energy in this specific order
@@ -264,7 +265,6 @@ def interpolate_psf_map(psf, geom, exposure_map=None):
     psfmap : `~gammapy.irf.PSFMap`
         the resulting PSF map
     """
-
     coords = geom.get_coord()
     psfmap = PSFMap.from_geom(geom)
     psfmap.psf_map.data = psf.psf_map.interp_by_coord(coords)
@@ -316,7 +316,7 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None):
     edispmap = Map.from_geom(geom, data=data, unit="")
     return EDispMap(edispmap, exposure_map)
 
-def interpolate_edisp_kernel_map(edisp, geom, exposure_map=None):
+def interpolate_edisp_kernel_map(edisp, geom):
     """Interpolate an all-sky edisp kernel map to the analysis geometry.
 
     Expected axes : (reco) energy and true energy in this specific order
@@ -338,7 +338,7 @@ def interpolate_edisp_kernel_map(edisp, geom, exposure_map=None):
     -------
     edispmap : `~gammapy.cube.EDispKernelMap`
         the resulting EDispKernel map
-    """    
+    """
     coords = geom.get_coord()
     edispmap = EDispKernelMap.from_geom(geom)
     edispmap.edisp_map.data = edisp.edisp_map.interp_by_coord(coords)

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -18,6 +18,7 @@ __all__ = [
     "make_map_exposure_true_energy",
     "make_map_exposure_from_map",
     "make_theta_squared_table",
+    "interpolate_map_IRF",
 ]
 
 
@@ -85,6 +86,26 @@ def make_map_exposure_from_map(aeff, geom):
     exposure.data = values
     return exposure
 
+def interpolate_map_IRF(map_IRF, geom):
+    """Compute IRF map for a given geom from an input
+        all-sky map.
+    Parameters
+    ----------
+    map_IRF : `~gammapy.maps.Map`
+        Effective area
+    geom : `~gammapy.maps.WcsGeom`
+        Map geometry (must have an energy axis)
+
+    Returns
+    -------
+    map : `~gammapy.maps.WcsNDMap`
+        Interpolated map
+    """
+    coords = geom.get_coord()
+    exposure = Map.from_geom(geom, unit=map_IRF.unit)
+    values = map_IRF.interp_by_coord(coords)
+    interp_map.data = values
+    return interp_map
 
 def _map_spectrum_weight(map, spectrum=None):
     """Weight a map with a spectrum.

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -17,8 +17,6 @@ __all__ = [
     "make_psf_map",
     "make_map_exposure_true_energy",
     "make_theta_squared_table",
-    "interpolate_edisp_kernel_map",
-    "interpolate_psf_map",
 ]
 
 
@@ -220,33 +218,6 @@ def make_psf_map(psf, pointing, geom, exposure_map=None):
     psfmap = Map.from_geom(geom, data=data, unit="sr-1")
     return PSFMap(psfmap, exposure_map)
 
-def interpolate_psf_map(psf, geom):
-    """Interpolate an all-sky psf map to the analysis geometry
-
-    Expected axes : rad and true energy in this specific order
-    The name of the rad MapAxis is expected to be 'rad'
-
-    Parameters
-    ----------
-    psf : `~gammapy.irf.PSFMap`
-        the all-sky PSF IRF map
-    geom : `~gammapy.maps.Geom`
-        the map geom to be used. It provides the target geometry.
-        rad and true energy axes should be given in this specific order.
-    exposure_map : `~gammapy.maps.Map`, optional
-        the associated exposure map.
-        default is None
-
-    Returns
-    -------
-    psfmap : `~gammapy.irf.PSFMap`
-        the resulting PSF map
-    """
-    coords = geom.get_coord()
-    psfmap = PSFMap.from_geom(geom)
-    psfmap.psf_map.data = psf.psf_map.interp_by_coord(coords)
-    return psfmap
-
 
 def make_edisp_map(edisp, pointing, geom, exposure_map=None):
     """Make a edisp map for a single observation
@@ -292,34 +263,6 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None):
     data = edisp_values.to_value("")
     edispmap = Map.from_geom(geom, data=data, unit="")
     return EDispMap(edispmap, exposure_map)
-
-def interpolate_edisp_kernel_map(edisp, geom):
-    """Interpolate an all-sky edisp kernel map to the analysis geometry.
-
-    Expected axes : (reco) energy and true energy in this specific order
-    The name of the reco energy MapAxis is expected to be 'energy'.
-    The name of the true energy MapAxis is expected to be 'energy_true'.
-
-    Parameters
-    ----------
-    edisp :  `~gammapy.cube.EDispKernelMap`
-        the input EDispKernelMap
-    geom : `~gammapy.maps.Geom`
-        the map geom to be used. It provides the target geometry.
-        energy and true energy axes should be given in this specific order.
-    exposure_map : `~gammapy.maps.Map`, optional
-        the associated exposure map.
-        default is None
-
-    Returns
-    -------
-    edispmap : `~gammapy.cube.EDispKernelMap`
-        the resulting EDispKernel map
-    """
-    coords = geom.get_coord()
-    edispmap = EDispKernelMap.from_geom(geom)
-    edispmap.edisp_map.data = edisp.edisp_map.interp_by_coord(coords)
-    return edispmap
 
 
 def make_edisp_kernel_map(edisp, pointing, geom, exposure_map=None):

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -59,6 +59,34 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
         geom=geom, data=exposure.value.reshape(geom.data_shape), unit=exposure.unit
     )
 
+def make_exposure_from_map(livetime, aeff, geom):
+    """Compute exposure map for a given geom from an input
+        all-sky map.
+
+    This map has a true energy axis, the exposure is not combined
+    with energy dispersion.
+
+    Parameters
+    ----------
+    livetime : `~astropy.units.Quantity`
+        Livetime
+    aeff : `~gammapy.maps.Map`
+        Effective area
+    geom : `~gammapy.maps.WcsGeom`
+        Map geometry (must have an energy axis)
+
+    Returns
+    -------
+    map : `~gammapy.maps.WcsNDMap`
+        Exposure map
+    """
+
+    coords = geom.get_coord()
+    exposure = Map.from_geom(geom, unit=aeff.unit)
+    values = aeff.interp_by_coord(coords)
+    exposure.data = livetime.value*values
+    return exposure
+
 
 def _map_spectrum_weight(map, spectrum=None):
     """Weight a map with a spectrum.

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -16,6 +16,7 @@ __all__ = [
     "make_edisp_kernel_map",
     "make_psf_map",
     "make_map_exposure_true_energy",
+    "make_map_exposure_from_map",
     "make_theta_squared_table",
 ]
 
@@ -59,7 +60,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
         geom=geom, data=exposure.value.reshape(geom.data_shape), unit=exposure.unit
     )
 
-def make_exposure_from_map(aeff, geom):
+def make_map_exposure_from_map(aeff, geom):
     """Compute exposure map for a given geom from an input
         all-sky map.
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -322,7 +322,7 @@ def interpolate_edisp_kernel_map(edisp, geom, exposure_map=None):
     Parameters
     ----------
     edisp :  `~gammapy.cube.EDispKernelMap`
-        the inpurt EDispKernelMap
+        the input EDispKernelMap
     geom : `~gammapy.maps.Geom`
         the map geom to be used. It provides the target geometry.
         energy and true energy axes should be given in this specific order.

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -311,6 +311,34 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None):
     edispmap = Map.from_geom(geom, data=data, unit="")
     return EDispMap(edispmap, exposure_map)
 
+def interpolate_edisp_kernel_map(edisp, geom, exposure_map=None):
+    """Interpolate an all-sky edisp kernel map to the analysis geometry.
+
+    Expected axes : (reco) energy and true energy in this specific order
+    The name of the reco energy MapAxis is expected to be 'energy'.
+    The name of the true energy MapAxis is expected to be 'energy_true'.
+
+    Parameters
+    ----------
+    edisp :  `~gammapy.cube.EDispKernelMap`
+        the inpurt EDispKernelMap
+    geom : `~gammapy.maps.Geom`
+        the map geom to be used. It provides the target geometry.
+        energy and true energy axes should be given in this specific order.
+    exposure_map : `~gammapy.maps.Map`, optional
+        the associated exposure map.
+        default is None
+
+    Returns
+    -------
+    edispmap : `~gammapy.cube.EDispKernelMap`
+        the resulting EDispKernel map
+    """    
+    coords = geom.get_coord()
+    edispmap = EDispKernelMap.from_geom(geom)
+    edispmap.edisp_map.data = edisp.edisp_map.interp_by_coord(coords)
+    return edispmap
+
 
 def make_edisp_kernel_map(edisp, pointing, geom, exposure_map=None):
     """Make a edisp kernel map for a single observation

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -59,7 +59,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
         geom=geom, data=exposure.value.reshape(geom.data_shape), unit=exposure.unit
     )
 
-def make_exposure_from_map(livetime, aeff, geom):
+def make_exposure_from_map(aeff, geom):
     """Compute exposure map for a given geom from an input
         all-sky map.
 
@@ -68,8 +68,6 @@ def make_exposure_from_map(livetime, aeff, geom):
 
     Parameters
     ----------
-    livetime : `~astropy.units.Quantity`
-        Livetime
     aeff : `~gammapy.maps.Map`
         Effective area
     geom : `~gammapy.maps.WcsGeom`
@@ -80,11 +78,10 @@ def make_exposure_from_map(livetime, aeff, geom):
     map : `~gammapy.maps.WcsNDMap`
         Exposure map
     """
-
     coords = geom.get_coord()
     exposure = Map.from_geom(geom, unit=aeff.unit)
     values = aeff.interp_by_coord(coords)
-    exposure.data = livetime.value*values
+    exposure.data = values
     return exposure
 
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -17,7 +17,6 @@ __all__ = [
     "make_psf_map",
     "make_map_exposure_true_energy",
     "make_theta_squared_table",
-    "interpolate_map_IRF",
     "interpolate_edisp_kernel_map",
     "interpolate_psf_map",
 ]
@@ -62,28 +61,6 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
         geom=geom, data=exposure.value.reshape(geom.data_shape), unit=exposure.unit
     )
 
-
-def interpolate_map_IRF(map_IRF, geom):
-    """Compute IRF map for a given geom from an input
-        all-sky map.
-
-    Parameters
-    ----------
-    map_IRF : `~gammapy.maps.Map`
-        Effective area
-    geom : `~gammapy.maps.WcsGeom`
-        Map geometry (must have an energy axis)
-
-    Returns
-    -------
-    map : `~gammapy.maps.WcsNDMap`
-        Interpolated map
-    """
-    coords = geom.get_coord()
-    interp_map = Map.from_geom(geom, unit=map_IRF.unit)
-    values = map_IRF.interp_by_coord(coords)
-    interp_map.data = values
-    return interp_map
 
 def _map_spectrum_weight(map, spectrum=None):
     """Weight a map with a spectrum.

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -4,7 +4,7 @@ from astropy.coordinates import SkyOffsetFrame
 from astropy.coordinates import Angle
 from astropy.table import Table
 from gammapy.data import FixedPointingInfo
-from gammapy.irf import EDispMap, PSFMap,EDispKernelMap
+from gammapy.irf import EDispMap, PSFMap
 from gammapy.stats import WStatCountsStatistic
 from gammapy.maps import Map, WcsNDMap
 from gammapy.modeling.models import PowerLawSpectralModel

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -102,7 +102,7 @@ def interpolate_map_IRF(map_IRF, geom):
         Interpolated map
     """
     coords = geom.get_coord()
-    exposure = Map.from_geom(geom, unit=map_IRF.unit)
+    interp_map = Map.from_geom(geom, unit=map_IRF.unit)
     values = map_IRF.interp_by_coord(coords)
     interp_map.data = values
     return interp_map

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -20,6 +20,7 @@ __all__ = [
     "make_theta_squared_table",
     "interpolate_map_IRF",
     "interpolate_edisp_kernel_map",
+    "interpolate_psf_map",
 ]
 
 
@@ -265,6 +266,34 @@ def make_psf_map(psf, pointing, geom, exposure_map=None):
     data = psf_values.to_value("sr-1")
     psfmap = Map.from_geom(geom, data=data, unit="sr-1")
     return PSFMap(psfmap, exposure_map)
+
+def interpolate_psf_map(psf, geom, exposure_map=None):
+    """Interpolate an all-sky psf map to the analysis geometry
+
+    Expected axes : rad and true energy in this specific order
+    The name of the rad MapAxis is expected to be 'rad'
+
+    Parameters
+    ----------
+    psf : `~gammapy.irf.PSFMap`
+        the all-sky PSF IRF map
+    geom : `~gammapy.maps.Geom`
+        the map geom to be used. It provides the target geometry.
+        rad and true energy axes should be given in this specific order.
+    exposure_map : `~gammapy.maps.Map`, optional
+        the associated exposure map.
+        default is None
+
+    Returns
+    -------
+    psfmap : `~gammapy.irf.PSFMap`
+        the resulting PSF map
+    """
+
+    coords = geom.get_coord()
+    psfmap = PSFMap.from_geom(geom)
+    psfmap.psf_map.data = psf.psf_map.interp_by_coord(coords)
+    return psfmap
 
 
 def make_edisp_map(edisp, pointing, geom, exposure_map=None):

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -19,6 +19,7 @@ __all__ = [
     "make_map_exposure_from_map",
     "make_theta_squared_table",
     "interpolate_map_IRF",
+    "interpolate_edisp_kernel_map",
 ]
 
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -772,7 +772,7 @@ class Map(abc.ABC):
         """
         pass
 
-    def interp_to_geom(self,geom):
+    def interp_to_geom(self, geom):
         """Interpolate map to input geometry.
 
         Parameters
@@ -782,7 +782,7 @@ class Map(abc.ABC):
 
         Returns
         -------
-        map : `Map`
+        interp_map : `Map`
             Interpolated Map
         """
         coords = geom.get_coord()

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -772,6 +772,25 @@ class Map(abc.ABC):
         """
         pass
 
+    def interp_to_geom(self,geom):
+        """Interpolate map to input geometry.
+
+        Parameters
+        ----------
+        geom : `~gammapy.maps.Geom`
+            Target Map geometry
+
+        Returns
+        -------
+        map : `Map`
+            Interpolated Map
+        """
+        coords = geom.get_coord()
+        interp_map = Map.from_geom(geom, unit=self.unit)
+        values = self.interp_by_coord(coords)
+        interp_map.data = values
+        return interp_map
+
     def fill_events(self, events):
         """Fill event coordinates (`~gammapy.data.EventList`)."""
         self.fill_by_coord(events.map_coord(self.geom))

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -371,3 +371,46 @@ def test_set_scalar():
     m.data = 1
     assert m.data.shape == (10, 10)
     assert_allclose(m.data, 1)
+
+def test_interp_to_geom():
+    energy = MapAxis.from_energy_bounds("1 TeV", "300 TeV", nbin=5, name="energy")
+    energy_target = MapAxis.from_energy_bounds("1 TeV", "300 TeV", nbin=7, name="energy")
+    value = 30
+    coords = {
+        'skycoord' : SkyCoord("0 deg", "0 deg"),
+        'energy' : energy_target.center[3]
+    }
+
+    #WcsNDMap
+    geom_wcs = WcsGeom.create(npix=(5, 3), proj="CAR", binsz=60, axes=[energy], skydir=(0, 0))
+    wcs_map = Map.from_geom(geom_wcs, unit="")
+    wcs_map.data = value*np.ones(wcs_map.data.shape)
+
+    wcs_geom_target = WcsGeom.create(
+        skydir=(0, 0),
+        width=(10, 10),
+        binsz=0.1*u.deg,
+        axes=[energy_target]
+    )
+    interp_wcs_map = wcs_map.interp_to_geom(wcs_geom_target)
+
+    assert_allclose(interp_wcs_map.get_by_coord(coords)[0], value, atol=1e-7)
+    assert isinstance(interp_wcs_map, WcsNDMap)
+    assert interp_wcs_map.geom  == wcs_geom_target
+
+    #HpxNDMap
+    geom_hpx = HpxGeom.create(binsz=60,axes=[energy], skydir=(0, 0))
+    hpx_map = Map.from_geom(geom_hpx, unit="")
+    hpx_map.data = value*np.ones(hpx_map.data.shape)
+
+    hpx_geom_target = HpxGeom.create(
+        skydir=(0, 0),
+        width=10,
+        binsz=0.1*u.deg,
+        axes=[energy_target]
+    )
+    interp_hpx_map = hpx_map.interp_to_geom(hpx_geom_target)
+
+    assert_allclose(interp_hpx_map.get_by_coord(coords)[0], value, atol=1e-7)
+    assert isinstance(interp_hpx_map, HpxNDMap)
+    assert interp_hpx_map.geom  == hpx_geom_target


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request makes it possible to have a `Map` object as the `aeff` and `bkg` inputs to the data reduction performed by the `MapDatasetMaker`, as well as an `EdispKernelMap` and `PSFMap` for the `edisp` and `psf`. The the input maps are interpolated to the reference geometry before being bundled into the resulting `MapDataset`.

**Dear reviewer**
I included a test that creates a dummy `Map` effective area and background, a dummy `PSFMap`, and `EdispKernelMap` and dummy `GTI` and `Events`. They are bundled into an `Observation` and run through the `MapDatasetMaker` with a given target `geom`. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
