### PR TITLE
Improve documentation of RegionGeom and RegionNDMap

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -574,6 +574,7 @@ found in the following sub-pages:
     :maxdepth: 1
 
     hpxmap
+    regionmap
 
 Reference/API
 =============

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -32,6 +32,7 @@ to use the abstract `~Map` interface for accessing or updating the contents of a
 map as this allows algorithms to be used interchangeably with different map
 representations. The following reviews methods of the abstract map interface.
 Documentation specific to WCS- and HEALPix-based maps is provided in :doc:`hpxmap`.
+Documentation specific to region-based maps is provided in :doc:`regionmap`.
 
 
 Getting Started

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -11,6 +11,7 @@ The RegionGeom and RegionNDMap
 This page provides examples and documentation specific to the Region
 classes. 
 
+
 RegionGeom
 ==========
 A `~RegionGeom` is analogous to a  map geometry `~Geom`, but instead of a fine grid on a rectangular region, 
@@ -301,17 +302,16 @@ created from an existing `~RegionGeom`, this can be done in the same step:
     region_map = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
 
     # Fill the region map
-    #with the same value for each of the 12 energy bins
-    region_map.data = 1 
-    # or with an entry for each of the 12 energy bins
-    region_map.data = np.linspace(1,50,12) 
+    # with an entry for each of the 12 energy bins
+    region_map.data = np.logspace(-2,3,12) 
 
-    # Create another region map with the same RegionGeom but different data
+    # Create another region map with the same RegionGeom but different data,
+    # with the same value for each of the 12 energy bins
     geom = region_map.geom
-    region_map_2 = RegionNDMap.from_geom(geom, data = np.linspace(50,100,12))
+    region_map_2 = RegionNDMap.from_geom(geom, data = 1)
 
     # Access the data
-    print(region_map_2.data)
+    print(region_map_1.data)
 
 The data contained in a region map is a `~numpy.ndarray` with shape defined by the underlying
 `~RegionGeom.data_shape`. In the case of only spatial dimensions, the shape is just (1,1), one single
@@ -336,4 +336,72 @@ or a function of the non-spatial axis bins. This is done by `~RegionNDMap.plot()
         region_map.plot_region()
 
 + Plotting the map contents:
-    T
+    This is only possible if the region map has a non-spatial axis.
+
+    .. code-block:: python
+
+        from gammapy.maps import MapAxis, RegionNDMap
+        import numpy as np  
+
+        # Create a RegionNDMap with 12 energy bins
+        energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+        region_map = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
+
+        # Fill the data along the energy axis and plot
+        region_map.data = np.logspace(-2,3,12) 
+        region_map.plot()
+
+    .. plot:: 
+
+        from gammapy.maps import MapAxis, RegionNDMap
+        import numpy as np  
+
+        # Create a RegionNDMap with 12 energy bins
+        energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+        region_map = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
+
+        # Fill the data along the energy axis and plot
+        region_map.data = np.logspace(-2,3,12) 
+        region_map.plot()
+
+    Similarly, the map contents can also be plotted as a histogram:
+
+    .. code-block:: python
+
+        from gammapy.maps import MapAxis, RegionNDMap
+        import numpy as np  
+
+        # Create a RegionNDMap with 12 energy bins
+        energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+        region_map = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
+
+        # Fill the data along the energy axis and plot
+        region_map.data = np.logspace(-2,3,12) 
+        region_map.plot_hist()
+
+    .. plot:: 
+
+        from gammapy.maps import MapAxis, RegionNDMap
+        import numpy as np  
+
+        # Create a RegionNDMap with 12 energy bins
+        energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+        region_map = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
+
+        # Fill the data along the energy axis and plot
+        region_map.data = np.logspace(-2,3,12) 
+        region_map.plot_hist()
+
+
+Writing and reading a RegionNDMap to/from a FITS file
+-----------------------------------------------------
+Region maps can be written to and read from a FITS file with the
+`~RegionNDMap.write()` and `~RegionNDMap.read()` methods:
+
+.. code-block:: python
+
+    from gammapy.maps import RegionNDMap,MapAxis
+    energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+    m = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
+    m.write('file.fits', overwrite=True)
+    m = RegionNDMap.read('file.fits')

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -7,4 +7,17 @@ This page provides examples and documentation specific to the Region
 classes. 
 
 RegionGeom
+-----------
+Like a geometry but instead of a small grid on a rectangular region, 
+this is just one large pixel with an arbitrary shape that can have any 
+number of non-spatial dimensions.
+
+
+
+RegionNDMap
+-----------
+It's essentially a Map with one spatial bin that can have an arbitrary 
+shape and whatever non-spatial axis you want.
+It is to a RegionGeom what a Map is to a WcsGeom: it contains the data 
+that goes into the grid.RegionGeom
 ----------

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -1,0 +1,10 @@
+.. _regionmap:
+
+The RegionGeom and RegionNDMap
+==============================
+
+This page provides examples and documentation specific to the Region
+classes. 
+
+RegionGeom
+----------

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -19,7 +19,7 @@ number of non-spatial dimensions.
 
 Creating a RegionGeom
 ---------------------
-A `~RegionGeom`can be created via a DS9 region string (see http://ds9.si.edu/doc/ref/region.html for a list of options)
+A `~RegionGeom` can be created via a DS9 region string (see http://ds9.si.edu/doc/ref/region.html for a list of options)
 or an Astropy Region (https://astropy-regions.readthedocs.io/en/latest/).
 
 .. code-block:: python
@@ -199,6 +199,30 @@ they can have any number of bins. There are different methods that can be used t
             projection : TAN
             center     : 0.0 deg, 0.0 deg
             width      : 2.0 deg x 2.0 deg
+
+Plotting a RegionGeom
+---------------------
+It can be useful to plot the region that defines a `~RegionGeom`, on its own or on top
+of an existing `~Map`. This is done via `~RegionGeom.plot_region()`:
+
+.. code-block:: python
+
+    from gammapy.maps import RegionGeom
+    geom = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
+    geom.plot_region()
+
+One can also plot the region on top of an existing map, and change the properties of the
+different regions by passing keyword arguments forwarded to `~regions.PixelRegion.as_artist`.
+
+.. code-block:: python
+
+    from gammapy.maps import RegionGeom, Map
+    m = Map.create(width=3, skydir=(83.63, 22.01), frame='icrs')
+    geom1 = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
+    geom2 = RegionGeom.create("icrs;box(83.63, 22.01, 1,2,45)")
+    m.plot(add_cbar=True)
+    geom1.plot_region(ec="k")
+    geom2.plot_region(lw=2, linestyle='--')
 
 RegionNDMap
 ===========

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -27,12 +27,14 @@ is distributed.
 Creating a RegionGeom
 ---------------------
 A `~RegionGeom` can be created via a DS9 region string (see http://ds9.si.edu/doc/ref/region.html for a list of options)
-or an Astropy Region (https://astropy-regions.readthedocs.io/en/latest/).
+or an Astropy Region (https://astropy-regions.readthedocs.io/en/latest/shapes.html). Note that region geometries have an associated
+WCS projection object. This requires the region to have a defined center, which is not the case for all the shapes defined
+in DS9. Hence only certain shapes are supported for constructing a `~RegionGeom`: circles, boxes, ellipses and annuli.
 
 .. code-block:: python
 
     from astropy.coordinates import SkyCoord
-    from regions import CircleSkyRegion, RectangleSkyRegion
+    from regions import CircleSkyRegion, RectangleSkyRegion, EllipseAnnulusSkyRegion
     from gammapy.maps import RegionGeom
     import astropy.units as u
 
@@ -55,10 +57,22 @@ or an Astropy Region (https://astropy-regions.readthedocs.io/en/latest/).
     geom = RegionGeom(region)
 
     # Equivalent factory method call
-    geom = RegionGeom.create(region) 
+    geom = RegionGeom.create(region)
+    
+    # Something a bit more complicated: an elliptical annulus
+    center_sky = SkyCoord(42, 43, unit='deg', frame='fk5')
+    region = EllipseAnnulusSkyRegion(center=center_sky,
+                                    inner_width=3 * u.deg,
+                                    outer_width=4 * u.deg,
+                                    inner_height=6 * u.deg,
+                                    outer_height=7 * u.deg,
+                                    angle=6 * u.deg)
+    geom = RegionGeom(region)
 
 
-Higher dimensional region geometries (cubes and hypercubes) can be constructed by passing a list of `~MapAxis` objects for non-spatial dimensions with the axes parameter:
+
+Higher dimensional region geometries (cubes and hypercubes) can be constructed in exactly the same way as a `~WcsGeom`
+by passing a list of `~MapAxis` objects for non-spatial dimensions with the axes parameter:
 
 .. code-block:: python
 
@@ -232,11 +246,23 @@ different regions by passing keyword arguments forwarded to `~regions.PixelRegio
     import numpy as np
     m = Map.create(npix=100,binsz=3/100, skydir=(83.63, 22.01), frame='icrs')
     m.data = np.add(*np.indices((100, 100)))
