### PR TITLE
Fix and cleanup RegionNDMap I/O

### DIFF
--- a/gammapy/datasets/io.py
+++ b/gammapy/datasets/io.py
@@ -190,8 +190,7 @@ class OGIPDatasetWriter(DatasetWriter):
         aeff.write(
             filename=filename,
             overwrite=self.overwrite,
-            format=self.format,
-            ogip_column="SPECRESP",
+            format=self.format.replace("ogip", "ogip-arf"),
         )
 
     def to_counts_hdulist(self, dataset, is_bkg=False):

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -547,6 +547,9 @@ class MapDataset(Dataset):
         if self.mask_safe is None:
             return None
 
+        if self.mask_safe.geom.is_region:
+            return self.mask_safe
+
         geom = self.edisp.edisp_map.geom.squash("energy_true")
 
         if "migra" in geom.axes.names:
@@ -1724,7 +1727,9 @@ class MapDatasetOnOff(MapDataset):
         alpha : `Map`
             Alpha map
         """
-        alpha = self.acceptance / self.acceptance_off
+        with np.errstate(invalid="ignore", divide="ignore"):
+            alpha = self.acceptance / self.acceptance_off
+
         alpha.data = np.nan_to_num(alpha.data)
         return alpha
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1330,12 +1330,10 @@ class MapAxis:
             Table HDU
         """
         table = Table()
+        edges = self.edges
 
         if format in ["ogip", "ogip-sherpa"]:
-            if "energy" not in self.name:
-                raise ValueError("Only energy axes can be converted to HDU")
-
-            edges = self.edges
+            self.assert_name("energy")
 
             if format == "ogip-sherpa":
                 edges = edges.to("keV")
@@ -1344,7 +1342,8 @@ class MapAxis:
             table["E_MIN"] = edges[:-1]
             table["E_MAX"] = edges[1:]
         elif format in ["ogip-arf", "ogip-arf-sherpa"]:
-            edges = self.edges
+            self.assert_name("energy_true")
+
             if format == "ogip-arf-sherpa":
                 edges = edges.to("keV")
 
@@ -1361,7 +1360,7 @@ class MapAxis:
                         break
 
             if self.node_type == "edges":
-                edges_hi, edges_lo = self.edges[:-1], self.edges[1:]
+                edges_hi, edges_lo = edges[:-1], edges[1:]
             else:
                 edges_hi, edges_lo = self.center, self.center
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1343,6 +1343,13 @@ class MapAxis:
             table["CHANNEL"] = np.arange(self.nbin, dtype=np.int16)
             table["E_MIN"] = edges[:-1]
             table["E_MAX"] = edges[1:]
+        elif format in ["ogip-arf", "ogip-arf-sherpa"]:
+            edges = self.edges
+            if format == "ogip-arf-sherpa":
+                edges = edges.to("keV")
+
+            table["ENERG_LO"] = edges[:-1]
+            table["ENERG_HI"] = edges[1:]
         elif format == "gadf-dl3":
             from gammapy.irf.io import IRF_DL3_AXES_SPECIFICATION
 

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -365,7 +365,9 @@ class RegionGeom(Geom):
         for reg in region_list:
             pixel_region_list.append(reg.to_pixel(self.wcs))
         table = fits_region_objects_to_table(pixel_region_list)
-        table.meta.update(self.wcs.to_header())
+
+        header = WcsGeom(wcs=self.wcs, npix=self.wcs.array_shape).to_header()
+        table.meta.update(header)
         return table
 
     def to_hdulist(self, format="ogip"):
@@ -417,7 +419,7 @@ class RegionGeom(Geom):
             region_table = Table.read(hdulist["REGION"])
             parser = FITSRegionParser(region_table)
             pix_region = parser.shapes.to_regions()
-            wcs = WCS(region_table.meta)
+            wcs = WcsGeom.from_header(region_table.meta).wcs
 
             regions = []
             for reg in pix_region:
@@ -468,7 +470,7 @@ class RegionGeom(Geom):
             if not isinstance(ax, WCSAxes):
                 ax.remove()
                 wcs_geom = self.to_wcs_geom()
-                m = Map.from_geom(wcs_geom)
+                m = Map.from_geom(wcs_geom.to_image())
                 fig, ax, cbar = m.plot(add_cbar=False)
 
         regions = compound_region_to_list(self.region)

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -5,7 +5,6 @@ from astropy.table import Table
 from astropy.visualization import quantity_support
 from gammapy.extern.skimage import block_reduce
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
-from gammapy.utils.regions import compound_region_to_list
 from gammapy.utils.scripts import make_path
 from .core import Map
 from .geom import pix_tuple_to_idx
