### PR TITLE
Add Dataset.resample_energy_axis method

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1317,8 +1317,8 @@ class MapDataset(Dataset):
             if self.__dict__.pop(name, False):
                 log.info(f"Clearing {name} cache for dataset {self.name}")
 
-    def group_over_energy(self, e_edges=None, name=None):
-        """Group MapDataset over reco energy edges.
+    def resample_energy_axis(self, e_edges=None, name=None):
+        """Resample MapDataset over reco energy edges.
 
         Counts are summed taking into account safe mask.
 
@@ -1332,7 +1332,7 @@ class MapDataset(Dataset):
         Returns
         -------
         dataset: `MapDataset`
-            Grouped dataset .
+            Resampled dataset .
         """
         if e_edges is None:
             e_axis = self._geom.get_axis_by_name("energy")
@@ -1389,7 +1389,7 @@ class MapDataset(Dataset):
         dataset : `MapDataset`
             Map dataset containing images.
         """
-        return self.group_over_energy(e_edges=None, name=name)
+        return self.resample_energy_axis(e_edges=None, name=name)
 
 class MapDatasetOnOff(MapDataset):
     """Map dataset for on-off likelihood fitting.
@@ -1987,8 +1987,8 @@ class MapDatasetOnOff(MapDataset):
 
         return self.from_map_dataset(dataset, **kwargs)
 
-    def group_over_energy(self, e_edges=None, name=None):
-        """Group MapDatasetOnOff over reco energy edges.
+    def resample_energy_axis(self, e_edges=None, name=None):
+        """Resample MapDatasetOnOff over reco energy edges.
 
         Counts are summed taking into account safe mask.
 
@@ -2004,7 +2004,7 @@ class MapDatasetOnOff(MapDataset):
         dataset: `SpectrumDataset`
             Resampled spectrum dataset .
         """
-        dataset = super().group_over_energy(e_edges,name)
+        dataset = super().resample_energy_axis(e_edges,name)
 
         axis = dataset.counts.geom.get_axis_by_name("energy")
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1338,7 +1338,7 @@ class MapDataset(Dataset):
             e_axis = self._geom.get_axis_by_name("energy")
             e_edges = u.Quantity([e_axis.edges[0], e_axis.edges[-1]])
 
-        axis = MapAxis.from_edges(e_edges, name="energy")
+        axis = MapAxis.from_edges(e_edges, name="energy", interp=self._geom.axes[0].interp)
 
         name = make_name(name)
         kwargs = {}

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1355,7 +1355,6 @@ class MapDataset(Dataset):
 
         if self.counts is not None:
             kwargs["counts"] = self.counts.resample_axis(axis=axis, weights=weights)
-            print(kwargs["counts"].geom.axes[0].edges)
 
         if self.background_model is not None:
             background = self.background_model.evaluate()

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1353,9 +1353,9 @@ class MapDataset(Dataset):
         else:
             weights = None
 
-
         if self.counts is not None:
             kwargs["counts"] = self.counts.resample_axis(axis=axis, weights=weights)
+            print(kwargs["counts"].geom.axes[0].edges)
 
         if self.background_model is not None:
             background = self.background_model.evaluate()

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2024,10 +2024,9 @@ class MapDatasetOnOff(MapDataset):
             acceptance = self.acceptance
             acceptance = acceptance.resample_axis(axis=axis, weights=weights)
 
-            background = self.alpha * self.counts_off
-            background = background.resample_axis(axis=axis, weights=weights)
+            norm_factor = self.counts_off_normalised.resample_axis(axis=axis, weights=weights)
 
