### PR TITLE
Add various models and parameters management options

### DIFF
--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -95,7 +95,8 @@ class FluxPointsDataset(Dataset):
         if models is None:
             self._models = None
         else:
-            self._models = DatasetModels(models).select(self.name)
+            models = DatasetModels(models)
+            self._models = models.select(models.mask(datasets_names=self.name))
 
     def write(self, filename, overwrite=True, **kwargs):
         """Write flux point dataset to file.

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -96,7 +96,7 @@ class FluxPointsDataset(Dataset):
             self._models = None
         else:
             models = DatasetModels(models)
-            self._models = models.select(models.mask(datasets_names=self.name))
+            self._models = models.select(datasets_names=self.name)
 
     def write(self, filename, overwrite=True, **kwargs):
         """Write flux point dataset to file.

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2694,7 +2694,7 @@ class MapEvaluator:
     @property
     def parameters_changed(self):
         """Parameters changed"""
-        values = self.model.parameters.values
+        values = self.model.parameters.value
 
         # TODO: possibly allow for a tolerance here?
         changed = ~np.all(self._cached_parameter_values == values)
@@ -2707,7 +2707,7 @@ class MapEvaluator:
     @property
     def parameters_spatial_changed(self):
         """Parameters changed"""
-        values = self.model.spatial_model.parameters.values
+        values = self.model.spatial_model.parameters.value
 
         # TODO: possibly allow for a tolerance here?
         changed = ~np.all(self._cached_parameter_values_spatial == values)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -288,7 +288,7 @@ class MapDataset(Dataset):
 
         if models is not None:
             models = DatasetModels(models)
