### PR TITLE
Add alternative parametrization for ShellSpatialModel

### DIFF
--- a/examples/models/spatial/plot_gen_gauss.py
+++ b/examples/models/spatial/plot_gen_gauss.py
@@ -14,7 +14,7 @@ By default, the Generalized Gaussian is defined as :
 the normalization is expressed as:
 
 .. math::
-    N = \frac{1}{ 2 \pi (1-e) r_{\rm eff}^2 \eta \Gamma(2\eta)}\,
+    N = \frac{1}{ 2 \pi \sqrt(1-e^2) r_{\rm eff}^2 \eta \Gamma(2\eta)}\,
 
 where :math:`\Gamma` is the gamma function.
 This analytical norm is approximated so it may not integrate to unity in extremal cases

--- a/examples/models/spatial/plot_shell.py
+++ b/examples/models/spatial/plot_shell.py
@@ -28,43 +28,20 @@ although that approximation is still very good even for 10 deg radius shells.
 # %%
 # Example plot
 # ------------
-# Here is an example plot of the model for the parametrization using inner radius and width:
-import matplotlib.pyplot as plt
+# Here is an example plot of the model:
 
 from gammapy.modeling.models import (
     Models,
     PowerLawSpectralModel,
     ShellSpatialModel,
-    Shell2SpatialModel,
     SkyModel,
 )
 
-# 
 model = ShellSpatialModel(
     lon_0="10 deg", lat_0="20 deg", radius="2 deg", width="0.5 deg", frame="galactic",
 )
+
 model.plot(add_cbar=True)
-
-# %%
-# Here is an example plot of the model for the alternative parametrization using outer radius and relative width
-# In this case the relative width, eta, acts as a shape parameter.
-
-tags = [r"Disk-like, $\eta \rightarrow 0$", r"Shell, $\eta=0.25$",  r"Peaked, $\eta\rightarrow 1$"]
-eta_range = [0.001, 0.25, 1]
-fig, axes = plt.subplots(1, 3, figsize=(9, 6))
-for ax, eta, tag in zip(axes, eta_range, tags):
-    model = Shell2SpatialModel(
-        lon_0="10 deg",
-        lat_0="20 deg",
-        r_0= "2 deg",
-        eta=eta,
-        frame="galactic",
-    )
-    model.plot(ax=ax)
-    ax.set_title(tag)
-    ax.set_xticks([])
-    ax.set_yticks([])
-plt.tight_layout()
 
 # %%
 # YAML representation
@@ -73,11 +50,8 @@ plt.tight_layout()
 
 pwl = PowerLawSpectralModel()
 shell = ShellSpatialModel()
-shell2= Shell2SpatialModel()
 
 model = SkyModel(spectral_model=pwl, spatial_model=shell, name="pwl-shell-model")
-model2 = SkyModel(spectral_model=pwl, spatial_model=shell2, name="pwl-shell2-model")
-
-models = Models([model, model2])
+models = Models([model])
 
 print(models.to_yaml())

--- a/examples/models/spatial/plot_shell.py
+++ b/examples/models/spatial/plot_shell.py
@@ -28,20 +28,43 @@ although that approximation is still very good even for 10 deg radius shells.
 # %%
 # Example plot
 # ------------
-# Here is an example plot of the model:
+# Here is an example plot of the model for the parametrization using inner radius and width:
+import matplotlib.pyplot as plt
 
 from gammapy.modeling.models import (
     Models,
     PowerLawSpectralModel,
     ShellSpatialModel,
+    Shell2SpatialModel,
     SkyModel,
 )
 
+# 
 model = ShellSpatialModel(
     lon_0="10 deg", lat_0="20 deg", radius="2 deg", width="0.5 deg", frame="galactic",
 )
-
 model.plot(add_cbar=True)
+
+# %%
+# Here is an example plot of the model for the alternative parametrization using outer radius and relative width
+# In this case the relative width, eta, acts as a shape parameter.
+
+tags = [r"Disk-like, $\eta \rightarrow 0$", r"Shell, $\eta=0.25$",  r"Peaked, $\eta\rightarrow 1$"]
+eta_range = [0.001, 0.25, 1]
+fig, axes = plt.subplots(1, 3, figsize=(9, 6))
+for ax, eta, tag in zip(axes, eta_range, tags):
+    model = Shell2SpatialModel(
+        lon_0="10 deg",
+        lat_0="20 deg",
+        r_0= "2 deg",
+        eta=eta,
+        frame="galactic",
+    )
+    model.plot(ax=ax)
+    ax.set_title(tag)
+    ax.set_xticks([])
+    ax.set_yticks([])
+plt.tight_layout()
 
 # %%
 # YAML representation