-    geom1 = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
-    geom2 = RegionGeom.create("icrs;box(83.63, 22.01, 1,2,45)")
+    # A circle centered in the Crab position
+    circle = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
+    # A box centered in the same position
+    box = RegionGeom.create("icrs;box(83.63, 22.01, 1,2,45)")
+    # An ellipse in a different location
+    ellipse = RegionGeom.create("icrs;ellipse(84.63, 21.01, 0.3,0.6,-45)")
+    # An annulus in a different location
+    annulus = RegionGeom.create("icrs;annulus(82.8, 22.91, 0.1,0.3)")
+
     m.plot(add_cbar=True)
-    geom1.plot_region(ec="k")
-    geom2.plot_region(lw=2, linestyle='--')
+    # Default plotting settings
+    circle.plot_region()
+    # Different line styles, widths and colors
+    box.plot_region(lw=2, linestyle='--', ec='k')
+    ellipse.plot_region(lw=2, linestyle=':', ec='white')
+    # Filling the region with a color
+    annulus.plot_region(lw=2, ec='purple', fc='purple')
 
 .. plot::
 
@@ -244,11 +270,23 @@ different regions by passing keyword arguments forwarded to `~regions.PixelRegio
     import numpy as np
     m = Map.create(npix=100,binsz=3/100, skydir=(83.63, 22.01), frame='icrs')
     m.data = np.add(*np.indices((100, 100)))
-    geom1 = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
-    geom2 = RegionGeom.create("icrs;box(83.63, 22.01, 1,2,45)")
+    # A circle centered in the Crab position
+    circle = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
+    # A box centered in the same position
+    box = RegionGeom.create("icrs;box(83.63, 22.01, 1,2,45)")
+    # An ellipse in a different location
+    ellipse = RegionGeom.create("icrs;ellipse(84.63, 21.01, 0.3,0.6,-45)")
+    # An annulus in a different location
+    annulus = RegionGeom.create("icrs;annulus(82.8, 22.91, 0.1,0.3)")
+
     m.plot(add_cbar=True)
-    geom1.plot_region(ec="k")
-    geom2.plot_region(lw=2, linestyle='--')
+    # Default plotting settings
+    circle.plot_region()
+    # Different line styles, widths and colors
+    box.plot_region(lw=2, linestyle='--', ec='k')
+    ellipse.plot_region(lw=2, linestyle=':', ec='white')
+    # Filling the region with a color
+    annulus.plot_region(lw=2, ec='purple', fc='purple')
 
 RegionNDMap
 ===========
@@ -417,3 +455,17 @@ Region maps can be written to and read from a FITS file with the
     m = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
     m.write('file.fits', overwrite=True)
     m = RegionNDMap.read('file.fits')
+
+TO DO: add tutorial links,
+        wcs tangential projection
+        write/read
+        
+
+Relevant tutorials
+------------------
+:ref:`tutorials` that show examples using `~RegionNDMap` and `~RegionGeom`:
+
+* `spectrum_analysis.html <../tutorials/spectrum_analysis.html>`__
+* `extended_source_spectral_analysis.html <../tutorials/extended_source_spectral_analysis.html>`__
+* `spectrum_simulation.html <../tutorials/spectrum_simulation.html>`__
+* `cta_sensitivity.html <../tutorials/cta_sensitivity.html>`__

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -10,6 +10,7 @@ The RegionGeom and RegionNDMap
 
 This page provides examples and documentation specific to the Region
 classes. 
+TO DO: why would one use them??
 
 
 RegionGeom
@@ -224,7 +225,9 @@ different regions by passing keyword arguments forwarded to `~regions.PixelRegio
 .. code-block:: python
 
     from gammapy.maps import RegionGeom, Map
-    m = Map.create(width=3, skydir=(83.63, 22.01), frame='icrs')
+    import numpy as np
+    m = Map.create(npix=100,binsz=3/100, skydir=(83.63, 22.01), frame='icrs')
+    m.data = np.add(*np.indices((100, 100)))
     geom1 = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
     geom2 = RegionGeom.create("icrs;box(83.63, 22.01, 1,2,45)")
     m.plot(add_cbar=True)
