### PR TITLE
Unify handling of list of regions

### DIFF
--- a/docs/tutorials/analysis_2.ipynb
+++ b/docs/tutorials/analysis_2.ipynb
@@ -230,7 +230,7 @@
     "circle = CircleSkyRegion(\n",
     "    center=SkyCoord(\"83.63 deg\", \"22.14 deg\"), radius=0.2 * u.deg\n",
     ")\n",
-    "exclusion_mask = geom.region_mask(regions=[circle], inside=False)\n",
+    "exclusion_mask = ~geom.region_mask(regions=[circle])\n",
     "maker_fov = FoVBackgroundMaker(method=\"fit\", exclusion_mask=exclusion_mask)"
    ]
   },
@@ -603,9 +603,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1,
+   "current_citInitial": 1.0,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1,
+   "eqNumInitial": 1.0,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"
@@ -708,7 +708,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0,
+       "index": 0.0,
        "layout": "IPY_MODEL_095494c994ba43aa96803803704a7cdb",
        "orientation": "horizontal",
        "readout": true,
@@ -845,7 +845,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0,
+       "index": 0.0,
        "layout": "IPY_MODEL_cceb2b5d8e8241978dca97767054211d",
        "style": "IPY_MODEL_203fa8f78fd848f596a7e354c693d2f0"
       }
@@ -955,8 +955,8 @@
       }
      }
     },
-    "version_major": 2,
-    "version_minor": 0
+    "version_major": 2.0,
+    "version_minor": 0.0
    }
   }
  },

--- a/docs/tutorials/cta_data_analysis.ipynb
+++ b/docs/tutorials/cta_data_analysis.ipynb
@@ -50,7 +50,6 @@
     "import numpy as np\n",
     "import astropy.units as u\n",
     "from astropy.coordinates import SkyCoord\n",
-    "from astropy.convolution import Gaussian2DKernel\n",
     "from regions import CircleSkyRegion\n",
     "from gammapy.modeling import Fit\n",
     "from gammapy.data import DataStore\n",
@@ -65,7 +64,7 @@
     "    SkyModel,\n",
     "    GaussianSpatialModel,\n",
     ")\n",
-    "from gammapy.maps import MapAxis, WcsNDMap, WcsGeom, RegionGeom\n",
+    "from gammapy.maps import MapAxis, WcsGeom, RegionGeom\n",
     "from gammapy.makers import (\n",
     "    MapDatasetMaker,\n",
     "    SafeMaskMaker,\n",
@@ -379,7 +378,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "exclusion_mask = geom.to_image().region_mask([on_region], inside=False)\n",
+    "exclusion_mask = ~geom.to_image().region_mask([on_region])\n",
     "exclusion_mask.plot();"
    ]
   },

--- a/docs/tutorials/exclusion_mask.ipynb
+++ b/docs/tutorials/exclusion_mask.ipynb
@@ -149,7 +149,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask_map = geom.region_mask(regions, inside=False)"
+    "# to define the exclusion mask we take the inverse\n",
+    "mask_map = ~geom.region_mask(regions)"
    ]
   },
   {
@@ -226,7 +227,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask_map_catalog = geom.region_mask(regions, inside=False)"
+    "mask_map_catalog = ~geom.region_mask(regions)"
    ]
   },
   {

--- a/docs/tutorials/ring_background.ipynb
+++ b/docs/tutorials/ring_background.ipynb
@@ -219,7 +219,7 @@
     "\n",
     "# Make the exclusion mask\n",
     "regions = CircleSkyRegion(center=source_pos, radius=0.3 * u.deg)\n",
-    "exclusion_mask = geom_image.region_mask([regions], inside=False)\n",
+    "exclusion_mask = ~geom_image.region_mask([regions])\n",
     "exclusion_mask.sum_over_axes().plot();"
    ]
   },

--- a/docs/tutorials/spectrum_analysis.ipynb
+++ b/docs/tutorials/spectrum_analysis.ipynb
@@ -103,7 +103,7 @@
     "import astropy.units as u\n",
     "from astropy.coordinates import SkyCoord, Angle\n",
     "from regions import CircleSkyRegion\n",
-    "from gammapy.maps import Map, MapAxis, RegionGeom\n",
+    "from gammapy.maps import MapAxis, RegionGeom, WcsGeom\n",
     "from gammapy.modeling import Fit\n",
     "from gammapy.data import DataStore\n",
     "from gammapy.datasets import (\n",
