### PR TITLE
Fix evaluation radius for DiskSpatialModel and Generalized GaussianSpatialModel

### DIFF
--- a/examples/models/spatial/plot_gen_gauss.py
+++ b/examples/models/spatial/plot_gen_gauss.py
@@ -44,7 +44,7 @@ geom = WcsGeom.create(
     skydir=(lon_0, lat_0), binsz=dr, width=(2 * reval, 2 * reval), frame="galactic",
 )
 
-tags = [r"Disk, $\eta=0.01$", r"Gaussian, $\eta=0.5$", r"Laplacian, $\eta=1$"]
+tags = [r"Disk, $\eta=0.01$", r"Gaussian, $\eta=0.5$", r"Laplace, $\eta=1$"]
 eta_range = [0.01, 0.5, 1]
 r_0 = 1
 e = 0.5

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -520,16 +520,17 @@ class GeneralizedGaussianSpatialModel(SpatialModel):
             angle=self.phi.quantity,
             **kwargs,
         )
-        
+
     @property
     def evaluation_region(self):
         """Evaluation region"""
         region = self.to_region()
         scale = self.evaluation_radius / self.r_0.quantity
         # scale to be consistent with evaluation radius
-        region.height = scale * region.height  
+        region.height = scale * region.height
         region.width = scale * region.width
         return region
+
 
 class DiskSpatialModel(SpatialModel):
     r"""Constant disk model.

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -132,7 +132,7 @@ def test_generalized_gaussian_io():
     reg = model.to_region()
     assert isinstance(reg, EllipseSkyRegion)
     assert_allclose(reg.width.value, 1.73205, rtol=1e-5)
-    
+
     new_model = GeneralizedGaussianSpatialModel.from_dict(model.to_dict())
     assert isinstance(new_model, GeneralizedGaussianSpatialModel)
 
@@ -149,7 +149,7 @@ def test_sky_disk():
     assert_allclose(val.value, desired)
     radius = model.evaluation_radius
     assert radius.unit == "deg"
-    assert_allclose(radius.value, r_0.value)
+    assert_allclose(radius.value, r_0.value + model.edge.value)
 
     # test the normalization for an elongated ellipse near the Galactic Plane
     m_geom_1 = WcsGeom.create(
@@ -169,7 +169,7 @@ def test_sky_disk():
 
     radius = model_1.evaluation_radius
     assert radius.unit == "deg"
-    assert_allclose(radius.value, r_0.value)
+    assert_allclose(radius.value, r_0.value + model.edge.value)
     # test rotation
     r_0 = 2 * u.deg
     semi_minor = 1 * u.deg
@@ -267,7 +267,7 @@ def test_sky_diffuse_map(caplog):
     val = model(lon, lat)
 
     assert caplog.records[-1].levelname == "WARNING"
-    assert caplog.records[-1].message =="Missing spatial template unit, assuming sr^-1"
+    assert caplog.records[-1].message == "Missing spatial template unit, assuming sr^-1"
 
     assert val.unit == "sr-1"
     desired = [3269.178107, 0]


### PR DESCRIPTION
This PR fix the `evaluation_radius` for `DiskSpatialModel `and `GeneralizedGaussianSpatialModel` in order to prevent cuts of the models (at small radius for disk and large radius for gen-gauss).

The effect of these changes are shown [here](https://github.com/gammapy/gammapy/pull/3229#issuecomment-781318932).