### PR TITLE
Change FluxEstimator UL backend to scipy

### DIFF
--- a/docs/tutorials/light_curve.ipynb
+++ b/docs/tutorials/light_curve.ipynb
@@ -152,7 +152,7 @@
     "    min=0.7 * u.TeV, max=10 * u.TeV, nbins=5\n",
     ")\n",
     "conf_3d.datasets.geom.axes.energy_true = dict(\n",
-    "    min=0.3 * u.TeV, max=20 * u.TeV, nbins=10\n",
+    "    min=0.3 * u.TeV, max=20 * u.TeV, nbins=20\n",
     ")"
    ]
   },
@@ -340,10 +340,10 @@
     "\n",
     "# Finally we define the energy binning for the spectra\n",
     "conf_1d.datasets.geom.axes.energy = dict(\n",
-    "    min=0.7 * u.TeV, max=10 * u.TeV, nbins=20\n",
+    "    min=0.7 * u.TeV, max=10 * u.TeV, nbins=5\n",
     ")\n",
     "conf_1d.datasets.geom.axes.energy_true = dict(\n",
-    "    min=0.3 * u.TeV, max=20 * u.TeV, nbins=40\n",
+    "    min=0.3 * u.TeV, max=20 * u.TeV, nbins=20\n",
     ")"
    ]
   },
@@ -434,6 +434,15 @@
     "    energy_edges=[1, 10] * u.TeV, source=\"crab\", reoptimize=False\n",
     ")\n",
     "lc_1d = lc_maker_1d.run(analysis_1d.datasets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lc_1d.table"
    ]
   },
   {
@@ -538,7 +547,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/light_curve_simulation.ipynb
+++ b/docs/tutorials/light_curve_simulation.ipynb
@@ -300,8 +300,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = lc_1d.plot(marker=\"o\", label=\"3D\")\n",
-    "plt.ylim(0, 4e-11)"
+    "lc_1d.table[\"is_ul\"] = lc_1d.table[\"ts\"] < 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = lc_1d.plot(marker=\"o\", label=\"3D\")"
    ]
   },
   {

--- a/docs/tutorials/spectrum_analysis.ipynb
+++ b/docs/tutorials/spectrum_analysis.ipynb
@@ -544,8 +544,8 @@
     "flux_points.table[\"is_ul\"] = flux_points.table[\"ts\"] < 4\n",
     "ax = flux_points.plot(\n",
     "    energy_power=2, flux_unit=\"erg-1 cm-2 s-1\", color=\"darkorange\"\n",
-    ")\n",
-    "flux_points.to_sed_type(\"e2dnde\").plot_ts_profiles(ax=ax)"
+    ");\n",
+    "flux_points.to_sed_type(\"e2dnde\").plot_ts_profiles(ax=ax);"
    ]
   },
   {

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -218,7 +218,9 @@ class ParameterEstimator(Estimator):
         """
         self._setup_fit(datasets)
         self._fit.optimize()
-        res = self._fit.confidence(parameter=parameter, sigma=self.n_sigma_ul)
+        res = self._fit.confidence(
+            parameter=parameter, sigma=self.n_sigma_ul, backend="scipy"
+        )
         return {f"{parameter.name}_ul": res["errp"] + parameter.value}
 
     def run(self, datasets, parameter):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**

@registerrier reported that after #3088, the UL computation for some flux points with the standard backend failed. This PR changes the default backend in the `FLuxEstimator` to `scipy`, which fixes the issue:


<img width="582" alt="image" src="https://user-images.githubusercontent.com/3715928/98103959-17e8ea00-1e96-11eb-8ed2-f7986fe4ee15.png">

<!-- What is tre motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

I'll merge once the CI builds have passed...

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
