### PR TITLE
Modify MapDataset.downsample options and add MapDatasetOnOff.downsample

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1179,7 +1179,7 @@ class MapDataset(Dataset):
 
         if self.counts is not None:
             kwargs["counts"] = self.counts.downsample(
-                factor=factor, preserve_counts=True, axis=axis_name, weights=self.mask_safe
+                factor=factor, preserve_counts=True, axis_name=axis_name, weights=self.mask_safe
             )
 
         if self.exposure is not None:
@@ -1192,13 +1192,13 @@ class MapDataset(Dataset):
 
         if self.background_model is not None:
             m = self.background_model.evaluate().downsample(
-                factor=factor, axis=axis_name, weights=self.mask_safe
+                factor=factor, axis_name=axis_name, weights=self.mask_safe
             )
             kwargs["models"] = BackgroundModel(map=m, datasets_names=[name])
 
         if self.edisp is not None:
             if axis_name is not None:
-                kwargs["edisp"] = self.edisp.downsample(factor=factor, axis=axis_name)
+                kwargs["edisp"] = self.edisp.downsample(factor=factor, axis_name=axis_name)
             else:
                 kwargs["edisp"] = self.edisp.copy()
 
@@ -1207,12 +1207,12 @@ class MapDataset(Dataset):
 
         if self.mask_safe is not None:
             kwargs["mask_safe"] = self.mask_safe.downsample(
-                factor=factor, preserve_counts=False, axis=axis_name
+                factor=factor, preserve_counts=False, axis_name=axis_name
             )
 
         if self.mask_fit is not None:
             kwargs["mask_fit"] = self.mask_fit.downsample(
-                factor=factor, preserve_counts=False, axis=axis_name
+                factor=factor, preserve_counts=False, axis_name=axis_name
             )
 
         return self.__class__(**kwargs)
@@ -1969,16 +1969,16 @@ class MapDatasetOnOff(MapDataset):
         counts_off = None
         if self.counts_off is not None:
             counts_off = self.counts_off.downsample(
-                factor=factor, preserve_counts=True, axis=axis_name, weights=self.mask_safe
+                factor=factor, preserve_counts=True, axis_name=axis_name, weights=self.mask_safe
             )
 
         acceptance, acceptance_off = None, None
         if self.acceptance_off is not None:
             acceptance = self.acceptance.downsample(
-                factor=factor, preserve_counts=False, axis=axis_name
+                factor=factor, preserve_counts=False, axis_name=axis_name
             )
             factor = self.counts_off_normalised.downsample(
-                factor=factor, preserve_counts=True, axis=axis_name, weights=self.mask_safe
+                factor=factor, preserve_counts=True, axis_name=axis_name, weights=self.mask_safe
             )
             acceptance_off = acceptance * counts_off / factor
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1153,7 +1153,7 @@ class MapDataset(Dataset):
 
         return self.__class__(**kwargs)
 
