### PR TITLE
Add binary_erosion/dilation to WcsNDMap

### DIFF
--- a/docs/makers/ring.rst
+++ b/docs/makers/ring.rst
@@ -44,7 +44,7 @@ A given `MapDataset` has to be reduced to a single image by calling
 	)
 
 	circle = CircleSkyRegion(center=geom.center_skydir, radius=0.2 * u.deg)
-	exclusion_mask = Map.from_geom(geom, data=geom.region_mask([circle], inside=False))
+	exclusion_mask = geom.region_mask([circle], inside=False)
 
 	ring_bkg_maker = RingBackgroundMaker(r_in="0.3 deg", width="0.3 deg", exclusion_mask=exclusion_mask)
 

--- a/docs/tutorials/analysis_2.ipynb
+++ b/docs/tutorials/analysis_2.ipynb
@@ -230,8 +230,7 @@
     "circle = CircleSkyRegion(\n",
     "    center=SkyCoord(\"83.63 deg\", \"22.14 deg\"), radius=0.2 * u.deg\n",
     ")\n",
-    "data = geom.region_mask(regions=[circle], inside=False)\n",
-    "exclusion_mask = Map.from_geom(geom=geom, data=data)\n",
+    "exclusion_mask = geom.region_mask(regions=[circle], inside=False)\n",
     "maker_fov = FoVBackgroundMaker(method=\"fit\", exclusion_mask=exclusion_mask)"
    ]
   },

--- a/docs/tutorials/cta_data_analysis.ipynb
+++ b/docs/tutorials/cta_data_analysis.ipynb
@@ -202,7 +202,6 @@
    "outputs": [],
    "source": [
     "exclusion_mask = geom.to_image().region_mask([on_region], inside=False)\n",
-    "exclusion_mask = WcsNDMap(geom.to_image(), exclusion_mask)\n",
     "exclusion_mask.plot();"
    ]
   },

--- a/docs/tutorials/exclusion_mask.ipynb
+++ b/docs/tutorials/exclusion_mask.ipynb
@@ -149,8 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask_data = geom.region_mask(regions, inside=False)\n",
-    "mask_map = Map.from_geom(geom, data=mask_data)"
+    "mask_map = geom.region_mask(regions, inside=False)"
    ]
   },
   {
@@ -227,8 +226,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask_data = geom.region_mask(regions, inside=False)\n",
-    "mask_map_catalog = Map.from_geom(geom, data=mask_data)"
+    "mask_map_catalog = geom.region_mask(regions, inside=False)"
    ]
   },
   {

--- a/docs/tutorials/ring_background.ipynb
+++ b/docs/tutorials/ring_background.ipynb
@@ -219,8 +219,7 @@
     "\n",
     "# Make the exclusion mask\n",
     "regions = CircleSkyRegion(center=source_pos, radius=0.3 * u.deg)\n",
-    "exclusion_mask = Map.from_geom(geom_image)\n",
-    "exclusion_mask.data = geom_image.region_mask([regions], inside=False)\n",
+    "exclusion_mask =  geom_image.region_mask([regions], inside=False)\n",
     "exclusion_mask.sum_over_axes().plot();"
    ]
   },

--- a/docs/tutorials/spectrum_analysis.ipynb
+++ b/docs/tutorials/spectrum_analysis.ipynb
@@ -199,7 +199,7 @@
     ")\n",
     "\n",
     "mask = exclusion_mask.geom.region_mask([exclusion_region], inside=False)\n",
-    "exclusion_mask.data = mask\n",
+    "exclusion_mask.data = mask.data\n",
     "exclusion_mask.plot();"
    ]
   },

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -212,7 +212,7 @@ def test_exclusion_region(tmp_path):
     exclusion_region = CircleSkyRegion(center=SkyCoord("85d 23d"), radius=1 * u.deg)
     exclusion_mask = Map.create(npix=(150, 150), binsz=0.05, skydir=SkyCoord("83d 22d"))
     mask = exclusion_mask.geom.region_mask([exclusion_region], inside=False)
