### PR TITLE
Add info in developers HowTo docs

### DIFF
--- a/docs/development/dataformats.rst
+++ b/docs/development/dataformats.rst
@@ -6,9 +6,10 @@
 Data Formats
 ************
 
-.. note:: Since November 2015 there is the :ref:`gadf:main-page` project.
-    This page contains extra information about which formats we support in
-    Gammapy and which class corresponds to which format.
+.. note:: Since November 2015 there is the
+    `Data formats for gamma-ray astronomy <https://gamma-astro-data-formats.readthedocs.io/en/latest/index.html>`__
+    project. This page contains extra information about which formats we support in Gammapy and which class corresponds
+    to which format.
 
 Where available and useful existing standards are used, e.g. for spectral data
 the X-ray community has developed the ``PHA``, ``ARF`` and ``RMF`` file formats

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -995,6 +995,8 @@ instead of RST files. Once we have placed the notebook in the folder we choose w
         mynotebook
 
 
+.. _skip-nb-execution:
+
 Skip notebooks from being executed
 ----------------------------------
 You may choose if a notebook is not executed during the documentation building process, and hence

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -2,12 +2,12 @@
 
 .. _dev_howto:
 
-***************
-Developer HowTo
-***************
+****************
+Developer How To
+****************
 
 This page is a collection of notes for Gammapy contributors and maintainers,
-in the form of short "HowTo" or "Q&A" entries.
+in the form of short "How To" or "Q&A" entries.
 
 .. _dev-python2and3:
 

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -112,9 +112,43 @@ In order to perform tests of these snippets of code present in RST files, you ma
 .. code-block:: bash
 
     pytest --doctest-glob="*.rst" docs/
+
+Check Python code present in docstrings of Python files
+-------------------------------------------------------
+
+It is also advisable to add code snippets within the docstrings of the classes and functions present in Python files.
+These snippets show how to use the function or class that is documented, and are written in the docstrings using the
+following syntax.
+
+.. code-block:: text
+
+        Examples
+        --------
+        >>> from astropy.units import Quantity
+        >>> from gammapy.data import EventList
+        >>> event_list = EventList.read('events.fits') # doctest: +SKIP
+
+In the case above, we could check the execution of the first two lines importing the ``Quantity`` and ``EventList``
+modules, whilst the third line will be skipped. On the contrary, in the example below we could check the execution of
+the code as well as the output value produced.
+
+.. code-block:: text
+
+        Examples
+        --------
+        >>> from gammapy.maps import WcsGeom
+        >>> from gammapy.utils.regions import make_pixel_region
+        >>> wcs = WcsGeom.create().wcs
+        >>> region = make_pixel_region("galactic;circle(10,20,3)", wcs)
+        >>> region
+        <CirclePixelRegion(PixCoord(x=570.9301128316974, y=159.935542455567), radius=6.061376992149382)>
+
+In order to perform tests of these snippets of code present in the docstrings of the Python files, you may run the
+following command.
+
 .. code-block:: bash
 
-    pytest --doctest-glob="*.rst" docs/
+    pytest --doctest-modules --ignore-glob=*/tests gammapy
 
 Making a pull request with new or modified datasets
 ---------------------------------------------------

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -86,7 +86,6 @@ On the contrary, we could check the execution of the following code as well as t
         from astropy.time import Time
         time = Time(['1999-01-01T00:00:00.123456789', '2010-01-01T00:00:00'])
         print(time.mjd)
-        print(time.plot_date)
 
     .. testoutput::
 
