### PR TITLE
Add integral_error for models.spectral

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -169,18 +169,17 @@ class SpectralModel(Model):
 
         Parameters
         ----------
-        emin, emax : `~astropy.units.Quantity`
-            Lower and upper bound of integration range.
+        emin, emax : `~numpy.array`
+            Arrays of minimum and maximum energies.
 
         Returns
         -------
         flux, flux_err : tuple of `~astropy.units.Quantity`
             Integral flux and flux error betwen emin and emax.
         """
-        E = np.linspace(emin,emax,1000)
-        dE = E[1] - E[0]
-        flux = np.sum(self.integral(E[:-1],E[1:]))
-        flux_err = np.sum(self.evaluate_error(E[:-1], epsilon=1e-4)[1]) * dE
+        dE = emax - emin
+        flux = np.sum(self.integral(emin,emax))
+        flux_err = np.sum(self.evaluate_error(emin, epsilon=1e-4)[1] * dE)
 
         return u.Quantity([flux.value, flux_err.value], unit=flux.unit)
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -164,7 +164,8 @@ class SpectralModel(Model):
             return integrate_spectrum(self, emin, emax, **kwargs)
 
     def integral_error(self, emin, emax):
-        """Evaluate spectral model with error propagation.
+        """Evaluate the error of the integral flux of a given spectrum in
+        a given energy range.
 
         Parameters
         ----------

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -177,8 +177,10 @@ class SpectralModel(Model):
         flux, flux_err : tuple of `~astropy.units.Quantity`
             Integral flux and flux error betwen emin and emax.
         """
-        flux = self.integral(emin,emax)
-        flux_err = flux * self.evaluate_error(emin, epsilon=1e-4)[1] / self(emin)
+        energy = np.sqrt(emin * emax)
+        flux = self.integral(emin, emax, intervals=True)
+        dnde, dnde_err = self.evaluate_error(energy, epsilon=1e-4)
+        flux_err = flux * dnde_err / dnde
         return u.Quantity([flux.value, flux_err.value], unit=flux.unit)
 
     def energy_flux(self, emin, emax, **kwargs):

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -169,8 +169,8 @@ class SpectralModel(Model):
 
         Parameters
         ----------
-        emin, emax : `~numpy.array`
-            Arrays of minimum and maximum energies.
+        emin, emax :  `~astropy.units.Quantity`
+            Lower and upper bound of integration range.
 
         Returns
         -------

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -163,6 +163,26 @@ class SpectralModel(Model):
         else:
             return integrate_spectrum(self, emin, emax, **kwargs)
 
+    def integral_error(self, emin, emax):
+        """Evaluate spectral model with error propagation.
+
+        Parameters
+        ----------
+        emin, emax : `~astropy.units.Quantity`
+            Lower and upper bound of integration range.
+
+        Returns
+        -------
+        flux, flux_err : tuple of `~astropy.units.Quantity`
+            Integral flux and flux error betwen emin and emax.
+        """
+        E = np.linspace(emin,emax,1000)
+        dE = E[1] - E[0]
+        flux = np.sum(self.integral(E[:-1],E[1:]))
+        flux_err = np.sum(self.evaluate_error(E[:-1], epsilon=1e-4)[1]) * dE
+
+        return u.Quantity([flux.value, flux_err.value], unit=flux.unit)
+
     def energy_flux(self, emin, emax, **kwargs):
         r"""Compute energy flux in given energy range.
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -177,10 +177,8 @@ class SpectralModel(Model):
         flux, flux_err : tuple of `~astropy.units.Quantity`
             Integral flux and flux error betwen emin and emax.
         """
-        dE = emax - emin
-        flux = np.sum(self.integral(emin,emax))
-        flux_err = np.sum(self.evaluate_error(emin, epsilon=1e-4)[1] * dE)
-
+        flux = self.integral(emin,emax)
+        flux_err = flux * self.evaluate_error(emin, epsilon=1e-4)[1] / self(emin)
         return u.Quantity([flux.value, flux_err.value], unit=flux.unit)
 
     def energy_flux(self, emin, emax, **kwargs):

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -770,7 +770,7 @@ class TestSpectralModelErrorPropagation:
         assert_allclose(out.data, [1.548176e-10, 1.933612e-11], rtol=1e-3)
 
 
-def test_integral_error():
+def test_integral_error_PowerLaw():
     energy = np.linspace(1 * u.TeV, 10 * u.TeV, 10)
     emin = energy[:-1]
     emax = energy[1:]
@@ -781,5 +781,21 @@ def test_integral_error():
 
     flux, flux_error = powerlaw.integral_error(emin,emax)
 
