### PR TITLE
Fix some comments in the tutorial hess.ipynb

### DIFF
--- a/docs/tutorials/hess.ipynb
+++ b/docs/tutorials/hess.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "[H.E.S.S.](https://www.mpi-hd.mpg.de/hfm/HESS/) is an array of gamma-ray telescopes located in Namibia. Gammapy is regularly used and fully supports H.E.S.S. high-level data analysis, after export to the current [open data level 3 format](https://gamma-astro-data-formats.readthedocs.io/).\n",
     "\n",
-    "The H.E.S.S. data is private, and H.E.S.S. analysis is mostly documented and discussed at https://hess-confluence.desy.de/ and in H.E.S.S.-internal communication channels. However, in 2018, a small sub-set of archival H.E.S.S. data was publicly released, called the [H.E.S.S. DL3 DR1](https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/), the data level 3, data release number 1. This dataset is 50 MB in size and is used in many Gammapy analysis tutorials, and can be downloaded via `gammapy download` (TODO: add link to description).\n",
+    "The H.E.S.S. data is private, and H.E.S.S. analysis is mostly documented and discussed at https://hess-confluence.desy.de/ and in H.E.S.S.-internal communication channels. However, in 2018, a small sub-set of archival H.E.S.S. data was publicly released, called the [H.E.S.S. DL3 DR1](https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/), the data level 3, data release number 1. This dataset is 50 MB in size and is used in many Gammapy analysis tutorials, and can be downloaded via [`gammapy download`](https://docs.gammapy.org/dev/scripts/index.html?highlight=download).\n",
     "\n",
     "This notebook is a quick introduction to H.E.S.S. data and instrument responses and contains some specifics that are important for H.E.S.S. users:\n",
     "\n",
@@ -133,7 +133,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Theta sqared event distribution\n",
+    "## Theta squared event distribution\n",
     "As a quick look plot it can be helpful to plot the quadratic offset (theta squared) distribution of the events. "
    ]
   },


### PR DESCRIPTION

This pull request fixes a typo disabling to find the method to make theta-squared plot when using the search bar of the doc.
I have added a missing web link (quoted as ToDo).

