### PR TITLE
Corrected exclusion mask notebook

### DIFF
--- a/docs/tutorials/exclusion_mask.ipynb
+++ b/docs/tutorials/exclusion_mask.ipynb
@@ -323,6 +323,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because the `ExcessMapEstimator` returns NaN for masked pixels, we need to put the NaN values to `True` to avoid incorrectly excluding them. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "invalid_pixels = np.isnan(result[\"sqrt_ts\"].data)\n",
+    "mask_map_significance.data[invalid_pixels]=True"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/docs/tutorials/light_curve_flare.ipynb
+++ b/docs/tutorials/light_curve_flare.ipynb
@@ -337,7 +337,9 @@
    "outputs": [],
    "source": [
     "lc_maker_1d = LightCurveEstimator(\n",
-    "    energy_edges=[0.7, 20] * u.TeV, source=\"pks2155\"\n",
+    "    energy_edges=[0.7, 20] * u.TeV, \n",
+    "    source=\"pks2155\", \n",
+    "    time_intervals=time_intervals\n",
     ")"
    ]
   },


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request because of the safe mask of the Fermi crab dataset, the `ExcessMapEstimator` is returning some nan values over the map. This small change avoids having them in the exclusion mask.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
