### PR TITLE
Make reading DL3 data more standard conform

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -117,7 +117,7 @@ class Analysis:
             self.observations = self.observations.select_time([(start, stop)])
         log.info(f"Number of selected observations: {len(self.observations)}")
         for obs in self.observations:
-            log.debug(obs)
+            log.debug(str(obs))
 
     def get_datasets(self):
         """Produce reduced datasets."""
@@ -143,7 +143,7 @@ class Analysis:
         if not self.datasets or len(self.datasets) == 0:
             raise RuntimeError("Missing datasets")
 
-        log.info(f"Reading model.")
+        log.info("Reading model.")
         if isinstance(models, str):
             self.models = Models.from_yaml(models)
         elif isinstance(models, Models):
@@ -295,7 +295,7 @@ class Analysis:
                 if bkg_method == "ring":
                     dataset = dataset.to_map_dataset()
 
-                log.debug(dataset)
+                log.debug(str(dataset))
                 stacked.stack(dataset)
             datasets = [stacked]
         else:
@@ -308,7 +308,7 @@ class Analysis:
                 dataset = maker_safe_mask.run(dataset, obs)
                 if bkg_maker is not None:
                     dataset = bkg_maker.run(dataset)
-                log.debug(dataset)
+                log.debug(str(dataset))
                 datasets.append(dataset)
 
         self.datasets = Datasets(datasets)

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -278,7 +278,7 @@ class Analysis:
         else:
             bkg_maker = None
             log.warning(
-                f"No background maker set for 3d analysis. Check configuration."
+                "No background maker set for 3d analysis. Check configuration."
             )
 
         stacked = MapDataset.create(geom=geom, name="stacked", **geom_irf)

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -198,7 +198,7 @@ class Observation:
         The dead-time fraction is used in the live-time computation,
         which in turn is used in the exposure and flux computation.
         """
-        return 1 - self.obs_info["DEADC"]
+        return 1 - self.events.table.meta["DEADC"]
 
     @property
     def pointing_radec(self):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -63,6 +63,14 @@ class Observation:
         events=None,
         obs_filter=None,
     ):
+        if "DEADC" in obs_info:
+            deadc = obs_info["DEADC"]
+        else:
+            if events is None or "DEADC" not in events.meta:
+                raise ValueError("DEADC must be provided either in events or obs_info")
+            deadc = events.meta["DEADC"]
+
+        self._deadc = deadc
         self.obs_id = obs_id
         self.obs_info = obs_info
         self.aeff = aeff
@@ -198,7 +206,9 @@ class Observation:
         The dead-time fraction is used in the live-time computation,
         which in turn is used in the exposure and flux computation.
         """
-        return 1 - self.events.table.meta["DEADC"]
+        # if events is available, 'DEADC' is required to be 
+        # in the metadata of the events table
+        return 1 - self._deadc
 
     @property
     def pointing_radec(self):

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -210,7 +210,7 @@ def test_observations_select_time_time_intervals_list(data_store):
 
 
 @requires_data()
-def test_observation():
+def test_observation_2():
     livetime = 5.0 * u.hr
     pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
     irfs = load_cta_irfs(

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -252,7 +252,16 @@ class MapDatasetMaker(Maker):
         meta_table: `~astropy.table.Table`
         """
         meta_table = Table()
-        meta_table["TELESCOP"] = [observation.events.table.meta.get("TELESCOP", "UNKNOWN")]
+
+        # Look for telescop
+        telescope = None
+        if observation.events.table is not None:
+            telescope = observation.events.table.meta.get("TELESCOP")
+
+        if telescope is None and observation.aeff is not None:
+            observation.aeff.meta.get("TELESCOP")
+
+        meta_table["TELESCOP"] = [telescope or "UNKNOWN"]
         meta_table["OBS_ID"] = [observation.obs_id]
         meta_table["RA_PNT"] = [observation.pointing_radec.icrs.ra.deg] * u.deg
         meta_table["DEC_PNT"] = [observation.pointing_radec.icrs.dec.deg] * u.deg

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -252,7 +252,7 @@ class MapDatasetMaker(Maker):
         meta_table: `~astropy.table.Table`
         """
         meta_table = Table()
-        meta_table["TELESCOP"] = [observation.aeff.meta["TELESCOP"]]
+        meta_table["TELESCOP"] = [observation.events.table.meta.get("TELESCOP", "UNKNOWN")]
         meta_table["OBS_ID"] = [observation.obs_id]
         meta_table["RA_PNT"] = [observation.pointing_radec.icrs.ra.deg] * u.deg
         meta_table["DEC_PNT"] = [observation.pointing_radec.icrs.dec.deg] * u.deg

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -282,13 +282,14 @@ class TestTheta2Table:
         table["ENERGY"] = [1.0, 1.0, 1.5, 1.5, 10.0] * u.TeV
         table["OFFSET"] = [0.1, 0.1, 0.5, 1.0, 1.5] * u.deg
 
+        table.meta["DEADC"] = 1.0
         table.meta["RA_PNT"] = 0 * u.deg
         table.meta["DEC_PNT"] = 0.5 * u.deg
 
         meta_obs = dict()
         meta_obs["RA_PNT"] = 0 * u.deg
         meta_obs["DEC_PNT"] = 0.5 * u.deg
-        meta_obs["DEADC"] = 1
+        meta_obs["DEADC"] = 1.0
 
         meta = time_ref_to_dict("2010-01-01")
         gti_table = Table({"START": [1], "STOP": [3]}, meta=meta)


### PR DESCRIPTION
**Description**


### `TELESCOP`
Reading in DL3 data required that `TELESCOP` is set in the `AEFF` table. 

* This is a strange place to look for it
* It is not required by the GADF standard that `TELESCOP` is even present.


So I:

* changed it to get `TELESCOP` from the event list, where it is more commonly stored and make it optional (setting it to `UNKNOWN` if not available.


### `DEADC`

`DEADC` is an optional column in the `OBS_INDEX` HDU but a required header keyword in the `EVENTS` table.

Gammapy required that it was available in the `OBS_INDEX` HDU. Changed to read it from the `EVENTS` table, where
it is guaranteed to be there for a standard compliant file.