### PR TITLE
Replace SkyDiffuseCube by TemplateSpatialModel

### DIFF
--- a/docs/tutorials/event_sampling.ipynb
+++ b/docs/tutorials/event_sampling.ipynb
@@ -460,7 +460,7 @@
    "outputs": [],
    "source": [
     "diffuse_cube = TemplateSpatialModel.read(\n",
-    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\", normalize=False, unit = \"cm-2 s-1 MeV-1 sr-1\"\n",
+    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\", normalize=False\n",
     ")\n",
     "diffuse = SkyModel(PowerLawNormSpectralModel(), diffuse_cube)\n",
     "models_diffuse = Models([diffuse])\n",

--- a/docs/tutorials/event_sampling.ipynb
+++ b/docs/tutorials/event_sampling.ipynb
@@ -101,9 +101,10 @@
     "    Models,\n",
     "    SkyModel,\n",
     "    PowerLawSpectralModel,\n",
+    "    PowerLawNormSpectralModel,\n",
     "    PointSpatialModel,\n",
     "    GaussianSpatialModel,\n",
-    "    SkyDiffuseCube,\n",
+    "    TemplateSpatialModel,\n",
     ")\n",
     "from regions import CircleSkyRegion"
    ]
@@ -458,9 +459,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diffuse = SkyDiffuseCube.read(\n",
-    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\"\n",
+    "diffuse_cube = TemplateSpatialModel.read(\n",
+    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\", normalize=False, unit = \"cm-2 s-1 MeV-1 sr-1\"\n",
     ")\n",
+    "diffuse = SkyModel(PowerLawNormSpectralModel(), diffuse_cube)\n",
     "models_diffuse = Models([diffuse])\n",
     "\n",
     "file_model = \"./event_sampling/diffuse.yaml\"\n",
@@ -601,6 +603,24 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.3"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/fermi_lat.ipynb
+++ b/docs/tutorials/fermi_lat.ipynb
@@ -65,7 +65,8 @@
     "    PowerLawSpectralModel,\n",
     "    PointSpatialModel,\n",
     "    SkyModel,\n",
-    "    SkyDiffuseCube,\n",
+    "    TemplateSpatialModel,\n",
+    "    PowerLawNormSpectralModel,\n",
     "    Models,\n",
     "    create_fermi_isotropic_diffuse_model,\n",
     "    BackgroundModel,\n",
@@ -315,7 +316,7 @@
    "outputs": [],
    "source": [
     "diffuse_galactic_fermi = Map.read(\n",
-    "    \"$GAMMAPY_DATA/fermi_3fhl/gll_iem_v06_cutout.fits\"\n",
+    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\"\n",
     ")\n",
     "\n",
     "# Unit is not stored in the file, set it manually\n",
@@ -334,15 +335,15 @@
     "# Interpolate the diffuse emission model onto the counts geometry\n",
     "# The resolution of `diffuse_galactic_fermi` is low: bin size = 0.5 deg\n",
     "# We use ``interp=3`` which means cubic spline interpolation\n",
-    "coord = counts.geom.get_coord()\n",
+    "coord = exposure.geom.get_coord()\n",
     "\n",
     "data = diffuse_galactic_fermi.interp_by_coord(\n",
-    "    {\"skycoord\": coord.skycoord, \"energy\": coord[\"energy\"]}, interp=3\n",
+    "    {\"skycoord\": coord.skycoord, \"energy_true\": coord[\"energy_true\"]}, interp=3\n",
     ")\n",
     "diffuse_galactic = WcsNDMap(\n",
     "    exposure.geom, data, unit=diffuse_galactic_fermi.unit\n",
     ")\n",
-    "\n",
+    "diffuse_gal = TemplateSpatialModel(diffuse_galactic, normalize=False)\n",
     "print(diffuse_galactic.geom)\n",
     "print(diffuse_galactic.geom.axes[0])"
    ]
@@ -353,7 +354,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diffuse_gal = SkyDiffuseCube(diffuse_galactic, name=\"diffuse-gal\")"
+    "diffuse_iem = SkyModel(PowerLawNormSpectralModel(), diffuse_gal, name=\"diffuse-iem\")"
    ]
   },
   {
@@ -580,10 +581,10 @@
     "diffuse_iso = BackgroundModel(evaluator.compute_npred(), name=\"bkg-iso\")\n",
     "diffuse_iso.spectral_model.norm.value = 3.3\n",
     "# pre-compute diffuse model\n",
-    "evaluator = MapEvaluator(diffuse_gal)\n",
+    "evaluator = MapEvaluator(diffuse_iem)\n",
     "evaluator.update(exposure=exposure, psf=psf, edisp=edisp, geom=counts.geom)\n",
     "\n",
-    "diffuse_gal = BackgroundModel(evaluator.compute_npred(), name=\"bkg-iem\")"
+    "diffuse_iem = BackgroundModel(evaluator.compute_npred(), name=\"bkg-iem\")"
    ]
   },
   {
@@ -613,7 +614,7 @@
     "    name=\"source-gc\",\n",
     ")\n",
     "\n",
-    "models = Models([source, diffuse_gal, diffuse_iso])\n",
+    "models = Models([source, diffuse_iem, diffuse_iso])\n",
     "\n",
     "dataset = MapDataset(\n",
     "    models=models, counts=counts, exposure=exposure, psf=psf, edisp=edisp\n",

--- a/docs/tutorials/models.ipynb
+++ b/docs/tutorials/models.ipynb
@@ -568,7 +568,7 @@
    "outputs": [],
    "source": [
     "diffuse_cube = TemplateSpatialModel.read(\n",
-    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\", normalize=False, unit=\"cm-2 s-1 MeV-1 sr-1\"\n",
+    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\", normalize=False\n",
     ")\n",
     "diffuse = SkyModel(PowerLawNormSpectralModel(), diffuse_cube)\n",
     "print(diffuse)"
@@ -578,7 +578,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that if the spatial model is not normalized it has to be combine with a normalized spectral model for example `~gammapy.modeling.models.PowerLawNormSpectralModel`."
+    "Note that if the spatial model is not normalized over the sky it has to be combined with a normalized spectral model, for example `~gammapy.modeling.models.PowerLawNormSpectralModel`. This is the only case in `gammapy.models.SkyModel` where the unit is fully attached to the spatial model."
    ]
   },
   {

--- a/docs/tutorials/models.ipynb
+++ b/docs/tutorials/models.ipynb
@@ -570,7 +570,7 @@
     "diffuse_cube = TemplateSpatialModel.read(\n",
     "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\", normalize=False, unit=\"cm-2 s-1 MeV-1 sr-1\"\n",
     ")\n",
-    "diffuse = SkyModel( PowerLawNormSpectralModel(), diffuse_cube)\n",
+    "diffuse = SkyModel(PowerLawNormSpectralModel(), diffuse_cube)\n",
     "print(diffuse)"
    ]
   },

