### PR TITLE
Improve irf axis name checks

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -69,6 +69,7 @@ class Background3D:
             data=data,
             interp_kwargs=interp_kwargs,
         )
+        self.data.axes.assert_names(["energy", "fov_lon", "fov_lat"])
         self.meta = meta or {}
 
     def __str__(self):
@@ -146,6 +147,7 @@ class Background3D:
         axes = MapAxes(self.data.axes[::-1])
         table = axes.to_table(format="gadf-dl3")
         table.meta = self.meta.copy()
+        table.meta["HDUCLAS2"] = "BKG"
         table["BKG"] = self.data.data.T[np.newaxis]
         return table
 
@@ -249,11 +251,10 @@ class Background2D:
         if interp_kwargs is None:
             interp_kwargs = self.default_interp_kwargs
 
-        assert offset_axis.name == "offset"
-
         self.data = NDDataArray(
             axes=[energy_axis, offset_axis], data=data, interp_kwargs=interp_kwargs
         )
+        self.data.axes.assert_names(["energy", "offset"])
         self.meta = meta or {}
 
     def __str__(self):
@@ -326,6 +327,9 @@ class Background2D:
         """Convert to `~astropy.table.Table`."""
         table = self.data.axes.to_table(format="gadf-dl3")
         table.meta = self.meta.copy()
+
+        # TODO: add other required meta data
+        table.meta["HDUCLAS2"] = "BKG"
         table["BKG"] = self.data.data.T[np.newaxis]
         return table
 

--- a/gammapy/irf/edisp_kernel.py
+++ b/gammapy/irf/edisp_kernel.py
@@ -57,6 +57,7 @@ class EDispKernel:
         self.data = NDDataArray(
             axes=[energy_axis_true, energy_axis], data=data, interp_kwargs=interp_kwargs
         )
+        self.data.axes.assert_names(["energy_true", "energy"])
         self.meta = meta or {}
 
     def __str__(self):

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -77,14 +77,9 @@ class EDispMap(IRFMap):
     """
 
     _hdu_name = "edisp"
+    _axis_names = ["migra", "energy_true"]
 
     def __init__(self, edisp_map, exposure_map=None):
-        if edisp_map.geom.axes[1].name.upper() != "ENERGY_TRUE":
-            raise ValueError("Incorrect energy axis position in input Map")
-
-        if edisp_map.geom.axes[0].name.upper() != "MIGRA":
-            raise ValueError("Incorrect migra axis position in input Map")
-
         super().__init__(irf_map=edisp_map, exposure_map=exposure_map)
 
     @property
@@ -332,14 +327,9 @@ class EDispKernelMap(IRFMap):
 
     tag = "edisp_kernel_map"
     _hdu_name = "edisp"
+    _axis_names = ["energy", "energy_true"]
 
-    def __init__(self, edisp_kernel_map, exposure_map):
-        if edisp_kernel_map.geom.axes[1].name.upper() != "ENERGY_TRUE":
-            raise ValueError("Incorrect energy axis position in input Map")
-
-        if edisp_kernel_map.geom.axes[0].name.upper() != "ENERGY":
-            raise ValueError("Incorrect migra axis position in input Map")
-
+    def __init__(self, edisp_kernel_map, exposure_map=None):
         super().__init__(irf_map=edisp_kernel_map, exposure_map=exposure_map)
 
     @property

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -356,14 +356,6 @@ class EDispKernelMap(IRFMap):
         edisp_map : `EDispKernelMap`
             Energy dispersion kernel map.
         """
-        axis_names = [ax.name for ax in geom.axes]
-
-        if "energy_true" not in axis_names:
-            raise ValueError("EDispKernelMap requires true energy axis")
-
-        if "energy" not in axis_names:
-            raise ValueError("EDispKernelMap requires energy axis")
-
         geom_exposure = geom.squash(axis_name="energy")
         exposure = Map.from_geom(geom_exposure, unit="m2 s")
 

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -63,11 +63,10 @@ class EffectiveAreaTable:
     def __init__(self, energy_axis_true, data, meta=None):
         interp_kwargs = {"extrapolate": False, "bounds_error": False}
 
-        assert energy_axis_true.name == "energy_true"
-
         self.data = NDDataArray(
             axes=[energy_axis_true], data=data, interp_kwargs=interp_kwargs
         )
+        self.data.axes.assert_names(["energy_true"])
         self.meta = meta or {}
 
     @property
