### PR TITLE
Fix model contribution selection

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2568,14 +2568,9 @@ class MapEvaluator:
 
         if self.evaluation_mode == "local":
             self._init_position = self.model.position
-
-            try:
-                mask_cutout = mask.cutout(
-                    position=self.model.position, width=self.cutout_width
-                )
-                self.contributes = np.any(mask_cutout.data)
-            except (NoOverlapError, ValueError):
-                self.contributes = False
+            self.contributes = self.model.contributes(
+                mask=mask, margin=self.psf_width
+            )
 
             if self.contributes:
                 self.exposure = exposure.cutout(

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -419,7 +419,7 @@ class MapDataset(Dataset):
                     self.psf,
                     self.edisp,
                     self._geom,
-                    self.mask,
+                    self.mask_image,
                 )
 
             if evaluator.contributes:
@@ -545,6 +545,16 @@ class MapDataset(Dataset):
         if self.mask_safe is None:
             return None
         return self.mask_safe.reduce_over_axes(func=np.logical_or)
+
+    @property
+    def mask_image(self):
+        """Reduced mask"""
+        if self.mask is None:
+            mask = Map.from_geom(self._geom.to_image(), dtype=bool)
+            mask.data |= True
+            return mask
+
+        return self.mask.reduce_over_axes(func=np.logical_or)
 
     @property
     def mask_safe_psf(self):
@@ -2537,10 +2547,6 @@ class MapEvaluator:
         # TODO: simplify and clean up
         log.debug("Updating model evaluator")
 
-        if mask is None:
-            mask = Map.from_geom(geom.to_image(), dtype=bool)
-            mask.data |= True
-
         # lookup edisp
         if edisp:
             energy_axis = geom.axes["energy"]
@@ -2562,16 +2568,19 @@ class MapEvaluator:
 
         if self.evaluation_mode == "local":
             self._init_position = self.model.position
-            self.contributes = self.model.contributes(
-                mask=mask, margin=self.psf_width, use_evaluation_region=True
-            )
 
             try:
+                mask_cutout = mask.cutout(
+                    position=self.model.position, width=self.cutout_width
+                )
+                self.contributes = np.any(mask_cutout.data)
+            except (NoOverlapError, ValueError):
+                self.contributes = False
+
+            if self.contributes:
                 self.exposure = exposure.cutout(
                     position=self.model.position, width=self.cutout_width
                 )
-            except (NoOverlapError, ValueError):
-                pass
         else:
             self.exposure = exposure
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1457,8 +1457,9 @@ def test_source_outside_geom_fermi():
     source = catalog["3FHL J1637.8-3448"]
 
     dataset.models = source.sky_model()
-
     npred = dataset.npred()
