### PR TITLE
Remove pre-processing from Fermi tutorial

### DIFF
--- a/docs/tutorials/fermi_lat.ipynb
+++ b/docs/tutorials/fermi_lat.ipynb
@@ -69,7 +69,6 @@
     "    PowerLawNormSpectralModel,\n",
     "    Models,\n",
     "    create_fermi_isotropic_diffuse_model,\n",
-    "    BackgroundModel,\n",
     ")\n",
     "from gammapy.modeling import Fit"
    ]
@@ -332,20 +331,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Interpolate the diffuse emission model onto the counts geometry\n",
-    "# The resolution of `diffuse_galactic_fermi` is low: bin size = 0.5 deg\n",
-    "# We use ``interp=3`` which means cubic spline interpolation\n",
-    "coord = exposure.geom.get_coord()\n",
-    "\n",
-    "data = diffuse_galactic_fermi.interp_by_coord(\n",
-    "    {\"skycoord\": coord.skycoord, \"energy_true\": coord[\"energy_true\"]}, interp=3\n",
-    ")\n",
-    "diffuse_galactic = WcsNDMap(\n",
-    "    exposure.geom, data, unit=diffuse_galactic_fermi.unit\n",
-    ")\n",
-    "diffuse_gal = TemplateSpatialModel(diffuse_galactic, normalize=False)\n",
-    "print(diffuse_galactic.geom)\n",
-    "print(diffuse_galactic.geom.axes[0])"
+    "template_diffuse = TemplateSpatialModel(diffuse_galactic_fermi, normalize=False)"
    ]
   },
   {
@@ -355,7 +341,9 @@
    "outputs": [],
    "source": [
     "diffuse_iem = SkyModel(\n",
-    "    PowerLawNormSpectralModel(), diffuse_gal, name=\"diffuse-iem\"\n",
+    "    spectral_model=PowerLawNormSpectralModel(),\n",
+    "    spatial_model=template_diffuse,\n",
+    "    name=\"diffuse-iem\"\n",
     ")"
    ]
   },
@@ -372,7 +360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diffuse_gal.map.slice_by_idx({\"energy_true\": 0}).plot(add_cbar=True);"
+    "template_diffuse.map.slice_by_idx({\"energy_true\": 0}).plot(add_cbar=True);"
    ]
   },
   {
@@ -390,7 +378,7 @@
    "source": [
     "# Exposure varies very little with energy at these high energies\n",
     "energy = np.logspace(1, 3, 10) * u.GeV\n",
-    "dnde = diffuse_gal.map.interp_by_coord(\n",
+    "dnde = template_diffuse.map.interp_by_coord(\n",
     "    {\"skycoord\": gc_pos, \"energy_true\": energy},\n",
     "    interp=\"linear\",\n",
     "    fill_value=None,\n",
@@ -566,35 +554,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Pre-processing\n",
-    "\n",
-    "The model components for which only a norm is fitted can be pre-processed so we don't have to apply the IRF at each iteration of the fit and then save computation time. This can be done using the `MapEvaluator`.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# pre-compute iso model\n",
-    "evaluator = MapEvaluator(diffuse_iso)\n",
-    "evaluator.update(exposure=exposure, psf=psf, edisp=edisp, geom=counts.geom)\n",
-    "diffuse_iso = BackgroundModel(evaluator.compute_npred(), name=\"bkg-iso\")\n",
-    "diffuse_iso.spectral_model.norm.value = 3.3\n",
-    "# pre-compute diffuse model\n",
-    "evaluator = MapEvaluator(diffuse_iem)\n",
-    "evaluator.update(exposure=exposure, psf=psf, edisp=edisp, geom=counts.geom)\n",
-    "\n",
-    "diffuse_iem = BackgroundModel(evaluator.compute_npred(), name=\"bkg-iem\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Fit\n",
-    "Finally, the big finale: let’s do a 3D map fit for the source at the Galactic center, to measure it’s position and spectrum. We keep the background normalization free."
+    "Now, the big finale: let’s do a 3D map fit for the source at the Galactic center, to measure it’s position and spectrum. We keep the background normalization free."
    ]
   },
   {
@@ -702,7 +663,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,
@@ -710,9 +671,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1.0,
+   "current_citInitial": 1,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1.0,
+   "eqNumInitial": 1,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"
@@ -723,7 +684,7 @@
    "user_envs_cfg": false
   },
   "toc": {
-   "base_numbering": 1.0,
+   "base_numbering": 1,
    "nav_menu": {
     "height": "237px",
     "width": "253px"
@@ -740,9 +701,9 @@
   },
   "varInspector": {
    "cols": {
-    "lenName": 16.0,
-    "lenType": 16.0,
-    "lenVar": 40.0
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
    },
    "kernels_config": {
     "python": {

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -539,7 +539,7 @@ class EnergyDependentTablePSF:
         for fraction in fractions:
             rad = self.containment_radius(self.energy_axis_true.center, fraction)
             label = f"{100 * fraction:.1f}% Containment"
-            ax.plot(self.energy_axis_true.center.value, rad.value, label=label, **kwargs)
+            ax.plot(self.energy_axis_true.center.to("GeV").value, rad.to("deg").value, label=label, **kwargs)
 
         ax.semilogx()
         ax.legend(loc="best")

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -1,17 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Cube models (axes: lon, lat, energy)."""
 import copy
-from pathlib import Path
 import numpy as np
 import astropy.units as u
 from gammapy.maps import Map, MapAxis, RegionGeom, WcsGeom
-from gammapy.modeling import Covariance, Parameter, Parameters
+from gammapy.modeling import Covariance, Parameters
 from gammapy.modeling.parameter import _get_parameters_str
 from gammapy.utils.scripts import make_name, make_path
-from gammapy.utils.fits import LazyFitsData, HDULocation
+from gammapy.utils.fits import LazyFitsData
 from .core import Model, Models
-from .spatial import SpatialModel
-from .spectral import SpectralModel, PowerLawNormSpectralModel
+from .spatial import SpatialModel, ConstantSpatialModel
+from .spectral import SpectralModel, PowerLawNormSpectralModel, TemplateSpectralModel
 from .temporal import TemporalModel
 
 
@@ -626,9 +625,6 @@ def create_fermi_isotropic_diffuse_model(filename, **kwargs):
     diffuse_model : `SkyModel`
         Fermi isotropic diffuse sky model.
     """
-    from .spectral import TemplateSpectralModel
-    from .spatial import ConstantSpatialModel
-
     vals = np.loadtxt(make_path(filename))
     energy = u.Quantity(vals[:, 0], "MeV", copy=False)
     values = u.Quantity(vals[:, 1], "MeV-1 s-1 cm-2", copy=False)
@@ -644,4 +640,5 @@ def create_fermi_isotropic_diffuse_model(filename, **kwargs):
         spatial_model=spatial_model,
         spectral_model=spectral_model,
         name="fermi-diffuse-iso",
+        apply_irf={"psf": False, "exposure": True, "edisp": True}
     )

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -72,6 +72,11 @@ class SpectralModel(Model):
     def type(self):
         return self._type
 
+    @property
+    def is_norm_spectral_model(self):
+        """Whether model is a norm spectral model"""
+        return "Norm" in self.__class__.__name__
+
     @staticmethod
     def _convert_evaluate_unit(kwargs_ref, energy):
         kwargs = {}


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request remove the pre-processing from the Fermi-LAT tutorial. Yes, it speeds up the computation to do this, but we shouldn't encourage this as the standard way to work with the Fermi background models. Internally we can still improve our caching mechanism to further improve the performance in future...

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
