### PR TITLE
Unify npred background handling in dataset methods

### DIFF
--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -238,6 +238,9 @@ class Datasets(collections.abc.MutableSequence):
     def slice_by_energy(self, energy_min, energy_max):
         """Select and slice datasets in energy range
 
+        The method keeps the current dataset names. Datasets, that do not
+        contribute to the selected energy range are dismissed.
+
         Parameters
         ----------
         energy_min, energy_max : `~astropy.units.Quantity`
@@ -256,7 +259,7 @@ class Datasets(collections.abc.MutableSequence):
                 dataset_sliced = dataset.slice_by_energy(
                     energy_min=energy_min,
                     energy_max=energy_max,
-                    name=dataset.name + "-slice",
+                    name=dataset.name,
                 )
             except ValueError:
                 log.info(

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1415,7 +1415,7 @@ class MapDataset(Dataset):
             kwargs["exposure"] = self.exposure.pad(pad_width=pad_width, mode=mode)
 
         if self.background is not None:
-            kwargs["background"] = self.npred_background().pad(
+            kwargs["background"] = self.background.pad(
                 pad_width=pad_width, mode=mode
             )
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1530,7 +1530,7 @@ class MapDataset(Dataset):
         Returns
         -------
         dataset: `MapDataset` or `SpectrumDataset`
-            Resampled dataset .
+            Resampled dataset.
         """
         name = make_name(name)
         kwargs = {"gti": self.gti, "name": name, "meta_table": self.meta_table}
@@ -1557,7 +1557,7 @@ class MapDataset(Dataset):
             )
 
         if self.background is not None and self.stat_type == "cash":
-            kwargs["background"] = self.npred_background().resample_axis(
+            kwargs["background"] = self.background.resample_axis(
                 axis=energy_axis, weights=self.mask_safe
             )
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1229,7 +1229,7 @@ class MapDataset(Dataset):
             )
 
         if self.stat_type == "cash" and self.background is not None:
-            kwargs["background"] = self.npred_background().get_spectrum(
+            kwargs["background"] = self.background.get_spectrum(
                 on_region, func=np.sum, weights=self.mask_safe
             )
 
@@ -1301,7 +1301,7 @@ class MapDataset(Dataset):
             kwargs["exposure"] = self.exposure.cutout(**cutout_kwargs)
 
         if self.background is not None and self.stat_type == "cash":
-            kwargs["background"] = self.npred_background().cutout(**cutout_kwargs)
+            kwargs["background"] = self.background.cutout(**cutout_kwargs)
 
         if self.edisp is not None:
             kwargs["edisp"] = self.edisp.cutout(**cutout_kwargs)
@@ -1358,7 +1358,7 @@ class MapDataset(Dataset):
                 kwargs["exposure"] = self.exposure.copy()
 
         if self.background is not None and self.stat_type == "cash":
-            kwargs["background"] = self.npred_background().downsample(
+            kwargs["background"] = self.background.downsample(
                 factor=factor, axis_name=axis_name, weights=self.mask_safe
             )
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1463,7 +1463,7 @@ class MapDataset(Dataset):
             kwargs["exposure"] = self.exposure.slice_by_idx(slices=slices)
 
         if self.background is not None and self.stat_type == "cash":
-            kwargs["background"] = self.npred_background().slice_by_idx(slices=slices)
+            kwargs["background"] = self.background.slice_by_idx(slices=slices)
 
         if self.edisp is not None:
             kwargs["edisp"] = self.edisp.slice_by_idx(slices=slices)

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -163,8 +163,8 @@ def test_spectrum_dataset_create():
     assert empty_spectrum_dataset.name == "test"
     assert empty_spectrum_dataset.counts.data.sum() == 0
     assert empty_spectrum_dataset.data_shape[0] == 2
-    assert empty_spectrum_dataset.npred_background().data.sum() == 0
-    assert empty_spectrum_dataset.npred_background().geom.axes[0].nbin == 2
+    assert empty_spectrum_dataset.background.data.sum() == 0
+    assert empty_spectrum_dataset.background.geom.axes[0].nbin == 2
     assert empty_spectrum_dataset.exposure.geom.axes[0].nbin == 3
     assert empty_spectrum_dataset.edisp.edisp_map.geom.axes["energy"].nbin == 2
     assert empty_spectrum_dataset.gti.time_sum.value == 0
@@ -195,7 +195,7 @@ def test_spectrum_dataset_stack_diagonal_safe_mask(spectrum_dataset):
     )
     edisp.exposure_map.data = exposure.data[:, :, np.newaxis, :]
 
-    background = spectrum_dataset.npred_background().copy()
+    background = spectrum_dataset.background
 
     mask_safe = RegionNDMap.from_geom(geom=geom, dtype=bool)
     mask_safe.data += True
@@ -205,7 +205,7 @@ def test_spectrum_dataset_stack_diagonal_safe_mask(spectrum_dataset):
         counts=spectrum_dataset.counts.copy(),
         exposure=exposure.copy(),
         edisp=edisp.copy(),
-        background=background,
+        background=background.copy(),
         gti=gti.copy(),
         mask_safe=mask_safe
     )