@@ -194,12 +194,11 @@
     ")\n",
     "\n",
     "skydir = target_position.galactic\n",
-    "exclusion_mask = Map.create(\n",
+    "geom = WcsGeom.create(\n",
     "    npix=(150, 150), binsz=0.05, skydir=skydir, proj=\"TAN\", frame=\"icrs\"\n",
     ")\n",
     "\n",
-    "mask = exclusion_mask.geom.region_mask([exclusion_region], inside=False)\n",
-    "exclusion_mask.data = mask.data\n",
+    "exclusion_mask = ~geom.region_mask([exclusion_region])\n",
     "exclusion_mask.plot();"
    ]
   },

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -8,7 +8,7 @@ from regions import CircleSkyRegion
 from pydantic.error_wrappers import ValidationError
 from gammapy.analysis import Analysis, AnalysisConfig
 from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
-from gammapy.maps import Map, WcsNDMap
+from gammapy.maps import WcsNDMap, WcsGeom
 from gammapy.modeling.models import Models
 from gammapy.utils.testing import requires_data, requires_dependency
 
@@ -209,10 +209,10 @@ def test_geom_analysis_1d():
 def test_exclusion_region(tmp_path):
     config = get_example_config("1d")
     analysis = Analysis(config)
-    exclusion_region = CircleSkyRegion(center=SkyCoord("85d 23d"), radius=1 * u.deg)
-    exclusion_mask = Map.create(npix=(150, 150), binsz=0.05, skydir=SkyCoord("83d 22d"))
-    mask = exclusion_mask.geom.region_mask([exclusion_region], inside=False)
-    exclusion_mask.data = mask.data.astype(int)
+    region = CircleSkyRegion(center=SkyCoord("85d 23d"), radius=1 * u.deg)
+    geom = WcsGeom.create(npix=(150, 150), binsz=0.05, skydir=SkyCoord("83d 22d"))
+    exclusion_mask = ~geom.region_mask([region])
+
     filename = tmp_path / "exclusion.fits"
     exclusion_mask.write(filename)
     config.datasets.background.method = "reflected"
@@ -226,11 +226,9 @@ def test_exclusion_region(tmp_path):
     analysis.get_observations()
     analysis.get_datasets()
     geom = analysis.datasets[0]._geom
-    exclusion = WcsNDMap.from_geom(geom)
-    mask = exclusion_mask.geom.region_mask([exclusion_region], inside=False)
-    exclusion_mask.data = mask.data.astype(int)
+    exclusion_mask = ~geom.region_mask([region])
     filename = tmp_path / "exclusion3d.fits"
-    exclusion.write(filename)
+    exclusion_mask.write(filename)
     config.datasets.background.exclusion = filename
     analysis.get_datasets()
     assert len(analysis.datasets) == 1

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -263,8 +263,10 @@ class EventList:
 
         Parameters
         ----------
-        regions : list of `~regions.SkyRegion` or str
-            Sky region or string defining a sky region
+        regions : str, `~regions.Region` or list of `~regions.Region`
+            Region or list of regions (pixel or sky regions accepted).
+            A region can be defined as a string ind DS9 format as well.
+            See http://ds9.si.edu/doc/ref/region.html for details.
         wcs : `~astropy.wcs.WCS`
             World coordinate system transformation
 

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -258,12 +258,12 @@ class EventList:
         mask &= time < time_interval[1]
         return self.select_row_subset(mask)
 
-    def select_region(self, region, wcs=None):
+    def select_region(self, regions, wcs=None):
         """Select events in given region.
 
         Parameters
         ----------
-        region : `~regions.SkyRegion` or str
+        regions : list of `~regions.SkyRegion` or str
             Sky region or string defining a sky region
         wcs : `~astropy.wcs.WCS`
             World coordinate system transformation
@@ -273,7 +273,7 @@ class EventList:
         event_list : `EventList`
             Copy of event list with selection applied.
         """
-        geom = RegionGeom.create(region, wcs=wcs)
+        geom = RegionGeom.from_regions(regions, wcs=wcs)
         mask = geom.contains(self.radec)
         return self.select_row_subset(mask)
 
@@ -495,7 +495,7 @@ class EventList:
 
         return MapCoord.create(coord)
 
