### PR TITLE
Add option to remove default output in models yaml file

### DIFF
--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -359,9 +359,7 @@ class Fit:
 
         return {"values": values, "stat": np.array(stats)}
 
-    def stat_surface(
-        self, x, y, x_values, y_values, reoptimize=False, **optimize_opts
-    ):
+    def stat_surface(self, x, y, x_values, y_values, reoptimize=False, **optimize_opts):
         """Compute fit statistic surface.
 
         The method used is to vary two parameters, keeping all others fixed.

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -115,7 +115,7 @@ class Model:
             names = self.parameters.names
             for k, name in enumerate(names):
                 init = base.__dict__[name].to_dict()
-                for item in ["min", "max", "error"]:
+                for item in ["min", "max", "frozen", "error"]:
                     if params[k][item] == init[item] or np.isnan(init[item]):
                         del params[k][item]
         return {"type": tag, "parameters": params}

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -105,17 +105,17 @@ class Model:
         """A deep copy."""
         return copy.deepcopy(self)
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         """Create dict for YAML serialisation"""
         tag = self.tag[0] if isinstance(self.tag, list) else self.tag
         params = self.parameters.to_dict()
 
-        if full_output is False:
+        if not full_output:
             base = self.__class__
             names = self.parameters.names
             for k, name in enumerate(names):
                 init = base.__dict__[name].to_dict()
-                for item in ["min", "max", "frozen", "error"]:
+                for item in ["min", "max", "error"]:
                     if params[k][item] == init[item] or np.isnan(init[item]):
                         del params[k][item]
         return {"type": tag, "parameters": params}
@@ -291,7 +291,7 @@ class Models(collections.abc.MutableSequence):
                 shared_register = _set_link(shared_register, model)
         return models
 
-    def write(self, path, overwrite=False, full_output=True, write_covariance=True):
+    def write(self, path, overwrite=False, full_output=False, write_covariance=True):
         """Write to YAML file.
 
         Parameters
@@ -325,14 +325,14 @@ class Models(collections.abc.MutableSequence):
 
         path.write_text(self.to_yaml())
 
-    def to_yaml(self, full_output=True):
+    def to_yaml(self, full_output=False):
         """Convert to YAML string."""
         data = self.to_dict(full_output)
         return yaml.dump(
             data, sort_keys=False, indent=4, width=80, default_flow_style=False
         )
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         """Convert to dict."""
         # update linked parameters labels
         params_list = []

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -323,7 +323,7 @@ class Models(collections.abc.MutableSequence):
             self.write_covariance(base_path / filecovar, **kwargs)
             self._covar_file = filecovar
 
-        path.write_text(self.to_yaml())
+        path.write_text(self.to_yaml(full_output))
 
     def to_yaml(self, full_output=False):
         """Convert to YAML string."""

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -314,18 +314,18 @@ class SkyModel(SkyModelBase):
 
         return self.__class__(**kwargs)
 
-    def to_dict(self):
+    def to_dict(self, full_output=True):
         """Create dict for YAML serilisation"""
         data = {}
         data["name"] = self.name
         data["type"] = self.tag
-        data["spectral"] = self.spectral_model.to_dict()
+        data["spectral"] = self.spectral_model.to_dict(full_output)
 
         if self.spatial_model is not None:
-            data["spatial"] = self.spatial_model.to_dict()
+            data["spatial"] = self.spatial_model.to_dict(full_output)
 
         if self.temporal_model is not None:
-            data["temporal"] = self.temporal_model.to_dict()
+            data["temporal"] = self.temporal_model.to_dict(full_output)
 
         if self.apply_irf != self._apply_irf_default:
             data["apply_irf"] = self.apply_irf
@@ -488,11 +488,11 @@ class BackgroundModel(Model):
         back_values = self.map.data * value
         return self.map.copy(data=back_values)
 
-    def to_dict(self):
+    def to_dict(self, full_output=True):
         data = {}
         data["name"] = self.name
         data["type"] = self.tag
