### PR TITLE
Add todataset() on MapDatasetOff and SpectrumDatasetOnOff

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1572,7 +1572,7 @@ class MapDatasetOnOff(MapDataset):
     def from_map_dataset(
         cls, dataset, acceptance, acceptance_off, counts_off=None, name=None
     ):
-        """Create spectrum dataseton off from another dataset.
+        """Create map dataseton off from another dataset.
 
         Parameters
         ----------
@@ -1612,6 +1612,37 @@ class MapDatasetOnOff(MapDataset):
             acceptance_off=acceptance_off,
             name=dataset.name,
             psf=dataset.psf,
+        )
+
+    def to_map_dataset(self, name=None):
+        """ Convert a MapDatasetOnOff to  MapDataset
+
+        Parameters:
+        -----------
+        name: str
+            Name of the new dataset
+
+        Returns:
+        -------
+        dataset: `MapDataset`
+            MapDatset with cash statistics
+        """
+
+        name = make_name(name)
+
+        background_model = BackgroundModel(self.counts_off * self.alpha)
+        background_model.datasets_names = [name]
+        return MapDataset(
+            counts=self.counts,
+            exposure=self.exposure,
+            psf=self.psf,
+            edisp=self.edisp,
+            name=name,
+            gti=self.gti,
+            mask_fit=self.mask_fit,
+            mask_safe=self.mask_safe,
+            models=background_model,
+            meta_table=self.meta_table,
         )
 
     @property

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1616,6 +1616,7 @@ class MapDatasetOnOff(MapDataset):
 
     def to_map_dataset(self, name=None):
         """ Convert a MapDatasetOnOff to  MapDataset
+        The background model template is taken as alpha*counts_off
 
         Parameters:
         -----------

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -1446,6 +1446,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
     def to_spectrum_dataset(self, name=None):
         """ Convert a SpectrumDatasetOnOff to a SpectrumDataset
+        The background model template is taken as alpha*counts_off
 
         Parameters:
         -----------

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -1444,6 +1444,37 @@ class SpectrumDatasetOnOff(SpectrumDataset):
             meta_table=dataset.meta_table,
         )
 
+    def to_spectrum_dataset(self, name=None):
+        """ Convert a SpectrumDatasetOnOff to a SpectrumDataset
+
+        Parameters:
+        -----------
+            name: str
+                Name of the new dataset
+
+        Returns:
+        -------
+            dataset: `SpectrumDataset`
+                SpectrumDatset with cash statistics
+        """
+
+        name = make_name(name)
+
+        background_model = BackgroundModel(self.counts_off * self.alpha)
+        background_model.datasets_names = [name]
+        return SpectrumDataset(
+            counts=self.counts,
+            livetime=self.livetime,
+            aeff=self.aeff,
+            edisp=self.edisp,
+            name=name,
+            gti=self.gti,
+            mask_fit=self.mask_fit,
+            mask_safe=self.mask_safe,
+            models=background_model,
+            meta_table=self.meta_table,
+        )
+
     def slice_by_idx(self, slices, name=None):
         """Slice sub dataset.
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1140,3 +1140,28 @@ def test_plot_residual_onoff():
     )
     with mpl_plot_check():
         dataset.plot_residuals()
+
+
+def test_to_map_dataset():
+    axis = MapAxis.from_energy_bounds(1, 10, 2, unit="TeV")
+    geom = WcsGeom.create(npix=(10, 10), binsz=0.05, axes=[axis])
+
+    counts = Map.from_geom(geom, data=np.ones((2, 10, 10)))
+    counts_off = Map.from_geom(geom, data=np.ones((2, 10, 10)))
+    acceptance = Map.from_geom(geom, data=np.ones((2, 10, 10)))
+    acceptance_off = Map.from_geom(geom, data=np.ones((2, 10, 10)))
+    acceptance_off *= 2
+
+    dataset_onoff = MapDatasetOnOff(
+        counts=counts,
+        counts_off=counts_off,
+        acceptance=acceptance,
+        acceptance_off=acceptance_off,
+    )
+
+    dataset = dataset_onoff.to_map_dataset(name="ds")
+
+    assert dataset.name == "ds"
+    assert_allclose(dataset.background_model.map.data.sum(), 100)
+    assert isinstance(dataset, MapDataset)
+    assert dataset.counts == dataset_onoff.counts

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -419,6 +419,12 @@ class TestSpectrumOnOff:
 
         assert_allclose(dataset.npred().data.sum(), expected.value)
 
+    def test_to_spectrum_dataset(self):
+        ds = self.dataset.to_spectrum_dataset()
+
+        assert isinstance(ds, SpectrumDataset)
+        assert_allclose(ds.background_model.map.data.sum(), 4)
+
     @requires_dependency("matplotlib")
     def test_peek(self):
         dataset = self.dataset.copy()


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a small function to convert OnOff Datasets to normal datasets

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
