### PR TITLE
Add .reassign_dataset() method to models

### DIFF
--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -162,7 +162,7 @@ class FluxEstimator(Estimator):
         )
 
         new_names = [name + "-sliced" for name in datasets.names]
-        models = datasets.models.reassign_dataset(datasets.names, new_names)
+        models = datasets.models.reassign(datasets.names, new_names)
         datasets_sliced.models = models
         for d in datasets_sliced:
             if d.background_model:

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -161,10 +161,10 @@ class FluxEstimator(Estimator):
             energy_min=self.energy_min, energy_max=self.energy_max
         )
 
-        models = datasets.models.copy()
+        new_names = [name + "-sliced" for name in datasets.names]
+        models = datasets.models.reassign_dataset(datasets.names, new_names)
         datasets_sliced.models = models
-        for idx, d in enumerate(datasets_sliced):
-            d.models.reassign_dataset(datasets.names[idx], d.name)
+        for d in datasets_sliced:
             if d.background_model:
                 d.background_model.reset_to_default()
 

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -161,16 +161,12 @@ class FluxEstimator(Estimator):
             energy_min=self.energy_min, energy_max=self.energy_max
         )
 
-        # TODO: simplify model book-keeping!!
-        models = Models()
-
-        for model in datasets.models:
-            if "sky-model" in model.tag:
-                models.append(model)
-            elif "fov-bkg" in model.tag:
-                bkg_model = model.copy(dataset_name=model.datasets_names[0] + "-sliced")
-                bkg_model.reset_to_default()
-                models.append(bkg_model)
+        models = datasets.models.copy()
+        datasets_sliced.models = models
+        for idx, d in enumerate(datasets_sliced):
+            d.models.reassign_dataset(datasets.names[idx], d.name)
+            if d.background_model:
+                d.background_model.reset_to_default()
 
         if len(datasets_sliced) > 0:
             # TODO: this relies on the energy binning of the first dataset

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -205,18 +205,18 @@ class Model:
         
         Parameters
         ----------
-        dataset_name : str or list
+        datasets_names : str or list
             Name of the datasets where the model is currently defined
-        new_dataset_name : str or list
+        new_datasets_names : str or list
             Name of the datasets where the model should be defined instead.
             If multiple names are given the two list must have the save lenght,
             as the reassignment is element-wise.
         """
-        model = self.copy()
+        model = self.copy(name=self.name)
         if not isinstance(datasets_names, list):
             datasets_names = [datasets_names]
         if not isinstance(new_datasets_names, list):
-            datasets_names = [new_datasets_names]
+            new_datasets_names = [new_datasets_names]
 
         if model.datasets_names is not None:
             if not isinstance(model.datasets_names, list):
@@ -687,10 +687,12 @@ class DatasetModels(collections.abc.Sequence):
     
         Parameters
         ----------
-        dataset_name : str
-            Name of a dataset where the model is currently defined
-        new_dataset_name : str
-            Name of a dataset where the model should be defined instead
+        dataset_name : str or list
+            Name of the datasets where the model is currently defined
+        new_dataset_name : str or list
+            Name of the datasets where the model should be defined instead.
+            If multiple names are given the two list must have the save lenght,
+            as the reassignment is element-wise.
         """
         models = [m.reassign(dataset_name, new_dataset_name) for m in self]
         return self.__class__(models)

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -200,6 +200,23 @@ class Model:
         for p, default in zip(self.parameters, self.default_parameters):
             p.frozen = default.frozen
 
+    def reassign_dataset(self, dataset_name, new_dataset_name):
+        """Reassign a model from one dataset to another
+        
+        Parameters
+        ----------
+        dataset_name : str
+            Name of a dataset where the model is currently defined
+        new_dataset_name : str
+            Name of a dataset where the model should be defined instead
+        """
+        if self.datasets_names is not None:
+            if not isinstance(self.datasets_names, list):
+                self.datasets_names = [self.datasets_names]
+            for k, name in enumerate(self.datasets_names):
+                if name == dataset_name:
+                    self.datasets_names[k] = new_dataset_name
+
 
 class DatasetModels(collections.abc.Sequence):
     """Immutable models container
@@ -506,7 +523,9 @@ class DatasetModels(collections.abc.Sequence):
         models : `DatasetModels`
             Selected models
         """
