### PR TITLE
Add energy_flux_error to SpectralModel

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -220,7 +220,6 @@ class SpectralModel(Model):
             if parameter.frozen or eps[idx] == 0:
                 continue
 
-#            dp = epsilon * parameter.error
             parameter.value += eps[idx]
             df = self.energy_flux(emin,emax) - f
             df_dp[idx] = df.value / eps[idx]

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -192,6 +192,44 @@ class SpectralModel(Model):
         flux_err = flux * dnde_err / dnde
         return u.Quantity([flux.value, flux_err.value], unit=flux.unit)
 
+    def _propagate_error(self, fct, emin, emax, epsilon=0.01):
+        """Evaluate error of a given function with uncertainty propagation.
+
+        Parameters
+        ----------
+        fct : function to estimate the error.
+        emin, emax : `~astropy.units.Quantity`
+            Array of lower and upper bound of integration range.
+        epsilon : float
+            Step size of the gradient evaluation. Given as a
+            fraction of the parameter error.
+
+        Returns
+        -------
+        f_cov : `~astropy.units.Quantity`
+            Error of the given function.
+        """
+        n = len(self.parameters)
+        C = self.covariance
+        f = fct
+        shape = (n, len(np.atleast_1d(emin)))
+        df_dp = np.zeros(shape)
+
+        for idx, parameter in enumerate(self.parameters):
+            if parameter.frozen or epsilon == 0:
+                continue
+
+            dp = epsilon * parameter.error
+            parameter.value += dp
+            df = self.energy_flux(emin,emax) - f
+            df_dp[idx] = df.value / dp
+
+            # Reset model to original parameter
+        parameter.value -= dp
+
+        f_cov = df_dp.T @ C @ df_dp
+        return np.sqrt(np.diagonal(f_cov))
+
     def energy_flux(self, emin, emax, **kwargs):
         r"""Compute energy flux in given energy range.
 
@@ -215,6 +253,24 @@ class SpectralModel(Model):
             return self.evaluate_energy_flux(emin, emax, **kwargs)
         else:
             return integrate_spectrum(f, emin, emax, **kwargs)
+
+    def energy_flux_error(self, emin, emax):
+        """Evaluate the error of the energy flux of a given spectrum in
+            a given energy range.
+
+        Parameters
+        ----------
+        emin, emax :  `~astropy.units.Quantity`
+            Lower and upper bound of integration range.
+
+        Returns
+        -------
+        energy_flux, energy_flux_err : tuple of `~astropy.units.Quantity`
+            Energy flux and energy flux error betwen emin and emax.
+        """
+        enrg_flux = self.energy_flux(emin, emax, intervals=True)
+        enrg_flux_err = self._propagate_error(enrg_flux, emin, emax, epsilon=1e-4)
+        return u.Quantity([enrg_flux.value, enrg_flux_err], unit=enrg_flux.unit)
 
     def plot(
         self,

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -812,10 +812,9 @@ def test_integral_error_ExpCutOffPowerLaw():
     assert_allclose(flux_error.value[0]/1e-14, 8.90907063, rtol=0.01)
 
 
-def test_flux_energy_error_PowerLaw():
-    energy = np.linspace(1 * u.TeV, 10 * u.TeV, 10)
-    emin = energy[:-1]
-    emax = energy[1:]
+def test_energy_flux_error_PowerLaw():
+    emin = 1 * u.TeV
+    emax = 10 * u.TeV
 
     powerlaw = PowerLawSpectralModel()
     powerlaw.parameters['index'].error = 0.4
@@ -823,20 +822,19 @@ def test_flux_energy_error_PowerLaw():
 
     enrg_flux, enrg_flux_error = powerlaw.energy_flux_error(emin,emax)
 
-    assert_allclose(enrg_flux.value[0]/1e-13, 6.931445029651589, rtol=0.01)
-    assert_allclose(enrg_flux_error.value[0]/1e-14, 9.97498743157135, rtol=0.01)
+    assert_allclose(enrg_flux.value/1e-12, 2.303, rtol=0.001)
+    assert_allclose(enrg_flux_error.value/1e-12, 1.347, rtol=0.001)
 
-def test_flux_energy_error_ExpCutOffPowerLaw():
-    energy = np.linspace(1 * u.TeV, 10 * u.TeV, 10)
-    emin = energy[:-1]
-    emax = energy[1:]
+def test_energy_flux_error_ExpCutOffPowerLaw():
+    emin = 1 * u.TeV
+    emax = 10 * u.TeV
 
     exppowerlaw = ExpCutoffPowerLawSpectralModel()
     exppowerlaw.parameters['index'].error = 0.4
     exppowerlaw.parameters['amplitude'].error = 1e-13
     exppowerlaw.parameters['lambda_'].error = 0.03
 
-    enrg_flux, enrg_flux_error = exppowerlaw.energy_flux_error(emin,emax)
+    enrg_flux, enrg_flux_error = exppowerlaw.energy_flux_error(emin,emax, intervals=False)
 
-    assert_allclose(enrg_flux.value[0]/1e-13, 7.112764292271696, rtol=0.01)
-    assert_allclose(enrg_flux_error.value[0]/1e-8, 3.582442114831109, rtol=0.01)
+    assert_allclose(enrg_flux.value/1e-12, 2.788, rtol=0.001)
+    assert_allclose(enrg_flux_error.value/1e-12, 2.226, rtol=0.001)

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -802,11 +802,41 @@ def test_integral_error_ExpCutOffPowerLaw():
     emax = energy[1:]
 
     exppowerlaw = ExpCutoffPowerLawSpectralModel()
-    exppowerlaw.parameters["index"].error = 0.4
-    exppowerlaw.parameters["amplitude"].error = 1e-13
-    exppowerlaw.parameters["lambda_"].error = 0.03
+    exppowerlaw.parameters['index'].error = 0.4
+    exppowerlaw.parameters['amplitude'].error = 1e-13
+    exppowerlaw.parameters['lambda_'].error = 0.03
 
     flux, flux_error = exppowerlaw.integral_error(emin, emax)
 
-    assert_allclose(flux.value[0] / 1e-13, 5.05855622, rtol=0.01)
-    assert_allclose(flux_error.value[0] / 1e-14, 8.90907063, rtol=0.01)
+    assert_allclose(flux.value[0]/1e-13, 5.05855622, rtol=0.01)
+    assert_allclose(flux_error.value[0]/1e-14, 8.90907063, rtol=0.01)
+
+
+def test_flux_energy_error_PowerLaw():
+    energy = np.linspace(1 * u.TeV, 10 * u.TeV, 10)
+    emin = energy[:-1]
+    emax = energy[1:]
+
+    powerlaw = PowerLawSpectralModel()
+    powerlaw.parameters['index'].error = 0.4
+    powerlaw.parameters['amplitude'].error = 1e-13
+
+    enrg_flux, enrg_flux_error = powerlaw.energy_flux_error(emin,emax)
+
+    assert_allclose(enrg_flux.value[0]/1e-13, 6.931445029651589, rtol=0.01)
+    assert_allclose(enrg_flux_error.value[0]/1e-14, 9.97498743157135, rtol=0.01)
+
+def test_flux_energy_error_ExpCutOffPowerLaw():
+    energy = np.linspace(1 * u.TeV, 10 * u.TeV, 10)
+    emin = energy[:-1]
+    emax = energy[1:]
+
+    exppowerlaw = ExpCutoffPowerLawSpectralModel()
+    exppowerlaw.parameters['index'].error = 0.4
+    exppowerlaw.parameters['amplitude'].error = 1e-13
+    exppowerlaw.parameters['lambda_'].error = 0.03
+
+    enrg_flux, enrg_flux_error = exppowerlaw.energy_flux_error(emin,emax)
+
+    assert_allclose(enrg_flux.value[0]/1e-13, 7.112764292271696, rtol=0.01)
+    assert_allclose(enrg_flux_error.value[0]/1e-8, 3.582442114831109, rtol=0.01)


### PR DESCRIPTION
This PR adds the `energy_flux_error` function into `~modeling.models.spectral`. The function estimates the uncertainty on the energy flux of a given spectral model in an energy range. Tests for a `PowerLaw` and a `ExpCutOffPowerLaw` have been also included.