--- a/docs/tutorials/models.ipynb
+++ b/docs/tutorials/models.ipynb
@@ -445,7 +445,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# SkyModel and SkyDiffuseCube"
+    "# SkyModel"
    ]
   },
   {
@@ -547,7 +547,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Additionally the `~gammapy.modeling.models.SkyDiffuseCube` can be used to represent source models based on templates, where the spatial and energy axes are correlated. It can be created e.g. from an existing FITS file:\n",
+    "Additionally the spatial model of `~gammapy.modeling.models.SkyModel` can be used to represent source models based on templates, where the spatial and energy axes are correlated. It can be created e.g. from an existing FITS file:\n",
     "\n"
    ]
   },
@@ -557,7 +557,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gammapy.modeling.models import SkyDiffuseCube"
+    "from gammapy.modeling.models import TemplateSpatialModel\n",
+    "from gammapy.modeling.models import PowerLawNormSpectralModel"
    ]
   },
   {
@@ -566,10 +567,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diffuse = SkyDiffuseCube.read(\n",
-    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\"\n",
+    "diffuse_cube = TemplateSpatialModel.read(\n",
+    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\", normalize=False, unit=\"cm-2 s-1 MeV-1 sr-1\"\n",
     ")\n",
+    "diffuse = SkyModel( PowerLawNormSpectralModel(), diffuse_cube)\n",
     "print(diffuse)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that if the spatial model is not normalized it has to be combine with a normalized spectral model for example `~gammapy.modeling.models.PowerLawNormSpectralModel`."
    ]
   },
   {
@@ -872,7 +881,25 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
   }
  },
  "nbformat": 4,

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -17,7 +17,6 @@ from gammapy.modeling.models import (
     BackgroundModel,
     Models,
     ProperModels,
-    SkyDiffuseCube,
 )
 from gammapy.stats import cash, cash_sum_cython, wstat, get_wstat_mu_bkg
 from gammapy.utils.random import get_random_state
