### PR TITLE
Introduce FluxEstimate class

### DIFF
--- a/gammapy/estimators/flux_estimate.py
+++ b/gammapy/estimators/flux_estimate.py
@@ -10,6 +10,7 @@ SED_TYPES = ["dnde", "e2dnde", "flux", "eflux"]
 
 OPTIONAL_QUANTITIES = ["err", "errn", "errp", "ul", "scan"]
 
+
 class FluxEstimate:
     """A flux estimate produced by an Estimator.
 
@@ -31,6 +32,7 @@ class FluxEstimate:
     spectral_model : `SpectralModel`
         Reference spectral model used to produce the input data.
     """
+
     def __init__(self, data, spectral_model):
         # TODO: Check data
         self.data = data
@@ -38,14 +40,14 @@ class FluxEstimate:
         if hasattr(self.data["norm"], "geom"):
             self.energy_axis = self.data["norm"].geom.axes["energy"]
             self._keys = self.data.keys()
-            self._expand_slice = (slice(None),np.newaxis, np.newaxis)
+            self._expand_slice = (slice(None), np.newaxis, np.newaxis)
         else:
             # Here we assume there is only one row per energy
             e_edges = self.data["e_min"].quantity
             e_edges = e_edges.insert(len(self.data), self.data["e_max"].quantity[-1])
             self.energy_axis = MapAxis.from_energy_edges(e_edges)
             self._keys = self.data.columns
-            self._expand_slice = (slice(None))
+            self._expand_slice = slice(None)
 
         # Note that here we could use the specification from dnde_ref to build piecewise PL
         # But does it work beyond min and max centers?
@@ -58,11 +60,13 @@ class FluxEstimate:
             if norm_quantity in self._keys:
                 self._available_quantities.append(quantity)
 
-    #TODO: add support for scan
+    # TODO: add support for scan
 
     def _check_norm_quantity(self, quantity):
         if not quantity in self._available_quantities:
-            raise KeyError(f"Cannot compute required flux quantity. {quantity} is not defined on current flux estimate.")
+            raise KeyError(
+                f"Cannot compute required flux quantity. {quantity} is not defined on current flux estimate."
+            )
 
     @property
     def norm(self):
@@ -95,9 +99,10 @@ class FluxEstimate:
 
     @property
     def e2dnde_ref(self):
-        result = self.spectral_model(self.energy_axis.center)*self.energy_axis.center**2
+        result = (
+            self.spectral_model(self.energy_axis.center) * self.energy_axis.center ** 2
+        )
         return result[self._expand_slice]
-
 
     @property
     def flux_ref(self):
@@ -166,7 +171,7 @@ class FluxEstimate:
     @property
     def flux(self):
         """Return integral flux (flux) SED values."""
-        return  self.norm * self.flux_ref
+        return self.norm * self.flux_ref
 
     @property
     def flux_err(self):

--- a/gammapy/estimators/flux_estimate.py
+++ b/gammapy/estimators/flux_estimate.py
@@ -52,6 +52,8 @@ class FluxEstimate:
             if norm_quantity in self.data.columns:
                 self._available_quantities.append(quantity)
 
+    #TODO: add support for scan
+
     def _check_norm_quantity(self, quantity):
         if not quantity in self._available_quantities:
             raise KeyError(f"Cannot compute required flux quantity. {quantity} is not defined on current flux estimate.")

--- a/gammapy/estimators/flux_estimate.py
+++ b/gammapy/estimators/flux_estimate.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from gammapy.maps import Geom
+from gammapy.modeling.models import PowerLawSpectralModel
 
 __all__ = ["FluxEstimate"]
 
