### PR TITLE
Display progress bars in Analysis, Fit methods and Estimator classes

### DIFF
--- a/gammapy/estimators/asmooth_map.py
+++ b/gammapy/estimators/asmooth_map.py
@@ -138,13 +138,15 @@ class ASmoothMapEstimator(Estimator):
             )
         return scube
 
-    def run(self, dataset):
+    def run(self, dataset, show_pbar=True):
         """Run adaptive smoothing on input MapDataset.
 
         Parameters
         ----------
         dataset : `~gammapy.datasets.MapDataset` or `~gammapy.datasets.MapDatasetOnOff`
             the input dataset (with one bin in energy at most)
+        show_pbar : bool
+            Display progress bar.
 
         Returns
         -------
@@ -166,7 +168,7 @@ class ASmoothMapEstimator(Estimator):
 
         results = []
 
-        with pbar(total=len(e_edges) - 1, show_pbar=True) as pb:
+        with pbar(total=len(e_edges) - 1, show_pbar=show_pbar) as pb:
             for e_min, e_max in zip(e_edges[:-1], e_edges[1:]):
                 dataset = datasets.slice_energy(e_min, e_max)[0]
                 result = self.estimate_maps(dataset)

--- a/gammapy/estimators/asmooth_map.py
+++ b/gammapy/estimators/asmooth_map.py
@@ -7,6 +7,7 @@ from astropy.coordinates import Angle
 from gammapy.datasets import MapDatasetOnOff, Datasets
 from gammapy.maps import WcsNDMap, Map
 from gammapy.stats import CashCountsStatistic
+from gammapy.utils.pbar import pbar
 from gammapy.utils.array import scale_cube
 from gammapy.modeling.models import PowerLawSpectralModel
 from .core import Estimator
@@ -165,10 +166,12 @@ class ASmoothMapEstimator(Estimator):
 
         results = []
 
-        for e_min, e_max in zip(e_edges[:-1], e_edges[1:]):
-            dataset = datasets.slice_energy(e_min, e_max)[0]
-            result = self.estimate_maps(dataset)
-            results.append(result)
+        with pbar(total=len(e_edges) - 1, show_pbar=True) as pb:
+            for e_min, e_max in zip(e_edges[:-1], e_edges[1:]):
+                dataset = datasets.slice_energy(e_min, e_max)[0]
+                result = self.estimate_maps(dataset)
+                results.append(result)
+                pb.update(1)
 
         result_all = {}
 

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -5,6 +5,7 @@ import numpy as np
 from astropy.convolution import Tophat2DKernel
 from astropy.coordinates import Angle
 import astropy.units as u
+from gammapy.utils.pbar import pbar
 from gammapy.datasets import MapDataset, MapDatasetOnOff, Datasets
 from gammapy.maps import Map
 from gammapy.stats import CashCountsStatistic, WStatCountsStatistic
@@ -162,11 +163,13 @@ class ExcessMapEstimator(Estimator):
 
         results = []
 
-        for e_min, e_max in zip(e_edges[:-1], e_edges[1:]):
-            sliced_dataset = datasets.slice_energy(e_min, e_max)[0]
+        with pbar(total=len(e_edges) - 1, show_pbar=True) as pb:
+            for e_min, e_max in zip(e_edges[:-1], e_edges[1:]):
+                sliced_dataset = datasets.slice_energy(e_min, e_max)[0]
 
-            result = self.estimate_excess_map(sliced_dataset)
-            results.append(result)
+                result = self.estimate_excess_map(sliced_dataset)
+                results.append(result)
+                pb.update(1)
 
         results_all = {}
 

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -124,13 +124,15 @@ class ExcessMapEstimator(Estimator):
         """Sets radius"""
         self._correlation_radius = Angle(correlation_radius)
 
-    def run(self, dataset):
+    def run(self, dataset, show_pbar=True):
         """Compute correlated excess, Li & Ma significance and flux maps
 
         Parameters
         ----------
         dataset : `~gammapy.datasets.MapDataset` or `~gammapy.datasets.MapDatasetOnOff`
             input dataset
