### PR TITLE
Add CompoundSpatialModel

### DIFF
--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -23,6 +23,7 @@ from gammapy.modeling.models import (
     ShellSpatialModel,
     Shell2SpatialModel,
     TemplateSpatialModel,
+    CompoundSpatialModel,
 )
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
@@ -409,3 +410,20 @@ def test_integrate_geom_energy_axis():
     integral = model.integrate_geom(geom).data
 
     assert_allclose(integral, 1, rtol=0.01)
+
+
+def test_compound_model():
+    model1 = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.3 * u.deg, frame="icrs")
+    model2 = GaussianSpatialModel(
+        lon="0.3d", lat="0.3d", sigma=0.1 * u.deg, frame="icrs"
+    )
+    model_compound = CompoundSpatialModel(model1, model2, np.add)
+    lon = [0.3, 0.5] * u.deg
+    lat = 0.3 * u.deg
+    val1 = model1(lon, lat)
+    val2 = model2(lon, lat)
+    val = model_compound(lon, lat)
+    assert val.unit == "sr-1"
+    assert_allclose(val.value, val1.value + val2.value)
+    radius = model_compound.evaluation_radius
+    assert radius is None


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a `CompoundSpatialModel`.
As discussed in a previous dev call, this can be useful in dealing with the HGPS 3gauss and 2gauss models.


**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

One issue here is the behaviour to `.to_region`. A natural option might be to return `CompoundSkyRegion`, but the `CompoundSkyRegion.as_artist()` method is Not implemented yet (https://astropy-regions.readthedocs.io/en/latest/api/regions.CompoundSkyRegion.html#regions.CompoundSkyRegion.as_artist)

This raises issues with plotting.
@adonath what do you suggest?