@@ -234,7 +237,9 @@ different regions by passing keyword arguments forwarded to `~regions.PixelRegio
 .. plot::
 
     from gammapy.maps import RegionGeom, Map
-    m = Map.create(width=3, skydir=(83.63, 22.01), frame='icrs')
+    import numpy as np
+    m = Map.create(npix=100,binsz=3/100, skydir=(83.63, 22.01), frame='icrs')
+    m.data = np.add(*np.indices((100, 100)))
     geom1 = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
     geom2 = RegionGeom.create("icrs;box(83.63, 22.01, 1,2,45)")
     m.plot(add_cbar=True)

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -9,8 +9,8 @@ RegionGeom and RegionNDMap
 .. currentmodule:: gammapy.maps
 
 This page provides examples and documentation specific to the Region
-classes. These objecs are used to bundle the energy distribution (or any other
-non-spatial axis) of quantities (counts, exposure,...) inside of a given region in the sky while retaining
+classes. These objects are used to bundle the energy distribution - or any other
+non-spatial axis - of quantities (counts, exposure, ...) inside of a given region in the sky while retaining
 the information of the chosen spatial region.
 In particular, they are suited for so-called 1D analysis (see https://docs.gammapy.org/dev/references.html#glossary).
 
@@ -19,9 +19,9 @@ RegionGeom
 ==========
 A `~RegionGeom` describes the underlying geometry of a region in the sky with any number of non-spatial axes associated to it.
 Is analogous to a  map geometry `~Geom`, but instead of a fine spatial grid on a rectangular region, 
-the spatial dimension is reduced to a single bin with an arbitrary shape (cisrcular, rectangular,...), which describes a
+the spatial dimension is reduced to a single bin with an arbitrary shape, which describes a
 region in the sky with that same shape. Besides the spatial region, a `~RegionGeom` can also have any number of non-spatial dimensions, 
-the most common use being an energy axis. The `~RegionGeom` object defines the structure into which the data contained in a `~RegionNDMap`
+the most common case being an additional energy axis. The `~RegionGeom` object defines the structure into which the data contained in a `~RegionNDMap`
 is distributed.
 
 Creating a RegionGeom
@@ -93,7 +93,7 @@ The resulting `~RegionGeom` object has `ndim = 3`, two spatial dimensions with o
 
 RegionGeom and coordinates
 --------------------------
-A `~RegionGeom` defines a single spatial bin with arbitrary shape. The spatial coordinates are then given by the center of the region geometry. If one or more non-spatial axis are present, 
+A `~RegionGeom` defines a single spatial bin with arbitrary shape. The spatial coordinates are then given by the center of the region geometry. If one or more non-spatial axes are present, 
 they can have any number of bins. There are different methods that can be used to access or modify the coordinates of a `~RegionGeom`.
 
 + Bin volume and angular size:
@@ -116,7 +116,7 @@ they can have any number of bins. There are different methods that can be used t
 + Coordinates defined by the `~RegionGeom`:
     Given a map coordinate or `~MapCoord` object, the method `~RegionGeom.contains()` checks if they are contained in the region geometry. One can also retrieve the coordinates of the region geometry with
     `~RegionGeom.get_coord()` and `~RegionGeom.get_idx()`, which return the sky coordinates and indexes respectively. Note that the spatial coordinate will always be a single entry, namely the center, while any non-spatial 
-    axis can have as many bins as desired.
+    axes can have as many bins as desired.
 
     .. code-block:: python
 
@@ -160,9 +160,9 @@ they can have any number of bins. There are different methods that can be used t
         geom_6_energy_bins = geom.downsample(2, "energy")
 
 + Image and WCS geometries:
-    * If a `~RegionGeom` has any number of non-spatial axis, the corresponding region geometry with just the spatial dimensions is given by the method `~RegionGeom.to_image()`. If the region geometry only has spatial
+    * If a `~RegionGeom` has any number of non-spatial axes, the corresponding region geometry with just the spatial dimensions is given by the method `~RegionGeom.to_image()`. If the region geometry only has spatial
       dimensions, a copy of it is returned.
-    * Conversely, non-spatial axis can be added to an existing `~RegionGeom` by `~RegionGeom.to_cube()`, which takes a list of non-spatial axes with unique names to add to the region geometry.    
+    * Conversely, non-spatial axes can be added to an existing `~RegionGeom` by `~RegionGeom.to_cube()`, which takes a list of non-spatial axes with unique names to add to the region geometry.    
     * Region geometries are made of a single spatial bin, but are constructed on top of a finer `WcsGeom`. The method `~RegionGeom.to_wcs_geom()` returns the minimal equivalent geometry that contains the region geometry.
       It can also be given as an argument a minimal width for the resulting geometry.
 
@@ -177,7 +177,7 @@ they can have any number of bins. There are different methods that can be used t
         energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
         geom_energy = geom.to_cube([energy_axis])
 
-        # Get the image region geometry without energy axis. 
+        # Get the image region geometry without the energy axis. 
         # Note that geom_image == geom
         geom_image = geom_energy.to_image()
 
@@ -254,9 +254,10 @@ RegionNDMap
 ===========
 A `~RegionNDMap` owns a `~RegionGeom` instance as well as a data array containing the values associated 
 to that region in the sky along the non-spatial axis, which is usually an energy axis.
-It can be thought of as a `Map` but with a single spatial bin that can have an arbitrary 
-shape, together with any non-spatial axis. It is to a `~RegionGeom` what a `~Map` is to a `~Geom`, it contains
-the data that is distributed in the structure defined by the `~RegionGeom` axes.
+The spatial dimensions of a `~RegionNDMap` are reduced to a single spatial bin with an arbitrary 
+shape, and any extra dimensions are described by an arbitrary number of non-spatial axes. It is 
+to a `~RegionGeom` what a `~Map` is to a `~Geom`: it contains the data which is distributed 
+in the structure defined by the `~RegionGeom` axes.
 
 Creating a RegionNDMap
 ----------------------
@@ -329,8 +330,8 @@ The data contained in a region map is a `~numpy.ndarray` with shape defined by t
 spatial bin. If the associated `~RegionGeom` has a non-spatial axis with N bins, the data shape is
 then (N, 1, 1), and similarly for additional non-spatial axes.
 
-Visualization of a RegionNDMap
-------------------------------
+Visualing a RegionNDMap
+-----------------------
 Visualizing a `~RegionNDMap` can be interpreted in two different ways. One is to plot a sky map that contains the region,
 indicating the area of the sky encompassed by the spatial component of the region map. This is done via `~RegionNDMap.plot_region()`.
 Another option is to plot the contents of the region map, which would be either a single value for the case of only spatial axes, 

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -13,12 +13,14 @@ classes.
 
 RegionGeom
 ==========
-A `RegionGeom` is analogous to a  map geometry `Geom`, but instead of a fine grid on a rectangular region, 
+A `~RegionGeom` is analogous to a  map geometry `~Geom`, but instead of a fine grid on a rectangular region, 
 it is made up of a single large pixel with an arbitrary shape that can also have any 
 number of non-spatial dimensions.
 
 Creating a RegionGeom
 ---------------------
+A `~RegionGeom`can be created via a DS9 region string (see http://ds9.si.edu/doc/ref/region.html for a list of options)
+or an Astropy Region (https://astropy-regions.readthedocs.io/en/latest/).
 
 .. code-block:: python
 
@@ -29,11 +31,19 @@ Creating a RegionGeom
 
     # Create a circular region with radius 1 deg centered around
     # the Galactic Center
+    # from DS9 string
+    geom = RegionGeom.create("galactic;circle(0, 0, 1)")
+
+    # using the regions package
     center = SkyCoord("0 deg", "0 deg", frame="galactic")
     region =  CircleSkyRegion(center=center, radius=1*u.deg)
     geom = RegionGeom(region)
 
     # Create a rectangular region with a 45 degree tilt
+    # from DS9 string
+    geom = RegionGeom.create("galactic;box(0, 0, 1,2,45)")
+
+    # using the regions package
     region =  RectangleSkyRegion(center=center, width=1*u.deg, height=2*u.deg, angle=45*u.deg)
     geom = RegionGeom(region)
 
@@ -41,7 +51,7 @@ Creating a RegionGeom
     geom = RegionGeom.create(region) 
 
 
-Higher dimensional region geometries (cubes and hypercubes) can be constructed by passing a list of `MapAxis` objects for non-spatial dimensions with the axes parameter:
+Higher dimensional region geometries (cubes and hypercubes) can be constructed by passing a list of `~MapAxis` objects for non-spatial dimensions with the axes parameter:
 
 .. code-block:: python
 
@@ -49,12 +59,18 @@ Higher dimensional region geometries (cubes and hypercubes) can be constructed b
     from regions import CircleSkyRegion
     from gammapy.maps import MapAxis, RegionGeom
     import astropy.units as u
+
+    energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+
+    # from a DS9 string
+    geom = RegionGeom.create("galactic;circle(0, 0, 1)", axes=[energy_axis])
+
+    #using the regions package
     center = SkyCoord("0 deg", "0 deg", frame="galactic")
     region =  CircleSkyRegion(center=center, radius=1*u.deg)
-    energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
     geom = RegionGeom(region, axes=[energy_axis])
 
-The resulting `RegionGeom` object has `ndim = 3`, two spatial dimensions with one single bin and the chosen energy axis with 12 bins:
+The resulting `~RegionGeom` object has `ndim = 3`, two spatial dimensions with one single bin and the chosen energy axis with 12 bins:
 
 .. code-block:: python
 
@@ -70,59 +86,56 @@ The resulting `RegionGeom` object has `ndim = 3`, two spatial dimensions with on
 
 RegionGeom and coordinates
 --------------------------
-A `RegionGeom` defines a single spatial bin with arbitrary shape. The spatial coordinates are then given by the center of the region geometry. If one or more non-spatial axis are present, 
-they can have any number of bins. There are different methods that can be used to access or modify the coordinates of a `RegionGeom`.
+A `~RegionGeom` defines a single spatial bin with arbitrary shape. The spatial coordinates are then given by the center of the region geometry. If one or more non-spatial axis are present, 
+they can have any number of bins. There are different methods that can be used to access or modify the coordinates of a `~RegionGeom`.
 
 + Bin volume and angular size:
-    The angular size of the region geometry is given by the method `RegionGeom.solid_angle()`. If a region geometry has any number of non-spatial axes, then the volume of each bin is given by `RegionGeom.bin_volume()`.
+    The angular size of the region geometry is given by the method `~RegionGeom.solid_angle()`. If a region geometry has any number of non-spatial axes, 
+    then the volume of each bin is given by `~RegionGeom.bin_volume()`.
     If there are no non-spatial axes, both return the same quantity.
 
     .. code-block:: python
 
-        from astropy.coordinates import SkyCoord
-        from regions import CircleSkyRegion
         from gammapy.maps import MapAxis, RegionGeom
-        import astropy.units as u
 
         # Create a circular region geometry with an energy axis
-        center = SkyCoord("0 deg", "0 deg", frame="galactic")
-        region =  CircleSkyRegion(center=center, radius=1*u.deg)
         energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
-        geom = RegionGeom(region, axes=[energy_axis])
+        geom = RegionGeom.create("galactic;circle(0, 0, 1)", axes=[energy_axis])
 
         # Get angular size and bin volume
         angular_size = geom.solid_angle()
         bin_volume = geom.bin_volume()
     
-+ Coordinates defined by the `RegionGeom`:
-    Given a map coordinate or `MapCoord` object, the method `RegionGeom.contains(coords)` checks if they are contained in the region geometry. One can also retrieve the coordinates of the region geometry with
-    `RegionGeom.get_coord()` and `RegionGeom.get_idx()`, which return the sky coordinates and indexes respectively. Note that the spatial coordinate will always be a single entry, namely the center, while any non-spatial 
++ Coordinates defined by the `~RegionGeom`:
+    Given a map coordinate or `~MapCoord` object, the method `~RegionGeom.contains()` checks if they are contained in the region geometry. One can also retrieve the coordinates of the region geometry with
+    `~RegionGeom.get_coord()` and `~RegionGeom.get_idx()`, which return the sky coordinates and indexes respectively. Note that the spatial coordinate will always be a single entry, namely the center, while any non-spatial 
     axis can have as many bins as desired.
 
     .. code-block:: python
 
         from astropy.coordinates import SkyCoord
-        from regions import CircleSkyRegion
         from gammapy.maps import RegionGeom
-        import astropy.units as u
 
         # Create a circular region geometry
-        center = SkyCoord("0 deg", "0 deg", frame="galactic")
-        region =  CircleSkyRegion(center=center, radius=1*u.deg)
-        geom = RegionGeom(region)
+        geom = RegionGeom.create("galactic;circle(0, 0, 1)")
 
         # Get coordinates and indexes defined by the region geometry
-        coordinates = geom.get_coord()
+        coord = geom.get_coord()
         indexes = geom.get_idx()
 
         # Check if a coordinate is contained in the region
         >>> geom.contains(center)
             True
+        # Check if an  array  of coordinates are contained in the region
+        >>> coordinates = SkyCoord(l = [0, 0.5, 1.5], b = [0.5,2,0], frame='galactic', unit='deg')
+        >>> geom.contains(coordinates)
+            array([ True, False, False])
+        
 
 
 + Upsampling and downsampling the non-spatial axes:
-    The spatial binning of a `RegionGeom` is made up of a single bin, that cannot be modified as it defines the region. However, if any non-spatial axes are present, they can be modified using the 
-    `RegionGeom.upsample()` and `RegionGeom.downsample()` methods, which take as input a factor by which the indicated axis is to be up- or downsampled.
+    The spatial binning of a `~RegionGeom` is made up of a single bin, that cannot be modified as it defines the region. However, if any non-spatial axes are present, they can be modified using the 
+    `~RegionGeom.upsample()` and `~RegionGeom.downsample()` methods, which take as input a factor by which the indicated axis is to be up- or downsampled.
 
     .. code-block:: python
 
@@ -132,10 +145,8 @@ they can have any number of bins. There are different methods that can be used t
         import astropy.units as u
 
         # Create a circular region geometry with an energy axis
-        center = SkyCoord("0 deg", "0 deg", frame="galactic")
-        region =  CircleSkyRegion(center=center, radius=1*u.deg)
         energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
-        geom = RegionGeom(region, axes=[energy_axis])
+        geom = RegionGeom.create("galactic;circle(0, 0, 1)", axes=[energy_axis])
 
         # Upsample the energy axis by a factor 2
         geom_24_energy_bins = geom.upsample(2, "energy")
@@ -143,38 +154,130 @@ they can have any number of bins. There are different methods that can be used t
         geom_6_energy_bins = geom.downsample(2, "energy")
 
 + Image and WCS geometries:
-    * If a `RegionGeom` has any number of non-spatial axis, the corresponding region geometry with just the spatial dimensions is given by the method `RegionGeom.to_image()`. If the region geometry only has spatial
+    * If a `~RegionGeom` has any number of non-spatial axis, the corresponding region geometry with just the spatial dimensions is given by the method `~RegionGeom.to_image()`. If the region geometry only has spatial
       dimensions, a copy of it is returned.
-    * Conversely, non-spatial axis can be added to an existing `RegionGeom` by `RegionGeom.to_cube()`, which takes a list of non-spatial axes with unique names to add to the region geometry.    
-    * Region geometries are made of a single spatial bin, but are constructed on top of a finer `WcsGeom`. The method `RegionGeom.to_wcs_geom()` returns the minimal equivalent geometry that contains the region geometry.
+    * Conversely, non-spatial axis can be added to an existing `~RegionGeom` by `~RegionGeom.to_cube()`, which takes a list of non-spatial axes with unique names to add to the region geometry.    
+    * Region geometries are made of a single spatial bin, but are constructed on top of a finer `WcsGeom`. The method `~RegionGeom.to_wcs_geom()` returns the minimal equivalent geometry that contains the region geometry.
       It can also be given as an argument a minimal width for the resulting geometry.
 
     .. code-block:: python
 
-        from astropy.coordinates import SkyCoord
-        from regions import CircleSkyRegion
         from gammapy.maps import MapAxis, RegionGeom
-        import astropy.units as u
 
         # Create a circular region geometry
-        center = SkyCoord("0 deg", "0 deg", frame="galactic")
-        region =  CircleSkyRegion(center=center, radius=1*u.deg)
-        geom = RegionGeom(region)
+        geom = RegionGeom.create("galactic;circle(0, 0, 1)")
 
         # Add an energy axis to the region geometry
         energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
-        geom_energy = geom.to_cube[energy_axis]
+        geom_energy = geom.to_cube([energy_axis])
 
         # Get the image region geometry without energy axis. 
         # Note that geom_image == geom
         geom_image = geom_energy.to_image()
 
+        >>> geom_image
+
+            RegionGeom
+
+            region     : CircleSkyRegion
+            axes       : ['lon', 'lat']
+            shape      : (1, 1)
+            ndim       : 2
+            frame      : galactic
+            center     : 0.0 deg, 0.0 deg
+
         # Get the minimal wcs geometry that contains the region
         wcs_geom = geom.to_wcs_geom()
 
+        >>> wcs_geom
+            WcsGeom
+
+            axes       : ['lon', 'lat']
+            shape      : (202, 202)
+            ndim       : 2
+            frame      : galactic
+            projection : TAN
+            center     : 0.0 deg, 0.0 deg
+            width      : 2.0 deg x 2.0 deg
+
 RegionNDMap
 ===========
-A `RegionNDMap` owns a `RegionGeom` instance as well as a data array containing map values.
+A `~RegionNDMap` owns a `~RegionGeom` instance as well as a data array containing map values.
 It can be thought of as a `Map` but with a single spatial bin that can have an arbitrary 
-shape, together with any non-spatial axis.
-It is to a `RegionGeom` what a `Map` is to a `Geom`.
+shape, together with any non-spatial axis. It is to a `~RegionGeom` what a `~Map` is to a `~Geom`.
+
+Creating a RegionNDMap
+----------------------
+A region map can be created either from a DS9 region string, an `regions.SkyRegion` object or an existing `~RegionGeom`:
+
+.. code-block:: python
+
+    from gammapy.maps import RegionGeom, RegionNDMap
+    from astropy.coordinates import SkyCoord
+    from regions import CircleSkyRegion
+    import astropy.units as u
+
+    # Create a map of a circular region with radius 0.5 deg centered around
+    # the Crab Nebula
+
+    # from DS9 string
+    region_map = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)")
+
+    # using the regions package
+    center = SkyCoord("83.63 deg", "22.01 deg", frame="icrs")
+    region =  CircleSkyRegion(center=center, radius=0.5*u.deg)
+    region_map = RegionNDMap.create(region)
+
+    # from an existing RegionGeom, perhaps the one corresponding
+    # to another, existing RegionNDMap
+    geom = region_map.geom
+    region_map_2 = RegionNDMap.from_geom(geom)
+
+Higher dimensional region map objects (cubes and hypercubes) 
+can be constructed by passing a list of `~MapAxis` objects for non-spatial dimensions with the axes parameter:
+
+.. code-block:: python
+
+    from gammapy.maps import MapAxis, RegionNDMap
+
+    energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+    region_map = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
+
+
+Filling a RegionNDMap
+---------------------
+
+All the region maps created above are empty. In order to fill or access the data contained
+in a `~RegionNDMap`, the `~RegionNDMap.data` attribute is used. In case the region map is being 
+created from an existing `~RegionGeom`, this can be done in the same step:
+
+.. code-block:: python
+
+    from gammapy.maps import MapAxis, RegionNDMap
+    import numpy as np  
+
+    # Create a RegionNDMap with 12 energy bins
+    energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+    region_map = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
+
+    # Fill the region map
+    region_map.data = np.linspace(1,50,12) #an entry for each of the 12 energy bins
+
+    # Create another region map with the same RegionGeom but different data
+    geom = region_map.geom
+    region_map_2 = RegionNDMap.from_geom(geom, data = np.linspace(50,100,12))
+
+    # Access the data
+    print(region_map_2.data)
+
+The data contained in a region map is a `~numpy.ndarray` with shape defined by the underlying
+`~RegionGeom.data_shape`. In the case of only spatial dimensions, the shape is just (1,1), one single
+spatial bin. If the associated `~RegionGeom` has a non-spatial axis with N bins, the data shape is
+then (N, 1, 1), and similarly for additional non-spatial axes.
+
+Visualization of a RegionNDMap
+------------------------------
+Visualizing a `~RegionNDMap` can be interpreted in two different ways. One is to plot a sky map that contains the region,
+indicating the area of the sky encompassed by the spatial component of the region map. This is done via `~RegionNDMap.plot_region()`.
+Another option is to plot the contents of the region map, which would be either a single value for the case of only spatial axes, 
+or a function of the non-spatial axis bins. This is done by `~RegionNDMap.plot()` and `~RegionNDMap.plot_hist()`.

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -211,10 +211,26 @@ of an existing `~Map`. This is done via `~RegionGeom.plot_region()`:
     geom = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
     geom.plot_region()
 
+.. plot::
+
+    from gammapy.maps import RegionGeom
+    geom = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
+    geom.plot_region()
+
 One can also plot the region on top of an existing map, and change the properties of the
 different regions by passing keyword arguments forwarded to `~regions.PixelRegion.as_artist`.
 
 .. code-block:: python
+
+    from gammapy.maps import RegionGeom, Map
+    m = Map.create(width=3, skydir=(83.63, 22.01), frame='icrs')
+    geom1 = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
+    geom2 = RegionGeom.create("icrs;box(83.63, 22.01, 1,2,45)")
+    m.plot(add_cbar=True)
+    geom1.plot_region(ec="k")
+    geom2.plot_region(lw=2, linestyle='--')
+
+.. plot::
 
     from gammapy.maps import RegionGeom, Map
     m = Map.create(width=3, skydir=(83.63, 22.01), frame='icrs')
@@ -285,7 +301,10 @@ created from an existing `~RegionGeom`, this can be done in the same step:
     region_map = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
 
     # Fill the region map
-    region_map.data = np.linspace(1,50,12) #an entry for each of the 12 energy bins
+    #with the same value for each of the 12 energy bins
+    region_map.data = 1 
+    # or with an entry for each of the 12 energy bins
+    region_map.data = np.linspace(1,50,12) 
 
     # Create another region map with the same RegionGeom but different data
     geom = region_map.geom
@@ -305,3 +324,16 @@ Visualizing a `~RegionNDMap` can be interpreted in two different ways. One is to
 indicating the area of the sky encompassed by the spatial component of the region map. This is done via `~RegionNDMap.plot_region()`.
 Another option is to plot the contents of the region map, which would be either a single value for the case of only spatial axes, 
 or a function of the non-spatial axis bins. This is done by `~RegionNDMap.plot()` and `~RegionNDMap.plot_hist()`.
+
++ Plotting the underlying region:
+    This is equivalent to the `~RegionGeom.plot_region()` described above, and, in fact, the `~RegionNDMap` method simply calls it on the associated 
+    region geometry, `~RegionNDMap.geom`. Consequently, the use of this method is already described by the section above.
+
+    .. code-block:: python
+
+        from gammapy.maps import RegionNDMap
+        region_map = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)")
+        region_map.plot_region()
+
++ Plotting the map contents:
+    T

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -2,22 +2,27 @@
 
 .. _regionmap:
 
-******************************
-The RegionGeom and RegionNDMap
-******************************
+**************************
+RegionGeom and RegionNDMap
+**************************
 
 .. currentmodule:: gammapy.maps
 
 This page provides examples and documentation specific to the Region
-classes. 
-TO DO: why would one use them??
+classes. These objecs are used to bundle the energy distribution (or any other
+non-spatial axis) of quantities (counts, exposure,...) inside of a given region in the sky while retaining
+the information of the chosen spatial region.
+In particular, they are suited for so-called 1D analysis (see https://docs.gammapy.org/dev/references.html#glossary).
 
 
 RegionGeom
 ==========
-A `~RegionGeom` is analogous to a  map geometry `~Geom`, but instead of a fine grid on a rectangular region, 
-it is made up of a single large pixel with an arbitrary shape that can also have any 
-number of non-spatial dimensions.
+A `~RegionGeom` describes the underlying geometry of a region in the sky with any number of non-spatial axes associated to it.
+Is analogous to a  map geometry `~Geom`, but instead of a fine spatial grid on a rectangular region, 
+the spatial dimension is reduced to a single bin with an arbitrary shape (cisrcular, rectangular,...), which describes a
+region in the sky with that same shape. Besides the spatial region, a `~RegionGeom` can also have any number of non-spatial dimensions, 
+the most common use being an energy axis. The `~RegionGeom` object defines the structure into which the data contained in a `~RegionNDMap`
+is distributed.
 
 Creating a RegionGeom
 ---------------------
@@ -134,7 +139,6 @@ they can have any number of bins. There are different methods that can be used t
             array([ True, False, False])
         
 
-
 + Upsampling and downsampling the non-spatial axes:
     The spatial binning of a `~RegionGeom` is made up of a single bin, that cannot be modified as it defines the region. However, if any non-spatial axes are present, they can be modified using the 
     `~RegionGeom.upsample()` and `~RegionGeom.downsample()` methods, which take as input a factor by which the indicated axis is to be up- or downsampled.
@@ -248,9 +252,11 @@ different regions by passing keyword arguments forwarded to `~regions.PixelRegio
 
 RegionNDMap
 ===========
