### PR TITLE
Correct Models.from_dict to check input parameters names

### DIFF
--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import logging
 import collections.abc
 import copy
 from os.path import split
@@ -9,6 +10,7 @@ import yaml
 from gammapy.modeling import Covariance, Parameter, Parameters
 from gammapy.utils.scripts import make_name, make_path
 
+log = logging.getLogger(__name__)
 
 def _set_link(shared_register, model):
     for param in model.parameters:
@@ -138,9 +140,15 @@ class Model:
 
         par_data = []
 
-        for par, par_yaml in zip(cls.default_parameters, data["parameters"]):
+        input_names = [_["name"] for _ in data["parameters"]]
+
+        for par in cls.default_parameters:
             par_dict = par.to_dict()
-            par_dict.update(par_yaml)
+            try:
+                index = input_names.index(par_dict["name"])
+                par_dict.update(data["parameters"][index])
+            except ValueError:
+                log.warning(f"Parameter {par_dict['name']} not defined. Using default value: {par_dict['value']} {par_dict['unit']}")
             par_data.append(par_dict)
 
         parameters = Parameters.from_dict(par_data)

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -401,6 +401,9 @@ def test_to_from_dict():
     model = spectrum["model"]
 
     model_dict = model.to_dict()
+    # Here we reverse the order of parameters list to ensure assignment is correct
+    model_dict['parameters'].reverse()
+
     model_class = SPECTRAL_MODEL_REGISTRY.get_cls(model_dict["type"])
     new_model = model_class.from_dict(model_dict)
 
@@ -409,6 +412,32 @@ def test_to_from_dict():
     actual = [par.value for par in new_model.parameters]
     desired = [par.value for par in model.parameters]
     assert_quantity_allclose(actual, desired)
+
+    actual = [par.frozen for par in new_model.parameters]
+    desired = [par.frozen for par in model.parameters]
+    assert_allclose(actual, desired)
+
+def test_to_from_dict_partial_input():
+    spectrum = TEST_MODELS[0]
+    model = spectrum["model"]
+
+    model_dict = model.to_dict()
+    # Here we remove the reference energy
+    model_dict['parameters'].remove(model_dict['parameters'][2])
+    print(model_dict['parameters'][0])
+
+    model_class = SPECTRAL_MODEL_REGISTRY.get_cls(model_dict["type"])
+    new_model = model_class.from_dict(model_dict)
+
+    assert isinstance(new_model, PowerLawSpectralModel)
+
+    actual = [par.value for par in new_model.parameters]
+    desired = [par.value for par in model.parameters]
+    assert_quantity_allclose(actual, desired)
+
+    actual = [par.frozen for par in new_model.parameters]
+    desired = [par.frozen for par in model.parameters]
+    assert_allclose(actual, desired)
 
 
 def test_to_from_dict_compound():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects the behavior of `Models.from_dict()`. Each model is set according to the input parameter name rather than relying on the order of default parameters.
If a parameter is missing a warning is sent to `log` and the default value is set.

Maybe one could check also that all parameters on input are actually used to avoid silent errors? 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
