### PR TITLE
Uniform keys in fit methods and estimators

### DIFF
--- a/docs/tutorials/modeling.ipynb
+++ b/docs/tutorials/modeling.ipynb
@@ -273,7 +273,7 @@
     "for par in dataset_hess.models.parameters:\n",
     "    if par.frozen is False:\n",
     "        profile = fit.stat_profile(parameter=par)\n",
-    "        plt.plot(profile[\"values\"], profile[\"stat\"] - total_stat)\n",
+    "        plt.plot(profile[\"values\"], profile[\"stat_scan\"] - total_stat)\n",
     "        plt.xlabel(f\"{par.unit}\")\n",
     "        plt.ylabel(\"Delta TS\")\n",
     "        plt.title(f\"{par.name}: {par.value} +- {par.error}\")\n",

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -101,7 +101,7 @@ class TestFluxPointFit:
 
         profile = fit.stat_profile("amplitude", nvalues=3, bounds=1)
 
-        ts_diff = profile["stat"] - result.total_stat
+        ts_diff = profile["stat_scan"] - result.total_stat
         assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)
 
         value = result.parameters["amplitude"].value
@@ -110,7 +110,7 @@ class TestFluxPointFit:
 
         profile = fit.stat_profile("amplitude", values=values)
 
-        ts_diff = profile["stat"] - result.total_stat
+        ts_diff = profile["stat_scan"] - result.total_stat
         assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)
 
     @staticmethod

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -1037,5 +1037,5 @@ class TestFit:
         true_idx = result.parameters["index"].value
         values = np.linspace(0.95 * true_idx, 1.05 * true_idx, 100)
         profile = fit.stat_profile("index", values=values)
-        actual = values[np.argmin(profile["stat"])]
+        actual = values[np.argmin(profile["stat_scan"])]
         assert_allclose(actual, true_idx, rtol=0.01)

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -199,8 +199,8 @@ class ParameterEstimator(Estimator):
         )
 
         return {
-            f"{parameter.name}_scan": profile["values"],
-            "stat_scan": profile["stat"]
+            f"{parameter.name}_scan": profile[f"{parameter.name}_scan"],
+            "stat_scan": profile["stat_scan"]
         }
 
     def estimate_ul(self, datasets, parameter):

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -326,7 +326,7 @@ class Fit:
         Returns
         -------
         results : dict
-            Dictionary with keys "values" and "stat".
+            Dictionary with keys "values" and "stat_scan".
         """
         parameters = self._parameters
         parameter = parameters[parameter]
@@ -357,11 +357,9 @@ class Fit:
                     stat = self.datasets.stat_sum()
                 stats.append(stat)
 
-        return {"values": values, "stat": np.array(stats)}
+        return {f"{parameter.name}_scan": values, "stat_scan": np.array(stats)}
 
-    def stat_surface(
-        self, x, y, x_values, y_values, reoptimize=False, **optimize_opts
-    ):
+    def stat_surface(self, x, y, x_values, y_values, reoptimize=False, **optimize_opts):
         """Compute fit statistic surface.
 
         The method used is to vary two parameters, keeping all others fixed.
@@ -385,7 +383,7 @@ class Fit:
         Returns
         -------
         results : dict
-            Dictionary with keys "x_values", "y_values" and "stat".
+            Dictionary with keys "x_values", "y_values" and "stat_scan".
 
         """
         parameters = self._parameters
@@ -414,7 +412,11 @@ class Fit:
             (np.asarray(x_values).shape[0], np.asarray(y_values).shape[0])
         )
 
-        return {"x_values": x_values, "y_values": y_values, "stat": stats}
+        return {
+            f"{x.name}_scan": x_values,
+            f"{y.name}_scan": y_values,
+            "stat_scan": stats,
+        }
 
     def minos_contour(self, x, y, numpoints=10, sigma=1.0):
         """Compute MINOS contour.
@@ -453,15 +455,17 @@ class Fit:
         with parameters.restore_values:
             result = mncontour(self.minuit, parameters, x, y, numpoints, sigma)
 
+        x_name = x.name
+        y_name = y.name
         x = result["x"] * x.scale
         y = result["y"] * y.scale
 
         return {
-            "x": x,
-            "y": y,
+            f"{x_name}_scan": x,
+            f"{y_name}_scan": y,
             "success": result["success"],
-            "x_info": result["x_info"],
-            "y_info": result["y_info"],
+            f"{x_name}_info": result["x_info"],
+            f"{y_name}_info": result["y_info"],
         }
 
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -326,7 +326,7 @@ class Fit:
         Returns
         -------
         results : dict
-            Dictionary with keys "values" and "stat_scan".
+            Dictionary containing the scan of parameter and stat (-2 loglike) values.
         """
         parameters = self._parameters
         parameter = parameters[parameter]
@@ -383,7 +383,7 @@ class Fit:
         Returns
         -------
         results : dict
-            Dictionary with keys "x_values", "y_values" and "stat_scan".
+            Dictionary containing the scan of parameters and stat (-2 loglike) values.
 
         """
         parameters = self._parameters
@@ -443,10 +443,8 @@ class Fit:
         Returns
         -------
         result : dict
