### PR TITLE
Fix documentation for gammapy.irf

### DIFF
--- a/docs/irf/aeff.rst
+++ b/docs/irf/aeff.rst
@@ -3,4 +3,34 @@
 Effective area
 ==============
 
-TODO: show and plot examples.
+as a function of true energy and offset angle (:ref:`gadf:aeff_2d`)
+-------------------------------------------------------------------
+The `~gammapy.irf.EffectiveAreaTable2D` class represents an effective area as a function of true energy and offset angle from the field of view center
+(:math:`A_{\rm eff}(p, E)`, following the notation in :ref:`irf-theory`). 
+
+Its format specifications are available in :ref:`gadf:aeff_2d`.
+
+This is the format in which IACT DL3 effective areas are usually provided, as an example
+
+.. plot:: irf/plot_aeff.py
+    :include-source:
+    
+as a function of true energy (:ref:`gadf:ogip-arf`)
+---------------------------------------------------
+`~gammapy.irf.EffectiveAreaTable` instead represents an effective area as a function of true energy only 
+(:math:`A_{\rm eff}(E)` following the notation in :ref:`irf-theory`).
+
+Its format specifications are available in :ref:`gadf:ogip-arf`.
+
+Such an area can be obtained, for example: 
+
+- selecting the value of an `~gammapy.irf.EffectiveAreaTable2D` at a given offset (using `~astropy.coordinates.Angle`)
+
+.. plot:: irf/plot_aeff_table.py
+    :include-source:
+
+- using a pre-defined effective area parameterisation
+
+.. plot:: irf/plot_aeff_param.py
+    :include-source:
+    

--- a/docs/irf/aeff.rst
+++ b/docs/irf/aeff.rst
@@ -6,7 +6,7 @@ Effective area
 as a function of true energy and offset angle (:ref:`gadf:aeff_2d`)
 -------------------------------------------------------------------
 The `~gammapy.irf.EffectiveAreaTable2D` class represents an effective area as a function of true energy and offset angle from the field of view center
-(:math:`A_{\rm eff}(p, E)`, following the notation in :ref:`irf-theory`). 
+(:math:`A_{\rm eff}(p_{\rm true}, E_{\rm true})`, following the notation in :ref:`irf-theory`). 
 
 Its format specifications are available in :ref:`gadf:aeff_2d`.
 
@@ -18,7 +18,7 @@ This is the format in which IACT DL3 effective areas are usually provided, as an
 as a function of true energy (:ref:`gadf:ogip-arf`)
 ---------------------------------------------------
 `~gammapy.irf.EffectiveAreaTable` instead represents an effective area as a function of true energy only 
-(:math:`A_{\rm eff}(E)` following the notation in :ref:`irf-theory`).
+(:math:`A_{\rm eff}(E_{\rm true})` following the notation in :ref:`irf-theory`).
 
 Its format specifications are available in :ref:`gadf:ogip-arf`.
 

--- a/docs/irf/bkg.rst
+++ b/docs/irf/bkg.rst
@@ -10,7 +10,7 @@ of detector coordinates and true energy.
 
 Its format specifications are available in :ref:`gadf:bkg_3d`.
 
-This is the format in which IACT DL3 energy dispersions are usually provided, as an example:
+This is the format in which IACT DL3 background rates are usually provided, as an example:
 
 .. plot:: irf/plot_bkg_3d.py
     :include-source:

--- a/docs/irf/bkg.rst
+++ b/docs/irf/bkg.rst
@@ -26,5 +26,3 @@ Its format specifications are available in :ref:`gadf:bkg_2d`.
 You can produce a radially-symmetric background from a list of DL3 observations 
 devoid of gamma-ray signal using the tutorial in 
 `background_model.html <../tutorials/backgorund_model.html>`__ 
-
-

--- a/docs/irf/bkg.rst
+++ b/docs/irf/bkg.rst
@@ -1,0 +1,30 @@
+.. _irf-bkg:
+
+Background
+==========
+
+as a function of of true energy and detector coordinates (:ref:`gadf:bkg_3d`) 
+-----------------------------------------------------------------------------
+The `~gammapy.irf.Background3D` class represents a background rate as a function
+of detector coordinates and true energy. 
+
+Its format specifications are available in :ref:`gadf:bkg_3d`.
+
+This is the format in which IACT DL3 energy dispersions are usually provided, as an example:
+
+.. plot:: irf/plot_bkg_3d.py
+    :include-source:
+
+
+as a function of of true energy and offset angle, radially symmetric (:ref:`gadf:bkg_2d`)
+-----------------------------------------------------------------------------------------
+The `~gammapy.irf.Background2D` class represents a background rate as a function 
+of offset angle from the field of view center and true energy.
+
+Its format specifications are available in :ref:`gadf:bkg_2d`.
+
+You can produce a radially-symmetric background from a list of DL3 observations 
+devoid of gamma-ray signal using the tutorial in 
+`background_model.html <../tutorials/backgorund_model.html>`__ 
+
+

--- a/docs/irf/bkg.rst
+++ b/docs/irf/bkg.rst
@@ -3,10 +3,10 @@
 Background
 ==========
 
-as a function of of true energy and detector coordinates (:ref:`gadf:bkg_3d`) 
------------------------------------------------------------------------------
-The `~gammapy.irf.Background3D` class represents a background rate as a function
-of detector coordinates and true energy. 
+as a function of reconstructed energy and detector coordinates (:ref:`gadf:bkg_3d`) 
+--------------------------------------------------------------------------------------
+The `~gammapy.irf.Background3D` class represents a background rate per solid 
+angle as a function of detector coordinates and reconstructed energy. 
 
 Its format specifications are available in :ref:`gadf:bkg_3d`.
 
@@ -16,10 +16,10 @@ This is the format in which IACT DL3 background rates are usually provided, as a
     :include-source:
 
 
-as a function of of true energy and offset angle, radially symmetric (:ref:`gadf:bkg_2d`)
------------------------------------------------------------------------------------------
-The `~gammapy.irf.Background2D` class represents a background rate as a function 
-of offset angle from the field of view center and true energy.
+as a function of reconstructed energy and offset angle, radially symmetric (:ref:`gadf:bkg_2d`)
+-----------------------------------------------------------------------------------------------
+The `~gammapy.irf.Background2D` class represents a background rate per solid angle 
+as a function of offset angle from the field of view center and reconstructed energy.
 
 Its format specifications are available in :ref:`gadf:bkg_2d`.
 