@@ -50,8 +73,11 @@ model.plot(add_cbar=True)
 
 pwl = PowerLawSpectralModel()
 shell = ShellSpatialModel()
+shell2= Shell2SpatialModel()
 
 model = SkyModel(spectral_model=pwl, spatial_model=shell, name="pwl-shell-model")
-models = Models([model])
+model2 = SkyModel(spectral_model=pwl, spatial_model=shell2, name="pwl-shell2-model")
+
+models = Models([model, model2])
 
 print(models.to_yaml())

--- a/examples/models/spatial/plot_shell2.py
+++ b/examples/models/spatial/plot_shell2.py
@@ -23,6 +23,7 @@ and  :math:`r_{\text{in}}` is the inner radius.
 
 For Shell2SpatialModel, the radius parameter  r_0 correspond to :math:`r_{\text{out}}`
 and the relative width parameter is given as eta = :math:`(r_{\text{out}} - r_{\text{in}})/r_{\text{out}}`
+so we have :math:`r_{\text{in}} = (1-eta) r_{\text{out}}`.
 
 Note that the normalization is a small angle approximation,
 although that approximation is still very good even for 10 deg radius shells.

--- a/examples/models/spatial/plot_shell2.py
+++ b/examples/models/spatial/plot_shell2.py
@@ -1,0 +1,77 @@
+r"""
+.. _shell2-spatial-model:
+
+Shell2 Spatial Model
+===================
+
+This is a spatial model parametrizing a projected radiating shell.
+
+The shell spatial model is defined by the following equations:
+
+.. math::
+    \phi(lon, lat) = \frac{3}{2 \pi (r_{out}^3 - r_{in}^3)} \cdot
+            \begin{cases}
+                \sqrt{r_{out}^2 - \theta^2} - \sqrt{r_{in}^2 - \theta^2} &
+                             \text{for } \theta \lt r_{in} \\
+                \sqrt{r_{out}^2 - \theta^2} &
+                             \text{for } r_{in} \leq \theta \lt r_{out} \\
+                0 & \text{for } \theta > r_{out}
+            \end{cases}
+
+where :math:`\theta` is the sky separation, :math:`r_{\text{out}}` is the outer radius
+and  :math:`r_{\text{in}}` is the inner radius.
+
+For Shell2SpatialModel, the radius parameter  r_0 correspond to :math:`r_{\text{out}}`
+and the relative width parameter is given as eta = :math:`(r_{\text{out}} - r_{\text{in}})/r_{\text{out}}`
+
+Note that the normalization is a small angle approximation,
+although that approximation is still very good even for 10 deg radius shells.
+
+
+"""
+
+# %%
+# Example plot
+# ------------
+# Here is an example plot of the shell model for the parametrization using outer radius and relative width.
+# In this case the relative width, eta, acts as a shape parameter.
+
+import matplotlib.pyplot as plt
+
+from gammapy.modeling.models import (
+    Models,
+    PowerLawSpectralModel,
+    Shell2SpatialModel,
+    SkyModel,
+)
+
+tags = [r"Disk-like, $\eta \rightarrow 0$", r"Shell, $\eta=0.25$",  r"Peaked, $\eta\rightarrow 1$"]
+eta_range = [0.001, 0.25, 1]
+fig, axes = plt.subplots(1, 3, figsize=(9, 6))
+for ax, eta, tag in zip(axes, eta_range, tags):
+    model = Shell2SpatialModel(
+        lon_0="10 deg",
+        lat_0="20 deg",
+        r_0= "2 deg",
+        eta=eta,
+        frame="galactic",
+    )
+    model.plot(ax=ax)
+    ax.set_title(tag)
+    ax.set_xticks([])
+    ax.set_yticks([])
+plt.tight_layout()
+
+# %%
+# YAML representation
+# -------------------
+# Here is an example YAML file using the model:
+
+pwl = PowerLawSpectralModel()
+shell2= Shell2SpatialModel()
+
+model = SkyModel(spectral_model=pwl, spatial_model=shell2, name="pwl-shell2-model")
+
+models = Models([model])
+
+print(models.to_yaml())

