### PR TITLE
Small modifs in documentation structure

### DIFF
--- a/docs/_static/gammapy.js
+++ b/docs/_static/gammapy.js
@@ -10,15 +10,15 @@ $(document).ready(function() {
           var match =  allText.match(/url=\.\.\/(.*)"/i);
           var version = match[1];
           var note = '<div class="admonition note"><p class="first admonition-title" style="background-color:red">Note</p>'
-          note += '<p class="last">You are not reading the most up to date version of Gammapy '
-          note += 'documentation.<br/>Access the <a href="https://docs.gammapy.org/'
+          note += '<p class="last">You are not reading the stable version of Gammapy '
+          note += 'documentation.<br/>Access the latest stable <a href="https://docs.gammapy.org/'
           note += version
-          note += '/">latest stable version v'
+          note += '/">version v'
           note += version
           note += '</a> or the <a href="https://gammapy.org/news.html#releases">list of Gammapy releases</a>.</p></div>'
 
           var url = window.location.href
-          if (url.includes("/dev/") == false && url.includes(version) == false ) {
+          if (url.includes(version) == false) {
               var divbody = document.querySelectorAll('[role="main"]');
               var divnote = document.createElement("div");
               divnote.innerHTML = note;

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,11 +9,12 @@ Gammapy
 -------
 
 Gammapy is a community-developed, open-source Python package for gamma-ray
-astronomy. It is a prototype for the `CTA`_ science tools. This page
-(https://docs.gammapy.org ) contains the Gammapy documentation. The Gammapy
-webpage ( https://gammapy.org ) contains information about Gammapy, including
-news and contact information if you have any questions, want to report and issue
-or request a feature, or need help with anything Gammapy-related.
+astronomy. It is a prototype for the `CTA`_ science tools. This webpage contains
+the Gammapy documentation. You may also check out the `Gammapy webpage <https://gammapy.org>`_
+where you may find more information about Gammapy, including the
+`list of releases <https://gammapy.org/news.html#releases>`_ and contact information if you
+have any questions, want to report and issue or request a feature, or need help with anything
+Gammapy-related.
 
 .. _gammapy_intro:
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,6 @@ or request a feature, or need help with anything Gammapy-related.
     tutorials/index
     howto
     references
-    changelog
 
 .. _gammapy_package:
 .. toctree::
@@ -53,8 +52,10 @@ or request a feature, or need help with anything Gammapy-related.
 
 .. _gammapy_dev:
 .. toctree::
-    :caption: Developer Documentation
+    :caption: Additional Documentation
     :titlesonly:
     :maxdepth: 1
 
     development/index
+    List of releases <https://gammapy.org/news.html#releases>
+    changelog


### PR DESCRIPTION
This PR adds to all the pages of the dev version of docs the red alert box stating we are not reading the stable version of the docs. It also modifies the left menu bar, adding a link to the list of releases, as well as in the introduction description text of Gammapy in the homepage of the docs.

You may see how it look likes in the [published dev version of the Gammapy docs](https://docs.gammapy.org/dev/).  