### PR TITLE
Clean IRF I/O by using MapAxes

### DIFF
--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -220,7 +220,7 @@ def test_to_spectrum_dataset(sky_model, geom, geom_etrue, edisp_mode):
     assert spectrum_dataset.edisp.get_edisp_kernel().e_true.nbin == 3
     assert spectrum_dataset_corrected.aeff.unit == "m2"
     assert_allclose(spectrum_dataset.aeff.data[1], 853023.423047, rtol=1e-5)
-    assert_allclose(spectrum_dataset_corrected.aeff.data[1], 559476.3357, rtol=1e-5)
+    assert_allclose(spectrum_dataset_corrected.aeff.data[1], 565527.524246, rtol=1e-5)
 
 
 @requires_data()
@@ -439,7 +439,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
 
     npred = dataset_1.npred().data.sum()
     assert_allclose(npred, 7525.790688, rtol=1e-3)
-    assert_allclose(result.total_stat, 21700.253246, rtol=1e-3)
+    assert_allclose(result.total_stat, 21659.2139, rtol=1e-3)
 
     pars = result.parameters
     assert_allclose(pars["lon_0"].value, 0.2, rtol=1e-2)
@@ -465,7 +465,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
     dataset_2.mask_safe = Map.from_geom(geom, data=mask_safe)
 
     stat = fit.datasets.stat_sum()
-    assert_allclose(stat, 14824.173099, rtol=1e-5)
+    assert_allclose(stat, 14823.579908, rtol=1e-5)
 
     region = sky_model.spatial_model.to_region()
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -148,7 +148,7 @@ def test_mde_sample_psf(dataset):
     assert_allclose(events.table["RA"][0], 266.2757792220, rtol=1e-5)
     assert events.table["RA"].unit == "deg"
 
-    assert_allclose(events.table["DEC"][0], -29.030257126, rtol=1e-5)
+    assert_allclose(events.table["DEC"][0], -29.030939, rtol=1e-5)
     assert events.table["DEC"].unit == "deg"
 
 

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -224,7 +224,7 @@ class TestFluxPointsEstimator:
         assert_allclose(actual, [0.2, 1, 5])
 
         actual = fp.table["stat_scan"][0] - fp.table["stat"][0]
-        assert_allclose(actual, [1.628746e02, 1.416280e-01, 2.006994e03], rtol=1e-2)
+        assert_allclose(actual, [1.628530e+02, 1.436323e-01, 2.007461e+03], rtol=1e-2)
 
     @staticmethod
     @requires_dependency("iminuit")

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -4,8 +4,7 @@ import numpy as np
 import astropy.units as u
 from astropy.io import fits
 from astropy.table import Table
-from gammapy.maps import MapAxis
-from gammapy.maps.utils import edges_from_lo_hi
+from gammapy.maps import MapAxis, MapAxes
 from gammapy.utils.integrate import trapz_loglog
 from gammapy.utils.nddata import NDDataArray
 from gammapy.utils.scripts import make_path
@@ -120,19 +119,10 @@ class Background3D:
 
     def to_table(self):
         """Convert to `~astropy.table.Table`."""
-        meta = self.meta.copy()
-
-        detx = self.data.axes["fov_lon"].edges
-        dety = self.data.axes["fov_lat"].edges
-        energy = self.data.axes["energy"].edges
-
-        table = Table(meta=meta)
-        table["DETX_LO"] = detx[:-1][np.newaxis]
-        table["DETX_HI"] = detx[1:][np.newaxis]
-        table["DETY_LO"] = dety[:-1][np.newaxis]
-        table["DETY_HI"] = dety[1:][np.newaxis]
-        table["ENERG_LO"] = energy[:-1][np.newaxis]
-        table["ENERG_HI"] = energy[1:][np.newaxis]
+        # TODO: fix axis order
+        axes = MapAxes(self.data.axes[::-1])
+        table = axes.to_table(format="gadf-dl3")
+        table.meta = self.meta.copy()
         table["BKG"] = self.data.data[np.newaxis]
         return table
 
@@ -297,16 +287,8 @@ class Background2D:
 
     def to_table(self):
         """Convert to `~astropy.table.Table`."""