@@ -979,6 +978,22 @@ The documentation built-in process uses the `sphinx-gallery <https://sphinx-gall
 extension to build galleries of illustrated examples on how to use Gammapy (i.e.
 :ref:`model-gallery`). The Python scripts used to produce the model gallery are placed in
 ``examples/models`` and the configuration of the ``sphinx-gallery`` module is done in ``docs/conf.py``.
+
+Add a notebook in a folder different than tutorials folder
+----------------------------------------------------------
+Most of the Gammapy notebooks are placed in the ``tutorials`` folder, and are are displayed in a
+:ref:`tutorials` Gallery. However, we can choose to place a notebook in a different folder of the
+documentation folder structure. In this way we can write some parts of the documentation as notebooks
+instead of RST files. Once we have placed the notebook in the folder we choose we can link it from the
+``index.rst`` file using the name of the notebook filename **without the extension** and the Sphinx
+``toctree`` directive as shown below.
+
+.. code-block:: text
+
+    .. toctree::
+
+        mynotebook
+
 
 Skip notebooks from being executed
 ----------------------------------

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -992,6 +992,23 @@ the following code to the notebook metadata:
     "skip_run": true
   }
 
+Choose a thumbnail and tooltip for the tutorials gallery
+--------------------------------------------------------
+The Gammapy :ref:`tutorials` are Jupyter notebooks that are displayed as a gallery with picture thumbnails and tooltips.
+You can choose the thumbnail for the tutorial and add the tooltip editing the metadata of the code cell that produces
+the picture that you've chosen. You can open the notebook in a text editor, and edit the internal code there. It may
+sound risky, but it is much simpler. Then, find the code cell that produces the figure that you would like for the
+gallery, and then replace the ``"metadata": {},`` bit above the code cell with the snippet below:
+
+.. code-block:: javascript
+
+    "metadata": {
+     "nbsphinx-thumbnail": {
+      "tooltip": "Learn how to do perform a Fit in gammapy."
+     },
+
+Note that you may write whatever you like after "tooltip".
+
 Dealing with links and notebooks
 --------------------------------
 
@@ -1047,8 +1064,8 @@ to the ``dev`` version of the on-line Gammapy documentation will be transformed 
 HTML formatted notebooks and to absolute links pointing to that specific released version of the on-line docs
 in the downloadable ``.ipynb`` files.
 
-Include images in the notebooks
--------------------------------
+Include png files as images in the notebooks
+--------------------------------------------
 
 You may include static images in notebooks using the following markdown directive:
 
@@ -1070,7 +1087,7 @@ use the ``gp-image`` directive instead of the usual Sphinx ``image`` directive l
     .. gp-image:: detect/fermi_ts_image.png
         :scale: 100%
 
-More info on the image directive is `here <http://www.sphinx-doc.org/en/stable/rest.html#images>`__
+More info on the `image directive <http://www.sphinx-doc.org/en/stable/rest.html#images>`__.
 
 .. _dev-check_html_links:
 

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -3,11 +3,18 @@
 .. _dev_howto:
 
 ***************
-Developer HOWTO
+Developer HowTo
 ***************
 
 This page is a collection of notes for Gammapy contributors and maintainers,
-in the form of short "How to" or "Q & A" entries.
+in the form of short "HowTo" or "Q&A" entries.
+
+.. _dev-python2and3:
+
+Python version support
+----------------------
+
+In Gammapy we currently support Python 3.7 or later.
 
 .. _dev_import:
 
@@ -49,13 +56,6 @@ For up to three things, if callers usually will want access to several things,
 using a ``tuple`` or ``collections.namedtuple`` is OK.
 For three or more things, using a Python ``dict`` instead should be preferred.
 
-.. _dev-python2and3:
-
-Python version support
-----------------------
-
-In Gammapy we currently support Python 3.7 or later.
-
 .. _dev-skip_tests:
 
 Skip unit tests for some Astropy versions
@@ -74,6 +74,44 @@ Skip unit tests for some Astropy versions
 Check Python code present in RST files
 --------------------------------------
 
+Most of the documentation of Gammapy is present in RST files that are converted into HTML pages with
+Sphinx during the build documentation process. You may include snippets of Python code in these RST files
+within blocks labelled with ``.. code-block:: python`` Sphinx directive. However this code could not be
+tested and it will not be possible to know if it fails in following versions of Gammapy. That's why we
+recommend to use the ``.. testcode::`` directive to enclose code that will be tested against the results
+present in a block labelled with ``.. testoutput::`` directive. If not ``.. testoutput::` directive is provided,
+only execution tests will be performed.
+
+For example, we could check that the code below does not fail, since it does not provide any output.
+
+.. code-block:: text
+
+    .. testcode::
+
+        from gammapy.astro import source
+        from gammapy.astro import population
+        from gammapy.astro import darkmatter
+
+On the contrary, we could check the execution of the following code as well as the output values produced.
+
+.. code-block:: text
+
+    .. testcode::
+
+        from astropy.time import Time
+        time = Time(['1999-01-01T00:00:00.123456789', '2010-01-01T00:00:00'])
+        print(time.mjd)
+        print(time.plot_date)
+
+    .. testoutput::
+
+        [51179.00000143 55197.        ]
+
+In order to perform tests of these snippets of code present in RST files, you may run the following command.
+
+.. code-block:: bash
+
+    pytest --doctest-glob="*.rst" docs/
 .. code-block:: bash
 
     pytest --doctest-glob="*.rst" docs/

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -45,8 +45,8 @@ Pages
   :maxdepth: 1
 
   intro
+  release
   setup
   howto
-  release
   pigs/index
   dataformats

--- a/docs/development/setup.rst
+++ b/docs/development/setup.rst
@@ -51,8 +51,9 @@ and execution. See ``gammapy jupyter -h`` for more info on this.
 The ``gammapy download`` command allows to download notebooks published in the documentation
 as well as the related datasets needed to execute them. The set of notebooks is versioned
 for each stable release as tar bundles published within the versioned documentation in the
-`gammapy-docs <https://github.com/gammapy/gammapy-docs>`__ Github repository.
-The same happens for conda working environments of stable releases. The datasets are not
+`gammapy-docs <https://github.com/gammapy/gammapy-docs>`__ repository.
+The same happens for conda working environments of stable releases, whose yaml files are published
+in the `gammapy-web <https://github.com/gammapy/gammapy-web>`__ repository. The datasets are not
 versioned and they are placed in the `gammapy-data <https://github.com/gammapy/gammapy-data>`__
 repository.
 
