### PR TITLE
Clean up and fix WcsNDMap binary operations

### DIFF
--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -12,20 +12,16 @@ from astropy.coordinates import Angle
 from astropy.utils import lazyproperty
 from gammapy.datasets import Datasets
 from gammapy.datasets.map import MapEvaluator
-from gammapy.maps import Map, WcsGeom
+from gammapy.maps import Map
 from gammapy.modeling.models import PointSpatialModel, PowerLawSpectralModel, SkyModel
 from gammapy.stats import cash_sum_cython, f_cash_root_cython, norm_bounds_cython
-from gammapy.utils.array import shape_2N, symmetric_crop_pad_width
+from gammapy.utils.array import shape_2N, symmetric_crop_pad_width, round_up_to_odd
 from .core import Estimator
 from .utils import estimate_exposure_reco_energy
 
 __all__ = ["TSMapEstimator"]
 
 log = logging.getLogger(__name__)
-
-
-def round_up_to_odd(f):
-    return int(np.ceil(f) // 2 * 2 + 1)
 
 
 def _extract_array(array, shape, position):

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -387,6 +387,20 @@ def test_energy_mask():
     assert mask[1, 0, 0]
 
 
+def test_boundary_mask():
+    axis = MapAxis.from_edges([1, 10, 100])
+    geom = WcsGeom.create(
+        skydir=(0, 0),
+        binsz=0.02,
+        width=(2, 2),
+        axes=[axis],
+    )
+
+    mask = geom.boundary_mask(width=(0.3 * u.deg, 0.1 * u.deg))
+    assert np.sum(mask.data[0, :, :]) == 6300
+    assert np.sum(mask.data[1, :, :]) == 6300
+
+
 @pytest.mark.parametrize(
     ("width", "out"),
     [

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -801,10 +801,10 @@ def test_binary_erode():
     geom = WcsGeom.create(binsz=0.02, width=2 * u.deg)
     mask = geom.region_mask("icrs;circle(0, 0, 1)")
 
-    mask = mask.binary_erode(width=0.2 * u.deg, kernel="disk")
+    mask = mask.binary_erode(width=0.2 * u.deg, kernel="disk", use_fft=False)
     assert_allclose(mask.data.sum(), 4832)
 
-    mask = mask.binary_erode(width=0.2 * u.deg, kernel="box")
+    mask = mask.binary_erode(width=0.2 * u.deg, kernel="box", use_fft=True)
     assert_allclose(mask.data.sum(), 3372)
 
 
@@ -812,11 +812,11 @@ def test_binary_dilate():
     geom = WcsGeom.create(binsz=0.02, width=2 * u.deg)
     mask = geom.region_mask("icrs;circle(0, 0, 0.8)")
 
-    mask = mask.binary_dilate(width=0.2 * u.deg, kernel="disk")
+    mask = mask.binary_dilate(width=0.2 * u.deg, kernel="disk", use_fft=False)
     assert_allclose(mask.data.sum(), 8048)
 
     mask = mask.binary_dilate(width=(10, 10), kernel="box")
-    assert_allclose(mask.data.sum(), 9260)
+    assert_allclose(mask.data.sum(), 9203)
 
 
 def test_binary_dilate_erode_3d():

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -884,7 +884,9 @@ class WcsGeom(Geom):
         """
         from . import Map
         data = np.ones(self.data_shape, dtype=bool)
-        return Map.from_geom(self, data=data).binary_erode(width)
+        return Map.from_geom(self, data=data).binary_erode(
+            width=2 * u.Quantity(width), kernel="box"
+        )
 
     def region_mask(self, regions, inside=True):
         """Create a mask from a given list of regions

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -13,6 +13,7 @@ from astropy.wcs.utils import (
     proj_plane_pixel_scales,
     wcs_to_celestial_frame,
 )
+from gammapy.utils.array import round_up_to_odd
 from .geom import (
     Geom,
     MapAxes,
@@ -24,10 +25,6 @@ from .geom import (
 from .utils import INVALID_INDEX, slice_to_str, str_to_slice
 
 __all__ = ["WcsGeom"]
-
-
-def round_up_to_odd(f):
-    return int(np.ceil(f) // 2 * 2 + 1)
 
 
 def _check_width(width):
@@ -62,6 +59,7 @@ def _check_binsz(binsz):
         binsz[:2] = Angle(binsz[:2], unit="deg").deg
         return binsz
     return Angle(binsz, unit="deg").deg
+
 
 def cast_to_shape(param, shape, dtype):
     """Cast a tuple of parameter arrays to a given shape."""

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -561,7 +561,7 @@ class WcsNDMap(WcsMap):
         structure = self.geom.binary_structure(width=width, kernel=kernel)
 
         if use_fft:
-            return self.convolve(structure, use_fft=use_fft) > (structure.sum() - 1)
+            return self.convolve(structure.squeeze(), use_fft=use_fft) > (structure.sum() - 1)
 
         data = ndi.binary_erosion(self.data, structure=structure)
         return self._init_copy(data=data)
@@ -591,7 +591,7 @@ class WcsNDMap(WcsMap):
         structure = self.geom.binary_structure(width=width, kernel=kernel)
 
         if use_fft:
-            return self.convolve(structure, use_fft=use_fft) > 1
+            return self.convolve(structure.squeeze(), use_fft=use_fft) > 1
 
         data = ndi.binary_dilation(self.data, structure=structure)
         return self._init_copy(data=data)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -520,9 +520,6 @@ class WcsNDMap(WcsMap):
         if not self.geom.is_image:
             raise ValueError("Method only supported for 2D images")
 
-        idx = self.geom.get_idx()
-        coords_pix = PixCoord(idx[0][self.data], idx[1][self.data])
-
         if isinstance(region, SkyRegion):
             region = region.to_pixel(self.geom.wcs)
 
@@ -530,6 +527,9 @@ class WcsNDMap(WcsMap):
             lon, lat = region.center.x, region.center.y
             return self.get_by_pix((lon, lat))[0]
 
+        idx = self.geom.get_idx()
+        coords_pix = PixCoord(idx[0][self.data], idx[1][self.data])
+        
         return np.any(region.contains(coords_pix))
 
     def binary_erode(self, width, kernel="disk", use_fft=True):

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -14,7 +14,6 @@ from gammapy.extern.skimage import block_reduce
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
 from gammapy.utils.random import InverseCDFSampler, get_random_state
 from gammapy.utils.units import unit_from_fits_image_hdu
-from gammapy.utils.array import round_up_to_odd
 from .geom import MapCoord, pix_tuple_to_idx
 from .regionnd import RegionGeom, RegionNDMap
 from .utils import INVALID_INDEX
@@ -628,7 +627,7 @@ class WcsNDMap(WcsMap):
             raise ValueError("Binary operations only supported for boolean masks")
 
         structure = self.geom.binary_structure(width=width, kernel=kernel)
-        data = ndi.binary_dilate(self.data, structure)
+        data = ndi.binary_dilation(self.data, structure)
         return self._init_copy(data=data)
 
     def convolve(self, kernel, use_fft=True, **kwargs):

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -603,8 +603,10 @@ class WcsNDMap(WcsMap):
 
         if mode == "full":
             geom = self.geom.pad(width // 2)
-        else:
+        elif mode == "same":
             geom = self.geom
+        else:
+            raise ValueError(f"Not a valid mode '{mode}', choose from: ['same', 'full']")
 
         shape = (1,) * len(self.geom.axes) + structure.shape
         data = func(self.data, structure.reshape(shape))

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -251,7 +251,7 @@ class SkyModel(Model):
             mask = geom.region_mask([mask.geom.region])
 
         if margin is not None:
-            mask = mask.binary_dilate(width=margin, mode="full")
+            mask = mask.binary_dilate(width=margin)
 
         # check center only first (faster)
         if np.nan_to_num(mask.get_by_coord(self.position)[0]):

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -100,7 +100,7 @@ def test_select_mask(models_gauss):
     inside = models_gauss.select_mask(mask, margin=None, use_evaluation_region=False)
     assert inside.names == ["source-1"]
 
-    contribute_margin = models_gauss    .select_mask(mask, margin=0.1 * u.deg, use_evaluation_region=True)
+    contribute_margin = models_gauss.select_mask(mask, margin=0.5 * u.deg, use_evaluation_region=True)
     assert contribute_margin.names == ["source-1", "source-2", "source-3"]
 
 

--- a/gammapy/utils/array.py
+++ b/gammapy/utils/array.py
@@ -86,6 +86,22 @@ def shape_divisible_by(shape, factor):
     return tuple(new_shape)
 
 
+def round_up_to_odd(f):
+    """Round float to odd integer
+
+    Parameters
+    ----------
+    f : float
+        Float value
+
+    Returns
+    -------
+    int : int
+        Odd integer
+    """
+    return (np.ceil(f) // 2 * 2 + 1).astype(int)
+
+
 def symmetric_crop_pad_width(shape, new_shape):
     """
     Compute symmetric crop or pad width.


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request unifies and fixe the binary operations on the `WcsNDMap`:
- Allow choice of the there kernel shape between box and disk
- Add fft option uniformly
- Fix fft option, which was broken before 

Before:


![image](https://user-images.githubusercontent.com/3715928/108528447-b6794980-72d3-11eb-9f7d-cd3d6cdfb846.png)
After:

![image](https://user-images.githubusercontent.com/3715928/108528150-65695580-72d3-11eb-881d-9c9317b635fc.png)

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
