### PR TITLE
Modify bounds handling and scan values generation in estimators

### DIFF
--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -8,6 +8,7 @@ from gammapy.estimators import FluxPoints
 from gammapy.modeling import Fit
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
+from gammapy.estimators.parameter import ScanValuesMaker
 
 
 @pytest.fixture()
@@ -110,7 +111,9 @@ class TestFluxPointFit:
         fit.backend = "minuit"
         result = fit.run()
 
-        profile = fit.stat_profile("amplitude", nvalues=3, bounds=1)
+        parameter = fit._parameters["amplitude"]
+        values = ScanValuesMaker(bounds=1, n_values=3)(parameter)
+        profile = fit.stat_profile("amplitude", values)
 
         ts_diff = profile["stat_scan"] - result.total_stat
         assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -8,7 +8,7 @@ from gammapy.estimators import FluxPoints
 from gammapy.modeling import Fit
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
-from gammapy.estimators.parameter import ScanValuesMaker
+from gammapy.estimators.parameter import ScanValuesGenerator
 
 
 @pytest.fixture()
@@ -112,7 +112,7 @@ class TestFluxPointFit:
         result = fit.run()
 
         parameter = fit._parameters["amplitude"]
-        values = ScanValuesMaker(bounds=1, n_values=3)(parameter)
+        values = ScanValuesGenerator(bounds=1, n_values=3)(parameter)
         profile = fit.stat_profile("amplitude", values)
 
         ts_diff = profile["stat_scan"] - result.total_stat

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -26,13 +26,13 @@ class FluxEstimator(Estimator):
         For which source in the model to compute the flux.
     energy_min, energy_max: `~astropy.units.Quantity`
         The energy interval on which to compute the flux
-    norm_min : float
+    norm_fit_min : float
         Minimum value for the norm used for the fit.
-    norm_max : float
+    norm_fit_max : float
         Maximum value for the norm used for the fit.
-    norm_values : `~numpy.ndarray` or `~gammapy.estimators.parameter.ScanValuesMaker`
+    norm_scan_values : `~numpy.ndarray` or `~gammapy.estimators.parameter.ScanValuesGenerator`
         Array of norm values to be used for the fit statistic profile
-        or `ScanValuesMaker` generator instance.
+        or `ScanValuesGenerator` generator instance.
     n_sigma : int
         Sigma to use for asymmetric error computation.
     n_sigma_ul : int
@@ -67,9 +67,9 @@ class FluxEstimator(Estimator):
         source,
         energy_min,
         energy_max,
-        norm_min=1e-8,
-        norm_max=1e8,
-        norm_values=None,
+        norm_fit_min=-1e5,
+        norm_fit_max=1e5,
+        norm_scan_values=None,
         n_sigma=1,
         n_sigma_ul=3,
         ul_method="confidence",
@@ -79,9 +79,9 @@ class FluxEstimator(Estimator):
         reoptimize=True,
         selection_optional=None,
     ):
-        self.norm_min = norm_min
-        self.norm_max = norm_max
-        self.norm_values = norm_values
+        self.norm_fit_min = norm_fit_min
+        self.norm_fit_max = norm_fit_max
+        self.norm_scan_values = norm_scan_values
         self.source = source
         self.energy_min = u.Quantity(energy_min)
         self.energy_max = u.Quantity(energy_max)
