### PR TITLE
Fix too small energy bin handling for FluxEstimator

### DIFF
--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -172,7 +172,7 @@ class FluxEstimator(Estimator):
                 bkg_model.reset_to_default()
                 models.append(bkg_model)
 
-        if len(datasets) > 0:
+        if len(datasets_sliced) > 0:
             # TODO: this relies on the energy binning of the first dataset
             energy_axis = datasets_sliced[0].counts.geom.axes["energy"]
             energy_min, energy_max = energy_axis.edges.min(), energy_axis.edges.max()

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
@@ -97,9 +98,19 @@ def test_flux_estimator_1d(hess_datasets):
     assert_allclose(result["e_max"], 10 * u.TeV, atol=1e-3)
 
 
-def test_flux_estimator_incorrect_energy_range():
+def test_flux_estimator_incorrect_energy_range(fermi_datasets):
     with pytest.raises(ValueError):
         FluxEstimator(source="Crab", energy_min=10 * u.TeV, energy_max=1 * u.TeV)
+
+    fe = FluxEstimator(
+        source="Crab Nebula",
+        energy_min=0.18 * u.TeV,
+        energy_max=0.2 * u.TeV
+    )
+
+    result = fe.run(fermi_datasets)
+
+    assert np.isnan(result["norm"])
 
 
 @requires_data()

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -98,6 +98,8 @@ def test_flux_estimator_1d(hess_datasets):
     assert_allclose(result["e_max"], 10 * u.TeV, atol=1e-3)
 
 
+@requires_data()
+@requires_dependency("iminuit")
 def test_flux_estimator_incorrect_energy_range(fermi_datasets):
     with pytest.raises(ValueError):
         FluxEstimator(source="Crab", energy_min=10 * u.TeV, energy_max=1 * u.TeV)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes and issue reported by @registerrier in private. If the requested energy bin for the `FluxEstimator` was too small it would fail, because the case was not matched correctly. 


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
