### PR TITLE
Change the `_compute_flux_spatial` method on `MapEvaluator`

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -153,12 +153,12 @@ class Analysis:
 
         self.models.extend(self.datasets.models)
 
-        for dataset in self.datasets:
+        if self.config.datasets.type == "3d":
+            for dataset in self.datasets:
+                if dataset.background_model is None:
+                    bkg_model = FoVBackgroundModel(dataset_name=dataset.name)
 
-            if dataset.background_model is None:
-                bkg_model = FoVBackgroundModel(dataset_name=dataset.name)
-
-            self.models.append(bkg_model)
+                self.models.append(bkg_model)
 
         self.datasets.models = self.models
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2572,12 +2572,12 @@ class MapEvaluator:
         value = self.compute_flux_spectral()
 
         if self.geom.is_region:
-            evaluate_spatial_model = self.geom.region is not None
+            evaluate_spatial_model = self.geom.region is not None and self.psf
         else:
             evaluate_spatial_model = True
 
         if self.model.spatial_model and evaluate_spatial_model:
-            value = value * self.compute_flux_spatial().quantity
+            value = value * self.compute_flux_spatial()
 
         if self.model.temporal_model:
             value *= self.compute_temporal_norm()
@@ -2599,7 +2599,7 @@ class MapEvaluator:
 
             if self.psf and self.model.apply_irf["psf"]:
                 values = self.apply_psf(values)
-            value = (values.data * mask).sum(axis=(1,2))
+            value = (values.quantity * mask).sum(axis=(1, 2))
 
         else:
             value = self.model.spatial_model.integrate_geom(self.geom)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2596,7 +2596,7 @@ class MapEvaluator:
 
             if self.psf and self.model.apply_irf["psf"]:
                 values = self.apply_psf(values)
-            value = (values.data[mask]).sum()
+            value = (values.data * mask).sum(axis=(1,2))
 
         else:
             value = self.model.spatial_model.integrate_geom(self.geom)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2571,8 +2571,13 @@ class MapEvaluator:
         """Compute psf convolved and temporal model corrected flux."""
         value = self.compute_flux_spectral()
 
-        if self.model.spatial_model:
-            value = value * self.compute_flux_spatial()#.quantity
+        if self.geom.is_region:
+            evaluate_spatial_model = self.geom.region is not None
+        else:
+            evaluate_spatial_model = True
+
+        if self.model.spatial_model and evaluate_spatial_model:
+            value = value * self.compute_flux_spatial().quantity
 
         if self.model.temporal_model:
             value *= self.compute_temporal_norm()

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2599,9 +2599,9 @@ class MapEvaluator:
             value = (values.data[mask]).sum()
 
         else:
-            values = self.model.spatial_model.integrate_geom(self.geom)
+            value = self.model.spatial_model.integrate_geom(self.geom)
             if self.psf and self.model.apply_irf["psf"]:
-                value = self.apply_psf(values)
+                value = self.apply_psf(value)
 
         return value
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1389,4 +1389,4 @@ def test_compute_flux_spatial():
     evaluator = MapEvaluator(model=model[0], exposure=exposure_region, psf=psf)
     flux = evaluator.compute_flux_spatial()
 