-    def downsample(self, factor, axis=None, name=None):
+    def downsample(self, factor, axis_name=None, name=None):
         """Downsample map dataset.
 
         The PSFMap and EDispKernelMap are not downsampled, except if
@@ -1163,8 +1163,8 @@ class MapDataset(Dataset):
         ----------
         factor : int
             Downsampling factor.
-        axis : str
-            Which axis to downsample. By default only spatial axes are downsampled.
+        axis_name : str
+            Which non-spatial axis to downsample. By default only spatial axes are downsampled.
         name : str
             Name of the downsampled dataset.
 
@@ -1179,11 +1179,11 @@ class MapDataset(Dataset):
 
         if self.counts is not None:
             kwargs["counts"] = self.counts.downsample(
-                factor=factor, preserve_counts=True, axis=axis, weights=self.mask_safe
+                factor=factor, preserve_counts=True, axis=axis_name, weights=self.mask_safe
             )
 
         if self.exposure is not None:
-            if axis is None:
+            if axis_name is None:
                 kwargs["exposure"] = self.exposure.downsample(
                     factor=factor, preserve_counts=False
                 )
@@ -1192,13 +1192,13 @@ class MapDataset(Dataset):
 
         if self.background_model is not None:
             m = self.background_model.evaluate().downsample(
-                factor=factor, axis=axis, weights=self.mask_safe
+                factor=factor, axis=axis_name, weights=self.mask_safe
             )
             kwargs["models"] = BackgroundModel(map=m, datasets_names=[name])
 
         if self.edisp is not None:
-            if axis is not None:
-                kwargs["edisp"] = self.edisp.downsample(factor=factor, axis=axis)
+            if axis_name is not None:
+                kwargs["edisp"] = self.edisp.downsample(factor=factor, axis=axis_name)
             else:
                 kwargs["edisp"] = self.edisp.copy()
 
@@ -1207,12 +1207,12 @@ class MapDataset(Dataset):
 
         if self.mask_safe is not None:
             kwargs["mask_safe"] = self.mask_safe.downsample(
-                factor=factor, preserve_counts=False, axis=axis
+                factor=factor, preserve_counts=False, axis=axis_name
             )
 
         if self.mask_fit is not None:
             kwargs["mask_fit"] = self.mask_fit.downsample(
-                factor=factor, preserve_counts=False, axis=axis
+                factor=factor, preserve_counts=False, axis=axis_name
             )
 
         return self.__class__(**kwargs)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -325,6 +325,20 @@ def test_to_image_mask_safe():
     dataset_im = dataset_copy.to_image()
     assert dataset_im.counts is None
 
+@requires_data()
+def test_downsample():
+    dataset = get_fermi_3fhl_gc_dataset()
+
+    downsampled = dataset.downsample(2)
+
+    assert downsampled.counts.data.shape == (11,100,200)
+    assert downsampled.counts.data.sum() == dataset.counts.data.sum()
+    assert_allclose(downsampled.background_model.map.data.sum(axis=(1,2)), dataset.background_model.map.data.sum(axis=(1,2)), rtol=1e-5)
+    assert_allclose(downsampled.exposure.data[5,50,100], 3.318082e+11, rtol=1e-5)
+
+    with pytest.raises(ValueError):
+        dataset.downsample(2, axis_name="energy")
+
 
 @requires_data()
 def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -132,7 +132,7 @@ def make_map_background_irf(pointing, ontime, bkg, geom, oversampling=None):
 
     # Get altaz coords for map
     if oversampling is not None:
-        geom = geom.upsample(factor=oversampling, axis="energy")
+        geom = geom.upsample(factor=oversampling, axis_name="energy")
 
     map_coord = geom.to_image().get_coord()
     sky_coord = map_coord.skycoord
@@ -164,7 +164,7 @@ def make_map_background_irf(pointing, ontime, bkg, geom, oversampling=None):
     bkg_map = WcsNDMap(geom, data=data)
 
     if oversampling is not None:
-        bkg_map = bkg_map.downsample(factor=oversampling, axis="energy")
+        bkg_map = bkg_map.downsample(factor=oversampling, axis_name="energy")
 
     return bkg_map
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1631,14 +1631,14 @@ class Geom(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def downsample(self, factor, axis):
+    def downsample(self, factor, axis_name):
         """Downsample the spatial dimension of the geometry by a given factor.
 
         Parameters
         ----------
         factor : int
             Downsampling factor.
-        axis : str
+        axis_name : str
             Axis to downsample.
 
         Returns
