### PR TITLE
Modified TSMapEstimator to keep model term

### DIFF
--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -7,14 +7,33 @@ from astropy.coordinates import Angle
 from gammapy.datasets import MapDataset
 from gammapy.estimators import TSMapEstimator
 from gammapy.irf import EDispKernelMap, EnergyDependentTablePSF, PSFMap
-from gammapy.maps import Map, MapAxis
+from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling.models import (
     GaussianSpatialModel,
+    PointSpatialModel,
     PowerLawSpectralModel,
     SkyModel,
 )
 from gammapy.utils.testing import requires_data
 
+@pytest.fixture(scope="session")
+def fake_dataset():
+    axis = MapAxis.from_energy_bounds(0.1, 10, 5, unit="TeV", name="energy")
+    axis_true = MapAxis.from_energy_bounds(0.05, 20, 10, unit="TeV", name="energy_true")
+
+    geom = WcsGeom.create(npix=50, binsz=0.02, axes=[axis])
+    dataset = MapDataset.create(geom)
+    dataset.psf = PSFMap.from_gauss(axis_true, sigma="0.05 deg")
+    dataset.mask_safe += np.ones(dataset.data_shape, dtype=bool)
+    dataset.background += 1
+    dataset.exposure += 1e12 * u.cm ** 2 * u.s
+
+    spatial_model = PointSpatialModel()
+    spectral_model = PowerLawSpectralModel(amplitude="1e-10 cm-2s-1TeV-1", index=2)
+    model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model, name='source')
+    dataset.models = [model]
+    dataset.fake(random_state=42)
+    return dataset
 
 @pytest.fixture(scope="session")
 def input_dataset():
@@ -181,3 +200,38 @@ def test_large_kernel(input_dataset):
 
     with pytest.raises(ValueError):
         ts_estimator.run(input_dataset)
+
+def test_ts_map_with_model(fake_dataset):
+    model = fake_dataset.models['source']
+
+    fake_dataset.models = []
+
+    estimator = TSMapEstimator(
+        model,
+        kernel_width="0.3 deg",
+        selection_optional=[],
+        energy_edges=[200, 3500] * u.GeV,
+    )
+    maps = estimator.run(fake_dataset)
+
+    assert_allclose(maps["sqrt_ts"].data[:,25,25],18.369942, atol=0.1)
+    assert_allclose(maps["flux"].data[:,25,25], 3.513e-10, atol=1e-12)
+
+    fake_dataset.models = [model]
+    maps = estimator.run(fake_dataset)
+
+    assert_allclose(maps["sqrt_ts"].data[:,25,25], -0.231187, atol=0.1)
+    assert_allclose(maps["flux"].data[:,25,25], -5.899423e-12, atol=1e-12)
+
+    # Try downsmapling
+    estimator = TSMapEstimator(
+        model,
+        kernel_width="0.3 deg",
+        selection_optional=[],
+        downsampling_factor=2,
+        energy_edges=[200, 3500] * u.GeV,
+    )
+    maps = estimator.run(fake_dataset)
+    assert_allclose(maps["sqrt_ts"].data[:,25,25], 0.323, atol=0.1)
+    assert_allclose(maps["flux"].data[:,25,25], 1.015417e-12, atol=1e-12)
+

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -398,6 +398,7 @@ class TSMapEstimator(Estimator):
                 * flux_ul : upper limit map
 
         """
+        dataset_models = dataset.models
         if self.downsampling_factor:
             shape = dataset.counts.geom.to_image().data_shape
             pad_width = symmetric_crop_pad_width(shape, shape_2N(shape))[0]
@@ -415,12 +416,13 @@ class TSMapEstimator(Estimator):
         results = []
 
         for energy_min, energy_max in zip(energy_edges[:-1], energy_edges[1:]):
-            dataset = datasets.slice_by_energy(energy_min, energy_max)[0]
+            sliced_dataset = datasets.slice_by_energy(energy_min, energy_max)[0]
 
             if self.sum_over_energy_groups:
-                dataset = dataset.to_image()
+                sliced_dataset = sliced_dataset.to_image()
 
-            result = self.estimate_flux_map(dataset)
+            sliced_dataset.models = dataset_models
+            result = self.estimate_flux_map(sliced_dataset)
             results.append(result)
 
         result_all = {}


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the `TSMapEstimator` to avoid losing the `model` when downsampling the dataset, or when slicing it.
A test is added to ensure inclusion of the model is properly taken into account.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
