### PR TITLE
Adapt ExcessProfileEstimator to use energy edges 

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -273,7 +273,8 @@ class MapDataset(Dataset):
                         self._background_model = model
                         break
         else:
-            log.warning(f"No background model defined for dataset {self.name}")
+            if not isinstance(self, MapDatasetOnOff):
+                log.warning(f"No background model defined for dataset {self.name}")
         self._evaluators = {}
 
     @property

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -230,7 +230,8 @@ class SpectrumDataset(Dataset):
                         self._background_model = model
                         break
         else:
-            log.warning(f"No background model defined for dataset {self.name}")
+            if not isinstance(self, SpectrumDatasetOnOff):
+                log.warning(f"No background model defined for dataset {self.name}")
         self._evaluators = {}
 
     @property

--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -2,12 +2,12 @@
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from regions import RectangleSkyRegion, CircleAnnulusSkyRegion
-from gammapy.utils.table import table_from_row_data
-from gammapy.stats import WStatCountsStatistic, CashCountsStatistic
-from gammapy.datasets import SpectrumDatasetOnOff, Datasets
+from regions import CircleAnnulusSkyRegion, RectangleSkyRegion
+from gammapy.datasets import Datasets, SpectrumDatasetOnOff
 from gammapy.maps import MapAxis
-from gammapy.modeling.models import SkyModel, PowerLawSpectralModel
+from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
+from gammapy.stats import CashCountsStatistic, WStatCountsStatistic
+from gammapy.utils.table import table_from_row_data
 from .core import Estimator
 
 __all__ = ["ExcessProfileEstimator"]

--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -95,7 +95,7 @@ class ExcessProfileEstimator(Estimator):
         self.n_sigma = n_sigma
         self.n_sigma_ul = n_sigma_ul
 
-        self.e_edges = e_edges
+        self.e_edges = u.Quantity(e_edges) if e_edges is not None else None
 
         if spectrum is None:
             spectrum = PowerLawSpectralModel()
@@ -254,7 +254,7 @@ class ExcessProfileEstimator(Estimator):
         """
         axis = None
         if self.e_edges is not None:
-            axis = MapAxis.from_edges(self.e_edges, name="energy")
+            axis = MapAxis.from_edges(self.e_edges, name="energy", interp="log")
 
         dataset = dataset.resample_energy_axis(axis=axis)
 

--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -254,7 +254,7 @@ class ExcessProfileEstimator(Estimator):
         """
         axis = None
         if self.e_edges is not None:
-            axis = MapAxis.from_edges(self.e_edges, name="energy", interp="log")
+            axis = MapAxis.from_energy_edges(self.e_edges)
 
         dataset = dataset.resample_energy_axis(axis=axis)
 

--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -20,6 +20,8 @@ class ExcessProfileEstimator(Estimator):
     ----------
     regions : list of `regions`
         regions to use
+    e_edges : `~astropy.units.Quantity`
+        Energy edges of the profiles to be computed.
     n_sigma : float (optional)
         Number of sigma to compute errors. By default, it is 1.
     n_sigma_ul : float (optional)
