### PR TITLE
Implement and clean-up IRF normalisation

### DIFF
--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -263,7 +263,7 @@ def test_to_spectrum_dataset(sky_model, geom, geom_etrue, edisp_mode):
     assert spectrum_dataset_mask.data_shape == (2, 1, 1)
     assert spectrum_dataset_corrected.exposure.unit == "m2s"
     assert_allclose(spectrum_dataset.exposure.data[1], 3.070884e09, rtol=1e-5)
-    assert_allclose(spectrum_dataset_corrected.exposure.data[1], 2.059559e09, rtol=1e-5)
+    assert_allclose(spectrum_dataset_corrected.exposure.data[1], 2.05201e+09, rtol=1e-5)
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -648,7 +648,7 @@ def test_create_with_migra(tmp_path):
     assert isinstance(empty_dataset.edisp, EDispMap)
     assert empty_dataset.edisp.edisp_map.data.shape == (3, 50, 10, 10)
     assert empty_dataset.edisp.exposure_map.data.shape == (3, 1, 10, 10)
-    assert_allclose(empty_dataset.edisp.edisp_map.data.sum(), 300)
+    assert_allclose(empty_dataset.edisp.edisp_map.data.sum(), 5000)
 
     assert_allclose(empty_dataset.gti.time_delta, 0.0 * u.s)
 
@@ -969,7 +969,7 @@ def test_create_onoff(geom):
     assert empty_dataset.edisp.edisp_map.data.shape == (2, 50, 10, 10)
     assert empty_dataset.edisp.exposure_map.data.shape == (2, 1, 10, 10)
 
-    assert_allclose(empty_dataset.edisp.edisp_map.data.sum(), 200)
+    assert_allclose(empty_dataset.edisp.edisp_map.data.sum(), 3333.333333)
 
     assert_allclose(empty_dataset.gti.time_delta, 0.0 * u.s)
 

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -186,6 +186,41 @@ class IRF:
         values = kwargs[axis_name]
         return trapz_loglog(data, values, axis=axis)
 
+    def cumsum(self, axis_name):
+        """Compute cumsum along a given axis
+
+        Parameters
+        ----------
+        axis_name : str
+            Along which axis to integrate.
+
+        Returns
+        -------
+        irf : `~IRF`
+            Cumsum IRF
+
+        """
+        axis = self.axes[axis_name]
+        axis_idx = self.axes.index(axis_name)
+
+        # TODO: the broadcasting should be done by axis.center, axis.bin_width etc.
+        shape = [1] * len(self.axes)
+        shape[axis_idx] = -1
+
+        values = self.quantity * axis.bin_width.reshape(shape)
+
+        if axis_name == "rad":
+            # take Jacobian into account
+            values = 2 * np.pi * axis.center.reshape(shape) * values
+
+        data = values.cumsum(axis=axis_idx)
+
+        axis_shifted = MapAxis.from_nodes(
+            axis.edges[1:], name=axis.name, interp=axis.interp
+        )
+        axes = self.axes.replace(axis_shifted)
+        return self.__class__(axes=axes, data=data.value, unit=data.unit)
+
     def integral(self, axis_name, **kwargs):
         """Compute integral along a given axis
 
@@ -204,33 +239,8 @@ class IRF:
             Returns 2D array with axes offset
 
         """