--- a/docs/irf/edisp.rst
+++ b/docs/irf/edisp.rst
@@ -6,7 +6,7 @@ Energy Dispersion
 as a function of of true energy and offset angle (:ref:`gadf:edisp_2d`)
 -----------------------------------------------------------------------
 The `~gammapy.irf.EnergyDispersion2D` class represents the probability density of the energy migration 
-:math:`\mu=\frac{E_{\rm reco}}{E_{\rm true}}` as a function of true energy and offset angle from the field of view center
+:math:`\mu=\frac{E_{\rm reco}}{E}` as a function of true energy and offset angle from the field of view center
 (:math:`E_{\rm disp}(\mu|p, E)` in :ref:`irf-theory`).
 
 Its format specifications are available in :ref:`gadf:edisp_2d`

--- a/docs/irf/edisp.rst
+++ b/docs/irf/edisp.rst
@@ -7,7 +7,7 @@ as a function of of true energy and offset angle (:ref:`gadf:edisp_2d`)
 -----------------------------------------------------------------------
 The `~gammapy.irf.EnergyDispersion2D` class represents the probability density of the energy migration 
 :math:`\mu=\frac{E_{\rm reco}}{E_{\rm true}}` as a function of true energy and offset angle from the field of view center
-(:math:`E_{\rm disp}(E_{\rm reco}|p, E)` in :ref:`irf-theory`).
+(:math:`E_{\rm disp}(\mu|p, E)` in :ref:`irf-theory`).
 
 Its format specifications are available in :ref:`gadf:edisp_2d`
 
@@ -20,6 +20,10 @@ as a function of true energy (:ref:`gadf:ogip-rmf`)
 ---------------------------------------------------
 `~gammapy.irf.EDispKernel` instead represents an energy dispersion as a function of true energy only 
 (:math:`E_{\rm disp}(E_{\rm reco}| E)` following the notation in :ref:`irf-theory`).
+`~gammapy.irf.EDispKernel` contains the energy redistribution matrix (or redistribution matrix function, RMF, 
+in the OGIP standard). The energy redistribution provides the integral of the energy dispersion probability function over 
+bins of reconstructed energy. It is used to convert vectors of predicted counts in true energy in vectors of predicted 
+counts in reconstructed energy.
 
 Its format specifications are available in :ref:`gadf:ogip-rmf`.
 

--- a/docs/irf/edisp.rst
+++ b/docs/irf/edisp.rst
@@ -1,11 +1,36 @@
 .. _irf-edisp:
 
-Energy dispersion
+Energy Dispersion
 =================
 
-TODO: describe / illustrate the existing classes:
+as a function of of true energy and offset angle (:ref:`gadf:edisp_2d`)
+-----------------------------------------------------------------------
+The `~gammapy.irf.EnergyDispersion2D` class represents the probability density of the energy migration 
+:math:`\mu=\frac{E_{\rm reco}}{E_{\rm true}}` as a function of true energy and offset angle from the field of view center
+(:math:`E_{\rm disp}(E_{\rm reco}|p, E)` in :ref:`irf-theory`).
 
-* `~gammapy.irf.EDispKernel`
-* `~gammapy.irf.EnergyDispersion2D`
+Its format specifications are available in :ref:`gadf:edisp_2d`
+
+This is the format in which IACT DL3 energy dispersions are usually provided, as an example:
 
 .. plot:: irf/plot_edisp.py
+    :include-source:
+
+as a function of true energy (:ref:`gadf:ogip-rmf`)
+---------------------------------------------------
+`~gammapy.irf.EDispKernel` instead represents an energy dispersion as a function of true energy only 
+(:math:`E_{\rm disp}(E_{\rm reco}| E)` following the notation in :ref:`irf-theory`).
+
+Its format specifications are available in :ref:`gadf:ogip-rmf`.
+
+Such an energy dispersion can be obtained for example: 
+
+- selecting the value of an `~gammapy.irf.EnergyDispersion2D` at a given offset (using `~astropy.coordinates.Angle`)
+
+.. plot:: irf/plot_edisp_kernel.py
+    :include-source:
+
+- or starting from a parameterisation:
+
+.. plot:: irf/plot_edisp_kernel_param.py
+    :include-source:

--- a/docs/irf/edisp.rst
+++ b/docs/irf/edisp.rst
@@ -6,8 +6,8 @@ Energy Dispersion
 as a function of of true energy and offset angle (:ref:`gadf:edisp_2d`)
 -----------------------------------------------------------------------
 The `~gammapy.irf.EnergyDispersion2D` class represents the probability density of the energy migration 
-:math:`\mu=\frac{E_{\rm reco}}{E}` as a function of true energy and offset angle from the field of view center
-(:math:`E_{\rm disp}(\mu|p, E)` in :ref:`irf-theory`).
+:math:`\mu=\frac{E}{E_{\rm true}}` as a function of true energy and offset angle from the field of view center
+(:math:`E_{\rm disp}(\mu|p_{\rm true}, E_{\rm true})` in :ref:`irf-theory`).
 
 Its format specifications are available in :ref:`gadf:edisp_2d`
 
@@ -19,7 +19,7 @@ This is the format in which IACT DL3 energy dispersions are usually provided, as
 as a function of true energy (:ref:`gadf:ogip-rmf`)
 ---------------------------------------------------
 `~gammapy.irf.EDispKernel` instead represents an energy dispersion as a function of true energy only 
-(:math:`E_{\rm disp}(E_{\rm reco}| E)` following the notation in :ref:`irf-theory`).
+(:math:`E_{\rm disp}(E| E_{\rm true})` following the notation in :ref:`irf-theory`).
 `~gammapy.irf.EDispKernel` contains the energy redistribution matrix (or redistribution matrix function, RMF, 
 in the OGIP standard). The energy redistribution provides the integral of the energy dispersion probability function over 
 bins of reconstructed energy. It is used to convert vectors of predicted counts in true energy in vectors of predicted 

--- a/docs/irf/index.rst
+++ b/docs/irf/index.rst
@@ -8,16 +8,17 @@ irf - Instrument response functions
 
 Introduction
 ============
+For a definition of the response function you are invited to read :ref:`irf-theory`.
 
-`gammapy.irf` handles instrument response functions (IRFs):
+`gammapy.irf` handles the following instrument response functions (IRFs):
 
 * Effective area (AEFF)
 * Energy dispersion (EDISP)
 * Point spread function (PSF)
 * Template background (BKG)
 
-Most of the formats defined at :ref:`gadf:iact-irf` are supported.  Otherwise,
-at the moment, there is very little support for Fermi-LAT or other instruments.
+Most of the formats defined at :ref:`gadf:iact-irf` are supported.    
+At the moment, there is little support for Fermi-LAT or other instruments.
 
 Most users will not use `gammapy.irf` directly, but will instead use IRFs as
 part of their spectrum, image or cube analysis to compute exposure and effective
