### PR TITLE
Harmonise npred between OnOff and normal datasets

### DIFF
--- a/docs/stats/fit_statistics.rst
+++ b/docs/stats/fit_statistics.rst
@@ -62,11 +62,12 @@ measurement containing only background to estimate it.
 
 In the OFF region, which contains background only, the number of counts
 :math:`n_{\mathrm{off}}` is a Poisson random variable of mean value
-:math:`\mu_{\mathrm{bkg}}`
+:math:`\alpha,\mu_{\mathrm{bkg}}`
 In the ON region which contains signal and background contribution, the number
 of counts, :math:`n_{\mathrm{on}}`, is a Poisson random variable of mean value
-:math:`\mu_{\mathrm{sig}} + \alpha \mu_{\mathrm{bkg}}`, where :math:`\alpha` is
-the ratio of the ON and OFF region acceptances.
+:math:`\mu_{\mathrm{sig}} +  \mu_{\mathrm{bkg}}`, where :math:`\alpha` is
+the ratio of the ON and OFF region acceptances, and :math:`\mu_{\mathrm{bkg}}`
+the mean background counts in the ON region.
 
 It is possible define a likelihood function and marginalize it over the unknown
 :math:`\mu_{\mathrm{bkg}}` to obtain :math:`\mu_{\mathrm{sig}}`.
@@ -76,12 +77,9 @@ for ON-OFF measurements in ground based gamma-ray astronomy.
 The WStat fit statistics is given by the following formula:
 
 .. math::
-    W = 2 \big(\mu_{\mathrm{sig}} + (1 + \alpha)\mu_{\mathrm{bkg}} -
-    n_{\mathrm{on}} - n_{\mathrm{off}} - & n_{\mathrm{on}}
-    (\log{(\mu_{\mathrm{sig}} + \alpha \mu_{\mathrm{bkg}}) -
-    \log{(n_{\mathrm{on}})}})\\
-    -& n_{\mathrm{off}} (\log{(\mu_{\mathrm{bkg}})} -
-    \log{(n_{\mathrm{off}})})\big)
+    W = 2 \big(\mu_{\mathrm{sig}} + (1 + 1/\alpha)\mu_{\mathrm{bkg}}
+    - n_{\mathrm{on}} \log{(\mu_{\mathrm{sig}} + \mu_{\mathrm{bkg}})}
+    - n_{\mathrm{off}} \log{(\mu_{\mathrm{bkg}}/\alpha)}\big)
 
 To see how to derive it see the :ref:`wstat derivation <wstat_derivation>`.
 

--- a/docs/stats/wstat_derivation.rst
+++ b/docs/stats/wstat_derivation.rst
@@ -24,14 +24,14 @@ constant terms, we define the **WStat**.
 .. math::
     W = 2 \big(\mu_{\mathrm{sig}} + (1 + 1/\alpha)\mu_{\mathrm{bkg}}
     - n_{\mathrm{on}} \log{(\mu_{\mathrm{sig}} + \mu_{\mathrm{bkg}})}
-    - n_{\mathrm{off}} \log{(\mu_{\mathrm{bkg}}/alpha)}\big)
+    - n_{\mathrm{off}} \log{(\mu_{\mathrm{bkg}}/\alpha)}\big)
 
 In the most general case, where :math:`\mu_{\mathrm{src}}` and
 :math:`\mu_{\mathrm{bkg}}` are free the minimum of :math:`W` is at
 
 .. math::
     \mu_{\mathrm{sig}} = n_{\mathrm{on}} - \alpha\,n_{\mathrm{off}} \\
-    \mu_{\mathrm{bkg}} = n_{\mathrm{off}}
+    \mu_{\mathrm{bkg}} = \alpha\,n_{\mathrm{off}}
 
 
 Profile Likelihood

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -343,25 +343,22 @@ class MapDataset(Dataset):
 
         Parameters
         -------------
-        model: `~gammapy.modeling.models.Models`, optional
-            The model to computed the npred for. If none, the sum of all components (minus the background model)
+        model: `~gammapy.modeling.models.SkyModel`, optional
+            Sky model to compute the npred for.
+            If none, the sum of all components (minus the background model)
             is returned
 
         Returns
         ----------
         npred_sig: `gammapy.maps.WcsNDMap`
+            Map of the predicted signal counts
         """
         if model is None:
             if self.background_model is None:
                 return self.npred()
             return self.npred() - self.background_model.evaluate()
         else:
-            return MapEvaluator(
-                model=model,
-                exposure=self.exposure,
-                edisp=self._edisp_kernel,
-                gti=self.gti,
-            ).compute_npred()
+            return self.evaluators.get(model).compute_npred()
 
     @classmethod
     def from_geoms(
@@ -1560,14 +1557,14 @@ class MapDatasetOnOff(MapDataset):
         """"Model predicted signal counts. If a model is passed, predicted counts from that component is returned.
             Else, the total signal counts are returned.
 