@@ -23,9 +24,13 @@ class FluxEstimate:
     energy_axis : `MapAxis`
         Reference energy axis
     """
-    def __init__(self, data, spectral_model):
+    def __init__(self, data, spectral_model=None):
         # TODO: Check data
         self._data = data
+
+        if spectral_model is None:
+            spectral_model = PowerLawSpectralModel(index=2)
+
         self.spectral_model = spectral_model
 
         if hasattr(self.data["norm"], Geom):
@@ -73,8 +78,6 @@ class FluxEstimate:
     def norm_ul(self):
         return self.data["norm_ul"]
 
-    def get_flux_quantity(self, type, quantity=""):
-
     @property
     def dnde(self):
         return self.dnde_ref * self.norm
@@ -95,3 +98,62 @@ class FluxEstimate:
     def dnde_ul(self):
         return self.dnde_ref * self.norm_ul
 
+    @property
+    def e2dnde(self):
+        return self.e2dnde_ref * self.norm
+
+    @property
+    def e2dnde_err(self):
+        return self.e2dnde_ref * self.norm_err
+
+    @property
+    def e2dnde_errn(self):
+        return self.e2dnde_ref * self.norm_errn
+
+    @property
+    def e2dnde_errp(self):
+        return self.e2dnde_ref * self.norm_errp
+
+    @property
+    def e2dnde_ul(self):
+        return self.e2dnde_ref * self.norm_ul
+
+    @property
+    def flux(self):
+        return self.flux_ref * self.norm
+
+    @property
+    def flux_err(self):
+        return self.flux_ref * self.norm_err
+
+    @property
+    def flux_errn(self):
+        return self.flux_ref * self.norm_errn
+
+    @property
+    def flux_errp(self):
+        return self.flux_ref * self.norm_errp
+
+    @property
+    def eflux_ul(self):
+        return self.eflux_ref * self.norm_ul
+
+    @property
+    def eflux(self):
+        return self.eflux_ref * self.norm
+
+    @property
+    def eflux_err(self):
+        return self.eflux_ref * self.norm_err
+
+    @property
+    def eflux_errn(self):
+        return self.eflux_ref * self.norm_errn
+
+    @property
+    def eflux_errp(self):
+        return self.eflux_ref * self.norm_errp
+
+    @property
+    def eflux_ul(self):
+        return self.eflux_ref * self.norm_ul

--- a/gammapy/estimators/flux_estimate.py
+++ b/gammapy/estimators/flux_estimate.py
@@ -1,0 +1,97 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from gammapy.maps import Geom
+
+__all__ = ["FluxEstimate"]
+
+
+SED_TYPES = ["dnde", "e2dnde", "flux", "eflux"]
+
+OPTIONAL_QUANTITIES = ["err", "errn", "errp", "ul", "scan"]
+
+class FluxEstimate:
+    """A flux estimate produced by an Estimator.
+
+    Follows the likelihood SED type description and allows norm values
+    to be converted to dnde, flux, eflux and e2dnde
+
+    Parameters
+    ----------
+    data : dict of `Map` or `Table`
+        Mappable containing the sed likelihood data
+    spectral_model : `SpectralModel`
+        Reference spectral model
+    energy_axis : `MapAxis`
+        Reference energy axis
+    """
+    def __init__(self, data, spectral_model):
+        # TODO: Check data
+        self._data = data
+        self.spectral_model = spectral_model
+
+        if hasattr(self.data["norm"], Geom):
+            self.energy_axis = self.data["norm"].geom.axes["energy"]
+        else:
+            pass
+
+    @property
+    def dnde_ref(self):
+        return self.spectral_model(self.energy_axis.center)
+
+    @property
+    def e2dnde_ref(self):
+        return self.spectral_model(self.energy_axis.center)*self.energy_axis.center**2
+
+    @property
+    def flux_ref(self):
+        energy_min = self.energy_axis.edges[:-1]
+        energy_max = self.energy_axis.edges[1:]
+        return self.spectral_model.integral(energy_min, energy_max)
+
+    @property
+    def eflux_ref(self):
+        energy_min = self.energy_axis.edges[:-1]
+        energy_max = self.energy_axis.edges[1:]
+        return self.spectral_model.energy_flux(energy_min, energy_max)
+
+    @property
+    def norm(self):
+        return self.data["norm"]
+
+    @property
+    def norm_err(self):
+        return self.data["norm_err"]
+
+    @property
+    def norm_errn(self):
+        return self.data["norm_errn"]
+
+    @property
+    def norm_errp(self):
+        return self.data["norm_errp"]
+
+    @property
+    def norm_ul(self):
+        return self.data["norm_ul"]
+
+    def get_flux_quantity(self, type, quantity=""):
+
+    @property
+    def dnde(self):
+        return self.dnde_ref * self.norm
+
+    @property
+    def dnde_err(self):
+        return self.dnde_ref * self.norm_err
+
+    @property
+    def dnde_errn(self):
+        return self.dnde_ref * self.norm_errn
+
+    @property
+    def dnde_errp(self):
+        return self.dnde_ref * self.norm_errp
+
+    @property
+    def dnde_ul(self):
+        return self.dnde_ref * self.norm_ul
+

--- a/gammapy/estimators/flux_estimate.py
+++ b/gammapy/estimators/flux_estimate.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from gammapy.maps import Geom
+import astropy.units as u
+from gammapy.maps import Geom, MapAxis
 from gammapy.modeling.models import PowerLawSpectralModel
 
 __all__ = ["FluxEstimate"]
@@ -20,23 +21,27 @@ class FluxEstimate:
     data : dict of `Map` or `Table`
         Mappable containing the sed likelihood data
     spectral_model : `SpectralModel`
-        Reference spectral model
-    energy_axis : `MapAxis`
-        Reference energy axis
+        Reference spectral model.
     """
