### PR TITLE
Make more use of MapAxis and MapAxes in gammapy.irf

### DIFF
--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -256,10 +256,16 @@ def test_spectrum_dataset_stack_diagonal_safe_mask(spectrum_dataset):
 
 
 def test_spectrum_dataset_stack_nondiagonal_no_bkg(spectrum_dataset):
-    energy = spectrum_dataset.counts.geom.axes[0]
+    energy = spectrum_dataset.counts.geom.axes["energy"]
     geom = spectrum_dataset.counts.geom.to_image()
 
-    edisp1 = EDispKernelMap.from_gauss(energy, energy, 0.1, 0, geom=geom)
+    edisp1 = EDispKernelMap.from_gauss(
+        energy_axis=energy,
+        energy_axis_true=energy.copy(name="energy_true"),
+        sigma=0.1,
+        bias=0,
+        geom=geom
+    )
     edisp1.exposure_map.data += 1
 
     aeff = EffectiveAreaTable.from_parametrization(energy.edges, "HESS").to_region_map(
@@ -278,7 +284,13 @@ def test_spectrum_dataset_stack_nondiagonal_no_bkg(spectrum_dataset):
         gti=gti.copy(),
     )
 
-    edisp2 = EDispKernelMap.from_gauss(energy, energy, 0.2, 0.0, geom=geom)
+    edisp2 = EDispKernelMap.from_gauss(
+        energy_axis=energy,
+        energy_axis_true=energy.copy(name="energy_true"),
+        sigma=0.2,
+        bias=0.0,
+        geom=geom
+    )
     edisp2.exposure_map.data += 1
 
     gti2 = GTI.create(start=100 * u.s, stop=200 * u.s)
@@ -804,7 +816,7 @@ def make_observation_list():
 
     aeff = RegionNDMap.from_geom(geom_true, data=1, unit="m2")
     edisp = EDispKernelMap.from_gauss(
-        energy_axis=axis, energy_axis_true=axis, sigma=0.2, bias=0, geom=geom
+        energy_axis=axis, energy_axis_true=axis_true, sigma=0.2, bias=0, geom=geom
     )
 
     time_ref = Time("2010-01-01")

--- a/gammapy/irf/edisp_kernel.py
+++ b/gammapy/irf/edisp_kernel.py
@@ -161,7 +161,7 @@ class EDispKernel:
         return edisp.to_edisp_kernel(offset=offset_axis.center[0], energy=energy_axis.edges)
 
     @classmethod
-    def from_diagonal_response(cls, energy_true, energy=None):
+    def from_diagonal_response(cls, energy_axis_true, energy_axis=None):
         """Create energy dispersion from a diagonal response, i.e. perfect energy resolution
 
         This creates the matrix corresponding to a perfect energy response.
@@ -173,31 +173,33 @@ class EDispKernel:
 
         Parameters
         ----------
-        energy_true, energy : `~astropy.units.Quantity`
-            Energy edges for true and reconstructed energy axis
+        energy_axis_true, energy_axis : `MapAxis`
+            True and reconstructed energy axis
 
         Examples
         --------
         If ``energy_true`` equals ``energy``, you get a diagonal matrix::
 
-            energy_true = [0.5, 1, 2, 4, 6] * u.TeV
-            edisp = EnergyDispersion.from_diagonal_response(energy_true)
+            from gammapy.irf import EDispKernel
+            from gammapy.maps import MapAxis
+
+            energy_true_axis = MapAxis.from_energy_edges([0.5, 1, 2, 4, 6] * u.TeV, name="energy_true")
+            edisp = EDispKernel.from_diagonal_response(energy_true_axis)
             edisp.plot_matrix()
 
         Example with different energy binnings::
 
-            energy_true = [0.5, 1, 2, 4, 6] * u.TeV
-            energy = [2, 4, 6] * u.TeV
-            edisp = EnergyDispersion.from_diagonal_response(energy_true, energy)
+            energy_true_axis = MapAxis.from_energy_edges([0.5, 1, 2, 4, 6] * u.TeV, name="energy_true")
+            energy_axis = MapAxis.from_energy_edges([2, 4, 6] * u.TeV)
+            edisp = EDispKernel.from_diagonal_response(energy_true_axis, energy_axis)
             edisp.plot_matrix()
         """
         from .edisp_map import get_overlap_fraction
 
