### PR TITLE
Make `is_norm_spectral_model` as classproperty

### DIFF
--- a/docs/tutorials/models.ipynb
+++ b/docs/tutorials/models.ipynb
@@ -243,7 +243,9 @@
    "metadata": {},
    "source": [
     "Normed spectral models are a special class of Spectral Models, which have a dimension-less normalisation. These spectral models feature a norm parameter instead\n",
-    "of amplitude and are named using the ``NormSpectralModel`` suffix. They **must** be used along with another spectral model, as a multiplicative correction factor according to their spectral shape. They can be typically used for adjusting template based models, or adding a EBL correction to some analytic model. "
+    "of amplitude and are named using the ``NormSpectralModel`` suffix. They **must** be used along with another spectral model, as a multiplicative correction factor according to their spectral shape. They can be typically used for adjusting template based models, or adding a EBL correction to some analytic model. \n",
+    "\n",
+    "To check if a given `SpectralModel` is a norm model, you can simply look at the `is_norm_spectral_model` property"
    ]
   },
   {
@@ -254,7 +256,7 @@
    "source": [
     "# To see the available norm models shipped with gammapy:\n",
     "for model in SPECTRAL_MODEL_REGISTRY:\n",
-    "    if str(model)[-19:-2] == \"NormSpectralModel\":\n",
+    "    if model.is_norm_spectral_model:\n",
     "        print(model)"
    ]
   },
@@ -299,17 +301,6 @@
    "source": [
     "energy = [0.3, 1, 3, 10, 30] * u.TeV\n",
     "pwl_norm(energy)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# To check if a Norm model\n",
-    "print(pwl_norm.is_norm_spectral_model)  # this is a norm model\n",
-    "print(pwl.is_norm_spectral_model)  # this is not a norm model"
    ]
   },
   {
@@ -1259,13 +1250,6 @@
     "    \"\"\"Evaluation radius (`~astropy.coordinates.Angle`).\"\"\"\n",
     "    return 5 * np.max([self.sigma_1TeV.value, self.sigma_10TeV.value]) * u.deg"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -7,6 +7,7 @@ import scipy.special
 import astropy.units as u
 from astropy import constants as const
 from astropy.table import Table
+from astropy.utils.decorators import classproperty
 from gammapy.maps import MapAxis
 from gammapy.modeling import Parameter, Parameters
 from gammapy.utils.integrate import trapz_loglog
@@ -51,10 +52,10 @@ class SpectralModel(Model):
         kwargs = self._convert_evaluate_unit(kwargs, energy)
         return self.evaluate(energy, **kwargs)
 
-    @property
-    def is_norm_spectral_model(self):
+    @classproperty
+    def is_norm_spectral_model(cls):
         """Whether model is a norm spectral model"""
-        return "Norm" in self.__class__.__name__
+        return "Norm" in cls.__name__
 
     @staticmethod
     def _convert_evaluate_unit(kwargs_ref, energy):
@@ -141,9 +142,7 @@ class SpectralModel(Model):
         dnde, dnde_error : tuple of `~astropy.units.Quantity`
             Tuple of flux and flux error.
         """
-        return self._propagate_error(
-            epsilon=epsilon, fct=self, energy=energy
-        )
+        return self._propagate_error(epsilon=epsilon, fct=self, energy=energy)
 
     def integral(self, energy_min, energy_max, **kwargs):
         r"""Integrate spectral model numerically if no analytical solution defined.
@@ -189,7 +188,7 @@ class SpectralModel(Model):
             fct=self.integral,
             energy_min=energy_min,
             energy_max=energy_max,
-            **kwargs
+            **kwargs,
         )
 
     def energy_flux(self, energy_min, energy_max, **kwargs):
@@ -239,7 +238,7 @@ class SpectralModel(Model):
             fct=self.energy_flux,
             energy_min=energy_min,
             energy_max=energy_max,
-            **kwargs
+            **kwargs,
         )
 
     def plot(


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request follows from #3210 and makes`SpectralModel.is_norm_spectral_model` as classproperty

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
