### PR TITLE
Expand extended source analysis tutorial

### DIFF
--- a/docs/tutorials/extended_source_spectral_analysis.ipynb
+++ b/docs/tutorials/extended_source_spectral_analysis.ipynb
@@ -9,7 +9,7 @@
     "## Prerequisites:\n",
     "\n",
     "- Understanding of spectral analysis techniques in classical Cherenkov astronomy.\n",
-    "- Understanding of how the spectrum and cube extraction API works, please refer to the [spectrum extraction notebook](spectrum_analysis.ipynb) and to the [3D analysis notebook](analysis_2.ipynb).\n",
+    "- Understanding the basic data reduction and modeling/fitting processes with the gammapy library API as shown in the [first gammapy analysis with the gammapy library API tutorial](analysis_2.ipynb)\n",
     "\n",
     "## Context\n",
     "\n",
@@ -23,11 +23,23 @@
     "\n",
     "We have seen in the general presentation of the spectrum extraction for point sources, see [the corresponding notebook](spectrum_analysis.ipynb), that Gammapy uses specific datasets makers to first produce reduced spectral data and then to extract OFF measurements with reflected background techniques: the `~gammapy.makers.SpectrumDatasetMaker` and the `~gammapy.makers.ReflectedRegionsBackgroundMaker`. However if the flag `use_region_center` is not set to `False`, the former simply computes the reduced IRFs at the center of the ON region (assumed to be circular).\n",
     "\n",
-    "This is no longer valid for extended sources. To be able to compute average responses in the ON region, Gammapy allows for two approaches. One relies on the creation of a cube enclosing it (i.e. a `~gammapy.datasets.MapDataset`) which can be reduced to a simple spectrum (i.e. a `~gammapy.datasets.SpectrumDataset`). We can then proceed with the OFF extraction as the standard point source case. We will refer to this as the **3D approach**.\n",
+    "This is no longer valid for extended sources. To be able to compute average responses in the ON region, we can set `use_region_center=False` with the `~gammapy.makers.SpectrumDatasetMaker`, in which case the values of the IRFs are averaged over the entire region.\n",
     "\n",
-    "Alternatively, we can set `use_region_center=False` with the `~gammapy.makers.SpectrumDatasetMaker`, in which case the values of the IRFs are averaged over the entire region. We will refer to this as the **1D approach**. Both approaches are equivalent and should yield the same results. \n",
+    "In summary we have to:\n",
     "\n",
-    "Below we will show both approaches, using the RX J1713-3945 observations from the H.E.S.S. first public test data release. The tutorial is implemented with the intermediate level API.\n",
+    "- Define an ON region (a `~regions.SkyRegion`) fully enclosing the source we want to study.\n",
+    "- Define a `~gammapy.maps.RegionGeom` with the ON region and the required energy range (beware in particular, the true energy range).  \n",
+    "- Create the necessary makers : \n",
+    "    - the spectrum dataset maker : `~gammapy.makers.SpectrumDatasetMaker` with `use_region_center=False`\n",
+    "    - the OFF background maker, here a `~gammapy.makers.ReflectedRegionsBackgroundMaker`\n",
+    "    - and usually the safe range maker : `~gammapy.makers.SafeRangeMaker`\n",
+    "- Perform the data reduction loop. And for every observation:\n",
+    "    - Produce a spectrum dataset\n",
+    "    - Extract the OFF data to produce a `~gammapy.datasets.SpectrumDatasetOnOff` and compute a safe range for it.\n",
+    "    - Stack or store the resulting spectrum dataset.\n",
+    "- Finally proceed with model fitting on the dataset as usual.\n",
+    "\n",
+    "Here, we will use the RX J1713-3945 observations from the H.E.S.S. first public test data release. The tutorial is implemented with the intermediate level API.\n",
     "\n",
     "## Setup \n",
     "\n",
@@ -39,10 +51,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:40.146978Z",
-     "iopub.status.busy": "2021-02-09T17:05:40.144510Z",
-     "iopub.status.idle": "2021-02-09T17:05:40.504114Z",
-     "shell.execute_reply": "2021-02-09T17:05:40.503567Z"
+     "iopub.execute_input": "2021-02-12T11:31:16.338629Z",
+     "iopub.status.busy": "2021-02-12T11:31:16.336652Z",
+     "iopub.status.idle": "2021-02-12T11:31:16.656635Z",
+     "shell.execute_reply": "2021-02-12T11:31:16.657024Z"
     }
    },
    "outputs": [],
@@ -56,10 +68,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:40.508963Z",
-     "iopub.status.busy": "2021-02-09T17:05:40.508254Z",
-     "iopub.status.idle": "2021-02-09T17:05:41.417321Z",
-     "shell.execute_reply": "2021-02-09T17:05:41.416219Z"
+     "iopub.execute_input": "2021-02-12T11:31:16.661192Z",
+     "iopub.status.busy": "2021-02-12T11:31:16.660603Z",
+     "iopub.status.idle": "2021-02-12T11:31:17.538307Z",
+     "shell.execute_reply": "2021-02-12T11:31:17.537799Z"
     }
    },
    "outputs": [],
@@ -67,37 +79,16 @@
     "import astropy.units as u\n",
     "from astropy.coordinates import SkyCoord, Angle\n",
     "from regions import CircleSkyRegion\n",
-    "from gammapy.maps import Map, MapAxis, WcsGeom\n",
+    "from gammapy.maps import MapAxis, RegionGeom\n",
     "from gammapy.modeling import Fit\n",
     "from gammapy.data import DataStore\n",
     "from gammapy.modeling.models import PowerLawSpectralModel, SkyModel\n",
-    "from gammapy.datasets import Datasets, MapDataset\n",
+    "from gammapy.datasets import Datasets, SpectrumDataset\n",
     "from gammapy.makers import (\n",
     "    SafeMaskMaker,\n",
-    "    MapDatasetMaker,\n",
+    "    SpectrumDatasetMaker,\n",
     "    ReflectedRegionsBackgroundMaker,\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# 3D analysis\n",
-    "## Proposed approach:\n",
-    "For this case, we have to:\n",
-    "\n",
-    "- Define an ON region (a `~regions.SkyRegion`) fully enclosing the source we want to study.\n",
-    "- Define a geometry that fully contains the region and that covers the required energy range (beware in particular, the true energy range).  \n",
-    "- Create the necessary makers : \n",
-    "    - the map dataset maker : `~gammapy.makers.MapDatasetMaker`\n",
-    "    - the OFF background maker, here a `~gammapy.makers.ReflectedRegionsBackgroundMaker`\n",
-    "    - and usually the safe range maker : `~gammapy.makers.SafeRangeMaker`\n",
-    "- Perform the data reduction loop. And for every observation:\n",
-    "    - Produce a map dataset and squeeze it to a spectrum dataset with `~gammapy.datasets.MapDataset.to_spectrum_dataset(on_region)`\n",
-    "    - Extract the OFF data to produce a `~gammapy.datasets.SpectrumDatasetOnOff` and compute a safe range for it.\n",
-    "    - Stack or store the resulting spectrum dataset.\n",
-    "- Finally proceed with model fitting on the dataset as usual.\n"
    ]
   },
   {
@@ -114,10 +105,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:41.427785Z",
-     "iopub.status.busy": "2021-02-09T17:05:41.426740Z",
-     "iopub.status.idle": "2021-02-09T17:05:41.470575Z",
-     "shell.execute_reply": "2021-02-09T17:05:41.470121Z"
+     "iopub.execute_input": "2021-02-12T11:31:17.542382Z",
+     "iopub.status.busy": "2021-02-12T11:31:17.541915Z",
+     "iopub.status.idle": "2021-02-12T11:31:17.589327Z",
+     "shell.execute_reply": "2021-02-12T11:31:17.588933Z"
     }
    },
    "outputs": [],
@@ -151,10 +142,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:41.474872Z",
-     "iopub.status.busy": "2021-02-09T17:05:41.474357Z",
-     "iopub.status.idle": "2021-02-09T17:05:41.476578Z",
-     "shell.execute_reply": "2021-02-09T17:05:41.476149Z"
+     "iopub.execute_input": "2021-02-12T11:31:17.593515Z",
+     "iopub.status.busy": "2021-02-12T11:31:17.593081Z",
+     "iopub.status.idle": "2021-02-12T11:31:17.595242Z",
+     "shell.execute_reply": "2021-02-12T11:31:17.594811Z"
     }
    },
    "outputs": [],
@@ -172,7 +163,7 @@
     "\n",
     "This part is especially important. \n",
     "- We have to define first energy axes. They define the axes of the resulting `~gammapy.datasets.SpectrumDatasetOnOff`. In particular, we have to be careful to the true energy axis: it has to cover a larger range than the reconstructed energy one.\n",
