### PR TITLE
Remove intervals option from integrate_spectrum()

### DIFF
--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -31,5 +31,5 @@ def test_dmfluxmap(jfact):
     diff_flux = DarkMatterAnnihilationSpectralModel(mass=massDM, channel=channel)
     int_flux = (jfact * diff_flux.integral(emin=emin, emax=emax)).to("cm-2 s-1")
     actual = int_flux[5, 5]
-    desired = 1.94834138e-12 / u.cm ** 2 / u.s
+    desired = 1.948246e-12 / u.cm ** 2 / u.s
     assert_quantity_allclose(actual, desired, rtol=1e-5)

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -31,5 +31,5 @@ def test_dmfluxmap(jfact):
     diff_flux = DarkMatterAnnihilationSpectralModel(mass=massDM, channel=channel)
     int_flux = (jfact * diff_flux.integral(emin=emin, emax=emax)).to("cm-2 s-1")
     actual = int_flux[5, 5]
-    desired = 1.948246e-12 / u.cm ** 2 / u.s
-    assert_quantity_allclose(actual, desired, rtol=1e-5)
+    desired = 1.9483e-12 / u.cm ** 2 / u.s
+    assert_quantity_allclose(actual, desired, rtol=1e-3)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2392,7 +2392,7 @@ class MapEvaluator:
         """Compute spectral flux"""
         energy = self.geom.axes["energy_true"].edges
         value = self.model.spectral_model.integral(
-            energy[:-1], energy[1:], intervals=True
+            energy[:-1], energy[1:],
         )
         return value.reshape((-1, 1, 1))
 

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -49,7 +49,7 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
 
     result = estimator.run(fermi_datasets)
 
-    assert_allclose(result["norm"], 1.010983, atol=1e-3)
+    assert_allclose(result["norm"], 1.003784, atol=1e-3)
     assert_allclose(result["ts"], 28086.565, atol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
     assert_allclose(result["norm_errn"], 0.0199, atol=1e-3)
@@ -71,7 +71,7 @@ def test_flux_estimator_fermi_with_reoptimization(fermi_datasets):
     )
     result = estimator.run(fermi_datasets)
 
-    assert_allclose(result["norm"], 1.010983, atol=1e-3)
+    assert_allclose(result["norm"], 1.003784, atol=1e-3)
     assert_allclose(result["ts"], 20896.1864, atol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
 
@@ -114,8 +114,8 @@ def test_inhomogeneous_datasets(fermi_datasets, hess_datasets):
     )
     result = estimator.run(datasets)
 
-    assert_allclose(result["norm"], 1.022802, atol=1e-3)
-    assert_allclose(result["ts"], 21584.515969, atol=1e-3)
+    assert_allclose(result["norm"], 1.015983, atol=1e-3)
+    assert_allclose(result["ts"], 21584.092045, atol=1e-3)
     assert_allclose(result["norm_err"], 0.01966, atol=1e-3)
 
 

--- a/gammapy/estimators/tests/test_parameter_estimator.py
+++ b/gammapy/estimators/tests/test_parameter_estimator.py
@@ -65,6 +65,6 @@ def test_parameter_estimator_3d_no_reoptimization(crab_datasets_fermi):
 
     assert not datasets[0].models.parameters["alpha"].frozen
     assert_allclose(datasets[0].models.parameters["alpha"].value, alpha_value)
-    assert_allclose(result["amplitude"], 0.018381, rtol=1e-4)
+    assert_allclose(result["amplitude"], 0.018251, rtol=1e-4)
     assert_allclose(result["amplitude_scan"].shape, 10)
     assert_allclose(result["amplitude_scan"][0], 0.017282, atol=1e-3)

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -370,7 +370,7 @@ class PSF3D:
         esafe = self.energy_thresh_lo
         omin = self.offset_axis.center.value.min()
         omax = self.offset_axis.center.value.max()
-        ax.hlines(y=esafe.value, xmin=omin, xmax=omax)
+        ax.vlines(x=esafe.value, ymin=omin, ymax=omax)
         label = f"Safe energy threshold: {esafe:3.2f}"
         ax.text(x=0.1, y=0.9 * esafe.value, s=label, va="top")
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -87,9 +87,7 @@ def _map_spectrum_weight(map, spectrum=None):
 
     # Compute weights vector
     energy_edges = map.geom.axes["energy_true"].edges
-    weights = spectrum.integral(
-        emin=energy_edges[:-1], emax=energy_edges[1:], intervals=True
-    )
+    weights = spectrum.integral(emin=energy_edges[:-1], emax=energy_edges[1:])
     weights /= weights.sum()
     shape = np.ones(len(map.geom.data_shape))
     shape[0] = -1

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -678,6 +678,20 @@ class MapAxis:
         return self._nbin
 
     @property
+    def nbin_per_decade(self):
+        """Return number of bins."""
+        if self.interp != "log":
+            raise ValueError("Bins per decade can only be computed for log-spaced axes")
+
+        if self.node_type == "edges":
+            values = self.edges
+        else:
+            values = self.center
+
+        ndecades = np.log10(values.max() / values.min())
+        return (self._nbin / ndecades).value
+
+    @property
     def node_type(self):
         """Return node type ('center' or 'edge')."""
         return self._node_type

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 from astropy.io import fits
+from astropy import units as u
 from gammapy.utils.random import get_random_state
 
 