+        show_pbar : bool
+            Display progress bar.
 
         Returns
         -------
@@ -163,7 +165,7 @@ class ExcessMapEstimator(Estimator):
 
         results = []
 
-        with pbar(total=len(e_edges) - 1, show_pbar=True) as pb:
+        with pbar(total=len(e_edges) - 1, show_pbar=show_pbar) as pb:
             for e_min, e_max in zip(e_edges[:-1], e_edges[1:]):
                 sliced_dataset = datasets.slice_energy(e_min, e_max)[0]
 

--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -140,7 +140,7 @@ class ExcessProfileEstimator(Estimator):
             u.Quantity(distances, "deg"), name="projected distance"
         )
 
-    def make_prof(self, sp_datasets):
+    def make_prof(self, sp_datasets, show_pbar):
         """ Utility to make the profile in each region
 
         Parameters
@@ -148,6 +148,8 @@ class ExcessProfileEstimator(Estimator):
         sp_datasets : `~gammapy.datasets.MapDatasets` of `~gammapy.datasets.SpectrumDataset` or \
         `~gammapy.datasets.SpectrumDatasetOnOff`
             the dataset to use for profile extraction
+        show_pbar : bool
+            Display progress bar.
 
         Returns
         --------
@@ -159,7 +161,7 @@ class ExcessProfileEstimator(Estimator):
 
         distance = self._get_projected_distance()
 
-        with pbar(total=len(sp_datasets), show_pbar=True) as pb:
+        with pbar(total=len(sp_datasets), show_pbar=show_pbar) as pb:
             for index, spds in enumerate(sp_datasets):
                 old_model = None
                 if spds.models is not None:
@@ -244,13 +246,15 @@ class ExcessProfileEstimator(Estimator):
 
         return results
 
-    def run(self, dataset):
+    def run(self, dataset, show_pbar=True):
         """Make the profiles
 
         Parameters
         ----------
         dataset : `~gammapy.datasets.MapDataset` or `~gammapy.datasets.MapDatasetOnOff`
             the dataset to use for profile extraction
+        show_pbar : bool
+            Display progress bar.
 
         Returns
         --------
@@ -265,7 +269,7 @@ class ExcessProfileEstimator(Estimator):
 
         spectrum_datasets = self.get_spectrum_datasets(dataset)
 
-        results = self.make_prof(spectrum_datasets)
+        results = self.make_prof(spectrum_datasets, show_pbar=show_pbar)
         table = table_from_row_data(results)
         if isinstance(self.regions[0], RectangleSkyRegion):
             table.meta["PROFILE_TYPE"] = "orthogonal_rectangle"

--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -140,7 +140,7 @@ class ExcessProfileEstimator(Estimator):
             u.Quantity(distances, "deg"), name="projected distance"
         )
 
-    def make_prof(self, sp_datasets, show_pbar):
+    def make_prof(self, sp_datasets, show_pbar=True):
         """ Utility to make the profile in each region
 
         Parameters

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -9,6 +9,7 @@ from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.utils.interpolation import interpolate_profile
 from gammapy.utils.scripts import make_path
 from gammapy.utils.table import table_from_row_data, table_standardise_units_copy
+from gammapy.utils.pbar import pbar
 from .core import Estimator
 from .flux import FluxEstimator
 
@@ -860,9 +861,11 @@ class FluxPointsEstimator(Estimator):
 
         rows = []
 
-        for e_min, e_max in zip(self.e_edges[:-1], self.e_edges[1:]):
-            row = self.estimate_flux_point(datasets, e_min=e_min, e_max=e_max)
-            rows.append(row)
+        with pbar(total=len(self.e_edges) - 1, show_pbar=True) as pb:
+            for e_min, e_max in zip(self.e_edges[:-1], self.e_edges[1:]):
+                row = self.estimate_flux_point(datasets, e_min=e_min, e_max=e_max)
+                rows.append(row)
+                pb.update(1)
 
         table = table_from_row_data(rows=rows, meta={"SED_TYPE": "likelihood"})
 

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -841,16 +841,17 @@ class FluxPointsEstimator(Estimator):
             n_sigma_ul=self.n_sigma_ul,
             reoptimize=self.reoptimize,
             selection_optional=self.selection_optional,
-
         )
 
-    def run(self, datasets):
+    def run(self, datasets, show_pbar=True):
         """Run the flux point estimator for all energy groups.
 
         Parameters
         ----------
         datasets : list of `~gammapy.datasets.Dataset`
             Datasets