-    exclusion_mask.data = mask.astype(int)
+    exclusion_mask.data = mask.data.astype(int)
     filename = tmp_path / "exclusion.fits"
     exclusion_mask.write(filename)
     config.datasets.background.method = "reflected"
@@ -227,7 +227,8 @@ def test_exclusion_region(tmp_path):
     analysis.get_datasets()
     geom = analysis.datasets[0]._geom
     exclusion = WcsNDMap.from_geom(geom)
-    exclusion.data = geom.region_mask([exclusion_region], inside=False).astype(int)
+    mask = exclusion_mask.geom.region_mask([exclusion_region], inside=False)
+    exclusion_mask.data = mask.data.astype(int)
     filename = tmp_path / "exclusion3d.fits"
     exclusion.write(filename)
     config.datasets.background.exclusion = filename

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -192,8 +192,7 @@ class TestEventSelection:
             skydir=(0, 0), binsz=0.2, width=4.0 * u.deg, proj="TAN", axes=[axis]
         )
 
-        mask_data = geom.region_mask(regions=[self.on_regions[0]], inside=True)
-        mask = Map.from_geom(geom, data=mask_data)
+        mask = geom.region_mask(regions=[self.on_regions[0]], inside=True)
         new_list = self.events.select_map_mask(mask)
         assert len(new_list.table) == 2
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1362,16 +1362,6 @@ def test_downsample_onoff():
     assert_allclose(downsampled.alpha.data, 0.5)
 
 
-def test_mask_fit_modifications(geom, geom_etrue):
-    d = get_map_dataset(geom, geom_etrue)
-    d.mask_fit.data = np.ones(d.mask_fit.data.shape, dtype=bool)
-    d.mask_fit = d.mask_fit.boundary_mask(width=(0.3 * u.deg, 0.1 * u.deg))
-    assert np.sum(d.mask_fit.data[0, :, :]) == 6300
-    assert np.sum(d.mask_fit.data[1, :, :]) == 6300
-    d.mask_fit = d.mask_fit.binary_dilate(width=(0.3 * u.deg, 0.1 * u.deg))
-    assert np.sum(d.mask_fit.data) == np.prod(d.mask_fit.data.shape)
-
-
 def test_compute_flux_spatial():
     center = SkyCoord("0 deg", "0 deg", frame="galactic")
     region = CircleSkyRegion(center=center, radius=0.1 * u.deg)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -957,7 +957,7 @@ def test_stack_onoff(images):
     assert_allclose(
         stacked.acceptance.data.sum(), dataset.data_shape[1] * dataset.data_shape[2]
     )
-    assert_allclose(np.nansum(stacked.acceptance_off.data), 2.925793e+08, rtol=1e-5)
+    assert_allclose(np.nansum(stacked.acceptance_off.data), 2.925793e08, rtol=1e-5)
     assert_allclose(stacked.exposure.data, 2.0 * dataset.exposure.data)
 
 
@@ -1368,4 +1368,3 @@ def test_mask_fit_modifications(geom, geom_etrue):
     assert np.sum(d.mask_fit.data[1, :, :]) == 6300
     d.mask_fit.binary_dilation(margin=(0.3 * u.deg, 0.1 * u.deg))
     assert np.sum(d.mask_fit.data) == np.prod(d.mask_fit.data.shape)
- 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1358,3 +1358,14 @@ def test_downsample_onoff():
     assert downsampled.counts.data.sum() == dataset_onoff.counts.data.sum()
     assert downsampled.counts_off.data.sum() == dataset_onoff.counts_off.data.sum()
     assert_allclose(downsampled.alpha.data, 0.5)
