### PR TITLE
Clean up Map I/O format handling

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -470,7 +470,7 @@ using a format other than the GADF format:
     m = Map.create(binsz=0.1, map_type='wcs', width=10.0,
                       axes=[energy_axis])
     # Write a counts cube in a format compatible with the Fermi Science Tools
-    m.write('ccube.fits', conv='fgst-ccube')
+    m.write('ccube.fits', format='fgst-ccube')
 
 Visualization
 -------------
@@ -509,7 +509,7 @@ This example shows how to fill a counts cube from an event list:
     events = EventList.read("$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-events.fits.gz")
 
     m.fill_by_coord({'skycoord': events.radec, 'energy': events.energy})
-    m.write('ccube.fits', conv='fgst-ccube')
+    m.write('ccube.fits', format='fgst-ccube')
 
 To make a counts map, create an empty map with a geometry of your choice
 and then fill it using this function
@@ -554,7 +554,7 @@ using the `WcsNDMap.cutout` method:
     m = WcsNDMap.read('$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz')
     position = SkyCoord(0, 0, frame="galactic", unit="deg")
     m_cutout = m.cutout(position=position, width=(5 * u.deg, 2 * u.deg))
-    m_cutout.write('cutout.fits', conv='fgst-template')
+    m_cutout.write('cutout.fits', format='fgst-template')
 
 Using `gammapy.maps`
 ====================

--- a/docs/tutorials/fermi_lat.ipynb
+++ b/docs/tutorials/fermi_lat.ipynb
@@ -231,8 +231,6 @@
     "exposure_hpx = Map.read(\n",
     "    \"$GAMMAPY_DATA/fermi_3fhl/fermi_3fhl_exposure_cube_hpx.fits.gz\"\n",
     ")\n",
-    "# Unit is not stored in the file, set it manually\n",
-    "exposure_hpx.unit = \"cm2 s\"\n",
     "print(exposure_hpx.geom)\n",
     "print(exposure_hpx.geom.axes[0])"
    ]
@@ -259,8 +257,7 @@
     ")\n",
     "geom = WcsGeom(wcs=counts.geom.wcs, npix=counts.geom.npix, axes=[axis])\n",
     "\n",
-    "coord = geom.get_coord()\n",
-    "data = exposure_hpx.interp_by_coord(coord)"
+    "exposure = exposure_hpx.interp_to_geom(geom)"
    ]
   },
   {
@@ -269,7 +266,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "exposure = WcsNDMap(geom, data, unit=exposure_hpx.unit, dtype=float)\n",
     "print(exposure.geom)\n",
     "print(exposure.geom.axes[0])"
    ]
@@ -711,9 +707,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1,
+   "current_citInitial": 1.0,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1,
+   "eqNumInitial": 1.0,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"
@@ -724,7 +720,7 @@
    "user_envs_cfg": false
   },
   "toc": {
-   "base_numbering": 1,
+   "base_numbering": 1.0,
    "nav_menu": {
     "height": "237px",
     "width": "253px"
@@ -741,9 +737,9 @@
   },
   "varInspector": {
    "cols": {
-    "lenName": 16,
-    "lenType": 16,
-    "lenVar": 40
+    "lenName": 16.0,
+    "lenType": 16.0,
+    "lenVar": 40.0
    },
    "kernels_config": {
     "python": {

--- a/docs/tutorials/maps.ipynb
+++ b/docs/tutorials/maps.ipynb
@@ -730,7 +730,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m_cube.write(\"example_cube_fgst.fits\", conv=\"fgst-template\", overwrite=True)"
+    "m_cube.write(\"example_cube_fgst.fits\", format=\"fgst-template\", overwrite=True)"
    ]
   },
   {
@@ -746,7 +746,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hdulist = m_4d.to_hdulist(conv=\"gadf\")\n",
+    "hdulist = m_4d.to_hdulist(format=\"gadf\")\n",
     "hdulist.info()"
    ]
   },
@@ -992,7 +992,22 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "01919aaa69254cb5a0d81e5352181c02": {
+     "022acea936e2411a811ef139e6cb1490": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": "initial"
+      }
+     },
+     "04e7e46eee924490831a5b41cd89a227": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "SelectionSliderModel",
@@ -1042,43 +1057,13 @@
        "description_tooltip": null,
        "disabled": false,
        "index": 0,
-       "layout": "IPY_MODEL_7d6da20bc1204bb794495c6d4dff8007",
+       "layout": "IPY_MODEL_97f6b4540c1f49c4b94a04592f8e4182",
        "orientation": "horizontal",
        "readout": true,
-       "style": "IPY_MODEL_3cbf9010445f4d52a463375517a3c8bf"
+       "style": "IPY_MODEL_cca9b8a8231c45f0ba1d7490a5a14758"
       }
      },
-     "0bcae35e5a6c414e940eec1eff0996ce": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": "initial"
-      }
-     },
-     "161e98f22eb94899a1dc2cfc4fd431f8": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": "initial"
-      }
-     },
-     "274414cb0146403fa1da214e644017b1": {
+     "0ea39b92814c44cea1728082f87717be": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -1130,63 +1115,7 @@
        "width": null
       }
      },
-     "293745c754334bc7b1e3455206ec82c6": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "SelectionSliderModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "SelectionSliderModel",
-       "_options_labels": [
-        "5.85e+01 MeV MeV",
-        "8.00e+01 MeV MeV",
-        "1.09e+02 MeV MeV",
-        "1.50e+02 MeV MeV",
-        "2.05e+02 MeV MeV",
-        "2.80e+02 MeV MeV",
-        "3.83e+02 MeV MeV",
-        "5.23e+02 MeV MeV",
-        "7.16e+02 MeV MeV",
-        "9.79e+02 MeV MeV",
-        "1.34e+03 MeV MeV",
-        "1.83e+03 MeV MeV",
-        "2.50e+03 MeV MeV",
-        "3.42e+03 MeV MeV",
-        "4.68e+03 MeV MeV",
-        "6.41e+03 MeV MeV",
-        "8.76e+03 MeV MeV",
-        "1.20e+04 MeV MeV",
-        "1.64e+04 MeV MeV",
-        "2.24e+04 MeV MeV",
-        "3.06e+04 MeV MeV",
-        "4.19e+04 MeV MeV",
-        "5.73e+04 MeV MeV",
-        "7.84e+04 MeV MeV",
-        "1.07e+05 MeV MeV",
-        "1.47e+05 MeV MeV",
-        "2.01e+05 MeV MeV",
-        "2.74e+05 MeV MeV",
-        "3.75e+05 MeV MeV",
-        "5.13e+05 MeV MeV"
-       ],
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "SelectionSliderView",
-       "continuous_update": false,
-       "description": "Select energy_true:",
-       "description_tooltip": null,
-       "disabled": false,
-       "index": 0,
-       "layout": "IPY_MODEL_6a5c1bf84bdb42ae9b90a0c1bbe0339a",
-       "orientation": "horizontal",
-       "readout": true,
-       "style": "IPY_MODEL_0bcae35e5a6c414e940eec1eff0996ce"
-      }
-     },
-     "3cbf9010445f4d52a463375517a3c8bf": {
+     "19a6ccb5f26d4a148b70db347867259d": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "DescriptionStyleModel",
@@ -1201,31 +1130,7 @@
        "description_width": "initial"
       }
      },
-     "4e515a034a8f41c997a77598edb16c53": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [
-        "widget-interact"
-       ],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "VBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_01919aaa69254cb5a0d81e5352181c02",
-        "IPY_MODEL_cad25cd6a60b48929df32a09b32cb66c",
-        "IPY_MODEL_c8f0ae2476ff4329ba519380d5a09609"
-       ],
-       "layout": "IPY_MODEL_81d211600f72430e9e1aa69f603c208b"
-      }
-     },
-     "65e0b0d612fc4db3b3a3961ee9d74090": {
+     "20664cfe7c82418e94df109443262fad": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -1277,202 +1182,7 @@
        "width": null
       }
      },
-     "6a5c1bf84bdb42ae9b90a0c1bbe0339a": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": "50%"
-      }
-     },
-     "7d6da20bc1204bb794495c6d4dff8007": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": "50%"
-      }
-     },
-     "81d211600f72430e9e1aa69f603c208b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "1.2.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "85d373dde0444de59d15c373e86bd9db": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [
-        "widget-interact"
-       ],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "VBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_293745c754334bc7b1e3455206ec82c6",
-        "IPY_MODEL_d4de68d5b5dc46f09f0d4890d1623b7b",
-        "IPY_MODEL_c082fb930d204554bd9604b9db96b7a4"
-       ],
-       "layout": "IPY_MODEL_65e0b0d612fc4db3b3a3961ee9d74090"
-      }
-     },
-     "b9ce9dfa9e8c4f1a8fb7cd9affbb6706": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "DescriptionStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "1.2.0",
-       "_view_name": "StyleView",
-       "description_width": "initial"
-      }
-     },
-     "c082fb930d204554bd9604b9db96b7a4": {
+     "245eff90b6b24fda908f0c267fbd9991": {
       "model_module": "@jupyter-widgets/output",
       "model_module_version": "1.0.0",
       "model_name": "OutputModel",
@@ -1485,56 +1195,12 @@
        "_view_module": "@jupyter-widgets/output",
        "_view_module_version": "1.0.0",
        "_view_name": "OutputView",
-       "layout": "IPY_MODEL_e1e5163061794452a4dd7998c41b416f",
+       "layout": "IPY_MODEL_87c716d63873460888d16beb5fa839e9",
        "msg_id": "",
        "outputs": []
       }
      },