@@ -1650,14 +1650,14 @@ class Geom(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def upsample(self, factor, axis):
+    def upsample(self, factor, axis_name):
         """Upsample the spatial dimension of the geometry by a given factor.
 
         Parameters
         ----------
         factor : int
             Upsampling factor.
-        axis : str
+        axis_name : str
             Axis to upsample.
 
         Returns

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -192,15 +192,15 @@ class RegionGeom(Geom):
     def to_image(self):
         return self._init_copy(axes=None)
 
-    def upsample(self, factor, axis):
+    def upsample(self, factor, axis_name):
         axes = copy.deepcopy(self.axes)
-        idx = self.get_axis_index_by_name(axis)
+        idx = self.get_axis_index_by_name(axis_name)
         axes[idx] = axes[idx].upsample(factor)
         return self._init_copy(axes=axes)
 
-    def downsample(self, factor, axis):
+    def downsample(self, factor, axis_name):
         axes = copy.deepcopy(self.axes)
-        idx = self.get_axis_index_by_name(axis)
+        idx = self.get_axis_index_by_name(axis_name)
         axes[idx] = axes[idx].downsample(factor)
         return self._init_copy(axes=axes)
 

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -185,10 +185,10 @@ class RegionNDMap(Map):
         geom = RegionGeom.create(region=region, axes=axes, wcs=wcs)
         return cls(geom=geom, dtype=dtype, unit=unit, meta=meta)
 
-    def downsample(self, factor, preserve_counts=True, axis="energy"):
-        geom = self.geom.downsample(factor=factor, axis=axis)
+    def downsample(self, factor, preserve_counts=True, axis_name="energy"):
+        geom = self.geom.downsample(factor=factor, axis_name=axis_name)
         block_size = [1] * self.data.ndim
-        idx = self.geom.get_axis_index_by_name(axis)
+        idx = self.geom.get_axis_index_by_name(axis_name)
         block_size[-(idx + 1)] = factor
 
         func = np.nansum if preserve_counts else np.nanmean
@@ -196,8 +196,8 @@ class RegionNDMap(Map):
 
         return self._init_copy(geom=geom, data=data)
 
-    def upsample(self, factor, preserve_counts=True, axis="energy"):
-        geom = self.geom.upsample(factor=factor, axis=axis)
+    def upsample(self, factor, preserve_counts=True, axis_name="energy"):
+        geom = self.geom.upsample(factor=factor, axis_name=axis_name)
         data = self.interp_by_coord(geom.get_coord())
 
         if preserve_counts:

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -182,7 +182,7 @@ def test_separation(region):
 def test_upsample(region):
     axis = MapAxis.from_edges([1, 10] * u.TeV, name="energy", interp="log")
     geom = RegionGeom.create(region, axes=[axis])
-    geom_up = geom.upsample(factor=2, axis="energy")
+    geom_up = geom.upsample(factor=2, axis_name="energy")
 
     assert_allclose(geom_up.axes[0].edges.value, [1.0, 3.162278, 10.0], rtol=1e-5)
 
@@ -190,7 +190,7 @@ def test_upsample(region):
 def test_downsample(region):
     axis = MapAxis.from_edges([1, 3.162278, 10] * u.TeV, name="energy", interp="log")
     geom = RegionGeom.create(region, axes=[axis])
-    geom_down = geom.downsample(factor=2, axis="energy")
+    geom_down = geom.downsample(factor=2, axis_name="energy")
 
     assert_allclose(geom_down.axes[0].edges.value, [1.0, 10.0], rtol=1e-5)
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -407,7 +407,7 @@ def test_wcsndmap_upsample_axis():
     m = WcsNDMap(geom, unit="m2")
     m.data += 1
 
-    m2 = m.upsample(2, preserve_counts=True, axis="test")
+    m2 = m.upsample(2, preserve_counts=True, axis_name="test")
     assert m2.data.shape == (8, 4, 4)
     assert_allclose(m.data.sum(), m2.data.sum())
 
@@ -418,7 +418,7 @@ def test_wcsndmap_downsample_axis():
     m = WcsNDMap(geom, unit="m2")
     m.data += 1
 
-    m2 = m.downsample(2, preserve_counts=True, axis="test")
+    m2 = m.downsample(2, preserve_counts=True, axis_name="test")
     assert m2.data.shape == (2, 4, 4)
 
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -710,8 +710,8 @@ class WcsGeom(Geom):
         cdelt = copy.deepcopy(self._cdelt)
         return self.__class__(wcs, npix, cdelt=cdelt, axes=copy.deepcopy(self.axes))
 
-    def downsample(self, factor, axis=None):
-        if axis is None:
+    def downsample(self, factor, axis_name=None):
+        if axis_name is None:
             if np.any(np.mod(self.npix, factor) > 0):
                 raise ValueError(
                     f"Spatial shape not divisible by factor {factor!r} in all axes."
@@ -729,12 +729,12 @@ class WcsGeom(Geom):
                 )
 
             axes = copy.deepcopy(self.axes)
-            idx = self.get_axis_index_by_name(axis)
+            idx = self.get_axis_index_by_name(axis_name)
             axes[idx] = axes[idx].downsample(factor)
             return self._init_copy(axes=axes)
 
-    def upsample(self, factor, axis=None):
-        if axis is None:
+    def upsample(self, factor, axis_name=None):
+        if axis_name is None:
             npix = (self.npix[0] * factor, self.npix[1] * factor)
             cdelt = (self._cdelt[0] / factor, self._cdelt[1] / factor)
             wcs = get_resampled_wcs(self.wcs, factor, False)
@@ -745,7 +745,7 @@ class WcsGeom(Geom):
                     "Upsampling in non-spatial axes not supported for irregular geometries"
                 )
             axes = copy.deepcopy(self.axes)
-            idx = self.get_axis_index_by_name(axis)
+            idx = self.get_axis_index_by_name(axis_name)
             axes[idx] = axes[idx].upsample(factor)
             return self._init_copy(axes=axes)
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -294,18 +294,18 @@ class WcsNDMap(WcsMap):
 
         return map_out
 
-    def upsample(self, factor, order=0, preserve_counts=True, axis=None):
-        geom = self.geom.upsample(factor, axis=axis)
+    def upsample(self, factor, order=0, preserve_counts=True, axis_name=None):
+        geom = self.geom.upsample(factor, axis_name=axis_name)
         idx = geom.get_idx()
 
-        if axis is None:
+        if axis_name is None:
             pix = (
                 (idx[0] - 0.5 * (factor - 1)) / factor,
                 (idx[1] - 0.5 * (factor - 1)) / factor,
             ) + idx[2:]
         else:
             pix = list(idx)
-            idx_ax = self.geom.get_axis_index_by_name(axis)
+            idx_ax = self.geom.get_axis_index_by_name(axis_name)
             pix[idx_ax] = (pix[idx_ax] - 0.5 * (factor - 1)) / factor
 
         data = scipy.ndimage.map_coordinates(
@@ -313,21 +313,21 @@ class WcsNDMap(WcsMap):
         )
 
         if preserve_counts:
-            if axis is None:
+            if axis_name is None:
                 data /= factor ** 2
             else:
                 data /= factor
 
         return self._init_copy(geom=geom, data=data.astype(self.data.dtype))
 
-    def downsample(self, factor, preserve_counts=True, axis=None, weights=None):
-        geom = self.geom.downsample(factor, axis=axis)
+    def downsample(self, factor, preserve_counts=True, axis_name=None, weights=None):
+        geom = self.geom.downsample(factor, axis_name=axis_name)
 
-        if axis is None:
+        if axis_name is None:
             block_size = (factor, factor) + (1,) * len(self.geom.axes)
         else:
             block_size = [1] * self.data.ndim
-            idx = self.geom.get_axis_index_by_name(axis)
+            idx = self.geom.get_axis_index_by_name(axis_name)
             block_size[idx + 2] = factor
 
         func = np.nansum if preserve_counts else np.nanmean


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies the `downsample` API for the `MapDataset`. For clarity, the `axis` argument becomes `axis_name` to make clear a string is expected. 
The `MapDatasetOnOff.downsample` method is also implemented (it used to `raise NotImplementedError`). 
Tests are added for both methods.

Technically, it is obvious that `downsample` is to be applied to the `energy` axis. So that a boolean flag, might be enough (e.g. `energy_downsample = False` by default). 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
Some possible further clean-up:
- Modify `Map.downsample` to take an `axis_name` as argument as well.
- Add a `downsample` method on `SpectrumDataset`.