### PR TITLE
Automate release process with Github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
       - name: modif docs
         run: |
           release="${{ github.event.release.tag_name }}"
-          sed -i -E "s/gammapy-.*-environment.yml/gammapy-$release-environment.yml/" docs/install/index.rst
-          sed -i -E "s/called\s``gammapy-.*``/called ``gammapy-$release``/" docs/install/index.rst
-          sed -i -E "s/activate\sgammapy-.*/activate gammapy-$release/" docs/install/index.rst
-          sed -i -E "s/--release\s.*/--release $release/" docs/install/index.rst
+          sed -i -E "s/gammapy-.*-environment.yml/gammapy-$release-environment.yml/" docs/getting-started/iquickstartndex.rst
+          sed -i -E "s/called\s``gammapy-.*``/called ``gammapy-$release``/" docs/getting-started/quickstart.rst
+          sed -i -E "s/activate\sgammapy-.*/activate gammapy-$release/" docs/getting-started/quickstart.rst
+          sed -i -E "s/--release\s.*/--release $release/" docs/getting-started/quickstart.rst
       - name: dispatch web
         run: |
           curl -XPOST -u "${{ secrets.REMOTE_DISPATCH }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: release
+on:
+  release:
+    types: [published]
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: modif docs
+        run: |
+          release="${{ github.event.release.tag_name }}"
+          sed -i -E "s/gammapy-.*-environment.yml/gammapy-$release-environment.yml/" docs/install/index.rst
+          sed -i -E "s/called\s``gammapy-.*``/called ``gammapy-$release``/" docs/install/index.rst
+          sed -i -E "s/activate\sgammapy-.*/activate gammapy-$release/" docs/install/index.rst
+          sed -i -E "s/--release\s.*/--release $release/" docs/install/index.rst
+      - name: dispatch web
+        run: |
+          curl -XPOST -u "${{ secrets.REMOTE_DISPATCH }}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          -H "Content-Type: application/json" https://api.github.com/repos/gammapy/gammapy-webpage/dispatches \
+          --data '{"event_type": "release", "client_payload": { "release": "${{ github.event.release.tag_name }}" }}'
+      - name: dispatch docs
+        run: |
+          curl -XPOST -u "${{ secrets.REMOTE_DISPATCH }}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          -H "Content-Type: application/json" https://api.github.com/repos/gammapy/gammapy-docs/dispatches \
+          --data '{"event_type": "release", "client_payload": { "release": "${{ github.event.release.tag_name }}" }}'
+      - name: commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4.9.0
+        with:
+          branch: master
+          commit_author: GitHub Actions <actions@github.com>
+          commit_message: commit docs modif

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: modif docs
         run: |
           release="${{ github.event.release.tag_name }}"
-          sed -i -E "s/gammapy-.*-environment.yml/gammapy-$release-environment.yml/" docs/getting-started/iquickstartndex.rst
+          sed -i -E "s/gammapy-.*-environment.yml/gammapy-$release-environment.yml/" docs/getting-started/quickstart.rst
           sed -i -E "s/called\s``gammapy-.*``/called ``gammapy-$release``/" docs/getting-started/quickstart.rst
           sed -i -E "s/activate\sgammapy-.*/activate gammapy-$release/" docs/getting-started/quickstart.rst
           sed -i -E "s/--release\s.*/--release $release/" docs/getting-started/quickstart.rst

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -61,29 +61,21 @@ Make release
 
 Steps for the day of the release:
 
-- Follow the instructions how to release an Astropy affiliated package `<https://docs.astropy.org/en/stable/development/astropy-package-template.html>`__.
+#. Follow the instructions how to release an Astropy affiliated package `<https://docs.astropy.org/en/stable/development/astropy-package-template.html>`__.
+#. Draft the release in the `gammapy` code repository.
 
-In the `gammapy repo <https://github.com/gammapy/gammapy>`__:
+At this moment a set of Github actions will automate the following steps:
 
-- Edit `docs/index.rst` and change the version numbers in the text.
+- The `docs/index.rst` is modified with the right release version numbers in `gammapy` repo.
+- The dev docs and the new release docs are built in `gammapy-docs` repo.
+- The new release is mentioned on the news page in `gammapy-web` repo.
+- The `download/install/gammapy-release-environment.yml` file is created in `gammapy-web` repo.
 
