### PR TITLE
Allowing Estimators norm parameter to be negative

### DIFF
--- a/gammapy/estimators/core.py
+++ b/gammapy/estimators/core.py
@@ -44,7 +44,7 @@ class Estimator(abc.ABC):
                 raise ValueError(f"{difference} is not a valid method.")
 
     @staticmethod
-    def get_sqrt_ts(ts):
+    def get_sqrt_ts(ts, norm):
         r"""Compute sqrt(TS) value.
 
         Compute sqrt(TS) as defined by:
@@ -52,7 +52,7 @@ class Estimator(abc.ABC):
         .. math::
             \sqrt{TS} = \left \{
             \begin{array}{ll}
-              -\sqrt{-TS} & : \text{if} \ TS < 0 \\
+              -\sqrt{TS} & : \text{if} \ norm < 0 \\
               \sqrt{TS} & : \text{else}
             \end{array}
             \right.
@@ -61,14 +61,15 @@ class Estimator(abc.ABC):
         ----------
         ts : `~numpy.ndarray`
             TS value.
-
+        norm : `~numpy.ndarray`
+            norm value
         Returns
         -------
         sqrt_ts : `~numpy.ndarray`
             Sqrt(TS) value.
         """
         with np.errstate(invalid="ignore", divide="ignore"):
-            return np.where(ts > 0, np.sqrt(ts), -np.sqrt(-ts))
+            return np.where(norm > 0, np.sqrt(ts), -np.sqrt(ts))
 
     def copy(self):
         """Copy estimator"""

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -136,7 +136,7 @@ class FluxEstimator(Estimator):
         """
         ref_model = models[self.source].spectral_model
         scale_model = ScaleSpectralModel(ref_model)
-        scale_model.norm.min = 0
+        scale_model.norm.min = -1e5
         scale_model.norm.max = 1e5
         scale_model.norm.value = 1.0
         scale_model.norm.frozen = False
@@ -171,6 +171,7 @@ class FluxEstimator(Estimator):
                 dataset.models[self.source].spectral_model = model
 
             result.update(self._parameter_estimator.run(datasets, model.norm))
+            result["sqrt_ts"] = self.get_sqrt_ts(result["ts"], result["norm"])
 
         return result
 
@@ -182,6 +183,7 @@ class FluxEstimator(Estimator):
             "success": False,
             "norm_err": np.nan,
             "ts": np.nan,
+            "sqrt_ts": np.nan,
         }
 
         if "errn-errp" in self.selection_optional:

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -135,7 +135,7 @@ class ParameterEstimator(Estimator):
 
             ts = datasets.stat_sum() - stat
 
-        return {"ts": ts}# "sqrt_ts": self.get_sqrt_ts(ts)}
+        return {"ts": ts}
 
     def estimate_errn_errp(self, datasets, parameter):
         """Estimate parameter assymetric errors

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -135,7 +135,7 @@ class ParameterEstimator(Estimator):
 
             ts = datasets.stat_sum() - stat
 
-        return {"ts": ts, "sqrt_ts": self.get_sqrt_ts(ts)}
+        return {"ts": ts}# "sqrt_ts": self.get_sqrt_ts(ts)}
 
     def estimate_errn_errp(self, datasets, parameter):
         """Estimate parameter assymetric errors

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -411,7 +411,7 @@ def test_lightcurve_estimator_spectrum_datasets_largerbin():
     assert_allclose(lightcurve.table["ref_eflux"][0], [3.453878e-12], rtol=1e-5)
     assert_allclose(lightcurve.table["ref_e2dnde"][0], [1e-12], rtol=1e-5)
     assert_allclose(lightcurve.table["stat"][0], [34.219808], rtol=1e-5)
-    assert_allclose(lightcurve.table["norm"][0], [0.909454], rtol=1e-5)
+    assert_allclose(lightcurve.table["norm"][0], [0.909646], rtol=1e-5)
     assert_allclose(lightcurve.table["norm_err"][0], [0.040874], rtol=1e-3)
     assert_allclose(lightcurve.table["ts"][0], [742.939324], rtol=1e-4)
 

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -291,8 +291,7 @@ class TSMapEstimator(Estimator):
         mask[background.data == 0] = False
         return Map.from_geom(data=mask, geom=geom)
 
-    @staticmethod
-    def estimate_sqrt_ts(map_ts):
+    def estimate_sqrt_ts(self, map_ts, norm):
         r"""Compute sqrt(TS) map.
 
         Compute sqrt(TS) as defined by:
@@ -315,9 +314,7 @@ class TSMapEstimator(Estimator):
         sqrt_ts : `gammapy.maps.WcsNDMap`
             Sqrt(TS) map.
         """
-        with np.errstate(invalid="ignore", divide="ignore"):
-            ts = map_ts.data
-            sqrt_ts = np.where(ts > 0, np.sqrt(ts), -np.sqrt(-ts))
+        sqrt_ts = self.get_sqrt_ts(map_ts.data, norm.data)
         return map_ts.copy(data=sqrt_ts)
 
     def estimate_flux_map(self, dataset):
@@ -448,6 +445,7 @@ class TSMapEstimator(Estimator):
 
             result_all[name] = map_all
 
+        result_all["sqrt_ts"] = self.estimate_sqrt_ts(result_all["ts"], result_all["flux"])
         return result_all
 
 

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -570,7 +570,6 @@ class BrentqFluxEstimator(Estimator):
         stat = dataset.stat_sum(norm=norm)
         stat_null = dataset.stat_sum(norm=0)
         result["ts"] = (stat_null - stat)
-        result["sqrt_ts"] = self.get_sqrt_ts(result["ts"], norm)
         result["norm"] = norm
         result["niter"] = niter
 
@@ -637,13 +636,12 @@ class BrentqFluxEstimator(Estimator):
         stat = dataset.stat_sum(norm=norm)
         stat_null = dataset.stat_sum(norm=0)
         ts = (stat_null - stat)
-        sqrt_ts = self.get_sqrt_ts(ts, norm)
 
         with np.errstate(invalid="ignore", divide="ignore"):
             norm_err = (
                     np.sqrt(1 / dataset.stat_2nd_derivative(norm)) * self.n_sigma
             )
-        return {"norm": norm, "ts": ts, "sqrt_ts": sqrt_ts, "norm_err": norm_err, "stat": stat, "niter": 0}
+        return {"norm": norm, "ts": ts, "norm_err": norm_err, "stat": stat, "niter": 0}
 
     def run(self, dataset):
         """"""

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -448,7 +448,6 @@ class TSMapEstimator(Estimator):
 
             result_all[name] = map_all
 
-        result_all["sqrt_ts"] = self.estimate_sqrt_ts(result_all["ts"])
         return result_all
 
 
@@ -570,7 +569,8 @@ class BrentqFluxEstimator(Estimator):
 
         stat = dataset.stat_sum(norm=norm)
         stat_null = dataset.stat_sum(norm=0)
-        result["ts"] = (stat_null - stat) * np.sign(norm)
+        result["ts"] = (stat_null - stat)
+        result["sqrt_ts"] = self.get_sqrt_ts(result["ts"], norm)
         result["norm"] = norm
         result["niter"] = niter
 
@@ -636,12 +636,14 @@ class BrentqFluxEstimator(Estimator):
         norm = dataset.norm_guess
         stat = dataset.stat_sum(norm=norm)
         stat_null = dataset.stat_sum(norm=0)
-        ts = (stat_null - stat) * np.sign(norm)
+        ts = (stat_null - stat)
+        sqrt_ts = self.get_sqrt_ts(ts, norm)
+        
         with np.errstate(invalid="ignore", divide="ignore"):
             norm_err = (
                     np.sqrt(1 / dataset.stat_2nd_derivative(norm)) * self.n_sigma
             )
-        return {"norm": norm, "ts": ts, "norm_err": norm_err, "stat": stat, "niter": 0}
+        return {"norm": norm, "ts": ts, "sqrt_ts": sqrt_ts, "norm_err": norm_err, "stat": stat, "niter": 0}
 
     def run(self, dataset):
         """"""

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -638,7 +638,7 @@ class BrentqFluxEstimator(Estimator):
         stat_null = dataset.stat_sum(norm=0)
         ts = (stat_null - stat)
         sqrt_ts = self.get_sqrt_ts(ts, norm)
-        
+
         with np.errstate(invalid="ignore", divide="ignore"):
             norm_err = (
                     np.sqrt(1 / dataset.stat_2nd_derivative(norm)) * self.n_sigma


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies the behavior of `Estimators` to have a consistent treatment of the `norm` parameter and of the `ts` value.

- `norm` was forced to be positive in all `Estimators` based on `FluxEstimator`. This follows a common approach in Fermi analysis, but this introduces systematic biases when looking at non-existent sources. Preventing the flux to become negative makes the mean value always positive. This might lead to incorrect results if the `Estimator` results are treated incorrectly: e.g. taking the average flux from `LightCurveEstimator` for a non-existent source. This is now changed. The `norm.min` is non longer 0. Only a single test value has changed (and only a very little). 

- The `ts` handling in `Estimator` is also confusing. In some estimators the sign of `norm` is applied to `ts`. Having a negative `ts` might be really confusing. This is now removed. 

- The `sqrt_ts` still carries the sign of the `norm`. We might change its name to `significance` to avoid false comparisons with Fermi tools results which are always positive.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
should we leave an option to force `norm>=0` on all `Estimator`?

Opinions @adonath , @QRemy @AtreyeeS @bkhelifi ?