### PR TITLE
Improve the plot_region method for RegionNDMap and RegionGeom

### DIFF
--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -4,6 +4,8 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.wcs import WCS
+from astropy.visualization.wcsaxes import WCSAxes
+
 from astropy.wcs.utils import proj_plane_pixel_area, wcs_to_celestial_frame
 from regions import FITSRegionParser, fits_region_objects_to_table
 from gammapy.utils.regions import (
@@ -432,12 +434,16 @@ class RegionGeom(Geom):
         from matplotlib.collections import PatchCollection
 
         if ax is None:
-            wcs_geom = self.to_wcs_geom()
-            m = Map.from_geom(wcs_geom)
-            fig, ax, cbar = m.plot(add_cbar=False)
+            ax = plt.gca()
+            if not isinstance(ax, WCSAxes):
+                ax.remove()
+                wcs_geom = self.to_wcs_geom()
+                m = Map.from_geom(wcs_geom)
+                fig, ax, cbar = m.plot(add_cbar=False)
         regions = compound_region_to_list(self.region)
         artists = [region.to_pixel(wcs=ax.wcs).as_artist() for region in regions]
-
+        kwargs.setdefault("fc", "None")
+        kwargs.setdefault("ec", "b")
         patches = PatchCollection(artists, **kwargs)
         ax.add_collection(patches)
         return ax

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -12,7 +12,7 @@ from gammapy.utils.regions import (
     make_region,
 )
 from gammapy.maps.wcs import _check_width
-from .core import MapCoord
+from .core import MapCoord, Map
 from .geom import Geom, MapAxes, MapAxis, pix_tuple_to_idx
 from .wcs import WcsGeom
 
@@ -415,3 +415,29 @@ class RegionGeom(Geom):
                 self._region = self.region.union(other.region)
             else:
                 self._region = other.region
+
+    def plot_region(self, ax=None, **kwargs):
+        """Plot region in the sky.
+
+        Parameters
+        ----------
+        ax : `~astropy.vizualisation.WCSAxes`
+            Axes to plot on. If no axes are given,
+            the region is shown using the minimal
+            equivalent WCS geometry.
+        **kwargs : dict
+            Keyword arguments forwarded to `~regions.PixelRegion.as_artist`
+        """
+        import matplotlib.pyplot as plt
+        from matplotlib.collections import PatchCollection
+
+        if ax is None:
+            wcs_geom = self.to_wcs_geom()
+            m = Map.from_geom(wcs_geom)
+            fig, ax, cbar = m.plot(add_cbar=False)
+        regions = compound_region_to_list(self.region)
+        artists = [region.to_pixel(wcs=ax.wcs).as_artist() for region in regions]
+
+        patches = PatchCollection(artists, **kwargs)
+        ax.add_collection(patches)
+        return ax

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -142,21 +142,13 @@ class RegionNDMap(Map):
         Parameters
         ----------
         ax : `~astropy.vizualisation.WCSAxes`
-            Axes to plot on.
+            Axes to plot on. If no axes are given,
+            the region is shown using the minimal
+            equivalent WCS geometry.
         **kwargs : dict
             Keyword arguments forwarded to `~regions.PixelRegion.as_artist`
         """
-        import matplotlib.pyplot as plt
-        from matplotlib.collections import PatchCollection
-
-        if ax is None:
-            ax = plt.gca()
-
-        regions = compound_region_to_list(self.geom.region)
-        artists = [region.to_pixel(wcs=ax.wcs).as_artist() for region in regions]
-
-        patches = PatchCollection(artists, **kwargs)
-        ax.add_collection(patches)
+        ax = self.geom.plot_region(ax, **kwargs)
         return ax
 
     @classmethod

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -6,6 +6,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion, RectangleSkyRegion
 from gammapy.maps import MapAxis, RegionGeom
+from gammapy.utils.testing import mpl_plot_check, requires_dependency
 
 
 @pytest.fixture()
@@ -289,3 +290,12 @@ def test_get_wcs_coord(region):
     coord = SkyCoord("100d", "30d")
     assert geom.contains(region_coords.skycoord[0])
     assert geom.contains(coord) is not True
+
+@requires_dependency("matplotlib")
+def test_region_nd_map_plot(region):
+    import matplotlib.pyplot as plt
+    geom = RegionGeom(region)
+
+    ax = plt.subplot(projection=geom.wcs)
+    with mpl_plot_check():
+        geom.plot_region(ax=ax)

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -289,7 +289,7 @@ def test_get_wcs_coord(region):
     region_coords = geom.get_wcs_coord()
     coord = SkyCoord("100d", "30d")
     assert geom.contains(region_coords.skycoord[0])
-    assert geom.contains(coord) is not True
+    assert not geom.contains(coord)
 
 @requires_dependency("matplotlib")
 def test_region_nd_map_plot(region):


### PR DESCRIPTION
This pull request fixes the default behavior of `RegionNDMap.plot_region()`, which used to fail if no axis was provided. The method has also been moved to the RegionGeom class, so a RegionGeom can be plotted too. 

If no axis is provided, the default behavior now is to plot on the minimal WCS geometry given by `RegionGeom.to_wcs_geom()`
Some examples:
```
from gammapy.maps import RegionNDMap
region_map = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)")
region_map.plot_region()
```

and
```
from gammapy.maps import RegionGeom
geom = RegionGeom.create("icrs;circle(83.63, 22.01, 0.5)")
geom.plot_region()
```
now both result in the same image:

![image](https://user-images.githubusercontent.com/22521727/102247153-dcfbbc80-3eff-11eb-9a0f-97d29b6b4b01.png)