@@ -51,12 +52,67 @@ See `cta.html <../tutorials/cta.html>`__ for an example how to access IACT IRFs.
 Effective area
 ==============
 
-See `~gammapy.irf.EffectiveAreaTable` and `~gammapy.irf.EffectiveAreaTable2D`.
+as a function of true energy and offset angle (:ref:`gadf:aeff_2d`)
+-------------------------------------------------------------------
+The `~gammapy.irf.EffectiveAreaTable2D` class represents an effective area as a function of true energy and offset angle 
+(:math:`A_{\rm eff}(p, E)` following the notation in :ref:`irf-theory`). 
+Its format specifications are available in :ref:`gadf:aeff_2d`.
 
-Background
-==========
+This is the format in which IACT DL3 effective areas are usually provided, as an example
 
-See `~gammapy.irf.Background2D` and `~gammapy.irf.Background3D`.
+.. plot:: irf/plot_aeff.py
+    :include-source:
+    
+as a function of true energy (:ref:`gadf:ogip-arf`)
+---------------------------------------------------
+`~gammapy.irf.EffectiveAreaTable` instead represents an effective area as a function of true energy only 
+(:math:`A_{\rm eff}(E)` following the notation in :ref:`irf-theory`).
+Its format specifications are available in :ref:`gadf:ogip-arf`.
+
+Such an area can be obtained, for example: 
+
+- selecting the value of an `~gammapy.irf.EffectiveAreaTable2D` at a given offset (using `~astropy.coordinates.Angle`)
+
+.. plot:: irf/plot_aeff_table.py
+    :include-source:
+
+- using a pre-defined effective area parameterisation
+
+.. plot:: irf/plot_aeff_param.py
+    :include-source:
+
+
+Energy Dispersion
+=================
+
+as a function of of true energy and offset angle (:ref:`gadf:edisp_2d`)
+-----------------------------------------------------------------------
+The `~gammapy.irf.EnergyDispersion2D` class represents the probability density of the energy migration 
+:math:`\mu=\frac{E_{\rm reco}}{E_{\rm true}}` as a function of true energy and offset angle (:math:`E_{\rm disp}(E_{\rm reco}|p, E)` in :ref:`irf-theory`).
+Its format specifications are available in :ref:`gadf:edisp_2d`
+
+This is the format in which IACT DL3 energy dispersions are usually provided, as an example
+
+.. plot:: irf/plot_edisp.py
+    :include-source:
+
+as a function of true energy (:ref:`gadf:ogip-rmf`)
+---------------------------------------------------
+`~gammapy.irf.EDispKernel` instead represents an energy dispersion as a function of true energy only 
+(:math:`E_{\rm disp}(E_{\rm reco}| E)` following the notation in :ref:`irf-theory`).
+Its format specifications are available in :ref:`gadf:ogip-rmf`.
+Such an energy dispersion can be obtained for example: 
+
+- selecting the value of an `~gammapy.irf.EnergyDispersion2D` at a given offset (using `~astropy.coordinates.Angle`)
+
+.. plot:: irf/plot_edisp_kernel.py
+    :include-source:
+
+- or starting from a parameterisation:
+
+.. plot:: irf/plot_edisp_kernel_param.py
+    :include-source:
+
 
 PSF
 ===
@@ -68,16 +124,10 @@ The `~gammapy.irf.PSFKernel` represents a PSF kernel.
 
 .. plot:: irf/plot_fermi_psf.py
 
-Energy Dispersion
-=================
+Background
+==========
 
-The `~gammapy.irf.EnergyDispersion` class represents an energy migration matrix
-(finite probabilities per pixel) with ``y=log(energy_reco)``.
-
-The `~gammapy.irf.EnergyDispersion2D` class represents a probability density
-with ``y=energy_reco/energy_true`` that can also have a FOV offset dependence.
-
-.. plot:: irf/plot_edisp.py
+See `~gammapy.irf.Background2D` and `~gammapy.irf.Background3D`.
 
 
 Using `gammapy.irf`

--- a/docs/irf/index.rst
+++ b/docs/irf/index.rst
@@ -33,17 +33,17 @@ IRF Axis naming
 ---------------
 In the IRF classes we use the following axis naming convention:
 
-================= ===================================
+================= ============================================================================
 Variable          Definition
-================= ===================================
-``energy``        Reconstructed energy axis
-``energy_true``   True energy axis
-``offset``        Field of view offset from center
+================= ============================================================================
+``energy``        Reconstructed energy axis (:math:`E` in :ref:`irf-theory`)
+``energy_true``   True energy axis (:math:`E_{\rm true}` in :ref:`irf-theory`)
+``offset``        Field of view offset from center (:math:`p_{\rm true}` in :ref:`irf-theory`)
 ``fov_lon``       Field of view	longitude
 ``fov_lat``       Field of view latitude
-``migra``         Energy migration
-``rad``        	  Offset angle from source position
-================= ===================================
+``migra``         Energy migration (:math:`\mu` in :ref:`irf-theory`)
+``rad``        	  Offset angle from source position (:math:`\delta p` in :ref:`irf-theory`)
+================= ============================================================================
 
 Getting Started
 ===============

--- a/docs/irf/index.rst
+++ b/docs/irf/index.rst
@@ -8,14 +8,15 @@ irf - Instrument response functions
 
 Introduction
 ============
-For a definition of the response function you are invited to read :ref:`irf-theory`.
+For a definition of the response function you are invited to read 
+:ref:`irf-theory`.
 
 `gammapy.irf` handles the following instrument response functions (IRFs):
 
-* Effective area (AEFF)
-* Energy dispersion (EDISP)
-* Point spread function (PSF)
-* Template background (BKG)
+* :ref:`irf-aeff` (AEFF)
+* :ref:`irf-edisp` (EDISP)
+* :ref:`irf-psf` (PSF)
+* :ref:`irf-bkg` (BKG)
 
 Most of the formats defined at :ref:`gadf:iact-irf` are supported.    
 At the moment, there is little support for Fermi-LAT or other instruments.
@@ -49,91 +50,10 @@ Getting Started
 
 See `cta.html <../tutorials/cta.html>`__ for an example how to access IACT IRFs.
 
