### PR TITLE
Fix model evaluation for point source model and speed up generalised gaussian tests

### DIFF
--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -131,6 +131,7 @@ class WcsGeom(Geom):
 
         # define cached methods
         self.get_coord = lru_cache()(self.get_coord)
+        self.get_pix = lru_cache()(self.get_pix)
         self.solid_angle = lru_cache()(self.solid_angle)
         self.bin_volume = lru_cache()(self.bin_volume)
         self.to_image = lru_cache()(self.to_image)
@@ -148,7 +149,7 @@ class WcsGeom(Geom):
 
     def __setstate__(self, state):
         for key, value in state.items():
-            if key in ["get_coord", "solid_angle", "bin_volume", "to_image"]:
+            if key in ["get_coord", "solid_angle", "bin_volume", "to_image", "get_pix"]:
                 state[key] = lru_cache()(value)
 
         self.__dict__ = state

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -109,26 +109,27 @@ def test_sky_gaussian():
 @pytest.mark.parametrize("r_0", np.arange(0.1, 1.01, 0.3))
 @pytest.mark.parametrize("e", np.arange(0.0, 0.801, 0.4))
 def test_generalized_gaussian(eta, r_0, e):
-    reval = 6
-    dr = 0.01
-    geom = WcsGeom.create(
-        skydir=(0, 0), binsz=dr, width=(2 * reval, 2 * reval), frame="galactic",
-    )
-
     # check normalization is robust for a large set of values
     model = GeneralizedGaussianSpatialModel(
         eta=eta, r_0=r_0 * u.deg, e=e, frame="galactic"
     )
 
-    eval_geom = model.evaluate_geom(geom)
-    integ_geom = model.integrate_geom(geom)
-    assert eval_geom.unit.is_equivalent("sr-1")
-    assert integ_geom.unit.is_equivalent("")
-    assert_allclose(integ_geom.data.sum(), 1.0, atol=3e-2)
+    geom = WcsGeom.create(
+        skydir=(0, 0), binsz=0.02, width=2 * model.evaluation_radius, frame="galactic",
+    )
+
+    integral = model.integrate_geom(geom)
+    assert integral.unit.is_equivalent("")
+    assert_allclose(integral.data.sum(), 1.0, atol=5e-3)
+
+
+def test_generalized_gaussian_io():
+    model = GeneralizedGaussianSpatialModel()
+
     assert isinstance(model.to_region(), EllipseSkyRegion)
     new_model = GeneralizedGaussianSpatialModel.from_dict(model.to_dict())
+
     assert isinstance(new_model, GeneralizedGaussianSpatialModel)
-    assert_allclose(new_model.integrate_geom(geom).data.sum(), integ_geom.data.sum())
 
 
 def test_sky_disk():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->


@LauraOlivera reported a significant performance decrease for fitting a point source in one of her scripts. Looking into it I noticed, that when we introduced the energy dependent spatial models, the special case of the `PointSpatialModel` was not implemented in an efficient way. In the `.integrate_geom()` the full 3D geom was used to compute the weights. However a point source is never energy dependent so it's sufficient to compute the weights on the 2D grid and rely on broadcasting. 

I also noticed that the tests of the generalised gaussian were really slow and not very precise. I changed the evaluation radius of the generalised gaussian to something empirical, which approaches r_0 for the disk case and 5 * r_0 for the Gaussian case. It's probably still not good, but it it's better than the hard-coded 5 * r_0....

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