-        axis = self.axes[axis_name]
-        axis_idx = self.axes.index(axis_name)
-
-        # TODO: the broadcasting should be done by axis.center, axis.bin_width etc.
-        shape = [1] * len(self.axes)
-        shape[axis_idx] = -1
-
-        values = self.quantity * axis.bin_width.reshape(shape)
-
-        if axis_name == "rad":
-            # take Jacobian into account
-            values = 2 * np.pi * axis.center.reshape(shape) * values
-
-        values = values.cumsum(axis=axis_idx)
-
-        points = [ax.center for ax in self.axes]
-        points[axis_idx] = axis.edges[1:]
-
-        f_integrate = ScaledRegularGridInterpolator(
-            points=points, values=values,
-        )
-        try:
-            coords = tuple(kwargs[name] for name in self.axes.names)
-        except KeyError as exc:
-            raise ValueError(f"Missing coordinate for axis: {str(exc)}")
-
-        return f_integrate(coords)
+        cumsum = self.cumsum(axis_name=axis_name)
+        return cumsum.evaluate(**kwargs)
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu=None, format="gadf-dl3"):

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -242,6 +242,23 @@ class IRF:
         cumsum = self.cumsum(axis_name=axis_name)
         return cumsum.evaluate(**kwargs)
 
+    def normalize(self, axis_name):
+        """Normalise data in place along a given axis.
+
+        Parameters
+        ----------
+        axis_name : str
+            Along which axis to normalize.
+
+        """
+        cumsum = self.cumsum(axis_name=axis_name).quantity
+
+        with np.errstate(invalid="ignore", divide="ignore"):
+            axis = self.axes.index(axis_name=axis_name)
+            normed = self.quantity / cumsum.max(axis=axis, keepdims=True)
+
+        self.data = np.nan_to_num(normed)
+
     @classmethod
     def from_hdulist(cls, hdulist, hdu=None, format="gadf-dl3"):
         """Create from `~astropy.io.fits.HDUList`.

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -257,7 +257,7 @@ class IRF:
             axis = self.axes.index(axis_name=axis_name)
             normed = self.quantity / cumsum.max(axis=axis, keepdims=True)
 
-        self.data = np.nan_to_num(normed)
+        self.quantity = np.nan_to_num(normed)
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu=None, format="gadf-dl3"):

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -89,6 +89,10 @@ class EDispMap(IRFMap):
     def edisp_map(self, value):
         self._irf_map = value
 
+    def normalize(self):
+        """Normalize PSF map"""
+        self.edisp_map.normalize(axis_name="migra")
+
     def get_edisp_kernel(self, position, energy_axis):
         """Get energy dispersion at a given position.
 

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -125,7 +125,7 @@ class EDispMap(IRFMap):
         }
 
         values = self.edisp_map.integral(
-            axis_name="migra", coords=coords, normalize=True
+            axis_name="migra", coords=coords
         )
 
         data = np.diff(np.clip(values, 0, 1))
@@ -164,7 +164,7 @@ class EDispMap(IRFMap):
         migra = geom.get_idx()[2]
         data = np.abs(migra - migra_0)
         data = np.where(data < 1, 1 - data, 0)
-        edisp_map.quantity = data
+        edisp_map.quantity = data / migra_axis.bin_width.reshape((1, -1, 1, 1))
         return cls(edisp_map, exposure_edisp)
 
     def sample_coord(self, map_coord, random_state=0):

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -152,12 +152,7 @@ class EnergyDispersion2D(IRF):
 
     def normalize(self):
         """Normalise energy dispersion"""
