### PR TITLE
Correct WcsNDMap full sky plot

### DIFF
--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -586,7 +586,8 @@ def test_plot_grid():
 
 @requires_dependency("matplotlib")
 def test_plot_allsky():
-    m = WcsNDMap.create(binsz=10 * u.deg)
+    axis = MapAxis([0, 1], node_type="edges")
+    m = WcsNDMap.create(binsz=10 * u.deg, axes=[axis])
     with mpl_plot_check():
         m.plot()
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -414,11 +414,11 @@ class WcsNDMap(WcsMap):
         ax.coords.frame.set_linewidth(0)
 
         # Set plot axis limits
-        xmin, _ = self.geom.coord_to_pix({"lon": 180, "lat": 0})
-        xmax, _ = self.geom.coord_to_pix({"lon": -180, "lat": 0})
+        xmin, _ = self.geom.to_image().coord_to_pix({"lon": 180, "lat": 0})
+        xmax, _ = self.geom.to_image().coord_to_pix({"lon": -180, "lat": 0})
 
-        _, ymin = self.geom.coord_to_pix({"lon": 0, "lat": -90})
-        _, ymax = self.geom.coord_to_pix({"lon": 0, "lat": 90})
+        _, ymin = self.geom.to_image().coord_to_pix({"lon": 0, "lat": -90})
+        _, ymax = self.geom.to_image().coord_to_pix({"lon": 0, "lat": 90})
 
         ax.set_xlim(xmin, xmax)
         ax.set_ylim(ymin, ymax)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects issue #3189 . It simply changes the method plotting the all sky map, by using the `Map.geom.to_image()`.
The corresponding test is modified to test all-sky maps with 1 bin axis.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
