### PR TITLE
Add caplog for safe mask maker tests

### DIFF
--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -74,14 +74,11 @@ def test_datastore_from_events():
 
 
 @requires_data()
-def test_datastore_get_observations(data_store, caplog):
+def test_datastore_get_observations(data_store):
     """Test loading data and IRF files via the DataStore"""
     observations = data_store.get_observations([23523, 23592])
     assert observations[0].obs_id == 23523
-    for record in caplog.records:
-        assert record.levelname == "WARNING"
-        assert record.message == "Skipping missing obs_id"
-        assert record.message == "Skipping run with missing IRFs; obs_id"
+
     # Test that default is all observations
     observations = data_store.get_observations()
     assert len(observations) == 105

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -74,11 +74,14 @@ def test_datastore_from_events():
 
 
 @requires_data()
-def test_datastore_get_observations(data_store):
+def test_datastore_get_observations(data_store, caplog):
     """Test loading data and IRF files via the DataStore"""
     observations = data_store.get_observations([23523, 23592])
     assert observations[0].obs_id == 23523
-
+    for record in caplog.records:
+        assert record.levelname == "WARNING"
+        assert record.message == "Skipping missing obs_id"
+        assert record.message == "Skipping run with missing IRFs; obs_id"
     # Test that default is all observations
     observations = data_store.get_observations()
     assert len(observations) == 105

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -16,7 +16,7 @@ def observations():
 
 
 @requires_data()
-def test_safe_mask_maker(observations):
+def test_safe_mask_maker(observations, caplog):
     obs = observations[0]
 
     axis = MapAxis.from_bounds(
@@ -51,3 +51,6 @@ def test_safe_mask_maker(observations):
 
     mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
     assert_allclose(mask_bkg_peak.data.sum(), 1815)
+    #assert "No default thresholds defined for obs"
+    assert caplog.records[-1].levelname == "WARNING"
+    assert caplog.records[-1].message == "No default thresholds defined for obs 110380"

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -50,7 +50,6 @@ def test_safe_mask_maker(observations, caplog):
     assert_allclose(mask_edisp_bias.data.sum(), 1815)
 
     mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
-    assert_allclose(mask_bkg_peak.data.sum(), 1815)
-    #assert "No default thresholds defined for obs"
+    assert_allclose(mask_bkg_peak.data.sum(), 1815)      
     assert caplog.records[-1].levelname == "WARNING"
     assert caplog.records[-1].message == "No default thresholds defined for obs 110380"


### PR DESCRIPTION


This pull request adds caplog to test_safe
 