-    def select_map_mask(self, mask):
+    def select_mask(self, mask):
         """Select events inside a mask (`EventList`).
 
         Parameters

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -192,8 +192,8 @@ class TestEventSelection:
             skydir=(0, 0), binsz=0.2, width=4.0 * u.deg, proj="TAN", axes=[axis]
         )
 
-        mask = geom.region_mask(regions=[self.on_regions[0]], inside=True)
-        new_list = self.events.select_map_mask(mask)
+        mask = geom.region_mask(regions=[self.on_regions[0]])
+        new_list = self.events.select_mask(mask)
         assert len(new_list.table) == 2
 
     def test_select_energy(self):

--- a/gammapy/data/tests/test_filters.py
+++ b/gammapy/data/tests/test_filters.py
@@ -44,7 +44,7 @@ def test_filter_events(observation):
     target_position = SkyCoord(ra=229.2, dec=-58.3, unit="deg", frame="icrs")
     region_radius = Angle("0.2 deg")
     region = SphericalCircleSkyRegion(center=target_position, radius=region_radius)
-    region_filter = {"type": "sky_region", "opts": {"region": region}}
+    region_filter = {"type": "sky_region", "opts": {"regions": region}}
 
     time_filter = Time([53090.12, 53090.13], format="mjd", scale="tt")
 

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -187,7 +187,7 @@ class ReflectedRegionsFinder:
         self._pix_center = PixCoord.from_sky(self.center, geom.wcs)
 
         # Make the ON reference map
-        mask = geom.region_mask([self.region], inside=True).data
+        mask = geom.region_mask([self.region]).data
         # on_reference_map = WcsNDMap(geom=geom, data=mask)
 
         # Extract all pixcoords in the geom

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -47,7 +47,7 @@ def exclusion_mask(geom):
     """Example mask for testing."""
     pos = SkyCoord(83.633, 22.014, unit="deg", frame="icrs")
     region = CircleSkyRegion(pos, Angle(0.3, "deg"))
-    return geom.region_mask([region], inside=False)
+    return ~geom.region_mask([region])
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/makers/background/tests/test_reflected.py
+++ b/gammapy/makers/background/tests/test_reflected.py
@@ -33,7 +33,7 @@ def exclusion_mask():
     pos = SkyCoord(83.63, 22.01, unit="deg", frame="icrs")
     exclusion_region = CircleSkyRegion(pos, Angle(0.3, "deg"))
     geom = WcsGeom.create(skydir=pos, binsz=0.02, width=10.0)
-    return geom.region_mask([exclusion_region], inside=False)
+    return ~geom.region_mask([exclusion_region])
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/makers/background/tests/test_ring.py
+++ b/gammapy/makers/background/tests/test_ring.py
@@ -41,7 +41,7 @@ def exclusion_mask(geom):
     """Example mask for testing."""
     pos = SkyCoord(83.633, 22.014, unit="deg", frame="icrs")
     region = CircleSkyRegion(pos, Angle(0.15, "deg"))
-    return  geom.region_mask([region], inside=False)
+    return ~geom.region_mask([region])
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -61,7 +61,7 @@ def reflected_regions_bkg_maker():
     pos = SkyCoord(83.63, 22.01, unit="deg", frame="icrs")
     exclusion_region = CircleSkyRegion(pos, Angle(0.3, "deg"))
     geom = WcsGeom.create(skydir=pos, binsz=0.02, width=10.0)
-    exclusion_mask = geom.region_mask([exclusion_region], inside=False)
+    exclusion_mask = ~geom.region_mask([exclusion_region])
 
     return ReflectedRegionsBackgroundMaker(
         exclusion_mask=exclusion_mask, min_distance_input="0.2 deg"

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
 from astropy.io import fits
+from regions import CircleSkyRegion
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.maps.wcs import _check_width, _check_binsz
 
@@ -350,8 +351,6 @@ def test_geom_refpix():
 
 
 def test_region_mask():
-    from regions import CircleSkyRegion
-
     geom = WcsGeom.create(npix=(3, 3), binsz=2, proj="CAR")
 
     r1 = CircleSkyRegion(SkyCoord(0, 0, unit="deg"), 1 * u.deg)
@@ -362,8 +361,8 @@ def test_region_mask():
     assert mask.dtype == bool
     assert np.sum(mask) == 1
 
-    mask = geom.region_mask(regions, inside=False).data
-    assert np.sum(mask) == 8
+    mask = ~geom.region_mask(regions)
+    assert np.sum(mask.data) == 8
 
 
 def test_energy_mask():

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -357,9 +357,9 @@ def test_region_mask():
     r2 = CircleSkyRegion(SkyCoord(20, 20, unit="deg"), 1 * u.deg)
     regions = [r1, r2]
 
-    mask = geom.region_mask(regions).data  # default inside=True
-    assert mask.dtype == bool
-    assert np.sum(mask) == 1
+    mask = geom.region_mask(regions)
+    assert mask.data.dtype == bool
+    assert np.sum(mask.data) == 1
 
     mask = ~geom.region_mask(regions)
     assert np.sum(mask.data) == 8

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -361,7 +361,7 @@ def test_region_mask():
     assert mask.data.dtype == bool
     assert np.sum(mask.data) == 1
 
-    mask = ~geom.region_mask(regions)
+    mask = geom.region_mask(regions, inside=False)
     assert np.sum(mask.data) == 8
 
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -12,8 +12,6 @@ from astropy.wcs.utils import (
     proj_plane_pixel_scales,
     wcs_to_celestial_frame,
 )
-from regions import SkyRegion, PixCoord, CompoundSkyRegion
-from gammapy.utils.regions import list_to_compound_region
 from .geom import (
     Geom,
     MapAxes,
@@ -869,7 +867,7 @@ class WcsGeom(Geom):
             wcs=c2d.wcs, npix=c2d.shape[::-1], cutout_info=cutout_info
         )
 
-    def boundary_mask(self, width, inside=True):
+    def boundary_mask(self, width):
         """Create a mask applying binary erosion with a given width from geom edges
 
         Parameters
