### PR TITLE
Further improve model region / mask selection

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -428,7 +428,7 @@ class MapDataset(Dataset):
                     self.psf,
                     self.edisp,
                     self._geom,
-                    self.mask_fit,
+                    self.mask,
                     self.mask_safe_psf,
                 )
 
@@ -2512,7 +2512,7 @@ class MapEvaluator:
         """Cutout width for the model component"""
         return get_cutout_width(self.model, psf=self.psf)
 
-    def update(self, exposure, psf, edisp, geom, mask_fit, mask_safe_psf):
+    def update(self, exposure, psf, edisp, geom, mask, mask_safe_psf):
         """Update MapEvaluator, based on the current position of the model component.
 
         Parameters
@@ -2525,7 +2525,7 @@ class MapEvaluator:
             Edisp map.
         geom : `WcsGeom`
             Counts geom
-        mask_fit : `~gammapy.maps.Map`
+        mask : `~gammapy.maps.Map`
             Mask to apply to the likelihood for fitting.
         mask_safe_psf : `~gammapy.maps.Map`
             Mask safe map of boolean type.
@@ -2557,9 +2557,6 @@ class MapEvaluator:
                 self.irf_position, energy_axis=energy_axis
             )
 
-        if mask_fit is None:
-            mask_fit = Map.from_geom(geom, data=np.ones(geom.data_shape, dtype=bool))
-
         # lookup psf
         if psf:
             if self.apply_psf_after_edisp:
@@ -2575,7 +2572,7 @@ class MapEvaluator:
         if self.evaluation_mode == "local" and self.model.evaluation_radius is not None:
             self._init_position = self.model.position
             self.contributes = self.model.contributes(
-                mask_fit, margin=self.cutout_width, use_evaluation_region=True
+                mask=mask, margin=self.cutout_width, use_evaluation_region=True
             )
             try:
                 self.exposure = exposure.cutout(

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2528,7 +2528,8 @@ class MapEvaluator:
         log.debug("Updating model evaluator")
 
         if mask is None:
-            mask = Map.from_geom(geom.to_image(), data=True, dtype=bool)
+            mask = Map.from_geom(geom.to_image(), dtype=bool)
+            mask.data |= True
 
         # lookup edisp
         if edisp:

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -5,7 +5,6 @@ import numpy as np
 import astropy.units as u
 from astropy.io import fits
 from astropy.nddata.utils import NoOverlapError
-from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.utils import lazyproperty
 from regions import CircleSkyRegion
@@ -13,7 +12,6 @@ from gammapy.data import GTI
 from gammapy.irf import EDispKernelMap, EDispMap, PSFKernel, PSFMap
 from gammapy.maps import Map, MapAxis, RegionGeom, WcsGeom
 from gammapy.modeling.models import (
-    Models,
     BackgroundModel,
     DatasetModels,
     FoVBackgroundModel,
@@ -50,16 +48,6 @@ BINSZ_IRF_DEFAULT = 0.2
 
 EVALUATION_MODE = "local"
 USE_NPRED_CACHE = True
-
-
-def get_cutout_width(model, psf=None, margin=CUTOUT_MARGIN):
-    """Cutout width for the model component"""
-    if psf is not None:
-        psf_width = np.max(psf.psf_kernel_map.geom.width)
-    else:
-        psf_width = 0 * u.deg
-
-    return psf_width + 2 * (model.evaluation_radius + margin)
 
 
 def create_map_dataset_geoms(
@@ -429,7 +417,6 @@ class MapDataset(Dataset):
                     self.edisp,
                     self._geom,
                     self.mask,
-                    self.mask_safe_psf,
                 )
 
             if evaluator.contributes:
@@ -2508,11 +2495,20 @@ class MapEvaluator:
         return update
 
     @property
+    def psf_width(self):
+        if self.psf is not None:
+            psf_width = np.max(self.psf.psf_kernel_map.geom.width)
+        else:
+            psf_width = 0 * u.deg
+        return psf_width
+
+    @property
     def cutout_width(self):
         """Cutout width for the model component"""
-        return get_cutout_width(self.model, psf=self.psf)
 
-    def update(self, exposure, psf, edisp, geom, mask, mask_safe_psf):
+        return self.psf_width + 2 * (self.model.evaluation_radius + CUTOUT_MARGIN)
+
+    def update(self, exposure, psf, edisp, geom, mask):
         """Update MapEvaluator, based on the current position of the model component.
 
         Parameters
@@ -2527,27 +2523,15 @@ class MapEvaluator:
             Counts geom
         mask : `~gammapy.maps.Map`
             Mask to apply to the likelihood for fitting.