--- a/gammapy/modeling/models/__init__.py
+++ b/gammapy/modeling/models/__init__.py
@@ -18,6 +18,7 @@ SPATIAL_MODEL_REGISTRY = Registry(
         GeneralizedGaussianSpatialModel,
         PointSpatialModel,
         ShellSpatialModel,
+        Shell2SpatialModel,
     ]
 )
 """Registry of spatial model classes."""

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -632,7 +632,7 @@ class ShellSpatialModel(SpatialModel):
         Center position coordinate frame
     See Also
     --------
-    ShellSpatialModel
+    Shell2SpatialModel
     """
 
     tag = ["ShellSpatialModel", "shell"]

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -513,7 +513,7 @@ class GeneralizedGaussianSpatialModel(SpatialModel):
 
     def to_region(self, **kwargs):
         """Model outline (`~regions.EllipseSkyRegion`)."""
-        minor_axis = Angle(self.r_0.quantity * (1 - self.e.quantity))
+        minor_axis = Angle(self.r_0.quantity * np.sqrt(1 - self.e.quantity ** 2))
         return EllipseSkyRegion(
             center=self.position,
             height=2 * self.r_0.quantity,

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -680,7 +680,7 @@ class ShellSpatialModel(SpatialModel):
 class Shell2SpatialModel(SpatialModel):
     r"""Shell model with outer radius and relative width parametrization
 
-    For more information see :ref:`shell-spatial-model`.
+    For more information see :ref:`shell2-spatial-model`.
 
     Parameters
     ----------

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -698,7 +698,7 @@ class Shell2SpatialModel(SpatialModel):
     ShellSpatialModel
     """
 
-    tag = "Shell2SpatialModel"
+    tag = ["Shell2SpatialModel", "shell2"]
     lon_0 = Parameter("lon_0", "0 deg")
     lat_0 = Parameter("lat_0", "0 deg", min=-90, max=90)
     r_0 = Parameter("r_0", "1 deg")
@@ -742,7 +742,8 @@ class Shell2SpatialModel(SpatialModel):
             outer_radius=self.r_0.quantity,
             **kwargs,
         )
-        
+
+
 class ConstantSpatialModel(SpatialModel):
     """Spatially constant (isotropic) spatial model.
 

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -225,9 +225,16 @@ def test_sky_shell():
     assert_allclose(radius.value, rad.value + width.value)
     assert isinstance(model.to_region(), CircleAnnulusSkyRegion)
 
+
+def test_sky_shell2():
+    width = 2 * u.deg
+    rad = 2 * u.deg
     model = Shell2SpatialModel(lon_0="1 deg", lat_0="45 deg", r_0=rad + width, eta=0.5)
+    lon = [1, 2, 4] * u.deg
+    lat = 45 * u.deg
     val = model(lon, lat)
     assert val.unit == "deg-2"
+    desired = [55.979449, 57.831651, 94.919895]
     assert_allclose(val.to_value("sr-1"), desired)
     radius = model.evaluation_radius
     assert radius.unit == "deg"

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -127,11 +127,13 @@ def test_generalized_gaussian(eta, r_0, e):
 
 
 def test_generalized_gaussian_io():
-    model = GeneralizedGaussianSpatialModel()
+    model = GeneralizedGaussianSpatialModel(e=0.5)
 
-    assert isinstance(model.to_region(), EllipseSkyRegion)
+    reg = model.to_region()
+    assert isinstance(reg, EllipseSkyRegion)
+    assert_allclose(reg.width.value, 1.73205, rtol=1e-5)
+    
     new_model = GeneralizedGaussianSpatialModel.from_dict(model.to_dict())
-
     assert isinstance(new_model, GeneralizedGaussianSpatialModel)
 
 

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -21,6 +21,7 @@ from gammapy.modeling.models import (
     GeneralizedGaussianSpatialModel,
     PointSpatialModel,
     ShellSpatialModel,
+    Shell2SpatialModel,
     TemplateSpatialModel,
 )
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
@@ -222,6 +223,16 @@ def test_sky_shell():
     radius = model.evaluation_radius
     assert radius.unit == "deg"
     assert_allclose(radius.value, rad.value + width.value)