-    "- Then we define the geometry itself. It does not need to be very finely binned and should enclose all the ON region. To limit CPU and memory usage, one should avoid using a much larger region."
+    "- Then we define the region geometry itself from the on region."
    ]
   },
   {
@@ -180,10 +171,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:41.482799Z",
-     "iopub.status.busy": "2021-02-09T17:05:41.482277Z",
-     "iopub.status.idle": "2021-02-09T17:05:41.484511Z",
-     "shell.execute_reply": "2021-02-09T17:05:41.484073Z"
+     "iopub.execute_input": "2021-02-12T11:31:17.600915Z",
+     "iopub.status.busy": "2021-02-12T11:31:17.600483Z",
+     "iopub.status.idle": "2021-02-12T11:31:17.602456Z",
+     "shell.execute_reply": "2021-02-12T11:31:17.602014Z"
     }
    },
    "outputs": [],
@@ -196,15 +187,7 @@
     "    0.05, 100, 30, unit=\"TeV\", name=\"energy_true\"\n",
     ")\n",
     "\n",
-    "# Here we use 1.5 degree which is slightly larger than needed.\n",
-    "geom = WcsGeom.create(\n",
-    "    skydir=target_position,\n",
-    "    binsz=0.01,\n",
-    "    width=(1.5, 1.5),\n",
-    "    frame=\"galactic\",\n",
-    "    proj=\"CAR\",\n",
-    "    axes=[energy_axis],\n",
-    ")"
+    "geom = RegionGeom(on_region, axes=[energy_axis])"
    ]
   },
   {
@@ -213,7 +196,7 @@
    "source": [
     "### Create the makers\n",
     "\n",
-    "First we instantiate the target `~gammapy.datasets.MapDataset`.  "
+    "First we instantiate the target `~gammapy.datasets.SpectrumDataset`.  "
    ]
   },
   {
@@ -221,16 +204,17 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:41.491473Z",
-     "iopub.status.busy": "2021-02-09T17:05:41.490767Z",
-     "iopub.status.idle": "2021-02-09T17:05:41.498130Z",
-     "shell.execute_reply": "2021-02-09T17:05:41.498570Z"
+     "iopub.execute_input": "2021-02-12T11:31:17.612183Z",
+     "iopub.status.busy": "2021-02-12T11:31:17.611760Z",
+     "iopub.status.idle": "2021-02-12T11:31:17.613913Z",
+     "shell.execute_reply": "2021-02-12T11:31:17.613481Z"
     }
    },
    "outputs": [],
    "source": [
-    "stacked = MapDataset.create(\n",
-    "    geom=geom, energy_axis_true=energy_axis_true, name=\"rxj-stacked\"\n",
+    "dataset_empty = SpectrumDataset.create(\n",
+    "    geom=geom,\n",
+    "    energy_axis_true=energy_axis_true,\n",
     ")"
    ]
   },
@@ -238,7 +222,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we create its associated maker. Here we need to produce, counts, exposure and edisp (energy dispersion) entries. PSF and IRF background are not needed, therefore we don't compute them."
+    "Now we create its associated maker. Here we need to produce, counts, exposure and edisp (energy dispersion) entries. PSF and IRF background are not needed, therefore we don't compute them.\n",
+    "\n",
+    "**IMPORTANT**: Note that `use_region_center` is set to `False`. This is necessary so that the `~gammapy.makers.SpectrumDatasetMaker` considers the whole region in the IRF computation and not only the center."
    ]
   },
   {
@@ -246,15 +232,17 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:41.511312Z",
-     "iopub.status.busy": "2021-02-09T17:05:41.510841Z",
-     "iopub.status.idle": "2021-02-09T17:05:41.513037Z",
-     "shell.execute_reply": "2021-02-09T17:05:41.512600Z"
+     "iopub.execute_input": "2021-02-12T11:31:17.616853Z",
+     "iopub.status.busy": "2021-02-12T11:31:17.616439Z",
+     "iopub.status.idle": "2021-02-12T11:31:17.618468Z",
+     "shell.execute_reply": "2021-02-12T11:31:17.618038Z"
     }
    },
    "outputs": [],
    "source": [
-    "maker = MapDatasetMaker(selection=[\"counts\", \"exposure\", \"edisp\"])"
+    "maker = SpectrumDatasetMaker(\n",
+    "    selection=[\"counts\", \"exposure\", \"edisp\"], use_region_center=False\n",
+    ")"
    ]
   },
   {
@@ -269,10 +257,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:41.516499Z",
-     "iopub.status.busy": "2021-02-09T17:05:41.516034Z",
-     "iopub.status.idle": "2021-02-09T17:05:41.518233Z",
-     "shell.execute_reply": "2021-02-09T17:05:41.517799Z"
+     "iopub.execute_input": "2021-02-12T11:31:17.621752Z",
+     "iopub.status.busy": "2021-02-12T11:31:17.621333Z",
+     "iopub.status.idle": "2021-02-12T11:31:17.623379Z",
+     "shell.execute_reply": "2021-02-12T11:31:17.622952Z"
     }
    },
    "outputs": [],
@@ -290,9 +278,8 @@
     "## Perform the data reduction loop.\n",
     "\n",
     "We can now run over selected observations. For each of them, we:\n",
-    "- create the map dataset and stack it on our target dataset.\n",
-    "- squeeze the map dataset to a spectral dataset in the ON region\n",
-    "- Compute the OFF and create a `~gammapy.datasets.SpectrumDatasetOnOff` object\n",
+    "- create the `~gammapy.datasets.SpectrumDataset`\n",
+    "- Compute the OFF via the reflected background method and create a `~gammapy.datasets.SpectrumDatasetOnOff` object\n",
     "- Run the safe mask maker on it\n",
     "- Add the `~gammapy.datasets.SpectrumDatasetOnOff` to the list."
    ]
@@ -302,10 +289,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:41.530107Z",
-     "iopub.status.busy": "2021-02-09T17:05:41.527402Z",
-     "iopub.status.idle": "2021-02-09T17:05:45.860468Z",
-     "shell.execute_reply": "2021-02-09T17:05:45.860026Z"
+     "iopub.execute_input": "2021-02-12T11:31:17.629511Z",
+     "iopub.status.busy": "2021-02-12T11:31:17.629063Z",
+     "iopub.status.idle": "2021-02-12T11:31:21.302179Z",
+     "shell.execute_reply": "2021-02-12T11:31:21.301734Z"
     }
    },
    "outputs": [],
@@ -314,28 +301,27 @@
     "datasets = Datasets()\n",
     "\n",
     "for obs in observations:\n",
-    "    # A MapDataset is filled in this geometry\n",
-    "    dataset = maker.run(stacked, obs)\n",
-    "    # To make images, the resulting dataset cutout is stacked onto the final one\n",
-    "    stacked.stack(dataset)\n",
-    "    # Extract 1D spectrum\n",
-    "    spectrum_dataset = dataset.to_spectrum_dataset(\n",
-    "        on_region, name=f\"obs-{obs.obs_id}\"\n",
-    "    )\n",
-    "\n",
+    "    # A SpectrumDataset is filled in this geometry\n",
+    "    dataset = maker.run(dataset_empty.copy(name=f\"obs-{obs.obs_id}\"), obs)\n",
     "    # Compute OFF\n",
-    "    spectrum_dataset = bkg_maker.run(spectrum_dataset, obs)\n",
+    "    dataset = bkg_maker.run(dataset, obs)\n",
     "    # Define safe mask\n",
-    "    spectrum_dataset = safe_mask_maker.run(spectrum_dataset, obs)\n",
+    "    dataset = safe_mask_maker.run(dataset, obs)\n",
     "    # Append dataset to the list\n",
-    "\n",
-    "    datasets.append(spectrum_dataset)"
+    "    datasets.append(dataset)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-12T11:31:21.309669Z",
+     "iopub.status.busy": "2021-02-12T11:31:21.309219Z",
+     "iopub.status.idle": "2021-02-12T11:31:21.311209Z",
+     "shell.execute_reply": "2021-02-12T11:31:21.311661Z"
+    }
+   },
    "outputs": [],
    "source": [
     "datasets.meta_table"
@@ -345,15 +331,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Explore the results"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "First let's look at the data to see if our region is correct.\n",
-    "We plot it over the excess. To do so we convert it to a pixel region using the WCS information stored on the geom."
+    "## Explore the results\n",
+    "We can peek at the content of the spectrum datasets"
    ]
   },
   {
@@ -361,42 +340,17 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:45.864659Z",
-     "iopub.status.busy": "2021-02-09T17:05:45.863896Z",
-     "iopub.status.idle": "2021-02-09T17:05:46.089673Z",
-     "shell.execute_reply": "2021-02-09T17:05:46.089283Z"
+     "iopub.execute_input": "2021-02-12T11:31:21.357547Z",
+     "iopub.status.busy": "2021-02-12T11:31:21.352863Z",
+     "iopub.status.idle": "2021-02-12T11:31:22.805800Z",
+     "shell.execute_reply": "2021-02-12T11:31:22.805324Z"
     },
