### PR TITLE
Fix spatial.integrate_geom

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -150,9 +150,10 @@ class SpatialModel(Model):
                 the predicted model counts integrated in each spatial bin.
         """
         if isinstance(geom, RegionGeom):
-            coordinates = geom.get_wcs_coord()
-            values = self(coordinates.lon, coordinates.lat)
-            data = values.sum() * geom.solid_angle()
+            wcs_geom = geom.to_wcs_geom().to_image()
+            mask = geom.contains(wcs_geom.get_coord())
+            values = self.evaluate_geom(wcs_geom)
+            data = ((values* wcs_geom.solid_angle())[mask]).sum()
         else:
             values = self.evaluate_geom(geom)
             data = values * geom.solid_angle()

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -147,7 +147,7 @@ class SpatialModel(Model):
         Returns
         ---------
         `~gammapy.maps.Map` or `gammapy.maps.RegionNDMap`, containing
-                the predicted model counts integrated in each spatial bin.
+                the integral value in each spatial bin.
         """
         if isinstance(geom, RegionGeom):
             wcs_geom = geom.to_wcs_geom().to_image()


### PR DESCRIPTION
@LauraOlivera and me open this PR to correct a bug in the current `modeling.models.spatial.integrate_geom()` function, which prevents to estimate the correct integral value of the spatial model for a given `RegionGeom` object. 
The new implementations fix it and it also allows for numpy broadcasting when the `RegionGeom` has an extra energy axis.