-A `~RegionNDMap` owns a `~RegionGeom` instance as well as a data array containing map values.
+A `~RegionNDMap` owns a `~RegionGeom` instance as well as a data array containing the values associated 
+to that region in the sky along the non-spatial axis, which is usually an energy axis.
 It can be thought of as a `Map` but with a single spatial bin that can have an arbitrary 
-shape, together with any non-spatial axis. It is to a `~RegionGeom` what a `~Map` is to a `~Geom`.
+shape, together with any non-spatial axis. It is to a `~RegionGeom` what a `~Map` is to a `~Geom`, it contains
+the data that is distributed in the structure defined by the `~RegionGeom` axes.
 
 Creating a RegionNDMap
 ----------------------

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -1,23 +1,180 @@
+.. include:: ../references.txt
+
 .. _regionmap:
 
+******************************
 The RegionGeom and RegionNDMap
-==============================
+******************************
+
+.. currentmodule:: gammapy.maps
 
 This page provides examples and documentation specific to the Region
 classes. 
 
 RegionGeom
------------
-Like a geometry but instead of a small grid on a rectangular region, 
-this is just one large pixel with an arbitrary shape that can have any 
+==========
+A `RegionGeom` is analogous to a  map geometry `Geom`, but instead of a fine grid on a rectangular region, 
+it is made up of a single large pixel with an arbitrary shape that can also have any 
 number of non-spatial dimensions.
 
