### PR TITLE
Caplog test spectral

### DIFF
--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -259,6 +259,40 @@ which does assert that units are equal, and calls `numpy.testing.assert_equal` f
 
 .. _dev_random:
 
+
+
+Caplog fixture
+--------------
+
+Inside tests, we have the possibility to change the log level for the captured log messages using the ``caplog`` fixture which allow you to access and control log capturing.
+When logging is part of your function and you want to verify the right message is logged with the expected logging level:
+
+
+.. testcode::
+
+    import pytest
+    import logging
+
+    @pytest.fixture
+    def my_caplog(caplog):
+    yield caplog
+    assert len(caplog.get_records(when='call')) > 0  # passes
+
+
+    def test_nowarn(my_caplog):
+    logging.getLogger().warning('Hello gammapy user')
+    assert len(my_caplog.records) > 0  # passes
+
+    def test_something(caplog):
+    assert caplog.records[-1].levelname == "WARNING"
+    assert "warning message" in caplog.records[-1].message
+
+
+
+
+
+
+
 Random numbers
 --------------
 
@@ -342,6 +376,8 @@ informing the user about what they are doing.
 
 Gammapy uses the Python standard library `logging` module. This module is extremely flexible,
 but also quite complex. But our logging needs are very modest, so it's actually quite simple ...
+
+It is worth mentioning that important logs returned to the user should be captured and tested using caplog fixture, see the section Caplog fixture above
 
 Generating log messages
 +++++++++++++++++++++++

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -395,6 +395,51 @@ def test_model_plot():
     with mpl_plot_check():
         pwl.plot_error((1 * u.TeV, 10 * u.TeV))
 
+def test_to_from_dict():
+    spectrum = TEST_MODELS[0]
+    model = spectrum["model"]
+
+    model_dict = model.to_dict()
+    # Here we reverse the order of parameters list to ensure assignment is correct
+    model_dict['parameters'].reverse()
+
+    model_class = SPECTRAL_MODEL_REGISTRY.get_cls(model_dict["type"][2])
+    new_model = model_class.from_dict(model_dict)
+
+    assert isinstance(new_model, PowerLawSpectralModel)
+
+    actual = [par.value for par in new_model.parameters]
+    desired = [par.value for par in model.parameters]
+    assert_quantity_allclose(actual, desired)
+
+    actual = [par.frozen for par in new_model.parameters]
+    desired = [par.frozen for par in model.parameters]
+    assert_allclose(actual, desired)
+
+def test_to_from_dict_partial_input(caplog):
+    spectrum = TEST_MODELS[0]
+    model = spectrum["model"]
+
+    model_dict = model.to_dict()
+    # Here we remove the reference energy
+    model_dict['parameters'].remove(model_dict['parameters'][0])
+    print(model_dict['parameters'][0])
+
+    model_class = SPECTRAL_MODEL_REGISTRY.get_cls(model_dict["type"])
+    new_model = model_class.from_dict(model_dict)
+
+    assert isinstance(new_model, PowerLawSpectralModel)
+
+    actual = [par.value for par in new_model.parameters]
+    desired = [par.value for par in model.parameters]
+    assert_quantity_allclose(actual, desired)
+
+    actual = [par.frozen for par in new_model.parameters]
+    desired = [par.frozen for par in model.parameters]
+    assert_allclose(actual, desired)
+
+
+
 
 def test_to_from_dict():
     spectrum = TEST_MODELS[0]
@@ -417,6 +462,8 @@ def test_to_from_dict():
     desired = [par.frozen for par in model.parameters]
     assert_allclose(actual, desired)
 
+
+
 def test_to_from_dict_partial_input():
     spectrum = TEST_MODELS[0]
     model = spectrum["model"]
@@ -438,6 +485,32 @@ def test_to_from_dict_partial_input():
     actual = [par.frozen for par in new_model.parameters]
     desired = [par.frozen for par in model.parameters]
     assert_allclose(actual, desired)
