### PR TITLE
Add an option to the SpectrumDatasetMaker to average IRFs over a Region

### DIFF
--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -148,10 +148,7 @@ class MapDatasetMaker(Maker):
                 "Options: ALTAZ, RADEC"
             )
 
-        try:
-            average_over_region = self.average_over_region
-        except AttributeError:
-            average_over_region = False
+        average_over_region = getattr(self, "average_over_region", False)
 
         return make_map_background_irf(
             pointing=pointing,

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -208,11 +208,15 @@ class MapDatasetMaker(Maker):
 
         exposure = self.make_exposure_irf(geom.squash(axis_name="energy"), observation)
 
+        average_over_region = getattr(self, "average_over_region", False)
+
         return make_edisp_kernel_map(
             edisp=observation.edisp,
             pointing=observation.pointing_radec,
             geom=geom,
             exposure_map=exposure,
+            average_over_region=average_over_region,
+
         )
 
     def make_psf(self, geom, observation):

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -70,7 +70,7 @@ class MapDatasetMaker(Maker):
         return counts
 
     @staticmethod
-    def make_exposure(geom, observation, average_over_region=False):
+    def make_exposure(geom, observation, use_region_center=True):
         """Make exposure map.
 
         Parameters
@@ -92,11 +92,11 @@ class MapDatasetMaker(Maker):
             livetime=observation.observation_live_time_duration,
             aeff=observation.aeff,
             geom=geom,
-            average_over_region=average_over_region,
+            use_region_center=use_region_center,
         )
 
     @staticmethod
-    def make_exposure_irf(geom, observation, average_over_region=False):
+    def make_exposure_irf(geom, observation, use_region_center=True):
         """Make exposure map with irf geometry.
 
         Parameters
@@ -116,7 +116,7 @@ class MapDatasetMaker(Maker):
             livetime=observation.observation_live_time_duration,
             aeff=observation.aeff,
             geom=geom,
-            average_over_region=average_over_region,
+            use_region_center=use_region_center,
         )
 
     def make_background(self, geom, observation):
@@ -148,7 +148,7 @@ class MapDatasetMaker(Maker):
                 "Options: ALTAZ, RADEC"
             )
 
-        average_over_region = getattr(self, "average_over_region", False)
+        use_region_center = getattr(self, "use_region_center", True)
 
         return make_map_background_irf(
             pointing=pointing,
@@ -156,7 +156,7 @@ class MapDatasetMaker(Maker):
             bkg=observation.bkg,
             geom=geom,
             oversampling=self.background_oversampling,
-            average_over_region=average_over_region,
+            use_region_center=use_region_center,
         )
 
     def make_edisp(self, geom, observation):
@@ -176,14 +176,14 @@ class MapDatasetMaker(Maker):
         """
         exposure = self.make_exposure_irf(geom.squash(axis_name="migra"), observation)
 
-        average_over_region = getattr(self, "average_over_region", False)
+        use_region_center = getattr(self, "use_region_center", True)
 
         return make_edisp_map(
             edisp=observation.edisp,
             pointing=observation.pointing_radec,
             geom=geom,
             exposure_map=exposure,
-            average_over_region=average_over_region,
+            use_region_center=use_region_center,
         )
 
     def make_edisp_kernel(self, geom, observation):
@@ -208,14 +208,14 @@ class MapDatasetMaker(Maker):
 
         exposure = self.make_exposure_irf(geom.squash(axis_name="energy"), observation)
 
-        average_over_region = getattr(self, "average_over_region", False)
+        use_region_center = getattr(self, "use_region_center", True)
 
         return make_edisp_kernel_map(
             edisp=observation.edisp,
             pointing=observation.pointing_radec,
             geom=geom,
             exposure_map=exposure,
-            average_over_region=average_over_region,
+            use_region_center=use_region_center,
 
         )
 
@@ -244,11 +244,14 @@ class MapDatasetMaker(Maker):
 
         exposure = self.make_exposure_irf(geom.squash(axis_name="rad"), observation)
 
+        use_region_center = getattr(self, "use_region_center", True)
+
         return make_psf_map(
             psf=psf,
             pointing=observation.pointing_radec,
             geom=geom,
             exposure_map=exposure,
+            use_region_center=use_region_center,
         )
 
     @staticmethod

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -70,7 +70,7 @@ class MapDatasetMaker(Maker):
         return counts
 
     @staticmethod
-    def make_exposure(geom, observation):
+    def make_exposure(geom, observation, average_over_region=False):
         """Make exposure map.
 
         Parameters