+Creating a RegionGeom
+---------------------
 
+.. code-block:: python
+
+    from astropy.coordinates import SkyCoord
+    from regions import CircleSkyRegion, RectangleSkyRegion
+    from gammapy.maps import RegionGeom
+    import astropy.units as u
+
+    # Create a circular region with radius 1 deg centered around
+    # the Galactic Center
+    center = SkyCoord("0 deg", "0 deg", frame="galactic")
+    region =  CircleSkyRegion(center=center, radius=1*u.deg)
+    geom = RegionGeom(region)
+
+    # Create a rectangular region with a 45 degree tilt
+    region =  RectangleSkyRegion(center=center, width=1*u.deg, height=2*u.deg, angle=45*u.deg)
+    geom = RegionGeom(region)
+
+    # Equivalent factory method call
+    geom = RegionGeom.create(region) 
+
+
+Higher dimensional region geometries (cubes and hypercubes) can be constructed by passing a list of `MapAxis` objects for non-spatial dimensions with the axes parameter:
+
+.. code-block:: python
+
+    from astropy.coordinates import SkyCoord
+    from regions import CircleSkyRegion
+    from gammapy.maps import MapAxis, RegionGeom
+    import astropy.units as u
+    center = SkyCoord("0 deg", "0 deg", frame="galactic")
+    region =  CircleSkyRegion(center=center, radius=1*u.deg)
+    energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+    geom = RegionGeom(region, axes=[energy_axis])
+
+The resulting `RegionGeom` object has `ndim = 3`, two spatial dimensions with one single bin and the chosen energy axis with 12 bins:
+
+.. code-block:: python
+
+    >>> geom
+
+    RegionGeom
+            region     : CircleSkyRegion
+            axes       : ['lon', 'lat', 'energy']
+            shape      : (1, 1, 12)
+            ndim       : 3
+            frame      : galactic
+            center     : 0.0 deg, 0.0 deg
+
+RegionGeom and coordinates
+--------------------------
+A `RegionGeom` defines a single spatial bin with arbitrary shape. The spatial coordinates are then given by the center of the region geometry. If one or more non-spatial axis are present, 
+they can have any number of bins. There are different methods that can be used to access or modify the coordinates of a `RegionGeom`.
+
++ Bin volume and angular size:
+    The angular size of the region geometry is given by the method `RegionGeom.solid_angle()`. If a region geometry has any number of non-spatial axes, then the volume of each bin is given by `RegionGeom.bin_volume()`.
+    If there are no non-spatial axes, both return the same quantity.
+
+    .. code-block:: python
+
+        from astropy.coordinates import SkyCoord
+        from regions import CircleSkyRegion
+        from gammapy.maps import MapAxis, RegionGeom
+        import astropy.units as u
+
+        # Create a circular region geometry with an energy axis
+        center = SkyCoord("0 deg", "0 deg", frame="galactic")
+        region =  CircleSkyRegion(center=center, radius=1*u.deg)
+        energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+        geom = RegionGeom(region, axes=[energy_axis])
+
+        # Get angular size and bin volume
+        angular_size = geom.solid_angle()
+        bin_volume = geom.bin_volume()
+    
++ Coordinates defined by the `RegionGeom`:
+    Given a map coordinate or `MapCoord` object, the method `RegionGeom.contains(coords)` checks if they are contained in the region geometry. One can also retrieve the coordinates of the region geometry with
+    `RegionGeom.get_coord()` and `RegionGeom.get_idx()`, which return the sky coordinates and indexes respectively. Note that the spatial coordinate will always be a single entry, namely the center, while any non-spatial 
+    axis can have as many bins as desired.
+
+    .. code-block:: python
+
+        from astropy.coordinates import SkyCoord
+        from regions import CircleSkyRegion
+        from gammapy.maps import RegionGeom
+        import astropy.units as u
+
+        # Create a circular region geometry
+        center = SkyCoord("0 deg", "0 deg", frame="galactic")
+        region =  CircleSkyRegion(center=center, radius=1*u.deg)
+        geom = RegionGeom(region)
+
+        # Get coordinates and indexes defined by the region geometry
+        coordinates = geom.get_coord()
+        indexes = geom.get_idx()
+
+        # Check if a coordinate is contained in the region
+        >>> geom.contains(center)
+            True
+
+
++ Upsampling and downsampling the non-spatial axes:
+    The spatial binning of a `RegionGeom` is made up of a single bin, that cannot be modified as it defines the region. However, if any non-spatial axes are present, they can be modified using the 
+    `RegionGeom.upsample()` and `RegionGeom.downsample()` methods, which take as input a factor by which the indicated axis is to be up- or downsampled.
+
+    .. code-block:: python
+
+        from astropy.coordinates import SkyCoord
+        from regions import CircleSkyRegion
+        from gammapy.maps import MapAxis, RegionGeom
+        import astropy.units as u
+
+        # Create a circular region geometry with an energy axis
+        center = SkyCoord("0 deg", "0 deg", frame="galactic")
+        region =  CircleSkyRegion(center=center, radius=1*u.deg)
+        energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+        geom = RegionGeom(region, axes=[energy_axis])
+
+        # Upsample the energy axis by a factor 2
+        geom_24_energy_bins = geom.upsample(2, "energy")
+        # Downsample the energy axis by a factor 2
+        geom_6_energy_bins = geom.downsample(2, "energy")
+
++ Image and WCS geometries:
+    * If a `RegionGeom` has any number of non-spatial axis, the corresponding region geometry with just the spatial dimensions is given by the method `RegionGeom.to_image()`. If the region geometry only has spatial
+      dimensions, a copy of it is returned.
+    * Conversely, non-spatial axis can be added to an existing `RegionGeom` by `RegionGeom.to_cube()`, which takes a list of non-spatial axes with unique names to add to the region geometry.    
+    * Region geometries are made of a single spatial bin, but are constructed on top of a finer `WcsGeom`. The method `RegionGeom.to_wcs_geom()` returns the minimal equivalent geometry that contains the region geometry.
+      It can also be given as an argument a minimal width for the resulting geometry.
+
+    .. code-block:: python
+
+        from astropy.coordinates import SkyCoord
+        from regions import CircleSkyRegion
+        from gammapy.maps import MapAxis, RegionGeom
+        import astropy.units as u
+
+        # Create a circular region geometry
+        center = SkyCoord("0 deg", "0 deg", frame="galactic")
+        region =  CircleSkyRegion(center=center, radius=1*u.deg)
+        geom = RegionGeom(region)
+
+        # Add an energy axis to the region geometry
+        energy_axis = MapAxis.from_bounds(100., 1e5, 12, interp='log', name='energy', unit='GeV')
+        geom_energy = geom.to_cube[energy_axis]
+
+        # Get the image region geometry without energy axis. 
+        # Note that geom_image == geom
+        geom_image = geom_energy.to_image()
+
+        # Get the minimal wcs geometry that contains the region
+        wcs_geom = geom.to_wcs_geom()
 
 RegionNDMap
