### PR TITLE
Introduce "gadf" format for RegionNDMap

### DIFF
--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -433,11 +433,15 @@ Similarly, the map contents can also be plotted as a histogram:
 Writing and reading a RegionNDMap to/from a FITS file
 -----------------------------------------------------
 Region maps can be written to and read from a FITS file with the
-`~RegionNDMap.write()` and `~RegionNDMap.read()` methods. The
-format specification depends on which type of axis the region has:
- 
-Region maps with a reconstructed energy axis
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`~RegionNDMap.write()` and `~RegionNDMap.read()` methods. Currently
+the following formats are supported:
+
+- "gadf": a generic serialisation format with support for ND axes
+- "ogip" / "ogip-sherpa": an ogip-like counts spectrum with reconstructed energy axis
+- "ogip-arf" / "ogip-sherpa": an ogip-like effective area with true energy axis
+
+The "sherpa" format is equivalent, except energies are stored in "keV" and "cm2".
+
 For data with an `energy` axis, so reconstructed energy, the formats `ogip` and
 `ogip-sherpa` store the data along with the `REGION` and `EBOUNDS HDU`.
 
@@ -449,10 +453,6 @@ For data with an `energy` axis, so reconstructed energy, the formats `ogip` and
     m.write("file.fits", overwrite=True, format="ogip")
     m = RegionNDMap.read("file.fits", format="ogip")
 
-The "sherpa" format is equivalent, except energies are stored in "keV".
-
-Region maps with a true energy axis
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 For data with an `energy_true` axis, so true energy, the formats `ogip-arf` and `ogip-arf-sherpa`
 store the data in true energy, with the definition of the energy bins. The region information is
 however lost.
@@ -465,7 +465,21 @@ however lost.
     m.write("file.fits", overwrite=True, format="ogip-arf")
     m = RegionNDMap.read("file.fits", format="ogip-arf")
 