-        meta = self.meta.copy()
-        table = Table(meta=meta)
-
-        theta = self.data.axes["offset"].edges
-        energy = self.data.axes["energy"].edges
-
-        table["THETA_LO"] = theta[:-1][np.newaxis]
-        table["THETA_HI"] = theta[1:][np.newaxis]
-        table["ENERG_LO"] = energy[:-1][np.newaxis]
-        table["ENERG_HI"] = energy[1:][np.newaxis]
+        table = self.data.axes.to_table(format="gadf-dl3")
+        table.meta = self.meta.copy()
         table["BKG"] = self.data.data[np.newaxis]
         return table
 

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -95,22 +95,9 @@ class Background3D:
                 "Invalid unit found in background table! Assuming (s-1 MeV-1 sr-1)"
             )
 
-        # TODO: move to MapAxis.from_table()
-        energy_lo = table["ENERG_LO"].quantity[0]
-        energy_hi = table["ENERG_HI"].quantity[0]
-        fov_lon_lo = table["DETX_LO"].quantity[0]
-        fov_lon_hi = table["DETX_HI"].quantity[0]
-        fov_lat_lo = table["DETY_LO"].quantity[0]
-        fov_lat_hi = table["DETY_HI"].quantity[0]
-
-        e_edges = edges_from_lo_hi(energy_lo, energy_hi)
-        energy_axis = MapAxis.from_edges(e_edges, interp="log", name="energy")
-
-        fov_lon_edges = edges_from_lo_hi(fov_lon_lo, fov_lon_hi)
-        fov_lon_axis = MapAxis.from_edges(fov_lon_edges, interp="lin", name="fov_lon")
-
-        fov_lat_edges = edges_from_lo_hi(fov_lat_lo, fov_lat_hi)
-        fov_lat_axis = MapAxis.from_edges(fov_lat_edges, interp="lin", name="fov_lat")
+        energy_axis = MapAxis.from_table(table, column_prefix="ENERG", format="gadf-dl3")
+        fov_lon_axis = MapAxis.from_table(table, column_prefix="DETX", format="gadf-dl3")
+        fov_lat_axis = MapAxis.from_table(table, column_prefix="DETY", format="gadf-dl3")
 
         return cls(
             energy_axis=energy_axis,
@@ -272,6 +259,7 @@ class Background2D:
         """Read from `~astropy.table.Table`."""
         # Spec says key should be "BKG", but there are files around
         # (e.g. CTA 1DC) that use "BGD". For now we support both
+        print(table.meta)
         if "BKG" in table.colnames:
             bkg_name = "BKG"
         elif "BGD" in table.colnames:
@@ -286,16 +274,9 @@ class Background2D:
                 "Invalid unit found in background table! Assuming (s-1 MeV-1 sr-1)"
             )
 
-        energy_lo = table["ENERG_LO"].quantity[0]
-        energy_hi = table["ENERG_HI"].quantity[0]
-        offset_lo = table["THETA_LO"].quantity[0]
-        offset_hi = table["THETA_HI"].quantity[0]
+        energy_axis = MapAxis.from_table(table, column_prefix="ENERG", format="gadf-dl3")
+        offset_axis = MapAxis.from_table(table, column_prefix="THETA", format="gadf-dl3")
 