-    def __init__(self, data, spectral_model=None):
+    def __init__(self, data, spectral_model):
         # TODO: Check data
-        self._data = data
+        self.data = data
 
-        if spectral_model is None:
-            spectral_model = PowerLawSpectralModel(index=2)
-
-        self.spectral_model = spectral_model
-
-        if hasattr(self.data["norm"], Geom):
+        if hasattr(self.data["norm"], "Geom"):
             self.energy_axis = self.data["norm"].geom.axes["energy"]
         else:
-            pass
+            # Here we assume there is only one row per energy
+            e_edges = self.data["e_min"].quantity
+            e_edges = e_edges.insert(len(self.data), self.data["e_max"].quantity[-1])
+            self.energy_axis = MapAxis.from_energy_edges(e_edges)
+
+        # Note that here we could use the specification from dnde_ref to build piecewise PL
+        # But does it work beyond min and max centers?
+        self.spectral_model = spectral_model
+
+        for quantity in OPTIONAL_QUANTITIES:
+            name_property = f"norm_{quantity}"
+            setattr(self, name_property, self.data[name_property])
 
     @property
     def dnde_ref(self):
@@ -61,7 +66,7 @@ class FluxEstimate:
     @property
     def norm(self):
         return self.data["norm"]
-
+"""
     @property
     def norm_err(self):
         return self.data["norm_err"]
@@ -157,3 +162,5 @@ class FluxEstimate:
     @property
     def eflux_ul(self):
         return self.eflux_ref * self.norm_ul
+
+"""

--- a/gammapy/estimators/tests/test_flux_estimate.py
+++ b/gammapy/estimators/tests/test_flux_estimate.py
@@ -8,42 +8,44 @@ from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.maps import MapAxis, WcsNDMap
 from gammapy.estimators.flux_estimate import FluxEstimate
 
+
 @pytest.fixture(scope="session")
 def table_flux_estimate():
-    axis = MapAxis.from_energy_edges((0.1, 1., 10.), unit='TeV')
+    axis = MapAxis.from_energy_edges((0.1, 1.0, 10.0), unit="TeV")
 
     cols = dict()
-    cols['norm'] = np.array([1.0, 1.0])
-    cols['norm_err'] = np.array([0.1, 0.1])
-    cols['norm_errn'] = np.array([0.2, 0.2])
-    cols['norm_errp'] = np.array([0.15, 0.15])
-    cols['norm_ul'] = np.array([2.0, 2.0])
-    cols['e_min'] = axis.edges[:-1]
-    cols['e_max'] = axis.edges[1:]
+    cols["norm"] = np.array([1.0, 1.0])
+    cols["norm_err"] = np.array([0.1, 0.1])
+    cols["norm_errn"] = np.array([0.2, 0.2])
+    cols["norm_errp"] = np.array([0.15, 0.15])
+    cols["norm_ul"] = np.array([2.0, 2.0])
+    cols["e_min"] = axis.edges[:-1]
+    cols["e_max"] = axis.edges[1:]
 
     table = Table(cols, names=cols.keys())
 
     return table
 
+
 @pytest.fixture(scope="session")
 def map_flux_estimate():
-    axis = MapAxis.from_energy_edges((0.1, 1., 10.), unit='TeV')
+    axis = MapAxis.from_energy_edges((0.1, 1.0, 10.0), unit="TeV")
 
     nmap = WcsNDMap.create(npix=5, axes=[axis])
 
     cols = dict()