-    "nbsphinx-thumbnail": {
-     "tooltip": "Measure the spectrum of RX J1713-3945 in a 1 degree region fully enclosing it."
-    }
+    "scrolled": false
    },
    "outputs": [],
    "source": [
-    "stacked.counts.sum_over_axes().smooth(width=\"0.05 deg\").plot()\n",
-    "on_region.to_pixel(stacked.counts.geom.wcs).plot()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We now turn to the spectral datasets. We can peek at their content:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:46.113485Z",
-     "iopub.status.busy": "2021-02-09T17:05:46.102866Z",
-     "iopub.status.idle": "2021-02-09T17:05:47.343576Z",
-     "shell.execute_reply": "2021-02-09T17:05:47.343232Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "datasets[0].peek()"
+    "datasets[0].peek()\n",
+    "plt.show()"
    ]
   },
   {
@@ -413,10 +367,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:47.413508Z",
-     "iopub.status.busy": "2021-02-09T17:05:47.346628Z",
-     "iopub.status.idle": "2021-02-09T17:05:47.546850Z",
-     "shell.execute_reply": "2021-02-09T17:05:47.547232Z"
+     "iopub.execute_input": "2021-02-12T11:31:23.036360Z",
+     "iopub.status.busy": "2021-02-12T11:31:22.926618Z",
+     "iopub.status.idle": "2021-02-12T11:31:23.037741Z",
+     "shell.execute_reply": "2021-02-12T11:31:23.038118Z"
     }
    },
    "outputs": [],
@@ -429,10 +383,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:47.554334Z",
-     "iopub.status.busy": "2021-02-09T17:05:47.553441Z",
-     "iopub.status.idle": "2021-02-09T17:05:47.556635Z",
-     "shell.execute_reply": "2021-02-09T17:05:47.557403Z"
+     "iopub.execute_input": "2021-02-12T11:31:23.043714Z",
+     "iopub.status.busy": "2021-02-12T11:31:23.043191Z",
+     "iopub.status.idle": "2021-02-12T11:31:23.045663Z",
+     "shell.execute_reply": "2021-02-12T11:31:23.045258Z"
     }
    },
    "outputs": [],
@@ -445,10 +399,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:47.599652Z",
-     "iopub.status.busy": "2021-02-09T17:05:47.582537Z",
-     "iopub.status.idle": "2021-02-09T17:05:47.853656Z",
-     "shell.execute_reply": "2021-02-09T17:05:47.853263Z"
+     "iopub.execute_input": "2021-02-12T11:31:23.074344Z",
+     "iopub.status.busy": "2021-02-12T11:31:23.061486Z",
+     "iopub.status.idle": "2021-02-12T11:31:23.231668Z",
+     "shell.execute_reply": "2021-02-12T11:31:23.231239Z"
     }
    },
    "outputs": [],
@@ -456,8 +410,12 @@
     "fig = plt.figure(figsize=(10, 6))\n",
     "ax = fig.add_subplot(121)\n",
     "ax.plot(\n",
-    "    info_table[\"livetime\"].to(\"h\"), info_table[\"excess\"], marker=\"o\", ls=\"none\"\n",
+    "    info_table[\"livetime\"].to(\"h\"),\n",
+    "    info_table[\"excess\"],\n",
+    "    marker=\"o\",\n",
+    "    ls=\"none\",\n",
     ")\n",
+    "\n",
     "plt.xlabel(\"Livetime [h]\")\n",
     "plt.ylabel(\"Excess events\")\n",
     "\n",
@@ -468,6 +426,7 @@
     "    marker=\"o\",\n",
     "    ls=\"none\",\n",
     ")\n",
+    "\n",
     "plt.xlabel(\"Livetime [h]\")\n",
     "plt.ylabel(\"Sqrt(TS)\");"
    ]
@@ -488,10 +447,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:47.863771Z",
-     "iopub.status.busy": "2021-02-09T17:05:47.863374Z",
-     "iopub.status.idle": "2021-02-09T17:05:47.864738Z",
-     "shell.execute_reply": "2021-02-09T17:05:47.865048Z"
+     "iopub.execute_input": "2021-02-12T11:31:23.240123Z",
+     "iopub.status.busy": "2021-02-12T11:31:23.239660Z",
+     "iopub.status.idle": "2021-02-12T11:31:23.241056Z",
+     "shell.execute_reply": "2021-02-12T11:31:23.241412Z"
     }
    },
    "outputs": [],
@@ -516,10 +475,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:47.868734Z",
-     "iopub.status.busy": "2021-02-09T17:05:47.868331Z",
-     "iopub.status.idle": "2021-02-09T17:05:48.606599Z",
-     "shell.execute_reply": "2021-02-09T17:05:48.606213Z"
+     "iopub.execute_input": "2021-02-12T11:31:23.245362Z",
+     "iopub.status.busy": "2021-02-12T11:31:23.244913Z",
+     "iopub.status.idle": "2021-02-12T11:31:24.054862Z",
+     "shell.execute_reply": "2021-02-12T11:31:24.054277Z"
     }
    },
    "outputs": [],
@@ -543,10 +502,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:48.611189Z",
-     "iopub.status.busy": "2021-02-09T17:05:48.610826Z",
-     "iopub.status.idle": "2021-02-09T17:05:48.612630Z",
-     "shell.execute_reply": "2021-02-09T17:05:48.612919Z"
+     "iopub.execute_input": "2021-02-12T11:31:24.060449Z",
+     "iopub.status.busy": "2021-02-12T11:31:24.060021Z",
+     "iopub.status.idle": "2021-02-12T11:31:24.062780Z",
+     "shell.execute_reply": "2021-02-12T11:31:24.062334Z"
     }
    },
    "outputs": [],
@@ -566,10 +525,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:48.761237Z",
-     "iopub.status.busy": "2021-02-09T17:05:48.744184Z",
-     "iopub.status.idle": "2021-02-09T17:05:49.436100Z",
-     "shell.execute_reply": "2021-02-09T17:05:49.436392Z"
+     "iopub.execute_input": "2021-02-12T11:31:24.088143Z",
+     "iopub.status.busy": "2021-02-12T11:31:24.065980Z",
+     "iopub.status.idle": "2021-02-12T11:31:24.910166Z",
+     "shell.execute_reply": "2021-02-12T11:31:24.910499Z"
     }
    },
    "outputs": [],
@@ -579,431 +538,8 @@
     "# Assign the fitted model\n",
     "reduced.models = model\n",
     "# Plot the result\n",
+    "\n",
     "reduced.plot_fit();"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# 1D analysis\n",