-In the `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__:
-
-- Build an updated version of the dev docs using the manual Github action.
-- Copy the `docs/dev` folder as a new `docs/0.14` folder.
-- In the `0.14/docs/_downloads` folder, rename `notebooks-dev.tar` file as `notebooks-0.14.tar`.
-- Edit `stable/index.html` to point to `0.14/index.html`.
-
-In the `gammapy-web repo <https://github.com/gammapy/gammapy-webpage>`__:
-
-- Mention the release on the front page and on the news page.
-- In the `download/install` folder, copy `gammapy-0.13-environment.yml` file as `gammapy-0.14-environment.yml`.
-- Adapt the dependency conda env name and versions as required in this file.
 
 Finally:
-
-- Update the Gammapy conda-forge package at https://github.com/conda-forge/gammapy-feedstock
-- Encourage the Gammapy developers to try out the new stable version (update and run tests) via the Github issue for the release and wait a day or two for feedback.
+#. If necessary, adapt the conda env name and versions required in `download/install/gammapy-release-environment.yml`.
+#. Update the Gammapy conda-forge package at https://github.com/conda-forge/gammapy-feedstock
+#. Encourage the Gammapy developers to try out the new stable version (update and run tests) via the Github issue for the release and wait a day or two for feedback.
 
 Post release
 ------------
@@ -106,8 +98,8 @@ Steps for the day to announce the release:
    while making the release (ideally try to script / automate the task or check,
    e.g. as a ``make release-check-xyz`` target.
 #. Update version number in Binder `Dockerfile` in
-   `gammapy-webpage repository <https://github.com/gammapy/gammapy-webpage>`__ master branch
-   and tag the release for Binder.
+   `gammapy-webpage repository <https://github.com/gammapy/gammapy-webpage>`__ **master branch**
+   and **tag the release** for Binder.
 #. Open a milestone and issue for the next release (and possibly also a milestone for the
    release after, so that low-priority issues can already be moved there) Find a
    release manager for the next release, assign the release issue to her / him,

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -36,9 +36,7 @@ Pre release
 
 Steps to prepare for the release (e.g. a week before) to check that things are in order:
 
-#. Check the issue (example: https://github.com/gammapy/gammapy/issues/302 )
-   and milestone (example: https://github.com/gammapy/gammapy/milestones/0.14 )
-   for the release. Try to get developers to finish up their PRs, try to help
+#. Check the issues and milestones for the release. Try to get developers to finish up their PRs, try to help
    fix bugs, and postpone non-critical issues to the next release.
 #. Do these extra checks and clean up any warnings / errors that come up::
 

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -62,15 +62,13 @@ Make release
 Steps for the day of the release:
 
 #. Follow the instructions how to release an Astropy affiliated package `<https://docs.astropy.org/en/stable/development/astropy-package-template.html>`__.
+#. Edit `docs/index.rst` and change the version numbers in the text in the `gammapy` code repository.
 #. Draft the release in the `gammapy` code repository.
 
 At this moment a set of Github actions will automate the following steps:
-
-- The `docs/index.rst` is modified with the right release version numbers in `gammapy` repo.
 - The dev docs and the new release docs are built in `gammapy-docs` repo.
 - The new release is mentioned on the news page in `gammapy-web` repo.
 - The `download/install/gammapy-release-environment.yml` file is created in `gammapy-web` repo.
-
 
 Finally:
 #. If necessary, adapt the conda env name and versions required in `download/install/gammapy-release-environment.yml`.

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -62,7 +62,7 @@ Make release
 Steps for the day of the release:
 
 #. Follow the instructions how to release an Astropy affiliated package `<https://docs.astropy.org/en/stable/development/astropy-package-template.html>`__.
-#. Edit `docs/index.rst` and change the version numbers in the text in the `gammapy` code repository.
+#. Edit `docs/getting-started/quickstart.rst` and change the version numbers in the text in the `gammapy` code repository.
 #. Draft the release in the `gammapy` code repository.
 
 At this moment a set of Github actions will automate the following steps:


### PR DESCRIPTION
This PR adds a remote dispatch Github action that automates a set of steps involved in the release process. Other complementary Github actions have been implemented as *listeners* in the `gammapy-docs` and `gammapy-web` repositories. The set of steps that are automated are the following:

In the gammapy repo:

- Edit docs/index.rst and change the version numbers in the text.

In the gammapy-docs repo:

- Build an updated version of the dev docs using the manual Github action.
- Copy the docs/dev folder as a new docs/0.14 folder.
- In the 0.14/docs/_downloads folder, rename notebooks-dev.tar file as notebooks-0.14.tar.
- Edit stable/index.html to point to 0.14/index.html.

In the gammapy-web repo:

- Mention the release on the news page.
- In the download/install folder, copy gammapy-0.13-environment.yml file as gammapy-0.14-environment.yml