@@ -83,6 +85,7 @@ class ExcessProfileEstimator(Estimator):
     def __init__(
         self,
         regions,
+        e_edges=None,
         spectrum=None,
         n_sigma=1.0,
         n_sigma_ul=3.0,
@@ -91,6 +94,8 @@ class ExcessProfileEstimator(Estimator):
         self.regions = regions
         self.n_sigma = n_sigma
         self.n_sigma_ul = n_sigma_ul
+
+        self.e_edges = e_edges
 
         if spectrum is None:
             spectrum = PowerLawSpectralModel()
@@ -247,6 +252,12 @@ class ExcessProfileEstimator(Estimator):
         imageprofile : `~gammapy.estimators.ImageProfile`
             Return an image profile class containing the result
         """
+        axis = None
+        if self.e_edges is not None:
+            axis = MapAxis.from_edges(self.e_edges, name="energy")
+
+        dataset = dataset.resample_energy_axis(axis=axis)
+
         spectrum_datasets = self.get_spectrum_datasets(dataset)
         results = self.make_prof(spectrum_datasets)
         table = table_from_row_data(results)

--- a/gammapy/estimators/tests/test_excess_profile.py
+++ b/gammapy/estimators/tests/test_excess_profile.py
@@ -81,7 +81,7 @@ def test_radial_profile():
     assert_allclose(imp_prof[0]["solid_angle"], [6.853891e-07, 6.853891e-07], atol=1e-5)
 
 
-def test_radial_profile():
+def test_radial_profile_one_interval():
     dataset = get_simple_dataset_on_off()
     geom = dataset.counts.geom
     regions = make_concentric_annulus_sky_regions(

--- a/gammapy/estimators/tests/test_excess_profile.py
+++ b/gammapy/estimators/tests/test_excess_profile.py
@@ -2,13 +2,13 @@
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-from gammapy.datasets import MapDatasetOnOff
 from gammapy.data import GTI
-from gammapy.maps import MapAxis, WcsGeom
+from gammapy.datasets import MapDatasetOnOff
 from gammapy.estimators import ExcessProfileEstimator
+from gammapy.maps import MapAxis, WcsGeom
 from gammapy.utils.regions import (
-    make_orthogonal_rectangle_sky_regions,
     make_concentric_annulus_sky_regions,
+    make_orthogonal_rectangle_sky_regions,
 )
 
 
@@ -47,7 +47,7 @@ def test_profile_content():
     wcs = mapdataset_onoff.counts.geom.wcs
     boxes = make_horizontal_boxes(wcs)
 
-    prof_maker = ExcessProfileEstimator(boxes, e_edges=[0.1,1,10]*u.TeV)
+    prof_maker = ExcessProfileEstimator(boxes, e_edges=[0.1, 1, 10] * u.TeV)
     imp_prof = prof_maker.run(mapdataset_onoff)
 
     assert_allclose(imp_prof[7]["x_min"], 0.1462, atol=1e-4)
@@ -67,7 +67,7 @@ def test_radial_profile():
         center=geom.center_skydir, radius_max=0.2 * u.deg,
     )
 
-    prof_maker = ExcessProfileEstimator(regions, e_edges=[0.1,1,10]*u.TeV)
+    prof_maker = ExcessProfileEstimator(regions, e_edges=[0.1, 1, 10] * u.TeV)
     imp_prof = prof_maker.run(dataset)
 
     assert_allclose(imp_prof[7]["x_min"], 0.14, atol=1e-4)
@@ -79,6 +79,7 @@ def test_radial_profile():
     assert_allclose(imp_prof[0]["ul"], [75.834983, 75.834983], atol=1e-5)
     assert_allclose(imp_prof[0]["flux"], [7.99999987e-06, 8.00000010e-06], atol=1e-3)
     assert_allclose(imp_prof[0]["solid_angle"], [6.853891e-07, 6.853891e-07], atol=1e-5)
+
 
 def test_radial_profile():
     dataset = get_simple_dataset_on_off()

--- a/gammapy/estimators/tests/test_excess_profile.py
+++ b/gammapy/estimators/tests/test_excess_profile.py
@@ -47,7 +47,7 @@ def test_profile_content():
     wcs = mapdataset_onoff.counts.geom.wcs
     boxes = make_horizontal_boxes(wcs)
 
-    prof_maker = ExcessProfileEstimator(boxes)
+    prof_maker = ExcessProfileEstimator(boxes, e_edges=[0.1,1,10]*u.TeV)
     imp_prof = prof_maker.run(mapdataset_onoff)
 
     assert_allclose(imp_prof[7]["x_min"], 0.1462, atol=1e-4)
@@ -67,7 +67,7 @@ def test_radial_profile():
         center=geom.center_skydir, radius_max=0.2 * u.deg,
     )
 
-    prof_maker = ExcessProfileEstimator(regions)
+    prof_maker = ExcessProfileEstimator(regions, e_edges=[0.1,1,10]*u.TeV)
     imp_prof = prof_maker.run(dataset)
 
     assert_allclose(imp_prof[7]["x_min"], 0.14, atol=1e-4)
@@ -79,3 +79,21 @@ def test_radial_profile():
     assert_allclose(imp_prof[0]["ul"], [75.834983, 75.834983], atol=1e-5)
     assert_allclose(imp_prof[0]["flux"], [7.99999987e-06, 8.00000010e-06], atol=1e-3)
     assert_allclose(imp_prof[0]["solid_angle"], [6.853891e-07, 6.853891e-07], atol=1e-5)
+
+def test_radial_profile():
+    dataset = get_simple_dataset_on_off()
+    geom = dataset.counts.geom
+    regions = make_concentric_annulus_sky_regions(
+        center=geom.center_skydir, radius_max=0.2 * u.deg,
+    )
+
+    prof_maker = ExcessProfileEstimator(regions)
+    imp_prof = prof_maker.run(dataset)
+
+    assert_allclose(imp_prof[7]["counts"], [1960], atol=1e-5)
+    assert_allclose(imp_prof[7]["excess"], [1568.0], atol=1e-5)
+    assert_allclose(imp_prof[7]["sqrt_ts"], [33.780533], atol=1e-5)
+    assert_allclose(imp_prof[7]["errn"], [-48.278367], atol=1e-5)
+    assert_allclose(imp_prof[0]["ul"], [134.285969], atol=1e-5)
+    assert_allclose(imp_prof[0]["flux"], [16e-06], atol=1e-3)
+    assert_allclose(imp_prof[0]["solid_angle"], [6.853891e-07], atol=1e-5)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -408,6 +408,44 @@ class MapAxis:
         return cls(nodes, **kwargs)
 
     @classmethod
+    def from_energy_edges(
+        cls, edges, unit=None, name=None, interp="log"
+    ):
+        """Make an energy axis from adjacent edges.
+
+        Parameters
+        ----------
+        edges : `~astropy.units.Quantity`, float
+            Energy edges
+        unit : `~astropy.units.Unit`
+            Energy unit
+        name : str
+            Name of the energy axis, either 'energy' or 'energy_true'
+        interp: str
+            interpolation mode. Default is 'log'.
+
+        Returns
+        -------
+        axis : `MapAxis`
+            Axis with name "energy" and interp "log".
+        """
+        edges = u.Quantity(edges, unit)
+
+        if unit is None:
+            unit = edges.unit
+            edges = edges.to(unit)
+
+        if name is None:
+            name = "energy"
+
+        if name not in ["energy", "energy_true"]:
+            raise ValueError("Energy axis can only be named 'energy' or 'energy_true'")
+
+        return cls.from_edges(
+            edges, unit=unit, interp=interp, name=name
+        )
+
+    @classmethod
     def from_energy_bounds(
         cls, emin, emax, nbin, unit=None, per_decade=False, name=None, node_type="edges"
     ):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -408,9 +408,7 @@ class MapAxis:
         return cls(nodes, **kwargs)
 
     @classmethod
-    def from_energy_edges(
-        cls, edges, unit=None, name=None, interp="log"
-    ):
+    def from_energy_edges(cls, edges, unit=None, name=None, interp="log"):
         """Make an energy axis from adjacent edges.
 
         Parameters
@@ -441,9 +439,7 @@ class MapAxis:
         if name not in ["energy", "energy_true"]:
             raise ValueError("Energy axis can only be named 'energy' or 'energy_true'")
 
-        return cls.from_edges(
-            edges, unit=unit, interp=interp, name=name
-        )
+        return cls.from_edges(edges, unit=unit, interp=interp, name=name)
 
     @classmethod
     def from_energy_bounds(
@@ -489,7 +485,13 @@ class MapAxis:
             raise ValueError("Energy axis can only be named 'energy' or 'energy_true'")
 
         return cls.from_bounds(
-            emin.value, emax.value, nbin=nbin, unit=unit, interp="log", name=name, node_type=node_type
+            emin.value,
+            emax.value,
+            nbin=nbin,
+            unit=unit,
+            interp="log",
+            name=name,
+            node_type=node_type,
         )
 
     @classmethod
@@ -552,13 +554,17 @@ class MapAxis:
             Appended axis
         """
         if self.node_type != axis.node_type:
-            raise ValueError(f"Node type must agree, got {self.node_type} and {axis.node_type}")
+            raise ValueError(
+                f"Node type must agree, got {self.node_type} and {axis.node_type}"
+            )
 
         if self.name != axis.name:
             raise ValueError(f"Names must agree, got {self.name} and {axis.name} ")
 
         if self.interp != axis.interp:
-            raise ValueError(f"Interp type must agree, got {self.interp} and {axis.interp}")
+            raise ValueError(
+                f"Interp type must agree, got {self.interp} and {axis.interp}"
+            )
 
         if self.node_type == "edges":
             edges = np.append(self.edges, axis.edges[1:])
@@ -1725,17 +1731,13 @@ class Geom(abc.ABC):
         groups = axis_self.group_table(axis.edges)
 
         # Keep only normal bins
-        #TODO: improve on this
-        groups = groups[groups["bin_type"]=="normal   "]
+        # TODO: improve on this
+        groups = groups[groups["bin_type"] == "normal   "]
 
-        edges = edges_from_lo_hi(
-            groups[axis.name + "_min"], groups[axis.name + "_max"]
-        )
+        edges = edges_from_lo_hi(groups[axis.name + "_min"], groups[axis.name + "_max"])
 
         axis_resampled = MapAxis.from_edges(
-            edges=edges,
-            interp=axis.interp,
-            name=axis.name
+            edges=edges, interp=axis.interp, name=axis.name
         )
 
         axes = []


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds the energy edges as `__init__` arguments for the `ExcessProfileEstimator`. It also introduces a new `classmethod` for `MapAxis`: `from_energy_edges` to easily create an energy axis from the edges using a `log` interpolation mode.

A test is also added to remove warnings, when setting the model on a `OnOff` `Dataset`, since no `BackgroundModel` is expected. This could lead to confusion.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
