### PR TITLE
Fix unit handling in .stack() methods and energy range in FluxEstimator

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1161,7 +1161,7 @@ class MapDataset(Dataset):
         from .spectrum import SpectrumDataset
 
         name = make_name(name)
-        kwargs = {"gti": self.gti, "name": name}
+        kwargs = {"gti": self.gti, "name": name, "meta_table": self.meta_table}
 
         if self.mask_safe is not None:
             kwargs["mask_safe"] = self.mask_safe.get_spectrum(on_region, func=np.any)
@@ -1230,7 +1230,7 @@ class MapDataset(Dataset):
             Cutout map dataset.
         """
         name = make_name(name)
-        kwargs = {"gti": self.gti, "name": name}
+        kwargs = {"gti": self.gti, "name": name, "meta_table": self.meta_table}
         cutout_kwargs = {"position": position, "width": width, "mode": mode}
 
         if self.counts is not None:
@@ -1278,7 +1278,7 @@ class MapDataset(Dataset):
         """
         name = make_name(name)
 
-        kwargs = {"gti": self.gti, "name": name}
+        kwargs = {"gti": self.gti, "name": name, "meta_table": self.meta_table}
 
         if self.counts is not None:
             kwargs["counts"] = self.counts.downsample(
@@ -1344,7 +1344,7 @@ class MapDataset(Dataset):
 
         """
         name = make_name(name)
-        kwargs = {"gti": self.gti, "name": name}
+        kwargs = {"gti": self.gti, "name": name, "meta_table": self.meta_table}
 
         if self.counts is not None:
             kwargs["counts"] = self.counts.pad(pad_width=pad_width, mode=mode)
@@ -1390,7 +1390,7 @@ class MapDataset(Dataset):
             Sliced dataset
         """
         name = make_name(name)
-        kwargs = {"gti": self.gti, "name": name}
+        kwargs = {"gti": self.gti, "name": name, "meta_table": self.meta_table}
 
         if self.counts is not None:
             kwargs["counts"] = self.counts.slice_by_idx(slices=slices)
@@ -1470,12 +1470,7 @@ class MapDataset(Dataset):
             Resampled dataset .
         """
         name = make_name(name)
-
-        kwargs = {}
-        kwargs["name"] = name
-
-        if self.gti:
-            kwargs["gti"] = self.gti
+        kwargs = {"gti": self.gti, "name": name, "meta_table": self.meta_table}
 
         if self.exposure:
             kwargs["exposure"] = self.exposure

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -163,9 +163,11 @@ class FluxEstimator(Estimator):
         )
 
         if len(datasets) > 0:
-            # TODO: refactor energy handling of FluxEstimator?
+            # TODO: this relies on the energy binning of the first dataset
             energy_axis = datasets[0].counts.geom.axes["energy"]
             energy_min, energy_max = energy_axis.edges.min(), energy_axis.edges.max()
+        else:
+            energy_min, energy_max = self.energy_min, self.energy_max
 
         with np.errstate(invalid="ignore", divide="ignore"):
             result = self.get_reference_flux_values(

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -93,32 +93,31 @@ class FluxEstimator(Estimator):
             selection_optional=self.selection_optional
         )
 
-    @property
-    def energy_ref(self):
-        """Reference energy"""
-        return np.sqrt(self.energy_min * self.energy_max)
-
-    def get_reference_flux_values(self, model):
+    @staticmethod
+    def get_reference_flux_values(model, energy_min, energy_max):
         """Get reference flux values
 
         Parameters
         ----------
         model : `SpectralModel`
             Models
+        energy_min, energy_max : `~astropy.units.Quantity`
+            Energy range
 
         Returns
         -------
         values : dict
             Dictionary with reference energies and flux values.
         """
+        energy_ref = np.sqrt(energy_min * energy_max)
         return {
-            "e_ref": self.energy_ref,
-            "e_min": self.energy_min,
-            "e_max": self.energy_max,
-            "ref_dnde": model(self.energy_ref),
-            "ref_flux": model.integral(self.energy_min, self.energy_max),
-            "ref_eflux": model.energy_flux(self.energy_min, self.energy_max),
-            "ref_e2dnde": model(self.energy_ref) * self.energy_ref ** 2,
+            "e_ref": energy_ref,
+            "e_min": energy_min,
+            "e_max": energy_max,
+            "ref_dnde": model(energy_ref),
+            "ref_flux": model.integral(energy_min, energy_max),
+            "ref_eflux": model.energy_flux(energy_min, energy_max),
+            "ref_e2dnde": model(energy_ref) * energy_ref ** 2,
         }
 
     def get_scale_model(self, models):
@@ -159,8 +158,19 @@ class FluxEstimator(Estimator):
 
         model = self.get_scale_model(datasets.models)
 
+        datasets = datasets.slice_by_energy(
+            energy_min=self.energy_min, energy_max=self.energy_max
+        )
+
+        if len(datasets) > 0:
+            # TODO: refactor energy handling of FluxEstimator?
+            energy_axis = datasets[0].counts.geom.axes["energy"]
+            energy_min, energy_max = energy_axis.edges.min(), energy_axis.edges.max()
+
         with np.errstate(invalid="ignore", divide="ignore"):
-            result = self.get_reference_flux_values(model.model)
+            result = self.get_reference_flux_values(
+                model.model, energy_min, energy_max
+            )
 
         any_contribution = np.any([dataset.mask.data.any() for dataset in datasets])
 

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -886,13 +886,6 @@ class FluxPointsEstimator(Estimator):
         """
         result = self.estimate_counts(datasets, energy_min=energy_min, energy_max=energy_max)
 
-        datasets = datasets.slice_by_energy(energy_min=energy_min, energy_max=energy_max)
-
-        if len(datasets) > 0:
-            # TODO: refactor energy handling of FluxEstimator?
-            energy_axis = datasets[0].counts.geom.axes["energy"]
-            energy_min, energy_max = energy_axis.edges.min(), energy_axis.edges.max()
-
         fe = self._flux_estimator(energy_min=energy_min, energy_max=energy_max)
 
         result.update(fe.run(datasets=datasets))

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -50,14 +50,17 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
 
     result = estimator.run(fermi_datasets)
 
-    assert_allclose(result["norm"], 1.003784, atol=1e-3)
-    assert_allclose(result["ts"], 28086.565, atol=1e-3)
+    assert_allclose(result["norm"], 0.98949, atol=1e-3)
+    assert_allclose(result["ts"], 25082.190245, atol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
     assert_allclose(result["norm_errn"], 0.0199, atol=1e-3)
     assert_allclose(result["norm_errp"], 0.0199, atol=1e-3)
     assert len(result["norm_scan"]) == 5
     assert_allclose(result["norm_scan"][0], 0.5)
     assert_allclose(result["norm_scan"][-1], 2)
+    assert_allclose(result["e_min"], 10 * u.GeV, atol=1e-3)
+    assert_allclose(result["e_max"], 83.255 * u.GeV, atol=1e-3)
+
 
 
 @requires_data()
@@ -72,8 +75,8 @@ def test_flux_estimator_fermi_with_reoptimization(fermi_datasets):
     )
     result = estimator.run(fermi_datasets)
 
-    assert_allclose(result["norm"], 1.003784, atol=1e-3)
-    assert_allclose(result["ts"], 20896.1864, atol=1e-3)
+    assert_allclose(result["norm"], 0.989989, atol=1e-3)
+    assert_allclose(result["ts"], 18728.35303, atol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
 
 
@@ -85,12 +88,14 @@ def test_flux_estimator_1d(hess_datasets):
     )
     result = estimator.run(hess_datasets)
 
-    assert_allclose(result["norm"], 1.176789, atol=1e-3)
-    assert_allclose(result["ts"], 693.111777, atol=1e-3)
-    assert_allclose(result["norm_err"], 0.07984, atol=1e-3)
-    assert_allclose(result["norm_errn"], 0.078046, atol=1e-3)
-    assert_allclose(result["norm_errp"], 0.081665, atol=1e-3)
-    assert_allclose(result["norm_ul"], 1.431722, atol=1e-3)
+    assert_allclose(result["norm"], 1.218139, atol=1e-3)
+    assert_allclose(result["ts"], 527.492959, atol=1e-3)
+    assert_allclose(result["norm_err"], 0.095496, atol=1e-3)
+    assert_allclose(result["norm_errn"], 0.093204, atol=1e-3)
+    assert_allclose(result["norm_errp"], 0.097818, atol=1e-3)
+    assert_allclose(result["norm_ul"], 1.525773, atol=1e-3)
+    assert_allclose(result["e_min"], 1 * u.TeV, atol=1e-3)
+    assert_allclose(result["e_max"], 10 * u.TeV, atol=1e-3)
 
 
 def test_flux_estimator_incorrect_energy_range():
@@ -115,9 +120,11 @@ def test_inhomogeneous_datasets(fermi_datasets, hess_datasets):
     )
     result = estimator.run(datasets)
 