-        mask_safe_psf : `~gammapy.maps.Map`
-            Mask safe map of boolean type.
         """
         # TODO: simplify and clean up
         log.debug("Updating model evaluator")
-        # cache current position of the model component
-        if mask_safe_psf:
-            if not self.model.contributes(mask_safe_psf, use_evaluation_region=False):
-                mask = mask_safe_psf.reduce_over_axes(func=np.logical_or)
-                self.irf_position = mask.mask_nearest_position(self.model.position)
-                log.warning(
-                    f"Center position for {self.model.name} model is outside dataset mask safe, using nearest IRF defined within"
-                )
-        else:
-            self.irf_position = self.model.position
 
         # lookup edisp
         if edisp:
             energy_axis = geom.axes["energy"]
             self.edisp = edisp.get_edisp_kernel(
-                self.irf_position, energy_axis=energy_axis
+                self.model.position, energy_axis=energy_axis
             )
 
         # lookup psf
@@ -2560,12 +2544,12 @@ class MapEvaluator:
             if geom.is_region:
                 geom = geom.to_wcs_geom()
 
-            self.psf = psf.get_psf_kernel(position=self.irf_position, geom=geom)
+            self.psf = psf.get_psf_kernel(position=self.model.position, geom=geom)
 
         if self.evaluation_mode == "local" and self.model.evaluation_radius is not None:
             self._init_position = self.model.position
             self.contributes = self.model.contributes(
-                mask=mask, margin=self.cutout_width, use_evaluation_region=True
+                mask=mask, margin=self.psf_width, use_evaluation_region=True
             )
             try:
                 self.exposure = exposure.cutout(

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2533,20 +2533,13 @@ class MapEvaluator:
         # TODO: simplify and clean up
         log.debug("Updating model evaluator")
         # cache current position of the model component
-        if (
-            self.model.position is not None
-            and mask_safe_psf is not None
-            and np.any(mask_safe_psf.data)
-            and isinstance(mask_safe_psf.geom, WcsGeom)
-        ):
-            coords = mask_safe_psf.geom.get_coord().skycoord
-            separation = coords.separation(self.model.position)
-            separation[~mask_safe_psf.data] = np.inf
-            idx = np.argmin(separation)
-            self.irf_position = coords.flatten()[idx]
-            log.warning(
-                f"Center position for {self.model.name} model is outside dataset mask safe, using nearest IRF defined within"
-            )
+        if mask_safe_psf:
+            if not self.model.contributes(mask_safe_psf, use_evaluation_region=False):
+                mask = mask_safe_psf.reduce_over_axes(func=np.logical_or)
+                self.irf_position = mask.mask_nearest_position(self.model.position)
+                log.warning(
+                    f"Center position for {self.model.name} model is outside dataset mask safe, using nearest IRF defined within"
+                )
         else:
             self.irf_position = self.model.position
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -73,8 +73,7 @@ class MapDatasetEventSampler:
                     dataset.psf,
                     dataset.edisp,
                     dataset._geom,
-                    dataset.mask_fit,
-                    dataset.mask_safe_psf,
+                    dataset.mask,
                 )
 
             flux = evaluator.compute_flux()

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -210,7 +210,6 @@ class TSMapEstimator(Estimator):
             dataset.edisp,
             dataset.counts.geom,
             dataset.mask_fit,
-            dataset.mask_safe_psf,
         )
 
         kernel = evaluator.compute_npred()

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -112,6 +112,8 @@ class EDispMap(IRFMap):
                 "EnergyDispersion can be extracted at one single position only."
             )
 
+        position = self._get_nearest_valid_position(position)
+
         energy_axis_true = self.edisp_map.geom.axes["energy_true"]
         migra_axis = self.edisp_map.geom.axes["migra"]
 
@@ -390,6 +392,7 @@ class EDispKernelMap(IRFMap):
         else:
             if position is None:
                 position = self.edisp_map.geom.center_skydir
+            position = self._get_nearest_valid_position(position)
 
             kernel_map = self.edisp_map.to_region_nd_map(region=position)
 

--- a/gammapy/irf/psf/psf_map.py
+++ b/gammapy/irf/psf/psf_map.py
@@ -264,6 +264,8 @@ class PSFMap(IRFMap):
         if position is None:
             position = self.psf_map.geom.center_skydir
 
+        position = self._get_nearest_valid_position(position)
+
         if max_radius is None:
             max_radius = np.max(self.psf_map.geom.axes["rad"].center)
             min_radius_geom = np.min(geom.width) / 2.0
@@ -370,7 +372,7 @@ class PSFMap(IRFMap):
                 binsz=180,
             )
 
-        geom = geom.to_cube([rad_axis, energy_axis_true])
+        geom = geom.to_image().to_cube([rad_axis, energy_axis_true])
 
         coords = geom.get_coord()
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1121,6 +1121,30 @@ class Map(abc.ABC):
         geom = self.geom.to_image().to_cube(axes=[energy_axis])
         return self._init_copy(geom=geom, data=data)
 
+    def mask_nearest_position(self, position):
+        """Given a sky coordinate return nearest valid position in the mask
+
+        If the mask contains additional axes, the mask is reduced over those.
+
+        Parameters
+        ----------
+        position : `SkyCoord`
+            Test position
+
+        Returns
+        -------
+        position : `SkyCoord`
+            Nearest position in the mask
+        """
+        if not self.geom.is_image:
+            raise ValueError("Method only supported for 2D images")
+
+        coords = self.geom.to_image().get_coord().skycoord
+        separation = coords.separation(position)
+        separation[~self.data] = np.inf
+        idx = np.argmin(separation)
+        return coords.flatten()[idx]
+
     def sum_over_axes(self, axes_names=None, keepdims=True, weights=None):
         """To sum map values over all non-spatial axes.
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -580,33 +580,29 @@ class WcsNDMap(WcsMap):
 
         return self.to_region_nd_map(region=region, func=func, weights=weights)
 