@@ -877,9 +875,6 @@ class WcsGeom(Geom):
         width : tuple of `~astropy.units.Quantity`
             Angular sizes of the margin in (lon, lat) in that specific order.
             If only one value is passed, the same margin is applied in (lon, lat).
-        inside : bool
-            For ``inside=True``, pixels in the region to True (the default).
-            For ``inside=False``, pixels in the region are False.
 
         Returns
         -------
@@ -889,14 +884,14 @@ class WcsGeom(Geom):
         """
         from . import Map
         data = np.ones(self.data_shape, dtype=bool)
-
-        if inside is False:
-            data = ~data
-
         return Map.from_geom(self, data=data).binary_erode(width)
 
     def region_mask(self, regions):
         """Create a mask from a given list of regions
+
+        The mask is filled such that a pixel inside the region is filled with
+        "True". To invert the mask, e.g. to create a mask with exclusion regions
+        the tilde (~) operator can be used (see examnple below).
 
         Parameters
         ----------

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -886,12 +886,12 @@ class WcsGeom(Geom):
         data = np.ones(self.data_shape, dtype=bool)
         return Map.from_geom(self, data=data).binary_erode(width)
 
-    def region_mask(self, regions):
+    def region_mask(self, regions, inside=True):
         """Create a mask from a given list of regions
 
         The mask is filled such that a pixel inside the region is filled with
         "True". To invert the mask, e.g. to create a mask with exclusion regions
-        the tilde (~) operator can be used (see examnple below).
+        the tilde (~) operator can be used (see example below).
 
         Parameters
         ----------
@@ -899,6 +899,9 @@ class WcsGeom(Geom):
             Region or list of regions (pixel or sky regions accepted).
             A region can be defined as a string ind DS9 format as well.
             See http://ds9.si.edu/doc/ref/region.html for details.
+        inside : bool
+            For ``inside=True``, pixels in the region to True (the default).
+            For ``inside=False``, pixels in the region are False.
 
         Returns
         -------
@@ -936,6 +939,10 @@ class WcsGeom(Geom):
         geom = RegionGeom.from_regions(regions, wcs=self.wcs)
         idx = self.get_idx()
         mask = geom.contains_wcs_pix(idx)
+
+        if not inside:
+            np.logical_not(mask, out=mask)
+
         return Map.from_geom(self, data=mask)
 
     def region_weights(self, regions, oversampling_factor=10):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -900,8 +900,10 @@ class WcsGeom(Geom):
 
         Parameters
         ----------
-        regions : list of `~regions.Region`
-            region or list of regions (pixel or sky regions accepted)
+        regions : str, `~regions.Region` or list of `~regions.Region`
+            Region or list of regions (pixel or sky regions accepted).
+            A region can be defined as a string ind DS9 format as well.
+            See http://ds9.si.edu/doc/ref/region.html for details.
 
         Returns
         -------
@@ -924,7 +926,9 @@ class WcsGeom(Geom):
                 SkyCoord(3, 2, unit='deg'),
                 Angle(1, 'deg'),
             )
-            mask = geom.region_mask([region])
+
+            # the Gammapy convention for exclusion regions is to take the inverse
+            mask = ~geom.region_mask([region])
 
         Note how we made a list with a single region,
         since this method expects a list of regions.
@@ -944,8 +948,10 @@ class WcsGeom(Geom):
 
         Parameters
         ----------
-        regions : list of  `~regions.Region`
-            Python list of regions (pixel or sky regions accepted)
+        regions : str, `~regions.Region` or list of `~regions.Region`
+            Region or list of regions (pixel or sky regions accepted).
+            A region can be defined as a string ind DS9 format as well.
+            See http://ds9.si.edu/doc/ref/region.html for details.
         oversampling_factor : int
             Over-sampling factor to compute the region weigths
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 from collections import OrderedDict
-import warnings
 import numpy as np
 import scipy.interpolate
 import scipy.ndimage as ndi
@@ -631,7 +630,7 @@ class WcsNDMap(WcsMap):
         return self._init_copy(data=mask_data)
 
     def binary_dilate(self, width, use_fft=True, mode="same"):
-        """Binary dilation of boolean mask addding a given margin
+        """Binary dilation of boolean mask adding a given margin
 
         Parameters
         ----------
@@ -641,7 +640,6 @@ class WcsNDMap(WcsMap):
         use_fft : bool
             Use `scipy.signal.fftconvolve` if True (default)
             and `ndi.binary_dilation` otherwise.
-            
         mode : str {'same', 'full'}
             A string indicating the size of the output.
             - 'same': The output is the same size as input (Default).
@@ -659,7 +657,7 @@ class WcsNDMap(WcsMap):
             func = ndi.binary_dilation
 
         if mode == "full":
-            pad_width = u.Quantity(width) / (self.geom.pixel_scales)
+            pad_width = u.Quantity(width) / self.geom.pixel_scales
             pad_width = list(np.ceil(pad_width.value).astype(int))
             mask = self.pad(pad_width)
         else:

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -672,26 +672,27 @@ class DatasetModels(collections.abc.Sequence):
 
         return self.__class__(models=models)
 
-    def select_region(self, regions):
+    def select_region(self, regions, wcs=None):
         """Select sky models with center position contained within a given region
 
         Parameters
         ----------
         regions : `~regions.SkyRegion` or list of `~regions.SkyRegion`
             Sky region or list of sky regions
