### PR TITLE
Correct fractional excess variance formula according to reference

### DIFF
--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -45,7 +45,7 @@ def compute_fvar(flux, flux_err):
     sig_square = np.nansum(flux_err ** 2) / n_points
     fvar = np.sqrt(np.abs(s_square - sig_square)) / flux_mean
 
-    sigxserr_a = np.sqrt(2 / n_points) * (sig_square / flux_mean) ** 2
+    sigxserr_a = np.sqrt(2 / n_points) * sig_square / flux_mean ** 2
     sigxserr_b = np.sqrt(sig_square / n_points) * (2 * fvar / flux_mean)
     sigxserr = np.sqrt(sigxserr_a ** 2 + sigxserr_b ** 2)
     fvar_err = sigxserr / (2 * fvar)


### PR DESCRIPTION
Looking at the [reference](https://arxiv.org/pdf/astro-ph/0307420.pdf), in particular equation 11, it should be σ²err / xbar², not (σ²err / xbar)².


<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes the code to follow the equation.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
