### PR TITLE
Add regression tests for background with  missing HDUCLAS keyword

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -37,8 +37,11 @@ class BackgroundIRF(IRF):
         """
         # TODO: some of the existing background files have missing HDUCLAS keywords
         #  which are required to define the correct Gammapy axis names
-        table = table.copy()
-        table.meta.setdefault("HDUCLAS2", "BKG")
+
+        if "HDUCLAS2" not in table.meta:
+            log.warning("Missing 'HDUCLAS2' keyword assuming 'BKG'")
+            table = table.copy()
+            table.meta["HDUCLAS2"] = "BKG"
 
         axes = MapAxes.from_table(table, format=format)[cls.required_axes]
 

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -35,16 +35,21 @@ class BackgroundIRF(IRF):
         bkg : `Background2D` or `Background2D`
             Background IRF class.
         """
+        # TODO: some of the existing background files have missing HDUCLAS keywords
+        #  which are required to define the correct Gammapy axis names
+        table = table.copy()
+        table.meta.setdefault("HDUCLAS2", "BKG")
+
         axes = MapAxes.from_table(table, format=format)[cls.required_axes]
 
-        # Spec says key should be "BKG", but there are files around
-        # (e.g. CTA 1DC) that use "BGD". For now we support both
+        # TODO: spec says key should be "BKG", but there are files around
+        #  (e.g. CTA 1DC) that use "BGD". For now we support both
         if "BKG" in table.colnames:
             bkg_name = "BKG"
         elif "BGD" in table.colnames:
             bkg_name = "BGD"
         else:
-            raise ValueError('Invalid column names. Need "BKG" or "BGD".')
+            raise ValueError("Invalid column names. Need 'BKG' or 'BGD'.")
 
         data = table[bkg_name].quantity[0].T
 
@@ -54,7 +59,7 @@ class BackgroundIRF(IRF):
                 "Invalid unit found in background table! Assuming (s-1 MeV-1 sr-1)"
             )
 
-        # TODO: The present HESS and CTA backgroundfits files
+        # TODO: The present HESS and CTA background fits files
         #  have a reverse order (lon, lat, E) than recommened in GADF(E, lat, lon)
         #  For now, we suport both.
 

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -319,6 +319,7 @@ class IRF:
         if format == "gadf-dl3":
             table.meta = self.meta.copy()
             spec = IRF_DL3_HDU_SPECIFICATION[self.tag]
+            # TODO: add missing required meta data!
             table.meta["HDUCLAS2"] = spec["hduclas2"]
             table[spec["column_name"]] = self.quantity.T[np.newaxis]
         else:

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -135,7 +135,7 @@ def test_background_3d_integrate(bkg_3d):
 
 
 @requires_data()
-def test_background_3D_read():
+def test_background_3d_read():
     filename = (
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
@@ -147,13 +147,30 @@ def test_background_3D_read():
 
 
 @requires_data()
-def test_background_3D_read_gadf():
+def test_background_3d_read_gadf():
     filename = "$GAMMAPY_DATA/tests/irf/bkg_3d_full_example.fits"
     bkg = Background3D.read(filename)
     data = bkg.quantity
     assert bkg.axes.names == ["energy", "fov_lon", "fov_lat"]
     assert data.shape == (20, 15, 15)
     assert data.unit == "s-1 MeV-1 sr-1"
+
+
+def test_background_2d_read_missing_hducls():
+    energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
+    offset_axis = MapAxis.from_edges([0, 1, 2], unit="deg", name="offset")
+
+    bkg = Background2D(
+        axes=[energy_axis, offset_axis],
+        unit="s-1 MeV-1 sr-1"
+    )
+
+    table = bkg.to_table()
+    table.meta.pop("HDUCLAS2")
+
+    bkg = Background2D.from_table(table)
+
+    assert bkg.axes[0].name == "energy"
 
 
 @requires_dependency("matplotlib")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds support for reading background files with missing `HDUCLAS` keywords. I decided to raise a warning, because I think invalid DL3 files should not be read silently.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