@@ -2233,20 +2232,7 @@ class MapEvaluator:
             self._pars_cached = pars
             if isinstance(self.model, BackgroundModel):
                 npred = self.model.evaluate()
-            elif isinstance(self.model, SkyDiffuseCube):
-                # TODO: remove once SkyDiffuseCube can be a spatial model
-                flux = self.compute_flux()
-
-                if self.model.apply_irf["exposure"]:
-                    npred = self.apply_exposure(flux)
-
-                if self.psf and self.model.apply_irf["psf"]:
-                    npred = self.apply_psf(npred)
-
-                if self.model.apply_irf["edisp"]:
-                    npred = self.apply_edisp(npred)
             else:
-
                 flux_conv = self._compute_flux_conv()
 
                 if self.model.apply_irf["exposure"]:
@@ -2272,8 +2258,7 @@ class MapEvaluator:
             spatial_conv = self._spatial_conv_cached
             if self._spatial_pars_cached != spatial_pars or spatial_conv is None:
                 self._spatial_pars_cached = spatial_pars
-                geom_image = self.geom.to_image()
-                spatial_conv = self.model.spatial_model.integrate_geom(geom_image)
+                spatial_conv = self.model.spatial_model.integrate_geom(self.geom)
                 if self.psf and self.model.apply_irf["psf"]:
                     spatial_conv = self.apply_psf(spatial_conv)
                 self._spatial_conv_cached = spatial_conv

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -150,9 +150,12 @@ class WcsMap(Map):
 
         wcs_map = cls.from_hdu(hdu, hdu_bands, format=format)
 
-        # exposure maps have an additional GTI hdu
-        if format == "fgst-template" and "GTI" in hdu_list:
-            wcs_map.unit = "cm2 s"
+        if wcs_map.unit.is_equivalent(""):
+            if format == "fgst-template":
+                if "GTI" in hdu_list:  # exposure maps have an additional GTI hdu
+                    wcs_map.unit = "cm2 s"
+                else:
+                    wcs_map.unit = "cm-2 s-1 MeV-1 sr-1"
 
         return wcs_map
 

--- a/gammapy/modeling/models/__init__.py
+++ b/gammapy/modeling/models/__init__.py
@@ -56,7 +56,7 @@ TEMPORAL_MODEL_REGISTRY = Registry(
 )
 """Registry of temporal models classes."""
 
-MODEL_REGISTRY = Registry([SkyModel, SkyDiffuseCube, BackgroundModel])
+MODEL_REGISTRY = Registry([SkyModel, BackgroundModel])
 """Registry of model classes"""
 
 
