### PR TITLE
Stats background convention 

### DIFF
--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -32,7 +32,7 @@ Variable          Dataset attribute name Definition
 ================= ====================== ====================================================
 ``n_on``          ``counts``             Total observed counts in the on region
 ``n_off``         ``counts_off``         Total observed counts in the off region
-``n_bkg``         ``background``         Background estimate in the on region, independent of ``mu_sig``
+``n_bkg``         ``background``         Known background in the on region, independent of ``mu_sig``
 ``mu_on``         ``npred``              Predicted counts in the on region
 ``mu_off``        ``npred_off``          Predicted counts in the off region
 ``mu_sig``        ``npred_signal``       Predicted signal counts in the on region
@@ -43,14 +43,14 @@ Variable          Dataset attribute name Definition
 ================= ====================== ====================================================
 
 
-The ON measurement, assumed to contain signal and background counts, :math:`n_{on}` follows
+The on measurement, assumed to contain signal and background counts, :math:`n_{on}` follows
 a Poisson random variable with expected value
 :math:`\mu_{on} = \mu_{sig} + \mu_{bkg}`.
 
-The OFF measurement is assumed to contain only background counts, with an acceptance to background
-:math:`a_{off}`. This OFF measurement can be used to etimate the number of background counts in the
-ON measurement: :math:`n_{bkg} = \alpha\ n_{off}` with :math:`\alpha = a_{on}/a_{off}` the ratio of
-ON and OFF acceptances.
+The off measurement is assumed to contain only background counts, with an acceptance to background
+:math:`a_{off}`. This off measurement can be used to estimate the number of background counts in the
+on region: :math:`n_{bkg} = \alpha\ n_{off}` with :math:`\alpha = a_{on}/a_{off}` the ratio of
+on and off acceptances.
 
 Therefore :math:`n_{off}` follows a Poisson distribution with expected value
 :math:`\mu_{off} = \mu_{bkg) / \alpha`

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -32,14 +32,14 @@ Variable          Dataset attribute name Definition
 ================= ====================== ====================================================
 ``n_on``          ``counts``             Total observed counts in the on region
 ``n_off``         ``counts_off``         Total observed counts in the off region
+``n_bkg``         ``background``         Background estimate in the on region
 ``mu_on``         ``npred``              Predicted counts in the on region
 ``mu_off``        ``npred_off``          Predicted counts in the off region
-``mu_sig``        ``npred_sig``          Predicted signal counts in the on region
+``mu_sig``        ``npred_signal``       Predicted signal counts in the on region
 ``mu_bkg``        ``npred_background``   Predicted background counts in the on region
 ``a_on``          ``acceptance``         Relative background exposure in the on region
 ``a_off``         ``acceptance_off``     Relative background exposure in the off region
 ``alpha``         ``alpha``              Background efficiency ratio ``a_on`` / ``a_off``
-``n_bkg``         ``background``         Background estimate in the on region
 ================= ====================== ====================================================
 
 

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -30,14 +30,14 @@ notation in [Cousins2007]_:
 ================= ====================== ====================================================
 Variable          Dataset attribute name Definition
 ================= ====================== ====================================================
-``n_on``          ``counts``             Total observed counts in the on region
+``n_on``          ``counts``             Total observed counts
 ``n_off``         ``counts_off``         Total observed counts in the off region
 ``n_bkg``         ``background``         Known background in the on region, independent of ``mu_sig``
-``mu_on``         ``npred``              Predicted counts in the on region
+``mu_on``         ``npred``              Predicted counts
 ``mu_off``        ``npred_off``          Predicted counts in the off region
-``mu_sig``        ``npred_signal``       Predicted signal counts in the on region
-``mu_bkg``        ``npred_background``   Predicted background counts in the on region, depends on ``mu_sig``
-``a_on``          ``acceptance``         Relative background exposure in the on region
+``mu_sig``        ``npred_signal``       Predicted signal counts
+``mu_bkg``        ``npred_background``   Predicted background counts, depends on ``mu_sig``
+``a_on``          ``acceptance``         Relative background exposure
 ``a_off``         ``acceptance_off``     Relative background exposure in the off region
 ``alpha``         ``alpha``              Background efficiency ratio ``a_on`` / ``a_off``
 ================= ====================== ====================================================

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -32,11 +32,11 @@ Variable          Dataset attribute name Definition
 ================= ====================== ====================================================
 ``n_on``          ``counts``             Total observed counts in the on region
 ``n_off``         ``counts_off``         Total observed counts in the off region
-``n_bkg``         ``background``         Background estimate in the on region
+``n_bkg``         ``background``         Background estimate in the on region, independent of ``mu_sig``
 ``mu_on``         ``npred``              Predicted counts in the on region
 ``mu_off``        ``npred_off``          Predicted counts in the off region
 ``mu_sig``        ``npred_signal``       Predicted signal counts in the on region