-    "## Proposed approach:\n",
-    "For this case, we have to:\n",
-    "\n",
-    "- Define an ON region (a `~regions.SkyRegion`) fully enclosing the source we want to study.\n",
-    "- Define a `~gammapy.maps.RegionGeom` with the ON region and the required energy range (beware in particular, the true energy range).  \n",
-    "- Create the necessary makers : \n",
-    "    - the spectrum dataset maker : `~gammapy.makers.SpectrumDatasetMaker`\n",
-    "    - the OFF background maker, here a `~gammapy.makers.ReflectedRegionsBackgroundMaker`\n",
-    "    - and usually the safe range maker : `~gammapy.makers.SafeRangeMaker`\n",
-    "- Perform the data reduction loop. And for every observation:\n",
-    "    - Produce a spectrum dataset\n",
-    "    - Extract the OFF data to produce a `~gammapy.datasets.SpectrumDatasetOnOff` and compute a safe range for it.\n",
-    "    - Stack or store the resulting spectrum dataset.\n",
-    "- Finally proceed with model fitting on the dataset as usual.\n",
-    "\n",
-    "Note that many of the steps are exactly the same as for the first case. In fact, the only difference is the use of the `~gammapy.makers.SpectrumDatasetMaker` and the `~gammapy.maps.RegionGeom` replacing the map dataset maker and WCS geom from the 3D case.\n",
-    "\n",
-    "We start by adding necessary imports not covered above..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:49.439138Z",
-     "iopub.status.busy": "2021-02-09T17:05:49.438762Z",
-     "iopub.status.idle": "2021-02-09T17:05:49.440269Z",
-     "shell.execute_reply": "2021-02-09T17:05:49.440556Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from gammapy.maps import RegionGeom\n",
-    "from gammapy.makers import SpectrumDatasetMaker\n",
-    "from gammapy.datasets import SpectrumDataset"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Create the RegionGeom \n",
-    "From the ON region with the corresponding energy axis"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:49.444731Z",
-     "iopub.status.busy": "2021-02-09T17:05:49.444353Z",
-     "iopub.status.idle": "2021-02-09T17:05:49.446210Z",
-     "shell.execute_reply": "2021-02-09T17:05:49.445882Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "region_geom = RegionGeom(on_region, axes=[energy_axis])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Create the makers\n",
-    "\n",
-    "First we instantiate the target `~gammapy.datasets.SpectrumDataset`.  "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:49.451282Z",
-     "iopub.status.busy": "2021-02-09T17:05:49.450869Z",
-     "iopub.status.idle": "2021-02-09T17:05:49.455540Z",
-     "shell.execute_reply": "2021-02-09T17:05:49.455851Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "spec_dataset_empty = SpectrumDataset.create(\n",
-    "    geom=region_geom,\n",
-    "    energy_axis_true=energy_axis_true,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we create its associated maker. Here we need to produce, counts, exposure and edisp (energy dispersion) entries. PSF and IRF background are not needed, therefore we don't compute them.\n",
-    "\n",
-    "**IMPORTANT**: Note that `use_region_center` is set to `False`. This is necessary so that the `~gammapy.makers.SpectrumDatasetMaker` considers the whole region in the IRF computation and not only the center."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:49.458901Z",
-     "iopub.status.busy": "2021-02-09T17:05:49.458329Z",
-     "iopub.status.idle": "2021-02-09T17:05:49.459896Z",
-     "shell.execute_reply": "2021-02-09T17:05:49.460203Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "spec_maker = SpectrumDatasetMaker(\n",
-    "    selection=[\"counts\", \"exposure\", \"edisp\"], use_region_center=False\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Perform the data reduction loop.\n",
-    "\n",
-    "We can now run over selected observations. For each of them, we:\n",
-    "- create the `~gammapy.datasets.SpectrumDataset`\n",
-    "- Compute the OFF and create a `~gammapy.datasets.SpectrumDatasetOnOff` object\n",
-    "- Run the safe mask maker on it\n",
-    "- Add the `~gammapy.datasets.SpectrumDatasetOnOff` to the list."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:49.467286Z",
-     "iopub.status.busy": "2021-02-09T17:05:49.466771Z",
-     "iopub.status.idle": "2021-02-09T17:05:52.711766Z",
-     "shell.execute_reply": "2021-02-09T17:05:52.712063Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "spec_datasets = Datasets()\n",
-    "\n",
-    "for obs in observations:\n",
-    "\n",
-    "    # A SpectrumDataset is filled in this geometry\n",
-    "    spectrum_dataset = spec_maker.run(\n",
-    "        spec_dataset_empty.copy(name=f\"obs-{obs.obs_id}\"), obs\n",
-    "    )\n",
-    "\n",
-    "    # These makers are the same as for the case above\n",
-    "    # Compute OFF\n",
-    "    spectrum_dataset = bkg_maker.run(spectrum_dataset, obs)\n",
-    "    # Define safe mask\n",
-    "    spectrum_dataset = safe_mask_maker.run(spectrum_dataset, obs)\n",
-    "    # Append dataset to the list\n",
-    "    spec_datasets.append(spectrum_dataset)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:52.717227Z",
-     "iopub.status.busy": "2021-02-09T17:05:52.716848Z",
-     "iopub.status.idle": "2021-02-09T17:05:52.718915Z",
-     "shell.execute_reply": "2021-02-09T17:05:52.718601Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "spec_datasets.meta_table"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:52.743033Z",
-     "iopub.status.busy": "2021-02-09T17:05:52.730619Z",
-     "iopub.status.idle": "2021-02-09T17:05:53.692699Z",
-     "shell.execute_reply": "2021-02-09T17:05:53.692317Z"
-    },
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "spec_datasets[0].peek()\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Cumulative excess and signficance\n",
-    "\n",
-    "Finally, we can look at cumulative significance and number of excesses. This is done with the `info_table` method of `~gammapy.datasets.Datasets`. We can compare the excess and significance evolution with the 3D approach"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:53.729843Z",
-     "iopub.status.busy": "2021-02-09T17:05:53.695561Z",
-     "iopub.status.idle": "2021-02-09T17:05:53.891086Z",
-     "shell.execute_reply": "2021-02-09T17:05:53.890754Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "info_table_spec = spec_datasets.info_table(cumulative=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:53.920222Z",
-     "iopub.status.busy": "2021-02-09T17:05:53.906096Z",
-     "iopub.status.idle": "2021-02-09T17:05:54.086979Z",
-     "shell.execute_reply": "2021-02-09T17:05:54.086587Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "fig = plt.figure(figsize=(10, 6))\n",
-    "ax = fig.add_subplot(121)\n",
-    "ax.plot(\n",
-    "    info_table[\"livetime\"].to(\"h\"),\n",
-    "    info_table[\"excess\"],\n",
-    "    marker=\"o\",\n",
-    "    ls=\"none\",\n",
-    "    label=\"3D\",\n",
-    ")\n",
-    "ax.plot(\n",
-    "    info_table_spec[\"livetime\"].to(\"h\"),\n",
-    "    info_table_spec[\"excess\"],\n",
-    "    marker=\"x\",\n",
-    "    ls=\"none\",\n",
-    "    label=\"1D\",\n",
-    ")\n",
-    "plt.legend()\n",
-    "plt.xlabel(\"Livetime [h]\")\n",
-    "plt.ylabel(\"Excess events\")\n",
-    "\n",
-    "ax = fig.add_subplot(122)\n",
-    "ax.plot(\n",
-    "    info_table[\"livetime\"].to(\"h\"),\n",
-    "    info_table[\"sqrt_ts\"],\n",
-    "    marker=\"o\",\n",
-    "    ls=\"none\",\n",
-    "    label=\"3D\",\n",
-    ")\n",
-    "ax.plot(\n",
-    "    info_table_spec[\"livetime\"].to(\"h\"),\n",
-    "    info_table_spec[\"sqrt_ts\"],\n",
-    "    marker=\"x\",\n",
-    "    ls=\"none\",\n",
-    "    label=\"1D\",\n",
-    ")\n",
-    "plt.legend()\n",
-    "plt.xlabel(\"Livetime [h]\")\n",
-    "plt.ylabel(\"Sqrt(TS)\");"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Perform spectral model fitting\n",
-    "From this step on, everything is the same as for the 3D approach.\n",
-    "\n",
-    "Here we perform a joint fit. \n",
-    "\n",
-    "We first create the model, here a simple powerlaw, and assign it to every dataset in the `~gammapy.datasets.Datasets`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:54.094235Z",
-     "iopub.status.busy": "2021-02-09T17:05:54.093851Z",
-     "iopub.status.idle": "2021-02-09T17:05:54.095503Z",
-     "shell.execute_reply": "2021-02-09T17:05:54.095105Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "spectral_model_1D = PowerLawSpectralModel(\n",
-    "    index=2, amplitude=2e-11 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
-    ")\n",
-    "model_1D = SkyModel(spectral_model=spectral_model_1D, name=\"RXJ 1713\")\n",
-    "\n",
-    "spec_datasets.models = [model_1D]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can run the fit"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:54.224413Z",
-     "iopub.status.busy": "2021-02-09T17:05:54.102721Z",
-     "iopub.status.idle": "2021-02-09T17:05:54.905835Z",
-     "shell.execute_reply": "2021-02-09T17:05:54.905434Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "fit_joint = Fit(spec_datasets)\n",
-    "result_joint_1D = fit_joint.run()\n",
-    "print(result_joint_1D)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Explore the fit results\n",
-    "\n",
-    "First the fitted parameters values and their errors."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:54.910457Z",
-     "iopub.status.busy": "2021-02-09T17:05:54.910072Z",
-     "iopub.status.idle": "2021-02-09T17:05:54.911933Z",
-     "shell.execute_reply": "2021-02-09T17:05:54.912222Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "result_joint_1D.parameters.to_table()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Then plot the fit result to compare measured and expected counts. Rather than plotting them for each individual dataset, we stack all datasets and plot the fit result on the result."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:55.039278Z",
-     "iopub.status.busy": "2021-02-09T17:05:55.008607Z",
-     "iopub.status.idle": "2021-02-09T17:05:55.636272Z",
-     "shell.execute_reply": "2021-02-09T17:05:55.635884Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# First stack them all\n",
-    "reduced_1D = spec_datasets.stack_reduce()\n",
-    "# Assign the fitted model\n",
-    "reduced_1D.models = model_1D\n",
-    "# Plot the result\n",
-    "\n",
-    "reduced_1D.plot_fit();"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Comparison between both approaches\n",
-    "We can compare the best-fit spectrum from both approaches, either looking at the parameters in the tables or directly plotting them together like below. As expected, they match."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:55.652564Z",
-     "iopub.status.busy": "2021-02-09T17:05:55.651592Z",
-     "iopub.status.idle": "2021-02-09T17:05:56.113542Z",
-     "shell.execute_reply": "2021-02-09T17:05:56.113152Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "plt.figure(figsize=(10, 8))\n",
-    "spectral_model.plot(energy_range=reduced.energy_range, color=\"k\", label=\"3D\")\n",
-    "spectral_model.plot_error(energy_range=reduced.energy_range, color=\"k\")\n",
-    "\n",
-    "spectral_model_1D.plot(\n",
-    "    energy_range=reduced_1D.energy_range, color=\"r\", linestyle=\"--\", label=\"1D\"\n",
-    ")\n",
-    "spectral_model_1D.plot_error(energy_range=reduced_1D.energy_range, color=\"r\")\n",
-    "plt.legend()\n",
-    "plt.show()"
    ]
   }
  ],

