### PR TITLE
Remove evaluator update from models setter

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -297,8 +297,6 @@ class MapDataset(Dataset):
                         gti=self.gti,
                         use_cache=USE_NPRED_CACHE,
                     )
-                    # TODO: do we need the update here?
-                    evaluator.update(self.exposure, self.psf, self.edisp, self._geom)
                     self._evaluators[model.name] = evaluator
 
         self._models = models

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -64,8 +64,14 @@ class MapDatasetEventSampler:
         events : `~gammapy.data.EventList`
             Event list
         """
+
         events_all = []
         for idx, evaluator in enumerate(dataset.evaluators.values()):
+            if evaluator.needs_update:
+                evaluator.update(
+                    dataset.exposure, dataset.psf, dataset.edisp, dataset._geom
+                )
+
             flux = evaluator.compute_flux()
             npred = evaluator.apply_exposure(flux)
 


### PR DESCRIPTION
Remove evaluator update from models setter for speed up.
Setting many models or reading large datasets will be considerably faster.
Then evaluators update will be done only  once npred is computed.