-    assert_allclose(flux, 0.397 * nbin, atol=0.001)
+    assert_allclose(flux, [0.39677402, 0.39677402], atol=0.001)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -5,12 +5,11 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
-from regions import CircleSkyRegion, RectangleSkyRegion
+from regions import CircleSkyRegion
 from gammapy.data import GTI
 from gammapy.datasets import Datasets, MapDataset, MapDatasetOnOff
 from gammapy.datasets.map import MapEvaluator
 from gammapy.irf import (
-    EDispKernel,
     EDispKernelMap,
     EDispMap,
     EffectiveAreaTable2D,

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1388,4 +1388,4 @@ def test_compute_flux_spatial():
     evaluator = MapEvaluator(model=model[0], exposure=exposure_region, psf=psf)
     flux = evaluator.compute_flux_spatial()
 
-    assert_allclose(flux, [0.39677402, 0.39677402], atol=0.001)
+    assert_allclose(flux.value, [0.39677402, 0.39677402], atol=0.001)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1368,6 +1368,7 @@ def test_compute_flux_spatial():
     region = RectangleSkyRegion(center=center, width = 0.5 * u.deg, height=0.5 * u.deg)
 
     energy_axis_true = MapAxis.from_energy_bounds(".1 TeV", "10 TeV", nbin=10, name="energy_true")
+    energy_axis = MapAxis.from_energy_bounds(".5 TeV", "8 TeV", nbin=10, name="energy")
 
     spectral_model = PowerLawSpectralModel(index = 2.0, amplitude="1e-10 cm-2 s-1 TeV-1", reference="1 TeV")
     spatial_model = PointSpatialModel(lon_0 = 0*u.deg, lat_0 = 0*u.deg, frame='galactic')
@@ -1392,11 +1393,13 @@ def test_compute_flux_spatial():
     npred_region = dataset_region.npred()
 
     # for a WCSmap
-    exposure_wcs = Map.create(axes=[energy_axis_true], region=region, map_type="region")
+#    exposure_wcs = Map.create(axes=[energy_axis_true], region=region, map_type="wcs")
+    exposure_wcs = WcsNDMap.create(skydir=center, axes=[energy_axis_true], frame='galactic', binsz=0.01, width=(0.5*u.deg,0.5*u.deg))
     exposure_wcs.data += 1e8
     exposure_wcs.unit = "m2 s"
 
-    background_wcs = Map.create(axes=[energy_axis_true], region=region, map_type="region")
+#    background_wcs = Map.create(axes=[energy_axis_true], region=region, map_type="wcs")
+    background_wcs = WcsNDMap.create(skydir=center, axes=[energy_axis], frame='galactic', binsz=0.01, width=(0.5*u.deg,0.5*u.deg))
     background_wcs.data += 2
 
     dataset_wcs = MapDataset(psf=psf, exposure=exposure_wcs, background=background_wcs)

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -153,10 +153,11 @@ class SpatialModel(Model):
             wcs_geom = geom.to_wcs_geom().to_image()
             mask = geom.contains(wcs_geom.get_coord())
             values = self.evaluate_geom(wcs_geom)
-            data = ((values* wcs_geom.solid_angle())[mask]).sum()
+            data = ((values * wcs_geom.solid_angle())[mask]).sum()
         else:
             values = self.evaluate_geom(geom)
             data = values * geom.solid_angle()
+
         return Map.from_geom(geom=geom, data=data.value, unit=data.unit)
 
     def to_dict(self, full_output=False):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -14,7 +14,7 @@ from regions import (
     PointSkyRegion,
     PolygonSkyRegion,
 )
-from gammapy.maps import Map, WcsGeom, RegionGeom
+from gammapy.maps import Map, WcsGeom
 from gammapy.modeling import Parameter
 from gammapy.utils.gauss import Gauss2DPDF
 from gammapy.utils.scripts import make_path
@@ -149,7 +149,7 @@ class SpatialModel(Model):
         `~gammapy.maps.Map` or `gammapy.maps.RegionNDMap`, containing
                 the integral value in each spatial bin.
         """
-        if isinstance(geom, RegionGeom):
+        if geom.is_region:
             wcs_geom = geom.to_wcs_geom().to_image()
             mask = geom.contains(wcs_geom.get_coord())
             values = self.evaluate_geom(wcs_geom)


### PR DESCRIPTION
This PR includes some changes in the `_compute_flux_spatial` function in `~gammapy.datasets.map.MapEvaluator`. 
We now allows the function to calculate the integral flux over either a `WcsGeom` or a `RegionNDMap`. The integrated flux is also corrected for the PSF.

To do:
1) We need to add tests!
2) possibility to enlarge the tangential geometry so that the PSF is fully contained.

@LauraOlivera 