### PR TITLE
Allow SkyModel.integrate_geom to integrate over a RegionGeom

### DIFF
--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -272,7 +272,7 @@ class SkyModel(Model):
 
         Parameters
         ----------
-        geom : `Geom`
+        geom : `Geom` or `~gammapy.maps.RegionGeom`
             Map geometry
         gti : `GTI`
             GIT table

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -287,9 +287,7 @@ class SkyModel(Model):
             (-1, 1, 1)
         )
 
-        if self.spatial_model and not isinstance(geom, RegionGeom):
-            # TODO: integrate spatial model over region to correct for
-            #  containment
+        if self.spatial_model:
             value = value * self.spatial_model.integrate_geom(geom).quantity
 
         if self.temporal_model:

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -636,10 +636,10 @@ def test_integrate_geom():
     center = SkyCoord("0d", "0d", frame='icrs')
     radius = 0.3 * u.deg
     square = CircleSkyRegion(center, radius)
-    
+
     axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=10, name='energy_true')
     geom = RegionGeom(region=square, axes=[axis])
-    
+
     integral = sky_model.integrate_geom(geom).data
     print(integral.sum())
     assert_allclose(integral.sum()/1e-12, 8.900, rtol=1e-3)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -637,9 +637,11 @@ def test_integrate_geom():
     radius = 0.3 * u.deg
     square = CircleSkyRegion(center, radius)
 
-    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=10, name='energy_true')
+    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3, name='energy_true')
     geom = RegionGeom(region=square, axes=[axis])
 
     integral = sky_model.integrate_geom(geom).data
-    print(integral.sum())
-    assert_allclose(integral.sum()/1e-12, 8.900, rtol=1e-3)
+
+    assert_allclose(integral[0]/1e-12, 5.299, rtol=1e-3)
+    assert_allclose(integral[1]/1e-12, 2.460, rtol=1e-3)
+    assert_allclose(integral[2]/1e-12, 1.142, rtol=1e-3)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -4,11 +4,13 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates import SkyCoord
 from astropy.time import Time
+from regions import CircleSkyRegion
 from gammapy.data.gti import GTI
 from gammapy.datasets.map import MapEvaluator
 from gammapy.irf import EDispKernel, PSFKernel
-from gammapy.maps import Map, MapAxis, WcsGeom
+from gammapy.maps import Map, MapAxis, WcsGeom, RegionGeom
 from gammapy.modeling import Parameter
 from gammapy.modeling.models import (
     BackgroundModel,
@@ -624,3 +626,20 @@ def test_sky_model_create():
     assert isinstance(m.spatial_model, PointSpatialModel)
     assert isinstance(m.spectral_model, PowerLawSpectralModel)
     assert m.name == "my-source"
+
+
+def test_integrate_geom():
+    model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1*u.deg, frame='icrs')
+    spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
+    sky_model = SkyModel(spectral_model=spectral_model, spatial_model=model)
+
+    center = SkyCoord("0d", "0d", frame='icrs')
+    radius = 0.3 * u.deg
+    square = CircleSkyRegion(center, radius)
+    
+    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=10, name='energy_true')
+    geom = RegionGeom(region=square, axes=[axis])
+    
+    integral = sky_model.integrate_geom(geom).data
+    print(integral.sum())
+    assert_allclose(integral.sum()/1e-12, 8.900, rtol=1e-3)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -642,6 +642,4 @@ def test_integrate_geom():
 
     integral = sky_model.integrate_geom(geom).data
 
-    assert_allclose(integral[0]/1e-12, 5.299, rtol=1e-3)
-    assert_allclose(integral[1]/1e-12, 2.460, rtol=1e-3)
-    assert_allclose(integral[2]/1e-12, 1.142, rtol=1e-3)
+    assert_allclose(integral/1e-12, [[[5.299]], [[2.460]], [[1.142]]], rtol=1e-3)


### PR DESCRIPTION
The current status of `modeling.model.SkyModel.integrate_geom` is such that the spatial component of the `SkyModel` is integrate over the whole spatial distribution.
This PR introduces the possibility to integrate the sky model only over a given RegionGeom. 
@LauraOlivera 