### PR TITLE
Add an option to ExcessMapEstimator to choose to correlate off events

### DIFF
--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -59,6 +59,10 @@ class ExcessMapEstimator(Estimator):
     If a model is set on the dataset the excess map estimator will compute the excess taking into account
     the predicted counts of the model.
 
+    Some background estimation techniques like ring background or adaptive ring background will provide already
+    correlated data for OFF. In the case of already correlated OFF data, the OFF data should not be correlated again,
+    and so the option correlate_off should set to False (default).
+
     Parameters
     ----------
     correlation_radius : ~astropy.coordinate.Angle

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -30,18 +30,19 @@ def convolved_map_dataset_counts_statistics(dataset, kernel, mask, correlate_off
     n_on_conv = np.rint(n_on.convolve(kernel.array).data)
 
     if isinstance(dataset, MapDatasetOnOff):
-        background = dataset.background * mask
-        background.data[dataset.acceptance_off.data == 0] = 0.0
         n_off = dataset.counts_off * mask
         npred_sig = dataset.npred_signal() * mask
+        acceptance_on = dataset.acceptance * mask
+        acceptance_off = dataset.acceptance_off * mask
 
-        background_convolve = background.convolve(kernel.array)
         npred_sig_convolve = npred_sig.convolve(kernel.array)
+        acceptance_on_convolve = acceptance_on.convolve(kernel.array)
         if correlate_off:
             n_off = n_off.convolve(kernel.array)
+            acceptance_off = acceptance_off.convolve(kernel.array)
 
         with np.errstate(invalid="ignore", divide="ignore"):
-            alpha = background_convolve / n_off
+            alpha = acceptance_on_convolve / acceptance_off
 
         return WStatCountsStatistic(
             n_on_conv.data, n_off.data, alpha.data, npred_sig_convolve.data

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -18,7 +18,7 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 
-def convolved_map_dataset_counts_statistics(dataset, kernel, mask):
+def convolved_map_dataset_counts_statistics(dataset, kernel, mask, correlate_off):
     """Return CountsDataset objects containing smoothed maps from the MapDataset"""
     # Kernel is modified later make a copy here
     kernel = copy.deepcopy(kernel)
@@ -33,18 +33,18 @@ def convolved_map_dataset_counts_statistics(dataset, kernel, mask):
         background = dataset.background * mask
         background.data[dataset.acceptance_off.data == 0] = 0.0
         n_off = dataset.counts_off * mask
-
-        background_conv = background.convolve(kernel.array)
-        n_off_conv = n_off.convolve(kernel.array)
-
         npred_sig = dataset.npred_signal() * mask
-        mu_sig = npred_sig.convolve(kernel.array)
+
+        background_convolve = background.convolve(kernel.array)
+        npred_sig_convolve = npred_sig.convolve(kernel.array)
+        if correlate_off:
+            n_off = n_off.convolve(kernel.array)
 
         with np.errstate(invalid="ignore", divide="ignore"):
-            alpha_conv = background_conv / n_off_conv
+            alpha = background_convolve / n_off
 
         return WStatCountsStatistic(
-            n_on_conv.data, n_off_conv.data, alpha_conv.data, mu_sig.data
+            n_on_conv.data, n_off.data, alpha.data, npred_sig_convolve.data
         )
     else:
 
@@ -82,6 +82,8 @@ class ExcessMapEstimator(Estimator):
     apply_mask_fit : Bool
         Apply a mask for the computation.
         A `~gammapy.datasets.MapDataset.mask_fit` must be present on the input dataset
+    correlate_off : Bool
+        Correlate OFF events in the case of a MapDatasetOnOff
     """
 
     tag = "ExcessMapEstimator"
@@ -95,6 +97,7 @@ class ExcessMapEstimator(Estimator):
         selection_optional="all",
         energy_edges=None,
         apply_mask_fit=False,
+        correlate_off=True
     ):
         self.correlation_radius = correlation_radius
         self.n_sigma = n_sigma
@@ -102,6 +105,7 @@ class ExcessMapEstimator(Estimator):
         self.apply_mask_fit = apply_mask_fit
         self.selection_optional = selection_optional
         self.energy_edges = energy_edges
+        self.correlate_off = correlate_off
 
     @property
     def correlation_radius(self):
@@ -184,7 +188,7 @@ class ExcessMapEstimator(Estimator):
         else:
             mask = np.ones(dataset.data_shape, dtype=bool)
 
-        counts_stat = convolved_map_dataset_counts_statistics(dataset, kernel, mask)
+        counts_stat = convolved_map_dataset_counts_statistics(dataset, kernel, mask, self.correlate_off)
 
         n_on = Map.from_geom(geom, data=counts_stat.n_on)
         bkg = Map.from_geom(geom, data=counts_stat.n_on - counts_stat.n_sig)

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -97,7 +97,7 @@ class ExcessMapEstimator(Estimator):
         selection_optional="all",
         energy_edges=None,
         apply_mask_fit=False,
-        correlate_off=True
+        correlate_off=False
     ):
         self.correlation_radius = correlation_radius
         self.n_sigma = n_sigma

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -120,7 +120,24 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
     assert_allclose(result["ul"].data[0, 10, 10], 122.240837, atol=1e-3)
 
 
-def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
+def test_significance_map_estimator_map_dataset_on_off_no_correlation(simple_dataset_on_off):
+    exposure = simple_dataset_on_off.exposure
+    exposure.data += 1e6
+
+    # Test with exposure
+    simple_dataset_on_off.exposure = exposure
+    estimator_image = ExcessMapEstimator(0.11 * u.deg, energy_edges=[0.1, 1] * u.TeV, correlate_off=False)
+
+    result_image = estimator_image.run(simple_dataset_on_off)
+    assert result_image["counts"].data.shape == (1, 20, 20)
+    assert_allclose(result_image["counts"].data[0, 10, 10], 194)
+    assert_allclose(result_image["excess"].data[0, 10, 10], 97)
+    assert_allclose(result_image["background"].data[0, 10, 10], 97)
+    assert_allclose(result_image["sqrt_ts"].data[0, 10, 10], 0.780125, atol=1e-3)
+    assert_allclose(result_image["flux"].data[:, 10, 10], 9.7e-9, atol=1e-5)
+
+
+def test_significance_map_estimator_map_dataset_on_off_with_correlation(simple_dataset_on_off):
     exposure = simple_dataset_on_off.exposure
     exposure.data += 1e6
 
@@ -128,7 +145,7 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     simple_dataset_on_off.exposure = None
 
     estimator = ExcessMapEstimator(
-        0.11 * u.deg, selection_optional=None, energy_edges=[0.1, 1, 10] * u.TeV,
+        0.11 * u.deg, selection_optional=None, energy_edges=[0.1, 1, 10] * u.TeV, correlate_off=True
     )
     result = estimator.run(simple_dataset_on_off)
 
@@ -141,7 +158,7 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
 
     # Test with exposure
     simple_dataset_on_off.exposure = exposure
-    estimator_image = ExcessMapEstimator(0.11 * u.deg, energy_edges=[0.1, 1] * u.TeV)
+    estimator_image = ExcessMapEstimator(0.11 * u.deg, energy_edges=[0.1, 1] * u.TeV, correlate_off=True)
 
     result_image = estimator_image.run(simple_dataset_on_off)
     assert result_image["counts"].data.shape == (1, 20, 20)
@@ -160,7 +177,7 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     mask_fit.data[:, 10, :] = False
     simple_dataset_on_off.mask_fit = mask_fit
 
-    estimator_image = ExcessMapEstimator(0.11 * u.deg, apply_mask_fit=True)
+    estimator_image = ExcessMapEstimator(0.11 * u.deg, apply_mask_fit=True, correlate_off=True)
 
     result_image = estimator_image.run(simple_dataset_on_off)
     assert result_image["counts"].data.shape == (1, 20, 20)
@@ -190,7 +207,7 @@ def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
     #
     simple_dataset_on_off.models = [model]
 
-    estimator_mod = ExcessMapEstimator(0.11 * u.deg, apply_mask_fit=False)
+    estimator_mod = ExcessMapEstimator(0.11 * u.deg, apply_mask_fit=False, correlate_off=True)
     result_mod = estimator_mod.run(simple_dataset_on_off)
     assert result_mod["counts"].data.shape == (1, 20, 20)
 


### PR DESCRIPTION
**Description**
This pull request is linked to the issue #2915
An option to ExcessMapEstimator has been added to be able to choose to correlate OFF events. The default behavior is changed to not correlate off events in the case of a MapDatasetOnOff.
This option doesn't affect the behavior in the case of a MapDataset.

**Dear reviewer**
Wouldn't it better to calculate alpha from acceptance and acceptance_off field present in MapDatasetOnOff, than on the ratio between off events and predicted events by the background model ?