-``mu_bkg``        ``npred_background``   Predicted background counts in the on region
+``mu_bkg``        ``npred_background``   Predicted background counts in the on region, depends on ``mu_sig``
 ``a_on``          ``acceptance``         Relative background exposure in the on region
 ``a_off``         ``acceptance_off``     Relative background exposure in the off region
 ``alpha``         ``alpha``              Background efficiency ratio ``a_on`` / ``a_off``
@@ -52,8 +52,8 @@ The OFF measurement is assumed to contain only background counts, with an accept
 ON measurement: :math:`n_{bkg} = \alpha\ n_{off}` with :math:`\alpha = a_{on}/a_{off}` the ratio of
 ON and OFF acceptances.
 
-Therefore :math:`n_{off}` follows a Poisson distribution  with expected value
-:math:\mu_{off} = \mu_{bkg) / \alpha
+Therefore :math:`n_{off}` follows a Poisson distribution with expected value
+:math:`\mu_{off} = \mu_{bkg) / \alpha`
 
 
 Counts and fit statistics

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1728,7 +1728,7 @@ class MapDatasetOnOff(MapDataset):
 
     @classmethod
     def from_map_dataset(
-        cls, dataset, acceptance, acceptance_off, counts_off=None
+        cls, dataset, acceptance, acceptance_off, counts_off=None, name=None
     ):
         """Create on off dataset from a map dataset.
 
@@ -1744,6 +1744,8 @@ class MapDatasetOnOff(MapDataset):
             Off counts map . If the dataset provides a background model,
             and no off counts are defined. The off counts are deferred from
             counts_off / alpha.
+        name : str
+            Name of the returned dataset.
 
         Returns
         -------
@@ -1751,6 +1753,7 @@ class MapDatasetOnOff(MapDataset):
             Map dataset on off.
 
         """
+        name = make_name(name)
 
         if counts_off is None and dataset.background is not None:
             alpha = acceptance / acceptance_off
@@ -1766,7 +1769,7 @@ class MapDatasetOnOff(MapDataset):
             mask_fit=dataset.mask_fit,
             acceptance=acceptance,
             acceptance_off=acceptance_off,
-            name=dataset.name,
+            name=name,
             psf=dataset.psf,
         )
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -344,7 +344,7 @@ class MapDataset(Dataset):
 
     def npred(self):
         """Predicted source and background counts (`~gammapy.maps.Map`)."""
-        npred_total = self.npred_sig()
+        npred_total = self.npred_signal()
 
         if self.background:
             npred_total += self.npred_background()
@@ -363,8 +363,10 @@ class MapDataset(Dataset):
 
         return background
 
-    def npred_sig(self, model=None):
-        """"Model predicted signal counts. If a model is passed, predicted counts from that component is returned.
+    def npred_signal(self, model=None):
+        """"Model predicted signal counts.
+
+        If a model is passed, predicted counts from that component is returned.
         Else, the total signal counts are returned.
 
         Parameters
@@ -1619,7 +1621,7 @@ class MapDatasetOnOff(MapDataset):
             n_on=self.counts.data,
             n_off=self.counts_off.data,
             alpha=self.alpha.data,
-            mu_sig=self.npred_sig().data,
+            mu_sig=self.npred_signal().data,
         )
         mu_bkg = np.nan_to_num(mu_bkg)
         return Map.from_geom(geom=self._geom, data=mu_bkg)
@@ -1631,7 +1633,7 @@ class MapDatasetOnOff(MapDataset):
 
     def stat_array(self):
         """Likelihood per bin given the current model parameters"""