-Effective area
-==============
-
-as a function of true energy and offset angle (:ref:`gadf:aeff_2d`)
--------------------------------------------------------------------
-The `~gammapy.irf.EffectiveAreaTable2D` class represents an effective area as a function of true energy and offset angle 
-(:math:`A_{\rm eff}(p, E)` following the notation in :ref:`irf-theory`). 
-Its format specifications are available in :ref:`gadf:aeff_2d`.
-
-This is the format in which IACT DL3 effective areas are usually provided, as an example
-
-.. plot:: irf/plot_aeff.py
-    :include-source:
-    
-as a function of true energy (:ref:`gadf:ogip-arf`)
----------------------------------------------------
-`~gammapy.irf.EffectiveAreaTable` instead represents an effective area as a function of true energy only 
-(:math:`A_{\rm eff}(E)` following the notation in :ref:`irf-theory`).
-Its format specifications are available in :ref:`gadf:ogip-arf`.
-
-Such an area can be obtained, for example: 
-
-- selecting the value of an `~gammapy.irf.EffectiveAreaTable2D` at a given offset (using `~astropy.coordinates.Angle`)
-
-.. plot:: irf/plot_aeff_table.py
-    :include-source:
-
-- using a pre-defined effective area parameterisation
-
-.. plot:: irf/plot_aeff_param.py
-    :include-source:
-
-
-Energy Dispersion
-=================
-
-as a function of of true energy and offset angle (:ref:`gadf:edisp_2d`)
------------------------------------------------------------------------
-The `~gammapy.irf.EnergyDispersion2D` class represents the probability density of the energy migration 
-:math:`\mu=\frac{E_{\rm reco}}{E_{\rm true}}` as a function of true energy and offset angle (:math:`E_{\rm disp}(E_{\rm reco}|p, E)` in :ref:`irf-theory`).
-Its format specifications are available in :ref:`gadf:edisp_2d`
-
-This is the format in which IACT DL3 energy dispersions are usually provided, as an example
-
-.. plot:: irf/plot_edisp.py
-    :include-source:
-
-as a function of true energy (:ref:`gadf:ogip-rmf`)
----------------------------------------------------
-`~gammapy.irf.EDispKernel` instead represents an energy dispersion as a function of true energy only 
-(:math:`E_{\rm disp}(E_{\rm reco}| E)` following the notation in :ref:`irf-theory`).
-Its format specifications are available in :ref:`gadf:ogip-rmf`.
-Such an energy dispersion can be obtained for example: 
-
-- selecting the value of an `~gammapy.irf.EnergyDispersion2D` at a given offset (using `~astropy.coordinates.Angle`)
-
-.. plot:: irf/plot_edisp_kernel.py
-    :include-source:
-
-- or starting from a parameterisation:
-
-.. plot:: irf/plot_edisp_kernel_param.py
-    :include-source:
-
-
-PSF
-===
-
-The `~gammapy.irf.TablePSF` and `~gammapy.irf.EnergyDependentTablePSF` classes
-represent radially-symmetric PSFs where the PSF is given at a number of offsets.
-
-The `~gammapy.irf.PSFKernel` represents a PSF kernel.
-
-.. plot:: irf/plot_fermi_psf.py
-
-Background
-==========
-
-See `~gammapy.irf.Background2D` and `~gammapy.irf.Background3D`.
-
-
 Using `gammapy.irf`
 ===================
 
-If you'd like to learn more about using `gammapy.irf`, read the following
+If you'd like to learn more about using `gammapy.irf`, read the following 
 sub-pages:
 
 .. toctree::
@@ -143,6 +63,7 @@ sub-pages:
     aeff
     edisp
     psf
+    bkg
 
 Reference/API
 =============

--- a/docs/irf/plot_aeff.py
+++ b/docs/irf/plot_aeff.py
@@ -1,0 +1,8 @@
+"""Plot an effective area from the HESS DL3 data release 1."""
+import matplotlib.pyplot as plt
+from gammapy.irf import EffectiveAreaTable2D
+
+filename = "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+aeff = EffectiveAreaTable2D.read(filename, hdu="AEFF")
+aeff.peek()
+plt.show()

--- a/docs/irf/plot_aeff_param.py
+++ b/docs/irf/plot_aeff_param.py
@@ -1,0 +1,16 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import astropy.units as u
+from gammapy.irf import EffectiveAreaTable
+
+energy = np.logspace(-3, 3, 100) * u.TeV
+
+for instrument in ['HESS', 'HESS2', 'CTA']:
+    aeff = EffectiveAreaTable.from_parametrization(energy, instrument)
+    ax = aeff.plot(label=instrument)
+
+ax.set_yscale('log')
+ax.set_xlim([1e-3, 1e3])
+ax.set_ylim([1e3, 1e12])
+plt.legend(loc='best')
+plt.show()

--- a/docs/irf/plot_aeff_table.py
+++ b/docs/irf/plot_aeff_table.py
@@ -1,0 +1,12 @@
+"""Plot the effective area at a given offset"""
+import matplotlib.pyplot as plt
+from astropy.coordinates import Angle
+from gammapy.irf import EffectiveAreaTable2D
+
+filename = "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+aeff = EffectiveAreaTable2D.read(filename, hdu="AEFF")
+# offset at which we want to examine the effective area
+offset = Angle("0.5 deg") 
+aeff_table = aeff.to_effective_area_table(offset=offset)
+aeff_table.plot()
+plt.show()

--- a/docs/irf/plot_bkg_3d.py
+++ b/docs/irf/plot_bkg_3d.py
@@ -1,0 +1,8 @@
+"""Plot the background rate from the HESS DL3 data release 1."""
+import matplotlib.pyplot as plt
+from gammapy.irf import Background3D
+
+filename = "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+bkg = Background3D.read(filename, hdu="BKG")
+bkg.peek()
+plt.show()

--- a/docs/irf/plot_edisp.py
+++ b/docs/irf/plot_edisp.py
@@ -1,12 +1,8 @@
-"""Plot energy dispersion example."""
-import numpy as np
-import astropy.units as u
+"""Plot an energy dispersion from the HESS DL3 data release 1."""
 import matplotlib.pyplot as plt
-from gammapy.irf import EDispKernel
+from gammapy.irf import EnergyDispersion2D
 
-ebounds = np.logspace(-1, 2, 101) * u.TeV
-
-edisp = EDispKernel.from_gauss(e_true=ebounds, e_reco=ebounds, bias=0, sigma=0.3)
-
+filename = "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+edisp = EnergyDispersion2D.read(filename, hdu="EDISP")
 edisp.peek()
 plt.show()

--- a/docs/irf/plot_edisp_kernel.py
+++ b/docs/irf/plot_edisp_kernel.py
@@ -1,0 +1,13 @@
+
+"""Plot the energy dispersion at a given offset."""
+import matplotlib.pyplot as plt
+from astropy.coordinates import Angle
+from gammapy.irf import EnergyDispersion2D
+
+filename = "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+edisp = EnergyDispersion2D.read(filename, hdu="EDISP")
+# offset at which we want to examine the energy dispersion
+offset = Angle("0.5 deg") 
+edisp_kernel = edisp.to_energy_dispersion(offset=offset)
+edisp_kernel.peek()
+plt.show()

