### PR TITLE
Allow to choose HDU name in Geom.to_bands_hdu 

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -580,8 +580,8 @@ class MapAxes(Sequence):
         elif format == "fgst-template":
             hdu = "ENERGIES"
         elif format == "gadf" or format is None:
-            if extname:
-                hdu = extname
+            if prefix:
+                hdu = prefix
             else:
                 hdu = "BANDS"
         else:
@@ -2130,8 +2130,8 @@ class Geom(abc.ABC):
 
         return cls.from_header(hdu.header, hdu_bands)
 
-    def to_bands_hdu(self, hdu=None, hdu_skymap=None, format="gadf"):
-        table_hdu = self.axes.to_table_hdu(format=format, prefix=hdu_skymap)
+    def to_bands_hdu(self, hdu_bands=None, format="gadf"):
+        table_hdu = self.axes.to_table_hdu(format=format, prefix=hdu_bands)
         cols = table_hdu.columns.columns
         cols.extend(self._make_bands_cols())
         return fits.BinTableHDU.from_columns(

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -580,8 +580,8 @@ class MapAxes(Sequence):
         elif format == "fgst-template":
             hdu = "ENERGIES"
         elif format == "gadf" or format is None:
-            if prefix:
-                hdu = f"{prefix}_BANDS"
+            if extname:
+                hdu = extname
             else:
                 hdu = "BANDS"
         else:
@@ -2131,7 +2131,7 @@ class Geom(abc.ABC):
         return cls.from_header(hdu.header, hdu_bands)
 
     def to_bands_hdu(self, hdu=None, hdu_skymap=None, format="gadf"):
-       table_hdu = self.axes.to_table_hdu(format=format, prefix=hdu_skymap)
+        table_hdu = self.axes.to_table_hdu(format=format, prefix=hdu_skymap)
         cols = table_hdu.columns.columns
         cols.extend(self._make_bands_cols())
         return fits.BinTableHDU.from_columns(

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -2131,7 +2131,7 @@ class Geom(abc.ABC):
         return cls.from_header(hdu.header, hdu_bands)
 
     def to_bands_hdu(self, hdu=None, hdu_skymap=None, format="gadf"):
-        table_hdu = self.axes.to_table_hdu(format=format, prefix=hdu_skymap)
+       table_hdu = self.axes.to_table_hdu(format=format, prefix=hdu_skymap)
         cols = table_hdu.columns.columns
         cols.extend(self._make_bands_cols())
         return fits.BinTableHDU.from_columns(

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -557,15 +557,15 @@ class MapAxes(Sequence):
 
         return table
 
-    def to_table_hdu(self, format="gadf", prefix=None):
+    def to_table_hdu(self, format="gadf", hdu_bands=None):
         """Make FITS table columns for map axes.
 
         Parameters
         ----------
         format : {"gadf", "fgst-ccube", "fgst-template"}
             Format to use.
-        prefix : str
-            HDU name prefix to use
+        hdu_bands : str
+            Name of the bands HDU to use.
 
         Returns
         -------
@@ -576,20 +576,18 @@ class MapAxes(Sequence):
         #  dimensionality of geometry and simplify!!!
 
         if format in ["fgst-ccube", "ogip", "ogip-sherpa"]:
-            hdu = "EBOUNDS"
+            hdu_bands = "EBOUNDS"
         elif format == "fgst-template":
-            hdu = "ENERGIES"
+            hdu_bands = "ENERGIES"
         elif format == "gadf" or format is None:
-            if prefix:
-                hdu = prefix
-            else:
-                hdu = "BANDS"
+            if hdu_bands is None:
+                hdu_bands = "BANDS"
         else:
             raise ValueError(f"Unknown format {format}")
 
         table = self.to_table(format=format)
         header = self.to_header(format=format)
-        return fits.BinTableHDU(table, name=hdu, header=header)
+        return fits.BinTableHDU(table, name=hdu_bands, header=header)
 
     @classmethod
     def from_table_hdu(cls, hdu, format="gadf"):
@@ -2131,7 +2129,7 @@ class Geom(abc.ABC):
         return cls.from_header(hdu.header, hdu_bands)
 
     def to_bands_hdu(self, hdu_bands=None, format="gadf"):
-        table_hdu = self.axes.to_table_hdu(format=format, prefix=hdu_bands)
+        table_hdu = self.axes.to_table_hdu(format=format, hdu_bands=hdu_bands)
         cols = table_hdu.columns.columns
         cols.extend(self._make_bands_cols())
         return fits.BinTableHDU.from_columns(

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -195,7 +195,7 @@ class HpxMap(Map):
 
         if self.geom.axes:
             hdu_bands_out = self.geom.to_bands_hdu(
-                extname=hdu_bands, format=format
+                hdu_bands=hdu_bands, format=format
             )
             hdu_bands = hdu_bands_out.name
         else:

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -192,7 +192,7 @@ class HpxMap(Map):
         """
         if self.geom.axes:
             hdu_bands_out = self.geom.to_bands_hdu(
-                hdu=hdu_bands, hdu_skymap=hdu, format=format
+                hdu_skymap=hdu_bands, format=format
             )
             hdu_bands = hdu_bands_out.name
         else:

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -190,9 +190,12 @@ class HpxMap(Map):
         -------
         hdu_list : `~astropy.io.fits.HDUList`
         """
+        if hdu_bands is None:
+            hdu_bands = f"{hdu.upper()}_BANDS"
+
         if self.geom.axes:
             hdu_bands_out = self.geom.to_bands_hdu(
-                hdu_skymap=hdu_bands, format=format
+                extname=hdu_bands, format=format
             )
             hdu_bands = hdu_bands_out.name
         else:

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -542,7 +542,7 @@ class RegionGeom(Geom):
         table.meta.update(header)
         return table
 
-    def to_hdulist(self, format="ogip", hdu=None):
+    def to_hdulist(self, format="ogip", hdu_bands=None, hdu_region=None):
         """Convert geom to hdulist
 
         Parameters
@@ -558,19 +558,22 @@ class RegionGeom(Geom):
             HDU list
 
         """
+        if hdu_bands is None:
+            hdu_bands = "HDU_BANDS"
+        if hdu_region is None:
+            hdu_region = "HDU_REGION"
+        if format != "gadf":
+            hdu_region = "REGION"
+
         hdulist = fits.HDUList()
 
-        hdulist.append(self.axes.to_table_hdu(prefix=hdu, format=format))
+        hdulist.append(self.axes.to_table_hdu(prefix=hdu_bands, format=format))
 
         # region HDU
         if self.region:
             region_table = self._to_region_table()
 
-            name = "REGION"
-            if hdu and format == "gadf":
-                name = hdu + "_" + name
-
-            region_hdu = fits.BinTableHDU(region_table, name=name)
+            region_hdu = fits.BinTableHDU(region_table, name=hdu_region)
             hdulist.append(region_hdu)
 
         return hdulist

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -567,7 +567,7 @@ class RegionGeom(Geom):
 
         hdulist = fits.HDUList()
 
-        hdulist.append(self.axes.to_table_hdu(prefix=hdu_bands, format=format))
+        hdulist.append(self.axes.to_table_hdu(hdu_bands=hdu_bands, format=format))
 
         # region HDU
         if self.region:

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -334,7 +334,7 @@ class RegionNDMap(Map):
             filename, overwrite=overwrite
         )
 
-    def to_hdulist(self, format="gadf", hdu="SKYMAP"):
+    def to_hdulist(self, format="gadf", hdu="SKYMAP", hdu_bands=None, hdu_region=None):
         """Convert to `~astropy.io.fits.HDUList`.
 
         Parameters
@@ -343,6 +343,10 @@ class RegionNDMap(Map):
             Format specification
         hdu : str
             Name of the HDU with the map data, used for "gadf" format.
+        hdu_bands : str
+            Name or index of the HDU with the BANDS table, used for "gadf" format.
+        hdu_region : str
+            Name or index of the HDU with the region table.
 
         Returns
         -------
@@ -351,6 +355,11 @@ class RegionNDMap(Map):
         """
         hdulist = fits.HDUList()
         table = self.to_table(format=format)
+
+        if hdu_bands is None:
+            hdu_bands = f"{hdu.upper()}_BANDS"
+        if hdu_region is None:
+            hdu_region = f"{hdu.upper()}_REGION"
 
         if format in ["ogip", "ogip-sherpa", "ogip-arf", "ogip-arf-sherpa"]:
             hdulist.append(fits.BinTableHDU(table))
@@ -361,7 +370,7 @@ class RegionNDMap(Map):
             raise ValueError(f"Unsupported format '{format}'")
 
         if format in ["ogip", "ogip-sherpa", "gadf"]:
-            hdulist_geom = self.geom.to_hdulist(format=format, hdu=hdu)
+            hdulist_geom = self.geom.to_hdulist(format=format, hdu_bands=hdu_bands, hdu_region=hdu_region)
             hdulist.extend(hdulist_geom[1:])
 
         return hdulist

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -666,7 +666,7 @@ def test_hpxgeom_from_header():
 @pytest.mark.parametrize(("nside", "nested", "frame", "region", "axes"), hpx_test_geoms)
 def test_hpxgeom_read_write(tmp_path, nside, nested, frame, region, axes):
     geom0 = HpxGeom(nside, nested, frame, region=region, axes=axes)
-    hdu_bands = geom0.to_bands_hdu(extname="TEST_BANDS")
+    hdu_bands = geom0.to_bands_hdu(hdu_bands="TEST_BANDS")
     hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.to_header())
 

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -666,7 +666,7 @@ def test_hpxgeom_from_header():
 @pytest.mark.parametrize(("nside", "nested", "frame", "region", "axes"), hpx_test_geoms)
 def test_hpxgeom_read_write(tmp_path, nside, nested, frame, region, axes):
     geom0 = HpxGeom(nside, nested, frame, region=region, axes=axes)
-    hdu_bands = geom0.to_bands_hdu(hdu_skymap="TEST")
+    hdu_bands = geom0.to_bands_hdu(extname="TEST_BANDS")
     hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.to_header())
 

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -666,7 +666,7 @@ def test_hpxgeom_from_header():
 @pytest.mark.parametrize(("nside", "nested", "frame", "region", "axes"), hpx_test_geoms)
 def test_hpxgeom_read_write(tmp_path, nside, nested, frame, region, axes):
     geom0 = HpxGeom(nside, nested, frame, region=region, axes=axes)
-    hdu_bands = geom0.to_bands_hdu(hdu="BANDS")
+    hdu_bands = geom0.to_bands_hdu(hdu_skymap="TEST")
     hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.to_header())
 
@@ -674,7 +674,7 @@ def test_hpxgeom_read_write(tmp_path, nside, nested, frame, region, axes):
     hdulist.writeto(tmp_path / "tmp.fits")
 
     with fits.open(tmp_path / "tmp.fits", memmap=False) as hdulist:
-        geom1 = HpxGeom.from_header(hdulist[0].header, hdulist["BANDS"])
+        geom1 = HpxGeom.from_header(hdulist[0].header, hdulist["TEST_BANDS"])
 
     assert_allclose(geom0.nside, geom1.nside)
     assert_allclose(geom0.npix, geom1.npix)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -93,7 +93,7 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, frame, proj, skydir, axes):
 def test_wcsgeom_read_write(tmp_path, npix, binsz, frame, proj, skydir, axes):
     geom0 = WcsGeom.create(npix=npix, binsz=binsz, proj=proj, frame=frame, axes=axes)
 
-    hdu_bands = geom0.to_bands_hdu(hdu_skymap="TEST")
+    hdu_bands = geom0.to_bands_hdu(extname="TEST_BANDS")
     hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.to_header())
 
@@ -111,7 +111,7 @@ def test_wcsgeom_to_hdulist():
     npix, binsz, frame, proj, skydir, axes = wcs_test_geoms[3]
     geom = WcsGeom.create(npix=npix, binsz=binsz, proj=proj, frame=frame, axes=axes)
 
-    hdu = geom.to_bands_hdu(hdu_skymap="TEST")
+    hdu = geom.to_bands_hdu(extname="TEST")
     assert hdu.header["AXCOLS1"] == "E_MIN,E_MAX"
     assert hdu.header["AXCOLS2"] == "AXIS1_MIN,AXIS1_MAX"
 

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -93,7 +93,7 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, frame, proj, skydir, axes):
 def test_wcsgeom_read_write(tmp_path, npix, binsz, frame, proj, skydir, axes):
     geom0 = WcsGeom.create(npix=npix, binsz=binsz, proj=proj, frame=frame, axes=axes)
 
-    hdu_bands = geom0.to_bands_hdu(hdu="BANDS")
+    hdu_bands = geom0.to_bands_hdu(hdu_skymap="TEST")
     hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.to_header())
 
@@ -101,7 +101,7 @@ def test_wcsgeom_read_write(tmp_path, npix, binsz, frame, proj, skydir, axes):
     hdulist.writeto(tmp_path / "tmp.fits")
 
     with fits.open(tmp_path / "tmp.fits", memmap=False) as hdulist:
-        geom1 = WcsGeom.from_header(hdulist[0].header, hdulist["BANDS"])
+        geom1 = WcsGeom.from_header(hdulist[0].header, hdulist["TEST_BANDS"])
 
     assert_allclose(geom0.npix, geom1.npix)
     assert geom0.frame == geom1.frame
@@ -111,7 +111,7 @@ def test_wcsgeom_to_hdulist():
     npix, binsz, frame, proj, skydir, axes = wcs_test_geoms[3]
     geom = WcsGeom.create(npix=npix, binsz=binsz, proj=proj, frame=frame, axes=axes)
 
-    hdu = geom.to_bands_hdu(hdu="TEST")
+    hdu = geom.to_bands_hdu(hdu_skymap="TEST")
     assert hdu.header["AXCOLS1"] == "E_MIN,E_MAX"
     assert hdu.header["AXCOLS2"] == "AXIS1_MIN,AXIS1_MAX"
 

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -93,7 +93,7 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, frame, proj, skydir, axes):
 def test_wcsgeom_read_write(tmp_path, npix, binsz, frame, proj, skydir, axes):
     geom0 = WcsGeom.create(npix=npix, binsz=binsz, proj=proj, frame=frame, axes=axes)
 
-    hdu_bands = geom0.to_bands_hdu(extname="TEST_BANDS")
+    hdu_bands = geom0.to_bands_hdu(hdu_bands="TEST_BANDS")
     hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.to_header())
 
@@ -111,7 +111,7 @@ def test_wcsgeom_to_hdulist():
     npix, binsz, frame, proj, skydir, axes = wcs_test_geoms[3]
     geom = WcsGeom.create(npix=npix, binsz=binsz, proj=proj, frame=frame, axes=axes)
 
-    hdu = geom.to_bands_hdu(extname="TEST")
+    hdu = geom.to_bands_hdu(hdu_bands="TEST")
     assert hdu.header["AXCOLS1"] == "E_MIN,E_MAX"
     assert hdu.header["AXCOLS2"] == "AXIS1_MIN,AXIS1_MAX"
 

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -194,9 +194,12 @@ class WcsMap(Map):
                     "All 'fgst' formats don't support extra axes except for energy."
                 )
 
+        if hdu_bands is None:
+            hdu_bands = f"{hdu.upper()}_BANDS"
+
         if self.geom.axes:
             hdu_bands_out = self.geom.to_bands_hdu(
-                hdu_skymap=hdu_bands, format=format
+                extname=hdu_bands, format=format
             )
             hdu_bands = hdu_bands_out.name
         else:

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -199,7 +199,7 @@ class WcsMap(Map):
 
         if self.geom.axes:
             hdu_bands_out = self.geom.to_bands_hdu(
-                extname=hdu_bands, format=format
+                hdu_bands=hdu_bands, format=format
             )
             hdu_bands = hdu_bands_out.name
         else:

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -196,7 +196,7 @@ class WcsMap(Map):
 
         if self.geom.axes:
             hdu_bands_out = self.geom.to_bands_hdu(
-                hdu=hdu_bands, hdu_skymap=hdu, format=format
+                hdu_skymap=hdu_bands, format=format
             )
             hdu_bands = hdu_bands_out.name
         else:


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request tries to correct the behavior of `Geom.to_bands_hdu`.  See issue #3240 .

Currently the `hdu` parameter is unused. This results in the impossibility to properly define the `hdu_bands` to use for `Map.to_hdulist`. 
Here the `hdu` parameter is removed and `hdu_skymap` is replaced with an `extname` keyword.

`Map.to_hdulist` sets the default to `HDU_BANDS` if input `hdu="HDU"` and `hdu_bands = None`. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This approach might not be the most relevant. One should be able to fully set the band hdu name. 
The PR is open for discussion.