+    assert isinstance(model.to_region(), CircleAnnulusSkyRegion)
+
+    model = Shell2SpatialModel(lon_0="1 deg", lat_0="45 deg", r_0=rad+width, eta=0.5)
+    val = model(lon, lat)
+    assert val.unit == "deg-2"
+    assert_allclose(val.to_value("sr-1"), desired)
+    radius = model.evaluation_radius
+    assert radius.unit == "deg"
+    assert_allclose(radius.value, rad.value + width.value)
+    assert_allclose(model.r_in.value, rad.value)
     assert isinstance(model.to_region(), CircleAnnulusSkyRegion)
 
 

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -11,7 +11,7 @@ from regions import (
     PointSkyRegion,
     PolygonSkyRegion,
     CircleSkyRegion,
-    RectangleSkyRegion
+    RectangleSkyRegion,
 )
 from gammapy.maps import Map, WcsGeom, RegionGeom, MapAxis
 from gammapy.modeling.models import (
@@ -225,7 +225,7 @@ def test_sky_shell():
     assert_allclose(radius.value, rad.value + width.value)
     assert isinstance(model.to_region(), CircleAnnulusSkyRegion)
 
-    model = Shell2SpatialModel(lon_0="1 deg", lat_0="45 deg", r_0=rad+width, eta=0.5)
+    model = Shell2SpatialModel(lon_0="1 deg", lat_0="45 deg", r_0=rad + width, eta=0.5)
     val = model(lon, lat)
     assert val.unit == "deg-2"
     assert_allclose(val.to_value("sr-1"), desired)
@@ -362,36 +362,38 @@ def test_spatial_model_plot():
 
 
 def test_integrate_geom():
-    center = SkyCoord("0d", "0d", frame='icrs')
-    model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1*u.deg, frame='icrs')
+    center = SkyCoord("0d", "0d", frame="icrs")
+    model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1 * u.deg, frame="icrs")
 
     radius_large = 1 * u.deg
     circle_large = CircleSkyRegion(center, radius_large)
     radius_small = 0.1 * u.deg
     circle_small = CircleSkyRegion(center, radius_small)
 
-    geom_large, geom_small = RegionGeom(region=circle_large), RegionGeom(region=circle_small)
+    geom_large, geom_small = (
+        RegionGeom(region=circle_large),
+        RegionGeom(region=circle_small),
+    )
 
-    integral_large, integral_small = model.integrate_geom(geom_large).data, model.integrate_geom(geom_small).data
+    integral_large, integral_small = (
+        model.integrate_geom(geom_large).data,
+        model.integrate_geom(geom_small).data,
+    )
 
     assert_allclose(integral_large[0], 1, rtol=0.01)
     assert_allclose(integral_small[0], 0.3953, rtol=0.01)
 
 
 def test_integrate_geom_energy_axis():
-    center = SkyCoord("0d", "0d", frame='icrs')
-    model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1*u.deg, frame='icrs')
-    
+    center = SkyCoord("0d", "0d", frame="icrs")
+    model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1 * u.deg, frame="icrs")
+
     radius = 1 * u.deg
     square = RectangleSkyRegion(center, radius, radius)
-    
+
     axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=10)
     geom = RegionGeom(region=square, axes=[axis])
-    
+
     integral = model.integrate_geom(geom).data
-    
+
     assert_allclose(integral, 1, rtol=0.01)
-
-
-
-

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -147,8 +147,8 @@ def compound_region_center(compound_region):
         lon, lat = x
         center = SkyCoord(lon * u.deg, lat * u.deg)
         return np.sum(center.separation(coords).deg)
-
-    result = minimize(f, x0=[0, 0], args=(positions,), bounds=[(-180, 180), (-90, 90)])
+    eps=1e-5
+    result = minimize(f, x0=[0, 0], args=(positions,), bounds=[(-180+eps, 180-eps), (-90+eps, 90-eps)], method="L-BFGS-B")
     return SkyCoord(result.x[0], result.x[1], frame="icrs", unit="deg")
 
 

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -147,8 +147,15 @@ def compound_region_center(compound_region):
         lon, lat = x
         center = SkyCoord(lon * u.deg, lat * u.deg)
         return np.sum(center.separation(coords).deg)
-    eps=1e-5
-    result = minimize(f, x0=[0, 0], args=(positions,), bounds=[(-180+eps, 180-eps), (-90+eps, 90-eps)], method="L-BFGS-B")
+
+    eps = 1e-5
+    result = minimize(
+        f,
+        x0=[0, 0],
+        args=(positions,),
+        bounds=[(-180 + eps, 180 - eps), (-90 + eps, 90 - eps)],
+        method="L-BFGS-B",
+    )
     return SkyCoord(result.x[0], result.x[1], frame="icrs", unit="deg")
 
 


### PR DESCRIPTION
This PR add an alternative parametrization for the ShellSpatialModel using outer radius and relative width, so eta=width/Rout  act as a shape parameter similarly than for the GeneralizedGaussian.