-    def mask_contains_region(self, regions):
-        """Check if input regions are overlaping with a boolean mask map.
+    def mask_contains_region(self, region):
+        """Check if input region is contained in a boolean mask map.
 
         Parameters
         ----------
-        regions: `~regions.Region`
+        region: `~regions.SkyRegion` or `~regions.PixRegion`
              Region or list of Regions (pixel or sky regions accepted).
 
         Returns
         -------
-        overlap : `numpy.array`
-            Boolean array of same length than regions
+        contained : bool
+            Whether region is contained in the mask
         """
-
         if not self.is_mask:
             raise ValueError("mask_contains_region is only supported for boolean masks")
 
-        pixcoords = self.geom.get_idx()
-        pixcoords = PixCoord(pixcoords[0][self.data], pixcoords[1][self.data])
-        if not isinstance(regions, list):
-            regions = [regions]
-        overlap = np.zeros(len(regions), dtype=bool)
-        for k, region in enumerate(regions):
-            if isinstance(region, SkyRegion):
-                region = region.to_pixel(self.geom.wcs)
-            overlap[k] = np.any(region.contains(pixcoords))
-        return overlap
+        idx = self.geom.get_idx()
+        coords_pix = PixCoord(idx[0][self.data], idx[1][self.data])
+
+        if isinstance(region, SkyRegion):
+            region = region.to_pixel(self.geom.wcs)
+
+        return np.any(region.contains(coords_pix))
 
     def binary_erode(self, width):
         """Binary erosion of boolean mask removing a given margin

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -191,6 +191,11 @@ class SkyModel(Model):
         return self.spatial_model.evaluation_radius
 
     @property
+    def evaluation_region(self):
+        """`~astropy.coordinates.Angle`"""
+        return self.spatial_model.evaluation_region
+
+    @property
     def frame(self):
         return self.spatial_model.frame
 
@@ -223,11 +228,9 @@ class SkyModel(Model):
         ----------
         mask : `~gammapy.maps.WcsNDMap` of boolean type
             Map containing a boolean mask
-
-        marign : `~astropy.coordinates.Angle`
+        margin : `~astropy.coordinates.Angle`
             Add a margin in degree to the source evaluation radius.
             The default is None. Used to take into account PSF width.
-
         use_evaluation_region : bool
             Account for the extension of the model or not. The default is True.   
 