-        mu_sig = self.npred_sig().data
+        mu_sig = self.npred_signal().data
         on_stat_ = wstat(
             n_on=self.counts.data,
             n_off=self.counts_off.data,
@@ -1833,7 +1835,7 @@ class MapDatasetOnOff(MapDataset):
                 Passed to `~gammapy.utils.random.get_random_state`.
         """
         random_state = get_random_state(random_state)
-        npred = self.npred_sig()
+        npred = self.npred_signal()
         npred.data = random_state.poisson(npred.data)
 
         npred_bkg = random_state.poisson(npred_background.data)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1613,6 +1613,8 @@ class MapDatasetOnOff(MapDataset):
     def alpha(self):
         """Exposure ratio between signal and background regions
 
+        See :ref:`wstat`
+
         Returns
         -------
         alpha : `Map`
@@ -1644,6 +1646,8 @@ class MapDatasetOnOff(MapDataset):
     def npred_off(self):
         """Predicted counts in the off region
 
+        See :ref:`wstat`
+
         Returns
         -------
         npred_off : `Map`
@@ -1654,6 +1658,8 @@ class MapDatasetOnOff(MapDataset):
     @property
     def background(self):
         """Computed as alpha * n_off
+
+        See :ref:`wstat`
 
         Returns
         -------

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -343,7 +343,13 @@ class MapDataset(Dataset):
         return self._geom.data_shape
 
     def npred(self):
-        """Predicted source and background counts (`~gammapy.maps.Map`)."""
+        """Predicted source and background counts
+
+        Returns
+        -------
+        npred : `Map`
+            Total predicted counts
+        """
         npred_total = self.npred_signal()
 
         if self.background:
@@ -352,7 +358,16 @@ class MapDataset(Dataset):
         return npred_total
 
     def npred_background(self):
-        """Background """
+        """Predicted background counts
+
+        The predicted background counts depend on the parameters
+        of the `FoVBackgroundModel` defined in the dataset.
+
+        Returns
+        -------
+        npred_background : `Map`
+            Predicted counts from the background.
+        """
         background = self.background
 
         if self.background_model and background:
@@ -1626,9 +1641,25 @@ class MapDatasetOnOff(MapDataset):
         mu_bkg = np.nan_to_num(mu_bkg)
         return Map.from_geom(geom=self._geom, data=mu_bkg)
 
+    def npred_off(self):
+        """Predicted counts in the off region
+
+        Returns
+        -------
+        npred_off : `Map`
+            Predicted off counts
+        """
+        return self.npred_background() / self.alpha
+
     @property
     def background(self):
-        """ alpha * n_off"""
+        """Computed as alpha * n_off
+
+        Returns
+        -------
+        background : `Map`
+            Background map
+        """
         return self.alpha * self.counts_off
 
     def stat_array(self):
@@ -1653,8 +1684,7 @@ class MapDatasetOnOff(MapDataset):
         name=None,
         **kwargs,
     ):
-        """
-        Create a MapDatasetOnOff object with zero filled maps according to the specified geometries
+        """Create a MapDatasetOnOff object  swith zero filled maps according to the specified geometries
 
         Parameters
         ----------
@@ -1698,9 +1728,9 @@ class MapDatasetOnOff(MapDataset):
 
     @classmethod
     def from_map_dataset(
-        cls, dataset, acceptance, acceptance_off, counts_off=None, name=None
+        cls, dataset, acceptance, acceptance_off, counts_off=None
     ):
-        """Create map dataseton off from another dataset.
+        """Create on off dataset from a map dataset.
 
         Parameters
         ----------
@@ -1714,8 +1744,6 @@ class MapDatasetOnOff(MapDataset):
             Off counts map . If the dataset provides a background model,
             and no off counts are defined. The off counts are deferred from
             counts_off / alpha.
-        name : str
-            Name of the returned dataset.
 
         Returns
         -------

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -219,7 +219,7 @@ class SpectrumDataset(MapDataset):
             label="Measured excess",
             yerr=np.sqrt(np.abs(self.excess.data.flatten())),
         )
-        self.npred_sig().plot_hist(ax=ax, label="Predicted signal counts")
+        self.npred_signal().plot_hist(ax=ax, label="Predicted signal counts")
 
         ax.legend(numpoints=1)
         ax.set_title("")
@@ -477,7 +477,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
             n_on=self.counts.data,
             n_off=self.counts_off.data,
             alpha=self.alpha.data,
-            mu_sig=self.npred_sig().data,
+            mu_sig=self.npred_signal().data,
         )
         return RegionNDMap.from_geom(geom=self._geom, data=mu_bkg)
 
@@ -511,7 +511,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
     def stat_array(self):
         """Likelihood per bin given the current model parameters"""
