### PR TITLE
Select nearest well-defined irf for sources outside geom

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2524,6 +2524,7 @@ class MapEvaluator:
 
         if (
             self.model.position is not None
+            and isinstance(mask.geom, WcsGeom)
             and not mask.geom.contains(self.model.position)[0]
         ):
             coords = mask.geom.get_coord().skycoord

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2521,6 +2521,9 @@ class MapEvaluator:
             separation[exposure.sum_over_axes().data.squeeze() == 0] = np.inf
             ilon, ilat = np.where(separation == np.min(separation))
             irf_position = coords[ilon[0], ilat[0]]
+            log.warning(
+                f"Center position for {self.model.name} model is outside dataset geom, using nearest IRF defined within geom"
+            )
         else:
             irf_position = self.model.position
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -69,7 +69,11 @@ class MapDatasetEventSampler:
         for idx, evaluator in enumerate(dataset.evaluators.values()):
             if evaluator.needs_update:
                 evaluator.update(
-                    dataset.exposure, dataset.psf, dataset.edisp, dataset._geom
+                    dataset.exposure,
+                    dataset.psf,
+                    dataset.edisp,
+                    dataset._geom,
+                    dataset.mask_safe_psf,
                 )
 
             flux = evaluator.compute_flux()

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -204,7 +204,13 @@ class TSMapEstimator(Estimator):
 
         # We use global evaluation mode to not modify the geometry
         evaluator = MapEvaluator(model, evaluation_mode="global")
-        evaluator.update(exposure, dataset.psf, dataset.edisp, dataset.counts.geom)
+        evaluator.update(
+            exposure,
+            dataset.psf,
+            dataset.edisp,
+            dataset.counts.geom,
+            dataset.mask_safe_psf,
+        )
 
         kernel = evaluator.compute_npred()
         kernel.data /= kernel.data.sum()


### PR DESCRIPTION
This PR forces the MapEvaluator to use the nearest  well-defined IRF inside geom to evaluate sources outside geom that contributes inside. The goal is to avoid extrapolation that may be unstable depending on the IRF files and could cause npred to be NaN. Among two non-optimal solutions better choose the stable one, right ?