-     "c8f0ae2476ff4329ba519380d5a09609": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/output",
-       "_model_module_version": "1.0.0",
-       "_model_name": "OutputModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/output",
-       "_view_module_version": "1.0.0",
-       "_view_name": "OutputView",
-       "layout": "IPY_MODEL_e56ebac5c35f4d0180d1f290ae57cc86",
-       "msg_id": "",
-       "outputs": []
-      }
-     },
-     "cad25cd6a60b48929df32a09b32cb66c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "RadioButtonsModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "1.5.0",
-       "_model_name": "RadioButtonsModel",
-       "_options_labels": [
-        "linear",
-        "sqrt",
-        "log"
-       ],
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "1.5.0",
-       "_view_name": "RadioButtonsView",
-       "description": "Select stretch:",
-       "description_tooltip": null,
-       "disabled": false,
-       "index": 0,
-       "layout": "IPY_MODEL_274414cb0146403fa1da214e644017b1",
-       "style": "IPY_MODEL_161e98f22eb94899a1dc2cfc4fd431f8"
-      }
-     },
-     "d4de68d5b5dc46f09f0d4890d1623b7b": {
+     "305ed49a758d4b608965454b3c2b5c35": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "RadioButtonsModel",
@@ -1556,11 +1222,134 @@
        "description_tooltip": null,
        "disabled": false,
        "index": 1,
-       "layout": "IPY_MODEL_f1baed97cd934eb3845e2f961d2eaf29",
-       "style": "IPY_MODEL_b9ce9dfa9e8c4f1a8fb7cd9affbb6706"
+       "layout": "IPY_MODEL_20664cfe7c82418e94df109443262fad",
+       "style": "IPY_MODEL_022acea936e2411a811ef139e6cb1490"
       }
      },
-     "e1e5163061794452a4dd7998c41b416f": {
+     "51aebbdd032840b8a9058204a14d29b2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SelectionSliderModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "SelectionSliderModel",
+       "_options_labels": [
+        "5.85e+01 MeV MeV",
+        "8.00e+01 MeV MeV",
+        "1.09e+02 MeV MeV",
+        "1.50e+02 MeV MeV",
+        "2.05e+02 MeV MeV",
+        "2.80e+02 MeV MeV",
+        "3.83e+02 MeV MeV",
+        "5.23e+02 MeV MeV",
+        "7.16e+02 MeV MeV",
+        "9.79e+02 MeV MeV",
+        "1.34e+03 MeV MeV",
+        "1.83e+03 MeV MeV",
+        "2.50e+03 MeV MeV",
+        "3.42e+03 MeV MeV",
+        "4.68e+03 MeV MeV",
+        "6.41e+03 MeV MeV",
+        "8.76e+03 MeV MeV",
+        "1.20e+04 MeV MeV",
+        "1.64e+04 MeV MeV",
+        "2.24e+04 MeV MeV",
+        "3.06e+04 MeV MeV",
+        "4.19e+04 MeV MeV",
+        "5.73e+04 MeV MeV",
+        "7.84e+04 MeV MeV",
+        "1.07e+05 MeV MeV",
+        "1.47e+05 MeV MeV",
+        "2.01e+05 MeV MeV",
+        "2.74e+05 MeV MeV",
+        "3.75e+05 MeV MeV",
+        "5.13e+05 MeV MeV"
+       ],
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "SelectionSliderView",
+       "continuous_update": false,
+       "description": "Select energy_true:",
+       "description_tooltip": null,
+       "disabled": false,
+       "index": 0,
+       "layout": "IPY_MODEL_78b8e46d304249a5bbc53c0a68644cf8",
+       "orientation": "horizontal",
+       "readout": true,
+       "style": "IPY_MODEL_5a35b63e56c24532beb5e8f840b38fed"
+      }
+     },
+     "5a35b63e56c24532beb5e8f840b38fed": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": "initial"
+      }
+     },
+     "78b8e46d304249a5bbc53c0a68644cf8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": "50%"
+      }
+     },
+     "87c716d63873460888d16beb5fa839e9": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -1612,7 +1401,151 @@
        "width": null
       }
      },
-     "e56ebac5c35f4d0180d1f290ae57cc86": {
+     "97f6b4540c1f49c4b94a04592f8e4182": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": "50%"
+      }
+     },
+     "a10ff6f17f2344e0a2ef6cba097e305c": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_dbe281ff3a164b7aabb1d58bf1d2cbbe",
+       "msg_id": "",
+       "outputs": []
+      }
+     },
+     "ad64f8300cb1463e9a1844e0b8d19e0e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "RadioButtonsModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "RadioButtonsModel",
+       "_options_labels": [
+        "linear",
+        "sqrt",
+        "log"
+       ],
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "RadioButtonsView",
+       "description": "Select stretch:",
+       "description_tooltip": null,
+       "disabled": false,
+       "index": 0,
+       "layout": "IPY_MODEL_b626a4d1dc714af399a264ff0c5d2de4",
+       "style": "IPY_MODEL_19a6ccb5f26d4a148b70db347867259d"
+      }
+     },
+     "b1797ef97595453abe4aa0e0afbba842": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "_dom_classes": [
+        "widget-interact"
+       ],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "VBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "VBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_04e7e46eee924490831a5b41cd89a227",
+        "IPY_MODEL_305ed49a758d4b608965454b3c2b5c35",
+        "IPY_MODEL_a10ff6f17f2344e0a2ef6cba097e305c"
+       ],
+       "layout": "IPY_MODEL_fff74ad9cf6d4eb28f55ae3c9e6a4860"
+      }
+     },
+     "b1b63a980a79451cae29c56f57b3b79d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "_dom_classes": [
+        "widget-interact"
+       ],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "VBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "VBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_51aebbdd032840b8a9058204a14d29b2",
+        "IPY_MODEL_ad64f8300cb1463e9a1844e0b8d19e0e",
+        "IPY_MODEL_245eff90b6b24fda908f0c267fbd9991"
+       ],
+       "layout": "IPY_MODEL_0ea39b92814c44cea1728082f87717be"
+      }
+     },
+     "b626a4d1dc714af399a264ff0c5d2de4": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
@@ -1664,7 +1597,74 @@
        "width": null
       }
      },
-     "f1baed97cd934eb3845e2f961d2eaf29": {
+     "cca9b8a8231c45f0ba1d7490a5a14758": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": "initial"
+      }
+     },
+     "dbe281ff3a164b7aabb1d58bf1d2cbbe": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "fff74ad9cf6d4eb28f55ae3c9e6a4860": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -313,7 +313,7 @@ class Map(abc.ABC):
         hdu_bands : str
             Set the name of the bands table extension.  By default this will
             be set to BANDS.
-        conv : str
+        format : str
             FITS format convention.  By default files will be written
             to the gamma-astro-data-formats (GADF) format.  This
             option can be used to write files that are compliant with

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -160,7 +160,7 @@ class Map(abc.ABC):
             raise ValueError(f"Unrecognized map type: {map_type!r}")
 
     @staticmethod
-    def read(filename, hdu=None, hdu_bands=None, map_type="auto"):
+    def read(filename, hdu=None, hdu_bands=None, map_type="auto", format=None):
         """Read a map from a FITS file.
 
         Parameters
@@ -186,7 +186,7 @@ class Map(abc.ABC):
             Map object
         """
         with fits.open(str(make_path(filename)), memmap=False) as hdulist:
-            return Map.from_hdulist(hdulist, hdu, hdu_bands, map_type)
+            return Map.from_hdulist(hdulist, hdu, hdu_bands, map_type, format=format)
 
     @staticmethod
     def from_geom(
@@ -228,12 +228,12 @@ class Map(abc.ABC):
         return cls_out(geom, data=data, meta=meta, unit=unit, dtype=dtype)
 
     @staticmethod
-    def from_hdulist(hdulist, hdu=None, hdu_bands=None, map_type="auto"):
+    def from_hdulist(hdulist, hdu=None, hdu_bands=None, map_type="auto", format=None):
         """Create from `astropy.io.fits.HDUList`."""
         if map_type == "auto":
             map_type = Map._get_map_type(hdulist, hdu)
         cls_out = Map._get_map_cls(map_type)
-        return cls_out.from_hdulist(hdulist, hdu=hdu, hdu_bands=hdu_bands)
+        return cls_out.from_hdulist(hdulist, hdu=hdu, hdu_bands=hdu_bands, format=format)
 
     @staticmethod
     def _get_meta_from_header(header):

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -190,7 +190,7 @@ class Map(abc.ABC):
 
     @staticmethod
     def from_geom(
-        geom, meta=None, data=None, map_type="auto", unit="", dtype="float32"
+        geom, meta=None, data=None, unit="", dtype="float32"
     ):
         """Generate an empty map from a `Geom` instance.
 
@@ -202,11 +202,6 @@ class Map(abc.ABC):
             data array
         meta : `dict`
             Dictionary to store meta data.
-        map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse', 'auto'}
-            Map type.  Selects the class that will be used to
-            instantiate the map. The map type should be consistent
-            with the geometry. If map_type is 'auto' then an
-            appropriate map type will be inferred from type of ``geom``.
         unit : str or `~astropy.units.Unit`
             Data unit.
 
@@ -216,20 +211,18 @@ class Map(abc.ABC):
             Map object
 
         """
-        if map_type == "auto":
+        from .hpx import HpxGeom
+        from .wcs import WcsGeom
+        from .region import RegionGeom
 
-            from .hpx import HpxGeom
-            from .wcs import WcsGeom
-            from .region import RegionGeom
-
-            if isinstance(geom, HpxGeom):
-                map_type = "hpx"
-            elif isinstance(geom, WcsGeom):
-                map_type = "wcs"
-            elif isinstance(geom, RegionGeom):
-                map_type = "region"
-            else:
-                raise ValueError("Unrecognized geom type.")
+        if isinstance(geom, HpxGeom):
+            map_type = "hpx"
+        elif isinstance(geom, WcsGeom):
+            map_type = "wcs"
+        elif isinstance(geom, RegionGeom):
+            map_type = "region"
+        else:
+            raise ValueError("Unrecognized geom type.")
 
         cls_out = Map._get_map_cls(map_type)
         return cls_out(geom, data=data, meta=meta, unit=unit, dtype=dtype)

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -8,7 +8,7 @@ from astropy import units as u
 from astropy.io import fits
 from gammapy.utils.scripts import make_path
 from .geom import MapCoord, pix_tuple_to_idx, MapAxis
-from .utils import INVALID_VALUE, edges_from_lo_hi
+from .utils import INVALID_VALUE
 
 __all__ = ["Map"]
 
@@ -306,15 +306,14 @@ class Map(abc.ABC):
         hdu_bands : str
             Set the name of the bands table extension.  By default this will
             be set to BANDS.
-        format : str
+        format : {'gadf', 'fgst-ccube', 'fgst-ltcube', 'fgst-bexpcube',
+                  'fgst-template', 'fgst-srcmap', 'fgst-srcmap-sparse',
+                  'galprop', 'galprop2'}
             FITS format convention.  By default files will be written
             to the gamma-astro-data-formats (GADF) format.  This
             option can be used to write files that are compliant with
             format conventions required by specific software (e.g. the
-            Fermi Science Tools).  Supported conventions are 'gadf',
-            'fgst-ccube', 'fgst-ltcube', 'fgst-bexpcube',
-            'fgst-template', 'fgst-srcmap', 'fgst-srcmap-sparse',
-            'galprop', and 'galprop2'.
+            Fermi Science Tools).
         sparse : bool
             Sparsify the map by dropping pixels with zero amplitude.
             This option is only compatible with the 'gadf' format.
