### PR TITLE
Enable different axis orders in Background fits files 

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -111,9 +111,14 @@ class Background3D:
         #  have a reverse order (lon, lat, E) than recommened in GADF(E, lat, lon)
         #  For now, we suport both.
 
-        data = table[bkg_name].data[0] * data_unit
+        data = table[bkg_name].data[0].T * data_unit
         shape = (energy_axis.nbin, fov_lon_axis.nbin, fov_lat_axis.nbin)
+
+        if shape == shape[::-1]:
+            log.error("Ambiguous axes order in Background fits files!")
+
         if np.shape(data) != shape:
+            log.debug("Transposing background table on read")
             data = data.transpose()
 
         return cls(
@@ -289,9 +294,14 @@ class Background2D:
         # have a reverse order (theta, E) than recommened in GADF(E, theta)
         # For now, we suport both.
 
-        data = table[bkg_name].data[0] * data_unit
+        data = table[bkg_name].data[0].T * data_unit
         shape = (energy_axis.nbin, offset_axis.nbin)
+
+        if shape == shape[::-1]:
+            log.error("Ambiguous axes order in Background fits files!")
+
         if np.shape(data) != shape:
+            log.debug("Transposing background table on read")
             data = data.transpose()
 
         return cls(

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -88,8 +88,10 @@ class Background3D:
         else:
             raise ValueError('Invalid column names. Need "BKG" or "BGD".')
 
-        data_unit = u.Unit(table[bkg_name].unit, parse_strict="silent")
-        if isinstance(data_unit, u.UnrecognizedUnit):
+        data_unit = table[bkg_name].unit
+        if data_unit is not None:
+            data_unit = u.Unit(table[bkg_name].unit, parse_strict="silent")
+        if isinstance(data_unit, u.UnrecognizedUnit) or (data_unit is None):
             data_unit = u.Unit("s-1 MeV-1 sr-1")
             log.warning(
                 "Invalid unit found in background table! Assuming (s-1 MeV-1 sr-1)"
@@ -105,11 +107,20 @@ class Background3D:
             table, column_prefix="DETY", format="gadf-dl3"
         )
 
+        # TODO: The present HESS and CTA backgroundfits files
+        #  have a reverse order (lon, lat, E) than recommened in GADF(E, lat, lon)
+        #  For now, we suport both.
+
+        data = table[bkg_name].data[0] * data_unit
+        shape = (energy_axis.nbin, fov_lon_axis.nbin, fov_lat_axis.nbin)
+        if np.shape(data) != shape:
+            data = data.transpose()
+
         return cls(
             energy_axis=energy_axis,
             fov_lon_axis=fov_lon_axis,
             fov_lat_axis=fov_lat_axis,
-            data=table[bkg_name].data[0] * data_unit,
+            data=data,
             meta=table.meta,
         )
 
@@ -130,7 +141,7 @@ class Background3D:
         axes = MapAxes(self.data.axes[::-1])
         table = axes.to_table(format="gadf-dl3")
         table.meta = self.meta.copy()
-        table["BKG"] = self.data.data[np.newaxis]
+        table["BKG"] = self.data.data.T[np.newaxis]
         return table
 
     def to_table_hdu(self, name="BACKGROUND"):
@@ -258,8 +269,10 @@ class Background2D:
         else:
             raise ValueError('Invalid column names. Need "BKG" or "BGD".')
 
-        data_unit = u.Unit(table[bkg_name].unit, parse_strict="silent")
-        if isinstance(data_unit, u.UnrecognizedUnit):
+        data_unit = table[bkg_name].unit
+        if data_unit is not None:
+            data_unit = u.Unit(data_unit, parse_strict="silent")
+        if isinstance(data_unit, u.UnrecognizedUnit) or (data_unit is None):
             data_unit = u.Unit("s-1 MeV-1 sr-1")
             log.warning(
                 "Invalid unit found in background table! Assuming (s-1 MeV-1 sr-1)"
@@ -272,10 +285,19 @@ class Background2D:
             table, column_prefix="THETA", format="gadf-dl3"
         )
 
+        # TODO: The present HESS and CTA backgroundfits files
+        # have a reverse order (theta, E) than recommened in GADF(E, theta)
+        # For now, we suport both.
+
+        data = table[bkg_name].data[0] * data_unit
+        shape = (energy_axis.nbin, offset_axis.nbin)
+        if np.shape(data) != shape:
+            data = data.transpose()
+
         return cls(
             energy_axis=energy_axis,
             offset_axis=offset_axis,
-            data=table[bkg_name].data[0] * data_unit,
+            data=data,
             meta=table.meta,
         )
 
@@ -294,7 +316,7 @@ class Background2D:
         """Convert to `~astropy.table.Table`."""
         table = self.data.axes.to_table(format="gadf-dl3")
         table.meta = self.meta.copy()
-        table["BKG"] = self.data.data[np.newaxis]
+        table["BKG"] = self.data.data.T[np.newaxis]
         return table
 
     def to_table_hdu(self, name="BACKGROUND"):

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -144,6 +144,15 @@ def test_background_3D_read():
     assert data.unit == "s-1 MeV-1 sr-1"
 
 
+@requires_data()
+def test_background_3D_read_gadf():
+    filename = "$GAMMAPY_DATA/tests/bkg_3d_full_example.fits"
+    bkg = Background3D.read(filename)
+    data = bkg.data.data
+    assert data.shape == (20, 15, 15)
+    assert data.unit == "s-1 MeV-1 sr-1"
+
+
 @requires_dependency("matplotlib")
 def test_plot(bkg_2d):
     with mpl_plot_check():
@@ -161,11 +170,7 @@ def bkg_2d():
     data = np.zeros((2, 3)) * u.Unit("s-1 MeV-1 sr-1")
     data.value[1, 0] = 2
     data.value[1, 1] = 4
-    return Background2D(
-        energy_axis=energy_axis,
-        offset_axis=offset_axis,
-        data=data,
-    )
+    return Background2D(energy_axis=energy_axis, offset_axis=offset_axis, data=data,)
 
 
 def test_background_2d_evaluate(bkg_2d):
@@ -214,6 +219,15 @@ def test_background_2d_read_write(tmp_path, bkg_2d):
 
     data = bkg_2d_2.data.data
     assert data.shape == (2, 3)
+    assert data.unit == "s-1 MeV-1 sr-1"
+
+
+@requires_data()
+def test_background_2D_read_gadf():
+    filename = "$GAMMAPY_DATA/tests/bkg_2d_full_example.fits"
+    bkg = Background2D.read(filename)
+    data = bkg.data.data
+    assert data.shape == (20, 5)
     assert data.unit == "s-1 MeV-1 sr-1"
 
 

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -140,15 +140,17 @@ def test_background_3D_read():
     )
     bkg = Background3D.read(filename)
     data = bkg.data.data
+    assert bkg.data.axes.names == ["energy", "fov_lon", "fov_lat"]
     assert data.shape == (21, 36, 36)
     assert data.unit == "s-1 MeV-1 sr-1"
 
 
 @requires_data()
 def test_background_3D_read_gadf():
-    filename = "$GAMMAPY_DATA/tests/bkg_3d_full_example.fits"
+    filename = "$GAMMAPY_DATA/tests/irf/bkg_3d_full_example.fits"
     bkg = Background3D.read(filename)
     data = bkg.data.data
+    assert bkg.data.axes.names == ["energy", "fov_lon", "fov_lat"]
     assert data.shape == (20, 15, 15)
     assert data.unit == "s-1 MeV-1 sr-1"
 
@@ -224,10 +226,11 @@ def test_background_2d_read_write(tmp_path, bkg_2d):
 
 @requires_data()
 def test_background_2D_read_gadf():
-    filename = "$GAMMAPY_DATA/tests/bkg_2d_full_example.fits"
+    filename = "$GAMMAPY_DATA/tests/irf/bkg_2d_full_example.fits"
     bkg = Background2D.read(filename)
     data = bkg.data.data
     assert data.shape == (20, 5)
+    assert bkg.data.axes.names == ["energy", "offset"]
     assert data.unit == "s-1 MeV-1 sr-1"
 
 

--- a/gammapy/irf/tests/test_irf_write.py
+++ b/gammapy/irf/tests/test_irf_write.py
@@ -9,10 +9,10 @@ from gammapy.maps import MapAxis
 
 class TestIRFWrite:
     def setup(self):
-        self.energy_lo = np.logspace(0, 1, 11)[:-1] * u.TeV
-        self.energy_hi = np.logspace(0, 1, 11)[1:] * u.TeV
+        self.energy_lo = np.logspace(0, 1, 10)[:-1] * u.TeV
+        self.energy_hi = np.logspace(0, 1, 10)[1:] * u.TeV
         self.energy_axis_true = MapAxis.from_energy_bounds(
-            "1 TeV", "10 TeV", nbin=10, name="energy_true"
+            "1 TeV", "10 TeV", nbin=9, name="energy_true"
         )
 
         self.offset_lo = np.linspace(0, 1, 4)[:-1] * u.deg
@@ -20,7 +20,6 @@ class TestIRFWrite:
 
         self.offset_axis = MapAxis.from_bounds(
             0, 1, nbin=3, unit="deg", name="offset", node_type="edges"
-
         )
         self.migra_lo = np.linspace(0, 3, 4)[:-1]
         self.migra_hi = np.linspace(0, 3, 4)[1:]
@@ -29,21 +28,15 @@ class TestIRFWrite:
         )
         self.fov_lon_lo = np.linspace(-6, 6, 11)[:-1] * u.deg
         self.fov_lon_hi = np.linspace(-6, 6, 11)[1:] * u.deg