@@ -295,11 +296,3 @@ will try to update as soon as they get the announcement email).
 * Source distribution releases: https://pypi.org/project/gammapy/
 * Binary conda packages for Linux, Mac and Windows:
   https://github.com/conda-forge/gammapy-feedstock
-
-Data formats
-============
-
-Data formats should be defined here, and then linked to from the Gammapy docs:
-
-* https://github.com/open-gamma-ray-astro/gamma-astro-data-formats
-* http://gamma-astro-data-formats.readthedocs.io

--- a/docs/development/setup.rst
+++ b/docs/development/setup.rst
@@ -35,15 +35,14 @@ documentation.
 Notebooks
 ---------
 
-The ``docs/tutorials`` folder contains Jupyter notebooks that are part of the user
-documentation for Gammapy, though there may be also notebooks in other parts of the
-documentation. Most of the notebooks present in the documentation are executed during
-the process of the documentation building and converted to the Sphinx-formatted HTML
-files. Clean output stripped ``.ipynb`` notebooks files and ``.py`` scripts versions are also
-generated during the documentation building process and placed in the
-``docs/_static/notebooks`` folder.
+The ``docs/tutorials`` folder contains tutorials that are part of the user
+documentation for Gammapy in the form of Jupyter notebooks. There may be also notebooks in
+other parts of the documentation. Except those specifically declared (see :ref:`skip-nb-execution`), all
+the notebooks present in the documentation are executed during the doc building process. They are all
+converted to the Sphinx-formatted HTML files, where clean output stripped ``.ipynb`` notebooks files
+and ``.py`` scripts versions are generated and placed in the ``docs/_static/notebooks`` folder.
 
-We do perform automated testing for notebooks set up (just check that they run
+We perform automated set-up testing for all notebooks (just check that they run
 and don't raise an exception) during the CI process (see below). It is also possible to
 perform tests locally on notebooks  with the ``gammapy jupyter`` command. This
 command provides functionalities for testing, code formatting, stripping output cells
@@ -218,7 +217,7 @@ Information from meetings is here:
 Gammapy webpages
 ================
 
-There are two webpages for Gammapy: gammapy.org and docs.gammapy.org.
+There are two webpages for Gammapy: http://gammapy.org and http://docs.gammapy.org.
 
 In addition we have Binder set up to allow users to try Gammapy in the browser.
 
@@ -237,9 +236,13 @@ docs.gammapy.org
 ----------------
 
 https://docs.gammapy.org/ contains most of the documentation for Gammapy,
-including information about Gammapy, the changelog, tutorials, ...
+including information about Gammapy, the changelog, tutorials,...
 
-TODO: describe how to update.
+The dev version of the docs may be built and updated with a manual github action. All
+the docs are versioned, and each version of the docs is placed in its dedicated
+version-labelled folder. It is recommended to build the docs locally before each release
+to identify and fix possible Sphinx warnings from badly formatted RST files or failing
+Python scripts used to display figures.
 
 Gammapy Binder
 --------------

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -63,7 +63,7 @@ the datasets and proceed with the following commands:
 
 .. code-block:: bash
 
-    gammapy download notebooks
+    gammapy download notebooks --release 0.18.2
     gammapy download datasets
     export GAMMAPY_DATA=$PWD/gammapy-datasets
 

--- a/examples/scripts.yaml
+++ b/examples/scripts.yaml
@@ -1,5 +1,0 @@
-# This is a list of available example scripts.
-# It's used for downloading of scripts with gammapy download.
-# Let's keep it alphabetical.
-- name: survey_map
-  url: https://raw.githubusercontent.com/gammapy/gammapy/master/examples/survey_map.py

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -34,8 +34,6 @@ class Analysis:
     parameters passed as a nested dictionary at the moment of instantiation. In that case these
     parameters will overwrite the default values of those present in the configuration file.
 
-    For more info see  :ref:`analysis`.
-
     Parameters
     ----------
     config : dict or `AnalysisConfig`


### PR DESCRIPTION
This PR adds the following missing info in the developers HowTo docs.

- Check Python code present in RST files
- Check Python code present in docstrings of Python files
- Choose a thumbnail and tooltip for the tutorials gallery
- Place a notebook in a folder different than tutorials folder

