### PR TITLE
Remove support for EDispKernel and PSFKernel from MapDataset

### DIFF
--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -120,10 +120,6 @@ def get_map_dataset(geom, geom_etrue, edisp="edispmap", name="test", **kwargs):
         edisp = EDispKernelMap.from_diagonal_response(
             energy_axis=e_reco, energy_axis_true=e_true
         )
-    elif edisp == "edispkernel":
-        edisp = EDispKernel.from_diagonal_response(
-            energy_true=e_true.edges, energy=e_reco.edges
-        )
     else:
         edisp = None
 
@@ -200,7 +196,7 @@ def test_different_exposure_unit(sky_model, geom):
     assert_allclose(npred.data[0, 50, 50], 6.086019)
 
 
-@pytest.mark.parametrize(("edisp_mode"), ["edispmap", "edispkernelmap", "edispkernel"])
+@pytest.mark.parametrize(("edisp_mode"), ["edispmap", "edispkernelmap"])
 @requires_data()
 def test_to_spectrum_dataset(sky_model, geom, geom_etrue, edisp_mode):
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request removes the support of `PSFKernel` and `EDispKernel` from the `MapDataset`. In the tutorial https://docs.gammapy.org/0.18.2/tutorials/fermi_lat.html, we show how to work with a single `EDispKernel` and `PSFMap` for Fermi-LAT data. In addition the various options were not tested and likely partly broken.

This breaks backwards compatibility, since datasets produced before v0.15 need to be re-created. However @registerrier mentioned, to get full support and correct stacking for the `EDispKernelMap`, datasets should be reproduced anyway. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