@@ -68,7 +68,6 @@ __all__ = [
     "SkyModelBase",
     "Models",
     "SkyModel",
-    "SkyDiffuseCube",
     "BackgroundModel",
     "create_crab_spectral_model",
     "create_cosmic_ray_spectral_model",

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -428,9 +428,9 @@ class Models(collections.abc.MutableSequence):
         del self._models[self.index(key)]
 
     def __setitem__(self, key, model):
-        from gammapy.modeling.models import SkyModel, SkyDiffuseCube
+        from gammapy.modeling.models import SkyModel, BackgroundModel
 
-        if isinstance(model, (SkyModel, SkyDiffuseCube)):
+        if isinstance(model, (SkyModel, BackgroundModel)):
             self._models[self.index(key)] = model
         else:
             raise TypeError(f"Invalid type: {model!r}")
@@ -536,11 +536,11 @@ class ProperModels(Models):
                     d._models.remove(key)
 
     def __setitem__(self, key, model):
-        from gammapy.modeling.models import SkyModel, SkyDiffuseCube
+        from gammapy.modeling.models import SkyModel, BackgroundModel
 
         for d in self._datasets:
             if model not in d._models:
-                if isinstance(model, (SkyModel, SkyDiffuseCube)):
+                if isinstance(model, (SkyModel, BackgroundModel)):
                     d._models[key] = model
 
                 else:
@@ -553,11 +553,11 @@ class ProperModels(Models):
                 model.datasets_names.append(d.name)
 
     def insert(self, idx, model):
-        from gammapy.modeling.models import SkyModel, SkyDiffuseCube
+        from gammapy.modeling.models import SkyModel, BackgroundModel
 
         for d in self._datasets:
             if model not in d._models:
-                if isinstance(model, (SkyModel, SkyDiffuseCube)):
+                if isinstance(model, (SkyModel, BackgroundModel)):
                     if idx == len(self):
                         index = len(d._models)
                     else:

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -232,10 +232,10 @@ class SkyModel(SkyModelBase):
 
         if self.spatial_model is not None:
             try:
-                spatial  = self.spatial_model(lon, lat) 
+                spatial = self.spatial_model(lon, lat)
             except:
-                spatial  = self.spatial_model(lon, lat, energy) 
-            value = value * spatial # pylint:disable=not-callable
+                spatial = self.spatial_model(lon, lat, energy)
+            value = value * spatial  # pylint:disable=not-callable
 
         if (self.temporal_model is not None) and (time is not None):
             value = value * self.temporal_model(time)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -231,7 +231,11 @@ class SkyModel(SkyModelBase):
         # TODO: case if self.temporal_model is not None, introduce time in arguments ?
 
         if self.spatial_model is not None:
-            value = value * self.spatial_model(lon, lat)  # pylint:disable=not-callable
+            try:
+                spatial  = self.spatial_model(lon, lat) 
+            except:
+                spatial  = self.spatial_model(lon, lat, energy) 
+            value = value * spatial # pylint:disable=not-callable
 
         if (self.temporal_model is not None) and (time is not None):
             value = value * self.temporal_model(time)

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -117,7 +117,11 @@ class SpatialModel(Model):
                 :, np.newaxis, np.newaxis
             ]
             coords = geom.to_image().get_coord(frame=self.frame)
-            return self(coords.lon, coords.lat, energy)
+            try:
+                data = self(coords.lon, coords.lat)
+            except:
+                data = self(coords.lon, coords.lat, energy)
+            return data
         else:
             coords = geom.get_coord(frame=self.frame)
             return self(coords.lon, coords.lat)

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -665,9 +665,9 @@ class TemplateSpatialModel(SpatialModel):
         return np.max(self.map.geom.width) / 2.0
 
     @classmethod
-    def read(cls, filename, normalize=True, unit=None, **kwargs):
+    def read(cls, filename, normalize=True, **kwargs):
         """Read spatial template model from FITS image.
-        If unit is not given in the FITS header or as argument the default is ``sr-1``.
+        If unit is not given in the FITS header the default is ``sr-1``.
 
         Parameters
         ----------
@@ -675,14 +675,10 @@ class TemplateSpatialModel(SpatialModel):
             FITS image filename.
         normalize : bool
             Normalize the input map so that it integrates to unity.
-        unit : str
-            Unit of the map, used only if not specified in the FITS header
         kwargs : dict
             Keyword arguments passed to `Map.read()`.
         """
         m = Map.read(filename, **kwargs)
-        if unit is not None and m.unit.is_equivalent(""):
-            m.unit = unit
         return cls(m, normalize=normalize, filename=filename)
 
     def evaluate(self, lon, lat, energy=None):
@@ -711,10 +707,7 @@ class TemplateSpatialModel(SpatialModel):
     def from_dict(cls, data):
         filename = data["filename"]
         normalize = data.get("normalize", True)
-        unit = data.get("unit", "")
         m = Map.read(filename)
-        if m.unit.is_equivalent(""):
-            m.unit = unit
         return cls(m, normalize=normalize, filename=filename)
 
     def to_dict(self):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -665,10 +665,9 @@ class TemplateSpatialModel(SpatialModel):
         return np.max(self.map.geom.width) / 2.0
 
     @classmethod