-            models = models.select(models.mask(datasets_names=self.name))
+            models = models.select(datasets_names=self.name)
 
             for model in models:
                 if not isinstance(model, FoVBackgroundModel):

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -123,7 +123,7 @@ class ParameterEstimator(Estimator):
         """
         stat = datasets.stat_sum()
 
-        with datasets.parameters.restore_values:
+        with datasets.parameters.restore_status():
 
             # compute ts value
             parameter.value = self.null_value
@@ -241,7 +241,7 @@ class ParameterEstimator(Estimator):
         datasets = Datasets(datasets)
         parameter = datasets.parameters[parameter]
 
-        with datasets.parameters.restore_values:
+        with datasets.parameters.restore_status():
 
             if not self.reoptimize:
                 datasets.parameters.freeze_all()

--- a/gammapy/modeling/covariance.py
+++ b/gammapy/modeling/covariance.py
@@ -200,7 +200,7 @@ class Covariance:
     def scipy_mvn(self):
         # TODO: use this, as in https://github.com/cdeil/multinorm/blob/master/multinorm.py
         return scipy.stats.multivariate_normal(
-            self.parameters.values, self.data, allow_singular=True
+            self.parameters.value, self.data, allow_singular=True
         )
 
     def __str__(self):

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -218,7 +218,7 @@ class Fit:
         parameters = self._parameters
 
         # TODO: wrap MINUIT in a stateless backend
-        with parameters.restore_values:
+        with parameters.restore_status():
             if backend == "minuit":
                 method = "hesse"
                 if hasattr(self, "minuit"):
@@ -280,7 +280,7 @@ class Fit:
         parameter = parameters[parameter]
 
         # TODO: wrap MINUIT in a stateless backend
-        with parameters.restore_values:
+        with parameters.restore_status():
             if backend == "minuit":
                 if hasattr(self, "minuit"):
                     # This is ugly. We will access parameters and make a copy
@@ -362,7 +362,7 @@ class Fit:
 
         stats = []
         fit_results = []
-        with parameters.restore_values:
+        with parameters.restore_status():
             for value in values:
                 parameter.value = value
                 if reoptimize:
@@ -413,7 +413,7 @@ class Fit:
 
         stats = []
         fit_results = []
-        with parameters.restore_values:
+        with parameters.restore_status():
             for x_value, y_value in itertools.product(x_values, y_values):
                 # TODO: Remove log.info() and provide a nice progress bar
                 log.info(f"Processing: x={x_value}, y={y_value}")
@@ -476,7 +476,7 @@ class Fit:
         x = parameters[x]
         y = parameters[y]
 
-        with parameters.restore_values:
+        with parameters.restore_status():
             result = mncontour(self.minuit, parameters, x, y, numpoints, sigma)
 
         x_name = x.name

--- a/gammapy/modeling/likelihood.py
+++ b/gammapy/modeling/likelihood.py
@@ -33,7 +33,7 @@ class Likelihood:
         row = {"total_stat": total_stat}
         pars = self.parameters.free_parameters
         names = [f"par-{idx}" for idx in range(len(pars))]
-        vals = dict(zip(names, pars.values))
+        vals = dict(zip(names, pars.value))
         row.update(vals)
         self.trace.append(row)
 

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -543,6 +543,50 @@ class DatasetModels(collections.abc.Sequence):
                     selection[km] &= ~all_frozen
         return selection
 
+    def set_parameters_bounds(
+        self, model_tag, parameters_names, min=None, max=None, value=None
+    ):
+        """Set bounds for the selected models types and parameters names
+        Parameters
+        ----------
+        model_tag : str or list
+            tag of the spatial or spectral models (do not mix spatial and spectral)
+        parameters_names : str or list
+            parameters names
+        min : float
+            min value
+        max : float
+            max value
+        value : float
+            init value
+        """
+
+        for m in self:
+            if not isinstance(model_tag, list):
+                model_tag = [model_tag]
+            if not isinstance(parameters_names, list):
+                parameters_names = [parameters_names]
+            sub_model = None
+            if hasattr(m, "spatial_model") and np.any(
+                [t in m.spatial_model.tag for t in model_tag]
+            ):
+                sub_model = m.spatial_model
+            if hasattr(m, "_spectral_model") and np.any(
+                [t in m._spectral_model.tag for t in model_tag]
+            ):
+                if sub_model is not None:
+                    raise ValueError("Do not mix spatial and spectral in model_tag")
+                sub_model = m.spectral_model
+            if sub_model is not None:
+                for p in sub_model.parameters:
+                    if p.name in parameters_names:
+                        if min is not None:
+                            p.min = min
+                        if max is not None:
+                            p.max = max
+                        if value is not None:
+                            p.value = value
+
 
 class Models(DatasetModels, collections.abc.MutableSequence):
     """Sky model collection.

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -616,11 +616,11 @@ class DatasetModels(collections.abc.Sequence):
         )
         n = len(parameters)
         if min is not None:
-            parameters.minima = np.ones(n) * min
+            parameters.min = np.ones(n) * min
         if max is not None:
-            parameters.maxima = np.ones(n) * max
+            parameters.max = np.ones(n) * max
         if value is not None:
-            parameters.values = np.ones(n) * value
+            parameters.value = np.ones(n) * value
 
     def freeze(self, model_type=None):
         """Freeze parameters depending on model type

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -595,8 +595,8 @@ class FoVBackgroundModel(Model):
 
     def reset_to_default(self):
         """Reset parameter values to default"""
-        values = self.spectral_model.default_parameters.values
-        self.spectral_model.parameters.values = values
+        values = self.spectral_model.default_parameters.value
+        self.spectral_model.parameters.value = values
 
     def copy(self, **kwargs):
         """Copy SkyModel"""

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -59,10 +59,6 @@ class SpatialModel(Model):
 
         return self.evaluate(lon, lat, **kwargs)
 
-    @property
-    def type(self):
-        return self._type
-
     # TODO: make this a hard-coded class attribute?
     @lazyproperty
     def is_energy_dependent(self):
@@ -153,7 +149,7 @@ class SpatialModel(Model):
             wcs_geom = geom.to_wcs_geom().to_image()
             mask = geom.contains(wcs_geom.get_coord())
             values = self.evaluate_geom(wcs_geom)
-            data = ((values* wcs_geom.solid_angle())[mask]).sum()
+            data = ((values * wcs_geom.solid_angle())[mask]).sum()
         else:
             values = self.evaluate_geom(geom)
             data = values * geom.solid_angle()

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -964,7 +964,7 @@ class PiecewiseNormSpectralModel(SpectralModel):
     @property
     def norms(self):
         """Norm values"""
-        return u.Quantity(self.parameters.values)
+        return u.Quantity(self.parameters.value)
 
     def evaluate(self, energy, **norms):
         scale = interpolation_scale(scale=self._interp)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -53,10 +53,6 @@ class SpectralModel(Model):
         return self.evaluate(energy, **kwargs)
 
     @property
-    def type(self):
-        return self._type
-
-    @property
     def is_norm_spectral_model(self):
         """Whether model is a norm spectral model"""
         return "Norm" in self.__class__.__name__

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -149,7 +149,7 @@ def test_compound_model():
     m = CoModel(m1, m2)
     assert len(m.parameters) == 5
     assert m.parameters.names == ["norm", "x", "y", "x", "y"]
-    assert_allclose(m.parameters.values, [42, 1, 2, 10, 20])
+    assert_allclose(m.parameters.value, [42, 1, 2, 10, 20])
 
 
 def test_parameter_link_init():

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -184,3 +184,23 @@ def test_freeze(models):
     assert models["bkg1"]._spectral_model.tilt.frozen == True
     assert models["bkg1"]._spectral_model.norm.frozen == False
     assert models["source-1"].spectral_model.index.frozen == False
+
+
+def test_parameters(models):
+
+    pars = models.parameters.select(frozen=False)
+    pars.freeze_all()
+    assert np.all([p.frozen for p in pars])
+    assert len(pars.select(frozen=True)) == len(pars)
+
+    pars.unfreeze_all()
+    assert np.all([not p.frozen for p in pars])
+    assert len(pars.min) == len(pars)
+    assert len(pars.max) == len(pars)
+
+    with pytest.raises(TypeError):
+        pars.min = 1
+    with pytest.raises(ValueError):
+        pars.min = [1]
+    with pytest.raises(ValueError):
+        pars.max = [2]

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -105,3 +105,21 @@ def test_restore_status(models):
         models[1].spectral_model.amplitude.value = 0
         models[1].spectral_model.amplitude.frozen = True
     assert models[1].spectral_model.amplitude.value == 0
+
+
+def test_bounds(models):
+
+    models.set_parameters_bounds(
+        model_tag="pl", parameters_names="index", min=0, max=5, value=2.4
+    )
+    pl_mask = models.mask(spectral_tag="pl")
+    assert np.all([m.spectral_model.index.value == 2.4 for m in models.select(pl_mask)])
+    models.set_parameters_bounds(
+        model_tag=["pl", "pl-norm"],
+        parameters_names=["norm", "amplitude"],
+        min=0,
+        max=None,
+    )
+    bkg_mask = models.mask(tag="BackgroundModel")
+    assert np.all([m.spectral_model.amplitude.min == 0 for m in models.select(pl_mask)])
+    assert np.all([m._spectral_model.norm.min == 0 for m in models.select(bkg_mask)])

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -130,23 +130,31 @@ def test_restore_status(models):
     assert model.amplitude.value == 0
 
 
-# def test_bounds(models):
-#
-#    models.set_parameters_bounds(
-#        model_tag="pl", parameters_names="index", min=0, max=5, value=2.4
-#    )
-#    pl_mask = models.mask(spectral_tag="pl")
-#    assert np.all([m.spectral_model.index.value == 2.4 for m in models[pl_mask]])
-#    models.set_parameters_bounds(
-#        tag=["pl", "pl-norm"],
-#        model_type="spectral",
-#        parameters_names=["norm", "amplitude"],
-#        min=0,
-#        max=None,
-#    )
-#    bkg_mask = models.mask(tag="BackgroundModel")
-#    assert np.all([m.spectral_model.amplitude.min == 0 for m in models[pl_mask]])
-#    assert np.all([m._spectral_model.norm.min == 0 for m in models[bkg_mask]])
+def test_bounds(models):
+
+    models.set_parameters_bounds(
+        tag="pl",
+        model_type="spectral",
+        parameters_names="index",
+        min=0,
+        max=5,
+        value=2.4,
+    )
+    pl_mask = models.mask(tag="pl", model_type="spectral")
+    assert np.all([m.spectral_model.index.value == 2.4 for m in models[pl_mask]])
+    assert np.all([m.spectral_model.index.min == 0 for m in models[pl_mask]])
+    assert np.all([m.spectral_model.index.max == 5 for m in models[pl_mask]])
+
+    models.set_parameters_bounds(
+        tag=["pl", "pl-norm"],
+        model_type="spectral",
+        parameters_names=["norm", "amplitude"],
+        min=0,
+        max=None,
+    )
+    bkg_mask = models.mask(tag="BackgroundModel")
+    assert np.all([m.spectral_model.amplitude.min == 0 for m in models[pl_mask]])
+    assert np.all([m._spectral_model.norm.min == 0 for m in models[bkg_mask]])
 
 
 def test_freeze(models):

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -1,0 +1,86 @@
+import pytest
+import numpy as np
+import astropy.units as u
+from gammapy.modeling.models import (
+    BackgroundModel,
+    GaussianSpatialModel,
+    Models,
+    PointSpatialModel,
+    PowerLawSpectralModel,
+    SkyModel,
+)
+from gammapy.maps import Map, MapAxis, WcsGeom
+
+
+@pytest.fixture(scope="session")
+def backgrounds():
+    axis = MapAxis.from_edges(np.logspace(-1, 1, 3), unit=u.TeV, name="energy")
+    geom = WcsGeom.create(skydir=(0, 0), npix=(5, 4), frame="galactic", axes=[axis])
+    m = Map.from_geom(geom)
+    m.quantity = np.ones(geom.data_shape) * 1e-7
+    background1 = BackgroundModel(m, name="bkg1", datasets_names="dataset-1")
+    background2 = BackgroundModel(m, name="bkg2", datasets_names=["dataset-2"])
+    backgrounds = [background1, background2]
+    return backgrounds
+
+
+@pytest.fixture(scope="session")
+def models(backgrounds):
+    spatial_model = GaussianSpatialModel(
+        lon_0="3 deg", lat_0="4 deg", sigma="3 deg", frame="galactic"
+    )
+    spectral_model = PowerLawSpectralModel(
+        index=2, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV"
+    )
+    model1 = SkyModel(
+        spatial_model=spatial_model, spectral_model=spectral_model, name="source-1",
+    )
+
+    model2 = model1.copy(name="source-2")
+    model2.datasets_names = ["dataset-1"]
+    model3 = model1.copy(name="source-3")
+    model3.datasets_names = "dataset-2"
+    model3.spatial_model = PointSpatialModel()
+    model3.parameters.freeze_all()
+    models = Models([model1, model2, model3] + backgrounds)
+    return models
+
+
+def test_select(models):
+    conditions = [
+        {"datasets_names": "dataset-1"},
+        {"datasets_names": "dataset-2"},
+        {"datasets_names": ["dataset-1", "dataset-2"]},
+        {"datasets_names": None},
+        {"tag": "BackgroundModel"},
+        {"tag": ["SkyModel", "BackgroundModel"]},
+        {"spatial_tag": "point"},
+        {"spatial_tag": ["point", "gauss"]},
+        {"spectral_tag": "pl"},
+        {"spectral_tag": ["pl", "pl-norm"]},
+        {"name_substring": "bkg"},
+        {"frozen": True},
+        {"frozen": False},
+        {"datasets_names": "dataset-1", "spectral_tag": "pl"},
+    ]
+
+    expected = [
+        ["source-1", "source-2", "bkg1"],
+        ["source-1", "source-3", "bkg2"],
+        ["source-1", "source-2", "source-3", "bkg1", "bkg2"],
+        ["source-1", "source-2", "source-3", "bkg1", "bkg2"],
+        ["bkg1", "bkg2"],
+        ["source-1", "source-2", "source-3", "bkg1", "bkg2"],
+        ["source-3"],
+        ["source-1", "source-2", "source-3"],
+        ["source-1", "source-2", "source-3"],
+        ["source-1", "source-2", "source-3", "bkg1", "bkg2"],
+        ["bkg1", "bkg2"],
+        ["source-3"],
+        ["source-1", "source-2", "bkg1", "bkg2"],
+        ["source-1", "source-2"],
+    ]
+    for cdt, xp in zip(conditions, expected):
+        mask = models.mask(**cdt)
+        selected = models.select(mask)
+        assert selected.names == xp

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -123,3 +123,32 @@ def test_bounds(models):
     bkg_mask = models.mask(tag="BackgroundModel")
     assert np.all([m.spectral_model.amplitude.min == 0 for m in models.select(pl_mask)])
     assert np.all([m._spectral_model.norm.min == 0 for m in models.select(bkg_mask)])
+
+
+def test_freeze(models):
+
+    models.freeze()
+    assert np.all([p.frozen for p in models.parameters])
+    models.unfreeze()
+    assert models["source-1"].spatial_model.lon_0.frozen == False
+    assert models["source-1"].spectral_model.reference.frozen == True
+    assert models["source-3"].spatial_model.lon_0.frozen == False
+    assert models["bkg1"]._spectral_model.tilt.frozen == True
+    assert models["bkg1"]._spectral_model.norm.frozen == False
+    models.freeze("spatial")
+    assert models["source-1"].spatial_model.lon_0.frozen == True
+    assert models["source-3"].spatial_model.lon_0.frozen == True
+    assert models["bkg1"]._spectral_model.norm.frozen == False
+    models.unfreeze("spatial")
+    assert models["source-1"].spatial_model.lon_0.frozen == False
+    assert models["source-1"].spectral_model.reference.frozen == True
+    assert models["source-3"].spatial_model.lon_0.frozen == False
+    models.freeze("spectral")
+    assert models["bkg1"]._spectral_model.tilt.frozen == True
+    assert models["bkg1"]._spectral_model.norm.frozen == True
+    assert models["source-1"].spectral_model.index.frozen == True
+    assert models["source-3"].spatial_model.lon_0.frozen == False
+    models.unfreeze("spectral")
+    assert models["bkg1"]._spectral_model.tilt.frozen == True
+    assert models["bkg1"]._spectral_model.norm.frozen == False
+    assert models["source-1"].spectral_model.index.frozen == False

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -514,8 +514,6 @@ class restore_parameters_status:
         pass
 
     def __exit__(self, type, value, traceback):
-        # TODO: also restore the covariance ?
-        # (for now reset to zero if frosen==False)
         for value, par, frozen in zip(self.values, self._parameters, self.frozen):
             if self.restore_values:
                 par.value = value

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -333,40 +333,40 @@ class Parameters(collections.abc.Sequence):
         return [par.type for par in self]
 
     @property
-    def minima(self):
+    def min(self):
         """Parameter mins (`numpy.ndarray`)."""
         return np.array([_.min for _ in self._parameters], dtype=np.float64)
 
-    @minima.setter
-    def minima(self, minima):
+    @min.setter
+    def min(self, min_array):
         """Parameter minima (`numpy.ndarray`)."""
-        if not len(self) == len(minima):
+        if not len(self) == len(min_array):
             raise ValueError("Minima must have same length as parameter list")
 
-        for min_, par in zip(minima, self):
+        for min_, par in zip(min_array, self):
             par.min = min_
 
     @property
-    def maxima(self):
+    def max(self):
         """Parameter maxima (`numpy.ndarray`)."""
         return np.array([_.max for _ in self._parameters], dtype=np.float64)
 
-    @maxima.setter
-    def maxima(self, maxima):
+    @max.setter
+    def max(self, max_array):
         """Parameter maxima (`numpy.ndarray`)."""
-        if not len(self) == len(maxima):
+        if not len(self) == len(max_array):
             raise ValueError("Maxima must have same length as parameter list")
 
-        for max_, par in zip(maxima, self):
+        for max_, par in zip(max_array, self):
             par.max = max_
 
     @property
-    def values(self):
+    def value(self):
         """Parameter values (`numpy.ndarray`)."""
         return np.array([_.value for _ in self._parameters], dtype=np.float64)
 
-    @values.setter
-    def values(self, values):
+    @value.setter
+    def value(self, values):
         """Parameter values (`numpy.ndarray`)."""
         if not len(self) == len(values):
             raise ValueError("Values must have same length as parameter list")

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -395,10 +395,13 @@ class Parameters(collections.abc.Sequence):
         else:
             raise TypeError(f"Invalid type: {type(val)!r}")
 
-    def __getitem__(self, name):
-        """Access parameter by name or index"""
-        idx = self.index(name)
-        return self._parameters[idx]
+    def __getitem__(self, key):
+        """Access parameter by name, index or boolean mask"""
+        if isinstance(key, np.ndarray) and key.dtype == bool:
+            return self.__class__(list(np.array(self._parameters)[key]))
+        else:
+            idx = self.index(key)
+            return self._parameters[idx]
 
     def __len__(self):
         return len(self._parameters)
@@ -493,6 +496,11 @@ class Parameters(collections.abc.Sequence):
         """Freeze all parameters"""
         for par in self._parameters:
             par.frozen = True
+
+    def unfreeze_all(self):
+        """ Unfreeze all parameters (even those frozen by default)"""
+        for par in self._parameters:
+            par.frozen = False
 
 
 class restore_parameters_status:

--- a/gammapy/modeling/scipy.py
+++ b/gammapy/modeling/scipy.py
@@ -112,7 +112,7 @@ def confidence_scipy(parameters, parameter, function, sigma, reoptimize=True, **
     if len(parameters.free_parameters) <= 1:
         reoptimize = False
 
-    with parameters.restore_values:
+    with parameters.restore_status():
         result = _confidence_scipy_brentq(
             parameters=parameters,
             parameter=parameter,
@@ -123,7 +123,7 @@ def confidence_scipy(parameters, parameter, function, sigma, reoptimize=True, **
             **kwargs
         )
 
-    with parameters.restore_values:
+    with parameters.restore_status():
         result_errp = _confidence_scipy_brentq(
             parameters=parameters,
             parameter=parameter,


### PR DESCRIPTION
This PR add various models and parameters management options:

- modify Models.select() to take only a boolean mask as input
- add Models.mask() that return a boolean mask combining the different conditions with AND operator. The separation between mask and select allows to build more complex selections using other operators.
- add conditions for Models.mask() based on spatial model tag, spectral model tag, and frozen status

- rename parameters.restore_value as parameters.restore_status
- add option restore_values (True by default, if False only the frozen status is restored).
 TODO: also restore the covariance (reset to zero if frozen is set to True) ?

- add Models.set_parameters_bounds() in order to set min/max/value for all the selected models types and parameters names.

- add Models.freeze()/unfreeze() methods
-- freeze: freeze all parameters or only spatial or only spectral 
-- unfreeze: restore frozen status to default for all parameters or only spatial or only spectral

- add all new tests in gammapy.modeling.models/test/test_management.py

Further models management related to Datasets operations, like .cutout(), will be added in a separate PR.