+
+
+def test_to_from_dict_partial_input_wrong_parameters(caplog):
+    spectrum = TEST_MODELS[0]
+    model = spectrum["model"]
+
+    model_dict = model.to_dict()
+    # Here we remove the reference energy
+    model_dict['parameters'].remove(model_dict['parameters'][0])
+    print(model_dict['parameters'][0])
+
+    model_class = SPECTRAL_MODEL_REGISTRY.get_cls(model_dict["type"])
+    new_model = model_class.from_dict(model_dict)
+
+    assert isinstance(new_model, PowerLawSpectralModel)
+
+    # actual = [par.value for par in new_model.parameters]
+    # desired = [par.value for par in model.parameters]
+    # assert_quantity_allclose(actual, desired)
+    #
+    # actual = [par.frozen for par in new_model.parameters]
+    # desired = [par.frozen for par in model.parameters]
+    # assert_allclose(actual, desired)
+
+    assert "gammapy.modeling.models.core:core.py:151 Parameter index not defined. Using default value: 2.0" in caplog.text
+    print(caplog.text)
 
 
 def test_to_from_dict_compound():

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -416,30 +416,6 @@ def test_to_from_dict():
     desired = [par.frozen for par in model.parameters]
     assert_allclose(actual, desired)
 
-def test_to_from_dict_partial_input(caplog):
-    spectrum = TEST_MODELS[0]
-    model = spectrum["model"]
-
-    model_dict = model.to_dict()
-    # Here we remove the reference energy
-    model_dict['parameters'].remove(model_dict['parameters'][0])
-    print(model_dict['parameters'][0])
-
-    model_class = SPECTRAL_MODEL_REGISTRY.get_cls(model_dict["type"])
-    new_model = model_class.from_dict(model_dict)
-
-    assert isinstance(new_model, PowerLawSpectralModel)
-
-    actual = [par.value for par in new_model.parameters]
-    desired = [par.value for par in model.parameters]
-    assert_quantity_allclose(actual, desired)
-
-    actual = [par.frozen for par in new_model.parameters]
-    desired = [par.frozen for par in model.parameters]
-    assert_allclose(actual, desired)
-
-
-
 
 def test_to_from_dict():
     spectrum = TEST_MODELS[0]

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -464,7 +464,7 @@ def test_to_from_dict():
 
 
 
-def test_to_from_dict_partial_input():
+def test_to_from_dict_partial_input(caplog):
     spectrum = TEST_MODELS[0]
     model = spectrum["model"]
 
@@ -485,32 +485,12 @@ def test_to_from_dict_partial_input():
     actual = [par.frozen for par in new_model.parameters]
     desired = [par.frozen for par in model.parameters]
     assert_allclose(actual, desired)
+    assert caplog.records[-1].levelname == "WARNING"
+    assert caplog.records[-1].message =="Parameter reference not defined. Using default value: 1.0 TeV"
 
 
-def test_to_from_dict_partial_input_wrong_parameters(caplog):
-    spectrum = TEST_MODELS[0]
-    model = spectrum["model"]
 
-    model_dict = model.to_dict()
-    # Here we remove the reference energy
-    model_dict['parameters'].remove(model_dict['parameters'][0])
-    print(model_dict['parameters'][0])
 
-    model_class = SPECTRAL_MODEL_REGISTRY.get_cls(model_dict["type"])
-    new_model = model_class.from_dict(model_dict)
-
-    assert isinstance(new_model, PowerLawSpectralModel)
-
-    # actual = [par.value for par in new_model.parameters]
-    # desired = [par.value for par in model.parameters]
-    # assert_quantity_allclose(actual, desired)
-    #
-    # actual = [par.frozen for par in new_model.parameters]
-    # desired = [par.frozen for par in model.parameters]
-    # assert_allclose(actual, desired)
-
-    assert "gammapy.modeling.models.core:core.py:151 Parameter index not defined. Using default value: 2.0" in caplog.text
-    print(caplog.text)
 
 
 def test_to_from_dict_compound():


### PR DESCRIPTION


This pull request adds caplog to test_to_from_dict_partial_input_wrong_parameters in test_spectral.py but there is some commented lines to be refined since they engender errors