+        wcs : `~astropy.wcs.WCS`
+            World coordinate system transformation
 
         Returns
         -------
         models : `DatasetModels`
             Selected models 
         """
-        geom = RegionGeom.from_regions(regions)
+        geom = RegionGeom.from_regions(regions, wcs=wcs)
 
         models = []
 
         for model in self.select(tag="sky-model"):
-            position = getattr(model, "position", None)
-            if position is None or geom.contains(position):
+            if geom.contains(model.position):
                 models.append(model)
 
         return self.__class__(models=models)

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -677,8 +677,10 @@ class DatasetModels(collections.abc.Sequence):
 
         Parameters
         ----------
-        regions : `~regions.SkyRegion` or list of `~regions.SkyRegion`
-            Sky region or list of sky regions
+        regions : str, `~regions.Region` or list of `~regions.Region`
+            Region or list of regions (pixel or sky regions accepted).
+            A region can be defined as a string ind DS9 format as well.
+            See http://ds9.si.edu/doc/ref/region.html for details.
         wcs : `~astropy.wcs.WCS`
             World coordinate system transformation
 

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -192,10 +192,9 @@ def list_to_compound_region(regions):
 
     Returns
     -------
-    compound : `~regions.CompoundSkyRegion`
+    compound : `~regions.CompoundSkyRegion` or `~regions.CompoundPixelRegion`
         Compound sky region
     """
-
     region_union = regions[0]
 
     for region in regions[1:]:


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request unifies the handling of regions in methods like `Models.select_region()`, `EventList.select_region()` and `WcsGeom.region_mask()`. The behaviour is now as following:
- The argument allows for either a ds9 region str, a `Region` object or a list of `Region`
- Internally this always goes through `RegioGeom.from_regions()`, which handles the creation of the required wcs
- If there is no wcs attached to the object (such as `EventList`), then optionally a wcs can be passed by the user

I decided to remove the `inside=` argument from the `.region_mask()` methods, even if it is explicit, I didn't want to add it to the other methods as well. Since we have support for boolean operations on the `Map` object we can easily use the `~` operator, which is a standard Numpy operation. However a bit of documentation is missing on mask `Map` object, possibly we should extend the existing or add another maps tutorial...

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