-    assert_allclose(result["norm"], 1.015983, atol=1e-3)
-    assert_allclose(result["ts"], 21584.092045, atol=1e-3)
-    assert_allclose(result["norm_err"], 0.01966, atol=1e-3)
+    assert_allclose(result["norm"], 1.190622, atol=1e-3)
+    assert_allclose(result["ts"], 612.500392, atol=1e-3)
+    assert_allclose(result["norm_err"], 0.090744, atol=1e-3)
+    assert_allclose(result["e_min"], 0.693145 * u.TeV, atol=1e-3)
+    assert_allclose(result["e_max"], 2 * u.TeV, atol=1e-3)
 
 
 

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -345,7 +345,7 @@ class RegionNDMap(Map):
             Array to be used as weights. The spatial geometry must be equivalent
             to `other` and additional axes must be broadcastable.
         """
-        data = other.data
+        data = other.quantity.to_value(self.unit)
 
         # TODO: re-think stacking of regions. Is making the union reasonable?
         # self.geom.union(other.geom)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -610,6 +610,7 @@ def test_get_spectrum():
     spec = m.get_spectrum(region=region)
     assert_allclose(spec.data.squeeze(), [1.0, 1.0, 1.0])
 
+
 def test_get_spectrum_type():
     axis = MapAxis.from_bounds(1, 10, nbin=3, unit="TeV", name="energy")
 
@@ -633,6 +634,7 @@ def test_get_spectrum_type():
     spec_bool = m_bool.get_spectrum(region=region, func=np.any)
     assert spec_bool.data.dtype == np.dtype('bool')
     assert_allclose(spec_bool.data.squeeze(), [1, 1, 1])
+
 
 def test_get_spectrum_weights():
     axis = MapAxis.from_bounds(1, 10, nbin=3, unit="TeV", name="energy")
@@ -658,6 +660,7 @@ def test_get_spectrum_weights():
 
     with pytest.raises(ValueError):
         m_int.get_spectrum(region=region, weights=bad_weights)
+
 
 def get_npred_map():
     position = SkyCoord(0.0, 0.0, frame="galactic", unit="deg")
@@ -770,3 +773,15 @@ def test_to_cube():
     ax4 = MapAxis.from_edges([8, 9, 10], name="ax4")
     with pytest.raises(ValueError):
         m1.to_cube([ax4])
+
+
+def test_stack_unit_handling():
+    m = WcsNDMap.create(npix=(3, 3), unit="m2 s")
+    m.data += 1
+
+    m_other = WcsNDMap.create(npix=(3, 3), unit="cm2 s")
+    m_other.data += 1
+
+    m.stack(m_other)
+
+    assert_allclose(m.data, 1.0001)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -712,7 +712,7 @@ class WcsNDMap(WcsMap):
                 "Can only stack equivalent maps or cutout of the same map."
             )
 
-        data = other.data[cutout_slices]
+        data = other.quantity[cutout_slices].to_value(self.unit)
 
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes two issue mentioned by @AtreyeeS in private:
- The unit was not handled correctly in `WcsNDMap.stack()` and `RegionNDMap.stack()`
- The energy range in `FluxEstimator` was adapted to the data 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