------------
-It's essentially a Map with one spatial bin that can have an arbitrary 
-shape and whatever non-spatial axis you want.
-It is to a RegionGeom what a Map is to a WcsGeom: it contains the data 
-that goes into the grid.RegionGeom
-----------
+===========
+A `RegionNDMap` owns a `RegionGeom` instance as well as a data array containing map values.
+It can be thought of as a `Map` but with a single spatial bin that can have an arbitrary 
+shape, together with any non-spatial axis.
+It is to a `RegionGeom` what a `Map` is to a `Geom`.

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -314,10 +314,24 @@ class RegionGeom(Geom):
         return self._init_copy(axes=None)
 
     def upsample(self, factor, axis_name):
+        """Upsample a non-spatial dimension of the region by a given factor.
+
+        Returns
+        -------
+        region : `~RegionGeom`
+            RegionGeom with the upsampled axis.
+        """
         axes = self.axes.upsample(factor=factor, axis_name=axis_name)
         return self._init_copy(axes=axes)
 
     def downsample(self, factor, axis_name):
+        """Downsample a non-spatial dimension of the region by a given factor.
+
+        Returns
+        -------
+        region : `~RegionGeom`
+            RegionGeom with the downsampled axis.
+        """
         axes = self.axes.downsample(factor=factor, axis_name=axis_name)
         return self._init_copy(axes=axes)
 

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -23,6 +23,9 @@ __all__ = ["RegionGeom"]
 
 class RegionGeom(Geom):
     """Map geometry representing a region on the sky.
+    The resulting object is effectively "one large pixel" with
+    the chosen shape and dimensions.
+    ADD: how is this different from an astropy region?
 
     Parameters
     ----------
@@ -106,6 +109,7 @@ class RegionGeom(Geom):
 
     @property
     def center_pix(self):
+        """Pixel values corresponding to the center of the region"""
         return tuple((np.array(self.data_shape) - 1.0) / 2)[::-1]
 
     @property
@@ -120,6 +124,21 @@ class RegionGeom(Geom):
             return SkyCoord.from_pixel(xp=xp, yp=yp, wcs=self.wcs)
 
     def contains(self, coords):
+        """Check if the input coordinates are inside the region.
+            Requires the `.region` attribute to be set.
+
+        Parameters
+        ----------
+        coords : tuple, dict, `MapCoord` or `~astropy.coordinates.SkyCoord`
+            Object containing coordinate arrays we wish to check for inclusion
+            in the region.
+
+        Returns
+        -------
+        mask : `~numpy.ndarray`
+            Boolean Numpy array with the same shape as the input that indicates
+            which coordinates are inside the region.
+        """
         if self.region is None:
             raise ValueError("Region definition required.")
 
@@ -127,6 +146,18 @@ class RegionGeom(Geom):
         return self.region.contains(coords.skycoord, self.wcs)
 
     def separation(self, position):
+        """Angular distance between the center of the region and the given position.
+
+        Parameters
+        ----------
+        position : `astropy.coordinates.SkyCoord`
+            Sky coordinate we want the angular distance to.
+
+        Returns
+        -------
+        sep : `~astropy.coordinates.Angle`
+            The on-sky separation between the given coordinate and the region center.
+        """
         return self.center_skydir.separation(position)
 
     @property

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -5,7 +5,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Table
 from astropy.wcs import WCS
-
+from astropy.visualization.wcsaxes import WCSAxes
 from astropy.wcs.utils import proj_plane_pixel_area, wcs_to_celestial_frame
 from regions import FITSRegionParser, fits_region_objects_to_table
 from gammapy.utils.regions import (
@@ -139,7 +139,7 @@ class RegionGeom(Geom):
 
     def contains(self, coords):
         """Check if a given map coordinate is contained in the region.
