### PR TITLE
Fix model handling in FluxEstimator

### DIFF
--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -325,8 +325,8 @@ def test_analysis_3d():
     assert len(analysis.flux_points.data.table) == 2
     dnde = analysis.flux_points.data.table["dnde"].quantity
 
-    assert_allclose(dnde[0].value, 1.376879e-11, rtol=1e-2)
-    assert_allclose(dnde[-1].value, 2.691466e-13, rtol=1e-2)
+    assert_allclose(dnde[0].value, 1.339052e-11, rtol=1e-2)
+    assert_allclose(dnde[-1].value, 2.775197e-13, rtol=1e-2)
     assert_allclose(res["index"].value, 3.097613, rtol=1e-2)
     assert_allclose(res["tilt"].value, -0.207792, rtol=1e-2)
 

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -239,7 +239,7 @@ class Datasets(collections.abc.MutableSequence):
         for dataset in self:
             try:
                 dataset_sliced = dataset.slice_by_energy(
-                    energy_min=energy_min, energy_max=energy_max,
+                    energy_min=energy_min, energy_max=energy_max, name=dataset.name + "-slice"
                 )
             except ValueError:
                 log.info(

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -239,7 +239,7 @@ class Datasets(collections.abc.MutableSequence):
         for dataset in self:
             try:
                 dataset_sliced = dataset.slice_by_energy(
-                    energy_min=energy_min, energy_max=energy_max, name=dataset.name,
+                    energy_min=energy_min, energy_max=energy_max,
                 )
             except ValueError:
                 log.info(

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -47,8 +47,8 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
 
     result = estimator.run(fermi_datasets)
 
-    assert_allclose(result["norm"], 0.982434, atol=1e-3)
-    assert_allclose(result["ts"], 23856.262603, atol=1e-3)
+    assert_allclose(result["norm"], 0.98949, atol=1e-3)
+    assert_allclose(result["ts"], 25082.190245, atol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
     assert_allclose(result["norm_errn"], 0.0199, atol=1e-3)
     assert_allclose(result["norm_errp"], 0.0199, atol=1e-3)
@@ -72,7 +72,7 @@ def test_flux_estimator_fermi_with_reoptimization(fermi_datasets):
     result = estimator.run(fermi_datasets)
 
     assert_allclose(result["norm"], 0.989989, atol=1e-3)
-    assert_allclose(result["ts"], 18728.35303, atol=1e-3)
+    assert_allclose(result["ts"], 25082.190245, atol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
 
 
@@ -123,7 +123,7 @@ def test_inhomogeneous_datasets(fermi_datasets, hess_datasets):
     result = estimator.run(datasets)
 
     assert_allclose(result["norm"], 1.190622, atol=1e-3)
-    assert_allclose(result["ts"], 612.500392, atol=1e-3)
+    assert_allclose(result["ts"], 660.422291, atol=1e-3)
     assert_allclose(result["norm_err"], 0.090744, atol=1e-3)
     assert_allclose(result["e_min"], 0.693145 * u.TeV, atol=1e-3)
     assert_allclose(result["e_max"], 2 * u.TeV, atol=1e-3)

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -247,16 +247,16 @@ class TestFluxPointsEstimator:
         assert_allclose(actual, 0.962368, rtol=1e-2)
 
         actual = fp.table["norm_err"].data
-        assert_allclose(actual, 0.054011, rtol=1e-2)
+        assert_allclose(actual, 0.051955, rtol=1e-2)
 
         actual = fp.table["sqrt_ts"].data
-        assert_allclose(actual, 25.196859, rtol=1e-2)
+        assert_allclose(actual, 28.408426, rtol=1e-2)
 
         actual = fp.table["norm_scan"][0]
         assert_allclose(actual, 1)
 
         actual = fp.table["stat_scan"][0] - fp.table["stat"][0]
-        assert_allclose(actual, 0.480491, rtol=1e-2)
+        assert_allclose(actual, 0.489359, rtol=1e-2)
 
     @staticmethod
     @requires_dependency("iminuit")

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -554,6 +554,15 @@ class FoVBackgroundModel(Model):
 
         return cls(spectral_model=spectral_model, dataset_name=datasets_names[0],)
 
+    def reset_to_default(self):
+        """Reset parameter values to default"""
+        values = self.spectral_model.default_parameters.values
+        self.spectral_model.parameters.values = values
+
+    def copy(self, **kwargs):
+        """Copy SkyModel"""
+        return self.__class__(**kwargs)
+
 
 class BackgroundModel(Model):
     """Background model.

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -330,6 +330,15 @@ class Parameters(collections.abc.Sequence):
         """Parameter values (`numpy.ndarray`)."""
         return np.array([_.value for _ in self._parameters], dtype=np.float64)
 
+    @values.setter
+    def values(self, values):
+        """Parameter values (`numpy.ndarray`)."""
+        if not len(self) == len(values):
+            raise ValueError("Values must have same length as parameter list")
+
+        for value, par in zip(values, self):
+            par.value = value
+
     @classmethod
     def from_stack(cls, parameters_list):
         """Create `Parameters` by stacking a list of other `Parameters` objects.


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes a bug in the model setting of the `FluxEstimator`: as the `slice_by_energy()` method relies on `.npred_background()` internally, the `FoVBackgroundModel` has to be reset to it's default values and not applying the old values....

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