@@ -92,10 +92,11 @@ class MapDatasetMaker(Maker):
             livetime=observation.observation_live_time_duration,
             aeff=observation.aeff,
             geom=geom,
+            average_over_region=average_over_region,
         )
 
     @staticmethod
-    def make_exposure_irf(geom, observation):
+    def make_exposure_irf(geom, observation, average_over_region=False):
         """Make exposure map with irf geometry.
 
         Parameters
@@ -115,6 +116,7 @@ class MapDatasetMaker(Maker):
             livetime=observation.observation_live_time_duration,
             aeff=observation.aeff,
             geom=geom,
+            average_over_region=average_over_region,
         )
 
     def make_background(self, geom, observation):

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -244,15 +244,12 @@ class MapDatasetMaker(Maker):
 
         exposure = self.make_exposure_irf(geom.squash(axis_name="rad"), observation)
 
-        use_region_center = getattr(self, "use_region_center", True)
-
         return make_psf_map(
             psf=psf,
             pointing=observation.pointing_radec,
             geom=geom,
             exposure_map=exposure,
-            use_region_center=use_region_center,
-        )
+       )
 
     @staticmethod
     def make_meta_table(observation):

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -6,6 +6,7 @@ from gammapy.datasets import MapDataset
 from gammapy.irf import EDispKernelMap, EnergyDependentMultiGaussPSF, PSFMap
 from gammapy.maps import Map
 from .core import Maker
+
 from .utils import (
     make_edisp_kernel_map,
     make_edisp_map,
@@ -148,12 +149,18 @@ class MapDatasetMaker(Maker):
                 "Options: ALTAZ, RADEC"
             )
 
+        try:
+            average_over_region = self.average_over_region
+        except AttributeError:
+            average_over_region = False
+
         return make_map_background_irf(
             pointing=pointing,
             ontime=observation.observation_time_duration,
             bkg=observation.bkg,
             geom=geom,
             oversampling=self.background_oversampling,
+            average_over_region=average_over_region,
         )
 
     def make_edisp(self, geom, observation):

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -176,11 +176,14 @@ class MapDatasetMaker(Maker):
         """
         exposure = self.make_exposure_irf(geom.squash(axis_name="migra"), observation)
 
+        average_over_region = getattr(self, "average_over_region", False)
+
         return make_edisp_map(
             edisp=observation.edisp,
             pointing=observation.pointing_radec,
             geom=geom,
             exposure_map=exposure,
+            average_over_region=average_over_region,
         )
 
     def make_edisp_kernel(self, geom, observation):

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -6,7 +6,6 @@ from gammapy.datasets import MapDataset
 from gammapy.irf import EDispKernelMap, EnergyDependentMultiGaussPSF, PSFMap
 from gammapy.maps import Map
 from .core import Maker