-        self.fov_lon_axis = MapAxis.from_bounds(
-            -6, 6, nbin=10, name="fov_lon"
-
-        )
+        self.fov_lon_axis = MapAxis.from_bounds(-6, 6, nbin=10, name="fov_lon")
 
         self.fov_lat_lo = np.linspace(-6, 6, 11)[:-1] * u.deg
         self.fov_lat_hi = np.linspace(-6, 6, 11)[1:] * u.deg
-        self.fov_lat_axis = MapAxis.from_bounds(
-            -6, 6, nbin=10, name="fov_lat"
+        self.fov_lat_axis = MapAxis.from_bounds(-6, 6, nbin=10, name="fov_lat")
 
-        )
-
-        self.aeff_data = np.random.rand(10, 3) * u.cm * u.cm
-        self.edisp_data = np.random.rand(10, 3, 3)
-        self.bkg_data = np.random.rand(10, 10, 10) / u.MeV / u.s / u.sr
+        self.aeff_data = np.random.rand(9, 3) * u.cm * u.cm
+        self.edisp_data = np.random.rand(9, 3, 3)
+        self.bkg_data = np.random.rand(9, 10, 10) / u.MeV / u.s / u.sr
 
         self.aeff = EffectiveAreaTable2D(
             energy_axis_true=self.energy_axis_true,
@@ -75,7 +68,7 @@ class TestIRFWrite:
 
         assert_allclose(self.aeff.to_table()["EFFAREA"].quantity[0].T, self.aeff_data)
         assert_allclose(self.edisp.to_table()["MATRIX"].quantity[0].T, self.edisp_data)
-        assert_allclose(self.bkg.to_table()["BKG"].quantity[0], self.bkg_data)
+        assert_allclose(self.bkg.to_table()["BKG"].quantity[0].T, self.bkg_data)
 
         assert self.aeff.to_table()["EFFAREA"].quantity[0].unit == self.aeff_data.unit
         assert self.bkg.to_table()["BKG"].quantity[0].unit == self.bkg_data.unit
@@ -110,7 +103,7 @@ class TestIRFWrite:
             hdu.data[hdu.header["TTYPE1"]][0], self.bkg.data.axes[1].edges[:-1].value
         )
         hdu = self.bkg.to_table_hdu()
-        assert_allclose(hdu.data[hdu.header["TTYPE7"]][0], self.bkg.data.data.value)
+        assert_allclose(hdu.data[hdu.header["TTYPE7"]][0].T, self.bkg.data.data.value)
 
     def test_writeread(self, tmp_path):
         path = tmp_path / "tmp.fits"


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request .enables `Background2D` and `Background3D` to work with both the GADF recommenced axis order and the current HESS/CTA release as discussed in #3081 .
Strangely enough, our tests in `test_irf_write` had the special case of same number of bins in (energy, lat, lon)! I changed the energy binning to get sane results. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

I added  GADF files in Gammapy-data in https://github.com/gammapy/gammapy-data/pull/5
Those are required for the tests.
