### PR TITLE
Fix inconsistency between EventList.stack(), GTI.stack() and rest of stack methods.

### DIFF
--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -93,6 +93,23 @@ class EventListBase:
         stacked_table = vstack_tables(tables, **kwargs)
         return cls(stacked_table)
 
+    def stack(self, other):
+        """Stack with another EventList.
+        
+        Calls `~astropy.table.vstack`.
+
+        Parameters
+        ----------
+        other : `~gammapy.data.EventList`
+            Event list to stack to self
+
+        Returns
+        -------
+        new_event_list : `~gammapy.data.EventList`
+            New event list
+        """
+        return self.__class__(vstack([self.table, other.table]))
+
     def __str__(self):
         ss = (
             "EventList info:\n"

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -94,7 +94,7 @@ class EventListBase:
         return cls(stacked_table)
 
     def stack(self, other):
-        """Stack with another EventList.
+        """Stack with another EventList in place.
 
         Calls `~astropy.table.vstack`.
 
@@ -102,13 +102,8 @@ class EventListBase:
         ----------
         other : `~gammapy.data.EventList`
             Event list to stack to self
-
-        Returns
-        -------
-        new_event_list : `~gammapy.data.EventList`
-            New event list
         """
-        return self.__class__(vstack_tables([self.table, other.table]))
+        self.table = vstack_tables([self.table, other.table])
 
     def __str__(self):
         ss = (

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -95,7 +95,7 @@ class EventListBase:
 
     def stack(self, other):
         """Stack with another EventList.
-        
+
         Calls `~astropy.table.vstack`.
 
         Parameters
@@ -108,7 +108,7 @@ class EventListBase:
         new_event_list : `~gammapy.data.EventList`
             New event list
         """
-        return self.__class__(vstack([self.table, other.table]))
+        return self.__class__(vstack_tables([self.table, other.table]))
 
     def __str__(self):
         ss = (

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -79,7 +79,7 @@ class EventListBase:
         return cls(table=table)
 
     @classmethod
-    def stack(cls, event_lists, **kwargs):
+    def from_stack(cls, event_lists, **kwargs):
         """Stack (concatenate) list of event lists.
 
         Calls `~astropy.table.vstack`.

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -203,7 +203,7 @@ class GTI:
         return self.__class__(gti_within)
 
     def stack(self, other):
-        """Stack with another GTI.
+        """Stack with another GTI in place.
 
         This simply changes the time reference of the second GTI table
         and stack the two tables. No logic is applied to the intervals.
@@ -213,15 +213,11 @@ class GTI:
         other : `~gammapy.data.GTI`
             GTI to stack to self
 
-        Returns
-        -------
-        new_gti : `~gammapy.data.GTI`
-            New GTI
         """
         start = (other.time_start - self.time_ref).sec
         end = (other.time_stop - self.time_ref).sec
         table = Table({"START": start, "STOP": end}, names=["START", "STOP"])
-        return self.__class__(vstack([self.table, table]))
+        self.table = vstack([self.table, table])
 
     def union(self, overlap_ok=True, merge_equal=True):
         """Union of overlapping time intervals.

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -77,13 +77,13 @@ class TestEventListHESS:
 
     def test_stack(self):
         other = self.events
-        stacked_list = self.events.stack(other)
-        assert len(stacked_list.table) == 11243 * 2
+        self.events.stack(other)
+        assert len(self.events.table) == 11243 * 2
 
     def test_offset_selection(self):
         offset_range = u.Quantity([0.5, 1.0]*u.deg)
         new_list = self.events.select_offset(offset_range)
-        assert len(new_list.table) == 1820
+        assert len(new_list.table) == 1820 * 2
 
     @requires_dependency("matplotlib")
     def test_plot_time(self):

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -75,6 +75,11 @@ class TestEventListHESS:
         stacked_list = EventList.from_stack(event_lists)
         assert len(stacked_list.table) == 11243 * 2
 
+    def test_stack(self):
+        other = self.events
+        stacked_list = self.events.stack(other)
+        assert len(stacked_list.table) == 11243 * 2
+
     def test_offset_selection(self):
         offset_range = u.Quantity([0.5, 1.0]*u.deg)
         new_list = self.events.select_offset(offset_range)

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -70,9 +70,9 @@ class TestEventListHESS:
         assert_allclose(altaz[0].alt.deg, 53.258024, atol=1e-3)
         # TODO: add asserts for frame properties
 
-    def test_stack(self):
+    def test_from_stack(self):
         event_lists = [self.events] * 2
-        stacked_list = EventList.stack(event_lists)
+        stacked_list = EventList.from_stack(event_lists)
         assert len(stacked_list.table) == 11243 * 2
 
     def test_offset_selection(self):

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -95,13 +95,15 @@ def make_gti(times, time_ref="2010-01-01"):
 def test_gti_stack():
     time_ref = Time("2010-01-01")
     gti1 = make_gti({"START": [0, 2], "STOP": [1, 3]}, time_ref=time_ref)
+    gt1_pre_stack = gti1.copy()
     gti2 = make_gti({"START": [4], "STOP": [5]}, time_ref=time_ref + 10 * u.s)
 
-    gti = gti1.stack(gti2)
+    gti1.stack(gti2)
 
-    assert_time_allclose(gti.time_ref, gti1.time_ref)
-    assert_allclose(gti.table["START"], [0, 2, 14])
-    assert_allclose(gti.table["STOP"], [1, 3, 15])
+    assert len(gti1.table) == 3
+    assert_time_allclose(gt1_pre_stack.time_ref, gti1.time_ref)
+    assert_allclose(gti1.table["START"], [0, 2, 14])
+    assert_allclose(gti1.table["STOP"], [1, 3, 15])
 
 
 def test_gti_union():

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -542,7 +542,8 @@ class MapDataset(Dataset):
         self.mask_safe.stack(other_mask_safe)
 
         if self.gti and other.gti:
-            self.gti = self.gti.stack(other.gti).union()
+            self.gti.stack(other.gti)
+            self.gti = self.gti.union()
 
         if self.meta_table and other.meta_table:
             self.meta_table = hstack_columns(self.meta_table, other.meta_table)

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -88,7 +88,7 @@ class MapDatasetEventSampler:
                 table.add_column(mcid)
             events_all.append(EventList(table))
 
-        return EventList.stack(events_all)
+        return EventList.from_stack(events_all)
 
     def sample_background(self, dataset):
         """Sample background
@@ -353,13 +353,13 @@ class MapDatasetEventSampler:
 
             if dataset.background_model:
                 events_bkg = self.sample_background(dataset)
-                events = EventList.stack([events_bkg, events_src])
+                events = EventList.from_stack([events_bkg, events_src])
             else:
                 events = events_src
 
         if len(dataset.models) == 1 and dataset.background_model is not None:
             events_bkg = self.sample_background(dataset)
-            events = EventList.stack([events_bkg])
+            events = EventList.from_stack([events_bkg])
 
         events = self.event_det_coords(observation, events)
         events.table["EVENT_ID"] = np.arange(len(events.table))

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -589,8 +589,9 @@ class SpectrumDataset(Dataset):
             self.mask_safe.stack(other.mask_safe)
 
         if self.gti is not None:
-            self.gti = self.gti.stack(other.gti).union()
-
+            self.gti.stack(other.gti)
+            self.gti = self.gti.union()
+            
         # TODO: for the moment, since dead time is not accounted for, livetime cannot be the sum of GTIs
         if self.livetime is not None:
             self.livetime += other.livetime

--- a/gammapy/makers/background/phase.py
+++ b/gammapy/makers/background/phase.py
@@ -45,7 +45,7 @@ class PhaseBackgroundMaker(Maker):
             )
             event_lists.append(events)
 
-        events = EventList.stack(event_lists)
+        events = EventList.from_stack(event_lists)
         counts = RegionNDMap.from_geom(dataset.counts.geom)
         counts.fill_events(events)
         return counts


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes the existing inconsistency with the behavior of `EventList.stack()`, renaming it to `EventList.from_stack()`, which takes as an input a list of `EventList` objects. It also creates a new method` eventlist.stack(other)` to append a single `EventList` to an existing one.


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