@@ -358,15 +357,13 @@ class EffectiveAreaTable2D:
     def __init__(
         self, energy_axis_true, offset_axis, data, meta=None, interp_kwargs=None,
     ):
-        assert energy_axis_true.name == "energy_true"
-        assert offset_axis.name == "offset"
-
         if interp_kwargs is None:
             interp_kwargs = self.default_interp_kwargs
 
         self.data = NDDataArray(
             axes=[energy_axis_true, offset_axis], data=data, interp_kwargs=interp_kwargs
         )
+        self.data.axes.assert_names(["energy_true", "offset"])
         self.meta = meta or {}
 
     def __str__(self):

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -69,6 +69,7 @@ class EnergyDispersion2D:
         axes = [energy_axis_true, migra_axis, offset_axis]
 
         self.data = NDDataArray(axes=axes, data=data, interp_kwargs=interp_kwargs)
+        self.data.axes.assert_names(["energy_true", "migra", "offset"])
         self.meta = meta or {}
 
     def __str__(self):

--- a/gammapy/irf/irf_map.py
+++ b/gammapy/irf/irf_map.py
@@ -6,10 +6,12 @@ from gammapy.maps import Map
 
 class IRFMap:
     """IRF map base class"""
+    _axis_names = []
 
     def __init__(self, irf_map, exposure_map):
         self._irf_map = irf_map
         self.exposure_map = exposure_map
+        irf_map.geom.axes.assert_names(self._axis_names)
 
     @classmethod
     def from_hdulist(

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -46,27 +46,14 @@ class PSF3D:
         energy_thresh_hi=u.Quantity(100, "TeV"),
         interp_kwargs=None,
     ):
-        if energy_axis_true.name != "energy_true":
-            raise ValueError(
-                "Unexpected `energy_axis_true.name`,"
-                f' expected "energy_true", got: {energy_axis_true.name}'
-            )
 
-        if offset_axis.name != "offset":
-            raise ValueError(
-                "Unexpected `offset_axis.name`,"
-                f' expected "offset", got: {offset_axis.name}'
-            )
-        if rad_axis.name != "rad":
-            raise ValueError(
-                "Unexpected `rad_axis.name`," f' expected "rad", got: {rad_axis.name}'
-            )
+        axes = MapAxes([energy_axis_true, offset_axis, rad_axis])
+        axes.assert_names(["energy_true", "offset", "rad"])
 
-        expected_shape = (energy_axis_true.nbin, offset_axis.nbin, rad_axis.nbin)
-        if psf_value.shape != expected_shape:
+        if psf_value.shape != axes.shape:
             raise ValueError(
                 "PSF has wrong shape"
-                f", expected {expected_shape}, got {psf_value.shape}"
+                f", expected {axes.shape}, got {psf_value.shape}"
             )
 
         self._energy_axis_true = energy_axis_true

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -71,8 +71,8 @@ class EnergyDependentMultiGaussPSF:
         energy_thresh_lo="0.1 TeV",
         energy_thresh_hi="100 TeV",
     ):
-        assert energy_axis_true.name == "energy_true"
-        assert offset_axis.name == "offset"
+        energy_axis_true.assert_name("energy_true")
+        offset_axis.assert_name("offset")
 
         self._energy_axis_true = energy_axis_true
         self._offset_axis = offset_axis

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -43,10 +43,9 @@ class PSFKing:
         energy_thresh_lo=Quantity(0.1, "TeV"),
         energy_thresh_hi=Quantity(100, "TeV"),
     ):
-        assert energy_axis_true.name == "energy_true"
+        energy_axis_true.assert_name("energy_true")
+        offset_axis.assert_name("offset")
         self._energy_axis_true = energy_axis_true
-
-        assert offset_axis.name == "offset"
         self._offset_axis = offset_axis
 
         self.gamma = np.asanyarray(gamma)

--- a/gammapy/irf/psf_map.py
+++ b/gammapy/irf/psf_map.py
@@ -68,6 +68,10 @@ class PSFMap(IRFMap):
 
     tag = "psf_map"
     _hdu_name = "psf"
+    _axis_names = ["rad", "energy_true"]
+
+    def __init__(self, psf_map, exposure_map=None):
+        super().__init__(irf_map=psf_map, exposure_map=exposure_map)
 
     @property
     def psf_map(self):
@@ -76,15 +80,6 @@ class PSFMap(IRFMap):
     @psf_map.setter
     def psf_map(self, value):
         self._irf_map = value
