### PR TITLE
Add bkg systematics condition for the sensitivity computation

### DIFF
--- a/docs/tutorials/cta_sensitivity.ipynb
+++ b/docs/tutorials/cta_sensitivity.ipynb
@@ -182,7 +182,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sensitivity_estimator = SensitivityEstimator(gamma_min=5, n_sigma=3)\n",
+    "sensitivity_estimator = SensitivityEstimator(gamma_min=5, n_sigma=3, bkg_syst_fraction=0.10)\n",
     "sensitivity_table = sensitivity_estimator.run(dataset_on_off)"
    ]
   },
@@ -237,6 +237,10 @@
     "is_g = t[\"criterion\"] == \"gamma\"\n",
     "plt.plot(\n",
     "    t[\"energy\"][is_g], t[\"e2dnde\"][is_g], \"*-\", color=\"blue\", label=\"gamma\"\n",
+    ")\n",
+    "is_bkg_syst = t[\"criterion\"] == \"bkg\"\n",
+    "plt.plot(\n",
+    "    t[\"energy\"][is_bkg_syst], t[\"e2dnde\"][is_bkg_syst], \"v-\", color=\"green\", label=\"bkg syst\"\n",
     ")\n",
     "\n",
     "plt.loglog()\n",

--- a/gammapy/estimators/sensitivity.py
+++ b/gammapy/estimators/sensitivity.py
@@ -27,6 +27,8 @@ class SensitivityEstimator(Estimator):
         Minimum significance. Default is 5.
     gamma_min : float, optional
         Minimum number of gamma-rays. Default is 10.
+    bkg_syst_fraction : float, optional
+        Fraction of background counts above which the number of gamma-rays is. Default is 0.05
 
     Examples
     --------
@@ -37,7 +39,7 @@ class SensitivityEstimator(Estimator):
     tag = "SensitivityEstimator"
 
     def __init__(
-        self, spectrum=None, n_sigma=5.0, gamma_min=10,
+        self, spectrum=None, n_sigma=5.0, gamma_min=10, bkg_syst_fraction=0.05
     ):
 
         if spectrum is None:
@@ -46,6 +48,7 @@ class SensitivityEstimator(Estimator):
         self.spectrum = spectrum
         self.n_sigma = n_sigma
         self.gamma_min = gamma_min
+        self.bkg_syst_fraction = bkg_syst_fraction
 
     def estimate_min_excess(self, dataset):
         """Estimate minimum excess to reach the given significance.
@@ -68,6 +71,8 @@ class SensitivityEstimator(Estimator):
         excess_counts = stat.excess_matching_significance(self.n_sigma)
         is_gamma_limited = excess_counts < self.gamma_min
         excess_counts[is_gamma_limited] = self.gamma_min
+        bkg_syst_limited = excess_counts < self.bkg_syst_fraction * dataset.counts_off_normalised.data
+        excess_counts[bkg_syst_limited] = self.bkg_syst_fraction * dataset.counts_off_normalised.data[bkg_syst_limited]
         excess = Map.from_geom(geom=dataset._geom, data=excess_counts)
         return excess
 
@@ -97,11 +102,13 @@ class SensitivityEstimator(Estimator):
         dnde = phi_0.data[:, 0, 0] * dnde_model * energy ** 2
         return dnde.to("erg / (cm2 s)")
 
-    def _get_criterion(self, excess):
+    def _get_criterion(self, excess, bkg):
         is_gamma_limited = excess == self.gamma_min
+        is_bkg_syst_limited = excess == bkg * self.bkg_syst_fraction
         criterion = np.chararray(excess.shape, itemsize=12)
         criterion[is_gamma_limited] = "gamma"
-        criterion[~is_gamma_limited] = "significance"
+        criterion[is_bkg_syst_limited] = "bkg"
+        criterion[~np.logical_or(is_gamma_limited, is_bkg_syst_limited)] = "significance"
         return criterion
 
     def run(self, dataset):
@@ -120,7 +127,7 @@ class SensitivityEstimator(Estimator):
         energy = dataset._geom.axes["energy"].center
         excess = self.estimate_min_excess(dataset)
         e2dnde = self.estimate_min_e2dnde(excess, dataset)
-        criterion = self._get_criterion(excess.data.squeeze())
+        criterion = self._get_criterion(excess.data.squeeze(), dataset.counts_off_normalised.data.squeeze())
 
         return Table(
             [

--- a/gammapy/estimators/tests/test_sensitivity.py
+++ b/gammapy/estimators/tests/test_sensitivity.py
@@ -16,6 +16,7 @@ def spectrum_dataset():
 
     background = RegionNDMap.create(region="icrs;circle(0, 0, 0.1)", axes=[e_reco])
     background.data += 3600
+    background.data[0] *= 1e3
     background.data[-1] *= 1e-3
     edisp = EDispKernelMap.from_diagonal_response(
         energy_axis_true=e_true, energy_axis=e_reco, geom=background.geom
@@ -35,7 +36,7 @@ def test_cta_sensitivity_estimator(spectrum_dataset):
     dataset_on_off = SpectrumDatasetOnOff.from_spectrum_dataset(
         dataset=spectrum_dataset, acceptance=1, acceptance_off=5
     )
-    sens = SensitivityEstimator(gamma_min=20)
+    sens = SensitivityEstimator(gamma_min=25, bkg_syst_fraction=0.075)
     table = sens.run(dataset_on_off)
 
     assert len(table) == 4
@@ -45,14 +46,21 @@ def test_cta_sensitivity_estimator(spectrum_dataset):
 
     row = table[0]
     assert_allclose(row["energy"], 1.33352, rtol=1e-3)
-    assert_allclose(row["e2dnde"], 3.40101e-11, rtol=1e-3)
+    assert_allclose(row["e2dnde"], 2.74559e-08, rtol=1e-3)
+    assert_allclose(row["excess"], 270000, rtol=1e-3)
+    assert_allclose(row["background"], 3.6e+06, rtol=1e-3)
+    assert row["criterion"] == "bkg"
+
+    row = table[1]
+    assert_allclose(row["energy"], 2.37137, rtol=1e-3)
+    assert_allclose(row["e2dnde"], 6.04795e-11, rtol=1e-3)
     assert_allclose(row["excess"], 334.454, rtol=1e-3)
     assert_allclose(row["background"], 3600, rtol=1e-3)
     assert row["criterion"] == "significance"
 
     row = table[3]
     assert_allclose(row["energy"], 7.49894, rtol=1e-3)
-    assert_allclose(row["e2dnde"], 1.14367e-11, rtol=1e-3)
-    assert_allclose(row["excess"], 20, rtol=1e-3)
+    assert_allclose(row["e2dnde"], 1.42959e-11, rtol=1e-3)
+    assert_allclose(row["excess"], 25, rtol=1e-3)
     assert_allclose(row["background"], 3.6, rtol=1e-3)
     assert row["criterion"] == "gamma"


### PR DESCRIPTION

**Description**
For the existing class, a new condition is added to compute the sensitivity, the excess being larger than a fraction of the number of background. This condition deals in the CTA way the background systematics.

**Dear reviewer**
An extra-argument is passed to the init function, the fraction of background counts. As a consequence, in addition to the criterion 'significance' and 'gamma', the new criteria 'bkg' is inserted in the final table.
The associated test function is updated to test this new criteria.