-            Dictionary with keys "x", "y" (Numpy arrays with contour points)
-            and a boolean flag "success".
-            The result objects from ``mncontour`` are in the additional
-            keys "x_info" and "y_info".
+            Dictionary containing the parameter values defining the contour, with the
+            boolean flag "success" and the info objects from ``mncontour``.
         """
         parameters = self._parameters
         x = parameters[x]
@@ -461,8 +459,8 @@ class Fit:
         y = result["y"] * y.scale
 
         return {
-            f"{x_name}_scan": x,
-            f"{y_name}_scan": y,
+            x_name: x,
+            y_name: y,
             "success": result["success"],
             f"{x_name}_info": result["x_info"],
             f"{y_name}_info": result["y_info"],

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -130,8 +130,8 @@ def test_stat_profile():
     fit.run()
     result = fit.stat_profile("x", nvalues=3)
 
-    assert_allclose(result["values"], [0, 2, 4], atol=1e-7)
-    assert_allclose(result["stat"], [4, 0, 4], atol=1e-7)
+    assert_allclose(result["x_scan"], [0, 2, 4], atol=1e-7)
+    assert_allclose(result["stat_scan"], [4, 0, 4], atol=1e-7)
 
     # Check that original value state wasn't changed
     assert_allclose(dataset.models.parameters["x"].value, 2)
@@ -145,8 +145,8 @@ def test_stat_profile_reoptimize():
     dataset.models.parameters["y"].value = 0
     result = fit.stat_profile("x", nvalues=3, reoptimize=True)
 
-    assert_allclose(result["values"], [0, 2, 4], atol=1e-7)
-    assert_allclose(result["stat"], [4, 0, 4], atol=1e-7)
+    assert_allclose(result["x_scan"], [0, 2, 4], atol=1e-7)
+    assert_allclose(result["stat_scan"], [4, 0, 4], atol=1e-7)
 
 
 def test_stat_surface():
@@ -157,14 +157,14 @@ def test_stat_surface():
     y_values = [2e2, 3e2, 4e2]
     result = fit.stat_surface("x", "y", x_values=x_values, y_values=y_values)
 
-    assert_allclose(result["x_values"], x_values, atol=1e-7)
-    assert_allclose(result["y_values"], y_values, atol=1e-7)
+    assert_allclose(result["x_scan"], x_values, atol=1e-7)
+    assert_allclose(result["y_scan"], y_values, atol=1e-7)
     expected_stat = [
         [1.0001e04, 1.0000e00, 1.0001e04],
         [1.0000e04, 0.0000e00, 1.0000e04],
         [1.0001e04, 1.0000e00, 1.0001e04],
     ]
-    assert_allclose(list(result["stat"]), expected_stat, atol=1e-7)
+    assert_allclose(list(result["stat_scan"]), expected_stat, atol=1e-7)
 
     # Check that original value state wasn't changed
     assert_allclose(dataset.models.parameters["x"].value, 2)
@@ -183,15 +183,15 @@ def test_stat_surface_reoptimize():
         "x", "y", x_values=x_values, y_values=y_values, reoptimize=True
     )
 
-    assert_allclose(result["x_values"], x_values, atol=1e-7)
-    assert_allclose(result["y_values"], y_values, atol=1e-7)
+    assert_allclose(result["x_scan"], x_values, atol=1e-7)
+    assert_allclose(result["y_scan"], y_values, atol=1e-7)
     expected_stat = [
         [1.0001e04, 1.0000e00, 1.0001e04],
         [1.0000e04, 0.0000e00, 1.0000e04],
         [1.0001e04, 1.0000e00, 1.0001e04],
     ]
 
-    assert_allclose(list(result["stat"]), expected_stat, atol=1e-7)
+    assert_allclose(list(result["stat_scan"]), expected_stat, atol=1e-7)
 
 
 def test_minos_contour():
@@ -203,11 +203,11 @@ def test_minos_contour():
 
     assert result["success"] is True
 
-    x = result["x"]
+    x = result["y_scan"]
     assert_allclose(len(x), 10)
     assert_allclose(x[0], 299, rtol=1e-5)
     assert_allclose(x[-1], 299.133975, rtol=1e-5)
-    y = result["y"]
+    y = result["z_scan"]
     assert_allclose(len(y), 10)
     assert_allclose(y[0], 0.04, rtol=1e-5)
     assert_allclose(y[-1], 0.54, rtol=1e-5)

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -148,7 +148,7 @@ def test_stat_profile_reoptimize():
 
     assert_allclose(result["x_scan"], [0, 2, 4], atol=1e-7)
     assert_allclose(result["stat_scan"], [4, 0, 4], atol=1e-7)
-    assert_allclose(result["fit_results"][0].total_stat, result["stat"][0], atol=1e-7)
+    assert_allclose(result["fit_results"][0].total_stat, result["stat_scan"][0], atol=1e-7)
 
 
 def test_stat_surface():
@@ -196,7 +196,7 @@ def test_stat_surface_reoptimize():
 
     assert_allclose(list(result["stat_scan"]), expected_stat, atol=1e-7)
     assert_allclose(
-        result["fit_results"][0][0].total_stat, result["stat"][0][0], atol=1e-7
+        result["fit_results"][0][0].total_stat, result["stat_scan"][0][0], atol=1e-7
     )
 
 

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -203,11 +203,11 @@ def test_minos_contour():
 
     assert result["success"] is True
 
-    x = result["y_scan"]
+    x = result["y"]
     assert_allclose(len(x), 10)
     assert_allclose(x[0], 299, rtol=1e-5)
     assert_allclose(x[-1], 299.133975, rtol=1e-5)
-    y = result["z_scan"]
+    y = result["z"]
     assert_allclose(len(y), 10)
     assert_allclose(y[0], 0.04, rtol=1e-5)
     assert_allclose(y[-1], 0.54, rtol=1e-5)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
Changed `"stat"` key to `"stat_scan"`, and use the actual parameter names (e.g. `"index_scan"`) instead of dummy `"x_value/"y_value""`.

Changes suggested in #3038 .

**Dear Reviewer**
I opened a couple of other PRs touching the same files (#3056 , #3057). I hope there's no conflict...
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
