### PR TITLE
Refactor SpectrumDataset to use exposure

### DIFF
--- a/docs/tutorials/cta_data_analysis.ipynb
+++ b/docs/tutorials/cta_data_analysis.ipynb
@@ -407,7 +407,7 @@
    "outputs": [],
    "source": [
     "dataset_maker = SpectrumDatasetMaker(\n",
-    "    containment_correction=False, selection=[\"counts\", \"aeff\", \"edisp\"]\n",
+    "    containment_correction=False, selection=[\"counts\", \"exposure\", \"edisp\"]\n",
     ")\n",
     "bkg_maker = ReflectedRegionsBackgroundMaker(exclusion_mask=exclusion_mask)\n",
     "safe_mask_masker = SafeMaskMaker(methods=[\"aeff-max\"], aeff_percent=10)"

--- a/docs/tutorials/cta_sensitivity.ipynb
+++ b/docs/tutorials/cta_sensitivity.ipynb
@@ -117,7 +117,7 @@
    "outputs": [],
    "source": [
     "spectrum_maker = SpectrumDatasetMaker(\n",
-    "    selection=[\"aeff\", \"edisp\", \"background\"]\n",
+    "    selection=[\"exposure\", \"edisp\", \"background\"]\n",
     ")\n",
     "dataset = spectrum_maker.run(empty_dataset, obs)"
    ]
@@ -137,8 +137,8 @@
    "source": [
     "containment = 0.68\n",
     "\n",
-    "# correct effective area\n",
-    "dataset.aeff.data *= containment\n",
+    "# correct exposure\n",
+    "dataset.exposure *= containment\n",
     "\n",
     "# correct background estimation\n",
     "on_radii = obs.psf.containment_radius(\n",

--- a/docs/tutorials/light_curve_flare.ipynb
+++ b/docs/tutorials/light_curve_flare.ipynb
@@ -239,7 +239,7 @@
    "outputs": [],
    "source": [
     "dataset_maker = SpectrumDatasetMaker(\n",
-    "    containment_correction=True, selection=[\"counts\", \"aeff\", \"edisp\"]\n",
+    "    containment_correction=True, selection=[\"counts\", \"exposure\", \"edisp\"]\n",
     ")\n",
     "bkg_maker = ReflectedRegionsBackgroundMaker()\n",
     "safe_mask_masker = SafeMaskMaker(methods=[\"aeff-max\"], aeff_percent=10)"

--- a/docs/tutorials/light_curve_simulation.ipynb
+++ b/docs/tutorials/light_curve_simulation.ipynb
@@ -212,7 +212,7 @@
     "    e_reco=energy_axis, e_true=energy_axis_true, region=on_region, name=\"empty\"\n",
     ")\n",
     "\n",
-    "maker = SpectrumDatasetMaker(selection=[\"aeff\", \"background\", \"edisp\"])\n",
+    "maker = SpectrumDatasetMaker(selection=[\"exposure\", \"background\", \"edisp\"])\n",
     "    \n",
     "for idx in range(n_obs):\n",
     "    obs = Observation.create(\n",

--- a/docs/tutorials/spectrum_analysis.ipynb
+++ b/docs/tutorials/spectrum_analysis.ipynb
@@ -252,7 +252,7 @@
    "outputs": [],
    "source": [
     "dataset_maker = SpectrumDatasetMaker(\n",
-    "    containment_correction=False, selection=[\"counts\", \"aeff\", \"edisp\"]\n",
+    "    containment_correction=False, selection=[\"counts\", \"exposure\", \"edisp\"]\n",
     ")\n",
     "bkg_maker = ReflectedRegionsBackgroundMaker(exclusion_mask=exclusion_mask)\n",
     "safe_mask_masker = SafeMaskMaker(methods=[\"aeff-max\"], aeff_percent=10)"

--- a/docs/tutorials/spectrum_simulation.ipynb
+++ b/docs/tutorials/spectrum_simulation.ipynb
@@ -151,7 +151,7 @@
     "dataset_empty = SpectrumDataset.create(\n",
     "    e_reco=energy_axis, e_true=energy_axis_true, region=on_region, name=\"obs-0\"\n",
     ")\n",
-    "maker = SpectrumDatasetMaker(selection=[\"aeff\", \"edisp\", \"background\"])\n",
+    "maker = SpectrumDatasetMaker(selection=[\"exposure\", \"edisp\", \"background\"])\n",
     "dataset = maker.run(dataset_empty, obs)"
    ]
   },

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -312,7 +312,7 @@ class Analysis:
             ] = datasets_settings.containment_correction
         e_reco = self._make_energy_axis(datasets_settings.geom.axes.energy)
 
-        maker_config["selection"] = ["counts", "aeff", "edisp"]
+        maker_config["selection"] = ["counts", "exposure", "edisp"]
         dataset_maker = SpectrumDatasetMaker(**maker_config)
 
         bkg_maker_config = {}

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -199,7 +199,7 @@ def test_geom_analysis_1d():
 
     assert len(analysis.datasets) == 1
 
-    axis = analysis.datasets[0].aeff.geom.axes[0]
+    axis = analysis.datasets[0].exposure.geom.axes["energy_true"]
     assert axis.nbin == 50
     assert_allclose(axis.edges[0].to_value("TeV"), 0.03)
     assert_allclose(axis.edges[-1].to_value("TeV"), 100)

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -75,8 +75,8 @@ class GTI:
         reference_time : `~astropy.time.Time`
             the reference time to use in GTI definition
         """
-        start = np.atleast_1d(Quantity(start))
-        stop = np.atleast_1d(Quantity(stop))
+        start = Quantity(start, ndmin=1)
+        stop = Quantity(stop, ndmin=1)
         reference_time = Time(reference_time)
         meta = time_ref_to_dict(reference_time)
         table = Table({"START": start.to("s"), "STOP": stop.to("s")}, meta=meta)

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
+import copy
 from operator import lt, le
 from astropy.table import Table, vstack
 from astropy.time import Time
@@ -60,7 +61,7 @@ class GTI:
         self.table = table
 
     def copy(self):
-        return self.__class__(self.table)
+        return copy.deepcopy(self)
 
     @classmethod
     def create(cls, start, stop, reference_time="2000-01-01"):

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1091,6 +1091,9 @@ class MapDataset(Dataset):
 
         if self.exposure is not None:
             kwargs["exposure"] = self.exposure.get_spectrum(on_region, np.mean)
+            if self.gti:
+                # TODO: this is mising the deadtime correction
+                kwargs["exposure"].meta["livetime"] = self.gti.time_sum
 
         if containment_correction:
             if not isinstance(on_region, CircleSkyRegion):

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -1378,6 +1378,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         arffile = phafile.replace("pha", "arf")
         aeff = RegionNDMap.read(dirname / arffile, format="ogip-arf")
         exposure = aeff * livetime
+        exposure.meta["livetime"] = livetime
 
         if edisp is not None:
             edisp.exposure_map.data = exposure.data[:, :, np.newaxis, :]

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -202,23 +202,22 @@ def test_to_spectrum_dataset(sky_model, geom, geom_etrue, edisp_mode):
         on_region, containment_correction=True
     )
     mask = np.ones_like(dataset_ref.counts, dtype='bool')
-    mask[1,40:60,40:60]=0
+    mask[1, 40:60, 40:60] = 0
     dataset_ref.mask_safe = Map.from_geom(dataset_ref.counts.geom, data=mask)
     spectrum_dataset_mask = dataset_ref.to_spectrum_dataset(on_region)
-
 
     assert np.sum(spectrum_dataset.counts.data) == 1
     assert spectrum_dataset.data_shape == (2, 1, 1)
     assert spectrum_dataset.background_model.map.geom.axes[0].nbin == 2
-    assert spectrum_dataset.aeff.geom.axes[0].nbin == 3
-    assert spectrum_dataset.aeff.unit == "m2"
+    assert spectrum_dataset.exposure.geom.axes[0].nbin == 3
+    assert spectrum_dataset.exposure.unit == "m2s"
     assert spectrum_dataset.edisp.get_edisp_kernel().e_reco.nbin == 2
     assert spectrum_dataset.edisp.get_edisp_kernel().e_true.nbin == 3
-    assert spectrum_dataset_corrected.aeff.unit == "m2"
-    assert_allclose(spectrum_dataset.aeff.data[1], 853023.423047, rtol=1e-5)
-    assert_allclose(spectrum_dataset_corrected.aeff.data[1], 565527.524246, rtol=1e-5)
     assert np.sum(spectrum_dataset_mask.counts.data) == 0
     assert spectrum_dataset_mask.data_shape == (2, 1, 1)
+    assert spectrum_dataset_corrected.exposure.unit == "m2s"
+    assert_allclose(spectrum_dataset.exposure.data[1], 3.070884e+09, rtol=1e-5)
+    assert_allclose(spectrum_dataset_corrected.exposure.data[1], 2.014115e+09, rtol=1e-5)
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -217,7 +217,7 @@ def test_to_spectrum_dataset(sky_model, geom, geom_etrue, edisp_mode):
     assert spectrum_dataset_mask.data_shape == (2, 1, 1)
     assert spectrum_dataset_corrected.exposure.unit == "m2s"
     assert_allclose(spectrum_dataset.exposure.data[1], 3.070884e+09, rtol=1e-5)
-    assert_allclose(spectrum_dataset_corrected.exposure.data[1], 2.014115e+09, rtol=1e-5)
+    assert_allclose(spectrum_dataset_corrected.exposure.data[1], 2.035899e+09, rtol=1e-5)
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -900,6 +900,9 @@ def test_datasets_stack_reduce():
         datasets.append(ds)
 
     stacked = datasets.stack_reduce(name="stacked")
+
+    assert_allclose(stacked.exposure.meta["livetime"].to_value("s"), 6313.8116406202325)
+
     info_table = datasets.info_table()
     assert_allclose(info_table["n_on"], [124, 126, 119, 90])
 

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -43,10 +43,12 @@ def simulate_spectrum_dataset(model, random_state=0):
         geom=geom,
     )
 
+    livetime = 100 * u.h
+    exposure = aeff * livetime
+
     dataset = SpectrumDatasetOnOff(
         name="test_onoff",
-        aeff=aeff,
-        livetime=100 * u.h,
+        exposure=exposure,
         acceptance=acceptance,
         acceptance_off=5,
         edisp=edisp,

--- a/gammapy/estimators/tests/test_sensitivity.py
+++ b/gammapy/estimators/tests/test_sensitivity.py
@@ -22,10 +22,13 @@ def spectrum_dataset():
     )
     aeff = RegionNDMap.create(region="icrs;circle(0, 0, 0.1)", axes=[e_true], unit="m2")
     aeff.data += 1e6
+
+    livetime = 1 * u.h
+    exposure = aeff * livetime
+
     return SpectrumDataset(
         name="test",
-        aeff=aeff,
-        livetime="1h",
+        exposure=exposure,
         edisp=edisp,
         models=BackgroundModel(background, name="test-bkg", datasets_names="test"),
     )

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -458,7 +458,7 @@ class EDispKernelMap(IRFMap):
         edisp_map : `EDispKernelMap`
             Energy dispersion kernel map.
         """
-        edisp_map = cls.from_diagonal_response(edisp.e_reco, edisp.e_true, geom)
+        edisp_map = cls.from_diagonal_response(edisp.e_reco, edisp.e_true, geom=geom)
         edisp_map.edisp_map.data *= 0
         edisp_map.edisp_map.data[:, :, ...] = edisp.pdf_matrix[
             :, :, np.newaxis, np.newaxis

--- a/gammapy/irf/irf_map.py
+++ b/gammapy/irf/irf_map.py
@@ -106,7 +106,7 @@ class IRFMap:
             slices = cutout_info["parent-slices"]
             parent_slices = Ellipsis, slices[0], slices[1]
         else:
-            parent_slices = None
+            parent_slices = slice(None)
 
         self._irf_map.data[parent_slices] *= self.exposure_map.data[parent_slices]
         self._irf_map.stack(other._irf_map * other.exposure_map.data, weights=weights)

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -87,8 +87,8 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hes
     assert_allclose(datasets[0].counts.data.sum(), 100)
     assert_allclose(datasets[1].counts.data.sum(), 92)
 
-    assert_allclose(datasets[0].livetime.value, 1581.736758)
-    assert_allclose(datasets[1].livetime.value, 1572.686724)
+    assert_allclose(datasets[0].exposure.meta["livetime"].value, 1581.736758)
+    assert_allclose(datasets[1].exposure.meta["livetime"].value, 1572.686724)
 
     assert_allclose(datasets[0].background_model.map.data.sum(), 7.74732, rtol=1e-5)
     assert_allclose(datasets[1].background_model.map.data.sum(), 6.118879, rtol=1e-5)
@@ -107,8 +107,8 @@ def test_spectrum_dataset_maker_hess_cta(spectrum_dataset_gc, observations_cta_d
     assert_allclose(datasets[0].counts.data.sum(), 53)
     assert_allclose(datasets[1].counts.data.sum(), 47)
 
-    assert_allclose(datasets[0].livetime.value, 1764.000034)
-    assert_allclose(datasets[1].livetime.value, 1764.000034)
+    assert_allclose(datasets[0].exposure.meta["livetime"].value, 1764.000034)
+    assert_allclose(datasets[1].exposure.meta["livetime"].value, 1764.000034)
 
     assert_allclose(datasets[0].background_model.map.data.sum(), 2.238345, rtol=1e-5)
     assert_allclose(datasets[1].background_model.map.data.sum(), 2.164593, rtol=1e-5)
@@ -201,19 +201,20 @@ class TestSpectrumMakerChain:
         dataset = reflected_regions_bkg_maker.run(dataset, obs)
         dataset = safe_mask_maker.run(dataset, obs)
 
-        aeff_actual = (
-            dataset.aeff.interp_by_coord(
+        exposure_actual = (
+            dataset.exposure.interp_by_coord(
                 {
                     "energy_true": 5 * u.TeV,
                     "skycoord": dataset.counts.geom.center_skydir,
                 }
             )
-            * u.m ** 2
+            * dataset.exposure.unit
         )
 
         edisp_actual = dataset._edisp_kernel.data.evaluate(
             energy_true=5 * u.TeV, energy=5.2 * u.TeV
         )
+        aeff_actual = exposure_actual / dataset.exposure.meta["livetime"]
 
         assert_quantity_allclose(aeff_actual, results["aeff"], rtol=1e-3)
         assert_quantity_allclose(edisp_actual, results["edisp"], rtol=1e-3)

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1134,6 +1134,32 @@ class Map(abc.ABC):
             unit=images[0].unit
         )
 
+    def to_cube(self, axes):
+        """Append non-spatial axes to create a higher-dimensional Map.
+
+        This will result in a Map with a new geometry with
+        N+M dimensions where N is the number of current dimensions and
+        M is the number of axes in the list. The data is reshaped onto the
+        new geometry
+
+        Parameters
+        ----------
+        axes : list
+            Axes that will be appended to this Map.
+            The axes should have only one bin
+
+        Returns
+        -------
+        map : `~gammapy.maps.WcsNDMap`
+            new map
+        """
+        for ax in axes:
+            if ax.nbin > 1:
+                raise ValueError(ax.name, "should have only one bin")
+        geom = self.geom.to_cube(axes)
+        data = self.data.reshape((1,) * len(axes) + self.data.shape)
+        return self.from_geom(data=data, geom=geom, unit=self.unit)
+
     def __repr__(self):
         geom = self.geom.__class__.__name__
         axes = ["skycoord"] if self.geom.is_hpx else ["lon", "lat"]

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -231,7 +231,6 @@ class RegionGeom(Geom):
         coords = MapCoord.create(
             coords, frame=self.frame, axis_names=self.axes.names
         )
-        print(coords)
 
         if self.region is None:
             pix = (0, 0)
@@ -365,7 +364,6 @@ class RegionGeom(Geom):
     def union(self, other):
         """Stack a RegionGeom by making the union"""
         if not self == other:
-            print(self, other)
             raise ValueError("Can only make union if extra axes are equivalent.")
         if other.region:
             if self.region:

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -36,6 +36,9 @@ class RegionNDMap(Map):
         if data is None:
             data = np.zeros(geom.data_shape, dtype=dtype)
 
+        if meta is None:
+            meta = {}
+
         self._geom = geom
         self.data = data
         self.meta = meta

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -343,13 +343,6 @@ class RegionNDMap(Map):
 
         self.data += data
 
-        # TODO: check whether this can be improved
-        if "livetime" in other.meta:
-            if "livetime" in self.meta:
-                self.meta["livetime"] += other.meta["livetime"]
-            else:
-                self.meta["livetime"] = other.meta["livetime"]
-
     def to_table(self, format="ogip", ogip_column="COUNTS"):
         """Convert to `~astropy.table.Table`.
 

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -343,6 +343,13 @@ class RegionNDMap(Map):
 
         self.data += data
 
+        # TODO: check whether this can be improved
+        if "livetime" in other.meta:
+            if "livetime" in self.meta:
+                self.meta["livetime"] += other.meta["livetime"]
+            else:
+                self.meta["livetime"] = other.meta["livetime"]
+
     def to_table(self, format="ogip", ogip_column="COUNTS"):
         """Convert to `~astropy.table.Table`.
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -747,28 +747,3 @@ class WcsNDMap(WcsMap):
 
         return MapCoord.create(cdict, frame=self.geom.frame)
 
-    def to_cube(self, axes):
-        """Append non-spatial axes to create a higher-dimensional Map.
-
-        This will result in a Map with a new geometry with
-        N+M dimensions where N is the number of current dimensions and
-        M is the number of axes in the list. The data is reshaped onto the
-        new geometry
-
-        Parameters
-        ----------
-        axes : list
-            Axes that will be appended to this Map.
-            The axes should have only one bin
-
-        Returns
-        -------
-        map : `~gammapy.maps.WcsNDMap`
-            new map
-        """
-        for ax in axes:
-            if ax.nbin > 1:
-                raise ValueError(ax.name, "should have only one bin")
-        geom = self.geom.to_cube(axes)
-        data = self.data.reshape((1,) * len(axes) + self.data.shape)
-        return self.from_geom(data=data, geom=geom, unit=self.unit)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request refactors the `SpectrumDataset` as well as `SpectrumDatasetOnOff` to use exposure internally as well. To support round-tripping the OGIP format in introduces the `livetime` meta keyword in the exposure map. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