+
+
+def test_mask_fit_modifications(geom, geom_etrue):
+    d = get_map_dataset(geom, geom_etrue)
+    d.mask_fit.data = np.ones(d.mask_fit.data.shape, dtype=bool)
+    d.mask_fit.binary_erosion(margin=(0.3 * u.deg, 0.1 * u.deg), from_edges=True)
+    assert np.sum(d.mask_fit.data[0, :, :]) == 6300
+    assert np.sum(d.mask_fit.data[1, :, :]) == 6300
+    d.mask_fit.binary_dilation(margin=(0.3 * u.deg, 0.1 * u.deg))
+    assert np.sum(d.mask_fit.data) == np.prod(d.mask_fit.data.shape)
+ 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -129,7 +129,6 @@ def get_map_dataset(geom, geom_etrue, edisp="edispmap", name="test", **kwargs):
     center = SkyCoord("0.2 deg", "0.1 deg", frame="galactic")
     circle = CircleSkyRegion(center=center, radius=1 * u.deg)
     mask_fit = geom.region_mask([circle])
-    mask_fit = Map.from_geom(geom, data=mask_fit)
 
     models = FoVBackgroundModel(dataset_name=name)
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -15,7 +15,7 @@ from gammapy.irf import (
     EffectiveAreaTable2D,
     EnergyDependentMultiGaussPSF,
     PSFMap,
-    PSFKernel
+    PSFKernel,
 )
 from gammapy.makers.utils import make_map_exposure_true_energy
 from gammapy.maps import Map, MapAxis, WcsGeom, WcsNDMap, RegionGeom, RegionNDMap
@@ -27,7 +27,7 @@ from gammapy.modeling.models import (
     PointSpatialModel,
     PowerLawSpectralModel,
     SkyModel,
-    ConstantSpectralModel
+    ConstantSpectralModel,
 )
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
@@ -1365,21 +1365,26 @@ def test_downsample_onoff():
 def test_mask_fit_modifications(geom, geom_etrue):
     d = get_map_dataset(geom, geom_etrue)
     d.mask_fit.data = np.ones(d.mask_fit.data.shape, dtype=bool)
-    d.mask_fit.binary_erosion(margin=(0.3 * u.deg, 0.1 * u.deg), from_edges=True)
+    d.mask_fit = d.mask_fit.boundary_mask(width=(0.3 * u.deg, 0.1 * u.deg))
     assert np.sum(d.mask_fit.data[0, :, :]) == 6300
     assert np.sum(d.mask_fit.data[1, :, :]) == 6300
-    d.mask_fit.binary_dilation(margin=(0.3 * u.deg, 0.1 * u.deg))
+    d.mask_fit = d.mask_fit.binary_dilate(width=(0.3 * u.deg, 0.1 * u.deg))
     assert np.sum(d.mask_fit.data) == np.prod(d.mask_fit.data.shape)
+
 
 def test_compute_flux_spatial():
     center = SkyCoord("0 deg", "0 deg", frame="galactic")
     region = CircleSkyRegion(center=center, radius=0.1 * u.deg)
 
     nbin = 2
-    energy_axis_true = MapAxis.from_energy_bounds(".1 TeV", "10 TeV", nbin=nbin, name="energy_true")
+    energy_axis_true = MapAxis.from_energy_bounds(
+        ".1 TeV", "10 TeV", nbin=nbin, name="energy_true"
+    )
 
     spectral_model = ConstantSpectralModel()
-    spatial_model = PointSpatialModel(lon_0 = 0*u.deg, lat_0 = 0*u.deg, frame='galactic')
+    spatial_model = PointSpatialModel(
+        lon_0=0 * u.deg, lat_0=0 * u.deg, frame="galactic"
+    )
 
     models = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)
     model = Models(models)

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -187,7 +187,7 @@ class ReflectedRegionsFinder:
         self._pix_center = PixCoord.from_sky(self.center, geom.wcs)
 
         # Make the ON reference map
-        mask = geom.region_mask([self.region], inside=True)
+        mask = geom.region_mask([self.region], inside=True).data
         # on_reference_map = WcsNDMap(geom=geom, data=mask)
 
         # Extract all pixcoords in the geom

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -47,9 +47,7 @@ def exclusion_mask(geom):
     """Example mask for testing."""
     pos = SkyCoord(83.633, 22.014, unit="deg", frame="icrs")
     region = CircleSkyRegion(pos, Angle(0.3, "deg"))