-        if energy is None:
-            energy = energy_true
+        energy_axis_true.assert_name("energy_true")
 
-        energy_axis = MapAxis.from_energy_edges(energy)
-        energy_axis_true = MapAxis.from_energy_edges(energy_true, name="energy_true")
+        if energy_axis is None:
+            energy_axis = energy_axis_true.copy(name="energy")
 
         data = get_overlap_fraction(energy_axis, energy_axis_true)
         return cls(

--- a/gammapy/irf/edisp_kernel.py
+++ b/gammapy/irf/edisp_kernel.py
@@ -142,6 +142,11 @@ class EDispKernel:
             RMS width of Gaussian energy dispersion, resolution
         pdf_threshold : float, optional
             Zero suppression threshold
+
+        Returns
+        -------
+        edisp : `EDispKernel`
+            Edisp kernel.
         """
         from .energy_dispersion import EnergyDispersion2D
 

--- a/gammapy/irf/edisp_kernel.py
+++ b/gammapy/irf/edisp_kernel.py
@@ -125,16 +125,16 @@ class EDispKernel:
         )
 
     @classmethod
-    def from_gauss(cls, energy_true, energy, sigma, bias, pdf_threshold=1e-6):
+    def from_gauss(cls, energy_axis_true, energy_axis, sigma, bias, pdf_threshold=1e-6):
         """Create Gaussian energy dispersion matrix (`EnergyDispersion`).
 
         Calls :func:`gammapy.irf.EnergyDispersion2D.from_gauss`
 
         Parameters
         ----------
-        energy_true : `~astropy.units.Quantity`
+        energy_axis_true : `~astropy.units.Quantity`
             Bin edges of true energy axis
-        energy : `~astropy.units.Quantity`
+        energy_axis : `~astropy.units.Quantity`
             Bin edges of reconstructed energy axis
         bias : float or `~numpy.ndarray`
             Center of Gaussian energy dispersion, bias
@@ -145,19 +145,20 @@ class EDispKernel:
         """
         from .energy_dispersion import EnergyDispersion2D
 
-        migra = np.linspace(1.0 / 3, 3, 200)
+        migra_axis = MapAxis.from_bounds(1.0 / 3, 3, nbin=200, name="migra")
+
         # A dummy offset axis (need length 2 for interpolation to work)
-        offset = Quantity([0, 1, 2], "deg")
+        offset_axis = MapAxis.from_edges([0, 1, 2], unit="deg", name="offset")
 
         edisp = EnergyDispersion2D.from_gauss(
-            energy_true=energy_true,
-            migra=migra,
+            energy_axis_true=energy_axis_true,
+            migra_axis=migra_axis,
+            offset_axis=offset_axis,
             sigma=sigma,
             bias=bias,
-            offset=offset,
             pdf_threshold=pdf_threshold,
         )
-        return edisp.to_edisp_kernel(offset=offset[0], energy=energy)
+        return edisp.to_edisp_kernel(offset=offset_axis.center[0], energy=energy_axis.edges)
 
     @classmethod
     def from_diagonal_response(cls, energy_true, energy=None):

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -464,8 +464,16 @@ class EDispKernelMap(IRFMap):
 
         Parameters
         ----------
-        edisp : `~gammapy.irfs.EDispKernel`
-            the input 1D kernel.
+        energy_axis_true : `~astropy.units.Quantity`
+            Bin edges of true energy axis
+        energy_axis : `~astropy.units.Quantity`
+            Bin edges of reconstructed energy axis
+        bias : float or `~numpy.ndarray`
+            Center of Gaussian energy dispersion, bias
+        sigma : float or `~numpy.ndarray`
+            RMS width of Gaussian energy dispersion, resolution
+        pdf_threshold : float, optional
+            Zero suppression threshold
         geom : `~gammapy.maps.Geom`
             The (2D) geom object to use. Default creates an all sky geometry with 2 bins.
 
@@ -475,8 +483,8 @@ class EDispKernelMap(IRFMap):
             Energy dispersion kernel map.
         """
         kernel = EDispKernel.from_gauss(
-            energy=energy_axis.edges,
-            energy_true=energy_axis_true.edges,
+            energy_axis=energy_axis,
+            energy_axis_true=energy_axis_true,
             sigma=sigma,
             bias=bias,
             pdf_threshold=pdf_threshold,

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -3,7 +3,7 @@ import numpy as np
 import astropy.units as u
 from astropy.io import fits
 from astropy.table import Table
-from gammapy.maps import MapAxis, RegionGeom, RegionNDMap
+from gammapy.maps import MapAxis, MapAxes, RegionGeom, RegionNDMap
 from gammapy.utils.nddata import NDDataArray
 from gammapy.utils.scripts import make_path
 
@@ -212,7 +212,7 @@ class EffectiveAreaTable:
 
         Data format specification: :ref:`gadf:ogip-arf`
         """
-        table = Table()
+        table = self.energy.to_table(format="ogip-arf")
         table.meta = {
             "EXTNAME": "SPECRESP",
             "hduclass": "OGIP",
@@ -388,16 +388,13 @@ class EffectiveAreaTable2D:
     @classmethod
     def from_table(cls, table):
         """Read from `~astropy.table.Table`."""
-        energy_axis_true = MapAxis.from_table(
-            table, column_prefix="ENERG", format="gadf-dl3"
-        )
-        offset_axis = MapAxis.from_table(
-            table, column_prefix="THETA", format="gadf-dl3"
+        axes = MapAxes.from_table(
+            table=table, column_prefixes=["ENERG", "THETA"], format="gadf-dl3"
         )
 
         return cls(
-            energy_axis_true=energy_axis_true,
-            offset_axis=offset_axis,
+            energy_axis_true=axes["energy_true"],
+            offset_axis=axes["offset"],
             data=table["EFFAREA"].quantity[0].transpose(),
             meta=table.meta,
         )

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -6,7 +6,7 @@ from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.table import Table
 from astropy.units import Quantity
-from gammapy.maps import MapAxis
+from gammapy.maps import MapAxis, MapAxes
 from gammapy.utils.nddata import NDDataArray
 from gammapy.utils.scripts import make_path
 from .edisp_kernel import EDispKernel
@@ -136,34 +136,39 @@ class EnergyDispersion2D:
 
     @classmethod
     def from_table(cls, table):
-        """Create from `~astropy.table.Table`."""
-        # TODO: move this to MapAxis.from_table()
+        """Create from `~astropy.table.Table`.
+
+        Parameters
+        ----------
+        table : `~astropy.table.Table`
+            Table with effective area.
+
+        Returns
+        -------
+        aeff : `EffectiveArea2D`
+            Effective area
+        """
 
         if "ENERG_LO" in table.colnames:
-            energy_axis_true = MapAxis.from_table(
-                table, column_prefix="ENERG", format="gadf-dl3"
-            )
+            column_prefixes = ["ENERG", "THETA", "MIGRA"]
         elif "ETRUE_LO" in table.colnames:
-            energy_axis_true = MapAxis.from_table(
-                table, column_prefix="ETRUE", format="gadf-dl3"
-            )
+            column_prefixes = ["ETRUE", "THETA", "MIGRA"]
         else:
             raise ValueError(
                 'Invalid column names. Need "ENERG_LO/ENERG_HI" or "ETRUE_LO/ETRUE_HI"'
             )
 
-        offset_axis = MapAxis.from_table(
-            table, column_prefix="THETA", format="gadf-dl3"
+        axes = MapAxes.from_table(
+            table, column_prefixes=column_prefixes, format="gadf-dl3"
         )
-        migra_axis = MapAxis.from_table(table, column_prefix="MIGRA", format="gadf-dl3")
 
-        matrix = table["MATRIX"].quantity[0].transpose()
+        data = table["MATRIX"].quantity[0].transpose()
 
         return cls(
-            energy_axis_true=energy_axis_true,
-            offset_axis=offset_axis,
-            migra_axis=migra_axis,
-            data=matrix,
+            energy_axis_true=axes["energy_true"],
+            offset_axis=axes["offset"],
+            migra_axis=axes["migra"],
+            data=data,
         )
 
     @classmethod

--- a/gammapy/irf/tests/test_edisp_map.py
+++ b/gammapy/irf/tests/test_edisp_map.py
@@ -13,8 +13,7 @@ from gammapy.irf import (
     EnergyDispersion2D,
 )
 from gammapy.makers.utils import make_edisp_map, make_map_exposure_true_energy
-from gammapy.maps import Map, MapAxis, MapCoord, RegionGeom, WcsGeom
-from gammapy.utils.regions import make_region
+from gammapy.maps import MapAxis, MapCoord, RegionGeom, WcsGeom
 
 
 def fake_aeff2d(area=1e6 * u.m ** 2):
@@ -34,24 +33,27 @@ def fake_aeff2d(area=1e6 * u.m ** 2):
 
 
 def make_edisp_map_test():
-    etrue = [0.2, 0.7, 1.5, 2.0, 10.0] * u.TeV
-    migra = np.linspace(0.0, 3.0, 51)
-    offsets = np.array((0.0, 1.0, 2.0, 3.0)) * u.deg
-
     pointing = SkyCoord(0, 0, unit="deg")
-    energy_axis = MapAxis(
-        nodes=[0.2, 0.7, 1.5, 2.0, 10.0],
-        unit="TeV",
+
+    energy_axis_true = MapAxis.from_energy_edges(
+        energy_edges=[0.2, 0.7, 1.5, 2.0, 10.0] * u.TeV,
         name="energy_true",
-        node_type="edges",
-        interp="log",
     )
+
     migra_axis = MapAxis(nodes=np.linspace(0.0, 3.0, 51), unit="", name="migra")
 
-    edisp2d = EnergyDispersion2D.from_gauss(etrue, migra, 0.0, 0.2, offsets)
+    offset_axis = MapAxis.from_nodes([0.0, 1.0, 2.0, 3.0] * u.deg, name="offset")
+
+    edisp2d = EnergyDispersion2D.from_gauss(
+        energy_axis_true=energy_axis_true,
+        migra_axis=migra_axis,
+        offset_axis=offset_axis,
+        bias=0,
+        sigma=0.2,
+    )
 
     geom = WcsGeom.create(
-        skydir=pointing, binsz=1.0, width=5.0, axes=[migra_axis, energy_axis]
+        skydir=pointing, binsz=1.0, width=5.0, axes=[migra_axis, energy_axis_true]
     )
 
     aeff2d = fake_aeff2d()
@@ -254,8 +256,7 @@ def test_edispkernel_from_diagonal_response():
         "0.3 TeV", "10 TeV", nbin=11, name="energy"
     )
 
-    region = make_region("fk5;circle(0.,0., 10.")
-    geom = RegionGeom(region)
+    geom = RegionGeom.create("fk5;circle(0.,0., 10.")
     region_edisp = EDispKernelMap.from_diagonal_response(
         energy_axis, energy_axis_true, geom=geom
     )
@@ -266,7 +267,7 @@ def test_edispkernel_from_diagonal_response():
     assert_allclose(sum_kernel[1:-1], 1)
 
 
-def test_edispkernel_from_1D():
+def test_edispkernel_from_1d():
     energy_axis_true = MapAxis.from_energy_bounds(
         "0.5 TeV", "5 TeV", nbin=31, name="energy_true"
     )
@@ -274,14 +275,16 @@ def test_edispkernel_from_1D():
         "0.1 TeV", "10 TeV", nbin=11, name="energy"
     )
 
-    edisp = EDispKernel.from_gauss(energy_axis_true.edges, energy_axis.edges, 0.1, 0.0)
-    region = make_region("fk5;circle(0.,0., 10.")
-    geom = RegionGeom(region)
+    edisp = EDispKernel.from_gauss(energy_axis_true, energy_axis, 0.1, 0.0)
+
+    geom = RegionGeom.create("fk5;circle(0.,0., 10.")
     region_edisp = EDispKernelMap.from_edisp_kernel(edisp, geom=geom)
+
     sum_kernel = np.sum(region_edisp.edisp_map.data[..., 0, 0], axis=1)
     assert_allclose(sum_kernel, 1, rtol=1e-5)
 
     allsky_edisp = EDispKernelMap.from_edisp_kernel(edisp)
+
     sum_kernel = np.sum(allsky_edisp.edisp_map.data[..., 0, 0], axis=1)
     assert allsky_edisp.edisp_map.data.shape == (31, 11, 1, 2)
     assert_allclose(sum_kernel, 1, rtol=1e-5)

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -24,10 +24,10 @@ class TestEDispKernel:
         )
 
     def test_from_diagonal_response(self):
-        e_true = [0.5, 1, 2, 4, 6] * u.TeV
-        e_reco = [2, 4, 6] * u.TeV
+        energy_axis_true = MapAxis.from_energy_edges([0.5, 1, 2, 4, 6] * u.TeV, name="energy_true")
+        energy_axis = MapAxis.from_energy_edges([2, 4, 6] * u.TeV)
 
-        edisp = EDispKernel.from_diagonal_response(e_true, e_reco)
+        edisp = EDispKernel.from_diagonal_response(energy_axis_true, energy_axis)
 
         assert edisp.pdf_matrix.shape == (4, 2)
         expected = [[0, 0], [0, 0], [1, 0], [0, 1]]
@@ -35,8 +35,8 @@ class TestEDispKernel:
         assert_equal(edisp.pdf_matrix, expected)
 
         # Test square matrix
-        edisp = EDispKernel.from_diagonal_response(e_true)
-        assert_allclose(edisp.energy_axis.edges.value, e_true.value)
+        edisp = EDispKernel.from_diagonal_response(energy_axis_true)
+        assert_allclose(edisp.energy_axis.edges, energy_axis_true.edges)
         assert edisp.energy_axis.unit == "TeV"
         assert_equal(edisp.pdf_matrix[0][0], 1)
         assert_equal(edisp.pdf_matrix[2][0], 0)

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -10,13 +10,14 @@ from gammapy.utils.testing import mpl_plot_check, requires_data, requires_depend
 
 class TestEDispKernel:
     def setup(self):
-        self.e_true = np.logspace(0, 1, 101) * u.TeV
-        self.e_reco = self.e_true
+        energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=100)
+        energy_axis_true = energy_axis.copy(name="energy_true")
+
         self.resolution = 0.1
         self.bias = 0
         self.edisp = EDispKernel.from_gauss(
-            energy_true=self.e_true,
-            energy=self.e_reco,
+            energy_axis_true=energy_axis_true,
+            energy_axis=energy_axis,
             pdf_threshold=1e-7,
             sigma=self.resolution,
             bias=self.bias,
@@ -42,12 +43,15 @@ class TestEDispKernel:
         assert edisp.pdf_matrix.sum() == 4
 
     def test_to_image(self):
-        e_reco = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=3)
-        e_true = MapAxis.from_energy_bounds(
+        energy_axis = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=3)
+        energy_axis_true = MapAxis.from_energy_bounds(
             "0.08 TeV", "20 TeV", nbin=5, name="energy_true"
         )
         edisp = EDispKernel.from_gauss(
-            energy=e_reco.edges, energy_true=e_true.edges, sigma=0.2, bias=0.1
+            energy_axis=energy_axis,
+            energy_axis_true=energy_axis_true,
+            sigma=0.2,
+            bias=0.1
         )
         im = edisp.to_image()
 
@@ -105,12 +109,24 @@ class TestEnergyDispersion2D:
         cls.edisp = EnergyDispersion2D.read(filename, hdu="EDISP")
 
         # Make a test case
-        e_true = np.logspace(-1.0, 2.0, 51) * u.TeV
-        migra = np.linspace(0.0, 4.0, 1001)
-        offset = np.linspace(0.0, 2.5, 5) * u.deg
-        sigma = 0.15 / (e_true[:-1] / (1 * u.TeV)).value ** 0.3
-        bias = 1e-3 * (e_true[:-1] - 1 * u.TeV).value
-        cls.edisp2 = EnergyDispersion2D.from_gauss(e_true, migra, bias, sigma, offset)
+        energy_axis_true = MapAxis.from_energy_bounds(
+            "0.1 TeV", "100 TeV", nbin=50, name="energy_true"
+        )
+
+        migra_axis = MapAxis.from_bounds(0, 4, nbin=1000, node_type="edges", name="migra")
+        offset_axis = MapAxis.from_bounds(0, 2.5, nbin=5, unit="deg", name="offset")
+
+        energy_true = energy_axis_true.edges[:-1]
+        sigma = 0.15 / (energy_true / (1 * u.TeV)).value ** 0.3
+        bias = 1e-3 * (energy_true - 1 * u.TeV).value
+
+        cls.edisp2 = EnergyDispersion2D.from_gauss(
+            energy_axis_true=energy_axis_true,
+            migra_axis=migra_axis,
+            bias=bias,
+            sigma=sigma,
+            offset_axis=offset_axis
+        )
 
     def test_str(self):
         assert "EnergyDispersion2D" in str(self.edisp)

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -261,7 +261,11 @@ def test_make_edisp_kernel_map():
     ereco = MapAxis.from_energy_bounds(0.5, 2, 3, unit="TeV", name="energy")
 
     edisp = EnergyDispersion2D.from_gauss(
-        etrue.edges, migra.edges, 0, 0.01, offset.edges
+        energy_axis_true=etrue,
+        migra_axis=migra,
+        bias=0,
+        sigma=0.01,
+        offset_axis=offset
     )
 
     geom = WcsGeom.create(10, binsz=0.5, axes=[ereco, etrue])

--- a/gammapy/maps/tests/test_regionnd.py
+++ b/gammapy/maps/tests/test_regionnd.py
@@ -151,10 +151,10 @@ def test_region_nd_map_fill_events(region_map):
 
 
 def test_apply_edisp(region_map_true):
-    e_true = region_map_true.geom.axes[0].edges
-    e_reco = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3).edges
+    e_true = region_map_true.geom.axes[0]
+    e_reco = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
 
-    edisp = EDispKernel.from_diagonal_response(energy_true=e_true, energy=e_reco)
+    edisp = EDispKernel.from_diagonal_response(energy_axis_true=e_true, energy_axis=e_reco)
 
     m = region_map_true.apply_edisp(edisp)
     assert m.geom.data_shape == (3, 1, 1)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -96,9 +96,11 @@ def background(geom):
 
 @pytest.fixture(scope="session")
 def edisp(geom, geom_true):
-    e_reco = geom.axes["energy"].edges
-    e_true = geom_true.axes["energy_true"].edges
-    return EDispKernel.from_diagonal_response(energy_true=e_true, energy=e_reco)
+    e_reco = geom.axes["energy"]
+    e_true = geom_true.axes["energy_true"]
+    return EDispKernel.from_diagonal_response(
+        energy_axis_true=e_true, energy_axis=e_reco
+    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request implements some changes to make more use of `MapAxis` and `MapAxes` in `gammapy.irf`:
- Use `MapAxis` in methods like `EnergyDispersion2D.from_gauss()` and `EDIsapKernel.from_gauss()`
- Simplify some I/O code to use `MapAxes` 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