-    def read(cls, filename, normalize=True, **kwargs):
+    def read(cls, filename, normalize=True, unit=None, **kwargs):
         """Read spatial template model from FITS image.
-
-        The unit of the map has to be equivalent to ``sr-1``. If no unit the default is ``sr-1``.
+        If unit is not given in the FITS header or as argument the default is ``sr-1``.
 
         Parameters
         ----------
@@ -676,11 +675,14 @@ class TemplateSpatialModel(SpatialModel):
             FITS image filename.
         normalize : bool
             Normalize the input map so that it integrates to unity.
+        unit : str
+            Unit of the map, used only if not specified in the FITS header
         kwargs : dict
             Keyword arguments passed to `Map.read()`.
         """
         m = Map.read(filename, **kwargs)
-
+        if unit is not None and m.unit.is_equivalent(""):
+            m.unit = unit
         return cls(m, normalize=normalize, filename=filename)
 
     def evaluate(self, lon, lat, energy=None):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -710,7 +710,7 @@ class TemplateSpatialModel(SpatialModel):
     @classmethod
     def from_dict(cls, data):
         filename = data["filename"]
-        normalize= data.get("normalize", True)
+        normalize = data.get("normalize", True)
         unit = data.get("unit", "")
         m = Map.read(filename)
         if m.unit.is_equivalent(""):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -611,8 +611,6 @@ class TemplateSpatialModel(SpatialModel):
     ----------
     map : `~gammapy.maps.Map`
         Map template.
-    norm : float
-        Norm parameter (multiplied with map values)
     meta : dict, optional
         Meta information, meta['filename'] will be used for serialization
     normalize : bool
@@ -709,21 +707,20 @@ class TemplateSpatialModel(SpatialModel):
 
     @classmethod
     def from_dict(cls, data):
-        m = Map.read(data["filename"])
-
-        parameters = Parameters.from_dict(data["parameters"])
-        return cls.from_parameters(
-            parameters=parameters,
-            map=m,
-            filename=data["filename"],
-            normalize=data.get("normalize", True),
-        )
+        filename = data["filename"]
+        normalize= data.get("normalize", True)
+        unit = data.get("unit", "")
+        m = Map.read(filename)
+        if m.unit.is_equivalent(""):
+            m.unit = unit
+        return cls(m, normalize=normalize, filename=filename)
 
     def to_dict(self):
         """Create dict for YAML serilisation"""
         data = super().to_dict()
         data["filename"] = self.filename
         data["normalize"] = self.normalize
+        data["unit"] = str(self.map.unit)
         return data
 
     def to_region(self, **kwargs):

--- a/gammapy/modeling/models/tests/data/examples.yaml
+++ b/gammapy/modeling/models/tests/data/examples.yaml
@@ -148,27 +148,33 @@ components:
       max: .nan
       frozen: false
 - name: cube_iem
-  filename: $GAMMAPY_DATA/fermi_3fhl/gll_iem_v06_cutout.fits
-  type: SkyDiffuseCube
-  parameters:
-  - name: norm
-    value: 1.09
-    scale: 1.0
-    unit: ''
-    min: 0.0
-    max: .nan
-    frozen: false
-  - name: tilt
-    value: 0.0
-    scale: 1.0
-    unit: ''
-    min: .nan
-    max: .nan
-    frozen: true
-  - name: reference
-    value: 1.0
-    scale: 1.0
-    unit: TeV
-    min: .nan
-    max: .nan
-    frozen: true
+  type: SkyModel
+  spatial:
+    type: TemplateSpatialModel
+    filename: $GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz
+    normalize: false
+    unit:  1 / (cm2 s MeV sr)
+  spectral:
+    type: PowerLawNormSpectralModel
+    parameters:
+    - name: norm
+      value: 1.09
+      scale: 1.0
+      unit: ''
+      min: 0.0
+      max: .nan
+      frozen: false
+    - name: tilt
+      value: 0.0
+      scale: 1.0
+      unit: ''
+      min: .nan
+      max: .nan
+      frozen: true
+    - name: reference
+      value: 1.0
+      scale: 1.0
+      unit: TeV
+      min: .nan
+      max: .nan
+      frozen: true

--- a/gammapy/modeling/models/tests/data/make.py
+++ b/gammapy/modeling/models/tests/data/make.py
@@ -104,7 +104,6 @@ def make_datasets_example():
         overwrite=True,
         write_covariance=False
     )