-            Requires the `.region` attribute to be set.
+        Requires the `.region` attribute to be set.
 
         Parameters
         ----------
@@ -237,8 +237,8 @@ class RegionGeom(Geom):
 
     def bin_volume(self):
         """If the RegionGeom has a non-spatial axis, it
-            returns the volume of the region. If not, it 
-            just retuns the solid angle size.
+        returns the volume of the region. If not, it 
+        just retuns the solid angle size.
 
         Returns
         -------
@@ -255,8 +255,8 @@ class RegionGeom(Geom):
         return bin_volume
 
     def to_wcs_geom(self, width_min=None):
-        """Get the minimal equivalent geometry that
-            contains the region.
+        """Get the minimal equivalent geometry
+        which contains the region.
 
         Parameters
          ----------

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -219,14 +219,6 @@ class RegionGeom(Geom):
         raise NotImplementedError("Cropping of `RegionGeom` not supported")
 
     def solid_angle(self):
-        """Get solid angle of the region.
-
-        Returns
-        -------
-        angle : `~astropy.units.Quantity`
-            Solid angle of the region. In sr.
-            Units: ``sr``
-        """
         if self.region is None:
             raise ValueError("Region definition required.")
 

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -219,6 +219,14 @@ class RegionGeom(Geom):
         raise NotImplementedError("Cropping of `RegionGeom` not supported")
 
     def solid_angle(self):
+        """Get solid angle of the region.
+
+        Returns
+        -------
+        angle : `~astropy.units.Quantity`
+            Solid angle of the region. In sr.
+            Units: ``sr``
+        """
         if self.region is None:
             raise ValueError("Region definition required.")
 

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -23,9 +23,10 @@ __all__ = ["RegionGeom"]
 
 class RegionGeom(Geom):
     """Map geometry representing a region on the sky.