-            acceptance_off = acceptance * counts_off / background
+            acceptance_off = acceptance * counts_off / norm_factor
 
         return self.__class__.from_map_dataset(
             dataset,

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -718,8 +718,8 @@ class SpectrumDataset(Dataset):
 
         return self.__class__(**kwargs)
 
-    def group_over_energy(self, e_edges=None, name=None):
-        """Group SpectrumDataset over reco energy edges.
+    def resample_energy_axis(self, e_edges=None, name=None):
+        """Resample SpectrumDataset over reco energy edges.
 
         Counts are summed taking into account safe mask.
 
@@ -787,7 +787,7 @@ class SpectrumDataset(Dataset):
         dataset: `SpectrumDataset`
             Resampled spectrum dataset .
         """
-        return self.group_over_energy(e_edges=None, name=name)
+        return self.resample_energy_axis(e_edges=None, name=name)
 
 
 class SpectrumDatasetOnOff(SpectrumDataset):
@@ -1560,8 +1560,8 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
         return self.__class__(**kwargs)
 
-    def group_over_energy(self, e_edges=None, name=None):
-        """Group SpectrumDatasetOnOff over reco energy edges.
+    def resample_energy_axis(self, e_edges=None, name=None):
+        """Resample SpectrumDatasetOnOff over reco energy edges.
 
         Counts are summed taking into account safe mask.
 
@@ -1577,7 +1577,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         dataset: `SpectrumDataset`
             Resampled spectrum dataset .
         """
-        dataset = super().group_over_energy(e_edges,name)
+        dataset = super().resample_energy_axis(e_edges,name)
 
         axis = dataset.counts.geom.get_axis_by_name("energy")
 

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -739,7 +739,7 @@ class SpectrumDataset(Dataset):
             e_axis = self.counts.geom.get_axis_by_name("energy")
             e_edges = u.Quantity([e_axis.edges[0], e_axis.edges[-1]])
 
-        axis = MapAxis.from_edges(e_edges, name="energy")
+        axis = MapAxis.from_edges(e_edges, name="energy", interp=self._geom.axes[0].interp)
 
         name = make_name(name)
         kwargs = {}

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -718,15 +718,15 @@ class SpectrumDataset(Dataset):
 
         return self.__class__(**kwargs)
 
-    def resample_energy_axis(self, e_edges=None, name=None):
-        """Resample SpectrumDataset over reco energy edges.
+    def resample_energy_axis(self, axis=None, name=None):
+        """Resample SpectrumDataset over new reco energy axis.
 
         Counts are summed taking into account safe mask.
 
         Parameters
         ----------
-        e_edges : `~astropy.units.Quantity`
-            the energy edges.
+        axis : `~gammapy.maps.MapAxis`
+            the new reco energy axis.
         name: str
             Name of the new dataset.
 
@@ -735,11 +735,10 @@ class SpectrumDataset(Dataset):
         dataset: `SpectrumDataset`
             Resampled spectrum dataset .
         """
-        if e_edges is None:
+        if axis is None:
             e_axis = self.counts.geom.get_axis_by_name("energy")
             e_edges = u.Quantity([e_axis.edges[0], e_axis.edges[-1]])
-
-        axis = MapAxis.from_edges(e_edges, name="energy", interp=self._geom.axes[0].interp)
+            axis = MapAxis.from_edges(e_edges, name="energy", interp=self._geom.axes[0].interp)
 
         name = make_name(name)
         kwargs = {}
@@ -787,7 +786,7 @@ class SpectrumDataset(Dataset):
         dataset: `SpectrumDataset`
             Resampled spectrum dataset .
         """
-        return self.resample_energy_axis(e_edges=None, name=name)
+        return self.resample_energy_axis(axis=None, name=name)
 
 
 class SpectrumDatasetOnOff(SpectrumDataset):
@@ -1560,15 +1559,16 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
         return self.__class__(**kwargs)
 
-    def resample_energy_axis(self, e_edges=None, name=None):
-        """Resample SpectrumDatasetOnOff over reco energy edges.
+    def resample_energy_axis(self, axis=None, name=None):
+        """Resample SpectrumDatasetOnOff over new reco energy axis.
 
         Counts are summed taking into account safe mask.
 
         Parameters
         ----------
-        e_edges : `~astropy.units.Quantity`
-            the energy edges.
+        axis : `~gammapy.maps.MapAxis`
+            the new reco energy axis. If None, reduce energy axis to one bin.
+            Default is None.
         name: str
             Name of the new dataset.
 
@@ -1577,7 +1577,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         dataset: `SpectrumDataset`
             Resampled spectrum dataset .
         """
-        dataset = super().resample_energy_axis(e_edges,name)
+        dataset = super().resample_energy_axis(axis,name)
 
         axis = dataset.counts.geom.get_axis_by_name("energy")
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -268,7 +268,8 @@ def get_fermi_3fhl_gc_dataset():
 def test_resample_energy_3fhl():
     dataset = get_fermi_3fhl_gc_dataset()
 
-    grouped = dataset.resample_energy_axis(e_edges=[10, 35, 100]*u.GeV)
+    new_axis = MapAxis.from_edges([10, 35, 100]*u.GeV, interp='log', name="energy")
+    grouped = dataset.resample_energy_axis(axis=new_axis)
 
     assert grouped.counts.data.shape == (2,200,400)
     assert grouped.counts.data[0].sum() == 28581

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -265,10 +265,10 @@ def get_fermi_3fhl_gc_dataset():
 
 
 @requires_data()
-def test_group_energy_3fhl():
+def test_resample_energy_3fhl():
     dataset = get_fermi_3fhl_gc_dataset()
 
-    grouped = dataset.group_over_energy(e_edges=[10, 35, 100]*u.GeV)
+    grouped = dataset.resample_energy_axis(e_edges=[10, 35, 100]*u.GeV)
 
     assert grouped.counts.data.shape == (2,200,400)
     assert grouped.counts.data[0].sum() == 28581

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -265,11 +265,28 @@ def get_fermi_3fhl_gc_dataset():
 
 
 @requires_data()
-def test_to_image_3fhl(geom):
+def test_group_energy_3fhl():
+    dataset = get_fermi_3fhl_gc_dataset()
+
+    grouped = dataset.group_over_energy(e_edges=[10, 35, 100]*u.GeV)
+
+    assert grouped.counts.data.shape == (2,200,400)
+    assert grouped.counts.data[0].sum() == 28581
+    assert_allclose(grouped.background_model.map.data.sum(axis=(1,2)), [25074.366386,  3474.265917], rtol=1e-5)
+    assert_allclose(grouped.exposure.data, dataset.exposure.data, rtol=1e-5)
+
+    axis = grouped.counts.geom.axes[0]
+    npred = dataset.npred()
+    npred_grouped = grouped.npred()
+    assert_allclose(npred.resample_axis(axis=axis).data.sum(), npred_grouped.data.sum())
+
+
+@requires_data()
+def test_to_image_3fhl():
     dataset = get_fermi_3fhl_gc_dataset()
 
     dataset_im = dataset.to_image()
-    print(dataset)
+
     assert dataset_im.counts.data.sum() == dataset.counts.data.sum()
     assert_allclose(dataset_im.background_model.map.data.sum(), 28548.625, rtol=1e-5)
     assert_allclose(dataset_im.exposure.data, dataset.exposure.data, rtol=1e-5)

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -551,8 +551,8 @@ class TestSpectrumOnOff:
 
         assert info_dict["name"] == "test"
 
-    def test_group_over_energy(self):
-        grouped = self.dataset.group_over_energy(e_edges=[0.1, 1, 10]*u.TeV)
+    def test_resample_energy_axis(self):
+        grouped = self.dataset.resample_energy_axis(e_edges=[0.1, 1, 10]*u.TeV)
 
         assert grouped.counts.data.shape == (2,1,1)
         assert_allclose(grouped.aeff.data, 1.0)

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -551,6 +551,27 @@ class TestSpectrumOnOff:
 
         assert info_dict["name"] == "test"
 
+    def test_group_over_energy(self):
+        grouped = self.dataset.group_over_energy(e_edges=[0.1, 1, 10]*u.TeV)
+
+        assert grouped.counts.data.shape == (2,1,1)
+        assert_allclose(grouped.aeff.data, 1.0)
+        assert_allclose(np.squeeze(grouped.counts), [2, 1])
+        assert_allclose(np.squeeze(grouped.counts_off), [20, 20])
+        assert grouped.edisp.edisp_map.data.shape == (9, 2, 1, 1)
+        assert_allclose(np.squeeze(grouped.acceptance), [2, 2])
+        assert_allclose(np.squeeze(grouped.acceptance_off), [20, 20])
+
+    def test_to_image(self):
+        grouped = self.dataset.to_image()
+
+        assert grouped.counts.data.shape == (1,1,1)
+        assert_allclose(grouped.aeff.data, 1.0)
+        assert_allclose(np.squeeze(grouped.counts), 3)
+        assert_allclose(np.squeeze(grouped.counts_off), 40)
+        assert grouped.edisp.edisp_map.data.shape == (9, 1, 1, 1)
+        assert_allclose(np.squeeze(grouped.acceptance), 4)
+        assert_allclose(np.squeeze(grouped.acceptance_off), 40)
 
 @requires_data()
 @requires_dependency("iminuit")

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -552,7 +552,8 @@ class TestSpectrumOnOff:
         assert info_dict["name"] == "test"
 
     def test_resample_energy_axis(self):
-        grouped = self.dataset.resample_energy_axis(e_edges=[0.1, 1, 10]*u.TeV)
+        axis = MapAxis([0.1, 1, 10]*u.TeV, name="energy", interp='log')
+        grouped = self.dataset.resample_energy_axis(axis=axis)
 
         assert grouped.counts.data.shape == (2,1,1)
         assert_allclose(grouped.aeff.data, 1.0)

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -518,3 +518,28 @@ class EDispKernelMap(IRFMap):
         return self.__class__(
             edisp_kernel_map=edisp_map, exposure_map=self.exposure_map
         )
+
+
+    def resample_axis(self, axis, weights=None):
+        """Returns a resampled EdispKernelMap grouped according to the
+        edges of the reconstructed energy axis provided.
+
+        The true energy is left unchanged.
+
+        Parameters
+        ----------
+        axis : `~gammapy.maps.MapAxis`
+            The reco energy axis to use for the reco energy grouping
+        weights: `~gammapy.maps.Map`, optional
+            Weights to be applied
+
+        Returns
+        -------
+        edisp : `EDispKernelMap`
+            Edisp kernel map
+        """
+        new_edisp_map = self.edisp_map.resample_axis(axis, weights)
+        return self.__class__(
+            edisp_kernel_map=new_edisp_map, exposure_map=self.exposure_map
+        )
+

--- a/gammapy/irf/tests/test_edisp_map.py
+++ b/gammapy/irf/tests/test_edisp_map.py
@@ -271,7 +271,7 @@ def test_edispkernel_from_1D():
     assert_allclose(sum_kernel, 1, rtol=1e-5)
 
 
-def test_edsip_kernel_map_to_image():
+def test_edisp_kernel_map_to_image():
     e_reco = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=3)
     e_true = MapAxis.from_energy_bounds(
         "0.08 TeV", "20 TeV", nbin=5, name="energy_true"
@@ -281,3 +281,18 @@ def test_edsip_kernel_map_to_image():
 
     assert im.edisp_map.data.shape == (5, 1, 1, 2)
     assert_allclose(im.edisp_map.data[0, 0, 0, 0], 0.87605894, rtol=1e-5)
+
+def test_edisp_kernel_map_resample_axis():
+    e_reco = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=4)
+    e_true = MapAxis.from_energy_bounds(
+        "0.08 TeV", "20 TeV", nbin=10, name="energy_true"
+    )
+    edisp = EDispKernelMap.from_diagonal_response(e_reco, e_true)
+
+    e_reco = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=2)
+    im = edisp.resample_axis(axis=e_reco)
+
+    res = np.sum(im.edisp_map.data[4, :, 0, 0])
+
+    assert im.edisp_map.data.shape == (10, 2, 1, 2)
+    assert_allclose(res, 1.0, rtol=1e-5)

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -457,8 +457,11 @@ class Map(abc.ABC):
         """
         pass
 
-    def resample_axis(self, axis, weights=None):
-        """Resample map to a new axis binning by grouping and summing smaller bins.
+    def resample_axis(self, axis, weights=None, ufunc=np.add):
+        """Resample map to a new axis binning by grouping over smaller bins and apply ufunc to the bin contents.
+
+        By default, the map content are summed over the smaller bins. Other numpy ufunc can be used,
+        e.g. np.logical_and, np.logical_or
 
         Parameters
         ----------
@@ -467,6 +470,9 @@ class Map(abc.ABC):
         weights : `Map`
             Array to be used as weights. The spatial geometry must be equivalent
             to `other` and additional axes must be broadcastable.
+        ufunc : `~numpy.ufunc`
+            ufunc to use to resample the axis. Default is numpy.add.
+
 
         Returns
         -------
@@ -487,7 +493,7 @@ class Map(abc.ABC):
 
         weights = 1 if weights is None else weights.data
 
-        data = np.add.reduceat(self.data * weights, indices=indices, axis=idx)
+        data = ufunc.reduceat(self.data * weights, indices=indices, axis=idx)
 
         return self._init_copy(data=data, geom=geom)
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1699,6 +1699,10 @@ class Geom(abc.ABC):
         axis_self = self.get_axis_by_name(axis.name)
         groups = axis_self.group_table(axis.edges)
 
+        # Keep only normal bins
+        #TODO: improve on this
+        groups = groups[groups["bin_type"]=="normal   "]
+
         edges = edges_from_lo_hi(
             groups[axis.name + "_min"], groups[axis.name + "_max"]
         )

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -306,6 +306,15 @@ def test_wcsgeom_drop():
     geom_drop = geom.drop(axis="ax1")
     assert geom_drop.data_shape == (4, 2, 3, 3)
 
+def test_wcsgeom_resample_overflows():
+    ax1 = MapAxis.from_edges([1, 2, 3, 4, 5], name="ax1")
+    ax2 = MapAxis.from_nodes([1, 2, 3], name="ax2")
+    geom = WcsGeom.create(npix=(3, 3), axes=[ax1, ax2])
+    new_axis = MapAxis.from_edges([-1., 1, 2.3,4.8,6], name="ax1")
+    geom_resample = geom.resample_axis(axis=new_axis)
+
+    assert geom_resample.data_shape == (3, 2, 3, 3)
+    assert_allclose(geom_resample.axes[0].edges, [1, 2, 5])
 
 def test_wcsgeom_get_pix_coords():
     geom = WcsGeom.create(

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -427,6 +427,18 @@ def test_wcsndmap_resample_axis():
     assert m2.data.shape == (3, 2, 6, 7)
     assert_allclose(m2.data, 2)
 
+def test_wcsndmap_resample_axis_logical_and():
+    axis_1 = MapAxis.from_edges([1, 2, 3, 4, 5], name="test-1")
+
+    geom = WcsGeom.create(npix=(2, 2), axes=[axis_1])
+    m = WcsNDMap(geom, dtype=bool)
+    m.data[:,:,:] = True
+    m.data[0,0,0] = False
+
+    new_axis = MapAxis.from_edges([1, 3, 5], name="test-1")
+    m2 = m.resample_axis(axis=new_axis, ufunc=np.logical_and)
+    assert_allclose(m2.data[0,0,0], False)
+    assert_allclose(m2.data[1,0,0], True)
 
 def test_coadd_unit():
     geom = WcsGeom.create(npix=(10, 10), binsz=1, proj="CAR", frame="galactic")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces new functionalities on `MapDataset`, `SpectrumDataset` and their ONOff variants. 
The `group_over_energy` method allows to rebin a `MapDataset` according to a set of reco energy edges. It relies on `Map.resample_axis`. The latter has been updated to support other `ufunc` than `np.add` (e.g. `np.logical_or` for masks). It has also been modified to consider only `normal` energy group and not `underflows` and `overflows` from `MapAxis.group_table`.
The `EDispKernelMap` has also been modified to support the `resample_axis` method.

This should be allow for simpler code for the edges support in the `Estimators`. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