@@ -1024,8 +1023,9 @@ class Map(abc.ABC):
         map_out : `~Map`
             Map with non-spatial axes summed over
         """
-        return self.reduce_over_axes(func=np.add, axes=axes, keepdims=keepdims, weights=weights)
-
+        return self.reduce_over_axes(
+            func=np.add, axes=axes, keepdims=keepdims, weights=weights
+        )
 
     def reduce_over_axes(self, func=np.add, keepdims=False, axes=None, weights=None):
         """Reduce map over non-spatial axes

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -80,15 +80,13 @@ def make_axes_cols(axes, axis_names=None):
     return cols
 
 
+# TODO: remove and use proper format handling
 def find_and_read_bands(hdu, format):
     if hdu is None:
         return []
-
-    print(format)
-    if hdu.name == "ENERGIES":
-        axes = [MapAxis.from_table_hdu(hdu, format="fgst-template")]
-    elif hdu.name == "EBOUNDS":
-        axes = [MapAxis.from_table_hdu(hdu, format="fgst-ccube")]
+    
+    if format in ["fgst-ccube", "fgst-template"]:
+        axes = [MapAxis.from_table_hdu(hdu, format=format)]
     else:
         axes = []
 
@@ -888,6 +886,7 @@ class MapAxis:
         header["HDUCLAS2"] = "EBOUNDS", "This is an EBOUNDS extension"
         header["HDUVERS"] = "1.2.0", "Version of file format"
         return hdu
+
 
     @classmethod
     def from_table_hdu(cls, hdu, format="ogip", idx=0):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -80,53 +80,6 @@ def make_axes_cols(axes, axis_names=None):
     return cols
 
 
-def axes_from_bands_hdu(hdu):
-    """Read and returns the map axes from a BANDS table.
-
-    Parameters
-    ----------
-    hdu : `~astropy.io.fits.BinTableHDU`
-        The BANDS table HDU.
-
-    Returns
-    -------
-    axes : list of `~MapAxis`
-        List of axis objects.
-    """
-    axes = []
-
-    bands = Table.read(hdu)
-
-    for idx in range(5):
-        axcols = bands.meta.get("AXCOLS{}".format(idx + 1))
-
-        if axcols is None:
-            break
-
-        colnames = axcols.split(",")
-        node_type = "edges" if len(colnames) == 2 else "center"
-
-        # TODO: check why this extra case is needed
-        if colnames[0] == "E_MIN":
-            name = "energy"
-        else:
-            name = colnames[0].replace("_MIN", "").lower()
-
-        interp = bands.meta.get("INTERP{}".format(idx + 1), "lin")
-
-        if node_type == "center":
-            nodes = np.unique(bands[colnames[0]].quantity)
-        else:
-            edges_min = np.unique(bands[colnames[0]].quantity)
-            edges_max = np.unique(bands[colnames[1]].quantity)
-            nodes = edges_from_lo_hi(edges_min, edges_max)
-
-        axis = MapAxis(nodes=nodes, node_type=node_type, interp=interp, name=name)
-        axes.append(axis)
-
-    return axes
-
-
 def find_and_read_bands(hdu):
     if hdu is None:
         return []
@@ -136,7 +89,14 @@ def find_and_read_bands(hdu):
     elif hdu.name == "EBOUNDS":
         axes = [MapAxis.from_table_hdu(hdu, format="fgst-ccube")]
     else:
-        axes = axes_from_bands_hdu(hdu)
+        axes = []
+
+        for idx in range(5):
+            try:
+                axis = MapAxis.from_table_hdu(hdu, format="gadf", idx=idx)
+                axes.append(axis)
+            except AttributeError:
+                continue
 
     return axes
 
@@ -929,7 +889,7 @@ class MapAxis:
         return hdu
 
     @classmethod