@@ -236,36 +239,28 @@ class SkyModel(Model):
         models : `DatasetModels`
             Selected models contributing inside the region where mask==True
         """
+        # TODO: there is a lot of computation done here maybe simplify
+        if not mask.geom.is_image:
+            mask = mask.reduce_over_axes(func=np.logical_or)
 
-        mask_shape = len(mask.data.squeeze().shape)
-        if mask_shape > 2:
-            mask = mask.sum_over_axes()
-            mask.data = mask.data.astype(bool)
-        elif mask_shape < 2:
-            return True
-        if not np.any(mask.data):
-            return False
+        if mask.geom.is_region:
+            if mask.geom.region is None:
+                return True
+
+            geom = mask.geom.to_wcs_geom()
+            mask = geom.region_mask([mask.geom.region])
+
         if margin is not None:
             mask = mask.binary_dilate(width=margin, mode="full")
 
         # check center only first (faster)
-        ind = self.position.to_pixel(mask.geom.wcs)
-        ind = tuple([int(round(idx.item())) for idx in ind])
-        try:
-            contributes = mask.data.squeeze()[ind]
-        except (IndexError):  # if outside geom
-            contributes = False
-        # account for extension or not
-        if (
-            not contributes
-            and use_evaluation_region
-            and self.spatial_model is not None
-            and self.spatial_model.evaluation_region is not None
-        ):
-            contributes = np.any(
-                mask.mask_contains_region(self.spatial_model.evaluation_region)
-            )
-        return contributes
+        if np.nan_to_num(mask.get_by_coord(self.position)[0]):
+            return True
+
+        if use_evaluation_region:
+            return mask.mask_contains_region(self.evaluation_region)
+
+        return False
 
     def evaluate(self, lon, lat, energy, time=None):
         """Evaluate the model at given points.
@@ -560,6 +555,10 @@ class FoVBackgroundModel(Model):
 
         self._spectral_model = spectral_model
         super().__init__()
+
+    def contributes(self, *args, **kwargs):
+        """FoV background models always contribute"""
+        return True
 
     @property
     def spectral_model(self):

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -52,6 +52,25 @@ def models(backgrounds):
     return models
 
 
+@pytest.fixture(scope="session")
+def models_gauss():
+    model1 = SkyModel.create("pl", "gauss", name="source-1")
+    model1.spatial_model.sigma.value = 0.1
+    model1.spatial_model.lon_0.value = 0
+    model1.spatial_model.lat_0.value = 0
+
+    model2 = SkyModel.create("pl", "gauss", name="source-2")
+    model2.spatial_model.sigma.value = 0.1
+    model2.spatial_model.lon_0.value = 1.1
+    model2.spatial_model.lat_0.value = 0
+
+    model3 = SkyModel.create("pl", "gauss", name="source-3")
+    model3.spatial_model.sigma.value = 0.1
+    model3.spatial_model.lon_0.value = -1.8
+    model3.spatial_model.lat_0.value = 0
+    return Models([model1, model2, model3])
+
+
 def test_select_region(models):
     center_sky = SkyCoord(3, 4, unit="deg", frame="galactic")
     circle_sky_12 = CircleSkyRegion(center=center_sky, radius=1 * u.deg)
@@ -66,24 +85,32 @@ def test_select_region(models):
     selected = models.select_region([circle_sky_3, circle_sky_12])
     assert selected.names == ["source-1", "source-2", "source-3"]
 
+
+def test_select_mask(models_gauss):
+    center_sky = SkyCoord("0d", "0d")
+    circle = CircleSkyRegion(center=center_sky, radius=1 * u.deg)
+    axis = MapAxis.from_energy_edges(np.logspace(-1, 1, 3), unit="TeV")
+    geom = WcsGeom.create(skydir=center_sky, width=(5, 4), axes=[axis], binsz=0.02)
+
+    mask = geom.region_mask([circle])
+
+    contribute = models_gauss.select_mask(mask, margin=None, use_evaluation_region=True)
+    assert contribute.names == ["source-1", "source-2"]
+
+    inside = models_gauss.select_mask(mask, margin=None, use_evaluation_region=False)
+    assert inside.names == ["source-1"]
+
+    contribute_margin = models_gauss    .select_mask(mask, margin=0.1 * u.deg, use_evaluation_region=True)
+    assert contribute_margin.names == ["source-1", "source-2", "source-3"]
+
+
+def test_contributes(models):
+    center_sky = SkyCoord(3, 4, unit="deg", frame="galactic")
+    circle_sky_12 = CircleSkyRegion(center=center_sky, radius=1 * u.deg)
     axis = MapAxis.from_edges(np.logspace(-1, 1, 3), unit=u.TeV, name="energy")
     geom = WcsGeom.create(skydir=(3, 4), npix=(5, 4), frame="galactic", axes=[axis])
-    mask = geom.region_mask([circle_sky_12])
-    contribute = models.select_mask(mask, margin=None, use_evaluation_region=True)
-    inside = models.select_mask(mask, margin=None, use_evaluation_region=False)
-    assert contribute.names == ["source-1", "source-2"]
-    assert inside.names == ["source-1", "source-2"]
 
-    axis = MapAxis.from_edges(np.logspace(-1, 1, 3), unit=u.TeV, name="energy")
-    geom = WcsGeom.create(
-        skydir=(3, 4), binsz=0.1, npix=(15, 15), frame="galactic", axes=[axis]
-    )
     mask = geom.region_mask([circle_sky_12])
