### PR TITLE
Adapt ExcessMapEstimator for missing models

### DIFF
--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -147,6 +147,9 @@ class ExcessMapEstimator(Estimator):
 
         resampled_dataset = dataset.resample_energy_axis(energy_axis=axis)
 
+        # Beware we rely here on the correct npred background in MapDataset.resample_energy_axis
+        resampled_dataset.models = dataset.models
+
         result = self.estimate_excess_map(resampled_dataset)
 
         return result

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -56,6 +56,9 @@ def convolved_map_dataset_counts_statistics(dataset, kernel, mask):
 class ExcessMapEstimator(Estimator):
     """Computes correlated excess, sqrt TS (i.e. Li-Ma significance) and errors for MapDatasets.
 
+    If a model is set on the dataset the excess map estimator will compute the excess taking into account
+    the predicted counts of the model.
+
     Parameters
     ----------
     correlation_radius : ~astropy.coordinate.Angle
@@ -111,6 +114,9 @@ class ExcessMapEstimator(Estimator):
 
     def run(self, dataset):
         """Compute correlated excess, Li & Ma significance and flux maps
+
+        If a model is set on the dataset the excess map estimator will compute the excess taking into account
+        the predicted counts of the model.
 
         Parameters
         ----------

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -7,7 +7,7 @@ from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.estimators import ExcessMapEstimator
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.utils.testing import requires_data
-
+from gammapy.modeling.models import SkyModel, PowerLawSpectralModel, GaussianSpatialModel
 
 def image_to_cube(input_map, energy_min, energy_max):
     energy_min = u.Quantity(energy_min)
@@ -175,28 +175,28 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     simple_dataset_on_off.psf = None
 
     # TODO: this has never worked...
-    # model = SkyModel(
-    #     PowerLawSpectralModel(),
-    #     GaussianSpatialModel(
-    #         lat_0=0.0 * u.deg, lon_0=0.0 * u.deg, sigma=0.1 * u.deg, frame="icrs"
-    #     ),
-    #     name="sky_model",
-    # )
+    model = SkyModel(
+         PowerLawSpectralModel(amplitude="1e-9 cm-2 s-1TeV-1"),
+         GaussianSpatialModel(
+             lat_0=0.0 * u.deg, lon_0=0.0 * u.deg, sigma=0.1 * u.deg, frame="icrs"
+         ),
+         name="sky_model",
+     )
     #
-    # #simple_dataset_on_off.models = [model]
+    simple_dataset_on_off.models = [model]
 
     estimator_mod = ExcessMapEstimator(0.11 * u.deg, apply_mask_fit=False)
     result_mod = estimator_mod.run(simple_dataset_on_off)
     assert result_mod["counts"].data.shape == (1, 20, 20)
 
-    assert_allclose(result_mod["sqrt_ts"].data[0, 10, 10], 8.119164, atol=1e-3)
+    assert_allclose(result_mod["sqrt_ts"].data[0, 10, 10], 6.240846, atol=1e-3)
 
     assert_allclose(result_mod["counts"].data[0, 10, 10], 388)
-    assert_allclose(result_mod["excess"].data[0, 10, 10], 194)
-    assert_allclose(result_mod["background"].data[0, 10, 10], 194)
+    assert_allclose(result_mod["excess"].data[0, 10, 10], 148.68057)
+    assert_allclose(result_mod["background"].data[0, 10, 10], 239.31943)
 
     assert result_mod["flux"].unit == u.Unit("cm-2s-1")
-    assert_allclose(result_mod["flux"].data[0, 10, 10], 1.94e-8, rtol=1e-3)
+    assert_allclose(result_mod["flux"].data[0, 10, 10], 1.486806e-08, rtol=1e-3)
 
 
 def test_incorrect_selection():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies the `ExcessMapEstimator` to take into account models after applying `MapDataset.resample_energy_axis`. 
A test is added.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