-    def from_table_hdu(cls, hdu, format="ogip"):
+    def from_table_hdu(cls, hdu, format="ogip", idx=0):
         """Instanciate MapAxis from table HDU
 
         Parameters
@@ -938,6 +898,8 @@ class MapAxis:
             Table HDU
         format : {"ogip", "ogip-arf", "fgst-ccube", "fgst-template"}
             Format specification
+        idx : int
+            Column index of the axis.
 
         Returns
         -------
@@ -951,11 +913,13 @@ class MapAxis:
             emax = table["E_MAX"].quantity
             edges = np.append(emin.value, emax.value[-1]) * emin.unit
             axis = cls.from_edges(edges, name="energy", interp="log")
+
         elif format == "ogip-arf":
             emin = table["ENERG_LO"].quantity
             emax = table["ENERG_HI"].quantity
             edges = np.append(emin.value, emax.value[-1]) * emin.unit
             axis = cls.from_edges(edges, name="energy_true", interp="log")
+
         elif format == "fgst-template":
             allowed_names = ["Energy", "ENERGY", "energy"]
             for colname in table.colnames:
@@ -965,6 +929,29 @@ class MapAxis:
 
             nodes = table[tag].data
             axis = cls.from_nodes(nodes=nodes, name="energy_true", unit="MeV", interp="log")
+
+        elif format == "gadf":
+            axcols = table.meta.get("AXCOLS{}".format(idx + 1))
+            colnames = axcols.split(",")
+            node_type = "edges" if len(colnames) == 2 else "center"
+
+            # TODO: check why this extra case is needed
+            if colnames[0] == "E_MIN":
+                name = "energy"
+            else:
+                name = colnames[0].replace("_MIN", "").lower()
+
+            interp = table.meta.get("INTERP{}".format(idx + 1), "lin")
+
+            if node_type == "center":
+                nodes = np.unique(table[colnames[0]].quantity)
+            else:
+                edges_min = np.unique(table[colnames[0]].quantity)
+                edges_max = np.unique(table[colnames[1]].quantity)
+                nodes = edges_from_lo_hi(edges_min, edges_max)
+
+            axis = MapAxis(nodes=nodes, node_type=node_type, interp=interp, name=name)
+
         else:
             raise ValueError(f"Format '{format}' not supported")
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -84,8 +84,8 @@ def make_axes_cols(axes, axis_names=None):
 def find_and_read_bands(hdu, format):
     if hdu is None:
         return []
-    
-    if format in ["fgst-ccube", "fgst-template"]:
+
+    if format in ["fgst-ccube", "fgst-template", "fgst-bexpcube"]:
         axes = [MapAxis.from_table_hdu(hdu, format=format)]
     else:
         axes = []
@@ -920,7 +920,7 @@ class MapAxis:
             edges = np.append(emin.value, emax.value[-1]) * emin.unit
             axis = cls.from_edges(edges, name="energy_true", interp="log")
 
-        elif format == "fgst-template":
+        elif format in ["fgst-template", "fgst-bexpcube"]:
             allowed_names = ["Energy", "ENERGY", "energy"]
             for colname in table.colnames:
                 if colname in allowed_names:

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1286,7 +1286,7 @@ class Geom(abc.ABC):
 
         return cls.from_header(hdu.header, hdu_bands)
 
-    def make_bands_hdu(self, hdu=None, hdu_skymap=None, conv=None):
+    def make_bands_hdu(self, hdu=None, hdu_skymap=None, format=None):
         header = fits.Header()
         self._fill_header_from_axes(header)
         axis_names = None
@@ -1294,13 +1294,13 @@ class Geom(abc.ABC):
         # FIXME: Check whether convention is compatible with
         # dimensionality of geometry
 
-        if conv == "fgst-ccube":
+        if format == "fgst-ccube":
             hdu = "EBOUNDS"
             axis_names = ["energy"]
-        elif conv == "fgst-template":
+        elif format == "fgst-template":
             hdu = "ENERGIES"
             axis_names = ["energy"]
-        elif conv == "gadf" and hdu is None:
+        elif format == "gadf" and hdu is None:
             if hdu_skymap:
                 hdu = f"{hdu_skymap}_BANDS"
             else:

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1273,7 +1273,7 @@ class Geom(abc.ABC):
 
         return cls.from_header(hdu.header, hdu_bands)
 
-    def make_bands_hdu(self, hdu=None, hdu_skymap=None, format=None):
+    def to_bands_hdu(self, hdu=None, hdu_skymap=None, format=None):
         header = fits.Header()
         self._fill_header_from_axes(header)
         axis_names = None

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -84,6 +84,7 @@ def find_and_read_bands(hdu, format):
     if hdu is None:
         return []
 
+    print(format)
     if hdu.name == "ENERGIES":
         axes = [MapAxis.from_table_hdu(hdu, format="fgst-template")]
     elif hdu.name == "EBOUNDS":

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -80,7 +80,7 @@ def make_axes_cols(axes, axis_names=None):
     return cols
 
 
-def find_and_read_bands(hdu):
+def find_and_read_bands(hdu, format):
     if hdu is None:
         return []
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1278,10 +1278,10 @@ class HpxGeom(Geom):
 
         return cls.from_header(hdu.header, hdu_bands=hdu_bands, pix=pix)
 
-    def make_header(self, conv="gadf", **kwargs):
+    def make_header(self, format="gadf", **kwargs):
         """Build and return FITS header for this HEALPIX map."""
         header = fits.Header()
-        conv = kwargs.get("conv", HPX_FITS_CONVENTIONS[conv])
+        format = kwargs.get("format", HPX_FITS_CONVENTIONS[format])
 
         # FIXME: For some sparse maps we may want to allow EXPLICIT
         # with an empty region string
@@ -1295,11 +1295,11 @@ class HpxGeom(Geom):
             else:
                 indxschm = "LOCAL"
 
-        if "FGST" in conv.convname.upper():
+        if "FGST" in format.convname.upper():
             header["TELESCOP"] = "GLAST"
             header["INSTRUME"] = "LAT"
 
-        header[conv.frame] = frame_to_coordsys(self.frame)
+        header[format.frame] = frame_to_coordsys(self.frame)
         header["PIXTYPE"] = "HEALPIX"
         header["ORDERING"] = self.ordering
         header["INDXSCHM"] = indxschm
@@ -1307,7 +1307,7 @@ class HpxGeom(Geom):
         header["NSIDE"] = np.max(self._nside)
         header["FIRSTPIX"] = 0
         header["LASTPIX"] = np.max(self._maxpix) - 1
-        header["HPX_CONV"] = conv.convname.upper()
+        header["HPX_CONV"] = format.convname.upper()
 
         if self.frame == "icrs":
             header["EQUINOX"] = (2000.0, "Equinox of RA & DEC specifications")

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -47,6 +47,45 @@ class HpxConv:
     def create(cls, convname="gadf"):
         return copy.deepcopy(HPX_FITS_CONVENTIONS[convname])
 
+    @staticmethod
+    def identify_hpx_format(header):
+        """Identify the convention used to write this file."""
+        # Hopefully the file contains the HPX_CONV keyword specifying
+        # the convention used
+        if "HPX_CONV" in header:
+            return header["HPX_CONV"].lower()
+
+        # Try based on the EXTNAME keyword
+        hduname = header.get("EXTNAME", None)
+        if hduname == "HPXEXPOSURES":
+            return "fgst-bexpcube"
+        elif hduname == "SKYMAP2":
+            if "COORDTYPE" in header.keys():
+                return "galprop"
+            else:
+                return "galprop2"
+
+        # Check the name of the first column
+        colname = header["TTYPE1"]
+        if colname == "PIX":
+            colname = header["TTYPE2"]
+
+        if colname == "KEY":
+            return "fgst-srcmap-sparse"
+        elif colname == "ENERGY1":
+            return "fgst-template"
+        elif colname == "COSBINS":
+            return "fgst-ltcube"
+        elif colname == "Bin0":
+            return "galprop"
+        elif colname == "CHANNEL1" or colname == "CHANNEL0":
+            if hduname == "SKYMAP":
+                return "fgst-ccube"
+            else:
+                return "fgst-srcmap"
+        else:
+            raise ValueError("Could not identify HEALPIX convention")
+
 
 HPX_FITS_CONVENTIONS = {}
 """Various conventions for storing HEALPIX maps in FITS files"""
@@ -186,66 +225,6 @@ def get_pix_size_from_nside(nside):
         raise ValueError(f"HEALPIX order must be 0 to 13. Got: {order!r}")
 
     return HPX_ORDER_TO_PIXSIZE[order]
-
-
-def make_hpx_to_wcs_mapping(hpx, wcs):
-    """Make the pixel mapping from HPX- to a WCS-based geometry.
-
-    Parameters
-    ----------
-    hpx : `~gammapy.maps.HpxGeom`
-       The HEALPIX geometry
-    wcs : `~gammapy.maps.WcsGeom`
-       The WCS geometry
-
-    Returns
-    -------
-    ipix : `~numpy.ndarray`
-        array(nx,ny) of HEALPIX pixel indices for each wcs pixel
-    mult_val : `~numpy.ndarray`
-        array(nx,ny) of 1./number of WCS pixels pointing at each HEALPIX pixel
-    npix : tuple
-        tuple(nx,ny) with the shape of the WCS grid
-    """
-    import healpy as hp
-
-    npix = wcs.npix
-
-    # FIXME: Calculation of WCS pixel centers should be moved into a
-    # method of WcsGeom
-    pix_crds = np.dstack(np.meshgrid(np.arange(npix[0]), np.arange(npix[1])))
-    pix_crds = pix_crds.swapaxes(0, 1).reshape((-1, 2))
-    sky_crds = wcs.wcs.wcs_pix2world(pix_crds, 0)
-    sky_crds *= np.radians(1.0)
-    sky_crds[0:, 1] = (np.pi / 2) - sky_crds[0:, 1]
-
-    mask = ~np.any(np.isnan(sky_crds), axis=1)
-    ipix = -1 * np.ones((len(hpx.nside), int(npix[0] * npix[1])), int)
-    m = mask[None, :] * np.ones_like(ipix, dtype=bool)
-
-    ipix[m] = hp.ang2pix(
-        hpx.nside[..., None],
-        sky_crds[:, 1][mask][None, ...],
-        sky_crds[:, 0][mask][None, ...],
-        hpx.nest,
-    ).flatten()
-
-    # Here we are counting the number of HEALPIX pixels each WCS pixel
-    # points to and getting a multiplicative factor that tells use how
-    # to split up the counts in each HEALPIX pixel (by dividing the
-    # corresponding WCS pixels by the number of associated HEALPIX
-    # pixels).
-    mult_val = np.ones_like(ipix, dtype=float)
-    for i, t in enumerate(ipix):
-        count = np.unique(t, return_counts=True)
-        idx = np.searchsorted(count[0], t)
-        mult_val[i, ...] = 1.0 / count[1][idx]
-
-    if hpx.nside.size == 1:
-        ipix = np.squeeze(ipix, axis=0)
-        mult_val = np.squeeze(mult_val, axis=0)
-
-    return ipix, mult_val, npix
 
 
 def match_hpx_pix(nside, nest, nside_pix, ipix_ring):
@@ -1148,45 +1127,6 @@ class HpxGeom(Geom):
 
         return cls(nside, nest=nest, frame=frame, region=region, axes=axes)
 
-    @staticmethod
-    def identify_hpx_convention(header):
-        """Identify the convention used to write this file."""
-        # Hopefully the file contains the HPX_CONV keyword specifying
-        # the convention used
-        if "HPX_CONV" in header:
-            return header["HPX_CONV"].lower()
-
-        # Try based on the EXTNAME keyword
-        hduname = header.get("EXTNAME", None)
-        if hduname == "HPXEXPOSURES":
-            return "fgst-bexpcube"
-        elif hduname == "SKYMAP2":
-            if "COORDTYPE" in header.keys():
-                return "galprop"
-            else:
-                return "galprop2"
-
-        # Check the name of the first column
-        colname = header["TTYPE1"]
-        if colname == "PIX":
-            colname = header["TTYPE2"]
-
-        if colname == "KEY":
-            return "fgst-srcmap-sparse"
-        elif colname == "ENERGY1":
-            return "fgst-template"
-        elif colname == "COSBINS":
-            return "fgst-ltcube"
-        elif colname == "Bin0":
-            return "galprop"
-        elif colname == "CHANNEL1" or colname == "CHANNEL0":
-            if hduname == "SKYMAP":
-                return "fgst-ccube"
-            else:
-                return "fgst-srcmap"
-        else:
-            raise ValueError("Could not identify HEALPIX convention")
-
     @classmethod
     def from_header(cls, header, hdu_bands=None, format=None):
         """Create an HPX object from a FITS header.
@@ -1208,7 +1148,7 @@ class HpxGeom(Geom):
             HEALPix geometry.
         """
         if format is None:
-            format = HpxGeom.identify_hpx_convention(header)
+            format = HpxConv.identify_hpx_format(header)
 
         conv = HPX_FITS_CONVENTIONS[format]
 
@@ -1690,9 +1630,47 @@ class HpxToWcsMapping:
         Returns
         -------
         hpx2wcs : `~HpxToWcsMapping`
+            Mapping
 
         """