+        show_pbar : bool
+            Display progress bar.
 
         Returns
         -------
@@ -861,7 +862,7 @@ class FluxPointsEstimator(Estimator):
 
         rows = []
 
-        with pbar(total=len(self.e_edges) - 1, show_pbar=True) as pb:
+        with pbar(total=len(self.e_edges) - 1, show_pbar=show_pbar) as pb:
             for e_min, e_max in zip(self.e_edges[:-1], self.e_edges[1:]):
                 row = self.estimate_flux_point(datasets, e_min=e_min, e_max=e_max)
                 rows.append(row)

--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -363,7 +363,7 @@ class LightCurveEstimator(Estimator):
         self.reoptimize = reoptimize
         self.selection_optional = selection_optional
 
-    def run(self, datasets):
+    def run(self, datasets, show_pbar=True):
         """Run light curve extraction.
 
         Normalize integral and energy flux between emin and emax.
@@ -372,6 +372,8 @@ class LightCurveEstimator(Estimator):
         ----------
         datasets : list of `~gammapy.datasets.SpectrumDataset` or `~gammapy.datasets.MapDataset`
             Spectrum or Map datasets.
+        show_pbar : bool
+            Display progress bar.
 
         Returns
         -------
@@ -389,7 +391,7 @@ class LightCurveEstimator(Estimator):
 
         rows = []
 
-        with pbar(total=len(gti.time_intervals), show_pbar=True) as pb:
+        with pbar(total=len(gti.time_intervals), show_pbar=show_pbar) as pb:
             for t_min, t_max in gti.time_intervals:
                 datasets_to_fit = datasets.select_time(
                     t_min=t_min, t_max=t_max, atol=self.atol
@@ -443,5 +445,5 @@ class LightCurveEstimator(Estimator):
             selection_optional=self.selection_optional,
 
         )
-        result = fe.run(datasets)
+        result = fe.run(datasets, show_pbar=False)
         return table_row_to_dict(result.table[0])

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -195,7 +195,8 @@ class ParameterEstimator(Estimator):
             values=self.scan_values,
             bounds=bounds,
             nvalues=self.scan_n_values,
-            reoptimize=self.reoptimize
+            reoptimize=self.reoptimize,
+            show_pbar=False,
         )
 
         return {

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -24,6 +24,7 @@ from gammapy.stats import (
     f_cash_root_cython,
 )
 from gammapy.utils.array import shape_2N, symmetric_crop_pad_width
+from gammapy.utils.pbar import pbar
 from .core import Estimator
 from .utils import estimate_exposure_reco_energy
 
@@ -425,14 +426,16 @@ class TSMapEstimator(Estimator):
 
         results = []
 
-        for e_min, e_max in zip(e_edges[:-1], e_edges[1:]):
-            dataset = datasets.slice_energy(e_min, e_max)[0]
+        with pbar(total=len(e_edges) - 1, show_pbar=True) as pb:
+            for e_min, e_max in zip(e_edges[:-1], e_edges[1:]):
+                dataset = datasets.slice_energy(e_min, e_max)[0]
 
-            if self.sum_over_energy_groups:
-                dataset = dataset.to_image()
+                if self.sum_over_energy_groups:
+                    dataset = dataset.to_image()
 
-            result = self.estimate_flux_map(dataset)
-            results.append(result)
+                result = self.estimate_flux_map(dataset)
+                results.append(result)
+                pb.update(1)
 
         result_all = {}
 

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -386,7 +386,7 @@ class TSMapEstimator(Estimator):
 
         return result
 
-    def run(self, dataset):
+    def run(self, dataset, show_pbar=True):
         """
         Run TS map estimation.
 