-The "sherpa" format is equivalent, except energies are stored in "keV".
+Again the "sherpa" format is equivalent, except energies are stored in "keV" and areas in "cm2".
+
+The "gadf" allows to serialise a region map with arbitrary extra axis as well:
+
+.. testcode::
+
+    from gammapy.maps import RegionNDMap, MapAxis
+
+    energy_axis = MapAxis.from_energy_bounds("1 TeV", "100 TeV", nbin=12)
+    time_axis = MapAxis.from_bounds(0., 12, nbin=12, interp='lin', unit='h', name='time')
+
+    m = RegionNDMap.create("icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis, time_axis])
+    m.write("file.fits", overwrite=True, format="gadf")
+    m = RegionNDMap.read("file.fits", format="gadf")
+
 
 Relevant tutorials
 ------------------

--- a/gammapy/datasets/io.py
+++ b/gammapy/datasets/io.py
@@ -194,7 +194,7 @@ class OGIPDatasetWriter(DatasetWriter):
         counts = dataset.counts_off if is_bkg else dataset.counts
         acceptance = dataset.acceptance_off if is_bkg else dataset.acceptance
 
-        hdulist = counts.to_hdulist()
+        hdulist = counts.to_hdulist(format=self.format)
 
         table = Table.read(hdulist["SPECTRUM"])
         meta = self.get_ogip_meta(dataset, is_bkg=is_bkg)
@@ -368,7 +368,7 @@ class OGIPDatasetReader(DatasetReader):
         with fits.open(filename, memmap=False) as hdulist:
             counts_off = RegionNDMap.from_hdulist(hdulist, format="ogip")
             acceptance_off = RegionNDMap.from_hdulist(
-                hdulist, ogip_column="BACKSCAL"
+                hdulist, ogip_column="BACKSCAL", format="ogip"
             )
         return {"counts_off": counts_off, "acceptance_off": acceptance_off}
 

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -430,14 +430,14 @@ class IRFMap:
             if hdu is None:
                 hdu = IRF_MAP_HDU_SPECIFICATION[cls.tag]
 
-            irf_map = Map.from_hdulist(hdulist, hdu=hdu, hdu_bands=hdu_bands)
+            irf_map = Map.from_hdulist(hdulist, hdu=hdu, hdu_bands=hdu_bands, format=format)
 
             if exposure_hdu is None:
                 exposure_hdu = IRF_MAP_HDU_SPECIFICATION[cls.tag] + "_exposure"
 
             if exposure_hdu in hdulist:
                 exposure_map = Map.from_hdulist(
-                    hdulist, hdu=exposure_hdu, hdu_bands=exposure_hdu_bands
+                    hdulist, hdu=exposure_hdu, hdu_bands=exposure_hdu_bands, format=format
                 )
             else:
                 exposure_map = None

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -503,11 +503,11 @@ class IRFMap:
         """
         if format == "gadf":
             hdu = IRF_MAP_HDU_SPECIFICATION[self.tag]
-            hdulist = self._irf_map.to_hdulist(hdu=hdu)
+            hdulist = self._irf_map.to_hdulist(hdu=hdu, format=format)
             exposure_hdu = hdu + "_exposure"
 
             if self.exposure_map is not None:
-                new_hdulist = self.exposure_map.to_hdulist(hdu=exposure_hdu)
+                new_hdulist = self.exposure_map.to_hdulist(hdu=exposure_hdu, format=format)
                 hdulist.extend(new_hdulist[1:])
 
         elif format == "gtpsf":

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -180,7 +180,7 @@ class Map(abc.ABC):
             Name or index of the HDU with the BANDS table.  If not
             defined this will be inferred from the FITS header of the
             map HDU.
-        map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse', 'auto'}
+        map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse', 'auto', 'region'}
             Map type.  Selects the class that will be used to
             instantiate the map.  The map type should be consistent
             with the format of the input file.  If map_type is 'auto'

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -266,8 +266,10 @@ class Map(abc.ABC):
 
         if ("PIXTYPE" in header) and (header["PIXTYPE"] == "HEALPIX"):
             return "hpx"
-        else:
+        elif "CTYPE1" in header:
             return "wcs"
+        else:
+            return "region"
 
     @staticmethod
     def _get_map_cls(map_type):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -491,7 +491,7 @@ class MapAxes(Sequence):
 
         Parameters
         ----------
-        format : {"gadf-dl3"}
+        format : {"gadf", "gadf-dl3", "ogip", "ogip-sherpa"}
             Format to use.
 
         Returns
@@ -524,7 +524,9 @@ class MapAxes(Sequence):
 
                 for colname, v in zip(colnames, [axes_ctr, axes_min, axes_max]):
                     table[colname] = np.ravel(v[idx]).astype(np.float32)
-
+        elif format in ["ogip", "ogip-sherpa"]:
+            energy_axis = self["energy"]
+            table = energy_axis.to_table(format=format)
         else:
             raise ValueError(f"Unsupported format: '{format}'")
 
@@ -548,7 +550,7 @@ class MapAxes(Sequence):
         # FIXME: Check whether convention is compatible with
         #  dimensionality of geometry and simplify!!!
 
-        if format == "fgst-ccube":
+        if format in ["fgst-ccube", "ogip", "ogip-sherpa"]:
             hdu = "EBOUNDS"
         elif format == "fgst-template":
             hdu = "ENERGIES"
@@ -561,7 +563,7 @@ class MapAxes(Sequence):
             raise ValueError(f"Unknown format {format}")
 
         table = self.to_table(format=format)
-        header = self.to_header()
+        header = self.to_header(format=format)
         return fits.BinTableHDU(table, name=hdu, header=header)
 
     @classmethod

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1491,7 +1491,7 @@ class MapAxis:
             header["HDUCLAS1"] = "RESPONSE", "File relates to response of instrument"
             header["HDUCLAS2"] = "EBOUNDS", "This is an EBOUNDS extension"
             header["HDUVERS"] = "1.2.0", "Version of file format"
-        elif format == "gadf":
+        elif format in ["gadf", "fgst-ccube", "fgst-template"]:
             key = f"AXCOLS{idx}"
             name = self.name.upper()
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -491,7 +491,8 @@ class MapAxes(Sequence):
 
         Parameters
         ----------
-        format : {"gadf", "gadf-dl3", "ogip", "ogip-sherpa"}
+        format : {"gadf", "gadf-dl3", "fgst-ccube", "fgst-template",
+                  "ogip", "ogip-sherpa", "ogip-arf", "ogip-arf-sherpa"}
             Format to use.
 
         Returns
@@ -524,7 +525,7 @@ class MapAxes(Sequence):
 
                 for colname, v in zip(colnames, [axes_ctr, axes_min, axes_max]):
                     table[colname] = np.ravel(v[idx]).astype(np.float32)
-        elif format in ["ogip", "ogip-sherpa"]:
+        elif format in ["ogip", "ogip-sherpa", "ogip", "ogip-arf"]:
             energy_axis = self["energy"]
             table = energy_axis.to_table(format=format)
         else:

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -544,13 +544,15 @@ class RegionGeom(Geom):
         table.meta.update(header)
         return table
 
-    def to_hdulist(self, format="ogip"):
+    def to_hdulist(self, format="ogip", hdu=None):
         """Convert geom to hdulist
 
         Parameters
         ----------
-        format : {"ogip", "ogip-sherpa"}
+        format : {"gadf", "ogip", "ogip-sherpa"}
             HDU format
+        hdu : str
+            Name of the HDU with the map data.
 
         Returns
         -------
@@ -560,14 +562,17 @@ class RegionGeom(Geom):
         """
         hdulist = fits.HDUList()
 
-        # energy bounds HDU
-        energy_axis = self.axes["energy"]
-        hdulist.append(energy_axis.to_table_hdu(format=format))
+        hdulist.append(self.axes.to_table_hdu(prefix=hdu, format=format))
 
         # region HDU
         if self.region:
             region_table = self._to_region_table()
-            region_hdu = fits.BinTableHDU(region_table, name="REGION")
+
+            name = "REGION"
+            if hdu and format == "gadf":
+                name = hdu + "_" + name
+
+            region_hdu = fits.BinTableHDU(region_table, name=name)
             hdulist.append(region_hdu)
 
         return hdulist
@@ -597,14 +602,14 @@ class RegionGeom(Geom):
         return cls(region, **kwargs)
 
     @classmethod
-    def from_hdulist(cls, hdulist, format="ogip"):
+    def from_hdulist(cls, hdulist, format="ogip", hdu=None):
         """Read region table and convert it to region list.
 
         Parameters
         ----------
         hdulist : `~astropy.io.fits.HDUList`
             HDU list
-        format : {"ogip", "ogip-arf"}
+        format : {"ogip", "ogip-arf", "gadf"}
             HDU format
 
         Returns
@@ -613,8 +618,13 @@ class RegionGeom(Geom):
             Region map geometry
 
         """
-        if "REGION" in hdulist:
-            region_table = Table.read(hdulist["REGION"])
+        region_hdu = "REGION"
+
+        if format == "gadf" and hdu:
+            region_hdu = hdu + "_" + region_hdu
+
+        if region_hdu in hdulist:
+            region_table = Table.read(hdulist[region_hdu])
             parser = FITSRegionParser(region_table)
             pix_region = parser.shapes.to_regions()
             wcs = WcsGeom.from_header(region_table.meta).wcs
@@ -630,11 +640,13 @@ class RegionGeom(Geom):
             hdu = "EBOUNDS"
         elif format == "ogip-arf":
             hdu = "SPECRESP"
+        elif format == "gadf":
+            hdu = hdu + "_BANDS"
         else:
             raise ValueError(f"Unknown format {format}")
 
-        axis = MapAxis.from_table_hdu(hdulist[hdu], format=format)
-        return cls(region=region, wcs=wcs, axes=[axis])
+        axes = MapAxes.from_table_hdu(hdulist[hdu], format=format)
+        return cls(region=region, wcs=wcs, axes=axes)
 
     def union(self, other):
         """Stack a RegionGeom by making the union"""

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -602,7 +602,7 @@ class RegionGeom(Geom):
         return cls(region, **kwargs)
 
     @classmethod
-    def from_hdulist(cls, hdulist, format="ogip", hdu=None, hdu_bands=None):
+    def from_hdulist(cls, hdulist, format="ogip", hdu=None):
         """Read region table and convert it to region list.
 
         Parameters
@@ -641,8 +641,7 @@ class RegionGeom(Geom):
         elif format == "ogip-arf":
             hdu_bands = "SPECRESP"
         elif format == "gadf":
-            if hdu_bands is None:
-                hdu_bands = hdu + "_BANDS"
+            hdu_bands = hdu
         else:
             raise ValueError(f"Unknown format {format}")
 

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -687,6 +687,7 @@ class RegionGeom(Geom):
         artists = [region.to_pixel(wcs=ax.wcs).as_artist() for region in regions]
 
         kwargs.setdefault("fc", "None")
+        kwargs.setdefault("ec", "tab:blue")
 
         patches = PatchCollection(artists, **kwargs)
         ax.add_collection(patches)

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -602,7 +602,7 @@ class RegionGeom(Geom):
         return cls(region, **kwargs)
 
     @classmethod
-    def from_hdulist(cls, hdulist, format="ogip", hdu=None):
+    def from_hdulist(cls, hdulist, format="ogip", hdu=None, hdu_bands=None):
         """Read region table and convert it to region list.
 
         Parameters
@@ -637,15 +637,16 @@ class RegionGeom(Geom):
             region, wcs = None, None
 
         if format == "ogip":
-            hdu = "EBOUNDS"
+            hdu_bands = "EBOUNDS"
         elif format == "ogip-arf":
-            hdu = "SPECRESP"
+            hdu_bands = "SPECRESP"
         elif format == "gadf":
-            hdu = hdu + "_BANDS"
+            if hdu_bands is None:
+                hdu_bands = hdu + "_BANDS"
         else:
             raise ValueError(f"Unknown format {format}")
 
-        axes = MapAxes.from_table_hdu(hdulist[hdu], format=format)
+        axes = MapAxes.from_table_hdu(hdulist[hdu_bands], format=format)
         return cls(region=region, wcs=wcs, axes=axes)
 
     def union(self, other):

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -641,7 +641,7 @@ class RegionGeom(Geom):
         elif format == "ogip-arf":
             hdu_bands = "SPECRESP"
         elif format == "gadf":
-            hdu_bands = hdu
+            hdu_bands = hdu + "_BANDS"
         else:
             raise ValueError(f"Unknown format {format}")
 

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -1,4 +1,3 @@
-import json
 import numpy as np
 from astropy import units as u
 from astropy.io import fits
@@ -7,11 +6,10 @@ from astropy.visualization import quantity_support
 from gammapy.extern.skimage import block_reduce
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
 from gammapy.utils.scripts import make_path
-from gammapy.utils.units import unit_from_fits_image_hdu
 from .core import Map
 from .geom import pix_tuple_to_idx
 from .region import RegionGeom
-from .utils import INVALID_INDEX, JsonQuantityEncoder
+from .utils import INVALID_INDEX
 
 __all__ = ["RegionNDMap"]
 
@@ -374,7 +372,7 @@ class RegionNDMap(Map):
         return hdulist
 
     @classmethod
-    def from_hdulist(cls, hdulist, format="gadf", ogip_column=None, hdu=None):
+    def from_hdulist(cls, hdulist, format="gadf", ogip_column=None, hdu=None, **kwargs):
         """Create from `~astropy.io.fits.HDUList`.
 
         Parameters
@@ -447,7 +445,7 @@ class RegionNDMap(Map):
 
         self.data += data
 
-    def to_table(self, format="ogip"):
+    def to_table(self, format="gadf"):
         """Convert to `~astropy.table.Table`.
 
         Data format specification: :ref:`gadf:ogip-pha`

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -317,7 +317,7 @@ class RegionNDMap(Map):
         with fits.open(filename, memmap=False) as hdulist:
             return cls.from_hdulist(hdulist, format=format, ogip_column=ogip_column, hdu=hdu)
 
-    def write(self, filename, overwrite=False, format="gadf", hdu=None):
+    def write(self, filename, overwrite=False, format="gadf", hdu="REGIONMAP"):
         """Write map to file
 
         Parameters
@@ -334,7 +334,7 @@ class RegionNDMap(Map):
             filename, overwrite=overwrite
         )
 