--- a/docs/irf/plot_edisp_kernel_param.py
+++ b/docs/irf/plot_edisp_kernel_param.py
@@ -1,0 +1,13 @@
+"""Plot an energy dispersion using a gaussian parametrisation"""
+import numpy as np
+import astropy.units as u
+from gammapy.irf import EDispKernel
+import matplotlib.pyplot as plt
+
+energy = np.logspace(0, 1, 101) * u.TeV
+edisp = EDispKernel.from_gauss(
+    e_true=energy, e_reco=energy,
+    sigma=0.1, bias=0,
+)
+edisp.peek()
+plt.show()

--- a/docs/irf/plot_psf.py
+++ b/docs/irf/plot_psf.py
@@ -1,0 +1,8 @@
+"""Plot a PSF from the HESS DL3 data release 1."""
+import matplotlib.pyplot as plt
+from gammapy.irf import PSF3D
+
+filename = "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+psf = PSF3D.read(filename, hdu="PSF")
+psf.peek()
+plt.show()

--- a/docs/irf/plot_psf_table.py
+++ b/docs/irf/plot_psf_table.py
@@ -1,0 +1,12 @@
+"""Plot the PSF at a given offset from the camera center"""
+import matplotlib.pyplot as plt
+from astropy.coordinates import Angle
+from gammapy.irf import PSF3D
+
+filename = "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+psf = PSF3D.read(filename, hdu="PSF")
+# offset at which we want to examine the PSF
+offset = Angle("0.5 deg") 
+psf_table = psf.to_energy_dependent_table_psf(offset)
+psf_table.plot_psf_vs_rad()
+plt.show()

--- a/docs/irf/psf.rst
+++ b/docs/irf/psf.rst
@@ -7,9 +7,9 @@ as a function of of true energy and offset angle (:ref:`gadf:psf_table`)
 ------------------------------------------------------------------------
 The `~gammapy.irf.PSF3D` class represents the radially symmetric probability 
 density of the angular separation between true and reconstructed directions 
-:math:`\delta p = p - p_{\rm reco}` (or `rad`), as a function of 
+:math:`\delta p = p_{\rm true} - p` (or `rad`), as a function of 
 true energy and offset angle from the field of view center 
-(:math:`PSF(\delta p|p, E)` in :ref:`irf-theory`).
+(:math:`PSF(\delta p|p_{\rm true}, E_{\rm true})` in :ref:`irf-theory`).
 
 Its format specifications are available in :ref:`gadf:psf_table`.
 
@@ -23,8 +23,8 @@ as a function of true energy (:ref:`gadf:psf_gtpsf`)
 ----------------------------------------------------
 `~gammapy.irf.EnergyDependentTablePSF` instead represents the probability density 
 of the angular separation between true direction and reconstructed directions 
-:math:`\delta p = p - p_{\rm reco}` (or `rad`) as a function of true 
-energy only (:math:`PSF(\delta p| E)` following the notation in :ref:`irf-theory`). 
+:math:`\delta p = p_{\rm true} - p` (or `rad`) as a function of true 
+energy only (:math:`PSF(\delta p| E_{\rm true})` following the notation in :ref:`irf-theory`). 
 
 Its format specifications are available in :ref:`gadf:psf_gtpsf`.
 

--- a/docs/irf/psf.rst
+++ b/docs/irf/psf.rst
@@ -1,12 +1,15 @@
 .. _irf-psf:
 
-PSF
-===
+Point Spread Function
+=====================
+
 as a function of of true energy and offset angle (:ref:`gadf:psf_table`)
 ------------------------------------------------------------------------
-The `~gammapy.irf.PSF3D` class represents the spatial probability of an event with true position :math:`p_{\rm true}` to
-have an estimated position :math:`p_{\rm reco}`, as a function of true energy and offset angle from the field of view center
-(:math:`PSF(p_{\rm reco}|p, E)` in :ref:`irf-theory`).
+The `~gammapy.irf.PSF3D` class represents the radially symmetric probability 
+density of the angular separation between true and reconstructed directions 
+:math:`\delta p = p_{\rm true} - p_{\rm reco}` (or `rad`), as a function of 
+true energy and offset angle from the field of view center 
+(:math:`PSF(\delta p|p, E)` in :ref:`irf-theory`).
 
 Its format specifications are available in :ref:`gadf:psf_table`.
 
@@ -18,8 +21,10 @@ This is the format in which IACT DL3 PSFs are usually provided, as an example:
 
 as a function of true energy (:ref:`gadf:psf_gtpsf`)
 ----------------------------------------------------
-`~gammapy.irf.EnergyDependentTablePSF` instead represents an energy dispersion as a function of true energy only 
-(:math:`PSF(p_{\rm reco}| E)` following the notation in :ref:`irf-theory`). 
+`~gammapy.irf.EnergyDependentTablePSF` instead represents the probability density 
+of the angular separation between true direction and reconstructed directions 
+:math:`\delta p = p_{\rm true} - p_{\rm reco}` (or `rad`) as a function of true 
+energy only (:math:`PSF(\delta p| E)` following the notation in :ref:`irf-theory`). 
 
 Its format specifications are available in :ref:`gadf:psf_gtpsf`.
 
@@ -27,16 +32,17 @@ Such a PSF can be obtained by evaluating the `~gammapy.irf.PSF3D` at a given off
 
 .. plot:: irf/plot_psf_table.py
     :include-source:
-
-**Note:** the offset angle on the x axis is not an offset angle from the field of view center but the distance between 
-the source position and the reconstructed gamma ray position.  
+  
+**Note:** the offset angle on the x axis is not an offset angle from the field of view center but the above mentioned 
+angular separation between true and reconstructed direction :math:`\delta p`
+(in the IRF axis naming convention - see :ref:`irf` - the term `rad` is used for this axis).
 
 additional PSF classes
 ----------------------
 
-The remaining IRF classes implement a particular type of PSF:
+The remaining IRF classes implement:
 
