### PR TITLE
Add the option to impose a minimal width in RegionGeom.to_wcs_geom()

### DIFF
--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -11,6 +11,7 @@ from gammapy.utils.regions import (
     list_to_compound_region,
     make_region,
 )
+from gammapy.maps.wcs import _check_width
 from .core import MapCoord
 from .geom import Geom, MapAxes, MapAxis, pix_tuple_to_idx
 from .wcs import WcsGeom
@@ -191,10 +192,10 @@ class RegionGeom(Geom):
 
         Parameters
          ----------
-            width_min : `~astropy.quantity.Quantity`
-            Minimal width for the resulting geometry.
-            Can be a single number or two, for 
-            different minimum widths in each spatial dimension.
+        width_min : `~astropy.quantity.Quantity`
+        Minimal width for the resulting geometry.
+        Can be a single number or two, for 
+        different minimum widths in each spatial dimension.
 
         Returns
         -------
@@ -202,12 +203,7 @@ class RegionGeom(Geom):
             A WCS geometry object.
         """
         if width_min is not None:
-            if np.size(width_min)==1:
-                width_min = 2*[width_min.value]*width_min.unit
-            width = self.width.copy()
-            for idx, entry in enumerate(width_min):
-                if entry > self.width[idx]:
-                   width[idx] = entry
+            width = np.min([self.width.to_value("deg"), _check_width(width_min)], axis=0)
         else:
             width = self.width
         wcs_geom_region = WcsGeom(wcs=self.wcs, npix=self.wcs.array_shape)

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -185,17 +185,33 @@ class RegionGeom(Geom):
 
         return bin_volume
 
-    def to_wcs_geom(self):
+    def to_wcs_geom(self, width_min=None):
         """Get the minimal equivalent geometry that
             contains the region.
+
+        Parameters
+         ----------
+            width_min : `~astropy.quantity.Quantity`
+            Minimal width for the resulting geometry.
+            Can be a single number or two, for 
+            different minimum widths in each spatial dimension.
 
         Returns
         -------
         wcs_geom : `~WcsGeom`
             A WCS geometry object.
         """
+        if width_min is not None:
+            if np.size(width_min)==1:
+                width_min = 2*[width_min.value]*width_min.unit
+            width = self.width.copy()
+            for idx, entry in enumerate(width_min):
+                if entry > self.width[idx]:
+                   width[idx] = entry
+        else:
+            width = self.width
         wcs_geom_region = WcsGeom(wcs=self.wcs, npix=self.wcs.array_shape)
-        wcs_geom = wcs_geom_region.cutout(position=self.center_skydir, width=self.width)
+        wcs_geom = wcs_geom_region.cutout(position=self.center_skydir, width=width)
         wcs_geom = wcs_geom.to_cube(self.axes)
         return wcs_geom
 

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -263,6 +263,16 @@ def test_to_wcs_geom(region):
     assert wcs_geom_cube.to_image() == wcs_geom
     assert wcs_geom_cube.axes[0] == axis
 
+    # test with minimum widths
+    width_min = 3*u.deg
+    wcs_geom = geom.to_wcs_geom(width_min=width_min)
+    assert_allclose(wcs_geom.center_coord[1].value, 0, rtol=0.001, atol=0)
+    assert_allclose(wcs_geom.width, [[3], [3]]*u.deg, rtol=1, atol=0)
+
+    width_min = [1,3]*u.deg
+    wcs_geom = geom.to_wcs_geom(width_min=width_min)
+    assert_allclose(wcs_geom.center_coord[1].value, 0, rtol=0.001, atol=0)
+    assert_allclose(wcs_geom.width, [[2], [3]]*u.deg, rtol=1, atol=0)
 
 def test_get_wcs_coord(region):
     # test on circular region


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds the option `width_min` to the existing method `RegionGeom.to_wcs_geom()` to force a minimum width for the geometry. The input can be both a single value or 2, one for each spatial dimension
