### PR TITLE
Correct plot_residual methods

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -675,7 +675,7 @@ class MapDataset(Dataset):
         residuals : `gammapy.maps.Map`
             Residual map.
         """
-        npred, counts = self.npred(), self.counts
+        npred, counts = self.npred(), self.counts.copy()
 
         if self.mask:
             npred = npred * self.mask
@@ -727,7 +727,7 @@ class MapDataset(Dataset):
         ax : `~astropy.visualization.wcsaxes.WCSAxes`
             WCSAxes object.
         """
-        counts, npred = self.counts, self.npred()
+        counts, npred = self.counts.copy(), self.npred()
 
         if self.mask is not None:
             counts *= self.mask
@@ -778,7 +778,7 @@ class MapDataset(Dataset):
         if not region:
             raise ValueError("'region' is a required parameter")
 
-        counts, npred = self.counts, self.npred()
+        counts, npred = self.counts.copy(), self.npred()
 
         if self.mask is not None:
             counts *= self.mask

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -514,8 +514,12 @@ def test_map_fit(sky_model, geom, geom_etrue):
 
     region = sky_model.spatial_model.to_region()
 
+    initial_counts = dataset_1.counts.copy()
     with mpl_plot_check():
         dataset_1.plot_residuals(kwargs_spectral=dict(region=region))
+
+    # check dataset has not changed
+    assert initial_counts == dataset_1.counts
 
     # test model evaluation outside image
     dataset_1.models[0].spatial_model.lon_0.value = 150


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects the `MapDataset.plot_residuals` methods to avoid modifying the `counts` attribute of the dataset.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