-        ipix, mult_val, npix = make_hpx_to_wcs_mapping(hpx, wcs)
+        import healpy as hp
+
+        npix = wcs.npix
+
+        # FIXME: Calculation of WCS pixel centers should be moved into a
+        # method of WcsGeom
+        pix_crds = np.dstack(np.meshgrid(np.arange(npix[0]), np.arange(npix[1])))
+        pix_crds = pix_crds.swapaxes(0, 1).reshape((-1, 2))
+        sky_crds = wcs.wcs.wcs_pix2world(pix_crds, 0)
+        sky_crds *= np.radians(1.0)
+        sky_crds[0:, 1] = (np.pi / 2) - sky_crds[0:, 1]
+
+        mask = ~np.any(np.isnan(sky_crds), axis=1)
+        ipix = -1 * np.ones((len(hpx.nside), int(npix[0] * npix[1])), int)
+        m = mask[None, :] * np.ones_like(ipix, dtype=bool)
+
+        ipix[m] = hp.ang2pix(
+            hpx.nside[..., None],
+            sky_crds[:, 1][mask][None, ...],
+            sky_crds[:, 0][mask][None, ...],
+            hpx.nest,
+        ).flatten()
+
+        # Here we are counting the number of HEALPIX pixels each WCS pixel
+        # points to and getting a multiplicative factor that tells use how
+        # to split up the counts in each HEALPIX pixel (by dividing the
+        # corresponding WCS pixels by the number of associated HEALPIX
+        # pixels).
+        mult_val = np.ones_like(ipix, dtype=float)
+        for i, t in enumerate(ipix):
+            count = np.unique(t, return_counts=True)
+            idx = np.searchsorted(count[0], t)
+            mult_val[i, ...] = 1.0 / count[1][idx]
+
+        if hpx.nside.size == 1:
+            ipix = np.squeeze(ipix, axis=0)
+            mult_val = np.squeeze(mult_val, axis=0)
+
         return cls(hpx, wcs, ipix, mult_val, npix)
 
     def fill_wcs_map_from_hpx_data(

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1188,7 +1188,7 @@ class HpxGeom(Geom):
             raise ValueError("Could not identify HEALPIX convention")
 
     @classmethod
-    def from_header(cls, header, hdu_bands=None, pix=None):
+    def from_header(cls, header, hdu_bands=None, format=None):
         """Create an HPX object from a FITS header.
 
         Parameters
@@ -1197,20 +1197,22 @@ class HpxGeom(Geom):
             The FITS header
         hdu_bands : `~astropy.io.fits.BinTableHDU`
             The BANDS table HDU.
-        pix : tuple
-            List of pixel index vectors defining the pixels
-            encompassed by the geometry.  For EXPLICIT geometries with
-            HPX_REG undefined this tuple defines the geometry.
+        format : {'gadf', 'fgst-ccube', 'fgst-ltcube', 'fgst-bexpcube',
+                  'fgst-srcmap', 'fgst-template', 'fgst-srcmap-sparse',
+                  'galprop', 'galprop2'}
+            FITS convention. If None the format is guessed.
 
         Returns
         -------
         hpx : `~HpxGeom`
             HEALPix geometry.
         """
-        convname = HpxGeom.identify_hpx_convention(header)
-        conv = HPX_FITS_CONVENTIONS[convname]
+        if format is None:
+            format = HpxGeom.identify_hpx_convention(header)
 
-        axes = find_and_read_bands(hdu_bands)
+        conv = HPX_FITS_CONVENTIONS[format]
+
+        axes = find_and_read_bands(hdu_bands, format=format)
         shape = [ax.nbin for ax in axes]
 
         if header["PIXTYPE"] != "HEALPIX":

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1409,7 +1409,7 @@ class HpxGeom(Geom):
         else:
             return self.nside
 
-    def make_wcs(self, proj="AIT", oversample=2, drop_axes=True, width_pix=None):
+    def to_wcs_geom(self, proj="AIT", oversample=2, drop_axes=True, width_pix=None):
         """Make a WCS projection appropriate for this HPX pixelization.
 
         Parameters

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1278,7 +1278,7 @@ class HpxGeom(Geom):
 
         return cls.from_header(hdu.header, hdu_bands=hdu_bands, pix=pix)
 
-    def make_header(self, format="gadf", **kwargs):
+    def to_header(self, format="gadf", **kwargs):
         """Build and return FITS header for this HEALPIX map."""
         header = fits.Header()
         format = kwargs.get("format", HPX_FITS_CONVENTIONS[format])

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -138,7 +138,13 @@ class HpxMap(Map):
         if hdu_bands is not None:
             hdu_bands_out = hdu_list[hdu_bands]
 
-        return cls.from_hdu(hdu_out, hdu_bands_out, format=format)
+        hpx_map = cls.from_hdu(hdu_out, hdu_bands_out, format=format)
+
+        # exposure maps have an additional GTI hdu
+        if format == "fgst-template" and "GTI" in hdu_list:
+            hpx_map.unit = "cm2 s"
+
+        return hpx_map
 
     def to_hdulist(self, hdu="SKYMAP", hdu_bands=None, sparse=False, format="gadf"):
         """Convert to `~astropy.io.fits.HDUList`.

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -276,7 +276,7 @@ class HpxMap(Map):
         hduname = hpxconv.hduname if hdu is None else hdu
         hduname_bands = hpxconv.bands_hdu if hdu_bands is None else hdu_bands
 
-        header = self.geom.make_header(format=format)
+        header = self.geom.to_header(format=format)
 
         if self.geom.axes:
             header["BANDSHDU"] = hduname_bands

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -158,7 +158,7 @@ class HpxMap(Map):
         hdu_list : `~astropy.io.fits.HDUList`
         """
         if self.geom.axes:
-            hdu_bands_out = self.geom.make_bands_hdu(
+            hdu_bands_out = self.geom.to_bands_hdu(
                 hdu=hdu_bands, hdu_skymap=hdu, format=format
             )
             hdu_bands = hdu_bands_out.name

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -25,11 +25,6 @@ class HpxMap(Map):
         The map unit
     """
 
-    def __init__(self, geom, data, meta=None, unit=""):
-        super().__init__(geom, data, meta, unit)
-        self._wcs2d = None
-        self._hpx2wcs = None
-
     @classmethod
     def create(
         cls,
@@ -117,6 +112,14 @@ class HpxMap(Map):
             BinTableHDU in the file.
         hdu_bands : str
             Name or index of the HDU with the BANDS table.
+        format : {'gadf', 'fgst-ccube', 'fgst-ltcube', 'fgst-bexpcube',
+                  'fgst-template', 'fgst-srcmap', 'fgst-srcmap-sparse',
+                  'galprop', 'galprop2'}
+            FITS format convention.  By default files will be written
+            to the gamma-astro-data-formats (GADF) format.  This
+            option can be used to write files that are compliant with
+            format conventions required by specific software (e.g. the
+            Fermi Science Tools).
 
         Returns
         -------
@@ -149,9 +152,14 @@ class HpxMap(Map):
         sparse : bool
             Set INDXSCHM to SPARSE and sparsify the map by only
             writing pixels with non-zero amplitude.
-        format : {'fgst-ccube','fgst-template','gadf',None}, optional
-            FITS format convention.  If None this will be set to the
-            default convention of the map.
+        format : {'gadf', 'fgst-ccube', 'fgst-ltcube', 'fgst-bexpcube',
+                  'fgst-template', 'fgst-srcmap', 'fgst-srcmap-sparse',
+                  'galprop', 'galprop2'}
+            FITS format convention.  By default files will be written
+            to the gamma-astro-data-formats (GADF) format.  This
+            option can be used to write files that are compliant with
+            format conventions required by specific software (e.g. the
+            Fermi Science Tools).
 
         Returns
         -------
@@ -166,7 +174,7 @@ class HpxMap(Map):
             hdu_bands_out = None
             hdu_bands = None
 
-        hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse, format=format)
+        hdu_out = self.to_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse, format=format)
         hdu_out.header["META"] = json.dumps(self.meta)
         hdu_out.header["BUNIT"] = self.unit.to_string("fits")
 
@@ -251,7 +259,7 @@ class HpxMap(Map):
         """
         pass
 
-    def make_hdu(self, hdu=None, hdu_bands=None, sparse=False, format=None):
+    def to_hdu(self, hdu=None, hdu_bands=None, sparse=False, format=None):
         """Make a FITS HDU with input data.
 
         Parameters

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -104,7 +104,7 @@ class HpxMap(Map):
             raise ValueError(f"Unrecognized map type: {map_type!r}")
 
     @classmethod
-    def from_hdulist(cls, hdu_list, hdu=None, hdu_bands=None):
+    def from_hdulist(cls, hdu_list, hdu=None, hdu_bands=None, format=None):
         """Make a HpxMap object from a FITS HDUList.
 
         Parameters
@@ -135,7 +135,7 @@ class HpxMap(Map):
         if hdu_bands is not None:
             hdu_bands_out = hdu_list[hdu_bands]
 
-        return cls.from_hdu(hdu_out, hdu_bands_out)
+        return cls.from_hdu(hdu_out, hdu_bands_out, format=format)
 
     def to_hdulist(self, hdu="SKYMAP", hdu_bands=None, sparse=False, format="gadf"):
         """Convert to `~astropy.io.fits.HDUList`.

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -138,10 +138,13 @@ class HpxMap(Map):
         if hdu_bands is not None:
             hdu_bands_out = hdu_list[hdu_bands]
 
+        if format is None:
+            format = HpxConv.identify_hpx_format(hdu_out.header)
+
         hpx_map = cls.from_hdu(hdu_out, hdu_bands_out, format=format)
 
         # exposure maps have an additional GTI hdu
-        if format == "fgst-template" and "GTI" in hdu_list:
+        if format == "fgst-bexpcube" and "GTI" in hdu_list:
             hpx_map.unit = "cm2 s"
 
         return hpx_map

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -137,7 +137,7 @@ class HpxMap(Map):
 
         return cls.from_hdu(hdu_out, hdu_bands_out)
 