-        data["spectral"] = self.spectral_model.to_dict()
+        data["spectral"] = self.spectral_model.to_dict(full_output)
 
         if self.filename is not None:
             data["filename"] = self.filename

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -314,7 +314,7 @@ class SkyModel(SkyModelBase):
 
         return self.__class__(**kwargs)
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         """Create dict for YAML serilisation"""
         data = {}
         data["name"] = self.name
@@ -488,7 +488,7 @@ class BackgroundModel(Model):
         back_values = self.map.data * value
         return self.map.copy(data=back_values)
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         data = {}
         data["name"] = self.name
         data["type"] = self.tag

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -38,6 +38,7 @@ def compute_sigma_eff(lon_0, lat_0, lon, lat, phi, major_axis, e):
 
 class SpatialModel(Model):
     """Spatial model base class."""
+
     _type = "spatial"
 
     def __init__(self, **kwargs):
@@ -142,9 +143,9 @@ class SpatialModel(Model):
         data = values * geom.solid_angle()
         return Map.from_geom(geom=geom, data=data.value, unit=data.unit)
 
-    def to_dict(self):
+    def to_dict(self, full_output=True):
         """Create dict for YAML serilisation"""
-        data = super().to_dict()
+        data = super().to_dict(full_output)
         data["frame"] = self.frame
         data["parameters"] = data.pop("parameters")
         return data
@@ -605,10 +606,10 @@ class ConstantSpatialModel(SpatialModel):
     evaluation_radius = None
     position = None
 
-    def to_dict(self):
+    def to_dict(self, full_output=True):
         """Create dict for YAML serilisation"""
         # redefined to ignore frame attribute from parent class
-        data = super().to_dict()
+        data = super().to_dict(full_output)
         data.pop("frame")
         data["parameters"] = data.pop("parameters")
         return data
@@ -643,10 +644,10 @@ class ConstantFluxSpatialModel(SpatialModel):
     evaluation_radius = None
     position = None
 
-    def to_dict(self):
+    def to_dict(self, full_output=True):
         """Create dict for YAML serilisation"""
         # redefined to ignore frame attribute from parent class
-        data = super().to_dict()
+        data = super().to_dict(full_output)
         data.pop("frame")
         return data
 
@@ -785,9 +786,9 @@ class TemplateSpatialModel(SpatialModel):
         m = Map.read(filename)
         return cls(m, normalize=normalize, filename=filename)
 
-    def to_dict(self):
+    def to_dict(self, full_output=True):
         """Create dict for YAML serilisation"""
-        data = super().to_dict()
+        data = super().to_dict(full_output)
         data["filename"] = self.filename
         data["normalize"] = self.normalize
         data["unit"] = str(self.map.unit)

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -143,7 +143,7 @@ class SpatialModel(Model):
         data = values * geom.solid_angle()
         return Map.from_geom(geom=geom, data=data.value, unit=data.unit)
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         """Create dict for YAML serilisation"""
         data = super().to_dict(full_output)
         data["frame"] = self.frame
@@ -606,7 +606,7 @@ class ConstantSpatialModel(SpatialModel):
     evaluation_radius = None
     position = None
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         """Create dict for YAML serilisation"""
         # redefined to ignore frame attribute from parent class
         data = super().to_dict(full_output)
@@ -644,7 +644,7 @@ class ConstantFluxSpatialModel(SpatialModel):
     evaluation_radius = None
     position = None
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         """Create dict for YAML serilisation"""
         # redefined to ignore frame attribute from parent class
         data = super().to_dict(full_output)
@@ -786,7 +786,7 @@ class TemplateSpatialModel(SpatialModel):
         m = Map.read(filename)
         return cls(m, normalize=normalize, filename=filename)
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         """Create dict for YAML serilisation"""
         data = super().to_dict(full_output)
         data["filename"] = self.filename

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1702,7 +1702,7 @@ class NaimaSpectralModel(SpectralModel):
         return dnde.to(unit)
 
     def to_dict(self, full_output=True):
