### PR TITLE
fixed broken link in bkg.rst irf documentation

### DIFF
--- a/docs/irf/bkg.rst
+++ b/docs/irf/bkg.rst
@@ -25,4 +25,4 @@ Its format specifications are available in :ref:`gadf:bkg_2d`.
 
 You can produce a radially-symmetric background from a list of DL3 observations 
 devoid of gamma-ray signal using the tutorial in 
-`background_model.html <../tutorials/backgorund_model.html>`__ 
+`background_model.html <../tutorials/background_model.html>`__ 


### PR DESCRIPTION
Checking the generated docs I spotted a broken link in the background description.
Fixed, apologies it was my mistake from the previous PR.