-        mu_sig = self.npred_sig().data
+        mu_sig = self.npred_signal().data
         on_stat_ = wstat(
             n_on=self.counts.data,
             n_off=self.counts_off.data,
@@ -535,7 +535,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         """
         random_state = get_random_state(random_state)
 
-        npred = self.npred_sig()
+        npred = self.npred_signal()
         npred.data = random_state.poisson(npred.data)
         npred_bkg = random_state.poisson(npred_background.data)
         self.counts = npred + npred_bkg

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -481,6 +481,16 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         )
         return RegionNDMap.from_geom(geom=self._geom, data=mu_bkg)
 
+    def npred_off(self):
+        """Predicted counts in the off region
+
+        Returns
+        -------
+        npred_off : `Map`
+            Predicted off counts
+        """
+        return self.npred_background() / self.alpha
+
     @property
     def background(self):
         """ alpha * noff"""

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -686,8 +686,8 @@ def test_npred_sig(sky_model, geom, geom_etrue):
     dataset.models.append(model1)
 
     assert_allclose(dataset.npred().data.sum(), 9676.047906, rtol=1e-3)
-    assert_allclose(dataset.npred_sig().data.sum(), 5676.04790, rtol=1e-3)
-    assert_allclose(dataset.npred_sig(model=model1).data.sum(), 150.7487, rtol=1e-3)
+    assert_allclose(dataset.npred_signal().data.sum(), 5676.04790, rtol=1e-3)
+    assert_allclose(dataset.npred_signal(model=model1).data.sum(), 150.7487, rtol=1e-3)
 
 
 def test_stack_npred():

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -128,10 +128,10 @@ def test_npred_models():
 
     assert_allclose(npred.data.sum(), 64.8)
 
-    npred_sig = spectrum_dataset.npred_sig()
+    npred_sig = spectrum_dataset.npred_signal()
     assert_allclose(npred_sig.data.sum(), 64.8)
 
-    npred_sig_model1 = spectrum_dataset.npred_sig(model=model_1)
+    npred_sig_model1 = spectrum_dataset.npred_signal(model=model_1)
     assert_allclose(npred_sig_model1.data.sum(), 32.4)
 
 
@@ -437,7 +437,7 @@ class TestSpectrumOnOff:
         energy = aeff.geom.axes[0].edges
         expected = aeff.data[0] * (energy[-1] - energy[0]) * const * livetime
 
-        assert_allclose(dataset.npred_sig().data.sum(), expected.value)
+        assert_allclose(dataset.npred_signal().data.sum(), expected.value)
 
     def test_to_spectrum_dataset(self):
         ds = self.dataset.to_spectrum_dataset()
@@ -854,13 +854,13 @@ class TestSpectrumDatasetOnOffStack:
 
         self.stacked_dataset.models = pwl
 
-        npred_stacked = self.stacked_dataset.npred_sig().data
+        npred_stacked = self.stacked_dataset.npred_signal().data
         npred_stacked[~self.stacked_dataset.mask_safe.data] = 0
         npred_summed = np.zeros_like(npred_stacked)
 
         for dataset in self.datasets:
             dataset.models = pwl
-            npred_summed[dataset.mask_safe] += dataset.npred_sig().data[
+            npred_summed[dataset.mask_safe] += dataset.npred_signal().data[
                 dataset.mask_safe
             ]
 

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -47,7 +47,7 @@ def convolved_map_dataset_counts_statistics(dataset, kernel, apply_mask_fit=Fals
         background_conv = background.convolve(kernel.array)
         n_off_conv = n_off.convolve(kernel.array)
 
-        npred_sig = dataset.npred_sig() * mask
+        npred_sig = dataset.npred_signal() * mask
         npred_sig = npred_sig.sum_over_axes(keepdims=True)
         mu_sig = npred_sig.convolve(kernel.array)
 

--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -178,7 +178,7 @@ class ExcessProfileEstimator(Estimator):
             else:
                 stats = CashCountsStatistic(
                     spds.counts.data[mask][:, 0, 0],
-                    spds.background_model.evaluate().data[mask][:, 0, 0],
+                    spds.npred_background().data[mask][:, 0, 0],
                 )
 
             result = {
@@ -192,7 +192,7 @@ class ExcessProfileEstimator(Estimator):
             result.update(
                 {
                     "counts": stats.n_on,
-                    "background": stats.background,
+                    "background": stats.mu_bkg,
                     "excess": stats.excess,
                 }
             )

--- a/gammapy/estimators/sensitivity.py
+++ b/gammapy/estimators/sensitivity.py
@@ -94,7 +94,7 @@ class SensitivityEstimator(Estimator):
         energy = dataset._geom.axes["energy"].center
 
         dataset.models = SkyModel(spectral_model=self.spectrum)
-        npred = dataset.npred_sig()
+        npred = dataset.npred_signal()
 
         phi_0 = excess / npred
 

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -54,7 +54,7 @@ def simulate_spectrum_dataset(model, random_state=0):
         edisp=edisp,
     )
     dataset.models = bkg_model
-    bkg_npred = dataset.npred_sig()
+    bkg_npred = dataset.npred_signal()
 
     dataset.models = model
     dataset.fake(

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -74,7 +74,7 @@ class NDDataArray:
         """
         data = Quantity(data)
         self._regular_grid_interp = None
-        self._data = data.reshape(self.axes.shape)
+        self._data = data
 
     def evaluate(self, method=None, **kwargs):
         """Evaluate NDData Array


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a follow up to #3051. It clarifies and unifies the notation between the datasets and stats classes. The convention is now the following:

- `n_bkg` or `background` is the "known" background level, computed as `counts_off * alpha`, neglecting errors on the background and ignoring the signal 
- `mu_bkg` or `npred_background` is the background level estimated from minimising the stat, possibly taking a signal into account

In addition this PR renames `npred_sig` to `npred_signal` and adapts the table in the `gammapy.stats` docs page.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