-    cols['norm'] = nmap.copy(data=1.0)
-    cols['norm_err'] = nmap.copy(data=0.1)
-    cols['norm_errn'] = nmap.copy(data=0.2)
-    cols['norm_errp'] = nmap.copy(data=0.15)
-    cols['norm_ul'] = nmap.copy(data=2.0)
+    cols["norm"] = nmap.copy(data=1.0)
+    cols["norm_err"] = nmap.copy(data=0.1)
+    cols["norm_errn"] = nmap.copy(data=0.2)
+    cols["norm_errp"] = nmap.copy(data=0.15)
+    cols["norm_ul"] = nmap.copy(data=2.0)
 
     return cols
 
 
 class TestFluxEstimate:
     def test_table_properties(self, table_flux_estimate):
-        model = PowerLawSpectralModel(amplitude='1e-10 cm-2s-1TeV-1', index=2)
+        model = PowerLawSpectralModel(amplitude="1e-10 cm-2s-1TeV-1", index=2)
         fe = FluxEstimate(data=table_flux_estimate, spectral_model=model)
 
         assert fe.dnde.unit == u.Unit("cm-2s-1TeV-1")
@@ -64,28 +66,46 @@ class TestFluxEstimate:
 
     def test_missing_column(self, table_flux_estimate):
         table_flux_estimate.remove_column("norm_errn")
-        model = PowerLawSpectralModel(amplitude='1e-10 cm-2s-1TeV-1', index=2)
+        model = PowerLawSpectralModel(amplitude="1e-10 cm-2s-1TeV-1", index=2)
         fe = FluxEstimate(data=table_flux_estimate, spectral_model=model)
 
         with pytest.raises(KeyError):
             fe.dnde_errn
 
     def test_map_properties(self, map_flux_estimate):
-        model = PowerLawSpectralModel(amplitude='1e-10 cm-2s-1TeV-1', index=2)
+        model = PowerLawSpectralModel(amplitude="1e-10 cm-2s-1TeV-1", index=2)
         fe = FluxEstimate(data=map_flux_estimate, spectral_model=model)
 
         assert fe.dnde.unit == u.Unit("cm-2s-1TeV-1")
-        assert_allclose(fe.dnde.quantity.value[:,2,2], [1e-9, 1e-11])
-        assert_allclose(fe.dnde_err.quantity.value[:,2,2], [1e-10, 1e-12])
-        assert_allclose(fe.dnde_errn.quantity.value[:,2,2], [2e-10, 2e-12])
-        assert_allclose(fe.dnde_errp.quantity.value[:,2,2], [1.5e-10, 1.5e-12])
-        assert_allclose(fe.dnde_ul.quantity.value[:,2,2], [2e-9, 2e-11])
+        assert_allclose(fe.dnde.quantity.value[:, 2, 2], [1e-9, 1e-11])
+        assert_allclose(fe.dnde_err.quantity.value[:, 2, 2], [1e-10, 1e-12])
+        assert_allclose(fe.dnde_errn.quantity.value[:, 2, 2], [2e-10, 2e-12])
+        assert_allclose(fe.dnde_errp.quantity.value[:, 2, 2], [1.5e-10, 1.5e-12])
+        assert_allclose(fe.dnde_ul.quantity.value[:, 2, 2], [2e-9, 2e-11])
 
         assert fe.e2dnde.unit == u.Unit("TeV cm-2s-1")
-        assert_allclose(fe.e2dnde.quantity.value[:,2,2], [1e-10, 1e-10])
+        assert_allclose(fe.e2dnde.quantity.value[:, 2, 2], [1e-10, 1e-10])
+        assert_allclose(fe.e2dnde_err.quantity.value[:, 2, 2], [1e-11, 1e-11])
+        assert_allclose(fe.e2dnde_errn.quantity.value[:, 2, 2], [2e-11, 2e-11])
+        assert_allclose(fe.e2dnde_errp.quantity.value[:, 2, 2], [1.5e-11, 1.5e-11])
+        assert_allclose(fe.e2dnde_ul.quantity.value[:, 2, 2], [2e-10, 2e-10])
 
         assert fe.flux.unit == u.Unit("cm-2s-1")
