### PR TITLE
Remove hard-coded wcs bin size in RegionGeom and make it a parameter

### DIFF
--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -38,7 +38,8 @@ class RegionGeom(Geom):
     binsz_wcs : `float`
         Angular bin size of the underlying `~WcsGeom` used to evaluate
         quantities in the region. Default size is 0.01 deg. This default
-        value is adequate for the majority of use cases.
+        value is adequate for the majority of use cases. If a wcs object
+        is provided, the input of binsz_wcs is overridden.
     """
 
     is_image = False

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -35,7 +35,7 @@ class RegionGeom(Geom):
         Non-spatial data axes.
     wcs : `~astropy.wcs.WCS`
         Optional wcs object to project the region if needed.
-    binsz : `float`
+    binsz_wcs : `float`
         Angular bin size of the underlying `~WcsGeom` used to evaluate
         quantities in the region. Default size is 0.01 deg. This default
         value is adequate for the majority of use cases.
@@ -51,15 +51,15 @@ class RegionGeom(Geom):
     _slice_non_spatial_axes = slice(2, None)
     projection = "TAN"
 
-    def __init__(self, region, axes=None, wcs=None, binsz=0.01):
+    def __init__(self, region, axes=None, wcs=None, binsz_wcs=0.01):
         self._region = region
         self._axes = MapAxes.from_default(axes)
-        self._binsz = binsz
+        self._binsz_wcs = binsz_wcs
 
         if wcs is None and region is not None:
             wcs = WcsGeom.create(
                 skydir=region.center,
-                binsz=binsz,
+                binsz=binsz_wcs,
                 proj=self.projection,
                 frame=self.frame,
             ).wcs

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -35,6 +35,10 @@ class RegionGeom(Geom):
         Non-spatial data axes.
     wcs : `~astropy.wcs.WCS`
         Optional wcs object to project the region if needed.
+    binsz : `float`
+        Angular bin size of the underlying `~WcsGeom` used to evaluate
+        quantities in the region. Default size is 0.01 deg. This default
+        value is adequate for the majority of use cases.
     """
 
     is_image = False
@@ -46,16 +50,16 @@ class RegionGeom(Geom):
     _slice_spatial_axes = slice(0, 2)
     _slice_non_spatial_axes = slice(2, None)
     projection = "TAN"
-    binsz = 0.01
 
-    def __init__(self, region, axes=None, wcs=None):
+    def __init__(self, region, axes=None, wcs=None, binsz=0.01):
         self._region = region
         self._axes = MapAxes.from_default(axes)
+        self._binsz = binsz
 
         if wcs is None and region is not None:
             wcs = WcsGeom.create(
                 skydir=region.center,
-                binsz=self.binsz,
+                binsz=binsz,
                 proj=self.projection,
                 frame=self.frame,
             ).wcs

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -33,7 +33,7 @@ def test_create(region):
     assert not geom.is_allsky
 
 def test_binsz(region):
-    geom = RegionGeom.create(region, binsz=0.05)
+    geom = RegionGeom.create(region, binsz_wcs=0.05)
     wcs_geom = geom.to_wcs_geom()
     assert wcs_geom.pixel_scales.deg[0] == 0.05
 

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -32,6 +32,10 @@ def test_create(region):
     assert not geom.is_image
     assert not geom.is_allsky
 
+def test_binsz(region):
+    geom = RegionGeom.create(region, binsz=0.05)
+    wcs_geom = geom.to_wcs_geom()
+    assert wcs_geom.pixel_scales.deg[0] == 0.05
 
 def test_centers(region):
     geom = RegionGeom.create(region)


### PR DESCRIPTION
This pull request removes the hard-coded `binsz=0.01` in the `RegionGeom and` instead introduces a user-defined parameter, `binsz_wcs` with a default value of 0.01 to allow advanced users to change this value if needed.


