### PR TITLE
Unify integration in EDispMap.get_edisp_kernel() and EnergyDispersion2D.get_edisp_kernel()

### DIFF
--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -218,6 +218,7 @@ class IRF:
             values = 2 * np.pi * axis.center.reshape(shape) * values
 
         values = values.cumsum(axis=axis_idx)
+
         points = [ax.center for ax in self.axes]
         points[axis_idx] = axis.edges[1:]
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -129,8 +129,8 @@ class EnergyDispersion2D(IRF):
         if energy_true is None:
             energy_axis_true = self.axes["energy_true"]
         else:
-            energy_axis_true = MapAxis.from_energy_edges(
-                energy_true, name="energy_true"
+            energy_axis_true = MapAxis.from_nodes(
+                energy_true, name="energy_true", interp="log"
             )
 
         # migration value of energy bounds

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -129,8 +129,8 @@ class EnergyDispersion2D(IRF):
         if energy_true is None:
             energy_axis_true = self.axes["energy_true"]
         else:
-            energy_axis_true = MapAxis.from_nodes(
-                energy_true, name="energy_true", interp="log"
+            energy_axis_true = MapAxis.from_energy_edges(
+                energy_true, name="energy_true",
             )
 
         # migration value of energy bounds

--- a/gammapy/irf/psf/core.py
+++ b/gammapy/irf/psf/core.py
@@ -30,7 +30,7 @@ class PSF(IRF):
             Containment
         """
         containment = self.integral(axis_name="rad", rad=rad, **kwargs)
-        return np.clip(containment.to(""), 0, 1)
+        return containment.to("")
 
     def containment_radius(self, fraction, factor=20, **kwargs):
         """Containment radius at given axes coordinates

--- a/gammapy/irf/psf/psf_map.py
+++ b/gammapy/irf/psf/psf_map.py
@@ -179,10 +179,13 @@ class PSFMap(IRFMap):
         if position is None:
             position = self.psf_map.geom.center_skydir
 
-        coords = self._get_irf_coords(
-            rad=rad, energy_true=energy_true, skycoord=position
-        )
-        return self._psf_irf.containment(**coords)
+        coords = {
+            "skycoord": position,
+            "rad": rad,
+            "energy_true": energy_true
+        }
+
+        return self.psf_map.integral(axis_name="rad", coords=coords).to("")
 
     def containment_radius(self, fraction, energy_true, position=None):
         """Containment at given coords

--- a/gammapy/irf/psf/tests/test_psf_map.py
+++ b/gammapy/irf/psf/tests/test_psf_map.py
@@ -378,7 +378,7 @@ def test_psf_map_read(position):
         position=position, energy_true=100 * u.GeV, rad=0.1 * u.deg
     )
 
-    assert_allclose(value, 0.682032, rtol=1e-5)
+    assert_allclose(value, 0.682022, rtol=1e-5)
     assert psf.psf_map.unit == "sr-1"
 
 

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -155,7 +155,7 @@ class TestEnergyDispersion2D:
     def test_get_response(self):
         pdf = self.edisp2.get_response(offset=0.7 * u.deg, energy_true=1 * u.TeV)
         assert_allclose(pdf.sum(), 1)
-        assert_allclose(pdf.max(), 0.010421, rtol=1e-4)
+        assert_allclose(pdf.max(), 0.010416, rtol=1e-4)
 
     def test_exporter(self):
         # Check RMF exporter

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -152,11 +152,6 @@ class TestEnergyDispersion2D:
         )
         assert_equal(actual, desired)
 
-    def test_get_response(self):
-        pdf = self.edisp2.get_response(offset=0.7 * u.deg, energy_true=1 * u.TeV)
-        assert_allclose(pdf.sum(), 1)
-        assert_allclose(pdf.max(), 0.010416, rtol=1e-4)
-
     def test_exporter(self):
         # Check RMF exporter
         offset = Angle(0.612, "deg")
@@ -164,10 +159,6 @@ class TestEnergyDispersion2D:
         e_true = MapAxis.from_energy_bounds(0.8, 5, 5, "TeV").edges
         rmf = self.edisp.to_edisp_kernel(offset, energy_true=e_true, energy=e_reco)
         assert_allclose(rmf.data.data[2, 3], 0.08, atol=5e-2)  # same tolerance as above
-        actual = rmf.pdf_matrix[2]
-        e_val = np.sqrt(e_true[2] * e_true[3])
-        desired = self.edisp.get_response(offset, e_val, e_reco)
-        assert_equal(actual, desired)
 
     def test_write(self):
         energy_axis_true = MapAxis.from_energy_bounds(

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -191,7 +191,7 @@ def make_map_background_irf(pointing, ontime, bkg, geom, oversampling=None, use_
     values = (bkg_de * d_omega * ontime).to_value("")
 
     if not use_region_center:
-        data = np.sum(weights*values, axis=2)
+        data = np.sum(weights * values, axis=2)
     else:
         data = values
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1236,13 +1236,15 @@ class Map(abc.ABC):
         data = func.reduce(data, axis=idx, keepdims=keepdims, where=~np.isnan(data))
         return self._init_copy(geom=geom, data=data)
 
-    def cumsum(self, axis_name):
+    def cumsum(self, axis_name, normalize=False):
         """Compute cumulative sum along a given axis
 
         Parameters
         ----------
         axis_name : str
             Along which axis to integrate.
+        normalize : bool
+            Normalize cum sum to unity.
 
         Returns
         -------
@@ -1264,6 +1266,9 @@ class Map(abc.ABC):
 
         data = values.cumsum(axis=axis_idx)
 
+        if normalize:
+            data /= np.sum(values, axis=axis_idx, keepdims=True)
+
         axis_shifted = MapAxis.from_nodes(
             axis.edges[1:], name=axis.name, interp=axis.interp
         )
@@ -1271,7 +1276,7 @@ class Map(abc.ABC):
         geom = self.geom.to_image().to_cube(axes)
         return self.__class__(geom=geom, data=data.value, unit=data.unit)
 
-    def integral(self, axis_name, coords, **kwargs):
+    def integral(self, axis_name, coords, normalize=False, **kwargs):
         """Compute integral along a given axis
 
         This method uses interpolation of the cumulative sum.
@@ -1282,6 +1287,9 @@ class Map(abc.ABC):
             Along which axis to integrate.
         coords : dict or `MapCoord`
             Map coordinates
+        normalize : bool
+            Normalize cum sum to unity.
+
         **kwargs : dict
             Coordinates at which to evaluate the IRF
 
@@ -1290,7 +1298,7 @@ class Map(abc.ABC):
         array : `~astropy.units.Quantity`
             Returns 2D array with axes offset
         """
-        cumsum = self.cumsum(axis_name=axis_name)
+        cumsum = self.cumsum(axis_name=axis_name, normalize=normalize)
         return u.Quantity(cumsum.interp_by_coord(coords, **kwargs), cumsum.unit, copy=False)
 
     @classmethod

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -220,6 +220,29 @@ class MapAxes(Sequence):
 
         return self.__class__(axes=axes)
 
+    def replace(self, axis):
+        """Replace a give axis
+
+        Parameters
+        ----------
+        axis : `MapAxis`
+            Map axis
+
+        Returns
+        -------
+        axes : MapAxes
+            Map axe
+        """
+        axes = []
+
+        for ax in self:
+            if ax.name == axis.name:
+                ax = axis
+
+            axes.append(ax)
+
+        return self.__class__(axes=axes)
+
     def resample(self, axis):
         """Resample axis binning.
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request unifies the integration in the `EDispMap.get_edisp_kernel()` and `EnergyDispersion.get_edisp_kernel()`, by relying on the `integral()` methods of the base classes. This includes adding a `Map.integral()` method.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
