### PR TITLE
Fix API links in notebooks

### DIFF
--- a/docs/tutorials/catalog.ipynb
+++ b/docs/tutorials/catalog.ipynb
@@ -360,7 +360,7 @@
    "source": [
     "## Lightcurves\n",
     "\n",
-    "The Fermi catalogs contain lightcurves for each source. It is available via the `source.lightcurve` property as a `~gammapy.time.LightCurve` object."
+    "The Fermi catalogs contain lightcurves for each source. It is available via the `source.lightcurve` property as a `~gammapy.estimators.LightCurve` object."
    ]
   },
   {

--- a/docs/tutorials/light_curve.ipynb
+++ b/docs/tutorials/light_curve.ipynb
@@ -237,7 +237,7 @@
     "We pass it the list of datasets and the name of the model component for which we want to build the light curve. \n",
     "We can optionally ask for parameters reoptimization during fit, that is most of the time to fit background normalization in each time bin. \n",
     "\n",
-    "If we don't set any time interval, the `~gammapy.time.LightCurveEstimator` is determines the flux of each dataset and places it at the corresponding time in the light curve. \n",
+    "If we don't set any time interval, the `~gammapy.estimators.LightCurveEstimator` is determines the flux of each dataset and places it at the corresponding time in the light curve. \n",
     "Here one dataset equals to one observing run."
    ]
   },

--- a/docs/tutorials/light_curve_flare.ipynb
+++ b/docs/tutorials/light_curve_flare.ipynb
@@ -327,7 +327,7 @@
    "source": [
     "## Extract the light curve\n",
     "\n",
-    "We first create the `~gammapy.time.LightCurveEstimator` for the list of datasets we just produced. We give the estimator the name of the source component to be fitted."
+    "We first create the `~gammapy.estimators.LightCurveEstimator` for the list of datasets we just produced. We give the estimator the name of the source component to be fitted."
    ]
   },
   {


### PR DESCRIPTION
This small PR fixes broken links found in notebooks pointing to the autogenerated API doc.