### PR TITLE
Add how to to copy part of a datastore

### DIFF
--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -140,3 +140,12 @@ This axis is used to define the geometry of the `~gammapy.irf.PSFMap` and contro
 used to sample the PSF. This will reduce the quality of the PSF description.
 - If one or several IRFs are not required for the study at hand, it is possible not to build them
 by removing it from the list of options passed to the `~gammapy.makers.MapDatasetMaker`.
+
+Copy part of a datastore
+++++++++++++++++++++++++
+
+To share specific data from a database, it might be necessary to create a new data storage with
+a limited set of observations and summary files following the scheme described in gadf_.
+This is possible with the method `~gammapy.data.DataStore.copy_obs` provided by the
+`~gammapy.data.DataStore`. It allows to copy individual observations files in a given directory
+and build the associated observation and HDU tables.


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a howto on the extraction and copy of a sub-datastore with `DataStore.copy_obs()`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
