### PR TITLE
Fix CI with python version 3.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false # true
       matrix:
         include:
-          - name: Linux python 3.6.1 core
+          - name: Linux python 3.6.2 core
             os: ubuntu-latest
           - name: Linux python 3.7 all
             os: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
       - name: install python3.6
         if: contains(matrix.name, '3.6')
         run: |
-          sed -i 's/python==3.7/python==3.6.1/' environment-dev.yml
+          sed -i 's/python==3.7/python==3.6.2/' environment-dev.yml
       - name: install python3.8
         if: contains(matrix.name, '3.8')
         run: |


### PR DESCRIPTION
This PR fixes `ImportError: cannot import name NoReturn` in CI using python version 3.6.2 instead of 3.6.1

