### PR TITLE
Remove TablePSF

### DIFF
--- a/docs/tutorials/fermi_lat.ipynb
+++ b/docs/tutorials/fermi_lat.ipynb
@@ -58,7 +58,7 @@
     "from astropy.coordinates import SkyCoord\n",
     "from gammapy.data import EventList\n",
     "from gammapy.datasets import MapDataset\n",
-    "from gammapy.irf import EnergyDependentTablePSF, PSFMap, EDispMap\n",
+    "from gammapy.irf import EnergyDependentTablePSF, PSFMap, EDispKernelMap\n",
     "from gammapy.maps import Map, MapAxis, WcsGeom\n",
     "from gammapy.modeling.models import (\n",
     "    PowerLawSpectralModel,\n",
@@ -187,7 +187,7 @@
     "# We put this call into the same Jupyter cell as the Map.create\n",
     "# because otherwise we could accidentally fill the counts\n",
     "# multiple times when executing the ``fill_by_coord`` multiple times.\n",
-    "counts.fill_by_coord({\"skycoord\": events.radec, \"energy\": events.energy})"
+    "counts.fill_events(events)"
    ]
   },
   {
@@ -251,12 +251,19 @@
    "source": [
     "# For exposure, we choose a geometry with node_type='center',\n",
     "# whereas for counts it was node_type='edge'\n",
-    "axis = MapAxis.from_nodes(\n",
-    "    counts.geom.axes[0].center, name=\"energy_true\", unit=\"MeV\", interp=\"log\"\n",
-    ")\n",
+    "axis = MapAxis.from_energy_bounds(\"10 GeV\", \"2 TeV\", nbin=10, per_decade=True, name=\"energy_true\",)\n",
     "geom = WcsGeom(wcs=counts.geom.wcs, npix=counts.geom.npix, axes=[axis])\n",
     "\n",
     "exposure = exposure_hpx.interp_to_geom(geom)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "counts.geom.axes[0]"
    ]
   },
   {
@@ -378,16 +385,10 @@
    "outputs": [],
    "source": [
     "# Exposure varies very little with energy at these high energies\n",
-    "energy = np.logspace(1, 3, 10) * u.GeV\n",
-    "dnde = template_diffuse.map.interp_by_coord(\n",
-    "    {\"skycoord\": gc_pos, \"energy_true\": energy},\n",
-    "    method=\"linear\",\n",
-    "    fill_value=None,\n",
-    ")\n",
-    "plt.plot(energy.value, dnde, \"+\")\n",
-    "plt.loglog()\n",
+    "dnde = template_diffuse.map.to_region_nd_map(region=gc_pos)\n",
+    "dnde.plot()\n",
     "plt.xlabel(\"Energy (GeV)\")\n",
-    "plt.ylabel(\"Flux (cm-2 s-1 MeV-1 sr-1)\")"
+    "plt.ylabel(\"Flux (cm-2 s-1 MeV-1 sr-1)\");"
    ]
   },
   {
@@ -495,16 +496,15 @@
    "source": [
     "plt.figure(figsize=(8, 5))\n",
     "\n",
-    "for energy in [100, 300, 1000] * u.GeV:\n",
-    "    psf_at_energy = psf_table.table_psf_at_energy(energy)\n",
-    "    psf_at_energy.plot_psf_vs_rad(label=f\"PSF @ {energy:.0f}\", lw=2)\n",
+    "energy = [100, 300, 1000] * u.GeV\n",
+    "psf_table.plot_psf_vs_rad(energy=energy)\n",
     "\n",
     "energy_range = [50, 2000] * u.GeV\n",
     "spectrum = PowerLawSpectralModel(index=2.3)\n",
     "psf_mean = psf_table.table_psf_in_energy_range(\n",
     "    energy_range=energy_range, spectrum=spectrum\n",
     ")\n",
-    "psf_mean.plot_psf_vs_rad(label=\"PSF Mean\", lw=4, c=\"k\", ls=\"--\")\n",
+    "psf_mean.plot_psf_vs_rad(c=\"k\", ls=\"--\", energy=[500] * u.GeV)\n",
     "\n",
     "plt.xlim(1e-3, 0.3)\n",
     "plt.ylim(1e3, 1e6)\n",
@@ -548,7 +548,18 @@
    "outputs": [],
    "source": [
     "e_true = exposure.geom.axes[\"energy_true\"]\n",
-    "edisp = EDispMap.from_diagonal_response(energy_axis_true=e_true)"
+    "edisp = EDispKernelMap.from_diagonal_response(\n",
+    "    energy_axis_true=e_true, energy_axis=energy_axis\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edisp.get_edisp_kernel().plot_matrix()"
    ]
   },
   {
@@ -676,9 +687,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1.0,
+   "current_citInitial": 1,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1.0,
+   "eqNumInitial": 1,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"
@@ -689,7 +700,7 @@
    "user_envs_cfg": false
   },
   "toc": {
-   "base_numbering": 1.0,
+   "base_numbering": 1,
    "nav_menu": {
     "height": "237px",
     "width": "253px"
@@ -706,9 +717,9 @@
   },
   "varInspector": {
    "cols": {
-    "lenName": 16.0,
-    "lenType": 16.0,
-    "lenVar": 40.0
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
    },
    "kernels_config": {
     "python": {

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -30,6 +30,7 @@ from gammapy.modeling.models import (
     ConstantSpectralModel,
 )
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
+from gammapy.utils.gauss import Gauss2DPDF
 
 
 @pytest.fixture
@@ -1393,4 +1394,6 @@ def test_compute_flux_spatial():
     evaluator = MapEvaluator(model=model[0], exposure=exposure_region, psf=psf)
     flux = evaluator.compute_flux_spatial()
 
-    assert_allclose(flux.value, [0.39677402, 0.39677402], atol=0.001)
+    g = Gauss2DPDF(0.1)
+    reference = g.containment_fraction(0.1)
+    assert_allclose(flux.value, reference, rtol=0.003)

--- a/gammapy/irf/psf/psf_map.py
+++ b/gammapy/irf/psf/psf_map.py
@@ -328,7 +328,7 @@ class PSFMap(IRFMap):
         axes = MapAxes([energy_axis_true, rad_axis])
         coords = axes.get_coord()
 
-        sigma = np.broadcast_to(sigma, energy_axis_true.nbin, subok=True)
+        sigma = np.broadcast_to(u.Quantity(sigma), energy_axis_true.nbin, subok=True)
         gauss = Gauss2DPDF(sigma=sigma.reshape((-1, 1)))
         data = gauss(coords["rad"])
 

--- a/gammapy/irf/psf/psf_map.py
+++ b/gammapy/irf/psf/psf_map.py
@@ -1,11 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 import astropy.units as u
-from gammapy.maps import Map, MapCoord, WcsGeom
+from gammapy.maps import Map, MapCoord, WcsGeom, MapAxes
 from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.utils.random import InverseCDFSampler, get_random_state
+from gammapy.utils.gauss import Gauss2DPDF
 from .kernel import PSFKernel
-from .table import EnergyDependentTablePSF, TablePSF
+from .table import EnergyDependentTablePSF
 from ..core import IRFMap
 
 __all__ = ["PSFMap"]
@@ -283,7 +284,6 @@ class PSFMap(IRFMap):
             )
         coords = geom.get_coord()
 
-        # TODO: support broadcasting in .evaluate()
         data = table_psf.evaluate(
             energy_true=coords["energy_true"], rad=coords["rad"]
         )
@@ -325,33 +325,15 @@ class PSFMap(IRFMap):
         if rad_axis is None:
             rad_axis = RAD_AXIS_DEFAULT.copy()
 
-        # note: it would be straightforward to also have disk shape instead
-        # of gauss
-        energy = energy_axis_true.center
-        rad = rad_axis.center
-        shape = (energy.shape[0], rad.shape[0])
+        axes = MapAxes([energy_axis_true, rad_axis])
+        coords = axes.get_coord()
 
-        if np.size(sigma) == 1:
-            # same width for all energies
-            table_psf = TablePSF.from_shape(shape="gauss", width=sigma, rad=rad)
-            data = np.tile(table_psf.quantity, (shape[0], 1))
-        elif np.size(sigma) == np.size(energy):
-            # one width per energy
-            data = np.zeros(shape) * u.sr ** -1
-            for idx in range(energy_axis_true.nbin):
-                data[idx, :] = TablePSF.from_shape(
-                    shape="gauss", width=sigma[idx], rad=rad
-                ).quantity
-        else:
-            raise AssertionError(
-                "There need to be the same number of sigma values as energies"
-            )
+        sigma = np.broadcast_to(sigma, energy_axis_true.nbin, subok=True)
+        gauss = Gauss2DPDF(sigma=sigma.reshape((-1, 1)))
+        data = gauss(coords["rad"])
 
         table_psf = EnergyDependentTablePSF(
-            axes=[energy_axis_true, rad_axis],
-            exposure=None,
-            data=data.value,
-            unit=data.unit
+            axes=axes, unit=data.unit, data=data.value
         )
         return cls.from_energy_dependent_table_psf(table_psf)
 

--- a/gammapy/irf/psf/table.py
+++ b/gammapy/irf/psf/table.py
@@ -149,7 +149,7 @@ class EnergyDependentTablePSF(PSF):
 
         energy_axis = MapAxis.from_edges(energy_range, name="energy_true")
 
-        data = psf_value_weighted.sum(axis=0)
+        data = psf_value_weighted.sum(axis=0, keepdims=True)
         return self.__class__(
             axes=[energy_axis, self.axes["rad"]], data=data.value, unit=data.unit, **kwargs
         )
@@ -206,8 +206,8 @@ class EnergyDependentTablePSF(PSF):
             )
             label = f"{100 * fraction:.1f}% Containment"
             ax.plot(
-                energy_true,
-                rad,
+                energy_true.to_value("GeV"),
+                rad.to_value("deg"),
                 label=label,
                 **kwargs,
             )

--- a/gammapy/irf/psf/tests/test_psf_kernel.py
+++ b/gammapy/irf/psf/tests/test_psf_kernel.py
@@ -2,30 +2,9 @@
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from astropy.coordinates import Angle
-from gammapy.irf import PSFKernel, TablePSF
+from gammapy.irf import PSFKernel
 from gammapy.maps import MapAxis, WcsGeom
-
-
-def test_table_psf_to_kernel_map():
-    sigma = 0.5 * u.deg
-    binsz = 0.1 * u.deg
-
-    geom = WcsGeom.create(binsz=binsz, npix=150)
-
-    rad = Angle(np.linspace(0.0, 3 * sigma.to("deg").value, 100), "deg")
-    table_psf = TablePSF.from_shape(shape="gauss", width=sigma, rad=rad)
-    kernel = PSFKernel.from_table_psf(table_psf, geom)
-
-    kernel_array = kernel.psf_kernel_map.data
-
-    # Is normalization OK?
-    assert_allclose(kernel_array.sum(), 1.0, atol=1e-5)
-
-    # maximum at the center of map?
-    ind = np.unravel_index(np.argmax(kernel_array, axis=None), kernel_array.shape)
-    # absolute tolerance at 0.5 because of even number of pixel here
-    assert_allclose(ind, geom.center_pix, atol=0.5)
+from gammapy.modeling.models import DiskSpatialModel
 
 
 def test_psf_kernel_from_gauss_read_write(tmp_path):
@@ -54,12 +33,12 @@ def test_psf_kernel_to_image():
     axis = MapAxis.from_energy_bounds(1, 10, 2, unit="TeV", name="energy_true")
     geom = WcsGeom.create(binsz=binsz, npix=50, axes=[axis])
 
-    rad = Angle(np.linspace(0.0, 1.5 * sigma1.to("deg").value, 100), "deg")
-    table_psf1 = TablePSF.from_shape(shape="disk", width=sigma1, rad=rad)
-    table_psf2 = TablePSF.from_shape(shape="disk", width=sigma2, rad=rad)
+    disk_1 = DiskSpatialModel(r_0=sigma1)
+    disk_2 = DiskSpatialModel(r_0=sigma2)
 
-    kernel1 = PSFKernel.from_table_psf(table_psf1, geom)
-    kernel2 = PSFKernel.from_table_psf(table_psf2, geom)
+    rad_max = 2.5 * u.deg
+    kernel1 = PSFKernel.from_spatial_model(disk_1, geom, max_radius=rad_max, factor=4)
+    kernel2 = PSFKernel.from_spatial_model(disk_2, geom, max_radius=rad_max, factor=4)
 
     kernel1.psf_kernel_map.data[1, :, :] = kernel2.psf_kernel_map.data[1, :, :]
 
@@ -67,13 +46,13 @@ def test_psf_kernel_to_image():
     kernel_image_2 = kernel1.to_image(exposure=[1, 2])
 
     assert_allclose(kernel_image_1.psf_kernel_map.data.sum(), 1.0, atol=1e-5)
-    assert_allclose(kernel_image_1.psf_kernel_map.data[0, 25, 25], 0.028415, atol=1e-5)
-    assert_allclose(kernel_image_1.psf_kernel_map.data[0, 22, 22], 0.009806, atol=1e-5)
+    assert_allclose(kernel_image_1.psf_kernel_map.data[0, 25, 25], 0.02844, atol=1e-5)
+    assert_allclose(kernel_image_1.psf_kernel_map.data[0, 22, 22], 0.009636, atol=1e-5)
     assert_allclose(kernel_image_1.psf_kernel_map.data[0, 20, 20], 0.0, atol=1e-5)
 
     assert_allclose(kernel_image_2.psf_kernel_map.data.sum(), 1.0, atol=1e-5)
     assert_allclose(
-        kernel_image_2.psf_kernel_map.data[0, 25, 25], 0.03791383, atol=1e-5
+        kernel_image_2.psf_kernel_map.data[0, 25, 25], 0.038091, atol=1e-5
     )
-    assert_allclose(kernel_image_2.psf_kernel_map.data[0, 22, 22], 0.0079069, atol=1e-5)
+    assert_allclose(kernel_image_2.psf_kernel_map.data[0, 22, 22], 0.00777, atol=1e-5)
     assert_allclose(kernel_image_2.psf_kernel_map.data[0, 20, 20], 0.0, atol=1e-5)

--- a/gammapy/irf/psf/tests/test_psf_map.py
+++ b/gammapy/irf/psf/tests/test_psf_map.py
@@ -440,5 +440,5 @@ def test_psfmap_from_gauss():
     assert_allclose(psfvalue, psfvalue1, atol=1e-7)
 
     # test that it won't work with different number of sigmas and energies
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         psfmap2 = PSFMap.from_gauss(energy_axis, rad_axis, sigma[:3])

--- a/gammapy/irf/psf/tests/test_psf_table.py
+++ b/gammapy/irf/psf/tests/test_psf_table.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import Angle
-from gammapy.irf import EnergyDependentTablePSF, TablePSF, PSF3D
+from gammapy.irf import EnergyDependentTablePSF, PSF3D
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 
@@ -50,7 +50,8 @@ def test_psf_3d_evaluate(psf_3d):
 def test_to_energy_dependent_table_psf(psf_3d):
     psf = psf_3d.to_energy_dependent_table_psf(offset=0 * u.deg)
     assert psf.data.data.shape == (32, 66)
-    radius = psf.table_psf_at_energy("1 TeV").containment_radius(0.68)
+
+    radius = psf.containment_radius(fraction=0.68, energy_true=1 * u.TeV)
     assert_allclose(radius, 0.123352 * u.deg, atol=1e-2)
 
 
@@ -91,45 +92,6 @@ def test_psf_3d_peek(psf_3d):
         psf_3d.peek()
 
 
-class TestTablePSF:
-    @staticmethod
-    def test_gauss():
-        # Make an example PSF for testing
-        width = Angle(0.3, "deg")
-
-        # containment radius for 80% containment
-        radius = width * np.sqrt(2 * np.log(5))
-
-        rad = Angle(np.linspace(0, 2.3, 1000), "deg")
-        psf = TablePSF.from_shape(shape="gauss", width=width, rad=rad)
-
-        assert_allclose(psf.containment(radius), 0.8, rtol=1e-4)
-
-        desired = radius.to_value("deg")
-        actual = psf.containment_radius(0.8).to_value("deg")
-        assert_allclose(actual, desired, rtol=1e-4)
-
-    @staticmethod
-    def test_disk():
-        width = Angle(2, "deg")
-        rad = Angle(np.linspace(0, 2.3, 1000), "deg")
-        psf = TablePSF.from_shape(shape="disk", width=width, rad=rad)
-
-        # test containment
-        radius = Angle(1, "deg")
-        actual = psf.containment(radius)
-        desired = (radius / width).to_value("") ** 2
-        assert_allclose(actual, desired, rtol=1e-4)
-
-        # test containment radius
-        actual = psf.containment_radius(0.25)
-        assert_allclose(actual, radius, rtol=1e-4)
-
-        # test info
-        info = psf.info()
-        assert info.find("integral") == 66
-
-
 @requires_data()
 class TestEnergyDependentTablePSF:
     def setup(self):
@@ -138,15 +100,11 @@ class TestEnergyDependentTablePSF:
 
     def test(self):
         # TODO: test __init__
+        radius = self.psf.containment_radius(
+            energy_true=1 * u.GeV, fraction=np.linspace(0, 0.95, 3)
+        )
 
-        # Test cases
-        energy = u.Quantity(1, "GeV")
-
-        psf1 = self.psf.table_psf_at_energy(energy)
-        containment = np.linspace(0, 0.95, 3)
-        actual = psf1.containment_radius(containment).to_value("deg")
-        desired = [0., 0.251731, 0.967178]
-        assert_allclose(actual, desired, rtol=1e-2)
+        assert_allclose(radius, [0., 0.194156, 1.037939] * u.deg, rtol=1e-2)
 
         # TODO: test average_psf
         # TODO: test containment_radius
@@ -154,19 +112,10 @@ class TestEnergyDependentTablePSF:
         # TODO: test info
         # TODO: test plotting methods
 
-        energy_range = u.Quantity([10, 500], "GeV")
-        psf_band = self.psf.table_psf_in_energy_range(energy_range)
-        # TODO: add assert
-
     @requires_dependency("matplotlib")
     def test_plot(self):
         with mpl_plot_check():
             self.psf.plot_containment_vs_energy()
-
-        energy = u.Quantity(1, "GeV")
-        psf_1GeV = self.psf.table_psf_at_energy(energy)
-        with mpl_plot_check():
-            psf_1GeV.plot_psf_vs_rad()
 
     @requires_dependency("matplotlib")
     def test_plot2(self):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -25,6 +25,8 @@ from .utils import INVALID_INDEX, slice_to_str, str_to_slice
 
 __all__ = ["WcsGeom"]
 
+def round_up_to_odd(f):
+    return int(np.ceil(f) // 2 * 2 + 1)
 
 def _check_width(width):
     """Check and normalise width argument.
@@ -959,12 +961,14 @@ class WcsGeom(Geom):
             Geom with odd number of pixels
         """
         if max_radius is None:
-            max_radius = self.width.max() / 2
+            width = self.width.max()
+        else:
+            width = 2 * max_radius
 
         binsz = self.pixel_scales.max()
 
-        radius_max_npix = (max_radius / binsz).to_value("")
-        npix = 2 * int(radius_max_npix) + 1
+        width_npix = (width / binsz).to_value("")
+        npix = round_up_to_odd(width_npix)
         return WcsGeom.create(
             skydir=self.center_skydir,
             binsz=binsz,

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -944,6 +944,36 @@ class WcsGeom(Geom):
             f"\twidth      : {self.width[0][0]:.1f} x {self.width[1][0]:.1f}\n"
         )
 
+    def to_odd_npix(self, max_radius=None):
+        """Create a new geom object with an odd number of pixel and a maximum size
+        This is useful for PSF kernel creation.
+
+        Parameters
+        ----------
+        max_radius : `~astropy.units.Quantity`
+            Max. radius of the geometry (half the width)
+
+        Returns
+        -------
+        geom : `WcsGeom`
+            Geom with odd number of pixels
+        """
+        if max_radius is None:
+            max_radius = self.width.max() / 2
+
+        binsz = self.pixel_scales.max()
+
+        radius_max_npix = (max_radius / binsz).to_value("")
+        npix = 2 * int(radius_max_npix) + 1
+        return WcsGeom.create(
+            skydir=self.center_skydir,
+            binsz=binsz,
+            npix=npix,
+            proj=self.projection,
+            frame=self.frame,
+            axes=self.axes,
+        )
+
     def is_aligned(self, other, tolerance=1e-6):
         """Check if WCS and extra axes are aligned.
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -963,7 +963,7 @@ class WcsGeom(Geom):
         if max_radius is None:
             width = self.width.max()
         else:
-            width = 2 * max_radius
+            width = 2 * u.Quantity(max_radius)
 
         binsz = self.pixel_scales.max()
 

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -282,6 +282,23 @@ class SpatialModel(Model):
         m = self._get_plot_map(geom)
         m.plot_grid(**kwargs)
 
+    @classmethod
+    def from_position(cls, position, **kwargs):
+        """Define the position of the model using a sky coord
+
+        Parameters
+        ----------
+        position : `SkyCoord`
+            Position
+
+        Returns
+        -------
+        model : `SpatialModel`
+            Spatial model
+        """
+        lon_0, lat_0 = position.data.lon, position.data.lat
+        return cls(lon_0=lon_0, lat_0=lat_0, frame=position.frame, **kwargs)
+
 
 class PointSpatialModel(SpatialModel):
     r"""Point Source.

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -437,8 +437,8 @@ class Test_template_cube_MapEvaluator:
         out = diffuse_evaluator.compute_flux()
         assert out.data.shape == (3, 4, 5)
         out = out.quantity.to("cm-2 s-1")
-        assert_allclose(out.value.sum(), 633263.444803, rtol=1e-5)
-        assert_allclose(out.value[0, 0, 0], 1164.656176, rtol=1e-5)
+        assert_allclose(out.value.sum(), 633263.444803, rtol=5e-3)
+        assert_allclose(out.value[0, 0, 0], 1164.656176, rtol=5e-3)
 
     @staticmethod
     def test_apply_psf(diffuse_evaluator):
@@ -446,8 +446,8 @@ class Test_template_cube_MapEvaluator:
         npred = diffuse_evaluator.apply_exposure(flux)
         out = diffuse_evaluator.apply_psf(npred)
         assert out.data.shape == (3, 4, 5)
-        assert_allclose(out.data.sum(), 1.106404e12, rtol=1e-5)
-        assert_allclose(out.data[0, 0, 0], 5.586508e08, rtol=1e-5)
+        assert_allclose(out.data.sum(), 1.106404e12, rtol=5e-3)
+        assert_allclose(out.data[0, 0, 0], 5.586508e08, rtol=5e-3)
 
     @staticmethod
     def test_apply_edisp(diffuse_evaluator):
@@ -455,15 +455,15 @@ class Test_template_cube_MapEvaluator:
         npred = diffuse_evaluator.apply_exposure(flux)
         out = diffuse_evaluator.apply_edisp(npred)
         assert out.data.shape == (2, 4, 5)
-        assert_allclose(out.data.sum(), 1.606345e12, rtol=1e-5)
-        assert_allclose(out.data[0, 0, 0], 1.83018e10, rtol=1e-5)
+        assert_allclose(out.data.sum(), 1.606345e12, rtol=5e-3)
+        assert_allclose(out.data[0, 0, 0], 1.83018e10, rtol=5e-3)
 
     @staticmethod
     def test_compute_npred(diffuse_evaluator):
         out = diffuse_evaluator.compute_npred()
         assert out.data.shape == (2, 4, 5)
-        assert_allclose(out.data.sum(), 1.106403e12, rtol=1e-5)
-        assert_allclose(out.data[0, 0, 0], 8.778828e09, rtol=1e-5)
+        assert_allclose(out.data.sum(), 1.106403e12, rtol=5e-3)
+        assert_allclose(out.data[0, 0, 0], 8.778828e09, rtol=5e-3)
 
 
 class TestSkyModelMapEvaluator:
@@ -497,8 +497,8 @@ class TestSkyModelMapEvaluator:
         npred = evaluator.apply_exposure(flux)
         out = evaluator.apply_psf(npred)
         assert out.data.shape == (3, 4, 5)
-        assert_allclose(out.data.sum(), 3.862314e-06, rtol=1e-5)
-        assert_allclose(out.data[0, 0, 0], 4.126612e-08, rtol=1e-5)
+        assert_allclose(out.data.sum(), 3.862314e-06, rtol=5e-3)
+        assert_allclose(out.data[0, 0, 0], 4.126612e-08, rtol=5e-3)
 
     @staticmethod
     def test_apply_edisp(evaluator):
@@ -513,8 +513,8 @@ class TestSkyModelMapEvaluator:
     def test_compute_npred(evaluator, gti):
         out = evaluator.compute_npred()
         assert out.data.shape == (2, 4, 5)
-        assert_allclose(out.data.sum(), 3.862314e-06, rtol=1e-5)
-        assert_allclose(out.data[0, 0, 0], 6.94503e-08, rtol=1e-5)
+        assert_allclose(out.data.sum(), 3.862314e-06, rtol=5e-3)
+        assert_allclose(out.data[0, 0, 0], 6.94503e-08, rtol=5e-3)
 
 
 def test_sky_point_source():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request remove the `TablePSF` object, which was almost unused. It is a follow up PR to #3197.

The little differences in the code are caused, by the fact that `PSFKernel.from_gauss()` now uses `GaussianSpatialModel` and does the integration of the model with the solid angle. This was neglected before.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
