### PR TITLE
Update energy naming convention for gammapy.analysis

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -167,10 +167,10 @@ class Analysis:
         fit_settings = self.config.fit
         for dataset in self.datasets:
             if fit_settings.fit_range:
-                e_min = fit_settings.fit_range.min
-                e_max = fit_settings.fit_range.max
+                energy_min = fit_settings.fit_range.min
+                energy_max = fit_settings.fit_range.max
                 geom = dataset.counts.geom
-                data = geom.energy_mask(e_min, e_max)
+                data = geom.energy_mask(energy_min, energy_max)
                 dataset.mask_fit = Map.from_geom(geom=geom, data=data)
 
         log.info("Fitting datasets.")
@@ -185,9 +185,9 @@ class Analysis:
 
         fp_settings = self.config.flux_points
         log.info("Calculating flux points.")
-        e_edges = self._make_energy_axis(fp_settings.energy).edges
+        energy_edges = self._make_energy_axis(fp_settings.energy).edges
         flux_point_estimator = FluxPointsEstimator(
-            e_edges=e_edges, source=fp_settings.source, **fp_settings.parameters,
+            e_edges=energy_edges, source=fp_settings.source, **fp_settings.parameters,
         )
         fp = flux_point_estimator.run(datasets=self.datasets)
         fp.table["is_ul"] = fp.table["ts"] < 4


### PR DESCRIPTION
This PR is the first step of a new energy naming convention in Gammapy, as discussed in #3078 . 
Here, I modified the package `gammapy.analysis`. To make the tests work, I had the need to partially update also the `gammapy.estimators.flux_point`.