-    def to_hdulist(self, format="gadf", hdu="REGIONMAP"):
+    def to_hdulist(self, format="gadf", hdu=None):
         """Convert to `~astropy.io.fits.HDUList`.
 
         Parameters

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -296,7 +296,7 @@ class RegionNDMap(Map):
         self.data[idx[::-1]] = value
 
     @classmethod
-    def read(cls, filename, format="ogip", ogip_column="COUNTS"):
+    def read(cls, filename, format="ogip", ogip_column="COUNTS", hdu=None):
         """Read from file.
 
         Parameters
@@ -307,6 +307,8 @@ class RegionNDMap(Map):
             Which format to use.
         ogip_column : {"COUNTS", "QUALITY", "BACKSCAL"}
             If format 'ogip' is chosen which table hdu column to read.
+        hdu : str
+            Name or index of the HDU with the map data.
 
         Returns
         -------
@@ -315,7 +317,7 @@ class RegionNDMap(Map):
         """
         filename = make_path(filename)
         with fits.open(filename, memmap=False) as hdulist:
-            return cls.from_hdulist(hdulist, format=format, ogip_column=ogip_column)
+            return cls.from_hdulist(hdulist, format=format, ogip_column=ogip_column, hdu=hdu)
 
     def write(self, filename, overwrite=False, format="ogip-arf", hdu=None):
         """Write map to file
