### PR TITLE
Move dataset I/O code

### DIFF
--- a/gammapy/datasets/io.py
+++ b/gammapy/datasets/io.py
@@ -12,8 +12,12 @@ from gammapy.irf import EDispKernelMap, EDispKernel
 from .spectrum import SpectrumDatasetOnOff
 
 
+__all__ = ["DatasetWriter", "DatasetReader", "OGIPDatasetReader", "OGIPDatasetWriter"]
+
+
 class DatasetReader(abc.ABC):
     """Dataset reader base class"""
+
     @property
     @abc.abstractmethod
     def tag(self):
@@ -127,7 +131,7 @@ class OGIPDatasetWriter(DatasetWriter):
 
         Parameters
         ----------
-        dataset : `SpectrumDataset`
+        dataset : `SpectrumDatasetOnOff`
             Dataset to write
         """
         filenames = self.get_filenames(dataset)
@@ -142,12 +146,29 @@ class OGIPDatasetWriter(DatasetWriter):
             self.write_edisp(dataset, filename=filenames["respfile"])
 
     def write_edisp(self, dataset, filename):
-        """Write energy dispersion"""
+        """Write energy dispersion.
+
+        Parameters
+        ----------
+        dataset : `SpectrumDatasetOnOff`
+            Dataset to write
+        filename : str
+            Filename to use.
+        """
         kernel = dataset.edisp.get_edisp_kernel()
         kernel.write(self.outdir / filename, overwrite=self.overwrite, use_sherpa=self.use_sherpa)
 
     def write_aeff(self, dataset, filename):
-        """Write effective area"""
+        """Write effective area
+
+        Parameters
+        ----------
+        dataset : `SpectrumDatasetOnOff`
+            Dataset to write
+        filename : str
+            Filename to use.
+
+        """
         aeff = dataset.exposure / dataset.exposure.meta["livetime"]
 
         hdu_format = "ogip-sherpa" if self.use_sherpa else "ogip"
@@ -160,7 +181,15 @@ class OGIPDatasetWriter(DatasetWriter):
         )
 
     def to_counts_hdulist(self, dataset, is_counts_off=False):
-        """"""
+        """Convert counts region map to hdulist
+
+        Parameters
+        ----------
+        dataset : `SpectrumDatasetOnOff`
+            Dataset to write
+        is_counts_off : bool
+            Whether to use counts off.
+        """
         counts = dataset.counts_off if is_counts_off else dataset.counts
         acceptance = dataset.acceptance_off if is_counts_off else dataset.acceptance
 
@@ -199,7 +228,16 @@ class OGIPDatasetWriter(DatasetWriter):
         return hdulist
 
     def write_counts(self, dataset, filename):
-        """Write counts file"""
+        """Write counts file
+
+        Parameters
+        ----------
+        dataset : `SpectrumDatasetOnOff`
+            Dataset to write
+        filename : str
+            Filename to use.
+
+        """
         hdulist = self.to_counts_hdulist(dataset)
 
         if dataset.gti:
@@ -209,7 +247,15 @@ class OGIPDatasetWriter(DatasetWriter):
         hdulist.writeto(str(self.outdir / filename), overwrite=self.overwrite)
 
     def write_counts_off(self, dataset, filename):
-        """Write off counts file"""
+        """Write off counts file
+
+        Parameters
+        ----------
+        dataset : `SpectrumDatasetOnOff`
+            Dataset to write
+        filename : str
+            Filename to use.
+        """
         hdulist = self.to_counts_hdulist(dataset, is_counts_off=True)
         hdulist.writeto(str(self.outdir / filename), overwrite=self.overwrite)
 

--- a/gammapy/datasets/io.py
+++ b/gammapy/datasets/io.py
@@ -1,0 +1,297 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from pathlib import Path
+from gammapy.utils.scripts import make_path
+import numpy as np
+from astropy.io import fits
+
+
+class DatasetIO:
+    pass
+
+
+class DatasetIOOGIP(DatasetIO):
+    tag = "ogip"
+
+    def __init__(self, outdir=None, use_sherpa=False, overwrite=False):
+        outdir = Path.cwd() if outdir is None else make_path(outdir)
+        outdir.mkdir(exist_ok=True, parents=True)
+
+        self.outdir = outdir
+        self.use_sherpa = use_sherpa
+        self.overwrite = overwrite
+
+    def get_filenames(self, dataset):
+        """"""
+        filenames = {}
+        phafile = f"pha_obs{dataset.name}.fits"
+
+        bkgfile = phafile.replace("pha", "bkg")
+        arffile = phafile.replace("pha", "arf")
+        rmffile = phafile.replace("pha", "rmf")
+
+        filenames["respfile"] = rmffile
+        filenames["backfile"] = bkgfile
+        filenames["ancrfile"] = arffile
+        return filenames
+
+    @staticmethod
+    def write_edisp(dataset, filename, overwrite):
+        """"""
+        kernel = self.edisp.get_edisp_kernel()
+        kernel.write(outdir / rmffile, overwrite=overwrite, use_sherpa=use_sherpa)
+
+    def write_aeff(self, dataset):
+        """Write effective area"""
+        aeff = dataset.exposure / dataset.exposure.meta["livetime"]
+
+        hdu_format = "ogip-sherpa" if use_sherpa else "ogip"
+
+        aeff.write(
+            filename,
+            overwrite=overwrite,
+            format=hdu_format,
+            ogip_column="SPECRESP",
+        )
+
+    def to_table_hdu(self, dataset):
+        """"""
+        counts_table = self.counts.to_table()
+        counts_table["QUALITY"] = np.logical_not(self.mask_safe.data[:, 0, 0])
+        counts_table["BACKSCAL"] = self.acceptance.data[:, 0, 0]
+        counts_table["AREASCAL"] = np.ones(self.acceptance.data.size)
+        meta = self._ogip_meta()
+
+    def write(self, dataset):
+        """"""
+        self.write_counts()
+        self.write_counts_off()
+
+        self.write_aeff()
+        self.write_edisp()
+        pass
+
+    def to_ogip_files(self, outdir=None, use_sherpa=False, overwrite=False):
+        """Write OGIP files.
+
+        If you want to use the written files with Sherpa you have to set the
+        ``use_sherpa`` flag. Then all files will be written in units 'keV' and
+        'cm2'.
+
+        The naming scheme is fixed, with {name} the dataset name:
+
+        * PHA file is named pha_obs{name}.fits
+        * BKG file is named bkg_obs{name}.fits
+        * ARF file is named arf_obs{name}.fits
+        * RMF file is named rmf_obs{name}.fits
+
+        Parameters
+        ----------
+        outdir : `pathlib.Path`
+            output directory, default: pwd
+        use_sherpa : bool, optional
+            Write Sherpa compliant files, default: False
+        overwrite : bool
+            Overwrite existing files?
+        """
+        # TODO: refactor and reduce amount of code duplication
+        outdir = Path.cwd() if outdir is None else make_path(outdir)
+        outdir.mkdir(exist_ok=True, parents=True)
+
+        phafile = f"pha_obs{self.name}.fits"
+
+        bkgfile = phafile.replace("pha", "bkg")
+        arffile = phafile.replace("pha", "arf")
+        rmffile = phafile.replace("pha", "rmf")
+
+        counts_table = self.counts.to_table()
+        counts_table["QUALITY"] = np.logical_not(self.mask_safe.data[:, 0, 0])
+        counts_table["BACKSCAL"] = self.acceptance.data[:, 0, 0]
+        counts_table["AREASCAL"] = np.ones(self.acceptance.data.size)
+        meta = self._ogip_meta()
+
+        meta["respfile"] = rmffile
+        meta["backfile"] = bkgfile
+        meta["ancrfile"] = arffile
+        meta["hduclas2"] = "TOTAL"
+        counts_table.meta = meta
+
+        name = counts_table.meta["name"]
+        hdu = fits.BinTableHDU(counts_table, name=name)
+
+        energy_axis = self.counts.geom.axes[0]
+
+        hdu_format = "ogip-sherpa" if use_sherpa else "ogip"
+
+        hdulist = fits.HDUList(
+            [fits.PrimaryHDU(), hdu, energy_axis.to_table_hdu(format=hdu_format)]
+        )
+
+        if self.gti is not None:
+            hdu = fits.BinTableHDU(self.gti.table, name="GTI")
+            hdulist.append(hdu)
+
+        if self.counts.geom._region is not None and self.counts.geom.wcs is not None:
+            region_table = self.counts.geom._to_region_table()
+            region_hdu = fits.BinTableHDU(region_table, name="REGION")
+            hdulist.append(region_hdu)
+
+        hdulist.writeto(str(outdir / phafile), overwrite=overwrite)
+
+
+
+        if self.counts_off is not None:
+            counts_off_table = self.counts_off.to_table()
+            counts_off_table["QUALITY"] = np.logical_not(self.mask_safe.data[:, 0, 0])
+            counts_off_table["BACKSCAL"] = self.acceptance_off.data[:, 0, 0]
+            counts_off_table["AREASCAL"] = np.ones(self.acceptance.data.size)
+            meta = self._ogip_meta()
+            meta["hduclas2"] = "BKG"
+
+            counts_off_table.meta = meta
+            name = counts_off_table.meta["name"]
+            hdu = fits.BinTableHDU(counts_off_table, name=name)
+            hdulist = fits.HDUList(
+                [fits.PrimaryHDU(), hdu, energy_axis.to_table_hdu(format=hdu_format)]
+            )
+            if (
+                self.counts_off.geom._region is not None
+                and self.counts_off.geom.wcs is not None
+            ):
+                region_table = self.counts_off.geom._to_region_table()
+                region_hdu = fits.BinTableHDU(region_table, name="REGION")
+                hdulist.append(region_hdu)
+
+            hdulist.writeto(str(outdir / bkgfile), overwrite=overwrite)
+
+        if self.edisp is not None:
+            kernel = self.edisp.get_edisp_kernel()
+            kernel.write(outdir / rmffile, overwrite=overwrite, use_sherpa=use_sherpa)
+
+    def _ogip_meta(self):
+        """Meta info for the OGIP data format"""
+        try:
+            livetime = self.exposure.meta["livetime"]
+        except KeyError:
+            raise ValueError(
+                "Storing in ogip format require the livetime "
+                "to be defined in the exposure meta data"
+            )
+        return {
+            "name": "SPECTRUM",
+            "hduclass": "OGIP",
+            "hduclas1": "SPECTRUM",
+            "corrscal": "",
+            "chantype": "PHA",
+            "detchans": self.counts.geom.axes[0].nbin,
+            "filter": "None",
+            "corrfile": "",
+            "poisserr": True,
+            "hduclas3": "COUNT",
+            "hduclas4": "TYPE:1",
+            "lo_thres": self.energy_range[0].to_value("TeV"),
+            "hi_thres": self.energy_range[1].to_value("TeV"),
+            "exposure": livetime.to_value("s"),
+            "obs_id": self.name,
+        }
+
+    @classmethod
+    def from_ogip_files(cls, filename):
+        """Read `~gammapy.datasets.SpectrumDatasetOnOff` from OGIP files.
+
+        BKG file, ARF, and RMF must be set in the PHA header and be present in
+        the same folder.
+
+        The naming scheme is fixed to the following scheme:
+
+        * PHA file is named ``pha_obs{name}.fits``
+        * BKG file is named ``bkg_obs{name}.fits``
+        * ARF file is named ``arf_obs{name}.fits``
+        * RMF file is named ``rmf_obs{name}.fits``
+          with ``{name}`` the dataset name.
+
+        Parameters
+        ----------
+        filename : str
+            OGIP PHA file to read
+        """
+        filename = make_path(filename)
+        dirname = filename.parent
+
+        with fits.open(str(filename), memmap=False) as hdulist:
+            counts = RegionNDMap.from_hdulist(hdulist, format="ogip")
+            acceptance = RegionNDMap.from_hdulist(
+                hdulist, format="ogip", ogip_column="BACKSCAL"
+            )
+            livetime = counts.meta["EXPOSURE"] * u.s
+
+            if "GTI" in hdulist:
+                gti = GTI(Table.read(hdulist["GTI"]))
+            else:
+                gti = None
+
+            mask_safe = RegionNDMap.from_hdulist(
+                hdulist, format="ogip", ogip_column="QUALITY"
+            )
+            mask_safe.data = np.logical_not(mask_safe.data)
+
+        phafile = filename.name
+
+        try:
+            rmffile = phafile.replace("pha", "rmf")
+            kernel = EDispKernel.read(dirname / rmffile)
+            edisp = EDispKernelMap.from_edisp_kernel(kernel, geom=counts.geom)
+
+        except OSError:
+            # TODO : Add logger and echo warning
+            edisp = None
+
+        try:
+            bkgfile = phafile.replace("pha", "bkg")
+            with fits.open(str(dirname / bkgfile), memmap=False) as hdulist:
+                counts_off = RegionNDMap.from_hdulist(hdulist, format="ogip")
+                acceptance_off = RegionNDMap.from_hdulist(
+                    hdulist, ogip_column="BACKSCAL"
+                )
+        except OSError:
+            # TODO : Add logger and echo warning
+            counts_off, acceptance_off = None, None
+
+        arffile = phafile.replace("pha", "arf")
+        aeff = RegionNDMap.read(dirname / arffile, format="ogip-arf")
+        exposure = aeff * livetime
+        exposure.meta["livetime"] = livetime
+
+        if edisp is not None:
+            edisp.exposure_map.data = exposure.data[:, :, np.newaxis, :]
+
+        return cls(
+            counts=counts,
+            exposure=exposure,
+            counts_off=counts_off,
+            edisp=edisp,
+            mask_safe=mask_safe,
+            acceptance=acceptance,
+            acceptance_off=acceptance_off,
+            name=str(counts.meta["OBS_ID"]),
+            gti=gti,
+        )
+
+
+class DatasetIOGADF(DatasetIO):
+    tag = "gadf"
+
+
+    def to_hdulist(self):
+        pass
+
+
+    def from_hdulist(self):
+        pass
+
+
+    def read(self):
+        pass
+
+
+    def write(self):
+        pass

--- a/gammapy/datasets/io.py
+++ b/gammapy/datasets/io.py
@@ -1,15 +1,65 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import abc
 from pathlib import Path
-from gammapy.utils.scripts import make_path
 import numpy as np
+from astropy import units as u
 from astropy.io import fits
+from astropy.table import Table
+from gammapy.data import GTI
+from gammapy.utils.scripts import make_path
+from gammapy.maps import RegionNDMap
+from gammapy.irf import EDispKernelMap, EDispKernel
+from .spectrum import SpectrumDatasetOnOff
 
 
-class DatasetIO:
-    pass
+class DatasetReader(abc.ABC):
+    """Dataset reader base class"""
+    @property
+    @abc.abstractmethod
+    def tag(self):
+        pass
+
+    @abc.abstractmethod
+    def read(self):
+        pass
 
 
-class DatasetIOOGIP(DatasetIO):
+class DatasetWriter(abc.ABC):
+    """Dataset writer base class"""
+
+    @property
+    @abc.abstractmethod
+    def tag(self):
+        pass
+
+    @abc.abstractmethod
+    def write(self, dataset):
+        pass
+
+
+class OGIPDatasetWriter(DatasetWriter):
+    """Write OGIP files.
+
+    If you want to use the written files with Sherpa you have to set the
+    ``use_sherpa`` flag. Then all files will be written in units 'keV' and
+    'cm2'.
+
+    The naming scheme is fixed, with {name} the dataset name:
+
+    * PHA file is named pha_obs{name}.fits
+    * BKG file is named bkg_obs{name}.fits
+    * ARF file is named arf_obs{name}.fits
+    * RMF file is named rmf_obs{name}.fits
+
+    Parameters
+    ----------
+    outdir : `pathlib.Path`
+        output directory, default: pwd
+    use_sherpa : bool, optional
+        Write Sherpa compliant files, default: False
+    overwrite : bool
+        Overwrite existing files?
+    """
     tag = "ogip"
 
     def __init__(self, outdir=None, use_sherpa=False, overwrite=False):
@@ -20,8 +70,17 @@ class DatasetIOOGIP(DatasetIO):
         self.use_sherpa = use_sherpa
         self.overwrite = overwrite
 
-    def get_filenames(self, dataset):
-        """"""
+    @staticmethod
+    def get_filenames(dataset):
+        """Get filenames
+
+        Parameters
+        ----------
+        dataset : `SpectrumDataset`
+            Dataset to write
+
+        """
+        # TODO: allow
         filenames = {}
         phafile = f"pha_obs{dataset.name}.fits"
 
@@ -29,148 +88,17 @@ class DatasetIOOGIP(DatasetIO):
         arffile = phafile.replace("pha", "arf")
         rmffile = phafile.replace("pha", "rmf")
 
+        filenames["phafile"] = phafile
         filenames["respfile"] = rmffile
         filenames["backfile"] = bkgfile
         filenames["ancrfile"] = arffile
         return filenames
 
     @staticmethod
-    def write_edisp(dataset, filename, overwrite):
-        """"""
-        kernel = self.edisp.get_edisp_kernel()
-        kernel.write(outdir / rmffile, overwrite=overwrite, use_sherpa=use_sherpa)
-
-    def write_aeff(self, dataset):
-        """Write effective area"""
-        aeff = dataset.exposure / dataset.exposure.meta["livetime"]
-
-        hdu_format = "ogip-sherpa" if use_sherpa else "ogip"
-
-        aeff.write(
-            filename,
-            overwrite=overwrite,
-            format=hdu_format,
-            ogip_column="SPECRESP",
-        )
-
-    def to_table_hdu(self, dataset):
-        """"""
-        counts_table = self.counts.to_table()
-        counts_table["QUALITY"] = np.logical_not(self.mask_safe.data[:, 0, 0])
-        counts_table["BACKSCAL"] = self.acceptance.data[:, 0, 0]
-        counts_table["AREASCAL"] = np.ones(self.acceptance.data.size)
-        meta = self._ogip_meta()
-
-    def write(self, dataset):
-        """"""
-        self.write_counts()
-        self.write_counts_off()
-
-        self.write_aeff()
-        self.write_edisp()
-        pass
-
-    def to_ogip_files(self, outdir=None, use_sherpa=False, overwrite=False):
-        """Write OGIP files.
-
-        If you want to use the written files with Sherpa you have to set the
-        ``use_sherpa`` flag. Then all files will be written in units 'keV' and
-        'cm2'.
-
-        The naming scheme is fixed, with {name} the dataset name:
-
-        * PHA file is named pha_obs{name}.fits
-        * BKG file is named bkg_obs{name}.fits
-        * ARF file is named arf_obs{name}.fits
-        * RMF file is named rmf_obs{name}.fits
-
-        Parameters
-        ----------
-        outdir : `pathlib.Path`
-            output directory, default: pwd
-        use_sherpa : bool, optional
-            Write Sherpa compliant files, default: False
-        overwrite : bool
-            Overwrite existing files?
-        """
-        # TODO: refactor and reduce amount of code duplication
-        outdir = Path.cwd() if outdir is None else make_path(outdir)
-        outdir.mkdir(exist_ok=True, parents=True)
-
-        phafile = f"pha_obs{self.name}.fits"
-
-        bkgfile = phafile.replace("pha", "bkg")
-        arffile = phafile.replace("pha", "arf")
-        rmffile = phafile.replace("pha", "rmf")
-
-        counts_table = self.counts.to_table()
-        counts_table["QUALITY"] = np.logical_not(self.mask_safe.data[:, 0, 0])
-        counts_table["BACKSCAL"] = self.acceptance.data[:, 0, 0]
-        counts_table["AREASCAL"] = np.ones(self.acceptance.data.size)
-        meta = self._ogip_meta()
-
-        meta["respfile"] = rmffile
-        meta["backfile"] = bkgfile
-        meta["ancrfile"] = arffile
-        meta["hduclas2"] = "TOTAL"
-        counts_table.meta = meta
-
-        name = counts_table.meta["name"]
-        hdu = fits.BinTableHDU(counts_table, name=name)
-
-        energy_axis = self.counts.geom.axes[0]
-
-        hdu_format = "ogip-sherpa" if use_sherpa else "ogip"
-
-        hdulist = fits.HDUList(
-            [fits.PrimaryHDU(), hdu, energy_axis.to_table_hdu(format=hdu_format)]
-        )
-
-        if self.gti is not None:
-            hdu = fits.BinTableHDU(self.gti.table, name="GTI")
-            hdulist.append(hdu)
-
-        if self.counts.geom._region is not None and self.counts.geom.wcs is not None:
-            region_table = self.counts.geom._to_region_table()
-            region_hdu = fits.BinTableHDU(region_table, name="REGION")
-            hdulist.append(region_hdu)
-
-        hdulist.writeto(str(outdir / phafile), overwrite=overwrite)
-
-
-
-        if self.counts_off is not None:
-            counts_off_table = self.counts_off.to_table()
-            counts_off_table["QUALITY"] = np.logical_not(self.mask_safe.data[:, 0, 0])
-            counts_off_table["BACKSCAL"] = self.acceptance_off.data[:, 0, 0]
-            counts_off_table["AREASCAL"] = np.ones(self.acceptance.data.size)
-            meta = self._ogip_meta()
-            meta["hduclas2"] = "BKG"
-
-            counts_off_table.meta = meta
-            name = counts_off_table.meta["name"]
-            hdu = fits.BinTableHDU(counts_off_table, name=name)
-            hdulist = fits.HDUList(
-                [fits.PrimaryHDU(), hdu, energy_axis.to_table_hdu(format=hdu_format)]
-            )
-            if (
-                self.counts_off.geom._region is not None
-                and self.counts_off.geom.wcs is not None
-            ):
-                region_table = self.counts_off.geom._to_region_table()
-                region_hdu = fits.BinTableHDU(region_table, name="REGION")
-                hdulist.append(region_hdu)
-
-            hdulist.writeto(str(outdir / bkgfile), overwrite=overwrite)
-
-        if self.edisp is not None:
-            kernel = self.edisp.get_edisp_kernel()
-            kernel.write(outdir / rmffile, overwrite=overwrite, use_sherpa=use_sherpa)
-
-    def _ogip_meta(self):
+    def get_ogip_meta(dataset):
         """Meta info for the OGIP data format"""
         try:
-            livetime = self.exposure.meta["livetime"]
+            livetime = dataset.exposure.meta["livetime"]
         except KeyError:
             raise ValueError(
                 "Storing in ogip format require the livetime "
@@ -182,39 +110,137 @@ class DatasetIOOGIP(DatasetIO):
             "hduclas1": "SPECTRUM",
             "corrscal": "",
             "chantype": "PHA",
-            "detchans": self.counts.geom.axes[0].nbin,
+            "detchans": dataset.counts.geom.axes[0].nbin,
             "filter": "None",
             "corrfile": "",
             "poisserr": True,
             "hduclas3": "COUNT",
             "hduclas4": "TYPE:1",
-            "lo_thres": self.energy_range[0].to_value("TeV"),
-            "hi_thres": self.energy_range[1].to_value("TeV"),
+            "lo_thres": dataset.energy_range[0].to_value("TeV"),
+            "hi_thres": dataset.energy_range[1].to_value("TeV"),
             "exposure": livetime.to_value("s"),
-            "obs_id": self.name,
+            "obs_id": dataset.name,
         }
 
-    @classmethod
-    def from_ogip_files(cls, filename):
-        """Read `~gammapy.datasets.SpectrumDatasetOnOff` from OGIP files.
-
-        BKG file, ARF, and RMF must be set in the PHA header and be present in
-        the same folder.
-
-        The naming scheme is fixed to the following scheme:
-
-        * PHA file is named ``pha_obs{name}.fits``
-        * BKG file is named ``bkg_obs{name}.fits``
-        * ARF file is named ``arf_obs{name}.fits``
-        * RMF file is named ``rmf_obs{name}.fits``
-          with ``{name}`` the dataset name.
+    def write(self, dataset):
+        """Write dataset to files
 
         Parameters
         ----------
-        filename : str
-            OGIP PHA file to read
+        dataset : `SpectrumDataset`
+            Dataset to write
         """