-    contribute = models.select_mask(
-        mask, margin=4.1 * u.deg, use_evaluation_region=True
-    )
-    assert contribute.names == ["source-1", "source-2", "source-3"]
-
     spatial_model = GaussianSpatialModel(
         lon_0="0 deg", lat_0="0 deg", sigma="0.9 deg", frame="galactic"
     )

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -123,20 +123,21 @@ def make_pixel_region(region, wcs=None):
 
 
 def compound_region_center(compound_region):
-    """Get geometric mean of a set of sky coordinates
+    """Compute center for a CompoundRegion
 
-    The geometric meamn is defined as the point the minimises
-    the distance to all other points
+    The center of the compound region is defined here as the geometric median
+    of the individual centers of the regions. The geometric median is defined
+    as the point the minimises the distance to all other points.
 
     Parameters
     ----------
-    region : `CompoundRegion`
-        Positions in the sky
+    compound_region : `CompoundRegion`
+        Compound region
 
     Returns
     -------
     center : `SkyCoord`
-        Geometric median of the positions
+        Geometric median of the positions of the individual regions
     """
     regions = compound_region_to_list(compound_region)
     positions = SkyCoord([region.center for region in regions])

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -18,6 +18,7 @@ Options: keep as-is, hide from the docs, or to remove it completely
 """
 import operator
 import numpy as np
+from scipy.optimize import minimize
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from regions import (
@@ -119,6 +120,35 @@ def make_pixel_region(region, wcs=None):
         return region
     else:
         raise TypeError(f"Invalid type: {region!r}")
+
+
+def compound_region_center(compound_region):
+    """Get geometric mean of a set of sky coordinates
+
+    The geometric meamn is defined as the point the minimises
+    the distance to all other points
+
+    Parameters
+    ----------
+    region : `CompoundRegion`
+        Positions in the sky
+
+    Returns
+    -------
+    center : `SkyCoord`
+        Geometric median of the positions
+    """
+    regions = compound_region_to_list(compound_region)
+    positions = SkyCoord([region.center for region in regions])
+
+    def f(x, coords):
+        """Function to minimize"""
+        lon, lat = x
+        center = SkyCoord(lon * u.deg, lat * u.deg)
+        return np.sum(center.separation(coords).deg)
+
+    result = minimize(f, x0=[0, 0], args=(positions,), bounds=[(-180, 180), (-90, 90)])
+    return SkyCoord(result.x[0], result.x[1], frame="icrs", unit="deg")
 
 
 def compound_region_to_list(region):

--- a/gammapy/utils/tests/test_regions.py
+++ b/gammapy/utils/tests/test_regions.py
@@ -17,6 +17,7 @@ from gammapy.utils.regions import (
     SphericalCircleSkyRegion,
     make_pixel_region,
     make_region,
+    compound_region_center
 )
 
 
@@ -60,6 +61,21 @@ def test_make_pixel_region():
 
     with pytest.raises(TypeError):
         make_pixel_region(99)
+
+
+def test_compound_region_center():
+    region_1 = make_region("galactic;circle(1,1,0.1)")
+    region_2 = make_region("galactic;circle(-1,1,0.1)")
+    region_3 = make_region("galactic;circle(1,-1,0.1)")
+    region_4 = make_region("galactic;circle(-1,-1,0.1)")
+
+    for region in [region_2, region_3, region_4]:
+        region_1 = region_1.union(region)
+
+    center = compound_region_center(region_1)
+
+    assert_allclose(center.galactic.l.wrap_at("180d"), 0 * u.deg, atol=1e-6)
+    assert_allclose(center.galactic.b, 0 * u.deg, atol=1e-6)
 
 
 class TestSphericalCircleSkyRegion:


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
This pull request is a follow-up to #3169. It further breaks down the functionality like so:
- Introduce `Map.mask_nearest_position()`, which returns the nearest position inside the mask to given position
- Move the selection of the nearest IRF to `IRFMap`. Right now it was using the `mask_safe_psf` for PSF as EDisp, however it's not guaranteed that those agree. For this is introduce a `IRFMap.mask_safe_irf`, which derives the mask from the data. however we might think about moving the mask safe for the IRF to the `IRFMap` completely, this would be more than convenient for stacking as well...
- Test wise I introduced `RegionGeom.from_regions()`, which creates a `RegionGeom` with a `CompoundSkyRegion` from a list of regions, while working on this I think we should clarify the handling of `CompoundRegion` vs. a list of `Region`, everywhere in Gammapy. I added it as a discussion point on the agenda for the dev call on Friday. 



<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->


**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