-    datasets.models.write(DATA_PATH / "examples.yaml", overwrite=True, write_covariance=False)
 
 
 if __name__ == "__main__":

--- a/gammapy/modeling/models/tests/data/make.py
+++ b/gammapy/modeling/models/tests/data/make.py
@@ -15,7 +15,7 @@ from gammapy.modeling.models import (
     Models,
     PointSpatialModel,
     PowerLawSpectralModel,
-    SkyDiffuseCube,
+    TemplateSpatialModel,
     SkyModel,
 )
 
@@ -77,10 +77,11 @@ def make_datasets_example():
     obs_ids = [110380, 111140, 111159]
     data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps/")
 
-    diffuse_model = SkyDiffuseCube.read(
-        "$GAMMAPY_DATA/fermi_3fhl/gll_iem_v06_cutout.fits"
+    diffuse_spatial = TemplateSpatialModel.read(
+        "$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz"
     )
-
+    diffuse_model = SkyModel(PowerLawSpectralModel(), diffuse_spatial)
+    
     maker = MapDatasetMaker()
     datasets = Datasets()
 
@@ -103,6 +104,7 @@ def make_datasets_example():
         overwrite=True,
         write_covariance=False
     )
+    datasets.models.write(DATA_PATH / "examples.yaml", overwrite=True, write_covariance=False)
 
 
 if __name__ == "__main__":

--- a/gammapy/modeling/models/tests/data/make.py
+++ b/gammapy/modeling/models/tests/data/make.py
@@ -81,7 +81,7 @@ def make_datasets_example():
         "$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz"
     )
     diffuse_model = SkyModel(PowerLawSpectralModel(), diffuse_spatial)
-    
+
     maker = MapDatasetMaker()
     datasets = Datasets()
 
@@ -102,7 +102,7 @@ def make_datasets_example():
         "$GAMMAPY_DATA/tests/models",
         prefix="gc_example",
         overwrite=True,
-        write_covariance=False
+        write_covariance=False,
     )
 
 

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -254,7 +254,7 @@ def test_models_management(tmp_path):
     npred1b = datasets[0].npred().data.sum()
     assert npred1b != npred1
     assert npred1b != npred0
-    assert_allclose(npred1b, 5199.102662, rtol=1e-5)
+    assert_allclose(npred1b, 5157.137554, rtol=1e-5)
 
     datasets.models.remove(model1b)
     _ = datasets.models  # auto-update models

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -372,7 +372,6 @@ class Test_Template_with_cube:
         model = TemplateSpatialModel.read(
             "$GAMMAPY_DATA/tests/unbundled/fermi/gll_iem_v02_cutout.fits",
             normalize=False,
-            unit="cm-2 s-1 MeV-1 sr-1",
         )
         assert model.map.unit == "cm-2 s-1 MeV-1 sr-1"
 

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -371,8 +371,8 @@ class Test_Template_with_cube:
     def test_read():
         model = TemplateSpatialModel.read(
             "$GAMMAPY_DATA/tests/unbundled/fermi/gll_iem_v02_cutout.fits",
-        normalize=False)
-        model.map.unit = "cm-2 s-1 MeV-1 sr-1"
+        normalize=False, unit = "cm-2 s-1 MeV-1 sr-1")
+        assert model.map.unit == "cm-2 s-1 MeV-1 sr-1"
 
         # Check pixel inside map
         val = model.evaluate(0 * u.deg, 0 * u.deg, 100 * u.GeV)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -16,7 +16,8 @@ from gammapy.modeling.models import (
     Models,
     PointSpatialModel,
     PowerLawSpectralModel,
-    SkyDiffuseCube,
+    PowerLawNormSpectralModel,
+    TemplateSpatialModel,
     SkyModel,
     create_fermi_isotropic_diffuse_model,
 )
@@ -56,7 +57,8 @@ def diffuse_model():
         npix=(4, 3), binsz=2, axes=[axis], unit="cm-2 s-1 MeV-1 sr-1", frame="galactic"
     )
     m.data += 42
-    return SkyDiffuseCube(m)
+    spatial_model =  TemplateSpatialModel(m, normalize=False)
+    return SkyModel(PowerLawNormSpectralModel(), spatial_model)
 
 
 @pytest.fixture(scope="session")