-    exclusion = WcsNDMap.from_geom(geom)
-    exclusion.data = geom.region_mask([region], inside=False)
-    return exclusion
+    return geom.region_mask([region], inside=False)
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/makers/background/tests/test_reflected.py
+++ b/gammapy/makers/background/tests/test_reflected.py
@@ -33,8 +33,7 @@ def exclusion_mask():
     pos = SkyCoord(83.63, 22.01, unit="deg", frame="icrs")
     exclusion_region = CircleSkyRegion(pos, Angle(0.3, "deg"))
     geom = WcsGeom.create(skydir=pos, binsz=0.02, width=10.0)
-    mask = geom.region_mask([exclusion_region], inside=False)
-    return WcsNDMap(geom, data=mask)
+    return geom.region_mask([exclusion_region], inside=False)
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/makers/background/tests/test_ring.py
+++ b/gammapy/makers/background/tests/test_ring.py
@@ -41,9 +41,7 @@ def exclusion_mask(geom):
     """Example mask for testing."""
     pos = SkyCoord(83.633, 22.014, unit="deg", frame="icrs")
     region = CircleSkyRegion(pos, Angle(0.15, "deg"))
-    exclusion = WcsNDMap.from_geom(geom)
-    exclusion.data = geom.region_mask([region], inside=False)
-    return exclusion
+    return  geom.region_mask([region], inside=False)
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -61,8 +61,7 @@ def reflected_regions_bkg_maker():
     pos = SkyCoord(83.63, 22.01, unit="deg", frame="icrs")
     exclusion_region = CircleSkyRegion(pos, Angle(0.3, "deg"))
     geom = WcsGeom.create(skydir=pos, binsz=0.02, width=10.0)
-    mask = geom.region_mask([exclusion_region], inside=False)
-    exclusion_mask = WcsNDMap(geom, data=mask)
+    exclusion_mask = geom.region_mask([exclusion_region], inside=False)
 
     return ReflectedRegionsBackgroundMaker(
         exclusion_mask=exclusion_mask, min_distance_input="0.2 deg"

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -358,11 +358,11 @@ def test_region_mask():
     r2 = CircleSkyRegion(SkyCoord(20, 20, unit="deg"), 1 * u.deg)
     regions = [r1, r2]
 
-    mask = geom.region_mask(regions)  # default inside=True
+    mask = geom.region_mask(regions).data  # default inside=True
     assert mask.dtype == bool
     assert np.sum(mask) == 1
 
-    mask = geom.region_mask(regions, inside=False)
+    mask = geom.region_mask(regions, inside=False).data
     assert np.sum(mask) == 8
 
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -803,8 +803,7 @@ def test_stack_unit_handling():
     assert_allclose(m.data, 1.0001)
 
 
-def test_mask_fit_modifications(geom, geom_etrue):
-
+def test_mask_fit_modifications():
     axis = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=2)
     geom = WcsGeom.create(
         skydir=(266.40498829, -28.93617776),

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -801,3 +801,22 @@ def test_stack_unit_handling():
     m.stack(m_other)
 
     assert_allclose(m.data, 1.0001)
+
+
+def test_mask_fit_modifications(geom, geom_etrue):
+
+    axis = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=2)
+    geom = WcsGeom.create(
+        skydir=(266.40498829, -28.93617776),
+        binsz=0.02,
+        width=(2, 2),
+        frame="icrs",
+        axes=[axis],
+    )
+    mask_fit = Map.from_geom(geom)
+    mask_fit.data = np.ones(mask_fit.data.shape, dtype=bool)
+    mask_fit = mask_fit.boundary_mask(width=(0.3 * u.deg, 0.1 * u.deg))
+    assert np.sum(mask_fit.data[0, :, :]) == 6300
+    assert np.sum(mask_fit.data[1, :, :]) == 6300
+    mask_fit = mask_fit.binary_dilate(width=(0.3 * u.deg, 0.1 * u.deg))
+    assert np.sum(mask_fit.data) == np.prod(mask_fit.data.shape)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -814,7 +814,7 @@ def test_mask_fit_modifications():
     )
     mask_fit = Map.from_geom(geom)
     mask_fit.data = np.ones(mask_fit.data.shape, dtype=bool)