-
-    def __init__(self, psf_map, exposure_map=None):
-        if psf_map.geom.axes[1].name != "energy_true":
-            raise ValueError("Incorrect energy axis position in input Map")
-
-        if psf_map.geom.axes[0].name != "rad":
-            raise ValueError("Incorrect rad axis position in input Map")
-
-        super().__init__(irf_map=psf_map, exposure_map=exposure_map)
 
     def get_energy_dependent_table_psf(self, position=None):
         """Get energy-dependent PSF at a given position.

--- a/gammapy/irf/tests/test_edisp_map.py
+++ b/gammapy/irf/tests/test_edisp_map.py
@@ -114,6 +114,20 @@ def test_edisp_map_to_energydispersion():
     assert_allclose(edisp.get_resolution(energy_true=1.0 * u.TeV), 0.2, atol=3e-2)
 
 
+def test_edisp_map_from_geom_error():
+    energy_axis = MapAxis.from_energy_bounds(
+        "1 TeV", "10 TeV", nbin=3
+    )
+    energy_axis_true = MapAxis.from_energy_bounds(
+        "1 TeV", "10 TeV", nbin=3, name="energy_true"
+    )
+
+    geom = WcsGeom.create(npix=(1, 1), axes=[energy_axis_true, energy_axis])
+
+    with pytest.raises(ValueError):
+        EDispKernelMap.from_geom(geom=geom)
+
+
 def test_edisp_map_stacking():
     edmap1 = make_edisp_map_test()
     edmap2 = make_edisp_map_test()

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -521,8 +521,12 @@ class MapAxes(Sequence):
         required_names : list of str
             Required
         """
-        for ax, required_name in zip(self, required_names):
-            ax.assert_name(required_name)
+        try:
+            for ax, required_name in zip(self, required_names):
+                ax.assert_name(required_name)
+        except ValueError:
+            raise ValueError("Incorrect axis order or names. Expected axis "
+                             f"order: {required_names}, got: {self.names}.")
 
 
 class MapAxis:
@@ -610,7 +614,7 @@ class MapAxis:
         if self.name != required_name:
             raise ValueError(
                 "Unexpected axis name,"
-                f' expected "{required_name}", got: {self.name}'
+                f' expected "{required_name}", got: "{self.name}"'
             )
 
     def is_aligned(self, other, atol=2e-2):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -513,6 +513,17 @@ class MapAxes(Sequence):
 
         return cls(axes_out)
 
+    def assert_names(self, required_names):
+        """Assert required axis names and order
+
+        Parameters
+        ----------
+        required_names : list of str
+            Required
+        """
+        for ax, required_name in zip(self, required_names):
+            ax.assert_name(required_name)
+
 
 class MapAxis:
     """Class representing an axis of a map.
@@ -587,6 +598,20 @@ class MapAxis:
             raise ValueError(f"Invalid node type: {node_type!r}")
 
         self._nbin = nbin
+
+    def assert_name(self, required_name):
+        """Assert axis name if a specific one is required.
+
+        Parameters
+        ----------
+        required_name : str
+            Required
+        """
+        if self.name != required_name:
+            raise ValueError(
+                "Unexpected axis name,"
+                f' expected "{required_name}", got: {self.name}'
+            )
 
     def is_aligned(self, other, atol=2e-2):
         """Check if other map axis is aligned.
@@ -1439,8 +1464,8 @@ class MapAxis:
             name, interp = spec["name"], spec["interp"]
 
             # background models are stored in reconstructed energy
-            extname = table.meta.get("EXTNAME")
-            if extname in ["BACKGROUND", "BKG"] and column_prefix == "ENERG":
+            hduclass = table.meta.get("HDUCLAS2")
+            if hduclass == "BKG" and column_prefix == "ENERG":
                 name = "energy"
 
             edges_lo = table[f"{column_prefix}_LO"].quantity[0]


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request improves the check for IRF axis names and order. It mostly implements a `MapAxes.assert_names(required_names=)` method, which checks on the required axis names and order. In cases it does not match the following error is thrown:
```
ValueError: Incorrect axis order or names. Expected axis order: ['energy_true', 'rad'], got: ['rad', 'energy_true'].
```

I also fixes a bug in reading `Background3D` files, because for the creating of the energy axis we relied on the `EXTNAME` keyword which is optional in the GADF. This was changed to rely on `HDUCLAS2`, which is a mandatory keyword. During the implementation I noticed that, the IRF write methods are not compliant with the gadf format , as they miss required meta info. What do we do about this?

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