@@ -240,9 +240,9 @@ def test_spectrum_dataset_stack_diagonal_safe_mask(spectrum_dataset):
     assert_allclose(spectrum_dataset1.counts.data[0], 141363)
     assert_allclose(spectrum_dataset1.exposure.data[0], 4.755644e09)
     assert_allclose(
-        spectrum_dataset1.npred_background().data[1:], 3 * background.data[1:]
+        spectrum_dataset1.background.data[1:], 3 * background.data[1:]
     )
-    assert_allclose(spectrum_dataset1.npred_background().data[0], background.data[0])
+    assert_allclose(spectrum_dataset1.background.data[0], background.data[0])
 
     assert_allclose(
         spectrum_dataset1.exposure.quantity.to_value("m2s"),
@@ -471,7 +471,7 @@ class TestSpectrumOnOff:
         ds = self.dataset.to_spectrum_dataset()
 
         assert isinstance(ds, SpectrumDataset)
-        assert_allclose(ds.npred_background().data.sum(), 4)
+        assert_allclose(ds.background.data.sum(), 4)
 
     @requires_dependency("matplotlib")
     def test_peek(self):

--- a/gammapy/estimators/asmooth_map.py
+++ b/gammapy/estimators/asmooth_map.py
@@ -162,8 +162,8 @@ class ASmoothMapEstimator(Estimator):
         results = []
 
         for energy_min, energy_max in zip(energy_edges[:-1], energy_edges[1:]):
-            dataset_sliced = dataset.slice_by_energy(energy_min, energy_max)
-            dataset_sliced.models = dataset.models.reassign(dataset.name, dataset_sliced.name)
+            dataset_sliced = dataset.slice_by_energy(energy_min, energy_max, name=dataset.name)
+            dataset_sliced.models = dataset.models
             result = self.estimate_maps(dataset_sliced)
             results.append(result)
 
@@ -193,10 +193,8 @@ class ASmoothMapEstimator(Estimator):
                 * 'scales'
                 * 'sqrt_ts'.
         """
-        dataset_image = dataset.to_image()
-
-        if dataset.models:
-            dataset_image.models = dataset.models.reassign(dataset.name, dataset_image.name)
+        dataset_image = dataset.to_image(name=dataset.name)
+        dataset_image.models = dataset.models
 
         # extract 2d arrays
         counts = dataset_image.counts.data[0].astype(float)

--- a/gammapy/estimators/asmooth_map.py
+++ b/gammapy/estimators/asmooth_map.py
@@ -153,8 +153,6 @@ class ASmoothMapEstimator(Estimator):
                 * 'scales'
                 * 'sqrt_ts'.
         """
-        datasets = Datasets([dataset])
-
         if self.energy_edges is None:
             energy_axis = dataset.counts.geom.axes["energy"]
             energy_edges = u.Quantity([energy_axis.edges[0], energy_axis.edges[-1]])
@@ -164,8 +162,9 @@ class ASmoothMapEstimator(Estimator):
         results = []
 
         for energy_min, energy_max in zip(energy_edges[:-1], energy_edges[1:]):
-            dataset = datasets.slice_by_energy(energy_min, energy_max)[0]
-            result = self.estimate_maps(dataset)
+            dataset_sliced = dataset.slice_by_energy(energy_min, energy_max)
+            dataset_sliced.models = dataset.models.reassign(dataset.name, dataset_sliced.name)
+            result = self.estimate_maps(dataset_sliced)
             results.append(result)
 
         result_all = {}

--- a/gammapy/estimators/asmooth_map.py
+++ b/gammapy/estimators/asmooth_map.py
@@ -169,15 +169,14 @@ class ASmoothMapEstimator(Estimator):
 
         result_all = {}
 
-        for name in result.keys():
+        for name in results[0].keys():
             map_all = Map.from_images(images=[_[name] for _ in results])
             result_all[name] = map_all
 
         return result_all
 
     def estimate_maps(self, dataset):
-        """
-        Run adaptive smoothing on input Maps.
+        """Run adaptive smoothing on input Maps.
 
         Parameters
         ----------
@@ -194,21 +193,24 @@ class ASmoothMapEstimator(Estimator):
                 * 'scales'
                 * 'sqrt_ts'.
         """
-        dataset = dataset.to_image()
+        dataset_image = dataset.to_image()
+
+        if dataset.models:
+            dataset_image.models = dataset.models.reassign(dataset.name, dataset_image.name)
 
         # extract 2d arrays
-        counts = dataset.counts.data[0].astype(float)
-        background = dataset.npred_background().data[0]
+        counts = dataset_image.counts.data[0].astype(float)
+        background = dataset_image.npred_background().data[0]
 
-        if isinstance(dataset, MapDatasetOnOff):
-            background = dataset.background.data[0]
+        if isinstance(dataset_image, MapDatasetOnOff):
+            background = dataset_image.background.data[0]
 
-        if dataset.exposure is not None:
-            exposure = estimate_exposure_reco_energy(dataset, self.spectrum)
+        if dataset_image.exposure is not None:
+            exposure = estimate_exposure_reco_energy(dataset_image, self.spectrum)
         else:
             exposure = None
 
-        pixel_scale = dataset.counts.geom.pixel_scales.mean()
+        pixel_scale = dataset_image.counts.geom.pixel_scales.mean()
         kernels = self.get_kernels(pixel_scale)
 
         cubes = {}
@@ -216,7 +218,7 @@ class ASmoothMapEstimator(Estimator):
         cubes["background"] = scale_cube(background, kernels)
 
         if exposure is not None:
-            flux = (dataset.counts - background) / exposure
+            flux = (dataset_image.counts - background) / exposure
             cubes["flux"] = scale_cube(flux.data[0], kernels)
 
         cubes["sqrt_ts"] = self._sqrt_ts_cube(cubes, method=self.method)
@@ -225,7 +227,7 @@ class ASmoothMapEstimator(Estimator):
 
         result = {}
 
-        geom = dataset.counts.geom
+        geom = dataset_image.counts.geom
 
         for name, data in smoothed.items():
             # set remaining pixels with sqrt_ts < threshold to mean value

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -161,12 +161,9 @@ class FluxEstimator(Estimator):
             energy_min=self.energy_min, energy_max=self.energy_max
         )
 
-        new_names = [name + "-sliced" for name in datasets.names]
+        new_names = [name + "-slice" for name in datasets.names]
         models = datasets.models.reassign(datasets.names, new_names)
         datasets_sliced.models = models
-        for d in datasets_sliced:
-            if d.background_model:
-                d.background_model.reset_to_default()
 
         if len(datasets_sliced) > 0:
             # TODO: this relies on the energy binning of the first dataset

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -161,8 +161,7 @@ class FluxEstimator(Estimator):
             energy_min=self.energy_min, energy_max=self.energy_max
         )
 
-        new_names = [name + "-slice" for name in datasets.names]
-        models = datasets.models.reassign(datasets.names, new_names)
+        models = datasets.models.copy()
         datasets_sliced.models = models
 
         if len(datasets_sliced) > 0:

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -73,7 +73,7 @@ def test_flux_estimator_fermi_with_reoptimization(fermi_datasets):
     result = estimator.run(fermi_datasets)
 
     assert_allclose(result["norm"], 0.989989, atol=1e-3)
-    assert_allclose(result["ts"], 25083.75408, atol=1e-3)
+    assert_allclose(result["ts"], 18728.353031, atol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
 
 
@@ -134,7 +134,7 @@ def test_inhomogeneous_datasets(fermi_datasets, hess_datasets):
     result = estimator.run(datasets)
 
     assert_allclose(result["norm"], 1.190622, atol=1e-3)
-    assert_allclose(result["ts"], 660.422291, atol=1e-3)
+    assert_allclose(result["ts"], 612.500397, atol=1e-3)
     assert_allclose(result["norm_err"], 0.090744, atol=1e-3)
     assert_allclose(result["e_min"], 0.693145 * u.TeV, atol=1e-3)
     assert_allclose(result["e_max"], 2 * u.TeV, atol=1e-3)

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -73,7 +73,7 @@ def test_flux_estimator_fermi_with_reoptimization(fermi_datasets):
     result = estimator.run(fermi_datasets)
 
     assert_allclose(result["norm"], 0.989989, atol=1e-3)
-    assert_allclose(result["ts"], 18728.353031, atol=1e-3)
+    assert_allclose(result["ts"], 18729.907481, atol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
 
 
@@ -134,7 +134,7 @@ def test_inhomogeneous_datasets(fermi_datasets, hess_datasets):
     result = estimator.run(datasets)
 
     assert_allclose(result["norm"], 1.190622, atol=1e-3)
-    assert_allclose(result["ts"], 612.500397, atol=1e-3)
+    assert_allclose(result["ts"], 612.50171, atol=1e-3)
     assert_allclose(result["norm_err"], 0.090744, atol=1e-3)
     assert_allclose(result["e_min"], 0.693145 * u.TeV, atol=1e-3)
     assert_allclose(result["e_max"], 2 * u.TeV, atol=1e-3)

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -305,16 +305,16 @@ def test_run_map_pwl_reoptimize(fpe_map_pwl_reoptimize):
     assert_allclose(actual, 0.962368, rtol=1e-2)
 
     actual = fp.table["norm_err"].data
-    assert_allclose(actual, 0.051955, rtol=1e-2)
+    assert_allclose(actual, 0.053878, rtol=1e-2)
 
     actual = fp.table["sqrt_ts"].data
-    assert_allclose(actual, 28.408426, rtol=1e-2)
+    assert_allclose(actual, 25.196585, rtol=1e-2)
 
     actual = fp.table["norm_scan"][0]
     assert_allclose(actual, 1)
 
     actual = fp.table["stat_scan"][0] - fp.table["stat"][0]
-    assert_allclose(actual, 0.489359, rtol=1e-2)
+    assert_allclose(actual, 0.483593, rtol=1e-2)
 
 
 @requires_dependency("iminuit")

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -32,23 +32,33 @@ class FoVBackgroundMaker(Maker):
         Default norm spectral model to use for the `FoVBackgroundModel`, if none is defined
         on the dataset.
     """
-
     tag = "FoVBackgroundMaker"
+    available_methods = ["fit", "scale"]
 
     def __init__(
         self, method="scale", exclusion_mask=None, spectral_model_tag="pl-norm"
     ):
-        if method in ["fit", "scale"]:
-            self.method = method
-        else:
-            raise ValueError(f"Not a valid method for FoVBackgroundMaker: {method}.")
-
+        self.method = method
         self.exclusion_mask = exclusion_mask
 
         if "norm" not in spectral_model_tag:
             raise ValueError("Spectral model must be a norm spectral model")
 
         self.spectral_model_tag = spectral_model_tag
+
+    @property
+    def method(self):
+        """Method"""
+        return self._method
+
+    @method.setter
+    def method(self, value):
+        """Method setter"""
+        if value not in self.available_methods:
+            raise ValueError(f"Not a valid method for FoVBackgroundMaker: {value}."
+                             f" Choose from {self.available_methods}")
+
+        self._method = value
 
     def make_default_fov_background_model(self, dataset):
         """Add fov background model to the model definition

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -219,22 +219,25 @@ class Model:
             Name of the datasets where the model should be defined instead.
             If multiple names are given the two list must have the save lenght,
             as the reassignment is element-wise.
+
+        Returns
+        -------
+        model : `Model`
+            Reassigned model.
+
         """
         model = self.copy(name=self.name)
+
         if not isinstance(datasets_names, list):
             datasets_names = [datasets_names]
+
         if not isinstance(new_datasets_names, list):
             new_datasets_names = [new_datasets_names]
 
-        if model.datasets_names is not None:
-            if not isinstance(model.datasets_names, list):
-                model.datasets_names = [model.datasets_names]
-            for dataset_name, new_dataset_name in zip(
-                datasets_names, new_datasets_names
-            ):
-                for k, name in enumerate(model.datasets_names):
-                    if name == dataset_name:
-                        model.datasets_names[k] = new_dataset_name
+        if getattr(model, "datasets_names", None):
+            for name, name_new in zip(datasets_names, new_datasets_names):
+                model.datasets_names = [_.replace(name, name_new) for _ in model.datasets_names]
+
         return model
 
 

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -750,7 +750,6 @@ class Models(DatasetModels, collections.abc.MutableSequence):
 
 class restore_models_status:
     def __init__(self, models, restore_values=True):
-
         self.restore_values = restore_values
         self.models = models
         self.values = [_.value for _ in models.parameters]

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -648,6 +648,9 @@ class BackgroundModel(Model):
 
         self.spectral_model = spectral_model
 
+        if isinstance(datasets_names, str):
+            datasets_names = [datasets_names]
+
         if isinstance(datasets_names, list):
             if len(datasets_names) != 1:
                 raise ValueError(

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -42,7 +42,7 @@ def models(backgrounds):
     model2 = model1.copy(name="source-2")
     model2.datasets_names = ["dataset-1"]
     model3 = model1.copy(name="source-3")
-    model3.datasets_names = "dataset-2"
+    model3.datasets_names = ["dataset-2"]
     model3.spatial_model = PointSpatialModel()
     model3.parameters.freeze_all()
     models = Models([model1, model2, model3] + backgrounds)
@@ -229,8 +229,6 @@ def test_fov_bkg_models():
 
     assert models["test-1-bkg"].spectral_model.tilt.frozen
     assert models["test-1-bkg"].spectral_model.norm.frozen
-
-
 
 
 def test_reassign_dataset(models):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request unifies the `npred_background` handling in the `MapDataset` methods. The idea is that in methods such as `.to_image()` and `.to_spectrum()` we always rely on `background` and not `npred_background()`. I'm still not 100% sure whether this is the best default behaviour however it simplifies the model definition for the returned dataset a lot. Let's take it as a prototype and discuss some more...

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