-        mask = self.selection_mask(name_substring, datasets_names, tag, model_type, frozen)
+        mask = self.selection_mask(
+            name_substring, datasets_names, tag, model_type, frozen
+        )
         return self[mask]
 
     def selection_mask(
@@ -650,6 +669,19 @@ class DatasetModels(collections.abc.Sequence):
     def frozen(self):
         """Boolean mask, True if all parameters of a given model are frozen"""
         return np.all([m.frozen for m in self])
+
+    def reassign_dataset(self, dataset_name, new_dataset_name):
+        """Reassign a model from one dataset to another
+    
+        Parameters
+        ----------
+        dataset_name : str
+            Name of a dataset where the model is currently defined
+        new_dataset_name : str
+            Name of a dataset where the model should be defined instead
+        """
+        for m in self:
+            m.reassign_dataset(dataset_name, new_dataset_name)
 
 
 class Models(DatasetModels, collections.abc.MutableSequence):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -600,10 +600,6 @@ class FoVBackgroundModel(Model):
         values = self.spectral_model.default_parameters.value
         self.spectral_model.parameters.value = values
 
-    def copy(self, **kwargs):
-        """Copy SkyModel"""
-        return self.__class__(**kwargs)
-
     def freeze(self, model_type="spectral"):
         """Freeze model parameters"""
         if model_type is None or model_type == "spectral":

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -551,6 +551,15 @@ class FoVBackgroundModel(Model):
         """Evaluate model"""
         return self.spectral_model(energy)
 
+    def copy(self, **kwargs):
+        """Copy SkyModel"""
+        kwargs.pop("name")
+        if "spectral_model" not in kwargs:
+            kwargs.setdefault("spectral_model", self.spectral_model.copy())
+        if "dataset_name" not in kwargs:
+            kwargs.setdefault("dataset_name", self.datasets_names[0])
+        return self.__class__(**kwargs)
+
     def to_dict(self, full_output=False):
         data = {}
         data["type"] = self.tag[0]

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -235,7 +235,7 @@ def test_fov_bkg_models():
 
 def test_reassign_dataset(models):
     ref = models.select(datasets_names="dataset-2")
-    models.reassign_dataset("dataset-2", "dataset-2-copy")
+    models = models.reassign("dataset-2", "dataset-2-copy")
     assert len(models.select(datasets_names="dataset-2")) == np.sum(
         [m.datasets_names == None for m in models]
     )

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -88,7 +88,9 @@ def test_select(models):
         print(selected.names)
         assert selected.names == xp
 
-    mask = models.selection_mask(**conditions[4]) | models.selection_mask(**conditions[6])
+    mask = models.selection_mask(**conditions[4]) | models.selection_mask(
+        **conditions[6]
+    )
     selected = models[mask]
     assert selected.names == ["source-3", "bkg1", "bkg2"]
 
@@ -229,3 +231,15 @@ def test_fov_bkg_models():
     assert models["test-1-bkg"].spectral_model.norm.frozen
 
 
+
+
+def test_reassign_dataset(models):
+    ref = models.select(datasets_names="dataset-2")
+    models.reassign_dataset("dataset-2", "dataset-2-copy")
+    assert len(models.select(datasets_names="dataset-2")) == np.sum(
+        [m.datasets_names == None for m in models]
+    )
+    new = models.select(datasets_names="dataset-2-copy")
+    assert len(new) == len(ref)
+    assert new["source-1"].datasets_names == None
+    assert new["source-3"].datasets_names == ["dataset-2-copy"]


### PR DESCRIPTION
This PR add a .reassign_dataset(dataset_name, new_dataset_name) method to Model and Models 
in order to update the datasets_names replacing one name by another. This is used for example in the flux estimator, it could be also  used after the copy of a dataset. 