### PR TITLE
Implement Fit.stat_surface() method

### DIFF
--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -380,8 +380,6 @@ class Fit:
             Parameter values to evaluate the fit statistic for.
         reoptimize : bool
             Re-optimize other parameters, when computing the fit statistic profile.
-        backend : str
-            Which backend to use (see ``gammapy.modeling.registry``)
         **optimize_opts : dict
             Keyword arguments passed to the optimizer. See `Fit.optimize` for further details.
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -367,8 +367,7 @@ class Fit:
         The method used is to vary two parameters, keeping all others fixed.
         So this is taking a "slice" or "scan" of the fit statistic.
 
-        Caveat: This method can be very computationally intensive and slow. In future releases, multi-core computation
-        will make it more efficient.
+        Caveat: This method can be very computationally intensive and slow
 
         See also: `Fit.minos_contour`
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -359,7 +359,7 @@ class Fit:
 
         return {"values": values, "stat": np.array(stats)}
 
-    def stat_profile_2D(
+    def stat_surface(
         self, x, y, x_values, y_values, reoptimize=False, **optimize_opts
     ):
         """Compute fit statistic contour.

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -396,6 +396,8 @@ class Fit:
         stats = []
         with parameters.restore_values:
             for x_value, y_value in itertools.product(x_values, y_values):
+                # TODO: Remove log.info() and provide a nice progress bar
+                log.info(f"Processing: x={x_value}, y={y_value}")
                 x.value = x_value
                 y.value = y_value
                 if reoptimize:

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -362,12 +362,12 @@ class Fit:
     def stat_surface(
         self, x, y, x_values, y_values, reoptimize=False, **optimize_opts
     ):
-        """Compute fit statistic contour.
+        """Compute fit statistic surface.
 
         The method used is to vary two parameters, keeping all others fixed.
         So this is taking a "slice" or "scan" of the fit statistic.
 
-        Caveat: This method can be very computationally intensive and slow. In future releases, parallel computation
+        Caveat: This method can be very computationally intensive and slow. In future releases, multi-core computation
         will make it more efficient.
 
         See also: `Fit.minos_contour`

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -150,13 +150,13 @@ def test_stat_profile_reoptimize():
     assert_allclose(result["stat"], [4, 0, 4], atol=1e-7)
 
 
-def test_stat_surface_2D():
+def test_stat_surface():
     dataset = MyDataset()
     fit = Fit([dataset])
     fit.run()
     x_values = [1, 2, 3]
     y_values = [2e2, 3e2, 4e2]
-    result = fit.stat_profile_2D("x", "y", x_values=x_values, y_values=y_values)
+    result = fit.stat_surface("x", "y", x_values=x_values, y_values=y_values)
 
     assert_allclose(result["x_values"], x_values, atol=1e-7)
     assert_allclose(result["y_values"], y_values, atol=1e-7)
@@ -180,7 +180,7 @@ def test_stat_surface_reoptimize():
     dataset.models.parameters["z"].value = 0
     x_values = [1, 2, 3]
     y_values = [2e2, 3e2, 4e2]
-    result = fit.stat_profile_2D(
+    result = fit.stat_surface(
         "x", "y", x_values=x_values, y_values=y_values, reoptimize=True
     )
 

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -150,7 +150,7 @@ def test_stat_profile_reoptimize():
     assert_allclose(result["stat"], [4, 0, 4], atol=1e-7)
 
 
-def test_stat_profile_2D():
+def test_stat_surface_2D():
     dataset = MyDataset()
     fit = Fit([dataset])
     fit.run()
@@ -172,7 +172,7 @@ def test_stat_profile_2D():
     assert_allclose(dataset.models.parameters["y"].value, 3e2)
 
 
-def test_stat_profile_2D_reoptimize():
+def test_stat_surface_reoptimize():
     dataset = MyDataset()
     fit = Fit([dataset])
     fit.run()


### PR DESCRIPTION
**Description**
Implement a `Fit` method that computes the 2-dimensional fit statistic profile (or rather surface) by fitting the model on a 2D grid of parameters values. It is a simple extension of the `Fit.stat_profile()` method.

**Dear reviewer**
I have a few comments:
1) Is the name OK? Better ideas?
2) I propose, in a further PR, to improve both the `Fit.stat_profile()` and  `Fit.stat_profile_2D()` methods by:
- returning an additional dictionary element (`"results"`) containing the fit results (i.e. the output of `Fit.optimize()`) at each grid node. Extremely useful for debugging 
- using the `tqdm` library (already shipped with gammapy) to provide a nice progress bar. 
3) Regarding the plotting: I think it doesn't really reduce to a simple call of `plt.contour()`, because in the end what is nice to inspect is not the 2D profile of `-2loglike` values retuned by `Fit.stat_profile_2D`, but rather the profile of "how many Gaussian sigma deviations away from the minimum each point of the grid is". This is easy to achieve for the method `Fit.stat_profile`, because there is just 1 floating degree of freedom and the `sqrt(TS)` gives directly the profile in number of Gaussian sigmas, but in the 2D case people would have to compute the corresponding p-values of a Chi2 function with 2 df and convert that to standard deviations... it's actually 3 simple lines of `scipy.stats` code, but I would like to embed it into a a function. Whether this function goes into `gammapy.visualization` or lives in a tutorial, is an open question