### PR TITLE
Print parameter values to 4 significant digits

### DIFF
--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -406,7 +406,8 @@ class Parameters(collections.abc.Sequence):
         rows = [p.to_dict() for p in self._parameters]
         table = table_from_row_data(rows)
 
-        for name in ["value", "error", "min", "max"]:
+        table["value"].format = ".4e"
+        for name in ["error", "min", "max"]:
             table[name].format = ".3e"
 
         return table


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

Currently, `Parameters.to_table()` prints the values of the parameters to 3 significant places.
This is sometimes annoying for the longitude values, eg: `3.324e+02` where we do not know what the second value place is.

This is a small PR to fix the same.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