-        assert_allclose(fe.flux.quantity.value[:,2,2], [9e-10, 9e-11])
+        assert_allclose(fe.flux.quantity.value[:, 2, 2], [9e-10, 9e-11])
+        assert_allclose(fe.flux_err.quantity.value[:, 2, 2], [9e-11, 9e-12])
+        assert_allclose(fe.flux_errn.quantity.value[:, 2, 2], [1.8e-10, 1.8e-11])
+        assert_allclose(fe.flux_errp.quantity.value[:, 2, 2], [1.35e-10, 1.35e-11])
+        assert_allclose(fe.flux_ul.quantity.value[:, 2, 2], [1.8e-9, 1.8e-10])
 
         assert fe.eflux.unit == u.Unit("TeV cm-2s-1")
-        assert_allclose(fe.eflux.quantity.value[:,2,2], [2.302585e-10, 2.302585e-10])
+        assert_allclose(fe.eflux.quantity.value[:, 2, 2], [2.302585e-10, 2.302585e-10])
+        assert_allclose(
+            fe.eflux_err.quantity.value[:, 2, 2], [2.302585e-11, 2.302585e-11]
+        )
+        assert_allclose(
+            fe.eflux_errn.quantity.value[:, 2, 2], [4.60517e-11, 4.60517e-11]
+        )
+        assert_allclose(
+            fe.eflux_errp.quantity.value[:, 2, 2], [3.4538775e-11, 3.4538775e-11]
+        )
+        assert_allclose(fe.eflux_ul.quantity.value[:, 2, 2], [4.60517e-10, 4.60517e-10])

--- a/gammapy/estimators/tests/test_flux_estimate.py
+++ b/gammapy/estimators/tests/test_flux_estimate.py
@@ -1,0 +1,61 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+import astropy.units as u
+from astropy.table import Table
+import astropy.units as u
+from gammapy.modeling.models import PowerLawSpectralModel
+from gammapy.maps import MapAxis
+from gammapy.estimators.flux_estimate import FluxEstimate
+
+@pytest.fixture(scope="session")
+def table_flux_estimate():
+    axis = MapAxis.from_energy_edges((0.1, 1., 10.), unit='TeV')
+
+    cols = dict()
+    cols['norm'] = np.array([1.0, 1.0])
+    cols['norm_err'] = np.array([0.1, 0.1])
+    cols['norm_errn'] = np.array([0.2, 0.2])
+    cols['norm_errp'] = np.array([0.15, 0.15])
+    cols['norm_ul'] = np.array([2.0, 2.0])
+    cols['e_min'] = axis.edges[:-1]
+    cols['e_max'] = axis.edges[1:]
+
+    table = Table(cols, names=cols.keys())
+
+    print(axis.center)
+    print(table)
+    return table
+
+
+    return FluxEstimate(data=table, spectral_model=model)
+
+class TestTableFluxEstimate:
+    def test_properties(self, table_flux_estimate):
+        model = PowerLawSpectralModel(amplitude='1e-10 cm-2s-1TeV-1', index=2)
+        fe = FluxEstimate(data=table_flux_estimate, spectral_model=model)
+
+        assert fe.dnde.unit == u.Unit("cm-2s-1TeV-1")
+        assert_allclose(fe.dnde.value, [1e-9, 1e-11])
+        assert_allclose(fe.dnde_err.value, [1e-10, 1e-12])
+        assert_allclose(fe.dnde_errn.value, [2e-10, 2e-12])
+        assert_allclose(fe.dnde_errp.value, [1.5e-10, 1.5e-12])
+        assert_allclose(fe.dnde_ul.value, [2e-9, 2e-11])
+
+        assert fe.e2dnde.unit == u.Unit("TeV cm-2s-1")
+        assert_allclose(fe.e2dnde.value, [1e-10, 1e-10])
+
+        assert fe.flux.unit == u.Unit("cm-2s-1")
+        assert_allclose(fe.flux.value, [9e-10, 9e-11])
+
+        assert fe.eflux.unit == u.Unit("TeV cm-2s-1")
+        assert_allclose(fe.eflux.value, [2.302585e-10, 2.302585e-10])
+
+    def test_missing_column(self, table_flux_estimate):
+        table_flux_estimate.remove_column("norm_errn")
+        model = PowerLawSpectralModel(amplitude='1e-10 cm-2s-1TeV-1', index=2)
+        fe = FluxEstimate(data=table_flux_estimate, spectral_model=model)
+
+        with pytest.raises(KeyError):
+            fe.dnde_errn