-        cumsum = self.cumsum(axis_name="migra").quantity
-
-        with np.errstate(invalid="ignore", divide="ignore"):
-            normed = self.quantity / cumsum.max(axis=1, keepdims=True)
-
-        self.data = np.nan_to_num(normed)
+        super().normalize(axis_name="migra")
 
     def plot_migration(
         self, ax=None, offset=None, energy_true=None, migra=None, **kwargs

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -152,10 +152,12 @@ class EnergyDispersion2D(IRF):
 
     def normalize(self):
         """Normalise energy dispersion"""
-        coords = self.axes.get_coord()
-        coords["migra"] = self.axes["migra"].edges[-1]
-        integral = self.integral(axis_name="migra", **coords)
-        self.data /= integral.to_value(self.unit)
+        cumsum = self.cumsum(axis_name="migra").quantity
+
+        with np.errstate(invalid="ignore", divide="ignore"):
+            normed = self.quantity / cumsum.max(axis=1, keepdims=True)
+
+        self.data = np.nan_to_num(normed)
 
     def plot_migration(
         self, ax=None, offset=None, energy_true=None, migra=None, **kwargs

--- a/gammapy/irf/psf/core.py
+++ b/gammapy/irf/psf/core.py
@@ -10,9 +10,8 @@ class PSF(IRF):
     """PSF base class"""
 
     def normalize(self):
-        """Normalize PSF to integrate to unity"""
-        rad_max = self.axes["rad"].edges.max()
-        self.data /= self.containment(rad=rad_max)
+        """Normalise psf"""
+        super().normalize(axis_name="rad")
 
     def containment(self, rad, **kwargs):
         """Containment tof the PSF at given axes coordinates

--- a/gammapy/irf/psf/psf_map.py
+++ b/gammapy/irf/psf/psf_map.py
@@ -75,6 +75,10 @@ class PSFMap(IRFMap):
     def psf_map(self, value):
         self._irf_map = value
 
+    def normalize(self):
+        """Normalize PSF map"""
+        self.psf_map.normalize(axis_name="rad")
+
     @classmethod
     def from_geom(cls, geom):
         """Create psf map from geom.

--- a/gammapy/irf/psf/tests/test_psf_map.py
+++ b/gammapy/irf/psf/tests/test_psf_map.py
@@ -76,7 +76,7 @@ def test_make_psf_map():
 
     assert psfmap.psf_map.geom.axes[0] == rad_axis
     assert psfmap.psf_map.geom.axes[1] == energy_axis
-    assert psfmap.psf_map.unit == Unit("sr-1")
+    assert psfmap.psf_map.unit == "deg-2"
     assert psfmap.psf_map.data.shape == (4, 50, 25, 25)
 
 
@@ -197,8 +197,8 @@ def test_psfmap_stacking():
     psfmap_stack.stack(psfmap3)
 
     assert_allclose(psfmap_stack.psf_map.data[0, 40, 20, 20], 0.0)
-    assert_allclose(psfmap_stack.psf_map.data[0, 20, 20, 20], 5805.28955078125)
-    assert_allclose(psfmap_stack.psf_map.data[0, 0, 20, 20], 58052.78955078125)
+    assert_allclose(psfmap_stack.psf_map.data[0, 20, 20, 20], 1.768388, rtol=1e-6)
+    assert_allclose(psfmap_stack.psf_map.data[0, 0, 20, 20], 17.683883, rtol=1e-6)
 
 
 # TODO: add a test comparing make_mean_psf and PSFMap.stack for a set of observations in an Observations
@@ -282,7 +282,7 @@ def make_psf_map_obs(geom, obs):
             "psf_rad": 0.000524,
             "psf_exposure": 3.14711e12 * u.Unit("cm2 s"),
             "psf_value_shape": (32, 1000),
-            "psf_value": 25888.5047 * u.Unit("sr-1"),
+            "psf_value": 2.619861 * u.Unit("deg-2"),
         },
         {
             "energy": MapAxis.from_energy_bounds(1, 10, 100, "TeV", name="energy_true"),
@@ -293,7 +293,7 @@ def make_psf_map_obs(geom, obs):
             "psf_rad": 0.000524,
             "psf_exposure": 4.723409e12 * u.Unit("cm2 s"),
             "psf_value_shape": (100, 1000),
-            "psf_value": 22453.412121 * u.Unit("sr-1"),
+            "psf_value": 2.238232 * u.Unit("deg-2"),
         },
     ],
 )
@@ -336,7 +336,7 @@ def test_make_psf(pars, data_store):
     assert_allclose(exposure[15], pars["psf_exposure"], rtol=1e-3)
 
     data = psf.psf_map.quantity.squeeze()
-    assert data.unit == "sr-1"
+    assert data.unit == "deg-2"
     assert data.shape == pars["psf_value_shape"]
     assert_allclose(data[15, 50], pars["psf_value"], rtol=1e-3)
 