-
 from .utils import (
     make_edisp_kernel_map,
     make_edisp_map,

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -30,8 +30,9 @@ class SpectrumDatasetMaker(MapDatasetMaker):
     tag = "SpectrumDatasetMaker"
     available_selection = ["counts", "background", "exposure", "edisp"]
 
-    def __init__(self, selection=None, containment_correction=False, background_oversampling=None):
+    def __init__(self, selection=None, containment_correction=False, background_oversampling=None, average_over_region=False):
         self.containment_correction = containment_correction
+        self.average_over_region = average_over_region
         super().__init__(
             selection=selection, background_oversampling=background_oversampling
         )

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -52,7 +52,7 @@ class SpectrumDatasetMaker(MapDatasetMaker):
         exposure : `~gammapy.irf.EffectiveAreaTable`
             Exposure map.
         """
-        exposure = super().make_exposure(geom, observation)
+        exposure = super().make_exposure(geom, observation, average_over_region= self.average_over_region)
 
         if self.containment_correction:
             if not isinstance(geom.region, CircleSkyRegion):

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -25,14 +25,16 @@ class SpectrumDatasetMaker(MapDatasetMaker):
         Apply containment correction for point sources and circular on regions.
     background_oversampling : int
         Background evaluation oversampling factor in energy.
+    use_region_center : bool
+        Approximate the IRFs by the value at the center of the region
     """
 
     tag = "SpectrumDatasetMaker"
     available_selection = ["counts", "background", "exposure", "edisp"]
 
-    def __init__(self, selection=None, containment_correction=False, background_oversampling=None, average_over_region=False):
+    def __init__(self, selection=None, containment_correction=False, background_oversampling=None, use_region_center=True):
         self.containment_correction = containment_correction
-        self.average_over_region = average_over_region
+        self.use_region_center = use_region_center
         super().__init__(
             selection=selection, background_oversampling=background_oversampling
         )
@@ -52,7 +54,7 @@ class SpectrumDatasetMaker(MapDatasetMaker):
         exposure : `~gammapy.irf.EffectiveAreaTable`
             Exposure map.
         """
-        exposure = super().make_exposure(geom, observation, average_over_region= self.average_over_region)
+        exposure = super().make_exposure(geom, observation, use_region_center=self.use_region_center)
 
         if self.containment_correction:
             if not isinstance(geom.region, CircleSkyRegion):

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -126,8 +126,6 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hes
     assert_allclose(datasets[0].edisp.edisp_map.data[:,:,0,0].sum(), e_reco.nbin*2, rtol=1e-1)
     assert_allclose(datasets[1].edisp.edisp_map.data[:,:,0,0].sum(), e_reco.nbin*2, rtol=1e-1)
 
-    
-
 @requires_data()
 def test_spectrum_dataset_maker_hess_cta(spectrum_dataset_gc, observations_cta_dc1):
     maker = SpectrumDatasetMaker(use_region_center=True)

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -98,8 +98,8 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hes
         datasets.append(dataset)
 
     # Exposure
-    assert_allclose(datasets[0].exposure.data.sum(), 7374687188.97554)
-    assert_allclose(datasets[1].exposure.data.sum(), 6690976487.54471)
+    assert_allclose(datasets[0].exposure.data.sum(), 7199758923.66730)
+    assert_allclose(datasets[1].exposure.data.sum(), 6532241208.61468)
 
     # Background
     assert_allclose(datasets[0].npred_background().data.sum(), 7.778688, rtol=1e-5)
@@ -122,12 +122,10 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hes
     assert_allclose(ratio_bg_1, ratio_regions, rtol=1e-2) #precision should be higher once weights are used?
     assert_allclose(ratio_bg_2, ratio_regions, rtol=1e-2)
 
-    #Edisp -> it isn't exactly 8, is that right?
+    #Edisp -> it isn't exactly 8, is that right? it also isn't without averaging
     assert_allclose(datasets[0].edisp.edisp_map.data[:,:,0,0].sum(), e_reco.nbin*2, rtol=1e-1)
     assert_allclose(datasets[1].edisp.edisp_map.data[:,:,0,0].sum(), e_reco.nbin*2, rtol=1e-1)
 
-    #PSF
-    
     
 
 @requires_data()

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -88,6 +88,28 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hes
 
 
 @requires_data()
+def test_spectrum_dataset_maker_hess_dl3_average_region(spectrum_dataset_crab, observations_hess_dl3):
+    datasets = []
+    maker = SpectrumDatasetMaker(average_over_region=True)
+
+    for obs in observations_hess_dl3:
+        dataset = maker.run(spectrum_dataset_crab, obs)
+        datasets.append(dataset)
+
+    assert_allclose(datasets[0].counts.data.sum(), 100)
+    assert_allclose(datasets[1].counts.data.sum(), 92)
+
+    assert_allclose(datasets[0].exposure.data[0][0][0], 25332019.3623254)
+    assert_allclose(datasets[1].exposure.data[0][0][0], 77227668.692825)
+
+    assert_allclose(datasets[0].exposure.meta["livetime"].value, 1581.736758)
+    assert_allclose(datasets[1].exposure.meta["livetime"].value, 1572.686724)
+
+    assert_allclose(datasets[0].npred_background().data.sum(), 7.747881, rtol=1e-5)
+    assert_allclose(datasets[1].npred_background().data.sum(), 5.731624, rtol=1e-5)
+
+
+@requires_data()
 def test_spectrum_dataset_maker_hess_cta(spectrum_dataset_gc, observations_cta_dc1):
     maker = SpectrumDatasetMaker()
 

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -69,9 +69,9 @@ def reflected_regions_bkg_maker():
 
 
 @requires_data()
-def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hess_dl3):
+def test_region_center_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hess_dl3):
     datasets = []
-    maker = SpectrumDatasetMaker()
+    maker = SpectrumDatasetMaker(use_region_center=True)
 
     for obs in observations_hess_dl3:
         dataset = maker.run(spectrum_dataset_crab, obs)
@@ -88,9 +88,9 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hes
 
 
 @requires_data()
-def test_average_over_region_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hess_dl3):
+def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hess_dl3):
     datasets = []
-    maker = SpectrumDatasetMaker(average_over_region=True)
+    maker = SpectrumDatasetMaker(use_region_center=False)
 
     datasets = []
     for obs in observations_hess_dl3:
@@ -132,7 +132,7 @@ def test_average_over_region_spectrum_dataset_maker_hess_dl3(spectrum_dataset_cr
 
 @requires_data()
 def test_spectrum_dataset_maker_hess_cta(spectrum_dataset_gc, observations_cta_dc1):
-    maker = SpectrumDatasetMaker()
+    maker = SpectrumDatasetMaker(use_region_center=True)
 
     datasets = []
 

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -98,12 +98,12 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hes
         datasets.append(dataset)
 
     # Exposure
-    assert_allclose(datasets[0].exposure.data.sum(), 7199758923.66730)
-    assert_allclose(datasets[1].exposure.data.sum(), 6532241208.61468)
+    assert_allclose(datasets[0].exposure.data.sum(), 7374718644.757894)
+    assert_allclose(datasets[1].exposure.data.sum(), 6691006466.659032)
 
     # Background
-    assert_allclose(datasets[0].npred_background().data.sum(), 7.778688, rtol=1e-5)
-    assert_allclose(datasets[1].npred_background().data.sum(), 5.7579151, rtol=1e-5)
+    assert_allclose(datasets[0].npred_background().data.sum(), 7.7429157, rtol=1e-5)
+    assert_allclose(datasets[1].npred_background().data.sum(), 5.7314076, rtol=1e-5)
 
     # Compare background with using bigger region
     e_reco = datasets[0].background.geom.axes['energy']

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -119,7 +119,7 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hes
     ratio_regions = datasets[0].counts.geom.solid_angle()/datasets_big_region[1].counts.geom.solid_angle()
     ratio_bg_1 = datasets[0].npred_background().data.sum()/ datasets_big_region[0].npred_background().data.sum()
     ratio_bg_2 = datasets[1].npred_background().data.sum()/ datasets_big_region[1].npred_background().data.sum()
-    assert_allclose(ratio_bg_1, ratio_regions, rtol=1e-2) #precision should be higher once weights are used?
+    assert_allclose(ratio_bg_1, ratio_regions, rtol=1e-2)
     assert_allclose(ratio_bg_2, ratio_regions, rtol=1e-2)
 
     #Edisp -> it isn't exactly 8, is that right? it also isn't without averaging

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -105,8 +105,8 @@ def test_spectrum_dataset_maker_hess_dl3_average_region(spectrum_dataset_crab, o
     assert_allclose(datasets[0].exposure.meta["livetime"].value, 1581.736758)
     assert_allclose(datasets[1].exposure.meta["livetime"].value, 1572.686724)
 
-    assert_allclose(datasets[0].npred_background().data.sum(), 7.747881, rtol=1e-5)
-    assert_allclose(datasets[1].npred_background().data.sum(), 5.731624, rtol=1e-5)
+    assert_allclose(datasets[0].npred_background().data.sum(), 7.778688, rtol=1e-5)
+    assert_allclose(datasets[1].npred_background().data.sum(), 5.7579151, rtol=1e-5)
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -99,8 +99,8 @@ def test_spectrum_dataset_maker_hess_dl3_average_region(spectrum_dataset_crab, o
     assert_allclose(datasets[0].counts.data.sum(), 100)
     assert_allclose(datasets[1].counts.data.sum(), 92)
 
-    assert_allclose(datasets[0].exposure.data[0][0][0], 25332019.3623254)
-    assert_allclose(datasets[1].exposure.data[0][0][0], 77227668.692825)
+    assert_allclose(datasets[0].exposure.data[0][0][0], 25371485.648743)
+    assert_allclose(datasets[1].exposure.data[0][0][0], 77100448.721858)
 
     assert_allclose(datasets[0].exposure.meta["livetime"].value, 1581.736758)
     assert_allclose(datasets[1].exposure.meta["livetime"].value, 1572.686724)

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -92,31 +92,43 @@ def test_average_over_region_spectrum_dataset_maker_hess_dl3(spectrum_dataset_cr
     datasets = []
     maker = SpectrumDatasetMaker(average_over_region=True)
 
+    datasets = []
     for obs in observations_hess_dl3:
         dataset = maker.run(spectrum_dataset_crab, obs)
         datasets.append(dataset)
 
-    assert_allclose(datasets[0].exposure.data[0][0][0], 25371485.648743)
-    assert_allclose(datasets[1].exposure.data[0][0][0], 77100448.721858)
+    # Exposure
+    assert_allclose(datasets[0].exposure.data.sum(), 7374687188.97554)
+    assert_allclose(datasets[1].exposure.data.sum(), 6690976487.54471)
 
+    # Background
     assert_allclose(datasets[0].npred_background().data.sum(), 7.778688, rtol=1e-5)
     assert_allclose(datasets[1].npred_background().data.sum(), 5.7579151, rtol=1e-5)
 
+    # Compare background with using bigger region
     e_reco = datasets[0].background.geom.axes['energy']
     e_true = datasets[0].exposure.geom.axes['energy_true']
     geom_bigger = RegionGeom.create("icrs;circle(83.63, 22.01, 0.22)", axes=[e_reco])
 
+    datasets_big_region = []
     bigger_region_dataset = SpectrumDataset.create(geom=geom_bigger, energy_axis_true=e_true)
     for obs in observations_hess_dl3:
         dataset = maker.run(bigger_region_dataset, obs)
-        datasets.append(dataset)
+        datasets_big_region.append(dataset)
 
-    ratio_regions = datasets[0].counts.geom.solid_angle()/datasets[3].counts.geom.solid_angle()
-    ratio_bg_1 = datasets[0].npred_background().data.sum()/ datasets[2].npred_background().data.sum()
-    ratio_bg_2 = datasets[1].npred_background().data.sum()/ datasets[3].npred_background().data.sum()
-    assert_allclose(ratio_bg_1, ratio_regions, rtol=1e-2)
+    ratio_regions = datasets[0].counts.geom.solid_angle()/datasets_big_region[1].counts.geom.solid_angle()
+    ratio_bg_1 = datasets[0].npred_background().data.sum()/ datasets_big_region[0].npred_background().data.sum()
+    ratio_bg_2 = datasets[1].npred_background().data.sum()/ datasets_big_region[1].npred_background().data.sum()
+    assert_allclose(ratio_bg_1, ratio_regions, rtol=1e-2) #precision should be higher once weights are used?
     assert_allclose(ratio_bg_2, ratio_regions, rtol=1e-2)
 
+    #Edisp -> it isn't exactly 8, is that right?
+    assert_allclose(datasets[0].edisp.edisp_map.data[:,:,0,0].sum(), e_reco.nbin*2, rtol=1e-1)
+    assert_allclose(datasets[1].edisp.edisp_map.data[:,:,0,0].sum(), e_reco.nbin*2, rtol=1e-1)
+
+    #PSF
+    
+    
 
 @requires_data()
 def test_spectrum_dataset_maker_hess_cta(spectrum_dataset_gc, observations_cta_dc1):

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -56,7 +56,6 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, average_over_r
 
     energy_true = wcs_geom.axes["energy_true"].center
 
-
     exposure = aeff.evaluate(
         offset=offset, energy_true=energy_true[:, np.newaxis, np.newaxis]
     )

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -46,7 +46,8 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, use_region_cen
         Exposure map
     """
     if not use_region_center:
-        wcs_geom = geom.to_wcs_geom().upsample(2)
+        wcs_geom = geom.to_wcs_geom()
+        weights = geom.get_wcs_weights().data
         mask = geom.contains(wcs_geom.get_coord())
     else:
         wcs_geom = geom
@@ -66,7 +67,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, use_region_cen
     if not use_region_center:
         # TO DO: add weights
         exposure[~mask] = np.nan
-        data = np.nanmean(exposure.value, axis=(1,2))
+        data = np.nanmean(weights*exposure.value, axis=(1,2))
     else:
         data = exposure.value
 
@@ -204,7 +205,7 @@ def make_map_background_irf(pointing, ontime, bkg, geom, oversampling=None, use_
     return bkg_map
 
 
-def make_psf_map(psf, pointing, geom, exposure_map=None, use_region_center=True):
+def make_psf_map(psf, pointing, geom, exposure_map=None):
     """Make a psf map for a single observation
 
     Expected axes : rad and true energy in this specific order

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -66,6 +66,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, average_over_r
         data = np.mean(exposure.value, axis=(1,2))
     else:
         data = exposure.value
+        
     return Map.from_geom(
         geom=geom, data=data, unit=exposure.unit, meta=meta
     )

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -64,7 +64,8 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, average_over_r
 
     if average_over_region:
         # TO DO: add weights
-        data = np.mean(exposure.value, axis=(1,2))
+        exposure[~mask] = np.nan
+        data = np.nanmean(exposure.value, axis=(1,2))
     else:
         data = exposure.value
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -50,7 +50,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, use_region_cen
         weights = geom.get_wcs_weights().data
     else:
         wcs_geom = geom
-        
+
     offset = wcs_geom.separation(pointing)
 
     energy_true = wcs_geom.axes["energy_true"].center

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -48,11 +48,13 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, average_over_r
     if average_over_region:
         wcs_geom = geom.to_wcs_geom().upsample(2)
         mask = geom.contains(wcs_geom.get_coord())
-        offset = mask*wcs_geom.separation(pointing)
     else:
-        offset = geom.separation(pointing)
+        wcs_geom = geom
+        mask = 1
+        
+    offset = mask*wcs_geom.separation(pointing)
 
-    energy_true = geom.axes["energy_true"].center
+    energy_true = wcs_geom.axes["energy_true"].center
 
 
     exposure = aeff.evaluate(

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -270,6 +270,7 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None, average_over_region
         If geom is a RegionGeom, whether to just
         consider the values at the region center
         or the average over the whole region
+
     Returns
     -------
     edispmap : `~gammapy.irf.EDispMap`
@@ -280,7 +281,7 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None, average_over_region
 
     # Compute separations with pointing position
     if average_over_region:
-        wcs_geom = geom.to_wcs_geom().upsample(2)
+        wcs_geom = geom.to_wcs_geom()#.upsample(2)
         mask = geom.contains(wcs_geom.get_coord())
     else:
         wcs_geom = geom
@@ -306,7 +307,7 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None, average_over_region
     return EDispMap(edispmap, exposure_map)
 
 
-def make_edisp_kernel_map(edisp, pointing, geom, exposure_map=None):
+def make_edisp_kernel_map(edisp, pointing, geom, exposure_map=None, average_over_region=False):
     """Make a edisp kernel map for a single observation
 
     Expected axes : (reco) energy and true energy in this specific order
@@ -325,6 +326,10 @@ def make_edisp_kernel_map(edisp, pointing, geom, exposure_map=None):
     exposure_map : `~gammapy.maps.Map`, optional
         the associated exposure map.
         default is None
+    average_over_region: Bool
+        If geom is a RegionGeom, whether to just
+        consider the values at the region center
+        or the average over the whole region
 
     Returns
     -------
@@ -337,7 +342,7 @@ def make_edisp_kernel_map(edisp, pointing, geom, exposure_map=None):
     # Create temporary EDispMap Geom
     new_geom = geom.to_image().to_cube([migra_axis, geom.axes["energy_true"]])
 
-    edisp_map = make_edisp_map(edisp, pointing, new_geom, exposure_map)
+    edisp_map = make_edisp_map(edisp, pointing, new_geom, exposure_map, average_over_region)
 
     return edisp_map.to_edisp_kernel_map(geom.axes["energy"])
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -63,10 +63,11 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, average_over_r
     meta = {"livetime": livetime}
 
     if average_over_region:
+        # TO DO: add weights
         data = np.mean(exposure.value, axis=(1,2))
     else:
         data = exposure.value
-        
+
     return Map.from_geom(
         geom=geom, data=data, unit=exposure.unit, meta=meta
     )

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -281,8 +281,8 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None, use_region_center=T
 
     # Compute separations with pointing position
     if not use_region_center:
-        wcs_geom = geom.to_wcs_geom()#.upsample(2)
-        mask = geom.contains(wcs_geom.get_coord())
+        wcs_geom = geom.to_wcs_geom()
+        weights = geom.get_wcs_weights().data
     else:
         wcs_geom = geom
 
@@ -296,9 +296,7 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None, use_region_center=T
     ).to_value("")
 
     if not use_region_center:
-        # TO DO: add weights
-        edisp_values[~mask] = np.nan
-        data = np.nanmean(edisp_values, axis=(2,3))
+        data = np.average(edisp_values, axis=(2,3), weights=weights)
     else:
         data = edisp_values
 

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -80,7 +80,7 @@ class RegionGeom(Geom):
     @property
     def width(self):
         """Width of bounding box of the region.
-        
+
         Returns
         -------
         width : `~astropy.units.Quantity`
@@ -184,7 +184,7 @@ class RegionGeom(Geom):
     @property
     def _shape(self):
         """Number of bins in each dimension.
-        The spatial dimension is always (1, 1), as a 
+        The spatial dimension is always (1, 1), as a
         `RegionGeom` is not pixelized further
         """
         return tuple((1, 1) + self.axes.shape)
@@ -239,7 +239,7 @@ class RegionGeom(Geom):
 
     def bin_volume(self):
         """If the RegionGeom has a non-spatial axis, it
-        returns the volume of the region. If not, it 
+        returns the volume of the region. If not, it
         just retuns the solid angle size.
 
         Returns
@@ -264,7 +264,7 @@ class RegionGeom(Geom):
          ----------
         width_min : `~astropy.quantity.Quantity`
         Minimal width for the resulting geometry.
-        Can be a single number or two, for 
+        Can be a single number or two, for
         different minimum widths in each spatial dimension.
 
         Returns
@@ -297,7 +297,7 @@ class RegionGeom(Geom):
 
     def get_wcs_weights(self):
         """Get an array of weights that represent the
-            fraction of each pixel from the minimal 
+            fraction of each pixel from the minimal
             equivalent geometry contained in the region.
 
         Returns
@@ -306,11 +306,11 @@ class RegionGeom(Geom):
         """
         factor = 10
         wcs_geom = self.to_wcs_geom()
-        wcs_geom_upsampled = wcs_geom.to_image().upsample(factor=factor)
-        data = self.contains(wcs_geom_upsampled.get_coord()).astype(float)
 
         # if the region has non-spatial axis, this way is faster
         # create the spatial weights only
+        wcs_geom_upsampled = wcs_geom.to_image().upsample(factor=factor)
+        data = self.contains(wcs_geom_upsampled.get_coord()).astype(float)
         weights_no_axis = Map.from_geom(wcs_geom_upsampled, data=data)
         weights_no_axis = weights_no_axis.downsample(factor=factor)
         weights_no_axis.data /= weights_no_axis.data.max()
@@ -319,7 +319,7 @@ class RegionGeom(Geom):
         data = weights_no_axis.data
         for axis in self.axes:
             data = np.stack(axis.nbin*[data])
-            
+
         weights = Map.from_geom(wcs_geom, data=data)
 
         return weights

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -291,7 +291,7 @@ class RegionGeom(Geom):
         Parameters
         ----------
         factor : int
-            Oversampling factor to computw the weights
+            Oversampling factor to compute the weights
 
         Returns
         -------
@@ -593,7 +593,6 @@ class RegionGeom(Geom):
         artists = [region.to_pixel(wcs=ax.wcs).as_artist() for region in regions]
 
         kwargs.setdefault("fc", "None")
-        kwargs.setdefault("ec", "b")
 
         patches = PatchCollection(artists, **kwargs)
         ax.add_collection(patches)

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -281,11 +281,17 @@ class RegionGeom(Geom):
         wcs_geom = wcs_geom.to_cube(self.axes)
         return wcs_geom
 
-    def get_wcs_coord_and_weights(self):
-        """Get the array of spatial coordinates which are the center
-            of a pixel that intersects the region and the weights
-            that represent which fraction of the pixel
-            is contained in the region.
+    def get_wcs_coord_and_weights(self, factor=10):
+        """Get the array of spatial coordinates and corresponding weights
+
+        The coordinates are the center of a pixel that intersects the region and
+        the weights that represent which fraction of the pixel is contained
+        in the region.
+
+        Parameters
+        ----------
+        factor : int
+            Oversampling factor to computw the weights
 
         Returns
         -------
@@ -298,19 +304,16 @@ class RegionGeom(Geom):
         """
         wcs_geom = self.to_wcs_geom().to_image()
 
-        # Get weights
-        factor = 10
-        wcs_geom_upsampled = wcs_geom.upsample(factor=factor)
-        data = self.contains(wcs_geom_upsampled.get_coord()).astype(float)
-        weights = Map.from_geom(wcs_geom_upsampled, data = data)
-        weights = weights.downsample(factor=factor)
-        weights.data /= weights.data.max()
-        mask = (weights.data>0)
+        weights = wcs_geom.region_weights(
+            regions=[self.region], oversampling_factor=factor
+        )
+
+        mask = (weights.data > 0)
         weights = weights.data[mask]
 
         # Get coordinates
         region_coord = wcs_geom.get_coord().apply_mask(mask)
-
+        
         return region_coord, weights
 
     def to_binsz(self, binsz):

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -296,7 +296,7 @@ class RegionGeom(Geom):
             Weights representing the fraction of each pixel
             contained in the region.
         """
-        wcs_geom = self.to_wcs_geom()
+        wcs_geom = self.to_wcs_geom().to_image()
 
         # Get weights
         factor = 10

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -275,28 +275,30 @@ def test_to_wcs_geom(region):
     assert_allclose(wcs_geom.center_coord[1].value, 0, rtol=0.001, atol=0)
     assert_allclose(wcs_geom.width, [[2], [3]]*u.deg, rtol=1, atol=0)
 
-def test_get_wcs_coord(region):
+def test_get_wcs_coord_and_weights(region):
     # test on circular region
     geom = RegionGeom(region)
-    region_coords = geom.get_wcs_coord()
-    sep = geom.region.center.separation(region_coords.skycoord).value
-    assert max(sep) <= geom.region.radius.value
+    region_coord, weights = geom.get_wcs_coord_and_weights()
+
+    wcs_geom = geom.to_wcs_geom()
+    solid_angles = wcs_geom.solid_angle().T[wcs_geom.coord_to_idx(region_coord)]
+    area = (weights*solid_angles).sum()
+    assert_allclose(area.value, geom.solid_angle().value, rtol=1e-3)
+
+    assert  region_coord.shape  == weights.shape
 
     # test on rectangular region (assymetric)
     center = SkyCoord("0 deg", "0 deg", frame="galactic")
-    region = RectangleSkyRegion(center=center, width = 1 * u.deg, height=2 * u.deg)
+    region = RectangleSkyRegion(center=center, width = 1 * u.deg, height=2 * u.deg, angle=15*u.deg)
     geom = RegionGeom(region)
-    region_coords = geom.get_wcs_coord()
-    coord = SkyCoord("100d", "30d")
-    assert geom.contains(region_coords.skycoord[0])
-    assert not geom.contains(coord)
 
-def test_get_wcs_weights(region):
-    geom = RegionGeom(region)
-    weights = geom.get_wcs_weights()
     wcs_geom = geom.to_wcs_geom()
-    area = (weights.data*wcs_geom.solid_angle()).sum()
+    region_coord, weights = geom.get_wcs_coord_and_weights()
+    solid_angles = wcs_geom.solid_angle().T[wcs_geom.coord_to_idx(region_coord)]
+    area = (weights*solid_angles).sum()
     assert_allclose(area.value, geom.solid_angle().value, rtol=1e-3)
+    assert  region_coord.shape  == weights.shape
+
 
 @requires_dependency("matplotlib")
 def test_region_nd_map_plot(region):

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -291,6 +291,13 @@ def test_get_wcs_coord(region):
     assert geom.contains(region_coords.skycoord[0])
     assert not geom.contains(coord)
 
+def test_get_wcs_weights(region):
+    geom = RegionGeom(region)
+    weights = geom.get_wcs_weights()
+    wcs_geom = geom.to_wcs_geom()
+    area = (weights.data*wcs_geom.solid_angle()).sum()
+    assert_allclose(area.value, geom.solid_angle().value, rtol=1e-3)
+
 @requires_dependency("matplotlib")
 def test_region_nd_map_plot(region):
     import matplotlib.pyplot as plt

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -928,6 +928,26 @@ class WcsGeom(Geom):
 
         return Map.from_geom(self, data=mask)
 
+    def region_weights(self, regions, oversampling_factor=10):
+        """Compute regions weights
+
+        Parameters
+        ----------
+        regions : list of  `~regions.Region`
+            Python list of regions (pixel or sky regions accepted)
+        oversampling_factor : int
+            Over-sampling factor to compute the region weigths
+
+        Returns
+        -------
+        map : `~gammapy.maps.WcsNDMap` of boolean type
+            Weights region mask
+        """
+        geom = self.upsample(factor=oversampling_factor)
+        m = geom.region_mask(regions=regions, inside=True)
+        m.data = m.data.astype(float)
+        return m.downsample(factor=oversampling_factor, preserve_counts=False)
+
     def __repr__(self):
         axes = ["lon", "lat"] + [_.name for _ in self.axes]
         lon = self.center_skydir.data.lon.deg


### PR DESCRIPTION
This pull request adds a flag `average_over_region` to the `SpectrumDatasetMaker` to, instead of just taking the value at the region center, average (or add) the IRF values along the entire region.

The current status is very preliminary, as I've only modified the exposure calculation as a first step. Following steps are:

- Sum background over region :heavy_check_mark: 
- ~Average PSF~ 
- Average energy dispersion :heavy_check_mark: 
- Add the tests :heavy_check_mark:  

I will add these features in the following days.

A further step, ~cmaybe in a separate (or parallel) PR would be~  to add a method `RegionGeom.get_wcs_weight()` to compute spatial weights to achieve a better compromise between speed and accuracy in the integration steps. :heavy_check_mark: 
