### PR TITLE
Remove code duplication between SpectrumDatasetMaker and MapDatasetMaker

### DIFF
--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -262,7 +262,7 @@ def test_analysis_1d_stacked():
     pars = analysis.fit_result.parameters
 
     assert_allclose(pars["index"].value, 2.76913, rtol=1e-2)
-    assert_allclose(pars["amplitude"].value, 5.410243e-11, rtol=1e-2)
+    assert_allclose(pars["amplitude"].value, 5.479729e-11, rtol=1e-2)
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -386,6 +386,7 @@ def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
     dataset.gti = gti
 
     hdulist = dataset.to_hdulist()
+
     actual = [hdu.name for hdu in hdulist]
 
     desired = [
@@ -431,6 +432,8 @@ def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
 
     assert dataset.counts.geom == dataset_new.counts.geom
     assert dataset.exposure.geom == dataset_new.exposure.geom
+
+    assert_allclose(dataset.exposure.meta["livetime"], 1 * u.h)
     assert dataset.npred_background().geom == dataset_new.npred_background().geom
     assert dataset.edisp.edisp_map.geom == dataset_new.edisp.edisp_map.geom
 

--- a/gammapy/irf/edisp_kernel.py
+++ b/gammapy/irf/edisp_kernel.py
@@ -438,7 +438,10 @@ class EDispKernel(IRF):
         if energy_max is None:
             energy_max = energy_true[-1]
 
-        bias_spectrum = TemplateSpectralModel(energy_true, values)
+        bias_spectrum = TemplateSpectralModel(
+            energy=energy_true, values=values
+        )
+
         energy_true_bias = bias_spectrum.inverse(
             Quantity(bias), energy_min=energy_min, energy_max=energy_max
         )

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -197,6 +197,7 @@ class MapDatasetMaker(Maker):
             exposure = None
             interp_map = observation.edisp.edisp_map.interp_to_geom(geom)
             return EDispKernelMap(edisp_kernel_map=interp_map, exposure_map=exposure)
+
         exposure = self.make_exposure_irf(geom.squash(axis_name="energy"), observation)
 
         return make_edisp_kernel_map(

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -159,14 +159,11 @@ class SafeMaskMaker(Maker):
         """
         edisp, geom = dataset.edisp, dataset._geom
 
-        position = self.position
-        if position is None:
-            position = dataset.counts.geom.center_skydir
-            e_reco = dataset.counts.geom.axes["energy"].edges
         if isinstance(edisp, EDispKernelMap):
-            edisp = edisp.get_edisp_kernel(position)
+            edisp = edisp.get_edisp_kernel(self.position)
         else:
-            edisp = edisp.get_edisp_kernel(position, e_reco)
+            e_reco = dataset.counts.geom.axes["energy"].edges
+            edisp = edisp.get_edisp_kernel(self.position, e_reco)
 
         energy_min = edisp.get_bias_energy(self.bias_percent / 100)
         return geom.energy_mask(energy_min=energy_min)

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -5,8 +5,8 @@ from astropy.table import Table
 from regions import CircleSkyRegion
 from gammapy.datasets import SpectrumDataset
 from gammapy.maps import RegionNDMap
-from .core import Maker
-from .utils import make_map_exposure_true_energy, make_edisp_kernel_map, make_map_background_irf
+from .map import MapDatasetMaker
+#from .utils import make_map_exposure_true_energy, make_edisp_kernel_map, make_map_background_irf
 
 
 __all__ = ["SpectrumDatasetMaker"]
@@ -14,7 +14,7 @@ __all__ = ["SpectrumDatasetMaker"]
 log = logging.getLogger(__name__)
 
 
-class SpectrumDatasetMaker(Maker):
+class SpectrumDatasetMaker(MapDatasetMaker):
     """Make spectrum for a single IACT observation.
 
     The irfs and background are computed at a single fixed offset,
@@ -28,60 +28,17 @@ class SpectrumDatasetMaker(Maker):
         By default, all spectra are made.
     containment_correction : bool
         Apply containment correction for point sources and circular on regions.
+    background_oversampling : int
+        Background evaluation oversampling factor in energy.
     """
 
     tag = "SpectrumDatasetMaker"
     available_selection = ["counts", "background", "exposure", "edisp"]
 
-    def __init__(self, selection=None, containment_correction=False):
+    def __init__(self, selection=None, containment_correction=False, background_oversampling=None):
         self.containment_correction = containment_correction
-
-        if selection is None:
-            selection = self.available_selection
-
-        self.selection = selection
-
-    @staticmethod
-    def make_counts(geom, observation):
-        """Make counts map.
-
-        Parameters
-        ----------
-        geom : `~gammapy.maps.RegionGeom`
-            Reference map geom.
-        observation : `~gammapy.data.Observation`
-            Observation container.
-
-        Returns
-        -------
-        counts : `~gammapy.maps.RegionNDMap`
-            Counts map.
-        """
-        counts = RegionNDMap.from_geom(geom)
-        counts.fill_events(observation.events)
-        return counts
-
-    @staticmethod
-    def make_background(geom, observation):
-        """Make background.
-
-        Parameters
-        ----------
-        geom : `~gammapy.maps.RegionGeom`
-            Reference map geom.
-        observation: `~gammapy.data.Observation`
-            Observation to compute effective area for.
-
-        Returns
-        -------
-        background : `~gammapy.maps.RegionNDMap`
-            Background spectrum
-        """
-        return make_map_background_irf(
-            pointing=observation.pointing_radec,
-            ontime=observation.observation_time_duration,
-            bkg=observation.bkg,
-            geom=geom,
+        super().__init__(
+            selection=selection, background_oversampling=background_oversampling
         )
 
     def make_exposure(self, geom, observation):
@@ -99,12 +56,7 @@ class SpectrumDatasetMaker(Maker):
         exposure : `~gammapy.irf.EffectiveAreaTable`
             Exposure map.
         """
-        exposure = make_map_exposure_true_energy(
-            pointing=observation.pointing_radec,
-            livetime=observation.observation_live_time_duration,
-            aeff=observation.aeff,
-            geom=geom,
-        )
+        exposure = super().make_exposure(geom, observation)
 
         if self.containment_correction:
             if not isinstance(geom.region, CircleSkyRegion):
@@ -120,85 +72,3 @@ class SpectrumDatasetMaker(Maker):
             exposure.data *= containment.reshape(geom.data_shape)
 
         return exposure
-
-    def make_edisp_kernel(self, geom, observation):
-        """Make energy dispersion.
-
-        Parameters
-        ----------
-        geom : `~gammapy.maps.Geom`
-            Reference geom. Must contain "energy" and "energy_true" axes in that order.
-        observation: `~gammapy.data.Observation`
-            Observation to compute edisp for.
-
-        Returns
-        -------
-        edisp : `~gammapy.irf.EDispKernelMap`
-            Energy dispersion kernel map
-        """
-        exposure = self.make_exposure(geom.squash(axis_name="energy"), observation)
-
-        return make_edisp_kernel_map(
-            edisp=observation.edisp,
-            pointing=observation.pointing_radec,
-            geom=geom,
-            exposure_map=exposure,
-        )
-
-    @staticmethod
-    def make_meta_table(observation):
-        """Make info meta table.
-
-        Parameters
-        ----------
-        observation : `~gammapy.data.Observation`
-            Observation
-
-        Returns
-        -------
-        meta_table: `~astropy.table.Table`
-        """
-        meta_table = Table()
-        meta_table["TELESCOP"] = [observation.aeff.meta.get("TELESCOP")]
-        meta_table["OBS_ID"] = [observation.obs_id]
-        meta_table["RA_PNT"] = [observation.pointing_radec.icrs.ra.deg] * u.deg
-        meta_table["DEC_PNT"] = [observation.pointing_radec.icrs.dec.deg] * u.deg
-        return meta_table
-
-    def run(self, dataset, observation):
-        """Make spectrum dataset.
-
-        Parameters
-        ----------
-        dataset : `~gammapy.datasets.SpectrumDataset`
-            Spectrum dataset.
-        observation: `~gammapy.data.Observation`
-            Observation to reduce.
-
-        Returns
-        -------
-        dataset : `~gammapy.datasets.SpectrumDataset`
-            Spectrum dataset.
-        """
-        kwargs = {
-            "gti": observation.gti,
-            "meta_table": self.make_meta_table(observation),
-        }
-
-        if "counts" in self.selection:
-            kwargs["counts"] = self.make_counts(dataset.counts.geom, observation)
-
-        if "background" in self.selection:
-            kwargs["background"] = self.make_background(
-                dataset.counts.geom, observation
-            )
-
-        if "exposure" in self.selection:
-            kwargs["exposure"] = self.make_exposure(dataset.exposure.geom, observation)
-
-        if "edisp" in self.selection:
-            kwargs["edisp"] = self.make_edisp_kernel(
-                dataset.edisp.edisp_map.geom, observation
-            )
-
-        return SpectrumDataset(name=dataset.name, **kwargs)

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -144,24 +144,14 @@ class SpectrumDatasetMaker(Maker):
         edisp : `~gammapy.irf.EDispKernelMap`
             Energy dispersion kernel map
         """
-        make_edisp_kernel_map(
-            
+        exposure = self.make_exposure(geom.squash(axis_name="energy"), observation)
+
+        return make_edisp_kernel_map(
+            edisp=observation.edisp,
+            pointing=observation.pointing_radec,
+            geom=geom,
+            exposure_map=exposure,
         )
-        position = geom.center_skydir
-        energy_axis = geom.axes["energy"]
-        energy_axis_true = geom.axes["energy_true"]
-
-        offset = observation.pointing_radec.separation(position)
-
-        kernel = observation.edisp.to_edisp_kernel(
-            offset, energy=energy_axis.edges, energy_true=energy_axis_true.edges
-        )
-
-        edisp = EDispKernelMap.from_edisp_kernel(kernel, geom=geom.to_image())
-
-        exposure = self.make_exposure(geom.squash("energy"), observation)
-        edisp.exposure_map.data = exposure.data[:, :, np.newaxis, :]
-        return edisp
 
     @staticmethod
     def make_meta_table(observation):

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -1,12 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
-from astropy import units as u
-from astropy.table import Table
 from regions import CircleSkyRegion
-from gammapy.datasets import SpectrumDataset
-from gammapy.maps import RegionNDMap
 from .map import MapDatasetMaker
-#from .utils import make_map_exposure_true_energy, make_edisp_kernel_map, make_map_background_irf
 
 
 __all__ = ["SpectrumDatasetMaker"]

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -83,8 +83,8 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hes
     assert_allclose(datasets[0].exposure.meta["livetime"].value, 1581.736758)
     assert_allclose(datasets[1].exposure.meta["livetime"].value, 1572.686724)
 
-    assert_allclose(datasets[0].npred_background().data.sum(), 7.74732, rtol=1e-5)
-    assert_allclose(datasets[1].npred_background().data.sum(), 6.118879, rtol=1e-5)
+    assert_allclose(datasets[0].npred_background().data.sum(), 7.747881, rtol=1e-5)
+    assert_allclose(datasets[1].npred_background().data.sum(), 5.731624, rtol=1e-5)
 
 
 @requires_data()
@@ -103,8 +103,8 @@ def test_spectrum_dataset_maker_hess_cta(spectrum_dataset_gc, observations_cta_d
     assert_allclose(datasets[0].exposure.meta["livetime"].value, 1764.000034)
     assert_allclose(datasets[1].exposure.meta["livetime"].value, 1764.000034)
 
-    assert_allclose(datasets[0].npred_background().data.sum(), 2.238345, rtol=1e-5)
-    assert_allclose(datasets[1].npred_background().data.sum(), 2.164593, rtol=1e-5)
+    assert_allclose(datasets[0].npred_background().data.sum(), 2.238805, rtol=1e-5)
+    assert_allclose(datasets[1].npred_background().data.sum(), 2.165188, rtol=1e-5)
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -110,7 +110,7 @@ def test_spectrum_dataset_maker_hess_cta(spectrum_dataset_gc, observations_cta_d
 @requires_data()
 def test_safe_mask_maker_dl3(spectrum_dataset_crab, observations_hess_dl3):
 
-    safe_mask_maker = SafeMaskMaker()
+    safe_mask_maker = SafeMaskMaker(bias_percent=20)
     maker = SpectrumDatasetMaker()
 
     obs = observations_hess_dl3[0]
@@ -123,7 +123,7 @@ def test_safe_mask_maker_dl3(spectrum_dataset_crab, observations_hess_dl3):
     assert mask_safe.data.sum() == 4
 
     mask_safe = safe_mask_maker.make_mask_energy_edisp_bias(dataset)
-    assert mask_safe.data.sum() == 3
+    assert mask_safe.data.sum() == 2
 
     mask_safe = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
     assert mask_safe.data.sum() == 3
@@ -162,7 +162,7 @@ class TestSpectrumMakerChain:
             (
                 dict(containment_correction=False),
                 dict(
-                    n_on=125, sigma=18.953014, aeff=580254.9 * u.m ** 2, edisp=0.235864
+                    n_on=125, sigma=18.953014, aeff=580254.9 * u.m ** 2, edisp=0.23635
                 ),
             ),
             (
@@ -171,7 +171,7 @@ class TestSpectrumMakerChain:
                     n_on=125,
                     sigma=18.953014,
                     aeff=375314.356461 * u.m ** 2,
-                    edisp=0.235864,
+                    edisp=0.23635,
                 ),
             ),
         ],

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -160,7 +160,7 @@ def make_map_background_irf(pointing, ontime, bkg, geom, oversampling=None):
 
     d_omega = geom.to_image().solid_angle()
     data = (bkg_de * d_omega * ontime).to_value("")
-    bkg_map = WcsNDMap(geom, data=data)
+    bkg_map = Map.from_geom(geom, data=data)
 
     if oversampling is not None:
         bkg_map = bkg_map.downsample(factor=oversampling, axis_name="energy")

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -49,8 +49,9 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
     )
 
     exposure = (exposure * livetime).to("m2 s")
+    meta = {"livetime": livetime}
     return Map.from_geom(
-        geom=geom, data=exposure.value, unit=exposure.unit,
+        geom=geom, data=exposure.value, unit=exposure.unit, meta=meta
     )
 
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -9,7 +9,7 @@ from astropy.io import fits
 from gammapy.maps.hpx import HpxGeom
 from gammapy.utils.scripts import make_path
 from .geom import MapAxis, MapCoord, pix_tuple_to_idx
-from .utils import INVALID_VALUE
+from .utils import INVALID_VALUE, JsonQuantityDecoder
 
 __all__ = ["Map"]
 
@@ -246,7 +246,7 @@ class Map(abc.ABC):
     def _get_meta_from_header(header):
         """Load meta data from a FITS header."""
         if "META" in header:
-            return json.loads(header["META"])
+            return json.loads(header["META"], cls=JsonQuantityDecoder)
         else:
             return {}
 

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -3,8 +3,9 @@ import json
 import numpy as np
 from astropy.io import fits
 from .core import Map
-from .utils import find_bands_hdu, find_hdu
+from .utils import find_bands_hdu, find_hdu, JsonQuantityEncoder
 from .wcs import WcsGeom
+
 
 __all__ = ["WcsMap"]
 
@@ -203,9 +204,7 @@ class WcsMap(Map):
 
         hdu_out = self.to_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse)
 
-        # TODO: make this serialisable
-        self.meta.pop("livetime", None)
-        hdu_out.header["META"] = json.dumps(self.meta)
+        hdu_out.header["META"] = json.dumps(self.meta, cls=JsonQuantityEncoder)
 
         hdu_out.header["BUNIT"] = self.unit.to_string("fits")
 

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -203,6 +203,8 @@ class WcsMap(Map):
 
         hdu_out = self.to_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse)
 
+        # TODO: make this serialisable
+        self.meta.pop("livetime", None)
         hdu_out.header["META"] = json.dumps(self.meta)
 
         hdu_out.header["BUNIT"] = self.unit.to_string("fits")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request .remove the code duplication between `SpectrumDatasetMaker` and `MapDatasetMaker`, by making the `SpectrumDatasetMaker` inherit from the `MapDatasetMaker`. This has one little change in analysis results, if the background template is used: in the `SpectrumDataset` the background was extracted from the give offset forced at `fov_lon=0`. In the `MapDatasetMaker` the correct position is used, which is relevant for non-radially symmetric background models, which we have for HESS. That's why some test values changed. Otherwise it looks good.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