-        e_edges = edges_from_lo_hi(energy_lo, energy_hi)
-        energy_axis = MapAxis.from_edges(e_edges, interp="log", name="energy")
-
-        offset_edges = edges_from_lo_hi(offset_lo, offset_hi)
-        offset_axis = MapAxis.from_edges(offset_edges, interp="lin", name="offset")
         return cls(
             energy_axis=energy_axis,
             offset_axis=offset_axis,

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -259,7 +259,7 @@ class Background2D:
         """Read from `~astropy.table.Table`."""
         # Spec says key should be "BKG", but there are files around
         # (e.g. CTA 1DC) that use "BGD". For now we support both
-        print(table.meta)
+
         if "BKG" in table.colnames:
             bkg_name = "BKG"
         elif "BGD" in table.colnames:

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -392,22 +392,8 @@ class EffectiveAreaTable2D:
     @classmethod
     def from_table(cls, table):
         """Read from `~astropy.table.Table`."""
-        # TODO: move to MapAxis.from_table()
-        energy_lo = table["ENERG_LO"].quantity[0]
-        energy_hi = table["ENERG_HI"].quantity[0]
-        offset_lo = table["THETA_LO"].quantity[0]
-        offset_hi = table["THETA_HI"].quantity[0]
-
-        e_edges = edges_from_lo_hi(energy_lo, energy_hi)
-        energy_axis_true = MapAxis.from_edges(e_edges, interp="log", name="energy_true")
-
-        # TODO: for some reason the H.E.S.S. DL3 files contain the same values for
-        #  offset_hi and offset_lo
-        if np.allclose(offset_lo.to_value("deg"), offset_hi.to_value("deg")):
-            offset_axis = MapAxis.from_nodes(offset_lo, interp="lin", name="offset")
-        else:
-            offset_edges = edges_from_lo_hi(offset_lo, offset_hi)
-            offset_axis = MapAxis.from_edges(offset_edges, interp="lin", name="offset")
+        energy_axis_true = MapAxis.from_table(table, column_prefix="ENERG", format="gadf-dl3")
+        offset_axis = MapAxis.from_table(table, column_prefix="THETA", format="gadf-dl3")
 
         return cls(
             energy_axis_true=energy_axis_true,

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -565,16 +565,8 @@ class EffectiveAreaTable2D:
 
     def to_table(self):
         """Convert to `~astropy.table.Table`."""
-        meta = self.meta.copy()
-
-        energy = self.data.axes["energy_true"].edges
-        theta = self.data.axes["offset"].edges
-
-        table = Table(meta=meta)
-        table["ENERG_LO"] = energy[:-1][np.newaxis]
-        table["ENERG_HI"] = energy[1:][np.newaxis]
-        table["THETA_LO"] = theta[:-1][np.newaxis]
-        table["THETA_HI"] = theta[1:][np.newaxis]
+        table = self.data.axes.to_table(format="gadf-dl3")
+        table.meta = self.meta.copy()
         table["EFFAREA"] = self.data.data.T[np.newaxis]
         return table
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -399,19 +399,8 @@ class EnergyDispersion2D:
 
     def to_table(self):
         """Convert to `~astropy.table.Table`."""
-        meta = self.meta.copy()
-
-        energy = self.data.axes["energy_true"].edges
-        migra = self.data.axes["migra"].edges
-        theta = self.data.axes["offset"].edges
-
-        table = Table(meta=meta)
-        table["ENERG_LO"] = energy[:-1][np.newaxis]
-        table["ENERG_HI"] = energy[1:][np.newaxis]
-        table["MIGRA_LO"] = migra[:-1][np.newaxis]
-        table["MIGRA_HI"] = migra[1:][np.newaxis]
-        table["THETA_LO"] = theta[:-1][np.newaxis]
-        table["THETA_HI"] = theta[1:][np.newaxis]
+        table = self.data.axes.to_table(format="gadf-dl3")
+        table.meta = self.meta.copy()
         table["MATRIX"] = self.data.data.T[np.newaxis]
         return table
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -140,40 +140,22 @@ class EnergyDispersion2D:
         # TODO: move this to MapAxis.from_table()
 
         if "ENERG_LO" in table.colnames:
-            e_true_lo = table["ENERG_LO"].quantity[0]
-            e_true_hi = table["ENERG_HI"].quantity[0]
+            energy_axis_true = MapAxis.from_table(table, column_prefix="ENERG", format="gadf-dl3")
         elif "ETRUE_LO" in table.colnames:
-            e_true_lo = table["ETRUE_LO"].quantity[0]
-            e_true_hi = table["ETRUE_HI"].quantity[0]
+            energy_axis_true = MapAxis.from_table(table, column_prefix="ETRUE", format="gadf-dl3")
         else:
             raise ValueError(
                 'Invalid column names. Need "ENERG_LO/ENERG_HI" or "ETRUE_LO/ETRUE_HI"'
             )
-        offset_lo = table["THETA_LO"].quantity[0]
-        offset_hi = table["THETA_HI"].quantity[0]
-        migra_lo = table["MIGRA_LO"].quantity[0]
-        migra_hi = table["MIGRA_HI"].quantity[0]
+
+        offset_axis = MapAxis.from_table(table, column_prefix="THETA", format="gadf-dl3")
+        migra_axis = MapAxis.from_table(table, column_prefix="MIGRA", format="gadf-dl3")
 
         # TODO Why does this need to be transposed?
         matrix = table["MATRIX"].quantity[0].transpose()
 
-        e_true_edges = edges_from_lo_hi(e_true_lo, e_true_hi)
-        energy_true_axis = MapAxis.from_edges(e_true_edges, interp="log", name="energy_true")
-
-        migra_edges = edges_from_lo_hi(migra_lo, migra_hi)
-        migra_axis = MapAxis.from_edges(
-            migra_edges, interp="lin", name="migra", unit=""
-        )
-
-        # TODO: for some reason the H.E.S.S. DL3 files contain the same values for offset_hi and offset_lo
-        if np.allclose(offset_lo.to_value("deg"), offset_hi.to_value("deg")):
-            offset_axis = MapAxis.from_nodes(offset_lo, interp="lin", name="offset")
-        else:
-            offset_edges = edges_from_lo_hi(offset_lo, offset_hi)
-            offset_axis = MapAxis.from_edges(offset_edges, interp="lin", name="offset")
-
         return cls(
-            energy_axis_true=energy_true_axis,
+            energy_axis_true=energy_axis_true,
             offset_axis=offset_axis,
             migra_axis=migra_axis,
             data=matrix,

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -7,6 +7,17 @@ from .psf_gauss import EnergyDependentMultiGaussPSF
 __all__ = ["load_cta_irfs"]
 
 
+IRF_DL3_AXES_SPECIFICATION = {
+    "THETA": {"name": "offset", "interp": "lin"},
+    "ENERG": {"name": "energy_true", "interp": "log"},
+    "ETRUE": {"name": "energy_true", "interp": "log"},
+    "RAD": {"name": "rad", "interp": "lin"},
+    "DETX": {"name": "fov_lon", "interp": "lin"},
+    "DETY": {"name": "fov_lat", "interp": "lin"},
+    "MIGRA": {"name": "migra", "interp": "lin"},
+}
+
+
 def load_cta_irfs(filename):
     """load CTA instrument response function and return a dictionary container.
 

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -5,9 +5,7 @@ from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.table import Table
 from astropy.utils import lazyproperty
-from gammapy.maps import MapAxis
-from gammapy.maps.utils import edges_from_lo_hi
-from gammapy.utils.array import array_stats_str
+from gammapy.maps import MapAxis, MapAxes
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
 from gammapy.utils.scripts import make_path
 from .psf_table import EnergyDependentTablePSF, TablePSF
@@ -142,19 +140,9 @@ class PSF3D:
         hdu_list : `~astropy.io.fits.HDUList`
             PSF in HDU list format.
         """
-        # TODO: move this to `MapAxis.to_table()` and `MapAxes.to_table()`
-        table = Table()
+        axes = MapAxes([self.offset_axis, self.energy_axis_true, self.rad_axis])
+        table = axes.to_table(format="gadf-dl3")
 
-        offset = self.offset_axis.center
-        energy = self.energy_axis_true.edges
-        rad = self.rad_axis.edges
-
-        table["THETA_LO"] = offset[np.newaxis]
-        table["THETA_HI"] = offset[np.newaxis]
-        table["ENERG_LO"] = energy[:-1][np.newaxis]
-        table["ENERG_HI"] = energy[1:][np.newaxis]
-        table["RAD_LO"] = rad[:-1][np.newaxis]
-        table["RAD_HI"] = rad[1:][np.newaxis]
         table["RPSF"] = self.psf_value[np.newaxis]
 
         hdu = fits.BinTableHDU(table)

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -113,18 +113,6 @@ class PSF3D:
         table : `~astropy.table.Table`
             Table Table-PSF info.
         """
-        # TODO: move this code MapAxes.from_table()
-        theta_lo = table["THETA_LO"].quantity[0]
-        theta_hi = table["THETA_HI"].quantity[0]
-        offset = (theta_hi + theta_lo) / 2
-        offset = Angle(offset, unit=table["THETA_LO"].unit)
-
-        energy_lo = table["ENERG_LO"].quantity[0]
-        energy_hi = table["ENERG_HI"].quantity[0]
-
-        rad_lo = table["RAD_LO"].quantity[0]
-        rad_hi = table["RAD_HI"].quantity[0]
-
         psf_value = table["RPSF"].quantity[0]
 
         opts = {}
@@ -134,13 +122,9 @@ class PSF3D:
         except KeyError:
             pass
 
-        e_edges = edges_from_lo_hi(energy_lo, energy_hi)
-        energy_axis_true = MapAxis.from_edges(e_edges, interp="log", name="energy_true")
-
-        offset_axis = MapAxis.from_nodes(offset, interp="lin", name="offset")
-
-        rad_edges = edges_from_lo_hi(rad_lo, rad_hi)
-        rad_axis = MapAxis.from_edges(rad_edges, interp="lin", name="rad")
+        energy_axis_true = MapAxis.from_table(table, column_prefix="ENERG", format="gadf-dl3")
+        offset_axis = MapAxis.from_table(table, column_prefix="THETA", format="gadf-dl3")
+        rad_axis = MapAxis.from_table(table, column_prefix="RAD", format="gadf-dl3")
 
         return cls(
             energy_axis_true=energy_axis_true,

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -127,17 +127,13 @@ class EnergyDependentMultiGaussPSF:
         hdu : `~astropy.io.fits.BinTableHDU`
             HDU
         """
-        energy_lo = u.Quantity(hdu.data["ENERG_LO"][0], "TeV")
-        energy_hi = u.Quantity(hdu.data["ENERG_HI"][0], "TeV")
+        table = Table.read(hdu)
 
-        edges = edges_from_lo_hi(energy_lo, energy_hi)
-        energy_axis_true = MapAxis.from_edges(edges, name="energy_true", interp="log")
-
-        theta = Angle(hdu.data["THETA_LO"][0], "deg")
-        offset_axis = MapAxis.from_nodes(theta, name="offset", interp="lin")
+        energy_axis_true = MapAxis.from_table(table, column_prefix="ENERG", format="gadf-dl3")
+        offset_axis = MapAxis.from_table(table, column_prefix="THETA", format="gadf-dl3")
 
         # Get sigmas
-        shape = (len(theta), len(energy_hi))
+        shape = (offset_axis.nbin, energy_axis_true.nbin)
         sigmas = []
         for key in ["SIGMA_1", "SIGMA_2", "SIGMA_3"]:
             sigma = hdu.data[key].reshape(shape).copy()

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -7,8 +7,7 @@ from astropy.io import fits
 from astropy.stats import gaussian_fwhm_to_sigma
 from astropy.table import Table
 from astropy import units as u
-from gammapy.maps import MapAxis
-from gammapy.maps.utils import edges_from_lo_hi
+from gammapy.maps import MapAxis, MapAxes
 from gammapy.utils.array import array_stats_str
 from gammapy.utils.gauss import MultiGauss2D
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
@@ -171,10 +170,6 @@ class EnergyDependentMultiGaussPSF:
         """
         # Set up data
         names = [
-            "ENERG_LO",
-            "ENERG_HI",
-            "THETA_LO",
-            "THETA_HI",
             "SCALE",
             "SIGMA_1",
             "AMPL_2",
@@ -182,13 +177,9 @@ class EnergyDependentMultiGaussPSF:
             "AMPL_3",
             "SIGMA_3",
         ]
-        units = ["TeV", "TeV", "deg", "deg", "", "deg", "", "deg", "", "deg"]
+        units = ["", "deg", "", "deg", "", "deg"]
 
         data = [
-            self.energy_axis_true.edges[:-1],
-            self.energy_axis_true.edges[1:],
-            self.offset_axis.center,
-            self.offset_axis.center,
             self.norms[0],
             self.sigmas[0],
             self.norms[1],
@@ -197,7 +188,9 @@ class EnergyDependentMultiGaussPSF:
             self.sigmas[2],
         ]
 
-        table = Table()
+        axes = MapAxes([self.energy_axis_true, self.offset_axis])
+        table = axes.to_table(format="gadf-dl3")
+        
         for name_, data_, unit_ in zip(names, data, units):
             table[name_] = [data_]
             table[name_].unit = unit_

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -190,7 +190,7 @@ class EnergyDependentMultiGaussPSF:
 
         axes = MapAxes([self.energy_axis_true, self.offset_axis])
         table = axes.to_table(format="gadf-dl3")
-        
+
         for name_, data_, unit_ in zip(names, data, units):
             table[name_] = [data_]
             table[name_].unit = unit_

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -5,8 +5,7 @@ from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.table import Table
 from astropy.units import Quantity
-from gammapy.maps import MapAxis
-from gammapy.maps.utils import edges_from_lo_hi
+from gammapy.maps import MapAxis, MapAxes
 from gammapy.utils.array import array_stats_str
 from gammapy.utils.scripts import make_path
 from .psf_table import EnergyDependentTablePSF
@@ -131,20 +130,17 @@ class PSFKing:
         hdu_list : `~astropy.io.fits.HDUList`
             PSF in HDU list format.
         """
-        # TODO: move to MapAxes.to_table()
+        axes = MapAxes([self.energy_axis_true, self.offset_axis])
+        table = axes.to_table(format="gadf-dl3")
+
         # Set up data
-        names = ["ENERG_LO", "ENERG_HI", "THETA_LO", "THETA_HI", "SIGMA", "GAMMA"]
-        units = ["TeV", "TeV", "deg", "deg", "deg", ""]
+        names = ["SIGMA", "GAMMA"]
+        units = ["deg", ""]
         data = [
-            self.energy_axis_true.edges[:-1],
-            self.energy_axis_true.edges[1:],
-            self.offset_axis.center,
-            self.offset_axis.center,
             self.sigma,
             self.gamma,
         ]
 
-        table = Table()
         for name_, data_, unit_ in zip(names, data, units):
             table[name_] = [data_]
             table[name_].unit = unit_

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -101,20 +101,8 @@ class PSFKing:
         table : `~astropy.table.Table`
             Table King PSF info.
         """
-        # TODO: move to MapAxes.from_table()
-
-        offset_lo = table["THETA_LO"].quantity[0]
-        offset_hi = table["THETA_HI"].quantity[0]
-        offset = (offset_hi + offset_lo) / 2
-        offset = Angle(offset, unit=table["THETA_LO"].unit)
-
-        offset_axis = MapAxis.from_nodes(offset, name="offset", interp="lin")
-
-        energy_lo = table["ENERG_LO"].quantity[0]
-        energy_hi = table["ENERG_HI"].quantity[0]
-
-        edges = edges_from_lo_hi(energy_lo, energy_hi)
-        energy_axis_true = MapAxis.from_edges(edges, name="energy_true", interp="log")
+        energy_axis_true = MapAxis.from_table(table, column_prefix="ENERG", format="gadf-dl3")
+        offset_axis = MapAxis.from_table(table, column_prefix="THETA", format="gadf-dl3")
 
         gamma = table["GAMMA"].quantity[0]
         sigma = table["SIGMA"].quantity[0]

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -25,7 +25,7 @@ def test_cta_irf():
 
     psf = irf["psf"].psf_at_energy_and_theta(energy=energy, theta=offset)
     val = psf(Quantity(0.1, "deg"))
-    assert_allclose(val, 4.868832183, rtol=1e-5)
+    assert_allclose(val, 3.56989, rtol=1e-5)
 
     val = irf["bkg"].data.evaluate(energy=energy, fov_lon=offset, fov_lat="0 deg")
     assert_allclose(val.value, 9.400071e-05, rtol=1e-5)

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -89,7 +89,7 @@ def test_psf_cta_1dc():
     # Check that evaluation works for an energy / offset where an energy is available
     psf = psf_irf.to_energy_dependent_table_psf("2 deg")
     psf = psf.table_psf_at_energy("1 TeV")
-    assert_allclose(psf.containment_radius(0.68).deg, 0.053838, atol=1e-4)
+    assert_allclose(psf.containment_radius(0.68).deg, 0.052841, atol=1e-4)
 
 
 class TestHESS:

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1349,7 +1349,7 @@ class MapAxis:
 
             # background models are stored in reconstructed energy
             extname = table.meta.get("EXTNAME")
-            if extname == "BACKGROUND" and column_prefix == "ENERG":
+            if extname in ["BACKGROUND", "BKG"] and column_prefix == "ENERG":
                 name = "energy"
 
             edges_lo = table[f"{column_prefix}_LO"].quantity[0]


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request cleans up the IRF I/O a bit by using `MapAxes`. During the clean-up  found and fixed a ltittle bug: the `EnergyDependentMultiGaussPSF` used the lower offset bin edges instead of centers for the offset axis. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