-            Parameters
-            -------------
-            model: `~gammapy.modeling.models.Models`, optional
-               The model to computed the npred for.
+        Parameters
+        -------------
+        model: `~gammapy.modeling.models.Models`, optional
+           The model to computed the npred for.
 
-            Returns
-            ----------
-            npred_sig: `gammapy.maps.WcsNDMap`
+        Returns
+        ----------
+        npred_sig: `gammapy.maps.WcsNDMap`
         """
         if model is None:
             return super().npred()

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1533,9 +1533,9 @@ class MapDatasetOnOff(MapDataset):
 
     @property
     def background(self):
-        """
+        """`
         Background counts estimated from the marginalized likelihood estimate.
-        See :ref:wstat.
+        See :ref:`wstat`
         """
         mu_bkg = self.alpha.data * get_wstat_mu_bkg(
             n_on=self.counts.data,

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -936,7 +936,8 @@ class SpectrumDatasetOnOff(SpectrumDataset):
     @property
     def background(self):
         """Background counts estimated from the marginalized likelihood estimate.
-         See :ref:wstat."""
+         See :ref:`wstat`
+         """
         mu_bkg = self.alpha.data * get_wstat_mu_bkg(
             n_on=self.counts.data,
             n_off=self.counts_off.data,

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -268,12 +268,16 @@ def get_fermi_3fhl_gc_dataset():
 def test_resample_energy_3fhl():
     dataset = get_fermi_3fhl_gc_dataset()
 
-    new_axis = MapAxis.from_edges([10, 35, 100]*u.GeV, interp='log', name="energy")
+    new_axis = MapAxis.from_edges([10, 35, 100] * u.GeV, interp="log", name="energy")
     grouped = dataset.resample_energy_axis(energy_axis=new_axis)
 
-    assert grouped.counts.data.shape == (2,200,400)
+    assert grouped.counts.data.shape == (2, 200, 400)
     assert grouped.counts.data[0].sum() == 28581
-    assert_allclose(grouped.background_model.map.data.sum(axis=(1,2)), [25074.366386,  3474.265917], rtol=1e-5)
+    assert_allclose(
+        grouped.background_model.map.data.sum(axis=(1, 2)),
+        [25074.366386, 3474.265917],
+        rtol=1e-5,
+    )
     assert_allclose(grouped.exposure.data, dataset.exposure.data, rtol=1e-5)
 
     axis = grouped.counts.geom.axes[0]
@@ -325,19 +329,25 @@ def test_to_image_mask_safe():
     dataset_im = dataset_copy.to_image()
     assert dataset_im.counts is None
 
+
 @requires_data()
 def test_downsample():
     dataset = get_fermi_3fhl_gc_dataset()
 
     downsampled = dataset.downsample(2)
 
-    assert downsampled.counts.data.shape == (11,100,200)
+    assert downsampled.counts.data.shape == (11, 100, 200)
     assert downsampled.counts.data.sum() == dataset.counts.data.sum()
-    assert_allclose(downsampled.background_model.map.data.sum(axis=(1,2)), dataset.background_model.map.data.sum(axis=(1,2)), rtol=1e-5)
-    assert_allclose(downsampled.exposure.data[5,50,100], 3.318082e+11, rtol=1e-5)
+    assert_allclose(
+        downsampled.background_model.map.data.sum(axis=(1, 2)),
+        dataset.background_model.map.data.sum(axis=(1, 2)),
+        rtol=1e-5,
+    )
+    assert_allclose(downsampled.exposure.data[5, 50, 100], 3.318082e11, rtol=1e-5)
 
     with pytest.raises(ValueError):
         dataset.downsample(2, axis_name="energy")
+
 
 @requires_data()
 def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
@@ -1094,7 +1104,7 @@ def test_info_dict_on_off(images):
     assert_allclose(info_dict["excess"], -22.52295, rtol=1e-3)
     assert_allclose(info_dict["aeff_min"].value, 0.0, rtol=1e-3)
     assert_allclose(info_dict["aeff_max"].value, 3.4298378e09, rtol=1e-3)
-    assert_allclose(info_dict["npred"], 0.0, rtol=1e-3)
+    assert_allclose(info_dict["npred"], 4321.518, rtol=1e-3)
     assert_allclose(info_dict["counts_off"], 20407510.0, rtol=1e-3)
     assert_allclose(info_dict["acceptance"], 4272.7075, rtol=1e-3)
     assert_allclose(info_dict["acceptance_off"], 20175596.0, rtol=1e-3)
@@ -1217,7 +1227,7 @@ def test_downsample_onoff():
 
     downsampled = dataset_onoff.downsample(2, axis_name="energy")
 
-    assert downsampled.counts.data.shape == (2,10,10)
+    assert downsampled.counts.data.shape == (2, 10, 10)
     assert downsampled.counts.data.sum() == dataset_onoff.counts.data.sum()
     assert downsampled.counts_off.data.sum() == dataset_onoff.counts_off.data.sum()
     assert_allclose(downsampled.alpha.data, 0.5)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -680,6 +680,21 @@ def test_stack(sky_model):
     assert_allclose(dataset1.meta_table["OBS_ID"][0], [0, 1])
 
 
+@requires_data()
+def test_npred_sig(sky_model, geom, geom_etrue):
+    dataset = get_map_dataset(sky_model, geom, geom_etrue)
+    pwl = PowerLawSpectralModel()
+    gauss = GaussianSpatialModel(
+        lon_0="0.0 deg", lat_0="0.0 deg", sigma="0.5 deg", frame="galactic"
+    )
+    model1 = SkyModel(pwl, gauss)
+    dataset.models.append(model1)
+
+    assert_allclose(dataset.npred().data.sum(), 9676.047906, rtol=1e-3)
+    assert_allclose(dataset.npred_sig().data.sum(), 5676.04790, rtol=1e-3)
+    assert_allclose(dataset.npred_sig(model=model1).data.sum(), 150.7487, rtol=1e-3)
+
+
 def test_stack_npred():
     pwl = PowerLawSpectralModel()
     gauss = GaussianSpatialModel(sigma="0.2 deg")

--- a/gammapy/estimators/asmooth_map.py
+++ b/gammapy/estimators/asmooth_map.py
@@ -201,11 +201,10 @@ class ASmoothMapEstimator(Estimator):
 
         # extract 2d arrays
         counts = dataset.counts.data[0].astype(float)
-        background = dataset.npred().data[0]
+        background = dataset.background_model.evaluate().data[0]
 
-        # TODO: remove once MapDatasetOnOff.npred() returns the correct thing
         if isinstance(dataset, MapDatasetOnOff):
-            background += dataset.background
+            background = dataset.counts_off_normalised.data[0]
 
         if dataset.exposure is not None:
             exposure = estimate_exposure_reco_energy(dataset, self.spectrum)

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -36,9 +36,6 @@ def convolved_map_dataset_counts_statistics(dataset, kernel, apply_mask_fit=Fals
     n_on = n_on.sum_over_axes(keepdims=True)
     n_on_conv = np.rint(n_on.convolve(kernel.array).data)
 
-    npred = dataset.npred() * mask
-    npred = npred.sum_over_axes(keepdims=True)
-
     if isinstance(dataset, MapDatasetOnOff):
         background = dataset.counts_off_normalised * mask
         background.data[dataset.acceptance_off.data == 0] = 0.0
@@ -50,7 +47,9 @@ def convolved_map_dataset_counts_statistics(dataset, kernel, apply_mask_fit=Fals
         background_conv = background.convolve(kernel.array)
         n_off_conv = n_off.convolve(kernel.array)
 
-        mu_sig = npred.convolve(kernel.array)
+        npred_sig = dataset.npred_sig() * mask
+        npred_sig = npred_sig.sum_over_axes(keepdims=True)
+        mu_sig = npred_sig.convolve(kernel.array)
 
         with np.errstate(invalid="ignore", divide="ignore"):
             alpha_conv = background_conv / n_off_conv
@@ -59,6 +58,9 @@ def convolved_map_dataset_counts_statistics(dataset, kernel, apply_mask_fit=Fals
             n_on_conv.data, n_off_conv.data, alpha_conv.data, mu_sig.data
         )
     else:
+
+        npred = dataset.npred() * mask
+        npred = npred.sum_over_axes(keepdims=True)
         background_conv = npred.convolve(kernel.array)
         return CashCountsStatistic(n_on_conv.data, background_conv.data)
 

--- a/gammapy/estimators/sensitivity.py
+++ b/gammapy/estimators/sensitivity.py
@@ -89,7 +89,7 @@ class SensitivityEstimator(Estimator):
         energy = dataset._geom.axes["energy"].center
 
         dataset.models = SkyModel(spectral_model=self.spectrum)
-        npred = dataset.npred()
+        npred = dataset.npred_sig()
 
         phi_0 = excess / npred
 

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -52,7 +52,7 @@ def simulate_spectrum_dataset(model, random_state=0):
         edisp=edisp,
     )
     dataset.models = bkg_model
-    bkg_npred = dataset.npred()
+    bkg_npred = dataset.npred_sig()
 
     dataset.models = model
     dataset.fake(


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request ensures:
 - `npred_sig(model=None)`  : returns the model predicated counts
- `npred`  : returns the total (signal + background) counts

This behaviour is now consistent between OnOff and Normal datasets.
I also adapt the docs to sort the inconsistancy between `mu_sig` as the expected signal counts in the signal or the background region

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
