### PR TITLE
Add disk edge illustration

### DIFF
--- a/docs/makers/index.rst
+++ b/docs/makers/index.rst
@@ -290,6 +290,15 @@ Gammapy tutorial notebooks that show examples using ``gammapy.makers``:
 * `spectrum_analysis.html <../tutorials/spectrum_analysis.html>`__
 * `spectrum_simulation.html <../tutorials/spectrum_simulation.html>`__
 
+
+.. toctree::
+    :maxdepth: 1
+
+    fov
+    reflected
+    ring
+
+
 Reference/API
 =============
 

--- a/examples/models/spatial/plot_disk.py
+++ b/examples/models/spatial/plot_disk.py
@@ -64,6 +64,37 @@ ax.plot([2, 2 + np.sin(phi)], [2, 2 + np.cos(phi)], color="r", transform=transfo
 ax.vlines(x=2, color="r", linestyle="--", transform=transform, ymin=0, ymax=5)
 ax.text(2.15, 2.3, r"$\phi$", transform=transform)
 
+
+# %%
+# This plot illustrates the definition of the edge parameter:
+
+import matplotlib.pyplot as plt
+from astropy import units as u
+from gammapy.modeling.models import DiskSpatialModel
+import numpy as np
+
+lons = np.linspace(0, 0.3, 500) * u.deg
+
+r_0, edge = 0.2 * u.deg, 0.1 * u.deg
+
+disk = DiskSpatialModel(lon_0="0 deg", lat_0="0 deg", r_0=r_0, edge=edge)
+profile = disk(lons, 0 * u.deg)
+
+plt.plot(lons, profile / profile.max(), alpha=0.5)
+plt.xlabel("Radius (deg)")
+plt.ylabel("Profile (A.U.)")
+
+edge_min, edge_max = (r_0 - edge / 2.).value, (r_0 + edge / 2.).value
+plt.vlines([edge_min, edge_max], 0, 1, linestyles=["--"], color="k")
+plt.annotate("", xy=(edge_min, 0.5), xytext=(edge_min + edge.value, 0.5),
+             arrowprops=dict(arrowstyle="<->", lw=2))
+plt.text(0.2, 0.53, "Edge width", ha="center", size=12)
+plt.hlines([0.95], edge_min - 0.02, edge_min + 0.02, linestyles=["-"], color="k")
+plt.text(edge_min + 0.02, 0.95, "95%", size=12, va="center")
+plt.hlines([0.05], edge_max - 0.02, edge_max + 0.02, linestyles=["-"], color="k")
+plt.text(edge_max - 0.02, 0.05, "5%", size=12, va="center", ha="right")
+plt.show()
+
 # %%
 # YAML representation
 # -------------------


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds back the illustration of the edge definition for the `DiskSpatialModel` (see https://docs.gammapy.org/0.12/api/gammapy.image.models.SkyDisk.html#gammapy.image.models.SkyDisk). For some reason it has been removed, but I think it's actually useful.

**Dear reviewer**
I'll merge once the CI builds are green...
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
