### PR TITLE
Adding a function to update parameters from dict

### DIFF
--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -248,10 +248,11 @@ class Parameter:
         return copy.deepcopy(self)
 
     def update_from_dict(self, data):
-        """Update parameters from a dict. Do not modify the name of parameters.
-            Key name is accessed as a hidden parameters with _keyname. """
+        """Update parameters from a dict.
+           Protection against changing parameter name."""
         data.pop("name")
-        self.__dict__.update({ '_'+k: v for k, v in data.items() })
+        for k in data.keys(): setattr(self, k, data[k])
+
 
     def to_dict(self):
         """Convert to dict."""

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -247,6 +247,11 @@ class Parameter:
         """A deep copy"""
         return copy.deepcopy(self)
 
+    def update_from_dict(self, data):
+        """Update parameters from a dict.
+            Key name is accessed as a hidden parameters with _keyname. """
+        self.__dict__.update({ '_'+k: v for k, v in data.items() })
+
     def to_dict(self):
         """Convert to dict."""
         output = {

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -248,8 +248,9 @@ class Parameter:
         return copy.deepcopy(self)
 
     def update_from_dict(self, data):
-        """Update parameters from a dict.
+        """Update parameters from a dict. Do not modify the name of parameters.
             Key name is accessed as a hidden parameters with _keyname. """
+        data.pop("name")
         self.__dict__.update({ '_'+k: v for k, v in data.items() })
 
     def to_dict(self):

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -173,7 +173,7 @@ def test_update_from_dict():
     par = Parameter("test", value=1, scale=1e-2, min="nan", max="nan", frozen=False, unit="TeV")
     data={"name": "test", "factor":3.0, "scale":1e-2,"min":0, "max":np.nan, "frozen":True, "unit":"GeV"}
     par.update_from_dict(data)
-   
+    assert par.name == "test"
     assert par.factor == 3.0
     assert par.value == 3e-2
     assert par.unit == "GeV"

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -170,12 +170,13 @@ def test_parameters_autoscale():
     assert_allclose(pars[0].scale, 10)
 
 def test_update_from_dict():
-    par = Parameter("test", value=1, scale=1e-2, min="nan", max="nan", frozen=False, unit="TeV")
-    data={"name": "test", "factor":3.0, "scale":1e-2,"min":0, "max":np.nan, "frozen":True, "unit":"GeV"}
+    par = Parameter("test", value=1e-10, min="nan", max="nan", frozen=False, unit="TeV")
+    par.autoscale()
+    data={"name": "test2", "value":3e-10, "min":0, "max":np.nan, "frozen":True, "unit":"GeV"}
     par.update_from_dict(data)
     assert par.name == "test"
-    assert par.factor == 3.0
-    assert par.value == 3e-2
+    assert par.factor == 3
+    assert par.value == 3e-10
     assert par.unit == "GeV"
     assert par.min == 0
     assert par.max is np.nan    

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -168,3 +168,15 @@ def test_parameters_autoscale():
     pars.autoscale()
     assert_allclose(pars[0].factor, 2)
     assert_allclose(pars[0].scale, 10)
+
+def test_update_from_dict():
+    par = Parameter("test", value=1, scale=1e-2, min="nan", max="nan", frozen=False, unit="TeV")
+    data={"name": "test", "factor":3.0, "scale":1e-2,"min":0, "max":np.nan, "frozen":True, "unit":"GeV"}
+    par.update_from_dict(data)
+   
+    assert par.factor == 3.0
+    assert par.value == 3e-2
+    assert par.unit == "GeV"
+    assert par.min == 0
+    assert par.max is np.nan    
+    assert par.frozen == True


### PR DESCRIPTION
This PR adds the ability to update a Parameter from a dictionary.
This introduces a public API and avoids the need to access the hidden functions and hidden parameter name in the dict.
A simple test has been added to test that parameters are indeed updated.
This will be helpful for another PR #3029 