- - `~gammapy.irf.EnergyDependentMultiGaussPSF` implements :ref:`gadf:psf_3gauss`;
- - `~gammapy.irf.PSFKing` implements :ref:`gadf:psf_king`;
- - `~gammapy.irf.TablePSF` implements a radially-symmetric PSF which is not energy dependent;
- - `~gammapy.irf.PSFKernel` implements a PSF that can be used to convolve `~gammapy.maps.WcsNDMap` objects;
+- `~gammapy.irf.EnergyDependentMultiGaussPSF` a PSF whose probability density is parametrised by the sum of 1 to 3 2-dimensional gaussian (definition at :ref:`gadf:psf_3gauss`);
+- `~gammapy.irf.PSFKing` a PSF whose probability density is parametrised by the King function (definition at :ref:`gadf:psf_king`);
+- `~gammapy.irf.TablePSF` a radially-symmetric PSF which is not energy dependent;
+- `~gammapy.irf.PSFKernel` a PSF that can be used to convolve `~gammapy.maps.WcsNDMap` objects;

--- a/docs/irf/psf.rst
+++ b/docs/irf/psf.rst
@@ -1,10 +1,42 @@
 .. _irf-psf:
 
-Point Spread Function
-=====================
+PSF
+===
+as a function of of true energy and offset angle (:ref:`gadf:psf_table`)
+------------------------------------------------------------------------
+The `~gammapy.irf.PSF3D` class represents the spatial probability of an event with true position :math:`p_{\rm true}` to
+have an estimated position :math:`p_{\rm reco}`, as a function of true energy and offset angle from the field of view center
+(:math:`PSF(p_{\rm reco}|p, E)` in :ref:`irf-theory`).
 
-TODO: describe / illustrate the existing classes:
+Its format specifications are available in :ref:`gadf:psf_table`.
 
-* `~gammapy.irf.PSFKernel`
-* `~gammapy.irf.PSF3D`
+This is the format in which IACT DL3 PSFs are usually provided, as an example:
 
+.. plot:: irf/plot_psf.py
+    :include-source:
+
+
+as a function of true energy (:ref:`gadf:psf_gtpsf`)
+----------------------------------------------------
+`~gammapy.irf.EnergyDependentTablePSF` instead represents an energy dispersion as a function of true energy only 
+(:math:`PSF(p_{\rm reco}| E)` following the notation in :ref:`irf-theory`). 
+
+Its format specifications are available in :ref:`gadf:psf_gtpsf`.
+
+Such a PSF can be obtained by evaluating the `~gammapy.irf.PSF3D` at a given offset (using `~astropy.coordinates.Angle`)
+
+.. plot:: irf/plot_psf_table.py
+    :include-source:
+
+**Note:** the offset angle on the x axis is not an offset angle from the field of view center but the distance between 
+the source position and the reconstructed gamma ray position.  
+
+additional PSF classes
+----------------------
+
+The remaining IRF classes implement a particular type of PSF:
+
+ - `~gammapy.irf.EnergyDependentMultiGaussPSF` implements :ref:`gadf:psf_3gauss`;
+ - `~gammapy.irf.PSFKing` implements :ref:`gadf:psf_king`;
+ - `~gammapy.irf.TablePSF` implements a radially-symmetric PSF which is not energy dependent;
+ - `~gammapy.irf.PSFKernel` implements a PSF that can be used to convolve `~gammapy.maps.WcsNDMap` objects;

--- a/docs/irf/psf.rst
+++ b/docs/irf/psf.rst
@@ -7,7 +7,7 @@ as a function of of true energy and offset angle (:ref:`gadf:psf_table`)
 ------------------------------------------------------------------------
 The `~gammapy.irf.PSF3D` class represents the radially symmetric probability 
 density of the angular separation between true and reconstructed directions 
-:math:`\delta p = p_{\rm true} - p_{\rm reco}` (or `rad`), as a function of 
+:math:`\delta p = p - p_{\rm reco}` (or `rad`), as a function of 
 true energy and offset angle from the field of view center 
 (:math:`PSF(\delta p|p, E)` in :ref:`irf-theory`).
 
@@ -23,7 +23,7 @@ as a function of true energy (:ref:`gadf:psf_gtpsf`)
 ----------------------------------------------------
 `~gammapy.irf.EnergyDependentTablePSF` instead represents the probability density 
 of the angular separation between true direction and reconstructed directions 
-:math:`\delta p = p_{\rm true} - p_{\rm reco}` (or `rad`) as a function of true 
+:math:`\delta p = p - p_{\rm reco}` (or `rad`) as a function of true 
 energy only (:math:`PSF(\delta p| E)` following the notation in :ref:`irf-theory`). 
 
 Its format specifications are available in :ref:`gadf:psf_gtpsf`.

--- a/docs/irf/theory.rst
+++ b/docs/irf/theory.rst
@@ -42,9 +42,13 @@ where:
 * :math:`A_{\rm eff}(p, E)` is the effective collection area of the detector  (unit: :math:`{\rm m}^2`). It is the product
   of the detector collection area times its detection efficiency at true energy :math:`E` and position :math:`p`.
 * :math:`PSF(p_{\rm reco}|p, E)` is the point spread function (unit: :math:`{\rm sr}^{-1}`). It gives the probability of
-  measuring a position :math:`p_{\rm reco}` when the true position is :math:`p` and the true energy is :math:`E`.
+  measuring a direction :math:`p_{\rm reco}` when the true direction is :math:`p` and the true energy is :math:`E`.
+  Gamma-ray instruments consider the probability density of the angular separation between true and reconstructed directions 
+  :math:`\delta p = p_{\rm true} - p_{\rm reco}`, i.e. :math:`PSF(\delta p|p, E)`.
 * :math:`E_{\rm disp}(E_{\rm reco}|p, E)` is the energy dispersion (unit: :math:`{\rm TeV}^{-1}`). It gives the probability to
   reconstruct the photon at energy :math:`E_{\rm reco}` when the true energy is :math:`E` and the true position :math:`p`.
+  Gamma-ray instruments consider the probability density of the migration :math:`\mu=\frac{E_{\rm reco}}{E_{\rm true}}`, 
+  i.e. :math:`E_{\rm disp}(\mu|p, E)`.
 
 The implicit assumption here is that energy dispersion and PSF are completely independent. This is not totally
 valid in some situations.
@@ -52,9 +56,6 @@ valid in some situations.
 These functions are obtained through Monte-Carlo simulations of gamma-ray showers for different observing conditions,
 e.g.  detector configuration, zenith angle of the pointing position, detector state and different event reconstruction
 and selection schemes. In the DL3 format, the IRF are distributed for each observing run.
-
-The IRF components in the DL3 format are radially symmetric in the field of view, so :math:`p` always represents an offset
-angle from the field of view center.
 
 Further details on individuals responses and how they are implemented in gammapy are given in :ref:`irf-aeff`,
 :ref:`irf-edisp` and :ref:`irf-psf`.