-    mask_fit = mask_fit.boundary_mask(width=(0.3 * u.deg, 0.1 * u.deg))
+    mask_fit = mask_fit & geom.boundary_mask(width=(0.3 * u.deg, 0.1 * u.deg))
     assert np.sum(mask_fit.data[0, :, :]) == 6300
     assert np.sum(mask_fit.data[1, :, :]) == 6300
     mask_fit = mask_fit.binary_dilate(width=(0.3 * u.deg, 0.1 * u.deg))

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -176,9 +176,7 @@ class WcsNDMap(WcsMap):
                 for x in pix
             ]
         )
-        return ndi.map_coordinates(
-            self.data.T, pix, order=order, mode="nearest"
-        )
+        return ndi.map_coordinates(self.data.T, pix, order=order, mode="nearest")
 
     def _interp_by_coord_griddata(self, coords, interp=None):
         order = interp_to_order(interp)
@@ -312,9 +310,7 @@ class WcsNDMap(WcsMap):
         else:
             data = self.data
 
-        data = ndi.map_coordinates(
-            data.T, tuple(pix), order=order, mode="nearest"
-        )
+        data = ndi.map_coordinates(data.T, tuple(pix), order=order, mode="nearest")
 
         if preserve_counts:
             data *= geom.bin_volume().value
@@ -600,22 +596,28 @@ class WcsNDMap(WcsMap):
             If True apply the margin only from edges (Default is False).
         """
         if self.data.dtype != bool:
-            raise(TypeError, "Binary erosion should be applied only on boolean mask")
+            raise (TypeError, "Binary erosion should be applied only on boolean mask")
         if from_edges:
             mask_margin = np.ones(self.data.shape[-2:], dtype=bool)
         else:
-            #TODO: should we apply the erosin independently to each other dim
+            # TODO: should we apply the erosin independently to each other dim
             # for now just combine non-spatial dim with OR condition
             axis = tuple(np.arange(len(self.geom.axes)))
-            mask_margin = np.sum(self.data, axis=axis).astype(bool) 
+            mask_margin = np.sum(self.data, axis=axis).astype(bool)
         if not isinstance(margin, tuple):
             margin = (margin, margin)
-        shape = tuple([int(np.ceil(x / scale).value * 2 + 1) for x, scale in zip(margin, self.geom.pixel_scales)])
-        mask_margin =  ndi.binary_erosion(mask_margin[..., :, :], structure=np.ones(shape))
+        shape = tuple(
+            [
+                int(np.ceil(x / scale).value * 2 + 1)
+                for x, scale in zip(margin, self.geom.pixel_scales)
+            ]
+        )
+        mask_margin = ndi.binary_erosion(
+            mask_margin[..., :, :], structure=np.ones(shape)
+        )
         idx_y, idx_x = np.where(~mask_margin)
         self.data[..., idx_y, idx_x] = False
 
-            
     def binary_dilation(self, margin):
         """Binary dilation of boolean mask addding a given margin
         Parameters
@@ -625,14 +627,20 @@ class WcsNDMap(WcsMap):
             If only one value is passed, the same margin is applied in (lon, lat).
         """
         if self.data.dtype != bool:
-            raise(TypeError, "Binary dilation should be applied only on boolean mask")
+            raise (TypeError, "Binary dilation should be applied only on boolean mask")
         axis = tuple(np.arange(len(self.geom.axes)))
-        mask_margin = np.sum(self.data, axis=axis).astype(bool) 
-        shape = tuple([int(np.ceil(x / scale).value * 2 + 1) for x, scale in zip(margin, self.geom.pixel_scales)])
-        mask_margin =  ndi.binary_dilation(mask_margin[..., :, :], structure=np.ones(shape))
+        mask_margin = np.sum(self.data, axis=axis).astype(bool)
+        shape = tuple(
+            [
+                int(np.ceil(x / scale).value * 2 + 1)
+                for x, scale in zip(margin, self.geom.pixel_scales)
+            ]
+        )
+        mask_margin = ndi.binary_dilation(
+            mask_margin[..., :, :], structure=np.ones(shape)
+        )
         idx_y, idx_x = np.where(mask_margin)
         self.data[..., idx_y, idx_x] = True
-    
 
     def convolve(self, kernel, use_fft=True, **kwargs):
         """

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import warnings
 import numpy as np
 import scipy.interpolate