+
+    assert_allclose(npred.data.sum(), 28548.63, rtol=1e-4)
 
 
 def test_region_geom_io(tmpdir):

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -6,7 +6,8 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from regions import CircleSkyRegion
-from gammapy.data import GTI, Observation
+from gammapy.catalog import SourceCatalog3FHL
+from gammapy.data import GTI
 from gammapy.datasets import Datasets, MapDataset, MapDatasetOnOff
 from gammapy.datasets.map import MapEvaluator, RAD_AXIS_DEFAULT
 from gammapy.irf import (
@@ -1444,6 +1445,20 @@ def test_source_outside_geom(sky_model, geom, geom_etrue):
     assert np.sum(np.isnan(model_npred)) == 0
     assert np.sum(~np.isfinite(model_npred)) == 0
     assert np.sum(model_npred) > 0
+
+
+# this is a regression test for an issue found, where the model selection fails
+def test_source_outside_geom_fermi():
+    dataset = MapDataset.read(
+        "$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc.fits.gz", format="gadf"
+    )
+
+    catalog = SourceCatalog3FHL()
+    source = catalog["3FHL J1637.8-3448"]
+
+    dataset.models = source.sky_model()
+
+    npred = dataset.npred()
 
 
 def test_region_geom_io(tmpdir):

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1448,6 +1448,7 @@ def test_source_outside_geom(sky_model, geom, geom_etrue):
 
 
 # this is a regression test for an issue found, where the model selection fails
+@requires_data()
 def test_source_outside_geom_fermi():
     dataset = MapDataset.read(
         "$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc.fits.gz", format="gadf"

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -655,7 +655,7 @@ class Map(abc.ABC):
         data = self.data[idx[::-1]]
         return self.__class__(geom=geom, data=data, unit=self.unit, meta=self.meta)
 
-    def get_by_coord(self, coords):
+    def get_by_coord(self, coords, fill_value=np.nan):
         """Return map values at the given map coordinates.
 
         Parameters
@@ -664,6 +664,9 @@ class Map(abc.ABC):
             Coordinate arrays for each dimension of the map.  Tuple
             should be ordered as (lon, lat, x_0, ..., x_n) where x_i
             are coordinates for non-spatial dimensions of the map.
+        fill_value : float
+            Value which is returned if the position is outside of the projection
+            footprint
 
         Returns
         -------
@@ -675,10 +678,10 @@ class Map(abc.ABC):
             coords, frame=self.geom.frame, axis_names=self.geom.axes.names
         )
         pix = self.geom.coord_to_pix(coords)
-        vals = self.get_by_pix(pix)
+        vals = self.get_by_pix(pix, fill_value=fill_value)
         return vals
 
-    def get_by_pix(self, pix):
+    def get_by_pix(self, pix, fill_value=np.nan):
         """Return map values at the given pixel coordinates.
 
         Parameters
@@ -688,6 +691,9 @@ class Map(abc.ABC):
             Tuple should be ordered as (I_lon, I_lat, I_0, ..., I_n)
             for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
             Pixel indices can be either float or integer type.
+        fill_value : float
+            Value which is returned if the position is outside of the projection
+            footprint
 
         Returns
         -------
@@ -703,9 +709,8 @@ class Map(abc.ABC):
         mask = self.geom.contains_pix(pix)
 
         if not mask.all():
-            invalid = INVALID_VALUE[self.data.dtype]
-            vals = vals.astype(type(invalid))
-            vals[~mask] = invalid
+            vals = vals.astype(type(fill_value))
+            vals[~mask] = fill_value
 
         return vals
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -525,12 +525,13 @@ class WcsNDMap(WcsMap):
 
         if isinstance(region, PointPixelRegion):
             lon, lat = region.center.x, region.center.y
-            return bool(np.nan_to_num(self.get_by_pix((lon, lat))[0]))
+            contains = self.get_by_pix((lon, lat))
+        else:
+            idx = self.geom.get_idx()
+            coords_pix = PixCoord(idx[0][self.data], idx[1][self.data])
+            contains = region.contains(coords_pix)
 
-        idx = self.geom.get_idx()
-        coords_pix = PixCoord(idx[0][self.data], idx[1][self.data])
-        
-        return np.any(region.contains(coords_pix))
+        return np.any(contains)
 
     def binary_erode(self, width, kernel="disk", use_fft=True):
         """Binary erosion of boolean mask removing a given margin

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -663,11 +663,12 @@ class DatasetModels(collections.abc.Sequence):
             mask = mask.reduce_over_axes(func=np.logical_or)
 
         for model in self.select(tag="sky-model"):
-            if model.contributes(
-                    mask=mask,
-                    margin=margin,
-                    use_evaluation_region=use_evaluation_region
-            ):
+            if use_evaluation_region:
+                contributes = model.contributes(mask=mask, margin=margin)
+            else:
+                contributes = mask.get_by_coord(model.position, fill_value=0)
+
+            if np.any(contributes):
                 models.append(model)
 
         return self.__class__(models=models)

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -639,7 +639,7 @@ class DatasetModels(collections.abc.Sequence):
 
         return np.array(selection, dtype=bool)
 
-    def select_mask(self, mask, margin=None, use_evaluation_region=True):
+    def select_mask(self, mask, margin="0 deg", use_evaluation_region=True):
         """Check if sky models contribute within a mask map.
     
         Parameters
@@ -648,7 +648,7 @@ class DatasetModels(collections.abc.Sequence):
             Map containing a boolean mask
         margin : `~astropy.unit.Quantity`
             Add a margin in degree to the source evaluation radius.
-            The default is None. Used to take into account PSF width.
+            Used to take into account PSF width.
         use_evaluation_region : bool
             Account for the extension of the model or not. The default is True.   
 

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -99,7 +99,7 @@ def test_select_mask(models_gauss):
     inside = models_gauss.select_mask(mask, use_evaluation_region=False)
     assert inside.names == ["source-1"]
 
-    contribute_margin = models_gauss.select_mask(mask, margin=0.5 * u.deg, use_evaluation_region=True)
+    contribute_margin = models_gauss.select_mask(mask, margin=0.6 * u.deg, use_evaluation_region=True)
     assert contribute_margin.names == ["source-1", "source-2", "source-3"]
 
 

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -1,6 +1,5 @@
 import pytest
 import numpy as np
-import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 from regions import CircleSkyRegion
@@ -94,10 +93,10 @@ def test_select_mask(models_gauss):
 
     mask = geom.region_mask([circle])
 
-    contribute = models_gauss.select_mask(mask, margin=None, use_evaluation_region=True)
+    contribute = models_gauss.select_mask(mask, use_evaluation_region=True)
     assert contribute.names == ["source-1", "source-2"]
 
-    inside = models_gauss.select_mask(mask, margin=None, use_evaluation_region=False)
+    inside = models_gauss.select_mask(mask, use_evaluation_region=False)
     assert inside.names == ["source-1"]
 
     contribute_margin = models_gauss.select_mask(mask, margin=0.5 * u.deg, use_evaluation_region=True)
@@ -120,7 +119,7 @@ def test_contributes(models):
         spectral_model=PowerLawSpectralModel(),
         name="source-4",
     )
-    assert model4.contributes(mask, margin=None, use_evaluation_region=True)
+    assert model4.contributes(mask, margin=0*u.deg)
 
 
 def test_select(models):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes a bug in the model contribution selection. In the previous implementation, based on the evaluation region, the model could be selected to contribute, however the subsequent call to `exposure.cutout()` would fail. The issue is not understood completely, however the two approaches with checking the containment of the evaluation region and doing the cutout are not guaranteed to be consistent: the width computation in the cutout is based on the projected pixel scale, while the region containment is based on the angular separation of the pixelized region.

This PR makes the behaviour consistent, by relying on `.cutout()` for the mask as well as exposure selection and adds a regression test.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