--- a/docs/irf/theory.rst
+++ b/docs/irf/theory.rst
@@ -53,6 +53,9 @@ These functions are obtained through Monte-Carlo simulations of gamma-ray shower
 e.g.  detector configuration, zenith angle of the pointing position, detector state and different event reconstruction
 and selection schemes. In the DL3 format, the IRF are distributed for each observing run.
 
+The IRF components in the DL3 format are radially symmetric in the field of view, so :math:`p` always represents an offset
+angle from the field of view center.
+
 Further details on individuals responses and how they are implemented in gammapy are given in :ref:`irf-aeff`,
 :ref:`irf-edisp` and :ref:`irf-psf`.
 

--- a/docs/irf/theory.rst
+++ b/docs/irf/theory.rst
@@ -9,21 +9,22 @@ Modeling the expected number of detected events
 To model the expected number of events a gamma-ray source should produce on a detector
 one has to model its effect using an instrument responce function (IRF). In general,
 such a function gives the probability to detect a photon emitted from true position :math:`p`
-on the sky and true energy :math:`E` at reconstructed position :math:`p_{rec}` and energy
-:math:`E_{rec}` and the effective collection area of the detector at position :math:`p`
+on the sky and true energy :math:`E` at reconstructed position :math:`p_{\rm reco}` and energy
+:math:`E_{\rm reco}` and the effective collection area of the detector at position :math:`p`
 on the sky and true energy :math:`E`.
 
-We can write the expected number of detected events  :math:`N(p_{rec}, E_{rec})`:
+We can write the expected number of detected events  :math:`N(p_{\rm reco}, E_{\rm reco})`:
 
 .. math::
 
-   N(p_{rec}, E_{rec}) dp_{rec} dE_{rec} = t_{obs} \int_E \int_p R(p_{rec}, E_{rec}|p, E) \times \phi(p, E) dp dE
+   N(p_{\rm reco}, E_{\rm reco}) {\rm d}p_{\rm reco} {\rm d}E_{\rm reco} = 
+   t_{\rm obs} \int_E {\rm d}E \, \int_p {\rm d}p \, R(p_{\rm reco}, E_{\rm reco}|p, E) \times \Phi(p, E)
 
 where:
 
-* :math:`R(p_{rec}, E_{rec}|p, E)` is the instrument response  (unit: :math:`m^2 TeV^{-1}`)
-* :math:`\Phi(p, E)` is the sky flux model  (unit: :math:`m^{-2} s^{-1} TeV^{-1} sr^{-1}`)
-* :math:`t_{obs}` is the observation time:  (unit: :math:`s`)
+* :math:`R(p_{\rm reco}, E_{\rm reco}|p, E)` is the instrument response  (unit: :math:`{\rm m}^2\,{\rm TeV}^{-1}`)
+* :math:`\Phi(p, E)` is the sky flux model  (unit: :math:`{\rm m}^{-2}\,{\rm s}^{-1}\,{\rm TeV}^{-1}\,{\rm sr}^{-1}`)
+* :math:`t_{\rm obs}` is the observation time:  (unit: :math:`{\rm s}`)
 
 
 The Instrument Response Functions
@@ -34,16 +35,16 @@ be simplified as the product of three independent functions:
 
 .. math::
 
-   R(p_{rec}, E_{rec}|p, E) = A_{eff}(p, E) \times PSF(p_{rec}|p, E) \times Edisp(E_{rec}|p, E),
+   R(p_{\rm reco}, E_{\rm reco}|p, E) = A_{\rm eff}(p, E) \times PSF(p_{\rm reco}|p, E) \times E_{\rm disp}(E_{\rm reco}|p, E),
 
 where:
 
-* :math:`A_{eff}(p, E)` is the effective collection area of the detector  (unit: :math:`m^2`). It is the product
+* :math:`A_{\rm eff}(p, E)` is the effective collection area of the detector  (unit: :math:`{\rm m}^2`). It is the product
   of the detector collection area times its detection efficiency at true energy :math:`E` and position :math:`p`.
-* :math:`PSF(p_{rec}|p, E)` is the point spread function (unit: :math:`sr^{-1}`). It gives the probability of
-  measuring position :math:`p_{rec}` when the true position is :math:`p` as a function of true energy :math:`E`.
-* :math:`Edisp(E_{rec}|p, E)` is the energy dispersion (unit: :math:`TeV^{-1}`). It gives the probability to
-  reconstruct the photon at energy :math:`E_{rec}` when the true energy is :math:`E` as a function of position :math:`p`.
+* :math:`PSF(p_{\rm reco}|p, E)` is the point spread function (unit: :math:`{\rm sr}^{-1}`). It gives the probability of
+  measuring a position :math:`p_{\rm reco}` when the true position is :math:`p` and the true energy is :math:`E`.
+* :math:`E_{\rm disp}(E_{\rm reco}|p, E)` is the energy dispersion (unit: :math:`{\rm TeV}^{-1}`). It gives the probability to
+  reconstruct the photon at energy :math:`E_{\rm reco}` when the true energy is :math:`E` and the true position :math:`p`.
 
 The implicit assumption here is that energy dispersion and PSF are completely independent. This is not totally
 valid in some situations.

--- a/docs/irf/theory.rst
+++ b/docs/irf/theory.rst
@@ -8,22 +8,22 @@ Modeling the expected number of detected events
 
 To model the expected number of events a gamma-ray source should produce on a detector
 one has to model its effect using an instrument responce function (IRF). In general,
-such a function gives the probability to detect a photon emitted from true position :math:`p`
-on the sky and true energy :math:`E` at reconstructed position :math:`p_{\rm reco}` and energy
-:math:`E_{\rm reco}` and the effective collection area of the detector at position :math:`p`
-on the sky and true energy :math:`E`.
+such a function gives the probability to detect a photon emitted from true position :math:`p_{\rm true}`
+on the sky and true energy :math:`E_{\rm true}` at reconstructed position :math:`p` and energy
+:math:`E` and the effective collection area of the detector at position :math:`p_{\rm true}`
+on the sky and true energy :math:`E_{\rm true}`.
 
-We can write the expected number of detected events  :math:`N(p_{\rm reco}, E_{\rm reco})`:
+We can write the expected number of detected events  :math:`N(p, E)`:
 
 .. math::
 
-   N(p_{\rm reco}, E_{\rm reco}) {\rm d}p_{\rm reco} {\rm d}E_{\rm reco} = 
-   t_{\rm obs} \int_E {\rm d}E \, \int_p {\rm d}p \, R(p_{\rm reco}, E_{\rm reco}|p, E) \times \Phi(p, E)
+   N(p, E) {\rm d}p {\rm d}E = 
+   t_{\rm obs} \int_{E_{\rm true}} {\rm d}E_{\rm true} \, \int_{p_{\rm true}} {\rm d}p_{\rm true} \, R(p, E|p_{\rm true}, E_{\rm true}) \times \Phi(p_{\rm true}, E_{\rm true})
 
 where:
 