-        #for full_output to True otherwise broken
+        # for full_output to True otherwise broken
         return super().to_dict(full_output=True)
 
     @classmethod

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -57,6 +57,7 @@ def integrate_spectrum(func, emin, emax, ndecade=100, intervals=False):
 
 class SpectralModel(Model):
     """Spectral model base class."""
+
     _type = "spectral"
 
     def __call__(self, energy):
@@ -471,11 +472,11 @@ class CompoundSpectralModel(SpectralModel):
         val2 = self.model2(energy)
         return self.operator(val1, val2)
 
-    def to_dict(self):
+    def to_dict(self, full_output=True):
         return {
             "type": self.tag[0],
-            "model1": self.model1.to_dict(),
-            "model2": self.model2.to_dict(),
+            "model1": self.model1.to_dict(full_output),
+            "model2": self.model2.to_dict(full_output),
             "operator": self.operator.__name__,
         }
 
@@ -1249,7 +1250,7 @@ class TemplateSpectralModel(SpectralModel):
         """Evaluate the model (static function)."""
         return self._evaluate((energy,), clip=True)
 
-    def to_dict(self):
+    def to_dict(self, full_output=True):
         return {
             "type": self.tag[0],
             "energy": {
@@ -1334,7 +1335,7 @@ class Absorption:
             points=(self.param, self.energy), values=self.data, **interp_kwargs
         )
 
-    def to_dict(self):
+    def to_dict(self, full_output=True):
         if self.filename is None:
             return {
                 "type": self.tag,
@@ -1539,11 +1540,11 @@ class AbsorbedSpectralModel(SpectralModel):
         absorption = np.power(absorption, alpha_norm)
         return dnde * absorption
 
-    def to_dict(self):
+    def to_dict(self, full_output=True):
         return {
             "type": self.tag,
-            "base_model": self.spectral_model.to_dict(),
-            "absorption": self.absorption.to_dict(),
+            "base_model": self.spectral_model.to_dict(full_output),
+            "absorption": self.absorption.to_dict(full_output),
             "absorption_parameter": {"name": "redshift", "value": self.redshift.value,},
             "parameters": Parameters([self.redshift, self.alpha_norm]).to_dict(),
         }

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1701,6 +1701,10 @@ class NaimaSpectralModel(SpectralModel):
         unit = 1 / (energy.unit * u.cm ** 2 * u.s)
         return dnde.to(unit)
 
+    def to_dict(self, full_output=True):
+        #for full_output to True otherwise broken
+        return super().to_dict(full_output=True)
+
     @classmethod
     def from_dict(cls, data):
         raise NotImplementedError(

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -472,7 +472,7 @@ class CompoundSpectralModel(SpectralModel):
         val2 = self.model2(energy)
         return self.operator(val1, val2)
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         return {
             "type": self.tag[0],
             "model1": self.model1.to_dict(full_output),
@@ -1250,7 +1250,7 @@ class TemplateSpectralModel(SpectralModel):
         """Evaluate the model (static function)."""
         return self._evaluate((energy,), clip=True)
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         return {
             "type": self.tag[0],
             "energy": {
@@ -1335,7 +1335,7 @@ class Absorption:
             points=(self.param, self.energy), values=self.data, **interp_kwargs
         )
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         if self.filename is None:
             return {
                 "type": self.tag,
@@ -1540,7 +1540,7 @@ class AbsorbedSpectralModel(SpectralModel):
         absorption = np.power(absorption, alpha_norm)
         return dnde * absorption
 
-    def to_dict(self, full_output=True):
+    def to_dict(self, full_output=False):
         return {
             "type": self.tag,
             "base_model": self.spectral_model.to_dict(full_output),

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -17,6 +17,7 @@ from .core import Model
 class TemporalModel(Model):
     """Temporal model base class.
     evaluates on  astropy.time.Time objects"""
+
     _type = "temporal"
 
     def __call__(self, time):
@@ -72,17 +73,17 @@ class TemporalModel(Model):
             axis
         """
 
-
         import matplotlib.pyplot as plt
 
         ax = plt.gca() if ax is None else ax
         t_min, t_max = time_range
         n_value = 100
-        delta = (t_max - t_min)
+        delta = t_max - t_min
         times = t_min + delta * np.linspace(0, 1, n_value)
         val = self(times)
         ax.plot(times.mjd, val)
         return ax
+
 
 class ConstantTemporalModel(TemporalModel):
     """Constant temporal model."""
@@ -189,8 +190,6 @@ class ExpDecayTemporalModel(TemporalModel):
         t_ref = Time(pars["t_ref"].quantity, format="mjd")
         value = self.evaluate(t_max, t0, t_ref) - self.evaluate(t_min, t0, t_ref)
         return -t0 * value / self.time_sum(t_min, t_max)
-
-
 
 
 class GaussianTemporalModel(TemporalModel):
@@ -434,6 +433,6 @@ class LightCurveTemplateTemporalModel(TemporalModel):
     def from_dict(cls, data):
         return cls.read(data["filename"])
 
-    def to_dict(self, overwrite=False):
+    def to_dict(self, full_output=True, overwrite=False):
         """Create dict for YAML serilisation"""
         return {"type": self.tag[0], "filename": self.filename}

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -433,6 +433,6 @@ class LightCurveTemplateTemporalModel(TemporalModel):
     def from_dict(cls, data):
         return cls.read(data["filename"])
 
-    def to_dict(self, full_output=True, overwrite=False):
+    def to_dict(self, full_output=False, overwrite=False):
         """Create dict for YAML serilisation"""
         return {"type": self.tag[0], "filename": self.filename}

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -433,6 +433,6 @@ class LightCurveTemplateTemporalModel(TemporalModel):
     def from_dict(cls, data):
         return cls.read(data["filename"])
 
-    def to_dict(self, full_output=False, overwrite=False):
+    def to_dict(self, full_output=False):
         """Create dict for YAML serilisation"""
         return {"type": self.tag[0], "filename": self.filename}

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -9,12 +9,14 @@ from gammapy.utils.testing import requires_data
 
 class MyModel(Model):
     """Simple model example"""
+
     x = Parameter("x", 1, "cm")
     y = Parameter("y", 2)
 
 
 class CoModel(Model):
     """Compound model example"""
+
     norm = Parameter("norm", 42, "cm")
 
     def __init__(self, m1, m2, norm=norm.quantity):

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -59,10 +59,7 @@ def diffuse_model():
     )
     m.data += 42
     spatial_model = TemplateSpatialModel(m, normalize=False)
-    return SkyModel(
-        PowerLawNormSpectralModel(),
-        spatial_model
-    )
+    return SkyModel(PowerLawNormSpectralModel(), spatial_model)
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -8,6 +8,7 @@ from astropy.utils.data import get_pkg_data_filename
 from gammapy.maps import Map, MapAxis
 from gammapy.modeling.models import (
     MODEL_REGISTRY,
+    PowerLawSpectralModel,
     AbsorbedSpectralModel,
     Absorption,
     BackgroundModel,
@@ -231,6 +232,16 @@ def test_missing_parameters():
     models = Models.read(filename)
     assert models["source1"].spatial_model.e in models.parameters
     assert len(models["source1"].spatial_model.parameters) == 6
+
+
+def test_simplified_output():
+    model = PowerLawSpectralModel()
+    full = model.to_dict()
+    simplified = model.to_dict(full_output=False)
+    for k, name in enumerate(model.parameters.names):
+        for item in ["min", "max", "frozen", "error"]:
+            assert item in full["parameters"][k]
+            assert item not in simplified["parameters"][k]
 
 
 def test_registries_print():

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -236,10 +236,10 @@ def test_missing_parameters():
 
 def test_simplified_output():
     model = PowerLawSpectralModel()
-    full = model.to_dict()
-    simplified = model.to_dict(full_output=False)
+    full = model.to_dict(full_output=True)
+    simplified = model.to_dict()
     for k, name in enumerate(model.parameters.names):
-        for item in ["min", "max", "frozen", "error"]:
+        for item in ["min", "max", "error"]:
             assert item in full["parameters"][k]
             assert item not in simplified["parameters"][k]
 

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -238,8 +238,8 @@ def test_simplified_output():
     model = PowerLawSpectralModel()
     full = model.to_dict(full_output=True)
     simplified = model.to_dict()
-    for k, name in enumerate(model.parameters.names):
-        for item in ["min", "max", "error"]:
+    for k, _ in enumerate(model.parameters.names):
+        for item in ["min", "max", "frozen", "error"]:
             assert item in full["parameters"][k]
             assert item not in simplified["parameters"][k]
 

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -97,7 +97,7 @@ def test_sky_models_io(tmp_path):
     filename = get_pkg_data_filename("data/examples.yaml")
     models = Models.read(filename)
     models.covariance = np.eye(len(models.parameters))
-    models.write(tmp_path / "tmp.yaml")
+    models.write(tmp_path / "tmp.yaml", full_output=True)
     models = Models.read(tmp_path / "tmp.yaml")
     assert models._covar_file == "tmp_covariance.dat"
     assert_allclose(models.covariance.data, np.eye(len(models.parameters)))

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -776,26 +776,26 @@ def test_integral_error_PowerLaw():
     emax = energy[1:]
 
     powerlaw = PowerLawSpectralModel()
-    powerlaw.parameters['index'].error = 0.4
-    powerlaw.parameters['amplitude'].error = 1e-13
+    powerlaw.parameters["index"].error = 0.4
+    powerlaw.parameters["amplitude"].error = 1e-13
 
-    flux, flux_error = powerlaw.integral_error(emin,emax)
+    flux, flux_error = powerlaw.integral_error(emin, emax)
 
-    assert_allclose(flux.value[0]/1e-13, 5.0, rtol=0.1)
-    assert_allclose(flux_error.value[0]/1e-14, 8.546615432273905, rtol=0.01)
+    assert_allclose(flux.value[0] / 1e-13, 5.0, rtol=0.1)
+    assert_allclose(flux_error.value[0] / 1e-14, 8.546615432273905, rtol=0.01)
 
 
 def test_integral_error_ExpCutOffPowerLaw():
     energy = np.linspace(1 * u.TeV, 10 * u.TeV, 10)
     emin = energy[:-1]
     emax = energy[1:]
-    
+
     exppowerlaw = ExpCutoffPowerLawSpectralModel()
-    exppowerlaw.parameters['index'].error = 0.4
-    exppowerlaw.parameters['amplitude'].error = 1e-13
-    exppowerlaw.parameters['lambda_'].error = 0.03
-    
+    exppowerlaw.parameters["index"].error = 0.4
+    exppowerlaw.parameters["amplitude"].error = 1e-13
+    exppowerlaw.parameters["lambda_"].error = 0.03
+
     flux, flux_error = exppowerlaw.integral_error(emin, emax)
-    
-    assert_allclose(flux.value[0]/1e-13, 5.05855622, rtol=0.01)
-    assert_allclose(flux_error.value[0]/1e-14, 8.90907063, rtol=0.01)
+
+    assert_allclose(flux.value[0] / 1e-13, 5.05855622, rtol=0.01)
+    assert_allclose(flux_error.value[0] / 1e-14, 8.90907063, rtol=0.01)

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -217,4 +217,3 @@ def test_plot_constant_model():
     constant_model = ConstantTemporalModel(const=1)
     with mpl_plot_check():
         constant_model.plot(time_range)
-


### PR DESCRIPTION
Add option full_output (True by default) to model.to_yaml() and .to_dict(). Switching to False remove the entries for min, max, frozen and error if they are the same than the class defaults or nan.