-    def to_hdulist(self, hdu="SKYMAP", hdu_bands=None, sparse=False, conv="gadf"):
+    def to_hdulist(self, hdu="SKYMAP", hdu_bands=None, sparse=False, format="gadf"):
         """Convert to `~astropy.io.fits.HDUList`.
 
         Parameters
@@ -149,7 +149,7 @@ class HpxMap(Map):
         sparse : bool
             Set INDXSCHM to SPARSE and sparsify the map by only
             writing pixels with non-zero amplitude.
-        conv : {'fgst-ccube','fgst-template','gadf',None}, optional
+        format : {'fgst-ccube','fgst-template','gadf',None}, optional
             FITS format convention.  If None this will be set to the
             default convention of the map.
 
@@ -159,14 +159,14 @@ class HpxMap(Map):
         """
         if self.geom.axes:
             hdu_bands_out = self.geom.make_bands_hdu(
-                hdu=hdu_bands, hdu_skymap=hdu, conv=conv
+                hdu=hdu_bands, hdu_skymap=hdu, format=format
             )
             hdu_bands = hdu_bands_out.name
         else:
             hdu_bands_out = None
             hdu_bands = None
 
-        hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse, conv=conv)
+        hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse, format=format)
         hdu_out.header["META"] = json.dumps(self.meta)
         hdu_out.header["BUNIT"] = self.unit.to_string("fits")
 
@@ -251,7 +251,7 @@ class HpxMap(Map):
         """
         pass
 
-    def make_hdu(self, hdu=None, hdu_bands=None, sparse=False, conv=None):
+    def make_hdu(self, hdu=None, hdu_bands=None, sparse=False, format=None):
         """Make a FITS HDU with input data.
 
         Parameters
@@ -263,7 +263,7 @@ class HpxMap(Map):
         sparse : bool
             Set INDXSCHM to SPARSE and sparsify the map by only
             writing pixels with non-zero amplitude.
-        conv : {'fgst-ccube', 'fgst-template', 'gadf', None}, optional
+        format : {'fgst-ccube', 'fgst-template', 'gadf', None}, optional
             FITS format convention.  If None this will be set to the
             default convention of the map.
 
@@ -272,11 +272,11 @@ class HpxMap(Map):
         hdu_out : `~astropy.io.fits.BinTableHDU` or `~astropy.io.fits.ImageHDU`
             Output HDU containing map data.
         """
-        hpxconv = HpxConv.create(conv)
+        hpxconv = HpxConv.create(format)
         hduname = hpxconv.hduname if hdu is None else hdu
         hduname_bands = hpxconv.bands_hdu if hdu_bands is None else hdu_bands
 
-        header = self.geom.make_header(conv=conv)
+        header = self.geom.make_header(format=format)
 
         if self.geom.axes:
             header["BANDSHDU"] = hduname_bands

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -54,7 +54,7 @@ class HpxNDMap(HpxMap):
         return data
 
     @classmethod
-    def from_hdu(cls, hdu, hdu_bands=None):
+    def from_hdu(cls, hdu, hdu_bands=None, format=None):
         """Make a HpxNDMap object from a FITS HDU.
 
         Parameters
@@ -63,11 +63,23 @@ class HpxNDMap(HpxMap):
             The FITS HDU
         hdu_bands  : `~astropy.io.fits.BinTableHDU`
             The BANDS table HDU
+        format : {'gadf', 'fgst-ccube', 'fgst-ltcube', 'fgst-bexpcube',
+                  'fgst-srcmap', 'fgst-template', 'fgst-srcmap-sparse',
+                  'galprop', 'galprop2'}
+            FITS convention. If None the format is guessed.
+
+        Returns
+        -------
+        map : `HpxMap`
+            HEALPix map
+
         """
         hpx = HpxGeom.from_header(hdu.header, hdu_bands)
 
-        convname = HpxGeom.identify_hpx_convention(hdu.header)
-        hpx_conv = HPX_FITS_CONVENTIONS[convname]
+        if format is None:
+            format = HpxGeom.identify_hpx_convention(hdu.header)
+
+        hpx_conv = HPX_FITS_CONVENTIONS[format]
 
         shape = tuple([ax.nbin for ax in hpx.axes[::-1]])
         # shape_data = shape + tuple([np.max(hpx.npix)])
@@ -99,8 +111,8 @@ class HpxNDMap(HpxMap):
             if nbin == 1:
                 map_out.data = hdu.data.field(cnames[0])
             else:
-                for i, cname in enumerate(cnames):
-                    idx = np.unravel_index(i, shape)
+                for idx, cname in enumerate(cnames):
+                    idx = np.unravel_index(idx, shape)
                     map_out.data[idx + (slice(None),)] = hdu.data.field(cname)
 
         return map_out

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -72,21 +72,20 @@ class HpxNDMap(HpxMap):
             HEALPix map
 
         """
-        hpx = HpxGeom.from_header(hdu.header, hdu_bands)
-
         if format is None:
             format = HpxConv.identify_hpx_format(hdu.header)
 
+        geom = HpxGeom.from_header(hdu.header, hdu_bands, format=format)
+
         hpx_conv = HPX_FITS_CONVENTIONS[format]
 
-        shape = tuple([ax.nbin for ax in hpx.axes[::-1]])
-        # shape_data = shape + tuple([np.max(hpx.npix)])
+        shape = tuple([ax.nbin for ax in geom.axes[::-1]])
 
         # TODO: Should we support extracting slices?
 
         meta = cls._get_meta_from_header(hdu.header)
         unit = unit_from_fits_image_hdu(hdu.header)
-        map_out = cls(hpx, None, meta=meta, unit=unit)
+        map_out = cls(geom, None, meta=meta, unit=unit)
 
         colnames = hdu.columns.names
         cnames = []

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -39,7 +39,6 @@ class HpxNDMap(HpxMap):
             data = self._make_default_data(geom, data_shape, dtype)
 
         super().__init__(geom, data, meta, unit)
-        self._wcs2d = None
 
     @staticmethod
     def _make_default_data(geom, shape_np, dtype):

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -4,7 +4,7 @@ from astropy.io import fits
 from astropy.units import Quantity
 from gammapy.utils.units import unit_from_fits_image_hdu
 from .geom import MapCoord, pix_tuple_to_idx
-from .hpx import HPX_FITS_CONVENTIONS, HpxGeom, HpxToWcsMapping, nside_to_order
+from .hpx import HPX_FITS_CONVENTIONS, HpxGeom, HpxToWcsMapping, nside_to_order, HpxConv
 from .hpxmap import HpxMap
 from .utils import INVALID_INDEX, interp_to_order
 
@@ -75,7 +75,7 @@ class HpxNDMap(HpxMap):
         hpx = HpxGeom.from_header(hdu.header, hdu_bands)
 
         if format is None:
-            format = HpxGeom.identify_hpx_convention(hdu.header)
+            format = HpxConv.identify_hpx_format(hdu.header)
 
         hpx_conv = HPX_FITS_CONVENTIONS[format]
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -106,14 +106,12 @@ class HpxNDMap(HpxMap):
         return map_out
 
     def make_wcs_mapping(
-        self, sum_bands=False, proj="AIT", oversample=2, width_pix=None
+        self, proj="AIT", oversample=2, width_pix=None
     ):
         """Make a HEALPix to WCS mapping object.
 
         Parameters
         ----------
-        sum_bands : bool
-            sum over non-spatial dimensions before reprojecting
         proj  : str
             WCS-projection
         oversample : float
@@ -132,7 +130,7 @@ class HpxNDMap(HpxMap):
         hpx2wcs : `~HpxToWcsMapping`
 
         """