-        filename = make_path(filename)
+        filenames = self.get_filenames(dataset)
+
+        self.write_counts(dataset, filename=filenames["phafile"])
+        self.write_aeff(dataset, filename=filenames["ancrfile"])
+
+        if dataset.counts_off:
+            self.write_counts_off(dataset, filename=filenames["backfile"])
+
+        if dataset.edisp:
+            self.write_edisp(dataset, filename=filenames["respfile"])
+
+    def write_edisp(self, dataset, filename):
+        """Write energy dispersion"""
+        kernel = dataset.edisp.get_edisp_kernel()
+        kernel.write(self.outdir / filename, overwrite=self.overwrite, use_sherpa=self.use_sherpa)
+
+    def write_aeff(self, dataset, filename):
+        """Write effective area"""
+        aeff = dataset.exposure / dataset.exposure.meta["livetime"]
+
+        hdu_format = "ogip-sherpa" if self.use_sherpa else "ogip"
+
+        aeff.write(
+            self.outdir / filename,
+            overwrite=self.overwrite,
+            format=hdu_format,
+            ogip_column="SPECRESP",
+        )
+
+    def to_counts_hdulist(self, dataset, is_counts_off=False):
+        """"""
+        counts = dataset.counts_off if is_counts_off else dataset.counts
+        acceptance = dataset.acceptance_off if is_counts_off else dataset.acceptance
+
+        table = counts.to_table()
+        table["QUALITY"] = np.logical_not(dataset.mask_safe.data[:, 0, 0])
+        table["BACKSCAL"] = acceptance.data[:, 0, 0]
+        table["AREASCAL"] = np.ones(acceptance.data.size)
+
+        # prepare meta data
+        meta = self.get_ogip_meta(dataset)
+
+        if is_counts_off:
+            meta["hduclas2"] = "BKG"
+        else:
+            meta.update(self.get_filenames(dataset))
+            meta["hduclas2"] = "TOTAL"
+
+        table.meta = meta
+
+        name = table.meta["name"]
+        hdu = fits.BinTableHDU(table, name=name)
+
+        energy_axis = dataset.counts.geom.axes[0]
+
+        hdu_format = "ogip-sherpa" if self.use_sherpa else "ogip"
+
+        hdulist = fits.HDUList(
+            [fits.PrimaryHDU(), hdu, energy_axis.to_table_hdu(format=hdu_format)]
+        )
+
+        if counts.geom.region:
+            region_table = counts.geom._to_region_table()
+            region_hdu = fits.BinTableHDU(region_table, name="REGION")
+            hdulist.append(region_hdu)
+
+        return hdulist
+
+    def write_counts(self, dataset, filename):
+        """Write counts file"""
+        hdulist = self.to_counts_hdulist(dataset)
+
+        if dataset.gti:
+            hdu = fits.BinTableHDU(dataset.gti.table, name="GTI")
+            hdulist.append(hdu)
+
+        hdulist.writeto(str(self.outdir / filename), overwrite=self.overwrite)
+
+    def write_counts_off(self, dataset, filename):
+        """Write off counts file"""
+        hdulist = self.to_counts_hdulist(dataset, is_counts_off=True)
+        hdulist.writeto(str(self.outdir / filename), overwrite=self.overwrite)
+
+
+class OGIPDatasetReader(DatasetReader):
+    """Read `~gammapy.datasets.SpectrumDatasetOnOff` from OGIP files.
+
+    BKG file, ARF, and RMF must be set in the PHA header and be present in
+    the same folder.
+
+    The naming scheme is fixed to the following scheme:
+
+    * PHA file is named ``pha_obs{name}.fits``
+    * BKG file is named ``bkg_obs{name}.fits``
+    * ARF file is named ``arf_obs{name}.fits``
+    * RMF file is named ``rmf_obs{name}.fits``
+      with ``{name}`` the dataset name.
+
+    Parameters
+    ----------
+    filename : str
+        OGIP PHA file to read
+    """
+    tag = "ogip"
+
+    def __init__(self, filename):
+        self.filename = filename
+
+    def read(self):
+        """Read dataset"""
+        filename = make_path(self.filename)
         dirname = filename.parent
 
         with fits.open(str(filename), memmap=False) as hdulist:
@@ -264,7 +290,7 @@ class DatasetIOOGIP(DatasetIO):
         if edisp is not None:
             edisp.exposure_map.data = exposure.data[:, :, np.newaxis, :]
 
-        return cls(
+        return SpectrumDatasetOnOff(
             counts=counts,
             exposure=exposure,
             counts_off=counts_off,
@@ -275,23 +301,3 @@ class DatasetIOOGIP(DatasetIO):
             name=str(counts.meta["OBS_ID"]),
             gti=gti,
         )
-
-
-class DatasetIOGADF(DatasetIO):
-    tag = "gadf"
-
-
-    def to_hdulist(self):
-        pass
-
-
-    def from_hdulist(self):
-        pass
-
-
-    def read(self):
-        pass
-
-
-    def write(self):
-        pass

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -492,6 +492,11 @@ class TestSpectrumOnOff:
         expected_regions = compound_region_to_list(self.off_counts.geom.region)
         regions = compound_region_to_list(newdataset.counts_off.geom.region)
 
+        assert newdataset.counts.meta["PHAFILE"] == "pha_obstest.fits"
+        assert newdataset.counts.meta["RESPFILE"] == "rmf_obstest.fits"
+        assert newdataset.counts.meta["BACKFILE"] == "bkg_obstest.fits"
+        assert newdataset.counts.meta["ANCRFILE"] == "arf_obstest.fits"
+
         assert_allclose(self.on_counts.data, newdataset.counts.data)
         assert_allclose(self.off_counts.data, newdataset.counts_off.data)
         assert_allclose(self.edisp.edisp_map.data, newdataset.edisp.edisp_map.data)

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -328,9 +328,14 @@ class RegionNDMap(Map):
         table = Table.read(hdulist[hdu])
         geom = RegionGeom.from_hdulist(hdulist, format=format)
 
-        data = table[ogip_column].quantity
+        quantity = table[ogip_column].quantity
 
-        return cls(geom=geom, data=data.value, meta=table.meta, unit=data.unit)
+        if ogip_column == "QUALITY":
+            data, unit = np.logical_not(quantity.value), ""
+        else:
+            data, unit = quantity.value, quantity.unit
+
+        return cls(geom=geom, data=data, meta=table.meta, unit=unit)
 
     def crop(self):
         raise NotImplementedError("Crop is not supported by RegionNDMap")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request moves the code from `.to_ogip_files()` and `.from_ogip_files()` to `datasets/io.py`.  As `.to_ogip_files()` is one of the longest functions we had in Gammapy I wanted to refactor and split it. For this I introduced a new **non-public** API: `OGIPDatasetReader` and `OGIPDatasetWriter`. The motivation mostly was to simplify the code, but I can easily imaging that at some point the `Reader` and `Writer` API will become public and can be used in pipeline configurations...for now it remains an implementation detail. I think it's also likely that we will support further formats in future so I think splitting out the code and allow for a registry in future is a good first step.

@registerrier I realised we currently don't support `SpectrumDatasetOnOff.read()`. I think we should just change it to something like `SpectrumDatasetOnOff.read(filename, format="ogip")` for now. 


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