@@ -142,6 +143,9 @@ def find_bintable_hdu(hdulist):
 
 
 def edges_from_lo_hi(edges_lo, edges_hi):
+    if np.isscalar(edges_lo.value) and np.isscalar(edges_hi.value):
+        return u.Quantity([edges_lo, edges_hi])
+
     edges = edges_lo.copy()
     try:
         edges = edges.insert(len(edges), edges_hi[-1])

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -279,7 +279,7 @@ class SkyModel(SkyModelBase):
         """
         energy = geom.axes["energy_true"].edges
         value = self.spectral_model.integral(
-            energy[:-1], energy[1:], intervals=True
+            energy[:-1], energy[1:],
         ).reshape((-1, 1, 1))
 
         if self.spatial_model and not isinstance(geom, RegionGeom):

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -254,7 +254,7 @@ def test_models_management(tmp_path):
     npred1b = datasets[0].npred().data.sum()
     assert npred1b != npred1
     assert npred1b != npred0
-    assert_allclose(npred1b, 5157.137554, rtol=1e-5)
+    assert_allclose(npred1b, 5212.266068, rtol=1e-5)
 
     datasets.models.remove(model1b)
     _ = datasets.models  # auto-update models

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -834,7 +834,7 @@ def test_energy_flux_error_ExpCutOffPowerLaw():
     exppowerlaw.parameters['amplitude'].error = 1e-13
     exppowerlaw.parameters['lambda_'].error = 0.03
 
-    enrg_flux, enrg_flux_error = exppowerlaw.energy_flux_error(emin,emax, intervals=False)
+    enrg_flux, enrg_flux_error = exppowerlaw.energy_flux_error(emin, emax)
 
     assert_allclose(enrg_flux.value/1e-12, 2.788, rtol=0.001)
     assert_allclose(enrg_flux_error.value/1e-12, 2.226, rtol=0.001)

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -162,19 +162,45 @@ def plot_theta_squared_table(table):
     )
 
     ax0 = plt.subplot(2, 1, 1)
-    xerr = (theta2_axis.center - theta2_axis.edges[:-1], theta2_axis.edges[1:] - theta2_axis.center)
+
+    x = theta2_axis.center.value
+    x_edges = theta2_axis.edges.value
+    xerr = (x - x_edges[:-1], x_edges[1:] - x)
 
     ax0.errorbar(
-        theta2_axis.center, table["counts"], xerr=xerr, yerr=np.sqrt(table["counts"]), linestyle='None', label="Counts")
-    ax0.errorbar(theta2_axis.center, table["counts_off"], xerr=xerr, yerr=np.sqrt(table["counts_off"]), linestyle='None',
-                 label="Counts Off")
-    ax0.errorbar(theta2_axis.center, table["excess"], xerr=xerr, yerr=(-table["excess_errn"], table["excess_errp"]), fmt="+",
-                 linestyle='None', label="Excess")
+        x,
+        table["counts"],
+        xerr=xerr,
+        yerr=np.sqrt(table["counts"]),
+        linestyle='None',
+        label="Counts"
+    )
+
+    ax0.errorbar(
+        x,
+        table["counts_off"],
+        xerr=xerr,
+        yerr=np.sqrt(table["counts_off"]),
+        linestyle='None',
+        label="Counts Off"
+    )
+
+    ax0.errorbar(
+        x,
+        table["excess"],
+        xerr=xerr,
+        yerr=(-table["excess_errn"], table["excess_errp"]),
+        fmt="+",
+        linestyle='None',
+        label="Excess"
+    )
+
     ax0.set_ylabel("Counts")
     ax0.set_xticks([])
     ax0.set_xlabel('')
     ax0.legend()
+
     ax1 = plt.subplot(2, 1, 2)
-    ax1.errorbar(theta2_axis.center, table["sqrt_ts"], xerr=xerr, linestyle='None')
+    ax1.errorbar(x, table["sqrt_ts"], xerr=xerr, linestyle='None')
     ax1.set_xlabel(f"Theta  [{theta2_axis.unit}]")
     ax1.set_ylabel("Significance")

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -156,7 +156,7 @@ def plot_theta_squared_table(table):
     """
     import matplotlib.pyplot as plt
 
-    theta2_edges = edges_from_lo_hi(table["theta2_min"], table["theta2_max"])
+    theta2_edges = edges_from_lo_hi(table["theta2_min"].quantity, table["theta2_max"].quantity)
     theta2_axis = MapAxis.from_edges(
         theta2_edges, interp="lin", name="theta_squared"
     )


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request removes the `intervals` option from the `intergrate_spectrum`. I realised this option is basically not needed. The behaviour is now that `integrate_spectrum()` returns a single number if `emin` and `emax` are scalars, otherwise it just returns an array. Internally it always uses an integration precision, provided by the `ndecade` argument in both cases...

As we rely in addition on trapezoidal log-log integration, we could probably reduce the default integration precision of `ndecade=100`, but this can be done later. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