-import ndi as ndi
+import scipy.ndimage as ndi
 import scipy.signal
 import astropy.units as u
 from astropy.convolution import Tophat2DKernel
@@ -589,7 +589,7 @@ class WcsNDMap(WcsMap):
 
         return self.to_region_nd_map(region=region, func=func, weights=weights)
 
-    def binary_erosion(self, margin, from_edge = False):
+    def binary_erosion(self, margin, from_edges=False):
         """Binary erosion of boolean mask removing a given margin
         Parameters
         ----------
@@ -601,7 +601,7 @@ class WcsNDMap(WcsMap):
         """
         if self.data.dtype != bool:
             raise(TypeError, "Binary erosion should be applied only on boolean mask")
-        if from_edge:
+        if from_edges:
             mask_margin = np.ones(self.data.shape[-2:], dtype=bool)
         else:
             #TODO: should we apply the erosin independently to each other dim
@@ -612,8 +612,8 @@ class WcsNDMap(WcsMap):
             margin = (margin, margin)
         shape = tuple([int(np.ceil(x / scale).value * 2 + 1) for x, scale in zip(margin, self.geom.pixel_scales)])
         mask_margin =  ndi.binary_erosion(mask_margin[..., :, :], structure=np.ones(shape))
-        idx_y, idx_x = np.where(mask_margin)
-        self.data[..., idx_y, idx_x] &= mask_margin
+        idx_y, idx_x = np.where(~mask_margin)
+        self.data[..., idx_y, idx_x] = False
 
             
     def binary_dilation(self, margin):
@@ -631,7 +631,7 @@ class WcsNDMap(WcsMap):
         shape = tuple([int(np.ceil(x / scale).value * 2 + 1) for x, scale in zip(margin, self.geom.pixel_scales)])
         mask_margin =  ndi.binary_dilation(mask_margin[..., :, :], structure=np.ones(shape))
         idx_y, idx_x = np.where(mask_margin)
-        self.data[..., idx_y, idx_x] = mask_margin
+        self.data[..., idx_y, idx_x] = True
     
 
     def convolve(self, kernel, use_fft=True, **kwargs):

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -615,19 +615,6 @@ class WcsNDMap(WcsMap):
         mask_data = _apply_binary_operations(self, width, ndi.binary_erosion)
         return self._init_copy(data=mask_data)
 
-    def boundary_mask(self, width):
-        """Binary erosion of boolean mask removing a given margin from edges
-        Parameters
-        ----------
-        width : tuple of `~astropy.units.Quantity`
-            Angular sizes of the margin in (lon, lat) in that specific order.
-            If only one value is passed, the same margin is applied in (lon, lat).
-        """
-        mask_data = np.ones(self.data.shape, dtype=bool)
-        mask_map = self._init_copy(data=mask_data).binary_erode(width)
-        mask_map.data &= self.data
-        return mask_map
-
     def binary_dilate(self, width):
         """Binary dilation of boolean mask addding a given margin
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -567,7 +567,7 @@ class WcsNDMap(WcsMap):
                 )
                 cutout.data *= weights_cutout.data
 
-            mask = cutout.geom.to_image().region_mask([region])
+            mask = cutout.geom.to_image().region_mask([region]).data
             idx_y, idx_x = np.where(mask)
             data = func(cutout.data[..., idx_y, idx_x], axis=-1)
 


### PR DESCRIPTION
This PR add  binary_erosion and binary_dilation methods to WcsNDMap.
These methods are applied only if the map is a boolean mask.
The mask erosion can be used for example to reduce mask_fit by the width of the PSF after a dataset.cutout() operation.