@@ -411,7 +411,7 @@ def test_to_image():
     psf2D = psfmap.to_image()
     assert_allclose(psf2D.psf_map.geom.data_shape, (1, 100, 25, 25))
     assert_allclose(psf2D.exposure_map.geom.data_shape, (1, 1, 25, 25))
-    assert_allclose(psf2D.psf_map.data[0][0][12][12], 23255.41204827, rtol=1e-2)
+    assert_allclose(psf2D.psf_map.data[0][0][12][12], 7.068315, rtol=1e-2)
 
 
 def test_psf_map_from_gauss():

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -274,4 +274,4 @@ class TestSpectrumMakerChain:
         dataset = safe_mask_maker.run(dataset, obs)
 
         actual = dataset.energy_range[0]
-        assert_quantity_allclose(actual, 0.8799225 * u.TeV, rtol=1e-3)
+        assert_quantity_allclose(actual, 0.774264 * u.TeV, rtol=1e-3)

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -238,17 +238,16 @@ def make_psf_map(psf, pointing, geom, exposure_map=None):
     offset = geom.separation(pointing)
 
     # Compute PSF values
-    psf_values = psf.evaluate(
+    data = psf.evaluate(
             energy_true=energy_true[:, np.newaxis, np.newaxis, np.newaxis],
             offset=offset,
             rad=rad[:, np.newaxis, np.newaxis],
     )
 
-    # TODO: this probably does not ensure that probability is properly normalized in the PSFMap
     # Create Map and fill relevant entries
-    data = psf_values.to_value("sr-1")
-    psfmap = Map.from_geom(geom, data=data, unit="sr-1")
-    return PSFMap(psfmap, exposure_map)
+    psf_map = Map.from_geom(geom, data=data.value, unit=data.unit)
+    psf_map.normalize(axis_name="rad")
+    return PSFMap(psf_map, exposure_map)
 
 
 def make_edisp_map(edisp, pointing, geom, exposure_map=None, use_region_center=True):
@@ -306,8 +305,9 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None, use_region_center=T
         data = edisp_values
 
     # Create Map and fill relevant entries
-    edispmap = Map.from_geom(geom, data=data, unit="")
-    return EDispMap(edispmap, exposure_map)
+    edisp_map = Map.from_geom(geom, data=data, unit="")
+    edisp_map.normalize(axis_name="migra")
+    return EDispMap(edisp_map, exposure_map)
 
 
 def make_edisp_kernel_map(edisp, pointing, geom, exposure_map=None, use_region_center=True):

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1260,7 +1260,7 @@ class Map(abc.ABC):
         axis_idx = self.geom.axes.index_data(axis_name)
 
         # TODO: the broadcasting should be done by axis.center, axis.bin_width etc.
-        shape = [1] * len(self.data.shape)
+        shape = [1] * self.geom.ndim
         shape[axis_idx] = -1
 
         values = self.quantity * axis.bin_width.reshape(shape)
@@ -1299,7 +1299,11 @@ class Map(abc.ABC):
             Returns 2D array with axes offset
         """
         cumsum = self.cumsum(axis_name=axis_name)
-        return u.Quantity(cumsum.interp_by_coord(coords, **kwargs), cumsum.unit, copy=False)
+        return u.Quantity(
+            cumsum.interp_by_coord(coords, **kwargs),
+            cumsum.unit,
+            copy=False
+        )
 
     def normalize(self, axis_name=None):
         """Normalise data in place along a given axis.


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

In many situations we required "normalised" IRF to compute e.g. containment radii for PRFs, distributions of migra etc. This pull request implements and cleans up the handling of the IRF normalisation. For this it implements a `IRF.normalize(axis_name=)` and `Map.normalize(axis_name=)` method as well as the corresponding implementations in `PSFMap`, `EDispMap`, `PSF`, `EnergyDispersion` etc. By default a normalised `PSFMap` and `EDispMap` is computed.


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