--- a/gammapy/estimators/tests/test_flux_estimate.py
+++ b/gammapy/estimators/tests/test_flux_estimate.py
@@ -29,8 +29,6 @@ def table_flux_estimate():
     return table
 
 
-    return FluxEstimate(data=table, spectral_model=model)
-
 class TestTableFluxEstimate:
     def test_properties(self, table_flux_estimate):
         model = PowerLawSpectralModel(amplitude='1e-10 cm-2s-1TeV-1', index=2)

--- a/gammapy/estimators/tests/test_flux_estimate.py
+++ b/gammapy/estimators/tests/test_flux_estimate.py
@@ -2,11 +2,10 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-import astropy.units as u
 from astropy.table import Table
 import astropy.units as u
 from gammapy.modeling.models import PowerLawSpectralModel
-from gammapy.maps import MapAxis
+from gammapy.maps import MapAxis, WcsNDMap
 from gammapy.estimators.flux_estimate import FluxEstimate
 
 @pytest.fixture(scope="session")
@@ -24,13 +23,26 @@ def table_flux_estimate():
 
     table = Table(cols, names=cols.keys())
 
-    print(axis.center)
-    print(table)
     return table
 
+@pytest.fixture(scope="session")
+def map_flux_estimate():
+    axis = MapAxis.from_energy_edges((0.1, 1., 10.), unit='TeV')
 
-class TestTableFluxEstimate:
-    def test_properties(self, table_flux_estimate):
+    nmap = WcsNDMap.create(npix=5, axes=[axis])
+
+    cols = dict()
+    cols['norm'] = nmap.copy(data=1.0)
+    cols['norm_err'] = nmap.copy(data=0.1)
+    cols['norm_errn'] = nmap.copy(data=0.2)
+    cols['norm_errp'] = nmap.copy(data=0.15)
+    cols['norm_ul'] = nmap.copy(data=2.0)
+
+    return cols
+
+
+class TestFluxEstimate:
+    def test_table_properties(self, table_flux_estimate):
         model = PowerLawSpectralModel(amplitude='1e-10 cm-2s-1TeV-1', index=2)
         fe = FluxEstimate(data=table_flux_estimate, spectral_model=model)
 
@@ -57,3 +69,23 @@ class TestTableFluxEstimate:
 
         with pytest.raises(KeyError):
             fe.dnde_errn
+
+    def test_map_properties(self, map_flux_estimate):
+        model = PowerLawSpectralModel(amplitude='1e-10 cm-2s-1TeV-1', index=2)
+        fe = FluxEstimate(data=map_flux_estimate, spectral_model=model)
+
+        assert fe.dnde.unit == u.Unit("cm-2s-1TeV-1")
+        assert_allclose(fe.dnde.quantity.value[:,2,2], [1e-9, 1e-11])
+        assert_allclose(fe.dnde_err.quantity.value[:,2,2], [1e-10, 1e-12])
+        assert_allclose(fe.dnde_errn.quantity.value[:,2,2], [2e-10, 2e-12])
+        assert_allclose(fe.dnde_errp.quantity.value[:,2,2], [1.5e-10, 1.5e-12])
+        assert_allclose(fe.dnde_ul.quantity.value[:,2,2], [2e-9, 2e-11])
+
+        assert fe.e2dnde.unit == u.Unit("TeV cm-2s-1")
+        assert_allclose(fe.e2dnde.quantity.value[:,2,2], [1e-10, 1e-10])
+
+        assert fe.flux.unit == u.Unit("cm-2s-1")
+        assert_allclose(fe.flux.quantity.value[:,2,2], [9e-10, 9e-11])
+
+        assert fe.eflux.unit == u.Unit("TeV cm-2s-1")
+        assert_allclose(fe.eflux.quantity.value[:,2,2], [2.302585e-10, 2.302585e-10])


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds the `FluxEstimate` class that will serve as a basis for flux estimators results.  Following the proposal in PIG 22, it is designed to take a reference `SpectralModel` and a `data` element containing `norm` based quantities.  `data` can be a `Table` or a `dict` of `Map` to support flux points or flux maps.

Properties are defined to allow direct access to flux quantities in the various SED types defined in the current version of gadf (namely dnde, e2dnde, flux and eflux).  

Tests have been added to check both `Table` and `Map` inputs.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