-        self._wcs2d = self.geom.make_wcs(
+        self._wcs2d = self.geom.to_wcs_geom(
             proj=proj, oversample=oversample, width_pix=width_pix, drop_axes=True
         )
         self._hpx2wcs = HpxToWcsMapping.create(self.geom, self._wcs2d)
@@ -516,7 +514,7 @@ class HpxNDMap(HpxMap):
         from matplotlib.collections import PatchCollection
         import healpy as hp
 
-        wcs = self.geom.make_wcs(proj=proj, oversample=1)
+        wcs = self.geom.to_wcs_geom(proj=proj, oversample=1)
         if ax is None:
             fig = plt.gcf()
             ax = fig.add_subplot(111, projection=wcs.wcs, aspect="equal")

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -40,7 +40,6 @@ class HpxNDMap(HpxMap):
 
         super().__init__(geom, data, meta, unit)
         self._wcs2d = None
-        self._hpx2wcs = None
 
     @staticmethod
     def _make_default_data(geom, shape_np, dtype):
@@ -117,37 +116,6 @@ class HpxNDMap(HpxMap):
 
         return map_out
 
-    def make_wcs_mapping(
-        self, proj="AIT", oversample=2, width_pix=None
-    ):
-        """Make a HEALPix to WCS mapping object.
-
-        Parameters
-        ----------
-        proj  : str
-            WCS-projection
-        oversample : float
-            Oversampling factor for WCS map. This will be the
-            approximate ratio of the width of a HPX pixel to a WCS
-            pixel. If this parameter is None then the width will be
-            set from ``width_pix``.
-        width_pix : int
-            Width of the WCS geometry in pixels.  The pixel size will
-            be set to the number of pixels satisfying ``oversample``
-            or ``width_pix`` whichever is smaller.  If this parameter
-            is None then the width will be set from ``oversample``.
-
-        Returns
-        -------
-        hpx2wcs : `~HpxToWcsMapping`
-
-        """
-        self._wcs2d = self.geom.to_wcs_geom(
-            proj=proj, oversample=oversample, width_pix=width_pix, drop_axes=True
-        )
-        self._hpx2wcs = HpxToWcsMapping.create(self.geom, self._wcs2d)
-        return self._hpx2wcs
-
     def to_wcs(
         self,
         sum_bands=False,
@@ -171,9 +139,11 @@ class HpxNDMap(HpxMap):
 
         # FIXME: Check whether the old mapping is still valid and reuse it
         if hpx2wcs is None:
-            hpx2wcs = self.make_wcs_mapping(
-                oversample=oversample, proj=proj, width_pix=width_pix
+            geom_wcs_image = self.geom.to_wcs_geom(
+                proj=proj, oversample=oversample, width_pix=width_pix, drop_axes=True
             )
+
+            hpx2wcs = HpxToWcsMapping.create(self.geom, geom_wcs_image)
 
         # FIXME: Need a function to extract a valid shape from npix property
 

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -667,7 +667,7 @@ def test_hpxgeom_read_write(tmp_path, nside, nested, frame, region, axes):
     geom0 = HpxGeom(nside, nested, frame, region=region, axes=axes)
     hdu_bands = geom0.make_bands_hdu(hdu="BANDS")
     hdu_prim = fits.PrimaryHDU()
-    hdu_prim.header.update(geom0.make_header())
+    hdu_prim.header.update(geom0.to_header())
 
     hdulist = fits.HDUList([hdu_prim, hdu_bands])
     hdulist.writeto(tmp_path / "tmp.fits")

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -665,7 +665,7 @@ def test_hpxgeom_from_header():
 @pytest.mark.parametrize(("nside", "nested", "frame", "region", "axes"), hpx_test_geoms)
 def test_hpxgeom_read_write(tmp_path, nside, nested, frame, region, axes):
     geom0 = HpxGeom(nside, nested, frame, region=region, axes=axes)
-    hdu_bands = geom0.make_bands_hdu(hdu="BANDS")
+    hdu_bands = geom0.to_bands_hdu(hdu="BANDS")
     hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.to_header())
 

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -6,12 +6,12 @@ from astropy.io import fits
 from gammapy.maps import MapAxis, MapCoord
 from gammapy.maps.hpx import (
     HpxGeom,
+    HpxToWcsMapping,
     get_hpxregion_dir,
     get_hpxregion_size,
     get_pix_size_from_nside,
     get_subpixels,
     get_superpixels,
-    make_hpx_to_wcs_mapping,
     nside_to_order,
     ravel_hpx_index,
     unravel_hpx_index,
@@ -463,9 +463,9 @@ def test_make_hpx_to_wcs_mapping():
     hpx = HpxGeom(16, False, "galactic", region="DISK(110.,75.,2.)")
     # FIXME construct explicit WCS projection here
     wcs = hpx.to_wcs_geom()
-    hpx2wcs = make_hpx_to_wcs_mapping(hpx, wcs)
+    hpx2wcs = HpxToWcsMapping.create(hpx, wcs)
     assert_allclose(
-        hpx2wcs[0],
+        hpx2wcs.ipix,
         np.array(
             [
                 67,
@@ -508,7 +508,7 @@ def test_make_hpx_to_wcs_mapping():
         ),
     )
     assert_allclose(
-        hpx2wcs[1],
+        hpx2wcs.mult_val,
         np.array(
             [
                 0.11111111,
@@ -552,9 +552,9 @@ def test_make_hpx_to_wcs_mapping():
     )
 
     hpx = HpxGeom([8, 16], False, "galactic", region="DISK(110.,75.,2.)", axes=[ax0])
-    hpx2wcs = make_hpx_to_wcs_mapping(hpx, wcs)
+    hpx2wcs = HpxToWcsMapping.create(hpx, wcs)
     assert_allclose(
-        hpx2wcs[0],
+        hpx2wcs.ipix,
         np.array(
             [
                 [

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -396,11 +396,11 @@ def test_hpxgeom_make_wcs():
     ax0 = np.linspace(0.0, 3.0, 4)
 
     hpx = HpxGeom(64, False, "galactic", region="DISK(110.,75.,2.)")
-    wcs = hpx.make_wcs()
+    wcs = hpx.to_wcs_geom()
     assert_allclose(wcs.wcs.wcs.crval, np.array([110.0, 75.0]))
 
     hpx = HpxGeom(64, False, "galactic", region="DISK(110.,75.,2.)", axes=[ax0])
-    wcs = hpx.make_wcs()
+    wcs = hpx.to_wcs_geom()
     assert_allclose(wcs.wcs.wcs.crval, np.array([110.0, 75.0]))
 
 
@@ -462,7 +462,7 @@ def test_make_hpx_to_wcs_mapping():
     ax0 = np.linspace(0.0, 1.0, 3)
     hpx = HpxGeom(16, False, "galactic", region="DISK(110.,75.,2.)")
     # FIXME construct explicit WCS projection here
-    wcs = hpx.make_wcs()
+    wcs = hpx.to_wcs_geom()
     hpx2wcs = make_hpx_to_wcs_mapping(hpx, wcs)
     assert_allclose(
         hpx2wcs[0],

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -119,6 +119,15 @@ def test_hpxmap_read_write_fgst(tmp_path):
     m2 = Map.read(path)
 
 
+def test_read_fgst_exposure():
+    exposure = Map.read(
+        "$GAMMAPY_DATA/fermi_3fhl/fermi_3fhl_exposure_cube_hpx.fits.gz"
+    )
+    energy_axis = exposure.geom.get_axis_by_name("energy_true")
+    assert energy_axis.node_type == "center"
+    assert exposure.unit == "cm2 s"
+
+
 @pytest.mark.parametrize(("nside", "nested", "frame", "region", "axes"), hpx_test_geoms)
 def test_hpxmap_set_get_by_pix(nside, nested, frame, region, axes):
     m = create_map(nside, nested, frame, region, axes)

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -99,7 +99,7 @@ def test_hpxmap_read_write_fgst(tmp_path):
 
     # Test Counts Cube
     m = create_map(8, False, "galactic", None, [axis])
-    m.write(path, conv="fgst-ccube", overwrite=True)
+    m.write(path, format="fgst-ccube", overwrite=True)
     with fits.open(path, memmap=False) as hdulist:
         assert "SKYMAP" in hdulist
         assert "EBOUNDS" in hdulist
@@ -109,7 +109,7 @@ def test_hpxmap_read_write_fgst(tmp_path):
     m2 = Map.read(path)
 
     # Test Model Cube
-    m.write(path, conv="fgst-template", overwrite=True)
+    m.write(path, format="fgst-template", overwrite=True)
     with fits.open(path, memmap=False) as hdulist:
         assert "SKYMAP" in hdulist
         assert "ENERGIES" in hdulist

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -7,7 +7,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from gammapy.maps import HpxGeom, HpxMap, HpxNDMap, Map, MapAxis
 from gammapy.maps.utils import fill_poisson
-from gammapy.utils.testing import mpl_plot_check, requires_dependency
+from gammapy.utils.testing import mpl_plot_check, requires_dependency, requires_data
 
 pytest.importorskip("healpy")
 
@@ -119,6 +119,7 @@ def test_hpxmap_read_write_fgst(tmp_path):
     m2 = Map.read(path)
 
 
+@requires_data()
 def test_read_fgst_exposure():
     exposure = Map.read(
         "$GAMMAPY_DATA/fermi_3fhl/fermi_3fhl_exposure_cube_hpx.fits.gz"

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -94,7 +94,7 @@ def test_wcsgeom_read_write(tmp_path, npix, binsz, frame, proj, skydir, axes):
 
     hdu_bands = geom0.make_bands_hdu(hdu="BANDS")
     hdu_prim = fits.PrimaryHDU()
-    hdu_prim.header.update(geom0.make_header())
+    hdu_prim.header.update(geom0.to_header())
 
     hdulist = fits.HDUList([hdu_prim, hdu_bands])
     hdulist.writeto(tmp_path / "tmp.fits")
@@ -245,7 +245,7 @@ def test_cutout_info():
     assert cutout_geom.cutout_info["cutout-slices"][0].start == 0
     assert cutout_geom.cutout_info["cutout-slices"][1].start == 0
 
-    header = cutout_geom.make_header()
+    header = cutout_geom.to_header()
     assert "PSLICE1" in header
     assert "PSLICE2" in header
     assert "CSLICE1" in header

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -92,7 +92,7 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, frame, proj, skydir, axes):
 def test_wcsgeom_read_write(tmp_path, npix, binsz, frame, proj, skydir, axes):
     geom0 = WcsGeom.create(npix=npix, binsz=binsz, proj=proj, frame=frame, axes=axes)
 
-    hdu_bands = geom0.make_bands_hdu(hdu="BANDS")
+    hdu_bands = geom0.to_bands_hdu(hdu="BANDS")
     hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.to_header())
 
@@ -110,7 +110,7 @@ def test_wcsgeom_to_hdulist():
     npix, binsz, frame, proj, skydir, axes = wcs_test_geoms[3]
     geom = WcsGeom.create(npix=npix, binsz=binsz, proj=proj, frame=frame, axes=axes)
 
-    hdu = geom.make_bands_hdu(hdu="TEST")
+    hdu = geom.to_bands_hdu(hdu="TEST")
     assert hdu.header["AXCOLS1"] == "E_MIN,E_MAX"
     assert hdu.header["AXCOLS2"] == "AXIS1_MIN,AXIS1_MAX"
 

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -460,6 +460,7 @@ def test_irregular_geom_equality():
     with pytest.raises(NotImplementedError):
         geom0 == geom1
 
+
 @pytest.mark.parametrize("node_type", ["edges", "center"])
 @pytest.mark.parametrize("interp", ["log", "lin", "sqrt"])
 def test_read_write(tmp_path, node_type, interp):
@@ -470,7 +471,7 @@ def test_read_write(tmp_path, node_type, interp):
     m = Map.create(binsz=1, npix=10, axes=[e_ax, t_ax], unit="m2")
 
     # Check what Gammapy writes in the FITS header
-    header = m.make_hdu().header
+    header = m.to_hdu().header
     assert header["INTERP1"] == interp
     assert header["INTERP2"] == interp
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -97,7 +97,7 @@ def test_wcsndmap_read_write_fgst(tmp_path):
 
     # Test Counts Cube
     m = WcsNDMap(geom)
-    m.write(path, conv="fgst-ccube", overwrite=True)
+    m.write(path, format="fgst-ccube", overwrite=True)
     with fits.open(path, memmap=False) as hdulist:
         assert "EBOUNDS" in hdulist
 
@@ -105,7 +105,7 @@ def test_wcsndmap_read_write_fgst(tmp_path):
     assert m2.geom.axes[0].name == "energy"
 
     # Test Model Cube
-    m.write(path, conv="fgst-template", overwrite=True)
+    m.write(path, format="fgst-template", overwrite=True)
     with fits.open(path, memmap=False) as hdulist:
         assert "ENERGIES" in hdulist
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -118,6 +118,14 @@ def test_wcsndmap_read_ccube():
     assert_allclose(energy_axis.edges.min().to_value("GeV"), 10, rtol=1e-3)
 
 
+@requires_data()
+def test_wcsndmap_read_exposure():
+    exposure = Map.read("$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-exposure-cube.fits.gz")
+    energy_axis = exposure.geom.get_axis_by_name("energy_true")
+    assert energy_axis.node_type == "center"
+    assert exposure.unit == "cm2 s"
+
+
 def test_wcs_nd_map_data_transpose_issue(tmp_path):
     # Regression test for https://github.com/gammapy/gammapy/issues/1346
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -407,7 +407,7 @@ class WcsGeom(Geom):
         return cls(wcs, npix, cdelt=binsz, axes=axes)
 
     @classmethod
-    def from_header(cls, header, hdu_bands=None):
+    def from_header(cls, header, hdu_bands=None, format=None):
         """Create a WCS geometry object from a FITS header.
 
         Parameters
@@ -416,6 +416,8 @@ class WcsGeom(Geom):
             The FITS header
         hdu_bands : `~astropy.io.fits.BinTableHDU`
             The BANDS table HDU.
+        format : {'gadf', 'fgst-ccube','fgst-template'}
+            FITS format convention.
 
         Returns
         -------
@@ -426,7 +428,7 @@ class WcsGeom(Geom):
         # TODO: see https://github.com/astropy/astropy/issues/9259
         wcs._naxis = wcs._naxis[:2]
 
-        axes = find_and_read_bands(hdu_bands)
+        axes = find_and_read_bands(hdu_bands, format=format)
         shape = tuple([ax.nbin for ax in axes])
 
         if hdu_bands is not None and "NPIX" in hdu_bands.columns.names:

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -457,7 +457,7 @@ class WcsGeom(Geom):
 
         return cls(wcs, npix, cdelt=cdelt, axes=axes, cutout_info=cutout_info)
 
-    def _make_bands_cols(self, hdu=None, conv=None):
+    def _make_bands_cols(self):
 
         cols = []
         if not self.is_regular:

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -491,7 +491,7 @@ class WcsGeom(Geom):
             ]
         return cols
 
-    def make_header(self):
+    def to_header(self):
         header = self.wcs.to_header()
         self._fill_header_from_axes(header)
         shape = "{},{}".format(np.max(self.npix[0]), np.max(self.npix[1]))

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -105,7 +105,7 @@ class WcsMap(Map):
             raise ValueError(f"Invalid map type: {map_type!r}")
 
     @classmethod
-    def from_hdulist(cls, hdu_list, hdu=None, hdu_bands=None):
+    def from_hdulist(cls, hdu_list, hdu=None, hdu_bands=None, format=None):
         """Make a WcsMap object from a FITS HDUList.
 
         Parameters
@@ -116,6 +116,8 @@ class WcsMap(Map):
             Name or index of the HDU with the map data.
         hdu_bands : str
             Name or index of the HDU with the BANDS table.
+        format : {'gadf', 'fgst-ccube','fgst-template'}
+            FITS format convention.
 
         Returns
         -------
@@ -133,7 +135,7 @@ class WcsMap(Map):
         if hdu_bands is not None:
             hdu_bands = hdu_list[hdu_bands]
 
-        return cls.from_hdu(hdu, hdu_bands)
+        return cls.from_hdu(hdu, hdu_bands, format=format)
 
     def to_hdulist(self, hdu=None, hdu_bands=None, sparse=False, format="gadf"):
         """Convert to `~astropy.io.fits.HDUList`.

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -170,7 +170,7 @@ class WcsMap(Map):
                 )
 
         if self.geom.axes:
-            hdu_bands_out = self.geom.make_bands_hdu(
+            hdu_bands_out = self.geom.to_bands_hdu(
                 hdu=hdu_bands, hdu_skymap=hdu, format=format
             )
             hdu_bands = hdu_bands_out.name

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -177,7 +177,7 @@ class WcsMap(Map):
         else:
             hdu_bands = None
 
-        hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse)
+        hdu_out = self.to_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse)
 
         hdu_out.header["META"] = json.dumps(self.meta)
 
@@ -193,7 +193,7 @@ class WcsMap(Map):
 
         return fits.HDUList(hdulist)
 
-    def make_hdu(self, hdu="SKYMAP", hdu_bands=None, sparse=False):
+    def to_hdu(self, hdu="SKYMAP", hdu_bands=None, sparse=False):
         """Make a FITS HDU from this map.
 
         Parameters

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -74,8 +74,6 @@ class WcsMap(Map):
             be chosen to be center of the map.
         dtype : str, optional
             Data type, default is float32
-        conv : {'fgst-ccube','fgst-template','gadf'}, optional
-            FITS format convention.  Default is 'gadf'.
         meta : `dict`
             Dictionary to store meta data.
         unit : str or `~astropy.units.Unit`
@@ -137,7 +135,7 @@ class WcsMap(Map):
 
         return cls.from_hdu(hdu, hdu_bands)
 
-    def to_hdulist(self, hdu=None, hdu_bands=None, sparse=False, conv="gadf"):
+    def to_hdulist(self, hdu=None, hdu_bands=None, sparse=False, format="gadf"):
         """Convert to `~astropy.io.fits.HDUList`.
 
         Parameters
@@ -149,7 +147,7 @@ class WcsMap(Map):
         sparse : bool
             Sparsify the map by only writing pixels with non-zero
             amplitude.
-        conv : {'gadf', 'fgst-ccube','fgst-template'}
+        format : {'gadf', 'fgst-ccube','fgst-template'}
             FITS format convention.
 
         Returns
@@ -165,7 +163,7 @@ class WcsMap(Map):
         if sparse and hdu == "PRIMARY":
             raise ValueError("Sparse maps cannot be written to the PRIMARY HDU.")
 
-        if conv in ["fgst-ccube", "fgst-template"]:
+        if format in ["fgst-ccube", "fgst-template"]:
             if self.geom.axes[0].name != "energy" or len(self.geom.axes) > 1:
                 raise ValueError(
                     "All 'fgst' formats don't support extra axes except for energy."
@@ -173,13 +171,13 @@ class WcsMap(Map):
 
         if self.geom.axes:
             hdu_bands_out = self.geom.make_bands_hdu(
-                hdu=hdu_bands, hdu_skymap=hdu, conv=conv
+                hdu=hdu_bands, hdu_skymap=hdu, format=format
             )
             hdu_bands = hdu_bands_out.name
         else:
             hdu_bands = None
 
-        hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse, conv=conv)
+        hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse)
 
         hdu_out.header["META"] = json.dumps(self.meta)
 
@@ -195,7 +193,7 @@ class WcsMap(Map):
 
         return fits.HDUList(hdulist)
 
-    def make_hdu(self, hdu="SKYMAP", hdu_bands=None, sparse=False, conv=None):
+    def make_hdu(self, hdu="SKYMAP", hdu_bands=None, sparse=False):
         """Make a FITS HDU from this map.
 
         Parameters

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -211,7 +211,7 @@ class WcsMap(Map):
         hdu : `~astropy.io.fits.BinTableHDU` or `~astropy.io.fits.ImageHDU`
             HDU containing the map data.
         """
-        header = self.geom.make_header()
+        header = self.geom.to_header()
 
         if hdu_bands is not None:
             header["BANDSHDU"] = hdu_bands

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -70,7 +70,7 @@ class WcsNDMap(WcsMap):
         return data
 
     @classmethod
-    def from_hdu(cls, hdu, hdu_bands=None):
+    def from_hdu(cls, hdu, hdu_bands=None, format=None):
         """Make a WcsNDMap object from a FITS HDU.
 
         Parameters
@@ -79,8 +79,15 @@ class WcsNDMap(WcsMap):
             The map FITS HDU.
         hdu_bands : `~astropy.io.fits.BinTableHDU`
             The BANDS table HDU.
+        format : {'gadf', 'fgst-ccube','fgst-template'}
+            FITS format convention.
+
+        Returns
+        -------
+        map : `WcsNDMap`
+            Wcs map
         """
-        geom = WcsGeom.from_header(hdu.header, hdu_bands)
+        geom = WcsGeom.from_header(hdu.header, hdu_bands, format=format)
         shape = tuple([ax.nbin for ax in geom.axes])
         shape_wcs = tuple([np.max(geom.npix[0]), np.max(geom.npix[1])])
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request improves the `gammapy.maps` handling of I/O formats a bit. It exposes the `format` argument on the `.read()` API as well and uses guessing of the format if no format is given. In addition it also fixes the problem of setting the correct units for fgst format exposure maps. In general the clean up would require some more work.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