@@ -336,7 +338,7 @@ class TestSkyModel:
         sky_model.apply_irf["edisp"] = True
 
 
-class TestSkyDiffuseCube:
+class Test_Template_with_cube:
     @staticmethod
     def test_evaluate_scalar(diffuse_model):
         # Check pixel inside map
@@ -367,7 +369,7 @@ class TestSkyDiffuseCube:
     @staticmethod
     @requires_data()
     def test_read():
-        model = SkyDiffuseCube.read(
+        model = TemplateSpatialModel.read(
             "$GAMMAPY_DATA/tests/unbundled/fermi/gll_iem_v02_cutout.fits"
         )
         assert model.map.unit == "cm-2 s-1 MeV-1 sr-1"
@@ -412,7 +414,7 @@ class TestSkyDiffuseCube:
         assert "datasets_names" not in out
 
 
-class TestSkyDiffuseCubeMapEvaluator:
+class Test_template_cube_MapEvaluator:
     @staticmethod
     def test_compute_dnde(diffuse_evaluator):
         out = diffuse_evaluator.compute_dnde()

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -370,9 +370,9 @@ class Test_Template_with_cube:
     @requires_data()
     def test_read():
         model = TemplateSpatialModel.read(
-            "$GAMMAPY_DATA/tests/unbundled/fermi/gll_iem_v02_cutout.fits"
-        )
-        assert model.map.unit == "cm-2 s-1 MeV-1 sr-1"
+            "$GAMMAPY_DATA/tests/unbundled/fermi/gll_iem_v02_cutout.fits",
+        normalize=False)
+        model.map.unit = "cm-2 s-1 MeV-1 sr-1"
 
         # Check pixel inside map
         val = model.evaluate(0 * u.deg, 0 * u.deg, 100 * u.GeV)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -57,7 +57,7 @@ def diffuse_model():
         npix=(4, 3), binsz=2, axes=[axis], unit="cm-2 s-1 MeV-1 sr-1", frame="galactic"
     )
     m.data += 42
-    spatial_model =  TemplateSpatialModel(m, normalize=False)
+    spatial_model = TemplateSpatialModel(m, normalize=False)
     return SkyModel(PowerLawNormSpectralModel(), spatial_model)
 
 
@@ -371,7 +371,9 @@ class Test_Template_with_cube:
     def test_read():
         model = TemplateSpatialModel.read(
             "$GAMMAPY_DATA/tests/unbundled/fermi/gll_iem_v02_cutout.fits",
-        normalize=False, unit = "cm-2 s-1 MeV-1 sr-1")
+            normalize=False,
+            unit="cm-2 s-1 MeV-1 sr-1",
+        )
         assert model.map.unit == "cm-2 s-1 MeV-1 sr-1"
 
         # Check pixel inside map

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -208,7 +208,7 @@ def make_all_models():
     m1 = Map.create(
         npix=(10, 20, 30), axes=[MapAxis.from_nodes([1, 2] * u.TeV, name="energy")]
     )
-    yield Model.create("SkyDiffuseCube", map=m1)
+    yield Model.create("TemplateSpatialModel", "spatial", map=m1)
     m2 = Map.create(
         npix=(10, 20, 30), axes=[MapAxis.from_edges([1, 2] * u.TeV, name="energy")]
     )

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -237,8 +237,7 @@ def test_sky_diffuse_map_3d():
     val = model(lon, lat, energy)
     with pytest.raises(ValueError):
         model(lon, lat)
-    assert val.unit == "sr-1"
-    model.map.unit = "cm-2 s-1 MeV-1 sr-1"
+    assert model.map.unit == "cm-2 s-1 MeV-1 sr-1"
     val = model(lon, lat, energy)
     assert val.unit == "cm-2 s-1 MeV-1 sr-1"
     res = model.evaluate_geom(model.map.geom)


### PR DESCRIPTION
This PR implement changes to replace SkyDiffuseCube by SkyModel with 3D TemplateSpatialModel:
- remove SkyDiffuseCube
- fix the SkyModel evaluation with 3D TemplateSpatialModel
- add optional argument unit in TemplateSpatialModel.read() for convenience
- adapt test data (PR in gammapy-data to be merged)
- adapt notebooks