@@ -397,6 +397,8 @@ class TSMapEstimator(Estimator):
         ----------
         dataset : `~gammapy.datasets.MapDataset`
             Input MapDataset.
+        show_pbar : bool
+            Display progress bar.
 
         Returns
         -------
@@ -426,7 +428,7 @@ class TSMapEstimator(Estimator):
 
         results = []
 
-        with pbar(total=len(e_edges) - 1, show_pbar=True) as pb:
+        with pbar(total=len(e_edges) - 1, show_pbar=show_pbar) as pb:
             for e_min, e_max in zip(e_edges[:-1], e_edges[1:]):
                 dataset = datasets.slice_energy(e_min, e_max)[0]
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -233,7 +233,7 @@ class Fit:
         )
 
     def confidence(
-            self, parameter, backend="minuit", sigma=1, reoptimize=True, **kwargs
+        self, parameter, backend="minuit", sigma=1, reoptimize=True, **kwargs
     ):
         """Estimate confidence interval.
 
@@ -292,14 +292,14 @@ class Fit:
         return result
 
     def stat_profile(
-            self,
-            parameter,
-            values=None,
-            bounds=2,
-            nvalues=11,
-            reoptimize=False,
-            optimize_opts=None,
-            show_pbar=True
+        self,
+        parameter,
+        values=None,
+        bounds=2,
+        nvalues=11,
+        reoptimize=False,
+        optimize_opts=None,
+        show_pbar=True,
     ):
         """Compute fit statistic profile.
 
@@ -366,7 +366,14 @@ class Fit:
         return {"values": values, "stat": np.array(stats)}
 
     def stat_surface(
-            self, x, y, x_values, y_values, reoptimize=False, **optimize_opts
+        self,
+        x,
+        y,
+        x_values,
+        y_values,
+        reoptimize=False,
+        show_pbar=True,
+        **optimize_opts,
     ):
         """Compute fit statistic surface.
 

--- a/gammapy/utils/pbar.py
+++ b/gammapy/utils/pbar.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utilities for progress bar display"""
 from contextlib import contextmanager
-from tqdm.auto import tqdm
+from tqdm import tqdm
 
 
 @contextmanager

--- a/gammapy/utils/pbar.py
+++ b/gammapy/utils/pbar.py
@@ -1,0 +1,16 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Utilities for progress bar display"""
+from contextlib import contextmanager
+from tqdm import tqdm
+
+
+@contextmanager
+def pbar(total=None, show_pbar=False):
+    class dummy():
+        def update(self, x):
+            pass
+
+    if total == None and show_pbar == True:
+        raise AttributeError("Can't set up the progress bar if total is None")
+
+    yield tqdm(total=total, mininterval=0) if show_pbar == True else dummy()

--- a/gammapy/utils/pbar.py
+++ b/gammapy/utils/pbar.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utilities for progress bar display"""
 from contextlib import contextmanager
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 
 @contextmanager


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
I used `tqdm` to provide a progress bar in Analysis, Fit methods and Estimator classes.

In some places, there are warnings that break the progress bar, namely:
```
In: analysis_1d.get_datasets()
Out:
  0%|          | 0/4 [00:00<?, ?it/s]No background model defined for dataset cMBPsezR


 25%|██▌       | 1/4 [00:00<00:00,  3.24it/s]No background model defined for dataset gdLztbDM


 50%|█████     | 2/4 [00:00<00:00,  3.30it/s]No background model defined for dataset SQLYi5zW


 75%|███████▌  | 3/4 [00:00<00:00,  3.36it/s]No background model defined for dataset IeRiDiuG


100%|██████████| 4/4 [00:01<00:00,  3.41it/s]
```
In these cases, I guess we should probably display all the warnings after the progress bar is closed, but I wouldn't know how... 

**Dear reviewer**
In my local machine, I get a weird error when I test `pytest gammapy/analysis/test_analysis.py`: a very long traceback ending in `ValueError: I/O operation on closed file`. Hopefully someone knows how to fix this...

<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