@@ -106,7 +106,7 @@ class FluxEstimator(Estimator):
     def _parameter_estimator(self):
         return ParameterEstimator(
             null_value=0,
-            scan_values=self.norm_values,
+            scan_values=self.norm_scan_values,
             n_sigma=self.n_sigma,
             n_sigma_ul=self.n_sigma_ul,
             ul_method=self.ul_method,
@@ -160,8 +160,8 @@ class FluxEstimator(Estimator):
         """
         ref_model = models[self.source].spectral_model
         scale_model = ScaleSpectralModel(ref_model)
-        scale_model.norm.min = self.norm_min
-        scale_model.norm.max = self.norm_max
+        scale_model.norm.min = self.norm_fit_min
+        scale_model.norm.max = self.norm_fit_max
         scale_model.norm.value = 1.0
         scale_model.norm.frozen = False
         return scale_model

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -107,6 +107,7 @@ class FluxEstimator(Estimator):
             scan_values=self.norm_values,
             n_sigma=self.n_sigma,
             n_sigma_ul=self.n_sigma_ul,
+            ul_method=self.ul_method,
             ul_method = self.ul_method,
             backend=self.backend,
             optimize_opts=self.optimize_opts,

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -30,8 +30,9 @@ class FluxEstimator(Estimator):
         Minimum value for the norm used for the fit.
     norm_max : float
         Maximum value for the norm used for the fit.
-    norm_values : `numpy.ndarray`
-        Array of norm values to be used for the fit statistic profile.
+    norm_values : `~numpy.ndarray` or `~gammapy.estimators.parameter.ScanValuesMaker`
+        Array of norm values to be used for the fit statistic profile
+        or `ScanValuesMaker` generator instance.
     n_sigma : int
         Sigma to use for asymmetric error computation.
     n_sigma_ul : int
@@ -78,7 +79,8 @@ class FluxEstimator(Estimator):
         reoptimize=True,
         selection_optional=None,
     ):
-
+        self.norm_min = norm_min
+        self.norm_max = norm_max
         self.norm_values = norm_values
         self.source = source
         self.energy_min = u.Quantity(energy_min)
@@ -236,7 +238,7 @@ class FluxEstimator(Estimator):
             result.update({"norm_ul": np.nan})
 
         if "scan" in self.selection_optional:
-            nans = np.nan * np.empty_like(self.norm_values)
+            nans = np.nan
             result.update({"norm_scan": nans, "stat_scan": nans})
 
         return result

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -37,9 +37,6 @@ class FluxEstimator(Estimator):
         Sigma to use for asymmetric error computation.
     n_sigma_ul : int
         Sigma to use for upper limit computation.
-    ul_method : {"confidence", "profile"}
-        Select upper-limit computation method using confidence or stat profile.
-        Default is confidence".
     backend : str
         Backend used for fitting, default : minuit
     optimize_opts : dict
@@ -72,7 +69,6 @@ class FluxEstimator(Estimator):
         norm_scan_values=None,
         n_sigma=1,
         n_sigma_ul=3,
-        ul_method="confidence",
         backend="minuit",
         optimize_opts=None,
         covariance_opts=None,
@@ -99,7 +95,6 @@ class FluxEstimator(Estimator):
         self.optimize_opts = optimize_opts
         self.covariance_opts = covariance_opts
         self.reoptimize = reoptimize
-        self.ul_method = ul_method
         self.selection_optional = selection_optional
 
     @property
@@ -109,8 +104,6 @@ class FluxEstimator(Estimator):
             scan_values=self.norm_scan_values,
             n_sigma=self.n_sigma,
             n_sigma_ul=self.n_sigma_ul,
-            ul_method=self.ul_method,
-            ul_method = self.ul_method,
             backend=self.backend,
             optimize_opts=self.optimize_opts,
             covariance_opts=self.covariance_opts,

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -18,7 +18,7 @@ from .core import (
     OPTIONAL_QUANTITIES,
     REQUIRED_COLUMNS,
 )
-from. flux import FluxEstimator
+from .flux import FluxEstimator
 
 
 __all__ = ["FluxPoints", "FluxPointsEstimator"]
@@ -217,7 +217,9 @@ class FluxPoints(FluxEstimate):
             kwargs.setdefault("format", "ascii.ecsv")
             table = Table.read(filename, **kwargs)
 
-        return cls.from_table(table=table, sed_type=sed_type, reference_model=reference_model)
+        return cls.from_table(
+            table=table, sed_type=sed_type, reference_model=reference_model
+        )
 
     def write(self, filename, **kwargs):
         """Write flux points.
@@ -356,8 +358,7 @@ class FluxPoints(FluxEstimate):
         elif sed_type == "likelihood":
             data = cls._convert_loglike_columns(table)
             reference_model = TemplateSpectralModel(
-                energy=table["e_ref"].quantity,
-                values=table["ref_dnde"].quantity
+                energy=table["e_ref"].quantity, values=table["ref_dnde"].quantity
             )
         else:
             raise ValueError(f"Not a valid SED type {sed_type}")
@@ -388,7 +389,11 @@ class FluxPoints(FluxEstimate):
             table = self.table.copy()
         else:
             table = Table()
-            all_quantities = REQUIRED_COLUMNS[sed_type] + OPTIONAL_QUANTITIES[sed_type] + OPTIONAL_QUANTITIES_COMMON
+            all_quantities = (
+                REQUIRED_COLUMNS[sed_type]
+                + OPTIONAL_QUANTITIES[sed_type]
+                + OPTIONAL_QUANTITIES_COMMON
+            )
 
             for quantity in all_quantities:
                 if quantity == "e_ref":
@@ -429,7 +434,9 @@ class FluxPoints(FluxEstimate):
         ``gammapy download datasets --tests --out $GAMMAPY_DATA``
         """
         table_drop_ul = self.table[~self.is_ul]
-        return self.__class__(data=table_drop_ul, reference_spectral_model=self.reference_spectral_model)
+        return self.__class__(
+            data=table_drop_ul, reference_spectral_model=self.reference_spectral_model
+        )
 
     @staticmethod
     def _energy_ref_lafferty(model, energy_min, energy_max):
@@ -507,7 +514,13 @@ class FluxPoints(FluxEstimate):
         return y_err
 
     def plot(
-        self, ax=None, energy_unit="TeV", flux_unit=None, energy_power=0, sed_type="dnde", **kwargs
+        self,
+        ax=None,
+        energy_unit="TeV",
+        flux_unit=None,
+        energy_power=0,
+        sed_type="dnde",
+        **kwargs,
     ):
         """Plot flux points.
 
@@ -725,9 +738,6 @@ class FluxPointsEstimator(Estimator):
         Number of sigma to use for asymmetric error computation. Default is 1.
     n_sigma_ul : int
         Number of sigma to use for upper limit computation. Default is 2.
-    ul_method : {"confidence", "profile"}
-        Select upper-limit computation method using confidence or stat profile.
-        Default is confidence".
     backend : str
         Backend used for fitting, default : minuit
     optimize_opts : dict
@@ -759,7 +769,6 @@ class FluxPointsEstimator(Estimator):
         norm_scan_values=None,
         n_sigma=1,
         n_sigma_ul=2,
-        ul_method="confidence",
         backend="minuit",
         optimize_opts=None,
         covariance_opts=None,

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -717,8 +717,9 @@ class FluxPointsEstimator(Estimator):
         Minimum value for the norm used for the fit.
     norm_max : float
         Maximum value for the norm used for the fit.
-    norm_values : `numpy.ndarray`
-        Array of norm values to be used for the fit statistic profile.
+    norm_values : `~numpy.ndarray` or `~gammapy.estimators.parameter.ScanValuesMaker`
+        Array of norm values to be used for the fit statistic profile
+        or `ScanValuesMaker` generator instance.
     n_sigma : int
         Number of sigma to use for asymmetric error computation. Default is 1.
     n_sigma_ul : int

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -714,17 +714,18 @@ class FluxPointsEstimator(Estimator):
     source : str or int
         For which source in the model to compute the flux points.
     norm_min : float
-        Minimum value for the norm used for the fit statistic profile evaluation.
+        Minimum value for the norm used for the fit.
     norm_max : float
-        Maximum value for the norm used for the fit statistic profile evaluation.
-    norm_n_values : int
-        Number of norm values used for the fit statistic profile.
+        Maximum value for the norm used for the fit.
     norm_values : `numpy.ndarray`
         Array of norm values to be used for the fit statistic profile.
     n_sigma : int
         Number of sigma to use for asymmetric error computation. Default is 1.
     n_sigma_ul : int
         Number of sigma to use for upper limit computation. Default is 2.
+    ul_method : {"confidence", "profile"}
+        Select upper-limit computation method using confidence or stat profile.
+        Default is confidence".
     backend : str
         Backend used for fitting, default : minuit
     optimize_opts : dict
@@ -751,23 +752,23 @@ class FluxPointsEstimator(Estimator):
         self,
         energy_edges=[1, 10] * u.TeV,
         source=0,
-        norm_min=0.2,
-        norm_max=5,
-        norm_n_values=11,
+        norm_min=1e-8,
+        norm_max=1e8,
         norm_values=None,
         n_sigma=1,
         n_sigma_ul=2,
+        ul_method="confidence",
         backend="minuit",
         optimize_opts=None,
         covariance_opts=None,
         reoptimize=False,
         selection_optional=None,
     ):
+
         self.energy_edges = energy_edges
         self.source = source
         self.norm_min = norm_min
         self.norm_max = norm_max
-        self.norm_n_values = norm_n_values
         self.norm_values = norm_values
         self.n_sigma = n_sigma
         self.n_sigma_ul = n_sigma_ul
@@ -780,6 +781,7 @@ class FluxPointsEstimator(Estimator):
         self.covariance_opts = covariance_opts
         self.reoptimize = reoptimize
         self.selection_optional = selection_optional
