### PR TITLE
Make 'selection' first kwarg in Maker classes

### DIFF
--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -25,17 +25,17 @@ class MapDatasetMaker(Maker):
 
     Parameters
     ----------
-    background_oversampling : int
-        Background evaluation oversampling factor in energy.
     selection : list
         List of str, selecting which maps to make.
         Available: 'counts', 'exposure', 'background', 'psf', 'edisp'
         By default, all maps are made.
+    background_oversampling : int
+        Background evaluation oversampling factor in energy.
     """
     tag = "MapDatasetMaker"
     available_selection = ["counts", "exposure", "background", "psf", "edisp"]
 
-    def __init__(self, background_oversampling=None, selection=None):
+    def __init__(self, selection=None, background_oversampling=None):
         self.background_oversampling = background_oversampling
 
         if selection is None:

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -22,18 +22,18 @@ class SpectrumDatasetMaker(Maker):
 
     Parameters
     ----------
-    containment_correction : bool
-        Apply containment correction for point sources and circular on regions.
     selection : list
         List of str, selecting which maps to make.
         Available: 'counts', 'aeff', 'background', 'edisp'
         By default, all spectra are made.
+    containment_correction : bool
+        Apply containment correction for point sources and circular on regions.
     """
 
     tag = "SpectrumDatasetMaker"
     available_selection = ["counts", "background", "aeff", "edisp"]
 
-    def __init__(self, containment_correction=False, selection=None):
+    def __init__(self, selection=None, containment_correction=False):
         self.containment_correction = containment_correction
 
         if selection is None:


### PR DESCRIPTION
**Description**
Since `selection` is the only argument that makes sense passing positionally (an average reader could understand its meaning even without the keyword), it would be very convenient to make it the first keyword argument in the signatures. `SafeMaskMaker` already does something similar.