-* :math:`R(p_{\rm reco}, E_{\rm reco}|p, E)` is the instrument response  (unit: :math:`{\rm m}^2\,{\rm TeV}^{-1}`)
-* :math:`\Phi(p, E)` is the sky flux model  (unit: :math:`{\rm m}^{-2}\,{\rm s}^{-1}\,{\rm TeV}^{-1}\,{\rm sr}^{-1}`)
+* :math:`R(p, E| p_{\rm true}, E_{\rm true})` is the instrument response  (unit: :math:`{\rm m}^2\,{\rm TeV}^{-1}`)
+* :math:`\Phi(p_{\rm true}, E_{\rm true})` is the sky flux model  (unit: :math:`{\rm m}^{-2}\,{\rm s}^{-1}\,{\rm TeV}^{-1}\,{\rm sr}^{-1}`)
 * :math:`t_{\rm obs}` is the observation time:  (unit: :math:`{\rm s}`)
 
 
@@ -35,20 +35,20 @@ be simplified as the product of three independent functions:
 
 .. math::
 
-   R(p_{\rm reco}, E_{\rm reco}|p, E) = A_{\rm eff}(p, E) \times PSF(p_{\rm reco}|p, E) \times E_{\rm disp}(E_{\rm reco}|p, E),
+   R(p, E|p_{\rm true}, E_{\rm true}) = A_{\rm eff}(p_{\rm true}, E_{\rm true}) \times PSF(p|p_{\rm true}, E_{\rm true}) \times E_{\rm disp}(E|p_{\rm true}, E_{\rm true}),
 
 where:
 
-* :math:`A_{\rm eff}(p, E)` is the effective collection area of the detector  (unit: :math:`{\rm m}^2`). It is the product
-  of the detector collection area times its detection efficiency at true energy :math:`E` and position :math:`p`.
-* :math:`PSF(p_{\rm reco}|p, E)` is the point spread function (unit: :math:`{\rm sr}^{-1}`). It gives the probability of
-  measuring a direction :math:`p_{\rm reco}` when the true direction is :math:`p` and the true energy is :math:`E`.
+* :math:`A_{\rm eff}(p_{\rm true}, E_{\rm true})` is the effective collection area of the detector  (unit: :math:`{\rm m}^2`). It is the product
+  of the detector collection area times its detection efficiency at true energy :math:`E_{\rm true}` and position :math:`p_{\rm true}`.
+* :math:`PSF(p|p_{\rm true}, E_{\rm true})` is the point spread function (unit: :math:`{\rm sr}^{-1}`). It gives the probability of
+  measuring a direction :math:`p` when the true direction is :math:`p_{\rm true}` and the true energy is :math:`E_{\rm true}`.
   Gamma-ray instruments consider the probability density of the angular separation between true and reconstructed directions 
-  :math:`\delta p = p - p_{\rm reco}`, i.e. :math:`PSF(\delta p|p, E)`.
-* :math:`E_{\rm disp}(E_{\rm reco}|p, E)` is the energy dispersion (unit: :math:`{\rm TeV}^{-1}`). It gives the probability to
-  reconstruct the photon at energy :math:`E_{\rm reco}` when the true energy is :math:`E` and the true position :math:`p`.
-  Gamma-ray instruments consider the probability density of the migration :math:`\mu=\frac{E_{\rm reco}}{E}`, 
-  i.e. :math:`E_{\rm disp}(\mu|p, E)`.
+  :math:`\delta p = p_{\rm true} - p`, i.e. :math:`PSF(\delta p|p_{\rm true}, E_{\rm true})`.
+* :math:`E_{\rm disp}(E|p_{\rm true}, E_{\rm true})` is the energy dispersion (unit: :math:`{\rm TeV}^{-1}`). It gives the probability to
+  reconstruct the photon at energy :math:`E` when the true energy is :math:`E_{\rm true}` and the true position :math:`p_{\rm true}`.
+  Gamma-ray instruments consider the probability density of the migration :math:`\mu=\frac{E}{E_{\rm true}}`, 
+  i.e. :math:`E_{\rm disp}(\mu|p_{\rm true}, E_{\rm true})`.
 
 The implicit assumption here is that energy dispersion and PSF are completely independent. This is not totally
 valid in some situations.

--- a/docs/irf/theory.rst
+++ b/docs/irf/theory.rst
@@ -44,10 +44,10 @@ where:
 * :math:`PSF(p_{\rm reco}|p, E)` is the point spread function (unit: :math:`{\rm sr}^{-1}`). It gives the probability of
   measuring a direction :math:`p_{\rm reco}` when the true direction is :math:`p` and the true energy is :math:`E`.
   Gamma-ray instruments consider the probability density of the angular separation between true and reconstructed directions 
-  :math:`\delta p = p_{\rm true} - p_{\rm reco}`, i.e. :math:`PSF(\delta p|p, E)`.
+  :math:`\delta p = p - p_{\rm reco}`, i.e. :math:`PSF(\delta p|p, E)`.
 * :math:`E_{\rm disp}(E_{\rm reco}|p, E)` is the energy dispersion (unit: :math:`{\rm TeV}^{-1}`). It gives the probability to
   reconstruct the photon at energy :math:`E_{\rm reco}` when the true energy is :math:`E` and the true position :math:`p`.
-  Gamma-ray instruments consider the probability density of the migration :math:`\mu=\frac{E_{\rm reco}}{E_{\rm true}}`, 
+  Gamma-ray instruments consider the probability density of the migration :math:`\mu=\frac{E_{\rm reco}}{E}`, 
   i.e. :math:`E_{\rm disp}(\mu|p, E)`.
 
 The implicit assumption here is that energy dispersion and PSF are completely independent. This is not totally


### PR DESCRIPTION
I have been using the `gammapy.irf` classes a lot lately and noticed the documentation was incomplete and 
contained references to classes that do not exist anymore.

All the `.rst` files containing the irf components description have been updated. 
I linked every IRF components to the corresponding description in the OGADF format and provided a snippet of code
opening and visualising the component of a run of the HESS DL3 DR1 
(I think more detailed functionalities are anyhow covered by the API and the tutorial notebooks).

Let me know if the new irf documentation structure sits well with you, if it is too little or to much detailed.
I am also not familiar with the PSF classes so if something has to be improved there let me know. 

Thank you,

Cosimo