-    The resulting object is effectively "one large pixel" with
-    the chosen shape and dimensions.
-    ADD: how is this different from an astropy region?
+    The spatial component of the geometry is made up of a
+    single pixel with an arbitrary shape and size. It can
+    also have any number of non-spatial dimensions. This class
+    represents the geometry for the `RegionNDMap` maps.
 
     Parameters
     ----------

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -65,6 +65,8 @@ class RegionGeom(Geom):
 
     @property
     def frame(self):
+        """Coordinate system, either Galactic ("galactic") or Equatorial
+            ("icrs")."""
         if self.region is None:
             return "icrs"
         try:
@@ -99,6 +101,8 @@ class RegionGeom(Geom):
 
     @property
     def region(self):
+        """`~regions.SkyRegion` object that defines the spatial component
+        of the region geometry"""
         return self._region
 
     @property

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -15,7 +15,12 @@ __all__ = ["RegionNDMap"]
 
 
 class RegionNDMap(Map):
-    """Region ND map
+    """N-dimensional region map.
+    A `~RegionNDMap` owns a `~RegionGeom` instance as well as a data array
+    containing the values associated to that region in the sky along the non-spatial
+    axis, usually an energy axis. The spatial dimensions of a `~RegionNDMap`
+    are reduced to a single spatial bin with an arbitrary shape,
+    and any extra dimensions are described by an arbitrary number of non-spatial axes.
 
     Parameters
     ----------

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -44,7 +44,7 @@ class RegionNDMap(Map):
         self.unit = u.Unit(unit)
 
     def plot(self, ax=None, **kwargs):
-        """Plot region map.
+        """Plot the data contained in region map along the non-spatial axis.
 
         Parameters
         ----------
@@ -152,7 +152,7 @@ class RegionNDMap(Map):
 
     @classmethod
     def create(cls, region, axes=None, dtype="float32", meta=None, unit="", wcs=None):
-        """
+        """Create an empty region map object.
 
         Parameters
         ----------

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -180,6 +180,27 @@ class RegionNDMap(Map):
     def downsample(
         self, factor, preserve_counts=True, axis_name="energy", weights=None
     ):
+        """Downsample the non-spatial dimension by a given factor.
+
+        Parameters
+        ----------
+        factor : int
+            Downsampling factor.
+        preserve_counts : bool
+            Preserve the integral over each bin.  This should be true
+            if the map is an integral quantity (e.g. counts) and false if
+            the map is a differential quantity (e.g. intensity).
+        axis_name : str
+            Which axis to downsample. Default is "energy".
+        weights : `RegionNDMap`
+            Contains the weights to apply to the axis to reduce. Default 
+            is just weighs of one.
+
+        Returns
+        -------
+        map : `RegionNDMap`
+            Downsampled region map.
+        """
         if axis_name is None:
             return self.copy()
 
@@ -202,6 +223,24 @@ class RegionNDMap(Map):
         return self._init_copy(geom=geom, data=data)
 
     def upsample(self, factor, preserve_counts=True, axis_name="energy"):
+        """Upsample the non-spatial dimension by a given factor.
+
+        Parameters
+        ----------
+        factor : int
+            Upsampling factor.
+        preserve_counts : bool
+            Preserve the integral over each bin.  This should be true
+            if the RegionNDMap is an integral quantity (e.g. counts) and false if
+            the RegionNDMap is a differential quantity (e.g. intensity).
+        axis_name : str
+            Which axis to upsample. Default is "energy".
+
+        Returns
+        -------
+        map : `RegionNDMap`
+            Upsampled region map.
+        """
         geom = self.geom.upsample(factor=factor, axis_name=axis_name)
         data = self.interp_by_coord(geom.get_coord())
 


### PR DESCRIPTION
This pull request aims to expand the existing documentation for the `RegionGeom` and `RegionNDMap` classes.

This is done by adding missing docstrings and improving existing ones in the code, as well as with the creation of a `regionmap.rst` file.

Note that this is still a work in progress at the moment, as the RST file is missing the `RegionNDMap` section, and the rest is still in a draft state. I will keep working on it in the next days. However, general feedback at this stage is very welcome, since this is the first time I've ever contributed to gammapy documentation and I might be doing things in a less-than-optimal way.

So far I've just sort of listed what you can do with a `RegionGeom`, but I realize it might be maybe too much detail, and some of the code snippets have too much repetition. I intend to spend some more expanding more "conceptual" explanations, perhaps with examples in context of how you would normally use each of these objects.
