### PR TITLE
Change find_peaks to work with flat maps rather than images

### DIFF
--- a/docs/tutorials/cta_data_analysis.ipynb
+++ b/docs/tutorials/cta_data_analysis.ipynb
@@ -325,7 +325,7 @@
    "outputs": [],
    "source": [
     "sources = find_peaks(\n",
-    "    images_ts[\"sqrt_ts\"].get_image_by_idx((0,)),\n",
+    "    images_ts[\"sqrt_ts\"],\n",
     "    threshold=5,\n",
     "    min_distance=\"0.2 deg\",\n",
     ")\n",

--- a/docs/tutorials/detect.ipynb
+++ b/docs/tutorials/detect.ipynb
@@ -243,8 +243,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sqrt_ts_image = maps[\"sqrt_ts\"].get_image_by_idx((0,))\n",
-    "sources = find_peaks(sqrt_ts_image, threshold=5, min_distance=\"0.25 deg\")\n",
+    "sources = find_peaks(maps[\"sqrt_ts\"], threshold=5, min_distance=\"0.25 deg\")\n",
     "nsou = len(sources)\n",
     "sources"
    ]

--- a/gammapy/estimators/tests/test_utils.py
+++ b/gammapy/estimators/tests/test_utils.py
@@ -2,7 +2,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 from gammapy.estimators.utils import find_peaks
-from gammapy.maps import Map
+from gammapy.maps import Map, MapAxis
 
 
 class TestFindPeaks:
@@ -44,3 +44,22 @@ class TestFindPeaks:
 
         table = find_peaks(image, threshold=3)
         assert len(table) == 0
+
+    def test_flat_map(self):
+        """Test a simple example"""
+        axis1 = MapAxis.from_edges([1,2],name='axis1')
+        axis2 = MapAxis.from_edges([9,10],name='axis2')
+        image = Map.create(npix=(10, 5), unit="s", axes=[axis1,axis2])
+        image.data[..., 3, 3] = 11
+        image.data[..., 3, 4] = 10
+        image.data[..., 3, 5] = 12
+        image.data[..., 3, 6] = np.nan
+        image.data[..., 0, 9] = 1e20
+
+        table = find_peaks(image, threshold=3)
+        row = table[0]
+
+        assert len(table) == 3
+        assert_allclose(row["value"], 1e20)
+        assert_allclose(row["ra"], 359.55)
+        assert_allclose(row["dec"], -0.2)

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -43,7 +43,7 @@ def find_peaks(image, threshold, min_distance=1):
     Parameters
     ----------
     image : `~gammapy.maps.WcsNDMap`
-        2D map
+        Image like Map
     threshold : float or array-like
         The data value or pixel-wise data values to be used for the
         detection threshold.  A 2D ``threshold`` must have the same
@@ -62,8 +62,8 @@ def find_peaks(image, threshold, min_distance=1):
     if not isinstance(image, WcsNDMap):
         raise TypeError("find_peaks only supports WcsNDMap")
 
-    if not image.geom.is_image:
-        raise ValueError("find_peaks only supports 2D images")
+    if not image.geom.is_flat:
+        raise ValueError("find_peaks only supports flat Maps, with no spatial axes of length 1.")
 
     if isinstance(min_distance, (str, u.Quantity)):
         min_distance = np.mean(u.Quantity(min_distance) / image.geom.pixel_scales)
@@ -72,7 +72,7 @@ def find_peaks(image, threshold, min_distance=1):
     size = 2 * min_distance + 1
 
     # Remove non-finite values to avoid warnings or spurious detection
-    data = image.data.copy()
+    data = image.sum_over_axes(keepdims=False).data
     data[~np.isfinite(data)] = np.nanmin(data)
 
     # Handle edge case of constant data; treat as no peak


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a simple modification of `gammapy.estimators.utils.find_peaks` to work with flat `Map` and not only image like `Map`. The `map.get_image_by_idx((0,))` that was necessary in the detect.ipynb tutorial is unclear and unnecessary.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
