### PR TITLE
Correct Map.resample_axis for incomplete axis coverage and improve excess map mask handling

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1483,6 +1483,11 @@ class MapDataset(Dataset):
                 axis=energy_axis, ufunc=np.logical_or
             )
 
+        if self.mask_fit is not None:
+            kwargs["mask_fit"] = self.mask_fit.resample_axis(
+                axis=energy_axis, ufunc=np.logical_or
+            )
+
         if self.counts is not None:
             kwargs["counts"] = self.counts.resample_axis(
                 axis=energy_axis, weights=self.mask_safe

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -299,7 +299,7 @@ def test_resample_energy_3fhl():
 
     assert grouped.counts.data.shape == (2, 200, 400)
     assert grouped.counts.data[0].sum() == 28581
-    assert_allclose(grouped.npred_background().data.sum(axis=(1, 2)), [25074.366386, 3474.265917], rtol=1e-5)
+    assert_allclose(grouped.npred_background().data.sum(axis=(1, 2)), [25074.366386, 2194.298612], rtol=1e-5)
     assert_allclose(grouped.exposure.data, dataset.exposure.data, rtol=1e-5)
 
     axis = grouped.counts.geom.axes[0]

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -169,7 +169,7 @@ class ExcessMapEstimator(Estimator):
         size = self.correlation_radius.deg / pixel_size
         kernel = Tophat2DKernel(size)
 
-        geom = dataset.counts.geom #.squash("energy")
+        geom = dataset.counts.geom
 
         if self.apply_mask_fit:
             mask = dataset.mask
@@ -183,12 +183,6 @@ class ExcessMapEstimator(Estimator):
         n_on = Map.from_geom(geom, data=counts_stat.n_on)
         bkg = Map.from_geom(geom, data=counts_stat.n_on - counts_stat.n_sig)
         excess = Map.from_geom(geom, data=counts_stat.n_sig)
-
-        # if hasattr(counts_stat, "alpha"):
-        #     print(dataset.counts.data[:,10,10])
-        #     print(counts_stat.n_on[:,10,10])
-        #     print(counts_stat.n_off[:,10,10])
-        #     print(counts_stat.alpha[:,10,10])
 
         result = {"counts": n_on, "background": bkg, "excess": excess}
 

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -193,6 +193,12 @@ class ExcessMapEstimator(Estimator):
         bkg = Map.from_geom(geom, data=counts_stat.n_on - counts_stat.n_sig)
         excess = Map.from_geom(geom, data=counts_stat.n_sig)
 
+        if hasattr(counts_stat, "alpha"):
+            print(dataset.counts.data[:,10,10])
+            print(counts_stat.n_on[:,10,10])
+            print(counts_stat.n_off[:,10,10])
+            print(counts_stat.alpha[:,10,10])
+
         result = {"counts": n_on, "background": bkg, "excess": excess}
 
         tsmap = Map.from_geom(geom, data=counts_stat.ts)
@@ -224,7 +230,6 @@ class ExcessMapEstimator(Estimator):
             result.update({"ul": ul})
 
         # return nan values outside mask
-#        mask = mask.all(axis=0, keepdims=True)
         for key in result:
             result[key].data[~mask] = np.nan
 

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -125,7 +125,7 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     estimator = ExcessMapEstimator(
         0.11 * u.deg,
         selection_optional=None,
-        energy_edges=[0.1 * u.TeV, 1 * u.TeV, 10 * u.TeV],
+        energy_edges=[0.1, 1, 10]*u.TeV,
     )
     result = estimator.run(simple_dataset_on_off)
 
@@ -135,7 +135,7 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     assert_allclose(result["background"].data[:, 10, 10], 97)
     assert_allclose(result["sqrt_ts"].data[:, 10, 10], 5.741116, atol=1e-5)
 
-    estimator_image = ExcessMapEstimator(0.11 * u.deg, energy_edges=[0.1 * u.TeV, 1 * u.TeV])
+    estimator_image = ExcessMapEstimator(0.11 * u.deg, energy_edges=[0.1, 1]*u.TeV)
 
     result_image = estimator_image.run(simple_dataset_on_off)
     assert result_image["counts"].data.shape == (1, 20, 20)

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -122,6 +122,12 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
 
 
 def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
+    exposure = simple_dataset_on_off.exposure
+    exposure.data += 1e6
+
+    # First without exposure
+    simple_dataset_on_off.exposure = None
+
     estimator = ExcessMapEstimator(
         0.11 * u.deg,
         selection_optional=None,
@@ -134,16 +140,21 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     assert_allclose(result["excess"].data[:, 10, 10], 97)
     assert_allclose(result["background"].data[:, 10, 10], 97)
     assert_allclose(result["sqrt_ts"].data[:, 10, 10], 5.741116, atol=1e-5)
+    assert_allclose(result["flux"].data[:, 10, 10], np.nan)
 
+    # Test with exposure
+    simple_dataset_on_off.exposure = exposure
     estimator_image = ExcessMapEstimator(0.11 * u.deg, energy_edges=[0.1, 1]*u.TeV)
 
     result_image = estimator_image.run(simple_dataset_on_off)
     assert result_image["counts"].data.shape == (1, 20, 20)
-    assert_allclose(result["counts"].data[0, 10, 10], 194)
-    assert_allclose(result["excess"].data[0, 10, 10], 97)
-    assert_allclose(result["background"].data[0, 10, 10], 97)
+    assert_allclose(result_image["counts"].data[0, 10, 10], 194)
+    assert_allclose(result_image["excess"].data[0, 10, 10], 97)
+    assert_allclose(result_image["background"].data[0, 10, 10], 97)
     assert_allclose(result_image["sqrt_ts"].data[0, 10, 10], 5.741116, atol=1e-3)
+    assert_allclose(result_image["flux"].data[:, 10, 10], 9.7e-9, atol=1e-5)
 
+    # Test with mask fit
     mask_fit = Map.from_geom(
         simple_dataset_on_off._geom,
         data=np.ones(simple_dataset_on_off.counts.data.shape, dtype=bool),
@@ -154,9 +165,6 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
 
     estimator_image = ExcessMapEstimator(0.11 * u.deg, apply_mask_fit=True)
 
-    simple_dataset_on_off.exposure.data = (
-        np.ones(simple_dataset_on_off.exposure.data.shape) * 1e6
-    )
     result_image = estimator_image.run(simple_dataset_on_off)
     assert result_image["counts"].data.shape == (1, 20, 20)
 
@@ -170,12 +178,8 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     assert_allclose(result_image["background"].data[0, 9, 9], 152)
 
     assert result_image["flux"].unit == u.Unit("cm-2s-1")
-    assert_allclose(result_image["flux"].data[0, 9, 9], 7.6e-9, rtol=1e-3)
+    assert_allclose(result_image["flux"].data[0, 9, 9], 1.52e-8, rtol=1e-3)
 
-    # test with an npred()
-    simple_dataset_on_off.exposure.data = (
-        np.ones(simple_dataset_on_off.exposure.data.shape) * 1e10
-    )
     simple_dataset_on_off.psf = None
 
     # TODO: this has never worked...
@@ -200,7 +204,7 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     assert_allclose(result_mod["background"].data[0, 10, 10], 194)
 
     assert result_mod["flux"].unit == u.Unit("cm-2s-1")
-    assert_allclose(result_image["flux"].data[0, 10, 10], 7.6e-9, rtol=1e-3)
+    assert_allclose(result_mod["flux"].data[0, 10, 10], 1.94e-8, rtol=1e-3)
 
 
 def test_incorrect_selection():

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -139,6 +139,9 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
 
     result_image = estimator_image.run(simple_dataset_on_off)
     assert result_image["counts"].data.shape == (1, 20, 20)
+    assert_allclose(result["counts"].data[0, 10, 10], 194)
+    assert_allclose(result["excess"].data[0, 10, 10], 97)
+    assert_allclose(result["background"].data[0, 10, 10], 97)
     assert_allclose(result_image["sqrt_ts"].data[0, 10, 10], 5.741116, atol=1e-3)
 
     mask_fit = Map.from_geom(
@@ -157,14 +160,17 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     result_image = estimator_image.run(simple_dataset_on_off)
     assert result_image["counts"].data.shape == (1, 20, 20)
 
-    assert_allclose(result_image["sqrt_ts"].data[0, 10, 10], 7.186745, atol=1e-3)
-
-    assert_allclose(result_image["counts"].data[0, 10, 10], 304)
-    assert_allclose(result_image["excess"].data[0, 10, 10], 152)
-    assert_allclose(result_image["background"].data[0, 10, 10], 152)
+    assert_allclose(result_image["sqrt_ts"].data[0, 10, 10], np.nan, atol=1e-3)
+    assert_allclose(result_image["counts"].data[0, 10, 10], np.nan)
+    assert_allclose(result_image["excess"].data[0, 10, 10], np.nan)
+    assert_allclose(result_image["background"].data[0, 10, 10], np.nan)
+    assert_allclose(result_image["sqrt_ts"].data[0, 9, 9], 7.186745, atol=1e-3)
+    assert_allclose(result_image["counts"].data[0, 9, 9], 304)
+    assert_allclose(result_image["excess"].data[0, 9, 9], 152)
+    assert_allclose(result_image["background"].data[0, 9, 9], 152)
 
     assert result_image["flux"].unit == u.Unit("cm-2s-1")
-    assert_allclose(result_image["flux"].data[0, 10, 10], 7.6e-9, rtol=1e-3)
+    assert_allclose(result_image["flux"].data[0, 9, 9], 7.6e-9, rtol=1e-3)
 
     # test with an npred()
     simple_dataset_on_off.exposure.data = (

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -8,6 +8,7 @@ from astropy import units as u
 from astropy.io import fits
 from gammapy.utils.scripts import make_path
 from .geom import MapCoord, pix_tuple_to_idx, MapAxis
+from gammapy.maps.hpx import HpxGeom
 from .utils import INVALID_VALUE
 
 __all__ = ["Map"]
@@ -476,12 +477,26 @@ class Map(abc.ABC):
         axis_self = self.geom.axes[axis.name]
         axis_resampled = geom.axes[axis.name]
 
-        indices = axis_self.coord_to_idx(axis_resampled.edges[:-1])
+        # We don't use MapAxis.coord_to_idx because is does not behave as needed with boundaries
+        coord = axis_resampled.edges.value
+        edges = axis_self.edges.value
+        indices = np.digitize(coord, edges) - 1
+
         idx = self.geom.axes.index_data(axis.name)
 
         weights = 1 if weights is None else weights.data
 
-        data = ufunc.reduceat(self.data * weights, indices=indices, axis=idx)
+        if not isinstance(self.geom, HpxGeom):
+            shape = self.geom._shape[:2]
+        else:
+            shape = (1,)
+        shape += tuple([ax.nbin if ax != axis else 1 for ax in self.geom.axes])
+
+        padded_array = np.append(self.data * weights, np.zeros(shape[::-1]), axis=idx)
+
+        slices = tuple([slice(0, _) for _ in geom.data_shape])
+        data = ufunc.reduceat(padded_array, indices=indices, axis=idx)[slices]
+
         return self._init_copy(data=data, geom=geom)
 
     def slice_by_idx(self, slices, ):

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -489,7 +489,7 @@ class Map(abc.ABC):
         if not isinstance(self.geom, HpxGeom):
             shape = self.geom._shape[:2]
         else:
-            shape = (1,)
+            shape = (self.geom.data_shape[-1],)
         shape += tuple([ax.nbin if ax != axis else 1 for ax in self.geom.axes])
 
         padded_array = np.append(self.data * weights, np.zeros(shape[::-1]), axis=idx)

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -318,3 +318,22 @@ def test_plot_poly():
     m = HpxNDMap.create(binsz=10)
     with mpl_plot_check():
         m.plot(method="poly")
+
+def test_hpxndmap_resample_axis():
+    axis_1 = MapAxis.from_edges([1, 2, 3, 4, 5], name="test-1")
+    axis_2 = MapAxis.from_edges([1, 2, 3, 4], name="test-2")
+
+    geom = HpxGeom.create(nside=16, axes=[axis_1, axis_2])
+    m = HpxNDMap(geom, unit="m2")
+    m.data += 1
+
+    new_axis = MapAxis.from_edges([2, 3, 5], name="test-1")
+    m2 = m.resample_axis(axis=new_axis)
+    assert m2.data.shape == (3, 2, 3072)
+    assert_allclose(m2.data[0,:,0], [1,2])
+
+    # Test without all interval covered
+    new_axis = MapAxis.from_edges([1.7, 4], name="test-1")
+    m3 = m.resample_axis(axis=new_axis)
+    assert m3.data.shape == (3, 1, 3072)
+    assert_allclose(m3.data, 2)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -435,6 +435,11 @@ def test_wcsndmap_resample_axis():
     assert m2.data.shape == (3, 2, 6, 7)
     assert_allclose(m2.data, 2)
 
+    # Test without all interval covered
+    new_axis = MapAxis.from_edges([2, 3], name="test-1")
+    m3 = m.resample_axis(axis=new_axis)
+    assert m3.data.shape == (3, 1, 6, 7)
+    assert_allclose(m3.data, 1)
 
 def test_wcsndmap_resample_axis_logical_and():
     axis_1 = MapAxis.from_edges([1, 2, 3, 4, 5], name="test-1")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects issue #3102 and add relevant tests.
The `resample_energy_axis` is now used in `ExcessMapEstimator` and `nan` are returned where the `mask` is `False`. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
