### PR TITLE
Improve error messages for wrong shapes

### DIFF
--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -46,15 +46,29 @@ class PSF3D:
         energy_thresh_hi=u.Quantity(100, "TeV"),
         interp_kwargs=None,
     ):
-        assert energy_axis_true.name == "energy_true"
-        assert offset_axis.name == "offset"
-        assert rad_axis.name == "rad"
+        if energy_axis_true.name != "energy_true":
+            raise ValueError(
+                'Unexpected `energy_axis_true.name`,'
+                f' expected "energy_true", got: {energy_axis_true.name}'
+            )
 
-        assert psf_value.shape == (
-            energy_axis_true.nbin,
-            offset_axis.nbin,
-            rad_axis.nbin,
-        )
+        if offset_axis.name != "offset":
+            raise ValueError(
+                'Unexpected `offset_axis.name`,'
+                f' expected "offset", got: {offset_axis.name}'
+            )
+        if rad_axis.name != "rad":
+            raise ValueError(
+                'Unexpected `rad_axis.name`,'
+                f' expected "rad", got: {rad_axis.name}'
+            )
+
+        expected_shape = (energy_axis_true.nbin, offset_axis.nbin, rad_axis.nbin)
+        if psf_value.shape != expected_shape:
+            raise ValueError(
+                'PSF has wrong shape'
+                f', expected {expected_shape}, got {psf_value.shape}'
+            )
 
         self._energy_axis_true = energy_axis_true
         self._offset_axis = offset_axis

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -32,7 +32,11 @@ class TablePSF:
     """
 
     def __init__(self, rad_axis, psf_value, interp_kwargs=None):
-        assert rad_axis.name == "rad"
+        if rad_axis.name != "rad":
+            raise ValueError(
+                f'rad_axis has wrong name, expected "rad", got: {rad_axis.name}'
+            )
+
         self._rad_axis = rad_axis
 
         self.psf_value = u.Quantity(psf_value).to("sr^-1")
@@ -259,7 +263,11 @@ class EnergyDependentTablePSF:
         if psf_value is None:
             self.psf_value = np.zeros(shape) * u.Unit("sr^-1")
         else:
-            assert np.shape(psf_value) == shape
+            if np.shape(psf_value) != shape:
+                raise ValueError(
+                    'psf_value has wrong shape'
+                    f', expected {shape}, got {np.shape(psf_value)}'
+                )
             self.psf_value = u.Quantity(psf_value).to("sr^-1")
 
         self._interp_kwargs = interp_kwargs or {}

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -187,7 +187,7 @@ def test_wrong_axis_order():
 
     data = np.ones(shape=(offset_axis.nbin, energy_axis_true.nbin)) * u.cm ** 2
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         EffectiveAreaTable2D(
             energy_axis_true=energy_axis_true, offset_axis=offset_axis, data=data,
         )

--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -29,7 +29,7 @@ def test_psf_3d_basics(psf_3d):
 
     assert "PSF3D" in str(psf_3d)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         PSF3D(
             energy_axis_true=psf_3d.energy_axis_true,
             offset_axis=psf_3d.offset_axis,

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -34,7 +34,12 @@ class NDDataArray:
 
         self._axes = MapAxes(axes)
 
-        assert np.shape(data) == self._axes.shape
+        if np.shape(data) != self._axes.shape:
+            raise ValueError(
+                f'data shape {data.shape} does not match'
+                f'axes shape {self._axes.shape}'
+            )
+
         if data is not None:
             self.data = data
 

--- a/gammapy/utils/tests/test_nddata.py
+++ b/gammapy/utils/tests/test_nddata.py
@@ -44,7 +44,7 @@ def nddata_2d(axis_energy, axis_offset):
 
 class TestNDDataArray:
     def test_init_error(self):
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             NDDataArray(
                 axes=[MapAxis.from_nodes([1, 3, 6], name="x")],
                 data=np.arange(8).reshape(4, 2),


### PR DESCRIPTION


**Description**

Improve empty assertion errors by using meaningfull messages in `ValueErrors`.