--- a/docs/tutorials/extended_source_spectral_analysis.ipynb
+++ b/docs/tutorials/extended_source_spectral_analysis.ipynb
@@ -235,22 +235,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-09T17:05:41.505895Z",
-     "iopub.status.busy": "2021-02-09T17:05:41.505365Z",
-     "iopub.status.idle": "2021-02-09T17:05:41.508239Z",
-     "shell.execute_reply": "2021-02-09T17:05:41.507800Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "stacked.edisp.edisp_map.geom"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -328,9 +312,7 @@
    "source": [
     "%%time\n",
     "datasets = Datasets()\n",
-    "stacked = MapDataset.create(\n",
-    "    geom=geom, energy_axis_true=energy_axis_true, name=\"rxj-stacked\"\n",
-    ")\n",
+    "\n",
     "for obs in observations:\n",
     "    # A MapDataset is filled in this geometry\n",
     "    dataset = maker.run(stacked, obs)\n",
@@ -348,6 +330,15 @@
     "    # Append dataset to the list\n",
     "\n",
     "    datasets.append(spectrum_dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasets.meta_table"
    ]
   },
   {

--- a/docs/tutorials/extended_source_spectral_analysis.ipynb
+++ b/docs/tutorials/extended_source_spectral_analysis.ipynb
@@ -21,25 +21,13 @@
     "\n",
     "## Proposed approach:\n",
     "\n",
-    "We have seen in the general presentation of the spectrum extraction for point sources, see [the corresponding notebook](spectrum_analysis.ipynb), that Gammapy uses specific datasets makers to first produce reduced spectral data and then to extract OFF measurements with reflected background techniques: the `~gammapy.makers.SpectrumDatasetMaker` and the `~gammapy.makers.ReflectedRegionsBackgroundMaker`. The former simply computes the reduced IRF at the center of the ON region (assumed to be circular).\n",
+    "We have seen in the general presentation of the spectrum extraction for point sources, see [the corresponding notebook](spectrum_analysis.ipynb), that Gammapy uses specific datasets makers to first produce reduced spectral data and then to extract OFF measurements with reflected background techniques: the `~gammapy.makers.SpectrumDatasetMaker` and the `~gammapy.makers.ReflectedRegionsBackgroundMaker`. However if the flag `use_region_center` is not set to `False`, the former simply computes the reduced IRFs at the center of the ON region (assumed to be circular).\n",
     "\n",
-    "This is no longer valid for extended sources. To be able to compute average responses in the ON region, Gammapy relies on the creation of a cube enclosing it (i.e. a `~gammapy.datasets.MapDataset`) which can be reduced to a simple spectrum (i.e. a `~gammapy.datasets.SpectrumDataset`). We can then proceed with the OFF extraction as the standard point source case.\n",
+    "This is no longer valid for extended sources. To be able to compute average responses in the ON region, Gammapy allows for two approaches. One relies on the creation of a cube enclosing it (i.e. a `~gammapy.datasets.MapDataset`) which can be reduced to a simple spectrum (i.e. a `~gammapy.datasets.SpectrumDataset`). We can then proceed with the OFF extraction as the standard point source case. We will refer to this as the **3D approach**.\n",
     "\n",
-    "In summary, we have to:\n",
+    "Alternatively, we can set `use_region_center=False` with the `~gammapy.makers.SpectrumDatasetMaker`, in which case the values of the IRFs are averaged over the entire region. We will refer to this as the **1D approach**. Both approaches are equivalent and should yield the same results. \n",
     "\n",
-    "- Define an ON region (a `~regions.SkyRegion`) fully enclosing the source we want to study.\n",
-    "- Define a geometry that fully contains the region and that covers the required energy range (beware in particular, the true energy range).  \n",
-    "- Create the necessary makers : \n",
-    "    - the map dataset maker : `~gammapy.makers.MapDatasetMaker`\n",
-    "    - the OFF background maker, here a `~gammapy.makers.ReflectedRegionsBackgroundMaker`\n",
-    "    - and usually the safe range maker : `~gammapy.makers.SafeRangeMaker`\n",
-    "- Perform the data reduction loop. And for every observation:\n",
-    "    - Produce a map dataset and squeeze it to a spectrum dataset with `~gammapy.datasets.MapDataset.to_spectrum_dataset(on_region)`\n",
-    "    - Extract the OFF data to produce a `~gammapy.datasets.SpectrumDatasetOnOff` and compute a safe range for it.\n",
-    "    - Stack or store the resulting spectrum dataset.\n",
-    "- Finally proceed with model fitting on the dataset as usual.\n",
-    "\n",
-    "Here, we will use the RX J1713-3945 observations from the H.E.S.S. first public test data release. The tutorial is implemented with the intermediate level API.\n",
+    "Below we will show both approaches, using the RX J1713-3945 observations from the H.E.S.S. first public test data release. The tutorial is implemented with the intermediate level API.\n",
     "\n",
     "## Setup \n",
     "\n",
@@ -49,7 +37,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:40.146978Z",
+     "iopub.status.busy": "2021-02-09T17:05:40.144510Z",
+     "iopub.status.idle": "2021-02-09T17:05:40.504114Z",
+     "shell.execute_reply": "2021-02-09T17:05:40.503567Z"
+    }
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -59,7 +54,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:40.508963Z",
+     "iopub.status.busy": "2021-02-09T17:05:40.508254Z",
+     "iopub.status.idle": "2021-02-09T17:05:41.417321Z",
+     "shell.execute_reply": "2021-02-09T17:05:41.416219Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import astropy.units as u\n",
@@ -81,6 +83,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# 3D analysis\n",
+    "## Proposed approach:\n",
+    "For this case, we have to:\n",
+    "\n",
+    "- Define an ON region (a `~regions.SkyRegion`) fully enclosing the source we want to study.\n",
+    "- Define a geometry that fully contains the region and that covers the required energy range (beware in particular, the true energy range).  \n",
+    "- Create the necessary makers : \n",
+    "    - the map dataset maker : `~gammapy.makers.MapDatasetMaker`\n",
+    "    - the OFF background maker, here a `~gammapy.makers.ReflectedRegionsBackgroundMaker`\n",
+    "    - and usually the safe range maker : `~gammapy.makers.SafeRangeMaker`\n",
+    "- Perform the data reduction loop. And for every observation:\n",
+    "    - Produce a map dataset and squeeze it to a spectrum dataset with `~gammapy.datasets.MapDataset.to_spectrum_dataset(on_region)`\n",
+    "    - Extract the OFF data to produce a `~gammapy.datasets.SpectrumDatasetOnOff` and compute a safe range for it.\n",
+    "    - Stack or store the resulting spectrum dataset.\n",
+    "- Finally proceed with model fitting on the dataset as usual.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Select the data\n",
     "\n",
     "We first set the datastore and retrieve a few observations from our source."
@@ -89,7 +112,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:41.427785Z",
+     "iopub.status.busy": "2021-02-09T17:05:41.426740Z",
+     "iopub.status.idle": "2021-02-09T17:05:41.470575Z",
+     "shell.execute_reply": "2021-02-09T17:05:41.470121Z"
+    }
+   },
    "outputs": [],
    "source": [
     "datastore = DataStore.from_dir(\"$GAMMAPY_DATA/hess-dl3-dr1/\")\n",
@@ -119,7 +149,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:41.474872Z",
+     "iopub.status.busy": "2021-02-09T17:05:41.474357Z",
+     "iopub.status.idle": "2021-02-09T17:05:41.476578Z",
+     "shell.execute_reply": "2021-02-09T17:05:41.476149Z"
+    }
+   },
    "outputs": [],
    "source": [
     "target_position = SkyCoord(347.3, -0.5, unit=\"deg\", frame=\"galactic\")\n",
@@ -141,7 +178,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:41.482799Z",
+     "iopub.status.busy": "2021-02-09T17:05:41.482277Z",
+     "iopub.status.idle": "2021-02-09T17:05:41.484511Z",
+     "shell.execute_reply": "2021-02-09T17:05:41.484073Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# The binning of the final spectrum is defined here.\n",
@@ -155,7 +199,7 @@
     "# Here we use 1.5 degree which is slightly larger than needed.\n",
     "geom = WcsGeom.create(\n",
     "    skydir=target_position,\n",
-    "    binsz=0.04,\n",
+    "    binsz=0.01,\n",
     "    width=(1.5, 1.5),\n",
     "    frame=\"galactic\",\n",
     "    proj=\"CAR\",\n",
@@ -175,12 +219,35 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:41.491473Z",
+     "iopub.status.busy": "2021-02-09T17:05:41.490767Z",
+     "iopub.status.idle": "2021-02-09T17:05:41.498130Z",
+     "shell.execute_reply": "2021-02-09T17:05:41.498570Z"
+    }
+   },
    "outputs": [],
    "source": [
     "stacked = MapDataset.create(\n",
     "    geom=geom, energy_axis_true=energy_axis_true, name=\"rxj-stacked\"\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:41.505895Z",
+     "iopub.status.busy": "2021-02-09T17:05:41.505365Z",
+     "iopub.status.idle": "2021-02-09T17:05:41.508239Z",
+     "shell.execute_reply": "2021-02-09T17:05:41.507800Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stacked.edisp.edisp_map.geom"
    ]
   },
   {
@@ -193,7 +260,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:41.511312Z",
+     "iopub.status.busy": "2021-02-09T17:05:41.510841Z",
+     "iopub.status.idle": "2021-02-09T17:05:41.513037Z",
+     "shell.execute_reply": "2021-02-09T17:05:41.512600Z"
+    }
+   },
    "outputs": [],
    "source": [
     "maker = MapDatasetMaker(selection=[\"counts\", \"exposure\", \"edisp\"])"
@@ -209,7 +283,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:41.516499Z",
+     "iopub.status.busy": "2021-02-09T17:05:41.516034Z",
+     "iopub.status.idle": "2021-02-09T17:05:41.518233Z",
+     "shell.execute_reply": "2021-02-09T17:05:41.517799Z"
+    }
+   },
    "outputs": [],
    "source": [
     "bkg_maker = ReflectedRegionsBackgroundMaker()\n",
@@ -235,37 +316,38 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:41.530107Z",
+     "iopub.status.busy": "2021-02-09T17:05:41.527402Z",
+     "iopub.status.idle": "2021-02-09T17:05:45.860468Z",
+     "shell.execute_reply": "2021-02-09T17:05:45.860026Z"
+    }
+   },
    "outputs": [],
    "source": [
     "%%time\n",
     "datasets = Datasets()\n",
-    "\n",
+    "stacked = MapDataset.create(\n",
+    "    geom=geom, energy_axis_true=energy_axis_true, name=\"rxj-stacked\"\n",
+    ")\n",
     "for obs in observations:\n",
     "    # A MapDataset is filled in this geometry\n",
     "    dataset = maker.run(stacked, obs)\n",
     "    # To make images, the resulting dataset cutout is stacked onto the final one\n",
     "    stacked.stack(dataset)\n",
-    "\n",
     "    # Extract 1D spectrum\n",
     "    spectrum_dataset = dataset.to_spectrum_dataset(\n",
     "        on_region, name=f\"obs-{obs.obs_id}\"\n",
     "    )\n",
+    "\n",
     "    # Compute OFF\n",
     "    spectrum_dataset = bkg_maker.run(spectrum_dataset, obs)\n",
     "    # Define safe mask\n",
     "    spectrum_dataset = safe_mask_maker.run(spectrum_dataset, obs)\n",
     "    # Append dataset to the list\n",
+    "\n",
     "    datasets.append(spectrum_dataset)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "datasets.meta_table"
    ]
   },
   {
@@ -287,6 +369,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:45.864659Z",
+     "iopub.status.busy": "2021-02-09T17:05:45.863896Z",
+     "iopub.status.idle": "2021-02-09T17:05:46.089673Z",
+     "shell.execute_reply": "2021-02-09T17:05:46.089283Z"
+    },
     "nbsphinx-thumbnail": {
      "tooltip": "Measure the spectrum of RX J1713-3945 in a 1 degree region fully enclosing it."
     }
