### PR TITLE
Correct excess_matching_significance behavior

### DIFF
--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -193,7 +193,7 @@ class ExcessProfileEstimator(Estimator):
             result.update(
                 {
                     "counts": stats.n_on,
-                    "background": stats.mu_bkg,
+                    "background": stats.n_bkg,
                     "excess": stats.n_sig,
                 }
             )

--- a/gammapy/stats/counts_statistic.py
+++ b/gammapy/stats/counts_statistic.py
@@ -218,14 +218,6 @@ class WStatCountsStatistic(CountsStatistic):
             self.mu_sig = np.asanyarray(mu_sig)
 
     @property
-    def mu_bkg(self):
-        """Expected background"""
-        mu_bkg = self.alpha * get_wstat_mu_bkg(
-            n_on=self.n_on, n_off=self.n_off, alpha=self.alpha, mu_sig=self.mu_sig,
-        )
-        return np.nan_to_num(mu_bkg)
-
-    @property
     def n_bkg(self):
         """Known background computed alpha * n_off"""
         return self.alpha * self.n_off
@@ -263,9 +255,9 @@ class WStatCountsStatistic(CountsStatistic):
 
     def _n_sig_matching_significance_fcn(self, n_sig, significance, index):
         stat0 = wstat(
-            n_sig + self.mu_bkg[index], self.n_off[index], self.alpha[index], 0
+            n_sig + self.n_bkg[index], self.n_off[index], self.alpha[index], 0
         )
         stat1 = wstat(
-            n_sig + self.mu_bkg[index], self.n_off[index], self.alpha[index], n_sig,
+            n_sig + self.n_bkg[index], self.n_off[index], self.alpha[index], n_sig,
         )
         return np.sign(n_sig) * np.sqrt(np.clip(stat0 - stat1, 0, None)) - significance

--- a/gammapy/stats/tests/test_counts_statistic.py
+++ b/gammapy/stats/tests/test_counts_statistic.py
@@ -76,7 +76,7 @@ values = [
 
 @pytest.mark.parametrize(("mu_bkg", "significance", "result"), values)
 def test_cash_excess_matching_significance(mu_bkg, significance, result):
-    stat = CashCountsStatistic(1, mu_bkg)
+    stat = CashCountsStatistic(0, mu_bkg)
     excess = stat.n_sig_matching_significance(significance)
 
     assert_allclose(excess, result, atol=1e-3)
@@ -170,8 +170,8 @@ def test_wstat_ul(n_on, n_off, alpha, result):
 
 
 values = [
-    ([10, 20], [0.1, 0.1], 5, [9.82966, 12.129523]),
-    ([10, 10], [0.1, 0.3], 5, [9.82966, 17.130893]),
+    ([10, 20], [0.1, 0.1], 5, [9.82966, 12.0384229]),
+    ([10, 10], [0.1, 0.3], 5, [9.82966, 16.664516]),
     ([10], [0.1], 3, [4.818497]),
     (
         [[10, 20], [10, 20]],
@@ -184,7 +184,7 @@ values = [
 
 @pytest.mark.parametrize(("n_off", "alpha", "significance", "result"), values)
 def test_wstat_excess_matching_significance(n_off, alpha, significance, result):
-    stat = WStatCountsStatistic(1, n_off, alpha)
+    stat = WStatCountsStatistic(0, n_off, alpha)
     excess = stat.n_sig_matching_significance(significance)
 
     assert_allclose(excess, result, rtol=1e-2)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects `WStatCountsStatictics.n_sig_matching_significance`. 
After this commit : https://github.com/gammapy/gammapy/commit/5c962385f5ba016a68f43893cedcb27d9e9a4796  a bug was introduced in the method after replacing `background` or `n_bkg` (alpha*n_off)  by `mu_bkg` (the actual estimated background).

It seems that the estimated background as computed here is not a really relevant quantity. It has been removed, to avoid further confusion.

The error was reported by @maxnoe on slack.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