+        self.ul_method = ul_method
 
     def _flux_estimator(self, energy_min, energy_max):
         return FluxEstimator(
@@ -788,7 +790,6 @@ class FluxPointsEstimator(Estimator):
             energy_max=energy_max,
             norm_min=self.norm_min,
             norm_max=self.norm_max,
-            norm_n_values=self.norm_n_values,
             norm_values=self.norm_values,
             n_sigma=self.n_sigma,
             n_sigma_ul=self.n_sigma_ul,

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -713,13 +713,14 @@ class FluxPointsEstimator(Estimator):
         Energy edges of the flux point bins.
     source : str or int
         For which source in the model to compute the flux points.
-    norm_min : float
+    norm_fit_min : float
         Minimum value for the norm used for the fit.
-    norm_max : float
+        To follow Fermi-LAT science tools convention `norm_fit_min` must be set to 0.
+    norm_fit_max : float
         Maximum value for the norm used for the fit.
-    norm_values : `~numpy.ndarray` or `~gammapy.estimators.parameter.ScanValuesMaker`
+    norm_scan_values : `~numpy.ndarray` or `~gammapy.estimators.parameter.ScanValuesGenerator`
         Array of norm values to be used for the fit statistic profile
-        or `ScanValuesMaker` generator instance.
+        or `ScanValuesGenerator` generator instance.
     n_sigma : int
         Number of sigma to use for asymmetric error computation. Default is 1.
     n_sigma_ul : int
@@ -753,9 +754,9 @@ class FluxPointsEstimator(Estimator):
         self,
         energy_edges=[1, 10] * u.TeV,
         source=0,
-        norm_min=1e-8,
-        norm_max=1e8,
-        norm_values=None,
+        norm_fit_min=-1e5,
+        norm_fit_max=1e5,
+        norm_scan_values=None,
         n_sigma=1,
         n_sigma_ul=2,
         ul_method="confidence",
@@ -768,9 +769,9 @@ class FluxPointsEstimator(Estimator):
 
         self.energy_edges = energy_edges
         self.source = source
-        self.norm_min = norm_min
-        self.norm_max = norm_max
-        self.norm_values = norm_values
+        self.norm_fit_min = norm_fit_min
+        self.norm_fit_max = norm_fit_max
+        self.norm_scan_values = norm_scan_values
         self.n_sigma = n_sigma
         self.n_sigma_ul = n_sigma_ul
         self.backend = backend
@@ -788,9 +789,9 @@ class FluxPointsEstimator(Estimator):
             source=self.source,
             energy_min=energy_min,
             energy_max=energy_max,
-            norm_min=self.norm_min,
-            norm_max=self.norm_max,
-            norm_values=self.norm_values,
+            norm_fit_min=self.norm_fit_min,
+            norm_fit_max=self.norm_fit_max,
+            norm_scan_values=self.norm_scan_values,
             n_sigma=self.n_sigma,
             n_sigma_ul=self.n_sigma_ul,
             backend=self.backend,

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -782,7 +782,6 @@ class FluxPointsEstimator(Estimator):
         self.covariance_opts = covariance_opts
         self.reoptimize = reoptimize
         self.selection_optional = selection_optional
-        self.ul_method = ul_method
 
     def _flux_estimator(self, energy_min, energy_max):
         return FluxEstimator(

--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -323,13 +323,12 @@ class LightCurveEstimator(Estimator):
     atol : `~astropy.units.Quantity`
         Tolerance value for time comparison with different scale. Default 1e-6 sec.
     norm_min : float
-        Minimum value for the norm used for the fit statistic profile evaluation.
+        Minimum value for the norm used for the fit.
     norm_max : float
-        Maximum value for the norm used for the fit statistic profile evaluation.
-    norm_n_values : int
-        Number of norm values used for the fit statistic profile.
-    norm_values : `numpy.ndarray`
-        Array of norm values to be used for the fit statistic profile.
+        Maximum value for the norm used for the fit.
+    norm_values : `~numpy.ndarray` or `~gammapy.estimators.parameter.ScanValuesMaker`
+        Array of norm values to be used for the fit statistic profile
+        or `ScanValuesMaker` generator instance.
     n_sigma : int
         Number of sigma to use for asymmetric error computation. Default is 1.
     n_sigma_ul : int
@@ -362,9 +361,8 @@ class LightCurveEstimator(Estimator):
         source=0,
         energy_edges=None,
         atol="1e-6 s",
-        norm_min=0.2,
-        norm_max=5,
-        norm_n_values=11,
+        norm_min=1e-8,
+        norm_max=1e8,
         norm_values=None,
         n_sigma=1,
         n_sigma_ul=2,
@@ -384,7 +382,6 @@ class LightCurveEstimator(Estimator):
 
         self.norm_min = norm_min
         self.norm_max = norm_max
-        self.norm_n_values = norm_n_values
         self.norm_values = norm_values
         self.n_sigma = n_sigma
         self.n_sigma_ul = n_sigma_ul
@@ -491,7 +488,17 @@ class LightCurveEstimator(Estimator):
         else:
             energy_edges = self.energy_edges
 
-        fe = self._flux_poins_estimator(energy_edges)
+        fe = FluxPointsEstimator(
+            source=self.source,
+            energy_edges=energy_edges,
+            norm_min=self.norm_min,
+            norm_max=self.norm_max,
+            norm_values=self.norm_values,
+            n_sigma=self.n_sigma,
+            n_sigma_ul=self.n_sigma_ul,
+            reoptimize=self.reoptimize,
+            selection_optional=self.selection_optional,
+        )
         fp = fe.run(datasets)
 
         # TODO: remove once FluxPointsEstimator returns object with all energies in one row

--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -399,10 +399,9 @@ class LightCurveEstimator(Estimator):
         return FluxPointsEstimator(
             source=self.source,
             energy_edges=energy_edges,
-            norm_min=self.norm_min,
-            norm_max=self.norm_max,
-            norm_n_values=self.norm_n_values,
-            norm_values=self.norm_values,
+            norm_fit_min=self.norm_fit_min,
+            norm_fit_max=self.norm_fit_max,
+            norm_scan_values=self.norm_scan_values,
             n_sigma=self.n_sigma,
             n_sigma_ul=self.n_sigma_ul,
             backend=self.backend,

--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -322,13 +322,13 @@ class LightCurveEstimator(Estimator):
         Energy edges of the light curve.
     atol : `~astropy.units.Quantity`
         Tolerance value for time comparison with different scale. Default 1e-6 sec.
-    norm_min : float
+    norm_fit_min : float
         Minimum value for the norm used for the fit.
-    norm_max : float
+    norm_fit_max : float
         Maximum value for the norm used for the fit.
-    norm_values : `~numpy.ndarray` or `~gammapy.estimators.parameter.ScanValuesMaker`
+    norm_scan_values : `~numpy.ndarray` or `~gammapy.estimators.parameter.ScanValuesGenerator`
         Array of norm values to be used for the fit statistic profile
-        or `ScanValuesMaker` generator instance.
+        or `ScanValuesGenerator` generator instance.
     n_sigma : int
         Number of sigma to use for asymmetric error computation. Default is 1.
     n_sigma_ul : int
@@ -361,9 +361,9 @@ class LightCurveEstimator(Estimator):
         source=0,
         energy_edges=None,
         atol="1e-6 s",
-        norm_min=1e-8,
-        norm_max=1e8,
-        norm_values=None,
+        norm_fit_min=-1e5,
+        norm_fit_max=1e5,
+        norm_scan_values=None,
         n_sigma=1,
         n_sigma_ul=2,
         backend="minuit",
@@ -380,9 +380,9 @@ class LightCurveEstimator(Estimator):
 
         self.energy_edges = energy_edges
 
-        self.norm_min = norm_min
-        self.norm_max = norm_max
-        self.norm_values = norm_values
+        self.norm_fit_min = norm_fit_min
+        self.norm_fit_max = norm_fit_max
+        self.norm_scan_values = norm_scan_values
         self.n_sigma = n_sigma
         self.n_sigma_ul = n_sigma_ul
         self.backend = backend
@@ -491,9 +491,9 @@ class LightCurveEstimator(Estimator):
         fe = FluxPointsEstimator(
             source=self.source,
             energy_edges=energy_edges,
-            norm_min=self.norm_min,
-            norm_max=self.norm_max,
-            norm_values=self.norm_values,
+            norm_fit_min=self.norm_fit_min,
+            norm_fit_max=self.norm_fit_max,
+            norm_scan_values=self.norm_scan_values,
             n_sigma=self.n_sigma,
             n_sigma_ul=self.n_sigma_ul,
             reoptimize=self.reoptimize,

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -8,13 +8,8 @@ from gammapy.utils.interpolation import interpolation_scale
 
 log = logging.getLogger(__name__)
 
-def make_scan_values(
-    parameter,
-    bounds=3,
-    nvalues=30,
-    err_rel_min=0.05,
-    scaling='lin'
-):
+
+def make_scan_values(parameter, bounds=3, nvalues=30, err_rel_min=0.05, scaling="lin"):
     """Prepare values scan
 
     Parameters
@@ -49,14 +44,13 @@ def make_scan_values(
     else:
         parmin, parmax = make_scan_bounds(parameter, bounds, err_rel_min)
     scaler = interpolation_scale(scaling)
-    parmin, parmax = scaler(parmin, parmax )
+    parmin, parmax = scaler(parmin, parmax)
     values = np.linspace(parmin, parmax, nvalues)
     return scaler.inverse(values)
 
+
 def make_scan_bounds(
-    parameter,
-    scan_n_sigma=3,
-    err_rel_min=0.05,
+    parameter, scan_n_sigma=3, err_rel_min=0.05,
 ):
     """Prepare values scan bounds
 
@@ -82,10 +76,11 @@ def make_scan_bounds(
     """
     parval = parameter.value
     parerr = parameter.error
-    err_rel = np.abs(parameter.error/parameter.value)
+    err_rel = np.abs(parameter.error / parameter.value)
     if np.isnan(parerr) or (err_rel < err_rel_min):
         parerr = np.abs(parval)
     return [parval - scan_n_sigma * parerr, np.abs(parval) + scan_n_sigma * parerr]
+
 
 class ParameterEstimator(Estimator):
     """Model parameter estimator.
@@ -144,7 +139,7 @@ class ParameterEstimator(Estimator):
         reoptimize=True,
         selection_optional=None,
     ):
-        
+
         self.n_sigma = n_sigma
         self.n_sigma_ul = n_sigma_ul
         self.null_value = null_value
@@ -279,9 +274,7 @@ class ParameterEstimator(Estimator):
         if self.scan_values is None:
             self.scan_values = make_scan_values(parameter)
         profile = self._fit.stat_profile(
-            parameter=parameter,
-            values=self.scan_values,
-            reoptimize=self.reoptimize,
+            parameter=parameter, values=self.scan_values, reoptimize=self.reoptimize,
         )
         self._profile = {
             f"{parameter.name}_scan": profile[f"{parameter.name}_scan"],
@@ -317,7 +310,9 @@ class ParameterEstimator(Estimator):
                 self.scan_values = make_scan_values(parameter)
             if self._profile is None:
                 profile = self.estimate_scan(self, datasets, parameter)
-            ul = stat_profile_ul_scipy(self.scan_values, profile["stat_scan"], delta_ts=4, interp_scale="sqrt")
+            ul = stat_profile_ul_scipy(
+                self.scan_values, profile["stat_scan"], delta_ts=4, interp_scale="sqrt"
+            )
         return ul
 
     def run(self, datasets, parameter):

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -32,13 +32,14 @@ class ScanValuesMaker:
     scaling: {'lin', 'log', 'sqrt'}
         Choose values scaling. Defauld is linear ('lin')
 
-    """    
+    """
+
     def __init__(self, bounds=3, n_values=30, err_rel_min=0.05, scaling="lin"):
         self.bounds = bounds
         self.n_values = n_values
         self.err_rel_min = err_rel_min
         self.scaling = scaling
-    
+
     def __call__(self, parameter=None):
         """Generate scan values for a given parameter
 
@@ -51,7 +52,7 @@ class ScanValuesMaker:
         -------
         results : numpy.array
             Paramter scan values
-    """    
+    """
         if isinstance(self.bounds, tuple):
             parmin, parmax = self.bounds
         else:

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -37,14 +37,14 @@ def hess_datasets():
 @requires_data()
 @requires_dependency("iminuit")
 def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
-    norm_values = ScanValuesMaker(bounds=(0.5,2), n_values=5)
+    norm_values = ScanValuesMaker(bounds=(0.5, 2), n_values=5)
     estimator = FluxEstimator(
         0,
         energy_min="1 GeV",
         energy_max="100 GeV",
-        norm_min = -1e5,
-        norm_max = 1e5,
-        norm_values = norm_values,
+        norm_min=-1e5,
+        norm_max=1e5,
+        norm_values=norm_values,
         reoptimize=False,
         selection_optional="all"
     )
@@ -56,6 +56,7 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
     assert_allclose(result["norm_errn"], 0.0199, atol=1e-3)
     assert_allclose(result["norm_errp"], 0.0199, atol=1e-3)
+    assert_allclose(result["norm_ul"], 1.052905, atol=1e-3)
     assert len(result["norm_scan"]) == 5
     assert_allclose(result["norm_scan"][0], 0.5)
     assert_allclose(result["norm_scan"][-1], 2)

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -42,9 +42,9 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
         0,
         energy_min="1 GeV",
         energy_max="100 GeV",
-        norm_min=-1e5,
-        norm_max=1e5,
-        norm_values=norm_values,
+        norm_fit_min=-1e5,
+        norm_fit_max=1e5,
+        norm_scan_values=norm_values,
         reoptimize=False,
         selection_optional="all"
     )

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
 from gammapy.estimators.flux import FluxEstimator
-from gammapy.estimators.parameter import ScanValuesMaker
+from gammapy.estimators.parameter import ScanValuesGenerator
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.utils.testing import requires_data, requires_dependency
 
@@ -37,7 +37,7 @@ def hess_datasets():
 @requires_data()
 @requires_dependency("iminuit")
 def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
-    norm_values = ScanValuesMaker(bounds=(0.5, 2), n_values=5)
+    norm_values = ScanValuesGenerator(bounds=(0.5, 2), n_values=5)
     estimator = FluxEstimator(
         0,
         energy_min="1 GeV",

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
 from gammapy.estimators.flux import FluxEstimator
+from gammapy.estimators.parameter import ScanValuesMaker
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.utils.testing import requires_data, requires_dependency
 
@@ -36,13 +37,14 @@ def hess_datasets():
 @requires_data()
 @requires_dependency("iminuit")
 def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
+    norm_values = ScanValuesMaker(bounds=(0.5,2), n_values=5)
     estimator = FluxEstimator(
         0,
         energy_min="1 GeV",
         energy_max="100 GeV",
-        norm_n_values=5,
-        norm_min=0.5,
-        norm_max=2,
+        norm_min = -1e5,
+        norm_max = 1e5,
+        norm_values = norm_values,
         reoptimize=False,
         selection_optional="all"
     )

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -46,7 +46,7 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
         norm_fit_max=1e5,
         norm_scan_values=norm_values,
         reoptimize=False,
-        selection_optional="all"
+        selection_optional="all",
     )
 
     result = estimator.run(fermi_datasets)

--- a/gammapy/estimators/tests/test_flux_point.py
+++ b/gammapy/estimators/tests/test_flux_point.py
@@ -87,7 +87,9 @@ def test_dnde_from_flux():
 
     # Get values
     model = XSqrTestModel()
-    table["e_ref"] = FluxPoints._energy_ref_lafferty(model, table["e_min"], table["e_max"])
+    table["e_ref"] = FluxPoints._energy_ref_lafferty(
+        model, table["e_min"], table["e_max"]
+    )
     dnde = FluxPoints.from_table(table, reference_model=model)
 
     # Set up test case comparison
@@ -150,9 +152,7 @@ def test_fermi_to_dnde():
     fp = src.flux_points
 
     assert_allclose(
-        fp.dnde[1],
-        4.567393e-10 * u.Unit("cm-2 s-1 MeV-1"),
-        rtol=1e-5,
+        fp.dnde[1], 4.567393e-10 * u.Unit("cm-2 s-1 MeV-1"), rtol=1e-5,
     )
 
 

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -143,6 +143,7 @@ def fpe_map_pwl():
         norm_fit_max=1e5,
         norm_scan_values=norm_values,
         source="source",
+        selection_optional="all",
     )
     return datasets, fpe
 

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -83,7 +83,9 @@ def create_fpe(model):
     norm_values = ScanValuesGenerator(bounds=(0.2, 5), n_values=11, scaling="log")
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
-        norm_n_values=11,
+        norm_fit_min=-1e5,
+        norm_fit_max=1e5,
+        norm_scan_values=norm_values,
         source="source",
         selection_optional=["all"],
         backend="minuit",
@@ -137,9 +139,10 @@ def fpe_map_pwl():
     norm_values = ScanValuesGenerator(bounds=(0.2, 5), n_values=3, scaling="log")
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
-        norm_n_values=3,
+        norm_fit_min=-1e5,
+        norm_fit_max=1e5,
+        norm_scan_values=norm_values,
         source="source",
-        selection_optional=["all"],
     )
     return datasets, fpe
 
@@ -155,9 +158,9 @@ def fpe_map_pwl_reoptimize():
     datasets = [dataset]
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
-        norm_min=-1e5,
-        norm_max=1e5,
-        norm_values=[1],
+        norm_fit_min=-1e5,
+        norm_fit_max=1e5,
+        norm_scan_values=[1],
         reoptimize=True,
         source="source",
     )

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -7,7 +7,7 @@ from astropy.coordinates import SkyCoord
 from gammapy.data import Observation
 from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
 from gammapy.estimators import FluxPointsEstimator
-from gammapy.estimators.parameter import ScanValuesMaker
+from gammapy.estimators.parameter import ScanValuesGenerator
 from gammapy.irf import EDispKernelMap, EffectiveAreaTable2D, load_cta_irfs
 from gammapy.makers import MapDatasetMaker
 from gammapy.makers.utils import make_map_exposure_true_energy
@@ -80,7 +80,7 @@ def create_fpe(model):
     energy_edges = [0.1, 1, 10, 100] * u.TeV
     dataset.models = model
 
-    norm_values = ScanValuesMaker(bounds=(0.2, 5), n_values=11, scaling="log")
+    norm_values = ScanValuesGenerator(bounds=(0.2, 5), n_values=11, scaling="log")
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
         norm_n_values=11,
@@ -134,7 +134,7 @@ def fpe_map_pwl():
 
     energy_edges = [0.1, 1, 10, 100] * u.TeV
     datasets = [dataset_1, dataset_2]
-    norm_values = ScanValuesMaker(bounds=(0.2, 5), n_values=3, scaling="log")
+    norm_values = ScanValuesGenerator(bounds=(0.2, 5), n_values=3, scaling="log")
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
         norm_n_values=3,

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -79,8 +79,8 @@ def create_fpe(model):
     dataset = simulate_spectrum_dataset(model)
     energy_edges = [0.1, 1, 10, 100] * u.TeV
     dataset.models = model
-    
-    norm_values = ScanValuesMaker(bounds=(0.2,5), n_values=11, scaling="log")
+
+    norm_values = ScanValuesMaker(bounds=(0.2, 5), n_values=11, scaling="log")
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
         norm_n_values=11,
@@ -134,7 +134,7 @@ def fpe_map_pwl():
 
     energy_edges = [0.1, 1, 10, 100] * u.TeV
     datasets = [dataset_1, dataset_2]
-    norm_values = ScanValuesMaker(bounds=(0.2,5), n_values=3, scaling="log")
+    norm_values = ScanValuesMaker(bounds=(0.2, 5), n_values=3, scaling="log")
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
         norm_n_values=3,
@@ -154,7 +154,12 @@ def fpe_map_pwl_reoptimize():
     dataset.models.parameters["sigma"].frozen = True
     datasets = [dataset]
     fpe = FluxPointsEstimator(
-        energy_edges=energy_edges, norm_min=-1e5, norm_max=1e5, norm_values=[1], reoptimize=True, source="source"
+        energy_edges=energy_edges,
+        norm_min=-1e5,
+        norm_max=1e5,
+        norm_values=[1],
+        reoptimize=True,
+        source="source",
     )
     return datasets, fpe
 

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -7,6 +7,7 @@ from astropy.coordinates import SkyCoord
 from gammapy.data import Observation
 from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
 from gammapy.estimators import FluxPointsEstimator
+from gammapy.estimators.parameter import ScanValuesMaker
 from gammapy.irf import EDispKernelMap, EffectiveAreaTable2D, load_cta_irfs
 from gammapy.makers import MapDatasetMaker
 from gammapy.makers.utils import make_map_exposure_true_energy
@@ -78,11 +79,13 @@ def create_fpe(model):
     dataset = simulate_spectrum_dataset(model)
     energy_edges = [0.1, 1, 10, 100] * u.TeV
     dataset.models = model
+    
+    norm_values = ScanValuesMaker(bounds=(0.2,5), n_values=11, scaling="log")
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
         norm_n_values=11,
         source="source",
-        selection_optional="all",
+        selection_optional=["all"],
         backend="minuit",
         optimize_opts=dict(tol=0.2, strategy=1),
     )
@@ -131,11 +134,12 @@ def fpe_map_pwl():
 
     energy_edges = [0.1, 1, 10, 100] * u.TeV
     datasets = [dataset_1, dataset_2]
+    norm_values = ScanValuesMaker(bounds=(0.2,5), n_values=3, scaling="log")
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
         norm_n_values=3,
         source="source",
-        selection_optional="all",
+        selection_optional=["all"],
     )
     return datasets, fpe
 
@@ -150,7 +154,7 @@ def fpe_map_pwl_reoptimize():
     dataset.models.parameters["sigma"].frozen = True
     datasets = [dataset]
     fpe = FluxPointsEstimator(
-        energy_edges=energy_edges, norm_values=[1], reoptimize=True, source="source"
+        energy_edges=energy_edges, norm_min=-1e5, norm_max=1e5, norm_values=[1], reoptimize=True, source="source"
     )
     return datasets, fpe
 

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -17,9 +17,11 @@ from gammapy.maps import RegionNDMap
 from gammapy.modeling.models import FoVBackgroundModel, PowerLawSpectralModel, SkyModel
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
+
 @pytest.fixture(scope="session")
 def norm_values():
-    return ScanValuesMaker(bounds=(0.2,5), n_values=3, scaling="log")
+    return ScanValuesMaker(bounds=(0.2, 5), n_values=3, scaling="log")
+
 
 @pytest.fixture(scope="session")
 def lc():
@@ -402,7 +404,9 @@ def test_lightcurve_estimator_spectrum_datasets_default(norm_values):
     datasets = get_spectrum_datasets()
     selection = ["scan"]
     estimator = LightCurveEstimator(
-        energy_edges=[1, 30] * u.TeV, norm_values=norm_values, selection_optional=selection
+        energy_edges=[1, 30] * u.TeV,
+        norm_values=norm_values,
+        selection_optional=selection,
     )
     lightcurve = estimator.run(datasets)
     assert_allclose(lightcurve.table["time_min"], [55197.0, 55197.041667])
@@ -471,7 +475,9 @@ def test_lightcurve_estimator_spectrum_datasets_timeoverlaped(norm_values):
         Time(["2010-01-01T01:00:00", "2010-01-01T02:00:00"]),
     ]
     with pytest.raises(ValueError) as excinfo:
-        estimator = LightCurveEstimator(norm_values=norm_values, time_intervals=time_intervals)
+        estimator = LightCurveEstimator(
+            norm_values=norm_values, time_intervals=time_intervals
+        )
         estimator.run(datasets)
 
     msg = "Overlapping time bins"
@@ -480,7 +486,9 @@ def test_lightcurve_estimator_spectrum_datasets_timeoverlaped(norm_values):
 
 @requires_data()
 @requires_dependency("iminuit")
-def test_lightcurve_estimator_spectrum_datasets_gti_not_include_in_time_intervals(norm_values):
+def test_lightcurve_estimator_spectrum_datasets_gti_not_include_in_time_intervals(
+    norm_values,
+):
     # Check that it returns a ValueError if the time intervals are smaller than the dataset GTI.
     datasets = get_spectrum_datasets()
     time_intervals = [

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -250,7 +250,7 @@ def test_lightcurve_estimator_spectrum_datasets():
 
     estimator = LightCurveEstimator(
         energy_edges=[1, 30] * u.TeV,
-        norm_n_values=3,
+        norm_scan_values=norm_values,
         time_intervals=time_intervals,
         selection_optional="all",
     )
@@ -300,7 +300,7 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins(norm_values):
 
     estimator = LightCurveEstimator(
         energy_edges=[1, 5, 30] * u.TeV,
-        norm_n_values=3,
+        norm_scan_values=norm_values,
         time_intervals=time_intervals,
         selection_optional="all",
     )
@@ -386,7 +386,7 @@ def test_lightcurve_estimator_spectrum_datasets_withmaskfit(norm_values):
     selection = ["scan"]
     estimator = LightCurveEstimator(
         energy_edges=[1, 30] * u.TeV,
-        norm_values=norm_values,
+        norm_scan_values=norm_values,
         time_intervals=time_intervals,
         selection_optional=selection,
     )
@@ -405,7 +405,7 @@ def test_lightcurve_estimator_spectrum_datasets_default(norm_values):
     selection = ["scan"]
     estimator = LightCurveEstimator(
         energy_edges=[1, 30] * u.TeV,
-        norm_values=norm_values,
+        norm_scan_values=norm_values,
         selection_optional=selection,
     )
     lightcurve = estimator.run(datasets)
@@ -426,7 +426,7 @@ def test_lightcurve_estimator_spectrum_datasets_notordered(norm_values):
     ]
     estimator = LightCurveEstimator(
         energy_edges=[1, 100] * u.TeV,
-        norm_values=norm_values,
+        norm_scan_values=norm_values,
         time_intervals=time_intervals,
         selection_optional=["scan"],
     )
@@ -444,7 +444,7 @@ def test_lightcurve_estimator_spectrum_datasets_largerbin(norm_values):
     time_intervals = [Time(["2010-01-01T00:00:00", "2010-01-01T02:00:00"])]
     estimator = LightCurveEstimator(
         energy_edges=[1, 30] * u.TeV,
-        norm_values=norm_values,
+        norm_scan_values=norm_values,
         time_intervals=time_intervals,
         selection_optional=["scan"],
     )
@@ -476,7 +476,7 @@ def test_lightcurve_estimator_spectrum_datasets_timeoverlaped(norm_values):
     ]
     with pytest.raises(ValueError) as excinfo:
         estimator = LightCurveEstimator(
-            norm_values=norm_values, time_intervals=time_intervals
+            norm_scan_values=norm_values, time_intervals=time_intervals
         )
         estimator.run(datasets)
 
@@ -497,7 +497,7 @@ def test_lightcurve_estimator_spectrum_datasets_gti_not_include_in_time_interval
     ]
     estimator = LightCurveEstimator(
         energy_edges=[1, 30] * u.TeV,
-        norm_values=norm_values,
+        norm_scan_values=norm_values,
         time_intervals=time_intervals,
         selection_optional=["scan"],
     )

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -8,7 +8,7 @@ from astropy.time import Time
 from gammapy.data import GTI
 from gammapy.datasets import Datasets
 from gammapy.estimators import LightCurve, LightCurveEstimator
-from gammapy.estimators.parameter import ScanValuesMaker
+from gammapy.estimators.parameter import ScanValuesGenerator
 from gammapy.estimators.tests.test_flux_point_estimator import (
     simulate_map_dataset,
     simulate_spectrum_dataset,
@@ -20,7 +20,7 @@ from gammapy.utils.testing import mpl_plot_check, requires_data, requires_depend
 
 @pytest.fixture(scope="session")
 def norm_values():
-    return ScanValuesMaker(bounds=(0.2, 5), n_values=3, scaling="log")
+    return ScanValuesGenerator(bounds=(0.2, 5), n_values=3, scaling="log")
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -207,7 +207,7 @@ def test_group_datasets_in_time_interval_outflows():
 
 @requires_data()
 @requires_dependency("iminuit")
-def test_lightcurve_estimator_fit_options():
+def test_lightcurve_estimator_fit_options(norm_values):
     # Doing a LC on one hour bin
     datasets = get_spectrum_datasets()
     time_intervals = [
@@ -218,7 +218,7 @@ def test_lightcurve_estimator_fit_options():
 
     estimator = LightCurveEstimator(
         energy_edges=energy_edges,
-        norm_n_values=3,
+        norm_scan_values=norm_values,
         time_intervals=time_intervals,
         selection_optional="all",
         backend="minuit",
@@ -240,7 +240,7 @@ def test_lightcurve_estimator_fit_options():
 
 @requires_data()
 @requires_dependency("iminuit")
-def test_lightcurve_estimator_spectrum_datasets():
+def test_lightcurve_estimator_spectrum_datasets(norm_values):
     # Doing a LC on one hour bin
     datasets = get_spectrum_datasets()
     time_intervals = [

--- a/gammapy/estimators/tests/test_parameter_estimator.py
+++ b/gammapy/estimators/tests/test_parameter_estimator.py
@@ -56,7 +56,9 @@ def test_parameter_estimator_3d_no_reoptimization(crab_datasets_fermi):
     datasets = crab_datasets_fermi
     parameter = datasets[0].models.parameters["amplitude"]
     scan_values = ScanValuesGenerator(n_values=10, err_rel_min=1e-3)
-    estimator = ParameterEstimator(reoptimize=False, scan_values=scan_values, selection_optional=["scan"])
+    estimator = ParameterEstimator(
+        reoptimize=False, scan_values=scan_values, selection_optional=["scan"]
+    )
     alpha_value = datasets[0].models.parameters["alpha"].value
 
     result = estimator.run(datasets, parameter)

--- a/gammapy/estimators/tests/test_parameter_estimator.py
+++ b/gammapy/estimators/tests/test_parameter_estimator.py
@@ -2,7 +2,7 @@
 import pytest
 from numpy.testing import assert_allclose
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
-from gammapy.estimators.parameter import ParameterEstimator, ScanValuesMaker
+from gammapy.estimators.parameter import ParameterEstimator, ScanValuesGenerator
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.utils.testing import requires_data
 
@@ -36,7 +36,7 @@ def test_parameter_estimator_1d(crab_datasets_1d, PLmodel):
     for dataset in datasets:
         dataset.models = SkyModel(spectral_model=PLmodel, name="Crab")
 
-    scan_values = ScanValuesMaker(n_values=10)
+    scan_values = ScanValuesGenerator(n_values=10)
     estimator = ParameterEstimator(scan_values=scan_values, selection_optional="all")
 
     result = estimator.run(datasets, parameter="amplitude")
@@ -55,7 +55,7 @@ def test_parameter_estimator_1d(crab_datasets_1d, PLmodel):
 def test_parameter_estimator_3d_no_reoptimization(crab_datasets_fermi):
     datasets = crab_datasets_fermi
     parameter = datasets[0].models.parameters["amplitude"]
-    scan_values = ScanValuesMaker(n_values=10, err_rel_min=1e-3)
+    scan_values = ScanValuesGenerator(n_values=10, err_rel_min=1e-3)
     estimator = ParameterEstimator(reoptimize=False, scan_values=scan_values, selection_optional=["scan"])
     alpha_value = datasets[0].models.parameters["alpha"].value
 

--- a/gammapy/estimators/tests/test_parameter_estimator.py
+++ b/gammapy/estimators/tests/test_parameter_estimator.py
@@ -2,7 +2,7 @@
 import pytest
 from numpy.testing import assert_allclose
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
-from gammapy.estimators.parameter import ParameterEstimator
+from gammapy.estimators.parameter import ParameterEstimator, ScanValuesMaker
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.utils.testing import requires_data
 
@@ -36,7 +36,8 @@ def test_parameter_estimator_1d(crab_datasets_1d, PLmodel):
     for dataset in datasets:
         dataset.models = SkyModel(spectral_model=PLmodel, name="Crab")
 
-    estimator = ParameterEstimator(scan_n_values=10, selection_optional="all")
+    scan_values = ScanValuesMaker(n_values=10)
+    estimator = ParameterEstimator(scan_values=scan_values, selection_optional="all")
 
     result = estimator.run(datasets, parameter="amplitude")
 
@@ -54,7 +55,8 @@ def test_parameter_estimator_1d(crab_datasets_1d, PLmodel):
 def test_parameter_estimator_3d_no_reoptimization(crab_datasets_fermi):
     datasets = crab_datasets_fermi
     parameter = datasets[0].models.parameters["amplitude"]
-    estimator = ParameterEstimator(reoptimize=False, scan_n_values=10, selection_optional=["scan"])
+    scan_values = ScanValuesMaker(n_values=10, err_rel_min=1e-3)
+    estimator = ParameterEstimator(reoptimize=False, scan_values=scan_values, selection_optional=["scan"])
     alpha_value = datasets[0].models.parameters["alpha"].value
 
     result = estimator.run(datasets, parameter)

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -315,11 +315,7 @@ class Fit:
         return result
 
     def stat_profile(
-        self,
-        parameter,
-        values,
-        reoptimize=False,
-        optimize_opts=None,
+        self, parameter, values, reoptimize=False, optimize_opts=None,
     ):
         """Compute fit statistic profile.
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -328,9 +328,9 @@ class Fit:
         ----------
         parameter : `~gammapy.modeling.Parameter`
             Parameter of interest
-        values : `~astropy.units.Quantity` or `~gammapy.estimators.parameter.ScanValuesMaker`
+        values : `~astropy.units.Quantity` or `~gammapy.estimators.parameter.ScanValuesGenerator`
             Parameter values to evaluate the fit statistic for
-            or `ScanValuesMaker` generator instance (optional).
+            or `ScanValuesGenerator` generator instance (optional).
         reoptimize : bool
             Re-optimize other parameters, when computing the fit statistic profile.
             
@@ -340,13 +340,14 @@ class Fit:
             Dictionary with keys "values", "stat" and "fit_results". The latter contains an
             empty list, if `reoptimize` is set to False
         """
-        from gammapy.estimators.parameter import ScanValuesMaker
+        from gammapy.estimators.parameter import ScanValuesGenerator
+
         parameters = self._parameters
         parameter = parameters[parameter]
 
         if values is None:
-            values = ScanValuesMaker()(parameter)
-        elif isinstance(values, ScanValuesMaker):
+            values = ScanValuesGenerator()(parameter)
+        elif isinstance(values, ScanValuesGenerator):
             values = values(parameter)
 
         optimize_opts = optimize_opts or {}

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -315,7 +315,7 @@ class Fit:
         return result
 
     def stat_profile(
-        self, parameter, values, reoptimize=False, optimize_opts=None,
+        self, parameter, values=None, reoptimize=False, optimize_opts=None,
     ):
         """Compute fit statistic profile.
 
@@ -328,10 +328,9 @@ class Fit:
         ----------
         parameter : `~gammapy.modeling.Parameter`
             Parameter of interest
-        values : `~astropy.units.Quantity` (optional)
-            Parameter values to evaluate the fit statistic for.
-        nvalues : int
-            Number of parameter grid points to use.
+        values : `~astropy.units.Quantity` or `~gammapy.estimators.parameter.ScanValuesMaker`
+            Parameter values to evaluate the fit statistic for
+            or `ScanValuesMaker` generator instance (optional).
         reoptimize : bool
             Re-optimize other parameters, when computing the fit statistic profile.
             
@@ -341,8 +340,14 @@ class Fit:
             Dictionary with keys "values", "stat" and "fit_results". The latter contains an
             empty list, if `reoptimize` is set to False
         """
+        from gammapy.estimators.parameter import ScanValuesMaker
         parameters = self._parameters
         parameter = parameters[parameter]
+
+        if values is None:
+            values = ScanValuesMaker()(parameter)
+        elif isinstance(values, ScanValuesMaker):
+            values = values(parameter)
 
         optimize_opts = optimize_opts or {}
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -317,9 +317,7 @@ class Fit:
     def stat_profile(
         self,
         parameter,
-        values=None,
-        bounds=2,
-        nvalues=11,
+        values,
         reoptimize=False,
         optimize_opts=None,
     ):
@@ -336,17 +334,11 @@ class Fit:
             Parameter of interest
         values : `~astropy.units.Quantity` (optional)
             Parameter values to evaluate the fit statistic for.
-        bounds : int or tuple of float
-            When an `int` is passed the bounds are computed from `bounds * sigma`
-            from the best fit value of the parameter, where `sigma` corresponds to
-            the one sigma error on the parameter. If a tuple of floats is given
-            those are taken as the min and max values and ``nvalues`` are linearly
-            spaced between those.
         nvalues : int
             Number of parameter grid points to use.
         reoptimize : bool
             Re-optimize other parameters, when computing the fit statistic profile.
-
+            
         Returns
         -------
         results : dict
@@ -357,18 +349,6 @@ class Fit:
         parameter = parameters[parameter]
 
         optimize_opts = optimize_opts or {}
-
-        if values is None:
-            if isinstance(bounds, tuple):
-                parmin, parmax = bounds
-            else:
-                if np.isnan(parameter.error):
-                    raise ValueError("Parameter error is not properly set.")
-                parerr = parameter.error
-                parval = parameter.value
-                parmin, parmax = parval - bounds * parerr, parval + bounds * parerr
-
-            values = np.linspace(parmin, parmax, nvalues)
 
         stats = []
         fit_results = []

--- a/gammapy/modeling/scipy.py
+++ b/gammapy/modeling/scipy.py
@@ -4,6 +4,7 @@ import scipy.optimize
 from gammapy.utils.interpolation import interpolate_profile
 from .likelihood import Likelihood
 from gammapy.estimators.parameter import make_scan_bounds
+
 __all__ = [
     "optimize_scipy",
     "covariance_scipy",
@@ -71,7 +72,7 @@ def _confidence_scipy_brentq(
     bound = parameter.factor_max if upper else parameter.factor_min
 
     if np.isnan(bound):
-        bounds = make_scan_bounds(parameter, scan_n_sigma=1e2) 
+        bounds = make_scan_bounds(parameter, scan_n_sigma=1e2)
         bound = bounds[int(upper)] / parameter.scale
 
     kwargs.setdefault("b", bound)

--- a/gammapy/modeling/scipy.py
+++ b/gammapy/modeling/scipy.py
@@ -3,7 +3,6 @@ import numpy as np
 import scipy.optimize
 from gammapy.utils.interpolation import interpolate_profile
 from .likelihood import Likelihood
-from gammapy.estimators.parameter import make_scan_bounds
 
 __all__ = [
     "optimize_scipy",
@@ -63,6 +62,7 @@ class TSDifference:
 def _confidence_scipy_brentq(
     parameters, parameter, function, sigma, reoptimize, upper=True, **kwargs
 ):
+    from gammapy.estimators.parameter import make_scan_bounds
     ts_diff = TSDifference(
         function, parameters, parameter, reoptimize, ts_diff=sigma ** 2
     )

--- a/gammapy/modeling/scipy.py
+++ b/gammapy/modeling/scipy.py
@@ -3,7 +3,7 @@ import numpy as np
 import scipy.optimize
 from gammapy.utils.interpolation import interpolate_profile
 from .likelihood import Likelihood
-
+from gammapy.estimators.parameter import make_scan_bounds
 __all__ = [
     "optimize_scipy",
     "covariance_scipy",
@@ -71,11 +71,8 @@ def _confidence_scipy_brentq(
     bound = parameter.factor_max if upper else parameter.factor_min
 
     if np.isnan(bound):
-        bound = parameter.factor
-        if upper:
-            bound += 1e2 * parameter.error / parameter.scale
-        else:
-            bound -= 1e2 * parameter.error / parameter.scale
+        bounds = make_scan_bounds(parameter, scan_n_sigma=1e2) 
+        bound = bounds[int(upper)] / parameter.scale
 
     kwargs.setdefault("b", bound)
 

--- a/gammapy/modeling/scipy.py
+++ b/gammapy/modeling/scipy.py
@@ -62,7 +62,6 @@ class TSDifference:
 def _confidence_scipy_brentq(
     parameters, parameter, function, sigma, reoptimize, upper=True, **kwargs
 ):
-    from gammapy.estimators.parameter import make_scan_bounds
     ts_diff = TSDifference(
         function, parameters, parameter, reoptimize, ts_diff=sigma ** 2
     )
@@ -72,7 +71,7 @@ def _confidence_scipy_brentq(
     bound = parameter.factor_max if upper else parameter.factor_min
 
     if np.isnan(bound):
-        bounds = make_scan_bounds(parameter, scan_n_sigma=1e2)
+        bounds = parameter.get_scan_bounds(scan_n_sigma=1e2)
         bound = bounds[int(upper)] / parameter.scale
 
     kwargs.setdefault("b", bound)

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -7,7 +7,7 @@ from gammapy.datasets import Dataset
 from gammapy.modeling import Fit, Parameter
 from gammapy.modeling.models import Model, Models
 from gammapy.utils.testing import requires_dependency
-from gammapy.estimators.parameter import ScanValuesMaker
+from gammapy.estimators.parameter import ScanValuesGenerator
 
 
 pytest.importorskip("iminuit")
@@ -153,7 +153,7 @@ def test_stat_profile():
     fit = Fit([dataset])
     fit.run()
     parameter = dataset.models.parameters["x"]
-    values = ScanValuesMaker(bounds=2, n_values=3)(parameter)
+    values = ScanValuesGenerator(bounds=2, n_values=3)(parameter)
     result = fit.stat_profile("x", values=values)
 
     assert_allclose(result["x_scan"], [0, 2, 4], atol=1e-7)
@@ -171,7 +171,7 @@ def test_stat_profile_reoptimize():
 
     dataset.models.parameters["y"].value = 0
     parameter = dataset.models.parameters["x"]
-    values = ScanValuesMaker(bounds=2, n_values=3)(parameter)
+    values = ScanValuesGenerator(bounds=2, n_values=3)(parameter)
     result = fit.stat_profile("x", values=values, reoptimize=True)
 
     assert_allclose(result["x_scan"], [0, 2, 4], atol=1e-7)

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -7,6 +7,8 @@ from gammapy.datasets import Dataset
 from gammapy.modeling import Fit, Parameter
 from gammapy.modeling.models import Model, Models
 from gammapy.utils.testing import requires_dependency
+from gammapy.estimators.parameter import ScanValuesMaker
+
 
 pytest.importorskip("iminuit")
 
@@ -150,7 +152,9 @@ def test_stat_profile():
     dataset = MyDataset()
     fit = Fit([dataset])
     fit.run()
-    result = fit.stat_profile("x", nvalues=3)
+    parameter = dataset.models.parameters["x"]
+    values = ScanValuesMaker(bounds=2, n_values=3)(parameter)
+    result = fit.stat_profile("x", values=values)
 
     assert_allclose(result["x_scan"], [0, 2, 4], atol=1e-7)
     assert_allclose(result["stat_scan"], [4, 0, 4], atol=1e-7)
@@ -166,7 +170,9 @@ def test_stat_profile_reoptimize():
     fit.run()
 
     dataset.models.parameters["y"].value = 0
-    result = fit.stat_profile("x", nvalues=3, reoptimize=True)
+    parameter = dataset.models.parameters["x"]
+    values = ScanValuesMaker(bounds=2, n_values=3)(parameter)
+    result = fit.stat_profile("x", values=values, reoptimize=True)
 
     assert_allclose(result["x_scan"], [0, 2, 4], atol=1e-7)
     assert_allclose(result["stat_scan"], [4, 0, 4], atol=1e-7)

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -32,7 +32,10 @@ def test_parameter_outside_limit(caplog):
     par = Parameter("spam", 50, min=0, max=40)
     par.check_limits()
     assert caplog.records[-1].levelname == "WARNING"
-    assert caplog.records[-1].message == "Value 50.0 is outside bounds [0.0, 40.0] for parameter 'spam'"
+    assert (
+        caplog.records[-1].message
+        == "Value 50.0 is outside bounds [0.0, 40.0] for parameter 'spam'"
+    )
 
 
 def test_parameter_scale():
@@ -176,18 +179,37 @@ def test_parameters_autoscale():
     assert_allclose(pars[0].factor, 2)
     assert_allclose(pars[0].scale, 10)
 
+
 def test_update_from_dict():
     par = Parameter("test", value=1e-10, min="nan", max="nan", frozen=False, unit="TeV")
     par.autoscale()
-    data={"model":"gc", "type":"spectral", "name": "test2", "value":3e-10, "min":0, "max":np.nan, "frozen":True, "unit":"GeV"}
+    data = {
+        "model": "gc",
+        "type": "spectral",
+        "name": "test2",
+        "value": 3e-10,
+        "min": 0,
+        "max": np.nan,
+        "frozen": True,
+        "unit": "GeV",
+    }
     par.update_from_dict(data)
     assert par.name == "test"
     assert par.factor == 3
     assert par.value == 3e-10
     assert par.unit == "GeV"
     assert par.min == 0
-    assert par.max is np.nan    
+    assert par.max is np.nan
     assert par.frozen == True
-    data={"model":"gc", "type":"spectral", "name": "test2", "value":3e-10, "min":0, "max":np.nan, "frozen":'True', "unit":"GeV"}
+    data = {
+        "model": "gc",
+        "type": "spectral",
+        "name": "test2",
+        "value": 3e-10,
+        "min": 0,
+        "max": np.nan,
+        "frozen": "True",
+        "unit": "GeV",
+    }
     par.update_from_dict(data)
     assert par.frozen == True


### PR DESCRIPTION
This PR remove hard coded bounds in estimators and simplify their handling.
The parameters `norm_min` and `norm_max` now refers to the limits of the fit and not of the profile scan.
Now the values of the profile scan can only be set using `norm_values`.
I introduced two function `ScanValuesMaker` and `make_scan_bounds`  in order to help generating the bounds/scan values automatically.

 The new default settings  should prevent the upper limit to vanish when the parameter error is missing or poorly defined.