@@ -307,7 +395,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:46.113485Z",
+     "iopub.status.busy": "2021-02-09T17:05:46.102866Z",
+     "iopub.status.idle": "2021-02-09T17:05:47.343576Z",
+     "shell.execute_reply": "2021-02-09T17:05:47.343232Z"
+    }
+   },
    "outputs": [],
    "source": [
     "datasets[0].peek()"
@@ -325,7 +420,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:47.413508Z",
+     "iopub.status.busy": "2021-02-09T17:05:47.346628Z",
+     "iopub.status.idle": "2021-02-09T17:05:47.546850Z",
+     "shell.execute_reply": "2021-02-09T17:05:47.547232Z"
+    }
+   },
    "outputs": [],
    "source": [
     "info_table = datasets.info_table(cumulative=True)"
@@ -334,7 +436,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:47.554334Z",
+     "iopub.status.busy": "2021-02-09T17:05:47.553441Z",
+     "iopub.status.idle": "2021-02-09T17:05:47.556635Z",
+     "shell.execute_reply": "2021-02-09T17:05:47.557403Z"
+    }
+   },
    "outputs": [],
    "source": [
     "info_table"
@@ -343,7 +452,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:47.599652Z",
+     "iopub.status.busy": "2021-02-09T17:05:47.582537Z",
+     "iopub.status.idle": "2021-02-09T17:05:47.853656Z",
+     "shell.execute_reply": "2021-02-09T17:05:47.853263Z"
+    }
+   },
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(10, 6))\n",
@@ -379,7 +495,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:47.863771Z",
+     "iopub.status.busy": "2021-02-09T17:05:47.863374Z",
+     "iopub.status.idle": "2021-02-09T17:05:47.864738Z",
+     "shell.execute_reply": "2021-02-09T17:05:47.865048Z"
+    }
+   },
    "outputs": [],
    "source": [
     "spectral_model = PowerLawSpectralModel(\n",
@@ -400,7 +523,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:47.868734Z",
+     "iopub.status.busy": "2021-02-09T17:05:47.868331Z",
+     "iopub.status.idle": "2021-02-09T17:05:48.606599Z",
+     "shell.execute_reply": "2021-02-09T17:05:48.606213Z"
+    }
+   },
    "outputs": [],
    "source": [
     "fit_joint = Fit(datasets)\n",
@@ -420,7 +550,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:48.611189Z",
+     "iopub.status.busy": "2021-02-09T17:05:48.610826Z",
+     "iopub.status.idle": "2021-02-09T17:05:48.612630Z",
+     "shell.execute_reply": "2021-02-09T17:05:48.612919Z"
+    }
+   },
    "outputs": [],
    "source": [
     "result_joint.parameters.to_table()"
@@ -436,7 +573,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:48.761237Z",
+     "iopub.status.busy": "2021-02-09T17:05:48.744184Z",
+     "iopub.status.idle": "2021-02-09T17:05:49.436100Z",
+     "shell.execute_reply": "2021-02-09T17:05:49.436392Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# First stack them all\n",
@@ -448,11 +592,428 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 1D analysis\n",
+    "## Proposed approach:\n",
+    "For this case, we have to:\n",
+    "\n",
+    "- Define an ON region (a `~regions.SkyRegion`) fully enclosing the source we want to study.\n",
+    "- Define a `~gammapy.maps.RegionGeom` with the ON region and the required energy range (beware in particular, the true energy range).  \n",
+    "- Create the necessary makers : \n",
+    "    - the spectrum dataset maker : `~gammapy.makers.SpectrumDatasetMaker`\n",
+    "    - the OFF background maker, here a `~gammapy.makers.ReflectedRegionsBackgroundMaker`\n",
+    "    - and usually the safe range maker : `~gammapy.makers.SafeRangeMaker`\n",
+    "- Perform the data reduction loop. And for every observation:\n",
+    "    - Produce a spectrum dataset\n",
+    "    - Extract the OFF data to produce a `~gammapy.datasets.SpectrumDatasetOnOff` and compute a safe range for it.\n",
+    "    - Stack or store the resulting spectrum dataset.\n",
+    "- Finally proceed with model fitting on the dataset as usual.\n",
+    "\n",
+    "Note that many of the steps are exactly the same as for the first case. In fact, the only difference is the use of the `~gammapy.makers.SpectrumDatasetMaker` and the `~gammapy.maps.RegionGeom` replacing the map dataset maker and WCS geom from the 3D case.\n",
+    "\n",
+    "We start by adding necessary imports not covered above..."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:49.439138Z",
+     "iopub.status.busy": "2021-02-09T17:05:49.438762Z",
+     "iopub.status.idle": "2021-02-09T17:05:49.440269Z",
+     "shell.execute_reply": "2021-02-09T17:05:49.440556Z"
+    }
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "from gammapy.maps import RegionGeom\n",
+    "from gammapy.makers import SpectrumDatasetMaker\n",
+    "from gammapy.datasets import SpectrumDataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the RegionGeom \n",
+    "From the ON region with the corresponding energy axis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:49.444731Z",
+     "iopub.status.busy": "2021-02-09T17:05:49.444353Z",
+     "iopub.status.idle": "2021-02-09T17:05:49.446210Z",
+     "shell.execute_reply": "2021-02-09T17:05:49.445882Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "region_geom = RegionGeom(on_region, axes=[energy_axis])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the makers\n",
+    "\n",
+    "First we instantiate the target `~gammapy.datasets.SpectrumDataset`.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:49.451282Z",
+     "iopub.status.busy": "2021-02-09T17:05:49.450869Z",
+     "iopub.status.idle": "2021-02-09T17:05:49.455540Z",
+     "shell.execute_reply": "2021-02-09T17:05:49.455851Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "spec_dataset_empty = SpectrumDataset.create(\n",
+    "    geom=region_geom,\n",
+    "    energy_axis_true=energy_axis_true,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we create its associated maker. Here we need to produce, counts, exposure and edisp (energy dispersion) entries. PSF and IRF background are not needed, therefore we don't compute them.\n",
+    "\n",
+    "**IMPORTANT**: Note that `use_region_center` is set to `False`. This is necessary so that the `~gammapy.makers.SpectrumDatasetMaker` considers the whole region in the IRF computation and not only the center."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:49.458901Z",
+     "iopub.status.busy": "2021-02-09T17:05:49.458329Z",
+     "iopub.status.idle": "2021-02-09T17:05:49.459896Z",
+     "shell.execute_reply": "2021-02-09T17:05:49.460203Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "spec_maker = SpectrumDatasetMaker(\n",
+    "    selection=[\"counts\", \"exposure\", \"edisp\"], use_region_center=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Perform the data reduction loop.\n",
+    "\n",
+    "We can now run over selected observations. For each of them, we:\n",
+    "- create the `~gammapy.datasets.SpectrumDataset`\n",
+    "- Compute the OFF and create a `~gammapy.datasets.SpectrumDatasetOnOff` object\n",
+    "- Run the safe mask maker on it\n",
+    "- Add the `~gammapy.datasets.SpectrumDatasetOnOff` to the list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:49.467286Z",
+     "iopub.status.busy": "2021-02-09T17:05:49.466771Z",
+     "iopub.status.idle": "2021-02-09T17:05:52.711766Z",
+     "shell.execute_reply": "2021-02-09T17:05:52.712063Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "spec_datasets = Datasets()\n",
+    "\n",
+    "for obs in observations:\n",
+    "\n",
+    "    # A SpectrumDataset is filled in this geometry\n",
+    "    spectrum_dataset = spec_maker.run(\n",
+    "        spec_dataset_empty.copy(name=f\"obs-{obs.obs_id}\"), obs\n",
+    "    )\n",
+    "\n",
+    "    # These makers are the same as for the case above\n",
+    "    # Compute OFF\n",
+    "    spectrum_dataset = bkg_maker.run(spectrum_dataset, obs)\n",
+    "    # Define safe mask\n",
+    "    spectrum_dataset = safe_mask_maker.run(spectrum_dataset, obs)\n",
+    "    # Append dataset to the list\n",
+    "    spec_datasets.append(spectrum_dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:52.717227Z",
+     "iopub.status.busy": "2021-02-09T17:05:52.716848Z",
+     "iopub.status.idle": "2021-02-09T17:05:52.718915Z",
+     "shell.execute_reply": "2021-02-09T17:05:52.718601Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "spec_datasets.meta_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:52.743033Z",
+     "iopub.status.busy": "2021-02-09T17:05:52.730619Z",
+     "iopub.status.idle": "2021-02-09T17:05:53.692699Z",
+     "shell.execute_reply": "2021-02-09T17:05:53.692317Z"
+    },
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "spec_datasets[0].peek()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cumulative excess and signficance\n",
+    "\n",
+    "Finally, we can look at cumulative significance and number of excesses. This is done with the `info_table` method of `~gammapy.datasets.Datasets`. We can compare the excess and significance evolution with the 3D approach"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:53.729843Z",
+     "iopub.status.busy": "2021-02-09T17:05:53.695561Z",
+     "iopub.status.idle": "2021-02-09T17:05:53.891086Z",
+     "shell.execute_reply": "2021-02-09T17:05:53.890754Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "info_table_spec = spec_datasets.info_table(cumulative=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:53.920222Z",
+     "iopub.status.busy": "2021-02-09T17:05:53.906096Z",
+     "iopub.status.idle": "2021-02-09T17:05:54.086979Z",
+     "shell.execute_reply": "2021-02-09T17:05:54.086587Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(10, 6))\n",
+    "ax = fig.add_subplot(121)\n",
+    "ax.plot(\n",
+    "    info_table[\"livetime\"].to(\"h\"),\n",
+    "    info_table[\"excess\"],\n",
+    "    marker=\"o\",\n",
+    "    ls=\"none\",\n",
+    "    label=\"3D\",\n",
+    ")\n",
+    "ax.plot(\n",
+    "    info_table_spec[\"livetime\"].to(\"h\"),\n",
+    "    info_table_spec[\"excess\"],\n",
+    "    marker=\"x\",\n",
+    "    ls=\"none\",\n",
+    "    label=\"1D\",\n",
+    ")\n",
+    "plt.legend()\n",
+    "plt.xlabel(\"Livetime [h]\")\n",
+    "plt.ylabel(\"Excess events\")\n",
+    "\n",
+    "ax = fig.add_subplot(122)\n",
+    "ax.plot(\n",
+    "    info_table[\"livetime\"].to(\"h\"),\n",
+    "    info_table[\"sqrt_ts\"],\n",
+    "    marker=\"o\",\n",
+    "    ls=\"none\",\n",
+    "    label=\"3D\",\n",
+    ")\n",
+    "ax.plot(\n",
+    "    info_table_spec[\"livetime\"].to(\"h\"),\n",
+    "    info_table_spec[\"sqrt_ts\"],\n",
+    "    marker=\"x\",\n",
+    "    ls=\"none\",\n",
+    "    label=\"1D\",\n",
+    ")\n",
+    "plt.legend()\n",
+    "plt.xlabel(\"Livetime [h]\")\n",
+    "plt.ylabel(\"Sqrt(TS)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Perform spectral model fitting\n",
+    "From this step on, everything is the same as for the 3D approach.\n",
+    "\n",
+    "Here we perform a joint fit. \n",
+    "\n",
+    "We first create the model, here a simple powerlaw, and assign it to every dataset in the `~gammapy.datasets.Datasets`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:54.094235Z",
+     "iopub.status.busy": "2021-02-09T17:05:54.093851Z",
+     "iopub.status.idle": "2021-02-09T17:05:54.095503Z",
+     "shell.execute_reply": "2021-02-09T17:05:54.095105Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "spectral_model_1D = PowerLawSpectralModel(\n",
+    "    index=2, amplitude=2e-11 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
+    ")\n",
+    "model_1D = SkyModel(spectral_model=spectral_model_1D, name=\"RXJ 1713\")\n",
+    "\n",
+    "spec_datasets.models = [model_1D]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can run the fit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:54.224413Z",
+     "iopub.status.busy": "2021-02-09T17:05:54.102721Z",
+     "iopub.status.idle": "2021-02-09T17:05:54.905835Z",
+     "shell.execute_reply": "2021-02-09T17:05:54.905434Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fit_joint = Fit(spec_datasets)\n",
+    "result_joint_1D = fit_joint.run()\n",
+    "print(result_joint_1D)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Explore the fit results\n",
+    "\n",
+    "First the fitted parameters values and their errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:54.910457Z",
+     "iopub.status.busy": "2021-02-09T17:05:54.910072Z",
+     "iopub.status.idle": "2021-02-09T17:05:54.911933Z",
+     "shell.execute_reply": "2021-02-09T17:05:54.912222Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "result_joint_1D.parameters.to_table()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then plot the fit result to compare measured and expected counts. Rather than plotting them for each individual dataset, we stack all datasets and plot the fit result on the result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:55.039278Z",
+     "iopub.status.busy": "2021-02-09T17:05:55.008607Z",
+     "iopub.status.idle": "2021-02-09T17:05:55.636272Z",
+     "shell.execute_reply": "2021-02-09T17:05:55.635884Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# First stack them all\n",
+    "reduced_1D = spec_datasets.stack_reduce()\n",
+    "# Assign the fitted model\n",
+    "reduced_1D.models = model_1D\n",
+    "# Plot the result\n",
+    "\n",
+    "reduced_1D.plot_fit();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Comparison between both approaches\n",
+    "We can compare the best-fit spectrum from both approaches, either looking at the parameters in the tables or directly plotting them together like below. As expected, they match."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-09T17:05:55.652564Z",
+     "iopub.status.busy": "2021-02-09T17:05:55.651592Z",
+     "iopub.status.idle": "2021-02-09T17:05:56.113542Z",
+     "shell.execute_reply": "2021-02-09T17:05:56.113152Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 8))\n",
+    "spectral_model.plot(energy_range=reduced.energy_range, color=\"k\", label=\"3D\")\n",
+    "spectral_model.plot_error(energy_range=reduced.energy_range, color=\"k\")\n",
+    "\n",
+    "spectral_model_1D.plot(\n",
+    "    energy_range=reduced_1D.energy_range, color=\"r\", linestyle=\"--\", label=\"1D\"\n",
+    ")\n",
+    "spectral_model_1D.plot_error(energy_range=reduced_1D.energy_range, color=\"r\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1242,9 +1242,10 @@ class MapDataset(Dataset):
 
         if self.exposure is not None:
             kwargs["exposure"] = self.exposure.get_spectrum(on_region, np.mean)
-            if self.gti:
-                # TODO: this is mising the deadtime correction
-                kwargs["exposure"].meta["livetime"] = self.gti.time_sum
+            try:
+                kwargs["exposure"].meta["livetime"] = self.exposure.meta["livetime"].copy()
+            except KeyError:
+                kwargs["exposure"].meta["livetime"] = u.Quantity(np.nan, "s")
 
         if containment_correction:
             if not isinstance(on_region, CircleSkyRegion):

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1411,11 +1411,11 @@ def test_compute_flux_spatial():
     models = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)
     model = Models(models)
 
-    exposure_region = RegionNDMap.create(region, axes=[energy_axis_true])
+    exposure_region = RegionNDMap.create(region, axes=[energy_axis_true], binsz_wcs="0.01deg")
     exposure_region.data += 1.0
     exposure_region.unit = "m2 s"
 
-    geom = RegionGeom(region, axes=[energy_axis_true])
+    geom = RegionGeom(region, axes=[energy_axis_true], binsz_wcs="0.01deg")
     psf = PSFKernel.from_gauss(geom.to_wcs_geom(), sigma="0.1 deg")
 
     evaluator = MapEvaluator(model=model[0], exposure=exposure_region, psf=psf)

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -44,7 +44,7 @@ def spectrum_dataset_gc():
 def spectrum_dataset_crab():
     e_reco = MapAxis.from_edges(np.logspace(0, 2, 5) * u.TeV, name="energy")
     e_true = MapAxis.from_edges(np.logspace(-0.5, 2, 11) * u.TeV, name="energy_true")
-    geom = RegionGeom.create("icrs;circle(83.63, 22.01, 0.11)", axes=[e_reco])
+    geom = RegionGeom.create("icrs;circle(83.63, 22.01, 0.11)", axes=[e_reco], binsz_wcs="0.01deg")
     return SpectrumDataset.create(geom=geom, energy_axis_true=e_true)
 
 

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -53,7 +53,7 @@ class RegionGeom(Geom):
     _slice_non_spatial_axes = slice(2, None)
     projection = "TAN"
 
-    def __init__(self, region, axes=None, wcs=None, binsz_wcs="0.01 deg"):
+    def __init__(self, region, axes=None, wcs=None, binsz_wcs="0.1 deg"):
         self._region = region
         self._axes = MapAxes.from_default(axes)
         self._binsz_wcs = binsz_wcs
@@ -323,6 +323,22 @@ class RegionGeom(Geom):
         wcs_geom = wcs_geom.to_cube(self.axes)
         return wcs_geom
 
+    def to_binsz_wcs(self, binsz):
+        """Change the bin size of the underlying WCS geometry.
+
+        Parameters
+         ----------
+        binzs : float, string or `~astropy.quantity.Quantity`
+.
+        Returns
+        -------
+        `~RegionGeom`
+            A RegionGeom with the same axes and region as the input,
+            but different wcs pixelization.
+        """
+        new_geom = RegionGeom(self.region, axes=self.axes, binsz_wcs=binsz)
+        return new_geom
+
     def get_wcs_coord_and_weights(self, factor=10):
         """Get the array of spatial coordinates and corresponding weights
 
@@ -355,7 +371,7 @@ class RegionGeom(Geom):
 
         # Get coordinates
         region_coord = wcs_geom.get_coord().apply_mask(mask)
-        
+
         return region_coord, weights
 
     def to_binsz(self, binsz):

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -155,7 +155,7 @@ class RegionNDMap(Map):
         return ax
 
     @classmethod
-    def create(cls, region, axes=None, dtype="float32", meta=None, unit="", wcs=None):
+    def create(cls, region, axes=None, dtype="float32", meta=None, unit="", wcs=None, binsz_wcs="0.1deg"):
         """Create an empty region map object.
 
         Parameters
@@ -178,7 +178,7 @@ class RegionNDMap(Map):
         map : `RegionNDMap`
             Region map
         """
-        geom = RegionGeom.create(region=region, axes=axes, wcs=wcs)
+        geom = RegionGeom.create(region=region, axes=axes, wcs=wcs,binsz_wcs=binsz_wcs)
         return cls(geom=geom, dtype=dtype, unit=unit, meta=meta)
 
     def downsample(

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -47,6 +47,14 @@ def test_defined_wcs(region):
     geom = RegionGeom.create(region, wcs=wcs)
     assert geom.binsz_wcs[0].deg == 0.1
 
+def test_to_binsz_wcs(region):
+    binsz = 0.05*u.deg
+    geom = RegionGeom.create(region, binsz_wcs=0.01)
+    new_geom = geom.to_binsz_wcs(binsz)
+    assert geom.binsz_wcs[0].deg == 0.01
+    assert new_geom.binsz_wcs[0].deg == binsz.value
+
+
 def test_centers(region):
     geom = RegionGeom.create(region)
     assert_allclose(geom.center_skydir.l.deg, 0)
@@ -58,7 +66,7 @@ def test_centers(region):
 
 
 def test_width(region):
-    geom = RegionGeom.create(region)
+    geom = RegionGeom.create(region, binsz_wcs=0.01)
     assert_allclose(geom.width.value, [2.02, 2.02])
 
 

--- a/gammapy/maps/tests/test_regionnd.py
+++ b/gammapy/maps/tests/test_regionnd.py
@@ -189,7 +189,7 @@ def test_regionndmap_resample_axis():
 
 def test_region_nd_io_ogip(tmpdir):
     energy_axis = MapAxis.from_energy_bounds(0.1, 10, 12, unit="TeV")
-    m = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
+    m = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis], binsz_wcs="0.01deg")
     m.write(tmpdir / "test.fits", format="ogip")
 
     m_new = RegionNDMap.read(tmpdir / "test.fits", format="ogip")

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -318,7 +318,7 @@ class SpectralModel(Model):
 
         .. note::
 
-            This method calls ``ax.set_yscale("log", nonposy='clip')`` and
+            This method calls ``ax.set_yscale("log", nonpositive='clip')`` and
             ``ax.set_xscale("log", nonposx='clip')`` to create a log-log representation.
             The additional argument ``nonposx='clip'`` avoids artefacts in the plot,
             when the error band extends to negative values (see also
@@ -327,8 +327,8 @@ class SpectralModel(Model):
             When you call ``plt.loglog()`` or ``plt.semilogy()`` explicitely in your
             plotting code and the error band extends to negative values, it is not
             shown correctly. To circumvent this issue also use
-            ``plt.loglog(nonposx='clip', nonposy='clip')``
-            or ``plt.semilogy(nonposy='clip')``.
+            ``plt.loglog(nonposx='clip', nonpositive='clip')``
+            or ``plt.semilogy(nonpositive='clip')``.
 
         Parameters
         ----------
@@ -383,8 +383,8 @@ class SpectralModel(Model):
         else:
             ax.set_ylabel(f"Flux [{y.unit}]")
 
-        ax.set_xscale("log", nonposx="clip")
-        ax.set_yscale("log", nonposy="clip")
+        ax.set_xscale("log", nonpositive="clip")
+        ax.set_yscale("log", nonpositive="clip")
 
         if "norm" in self.__class__.__name__.lower():
             ax.set_ylabel(f"Norm [A.U.]")

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -640,7 +640,7 @@ def test_integrate_geom():
     square = CircleSkyRegion(center, radius)
 
     axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3, name='energy_true')
-    geom = RegionGeom(region=square, axes=[axis])
+    geom = RegionGeom(region=square, axes=[axis], binsz_wcs="0.01deg")
 
     integral = sky_model.integrate_geom(geom).data
 

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -380,8 +380,8 @@ def test_integrate_geom():
     circle_small = CircleSkyRegion(center, radius_small)
 
     geom_large, geom_small = (
-        RegionGeom(region=circle_large),
-        RegionGeom(region=circle_small),
+        RegionGeom(region=circle_large, binsz_wcs="0.01deg"),
+        RegionGeom(region=circle_small, binsz_wcs="0.01deg"),
     )
 
     integral_large, integral_small = (
@@ -401,7 +401,7 @@ def test_integrate_geom_energy_axis():
     square = RectangleSkyRegion(center, radius, radius)
 
     axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=10)
-    geom = RegionGeom(region=square, axes=[axis])
+    geom = RegionGeom(region=square, axes=[axis], binsz_wcs="0.01deg")
 
     integral = model.integrate_geom(geom).data
 


### PR DESCRIPTION
This pull request extends the extended source analysis tutorial to include the recently introduced option of using the `SpectrumDatasetMaker` with `use_region_center=False`, which averages the IRFs over the region. The results are then equivalent to the previous approach, which uses a `MapDatasetMaker` in the data reduction step and transforms it into a `SpectrumDatasetMaker`.

I kept the first part of the notebook almost exactly as it was, but I modified the introduction to explain that there are two ways to do the extended source analysis. Then, after the 3D case, I added the 1D case. A lot of cells are exactly the same as above, because there aren't that many differences between the two once the data reduction is done. In the end, I compared the resulting spectrum from both approaches.

This is the first time I change a notebook, and besides some instructions in https://docs.gammapy.org/dev/development/intro.html#contribute-with-jupyter-notebooks, I couldn't find more information. So maybe there is something else I can do so that the notebook can easily be looked at by a reviewer, please let me know.

This pull request also fixes a number of small issues I found along the way, namely:

- Set the right value for the `livetime` in `MapDataset.to_spectrum_dataset()`
- Downgrade the default `binsz_wcs` in the `RegionGeom` to speed up IRF evaluation. More careful optimization is planned in a follow-up PR. The "old" default is still used in the tests, to avoid having to change the values.
- Add the `binsz_wcs` option to the `RegionNDMap`, which was missing.
- Add a function `RegionGeom.to_binsz_wcs()` to easily change the `binsz_wcs` value in a region geometry.
- Fix a Matplotlib deprecation warning in `SpectralModel.plot()` (keyword `nonposy`, `nonposx` have changed to `nonpositive`)