@@ -391,6 +393,12 @@ class RegionNDMap(Map):
             Format specification
         ogip_column : {"COUNTS", "QUALITY", "BACKSCAL"}
             If format 'ogip' is chosen which table hdu column to read.
+        hdu : str
+            Name or index of the HDU with the map data.
+        hdu_bands : str
+            Name or index of the HDU with the BANDS table.  If not
+            defined this will be inferred from the FITS header of the
+            map HDU.
 
         Returns
         -------

--- a/gammapy/maps/tests/test_regionnd.py
+++ b/gammapy/maps/tests/test_regionnd.py
@@ -262,3 +262,14 @@ def test_region_nd_io_gadf_rad_axis(tmpdir):
     # check that the data is not re-shuffled
     assert_allclose(m_new.data, m.data)
     assert m_new.data.shape == (3, 2, 1, 1)
+
+
+def test_region_nd_hdulist():
+    energy_axis = MapAxis.from_edges([1, 3, 10] * u.TeV, name="energy")
+    m = RegionNDMap.create(region="icrs;circle(83.63, 22.01, 0.5)", axes=[energy_axis])
+
+    hdulist = m.to_hdulist()
+    assert hdulist[0].name == "PRIMARY"
+    assert hdulist[1].name == "SKYMAP"
+    assert hdulist[2].name == "SKYMAP_BANDS"
+    assert hdulist[3].name == "SKYMAP_REGION"


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a proof of concept for a "gadf" format for `RegionNDMap`. It serialises as following:
- Main HDU as an `ImageHDU` with the data, but no WCS info (to be defined / documented)
- Region HDU as an `BinTableHDU` in the ogip like format (see https://fits.gsfc.nasa.gov/registry/region.html)
- A bands HDU equivalent to what we have for normal maps (see https://gamma-astro-data-formats.readthedocs.io/en/latest/skymaps/index.html#bands-hdu)

The main question here is whether this is needed at all for now. The main use case I hand in mind was to be able to serialise a `RegionNDMap` with multiple axes. However this currently only applies to the `EDispKernelMap` and `PSFMap`, for both we can fall back to different solutions: they can be serialised as a WCS map with one spatial bin. 

Beside the extra axes the serialisation will also keep all the region information on the maps, which might be interesting for provenance and it provides a simple solution to serialise both `SpectrumDataset` as well as `SpectrumDatasetOnOff` in single FITS file, which is probably a convenient alternative to the current ogip format.

The goal here is not to define any official DL4 data format, but just provide a simple and convenient way to serialise a `RegionNDMap` of any kind. The format will not be optimised by any means, but contain all the info needed to allow for round-tripping of a `RegionNDMap`, without loss of information.

If we decide this is a useful addition to our serialisation functionality, the only remaining thing is to discuss the structure, that is used to store the data. Beside the `ImageHDU`, with no associated WCS, it could be an `BinTableHDU` as well, similar to the IRF DL3 formats.


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