@@ -353,7 +352,7 @@ class RegionNDMap(Map):
         quantity = table[ogip_column].quantity
 
         if ogip_column == "QUALITY":
-            data, unit = np.logical_not(quantity.value), ""
+            data, unit = np.logical_not(quantity.value.astype(bool)), ""
         else:
             data, unit = quantity.value, quantity.unit
 
@@ -376,7 +375,6 @@ class RegionNDMap(Map):
             Array to be used as weights. The spatial geometry must be equivalent
             to `other` and additional axes must be broadcastable.
         """
-        # TODO: check and remove the type-cast here...
         data = other.quantity.to_value(self.unit).astype(self.data.dtype)
 
         # TODO: re-think stacking of regions. Is making the union reasonable?

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -457,7 +457,8 @@ class RegionNDMap(Map):
         else:
             raise ValueError(f"Unsupported format: '{format}'")
 
-        table.meta.update(self.meta)
+        meta = {k: self.meta.get(k, v) for k, v in table.meta.items()}
+        table.meta.update(meta)
         return table
 
     def get_spectrum(self, *args, **kwargs):

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -309,10 +309,17 @@ class RegionNDMap(Map):
         hdulist : `~astropy.fits.HDUList`
             HDU list
         """
+        hdulist = fits.HDUList()
+
+        # add data hdu
         table = self.to_table(format=format)
-        return fits.HDUList(
-            [fits.PrimaryHDU(), fits.BinTableHDU(table)]
-        )
+        hdulist.append(fits.BinTableHDU(table))
+
+        if format in ["ogip", "ogip-sherpa"]:
+            hdulist_geom = self.geom.to_hdulist(format=format)[1:]
+            hdulist.extend(hdulist_geom)
+
+        return hdulist
 
     @classmethod
     def from_hdulist(cls, hdulist, format="ogip", ogip_column="COUNTS"):

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -286,7 +286,7 @@ class RegionNDMap(Map):
         ----------
         filename : `pathlib.Path` or str
             Filename.
-        format : {"ogip", "ogip-arf", "ogip-arf-sherpa"}
+        format : {"ogip", "ogip-sherpa", "ogip-arf", "ogip-arf-sherpa"}
             Which format to use.
         overwrite : bool
             Overwrite existing files?
@@ -301,7 +301,7 @@ class RegionNDMap(Map):
 
         Parameters
         ----------
-        format : {"ogip", "ogip-sherpa"}
+        format : {"ogip", "ogip-sherpa", "ogip-arf", "ogip-arf-sherpa"}
             Format specification
 
         Returns

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -404,14 +404,15 @@ class RegionNDMap(Map):
         table : `~astropy.table.Table`
             Table
         """
-        if len(self.geom.axes) > 1 or not self.geom.has_energy_axis:
-            raise ValueError(f"Writing to format '{format}' is only "
-                             "supported for a single energy axis.")
+        if len(self.geom.axes) > 1:
+            raise ValueError(f"Writing to format '{format}' only supports a "
+                             f"single energy axis. Got {self.geom.axes.names}")
 
         data = np.nan_to_num(self.quantity[:, 0, 0])
         energy_axis = self.geom.axes[0]
 
         if format == "ogip":
+            energy_axis.assert_name("energy")
             table = Table()
             table["CHANNEL"] = np.arange(energy_axis.nbin, dtype=np.int16)
             table["COUNTS"] = np.array(data, dtype=np.int32)
@@ -419,7 +420,6 @@ class RegionNDMap(Map):
 
         elif format in ["ogip-arf", "ogip-arf-sherpa"]:
             table = energy_axis.to_table(format=format)
-
             table.meta = {
                 "EXTNAME": "SPECRESP",
                 "hduclass": "OGIP",

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -440,6 +440,7 @@ class WcsGeom(Geom):
             wcs_shape = eval(header["WCSSHAPE"])
             npix = (wcs_shape[0], wcs_shape[1])
             cdelt = None
+            wcs.array_shape = npix
         else:
             npix = (header["NAXIS1"], header["NAXIS2"])
             cdelt = None


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes the issue mentioned by @LauraOlivera here: https://github.com/gammapy/gammapy/pull/3165#issuecomment-747554443

In general it introduces consistently the following formats:
- "ogip" and "ogip-sherpa": stores data in repo energy, along with the REGION and EBOUNDS HDU
- "ogip-arf" and "ogip-arf-sherpa": store data in true energy, with energy info. Region info is lost

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
