### PR TITLE
Fix containment radius computation

### DIFF
--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -261,7 +261,7 @@ def test_analysis_1d_stacked():
     pars = analysis.fit_result.parameters
 
     assert_allclose(pars["index"].value, 2.76913, rtol=1e-2)
-    assert_allclose(pars["amplitude"].value, 5.496388e-11, rtol=1e-2)
+    assert_allclose(pars["amplitude"].value, 5.410243e-11, rtol=1e-2)
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -237,7 +237,7 @@ def test_to_spectrum_dataset(sky_model, geom, geom_etrue, edisp_mode):
     assert spectrum_dataset_mask.data_shape == (2, 1, 1)
     assert spectrum_dataset_corrected.exposure.unit == "m2s"
     assert_allclose(spectrum_dataset.exposure.data[1], 3.070884e09, rtol=1e-5)
-    assert_allclose(spectrum_dataset_corrected.exposure.data[1], 2.035899e09, rtol=1e-5)
+    assert_allclose(spectrum_dataset_corrected.exposure.data[1], 2.035899e+09, rtol=1e-5)
 
 
 @requires_data()

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -316,9 +316,10 @@ class PSF3D:
 
         for theta in thetas:
             for fraction in fractions:
+                plot_kwargs = kwargs.copy()
                 radius = self.containment_radius(energy, theta, fraction)
-                kwargs.setdefault("label", f"{theta.deg} deg, {100 * fraction:.1f}%")
-                ax.plot(energy.value, radius.value, **kwargs)
+                plot_kwargs.setdefault("label", f"{theta.deg} deg, {100 * fraction:.1f}%")
+                ax.plot(energy.value, radius.value, **plot_kwargs)
 
         ax.semilogx()
         ax.legend(loc="best")

--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -52,18 +52,18 @@ def test_to_energy_dependent_table_psf(psf_3d):
     psf = psf_3d.to_energy_dependent_table_psf()
     assert psf.psf_value.shape == (32, 144)
     radius = psf.table_psf_at_energy("1 TeV").containment_radius(0.68).deg
-    assert_allclose(radius, 0.124733, atol=1e-4)
+    assert_allclose(radius, 0.123352, atol=1e-4)
 
 
 @requires_data()
 def test_psf_3d_containment_radius(psf_3d):
     q = psf_3d.containment_radius(energy="1 TeV")
-    assert_allclose(q.value, 0.124733, rtol=1e-2)
+    assert_allclose(q.value, 0.123352, rtol=1e-2)
     assert q.isscalar
     assert q.unit == "deg"
 
     q = psf_3d.containment_radius(energy=[1, 3] * u.TeV)
-    assert_allclose(q.value, [0.124733, 0.13762], rtol=1e-2)
+    assert_allclose(q.value, [0.123261, 0.13131], rtol=1e-2)
     assert q.shape == (2,)
 
 

--- a/gammapy/irf/tests/test_psf_map.py
+++ b/gammapy/irf/tests/test_psf_map.py
@@ -91,8 +91,8 @@ def make_test_psfmap(size, shape="gauss"):
     energy_axis = MapAxis(
         nodes=[0.2, 0.7, 1.5, 2.0, 10.0], unit="TeV", name="energy_true"
     )
-    rad_axis = MapAxis.from_nodes(
-        nodes=np.linspace(0.0, 0.6, 50), unit="deg", name="rad"
+    rad_axis = MapAxis.from_edges(
+        edges=np.linspace(0.0, 1, 101), unit="deg", name="rad"
     )
 
     geom = WcsGeom.create(
@@ -210,8 +210,8 @@ def test_sample_coord():
     coords = psf_map.sample_coord(map_coord=coords_in)
     assert coords.frame == "icrs"
     assert len(coords.lon) == 2
-    assert_allclose(coords.lon, [0.07498478, 0.04274561], rtol=1e-3)
-    assert_allclose(coords.lat, [-0.10173629, 0.34703959], rtol=1e-3)
+    assert_allclose(coords.lon, [0.074855, 0.042655], rtol=1e-3)
+    assert_allclose(coords.lat, [-0.101561,  0.347365], rtol=1e-3)
 
 
 def test_sample_coord_gauss():
@@ -380,13 +380,13 @@ def test_to_image():
     psfmap = make_test_psfmap(0.15 * u.deg)
 
     psf2D = psfmap.to_image()
-    assert_allclose(psf2D.psf_map.geom.data_shape, (1, 50, 25, 25))
+    assert_allclose(psf2D.psf_map.geom.data_shape, (1, 100, 25, 25))
     assert_allclose(psf2D.exposure_map.geom.data_shape, (1, 1, 25, 25))
     assert_allclose(psf2D.psf_map.data[0][0][12][12], 23255.41204827, rtol=1e-2)
 
 
 def test_psfmap_from_gauss():
-    rad = np.linspace(0, 1.5, 50) * u.deg
+    rad = np.linspace(0, 1.5, 100) * u.deg
     energy = np.logspace(-1, 2, 10) * u.TeV
     energy_axis = MapAxis.from_nodes(
         energy, name="energy_true", interp="log", unit="TeV"

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -177,7 +177,7 @@ class TestSpectrumMakerChain:
                 dict(
                     n_on=125,
                     sigma=18.953014,
-                    aeff=361924.746081 * u.m ** 2,
+                    aeff=375314.356461 * u.m ** 2,
                     edisp=0.235864,
                 ),
             ),


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

I noticed that in v0.18.1 the computation of the containment radius was partly broken, if the PSF was not normalised properly. See https://docs.gammapy.org/0.18.1/tutorials/hess.html#DL3-DR1. This PR fixes the behaviour. The result is now:


<img width="1144" alt="Screenshot 2020-11-17 at 14 34 59" src="https://user-images.githubusercontent.com/3715928/99409191-6617d780-28f1-11eb-8714-86ff45d79d0f.png">

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