-    assert_allclose(flux.value[0], 5.e-13, rtol=5e-14)
-    assert_allclose(flux_error.value[0], 4.9999999999580744e-14, rtol=5e-14)
+    assert_allclose(flux.value[0]/1e-13, 5.0, rtol=0.1)
+    assert_allclose(flux_error.value[0]/1e-14, 8.546615432273905, rtol=0.01)
+
+
+def test_integral_error_ExpCutOffPowerLaw():
+    energy = np.linspace(1 * u.TeV, 10 * u.TeV, 10)
+    emin = energy[:-1]
+    emax = energy[1:]
+    
+    exppowerlaw = ExpCutoffPowerLawSpectralModel()
+    exppowerlaw.parameters['index'].error = 0.4
+    exppowerlaw.parameters['amplitude'].error = 1e-13
+    exppowerlaw.parameters['lambda_'].error = 0.03
+    
+    flux, flux_error = exppowerlaw.integral_error(emin, emax)
+    
+    assert_allclose(flux.value[0]/1e-13, 5.05855622, rtol=0.01)
+    assert_allclose(flux_error.value[0]/1e-14, 8.90907063, rtol=0.01)

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -771,8 +771,12 @@ class TestSpectralModelErrorPropagation:
 
 
 def test_integral_error():
-    emin = 1 * u.TeV
-    emax = 10 * u.TeV
+    min = 1 * u.TeV
+    max = 10 * u.TeV
+
+    energy = np.linspace(min,max,1000)
+    emin = energy[:-1]
+    emax = energy[1:]
 
     powerlaw = PowerLawSpectralModel()
     powerlaw.parameters['index'].error = 0.4

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -771,10 +771,7 @@ class TestSpectralModelErrorPropagation:
 
 
 def test_integral_error():
-    min = 1 * u.TeV
-    max = 10 * u.TeV
-
-    energy = np.linspace(min,max,1000)
+    energy = np.linspace(1 * u.TeV, 10 * u.TeV, 1000)
     emin = energy[:-1]
     emax = energy[1:]
 

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -782,4 +782,3 @@ def test_integral_error():
 
     assert_allclose(flux.value, 9.e-13, rtol=1e-3)
     assert_allclose(flux_error.value, 2.947307639914628e-13, rtol=1e-14)
-

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -768,3 +768,18 @@ class TestSpectralModelErrorPropagation:
 
         out = model.evaluate_error(0.1 * u.TeV)
         assert_allclose(out.data, [1.548176e-10, 1.933612e-11], rtol=1e-3)
+
+
+def test_integral_error():
+    emin = 1 * u.TeV
+    emax = 10 * u.TeV
+
+    powerlaw = PowerLawSpectralModel()
+    powerlaw.parameters['index'].error = 0.4
+    powerlaw.parameters['amplitude'].error = 1e-13
+
+    flux, flux_error = powerlaw.integral_error(emin,emax)
+
+    assert_allclose(flux.value, 9.e-13, rtol=1e-3)
+    assert_allclose(flux_error.value, 2.947307639914628e-13, rtol=1e-14)
+

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -771,7 +771,7 @@ class TestSpectralModelErrorPropagation:
 
 
 def test_integral_error():
-    energy = np.linspace(1 * u.TeV, 10 * u.TeV, 1000)
+    energy = np.linspace(1 * u.TeV, 10 * u.TeV, 10)
     emin = energy[:-1]
     emax = energy[1:]
 
@@ -781,5 +781,5 @@ def test_integral_error():
 
     flux, flux_error = powerlaw.integral_error(emin,emax)
 
-    assert_allclose(flux.value, 9.e-13, rtol=1e-3)
-    assert_allclose(flux_error.value, 2.947307639914628e-13, rtol=5e-14)
+    assert_allclose(flux.value[0], 5.e-13, rtol=5e-14)
+    assert_allclose(flux_error.value[0], 4.9999999999580744e-14, rtol=5e-14)

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -781,4 +781,4 @@ def test_integral_error():
     flux, flux_error = powerlaw.integral_error(emin,emax)
 
     assert_allclose(flux.value, 9.e-13, rtol=1e-3)
-    assert_allclose(flux_error.value, 2.947307639914628e-13, rtol=1e-14)
+    assert_allclose(flux_error.value, 2.947307639914628e-13, rtol=5e-14)


### PR DESCRIPTION
This PR adds the `integral_error` function into ~gammapy.modeling.models.spectral, which will calculate the error of the integral flux for a given spectral model in a given energy range.
A test for a `PowerLawSpectralModel` has also been added.
