### PR TITLE
Add SourceCatalog.to_models() and improve models selection from catalogues

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -222,9 +222,9 @@ class SourceCatalog(abc.ABC):
         """Source positions (`~astropy.coordinates.SkyCoord`)."""
         return _skycoord_from_table(self.table)
 
-    def to_models(self):
+    def to_models(self, **kwargs):
         """ Create Models object from catalogue"""
-        return Models([_.sky_model() for _ in self])
+        return Models([_.sky_model(**kwargs) for _ in self])
 
 
 def _skycoord_from_table(table):

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -63,7 +63,7 @@ class SourceCatalogObject(abc.ABC):
     def sky_model(self):
         """Source sky model."""
         pass
-    
+
 
 class SourceCatalog(abc.ABC):
     """Generic source catalog.

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -2,6 +2,8 @@
 """Source catalog and object base classes."""
 import abc
 import numbers
+import numpy as np
+from copy import deepcopy
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
 from gammapy.utils.table import table_from_row_data, table_row_to_dict
@@ -174,6 +176,10 @@ class SourceCatalog(abc.ABC):
             index = self.row_index(key)
         elif isinstance(key, numbers.Integral):
             index = key
+        elif isinstance(key, np.ndarray) and key.dtype == bool:
+            new = deepcopy(self)
+            new.table = self.table[key]
+            return new
         else:
             raise TypeError(f"Invalid key: {key!r}, {type(key)}\n")
 

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -5,6 +5,7 @@ import numbers
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
 from gammapy.utils.table import table_from_row_data, table_row_to_dict
+from gammapy.modeling.models import Models
 
 __all__ = ["SourceCatalog", "SourceCatalogObject"]
 
@@ -16,10 +17,10 @@ class Bunch(dict):
         self.__dict__.update(kw)
 
 
-class SourceCatalogObject:
+class SourceCatalogObject(abc.ABC):
     """Source catalog object.
 
-    This class can be used directly, but it's mostly used as a
+    This class can't be used directly, it's used as a
     base class for the other source catalog classes.
 
     The catalog data on this source is stored in the `source.data`
@@ -56,11 +57,16 @@ class SourceCatalogObject:
         table = table_from_row_data([self.data])
         return _skycoord_from_table(table)[0]
 
+    @abc.abstractmethod
+    def sky_model(self):
+        """Source sky model."""
+        pass
+    
 
 class SourceCatalog(abc.ABC):
     """Generic source catalog.
 
-    This class can be used directly, but it's mostly used as a
+    This class can't be used directly, it's used as a
     base class for the other source catalog classes.
 
     This is a thin wrapper around `~astropy.table.Table`,
@@ -214,6 +220,10 @@ class SourceCatalog(abc.ABC):
     def positions(self):
         """Source positions (`~astropy.coordinates.SkyCoord`)."""
         return _skycoord_from_table(self.table)
+
+    def to_models(self):
+        """ Create Models object from catalogue"""
+        return Models([_.sky_model() for _ in self])
 
 
 def _skycoord_from_table(table):

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -19,10 +19,10 @@ class Bunch(dict):
         self.__dict__.update(kw)
 
 
-class SourceCatalogObject(abc.ABC):
+class SourceCatalogObject:
     """Source catalog object.
 
-    This class can't be used directly, it's used as a
+    This class can be used directly, but it is mostly used as a
     base class for the other source catalog classes.
 
     The catalog data on this source is stored in the `source.data`
@@ -59,16 +59,11 @@ class SourceCatalogObject(abc.ABC):
         table = table_from_row_data([self.data])
         return _skycoord_from_table(table)[0]
 
-    @abc.abstractmethod
-    def sky_model(self):
-        """Source sky model."""
-        pass
-
 
 class SourceCatalog(abc.ABC):
     """Generic source catalog.
 
-    This class can't be used directly, it's used as a
+    This class can be used directly, but it is mostly used as a
     base class for the other source catalog classes.
 
     This is a thin wrapper around `~astropy.table.Table`,

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -546,10 +546,12 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
                 spec_component = spectral_model.copy()
                 weight = component.data["Flux_Map"] / self.data["Flux_Map"]
                 spec_component.parameters["amplitude"].value *= weight
-                if components_status == 'linked':
-                    for name in spec_component.parameters.names: 
-                         if name not in ["norm", "amplitude"]:
-                             spec_component.__dict__[name] = spectral_model.parameters[name]
+                if components_status == "linked":
+                    for name in spec_component.parameters.names:
+                        if name not in ["norm", "amplitude"]:
+                            spec_component.__dict__[name] = spectral_model.parameters[
+                                name
+                            ]
                 model = SkyModel(
                     spatial_model=component.spatial_model(),
                     spectral_model=spec_component,

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -559,7 +559,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
                 )
                 models.append(model)
             if components_status == "merged":
-                return models.to_template_spatial_model()
+                return models.to_template_spatial_model(name=self.name)
             else:
                 return Models(models)
         else:

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -73,6 +73,10 @@ class TestSourceCatalog:
         positions = self.cat.positions
         assert len(positions) == 3
 
+    def test_selection(self):
+        new = self.cat[self.cat.table["Source_Name"] != "a"]
+        assert len(new.table) == 2
+
 
 class TestSourceCatalogObject:
     def setup(self):

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -624,3 +624,9 @@ class TestSourceCatalog3FHL:
     def test_extended_sources(self):
         table = self.cat.extended_sources_table
         assert len(table) == 55
+
+    def test_to_models(self):
+        mask = self.cat.table["GLAT"].data.data > 80
+        subcat = self.cat[mask]
+        models = subcat.to_models()
+        assert len(models) == 17

--- a/gammapy/catalog/tests/test_hawc.py
+++ b/gammapy/catalog/tests/test_hawc.py
@@ -30,6 +30,11 @@ class TestSourceCatalog2HWC:
     def test_positions(cat):
         assert len(cat.positions) == 40
 
+    @staticmethod
+    def test_to_models(cat):
+        models = cat.to_models(which="point")
+        assert len(models) == 40
+
 
 @requires_data()
 class TestSourceCatalogObject2HWC:
@@ -122,6 +127,13 @@ class TestSourceCatalog3HWC:
     @staticmethod
     def test_positions(ca_3hwc):
         assert len(ca_3hwc.positions) == 65
+
+
+#    TODO : add tests for SourceCatalogObject3HWC.sky_model() and fix it
+#    @staticmethod
+#    def test_to_models(ca_3hwc):
+#        models = ca_3hwc.to_models(which="point")
+#        assert len(models)==65
 
 
 @requires_data()

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -60,6 +60,15 @@ class TestSourceCatalogHGPS:
     def test_large_scale_component(cat):
         assert isinstance(cat.large_scale_component, SourceCatalogLargeScaleHGPS)
 
+    @staticmethod
+    def test_to_models(cat):
+        models = cat.to_models(components_status="independent")
+        assert len(models) == 96
+        models = cat.to_models(components_status="linked")
+        assert len(models) == 96
+        models = cat.to_models(components_status="merged")
+        assert len(models) == 78
+
 
 @requires_data()
 class TestSourceCatalogObjectHGPS:

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -195,7 +195,7 @@ class TestSourceCatalogObjectHGPS:
 
     @staticmethod
     def test_sky_model_gaussian2(cat):
-        models = cat["HESS J1843-033"].sky_model()
+        models = cat["HESS J1843-033"].components_models()
 
         p = models[0].parameters
         assert_allclose(p["amplitude"].value, 4.259815e-13, rtol=1e-5)
@@ -211,7 +211,7 @@ class TestSourceCatalogObjectHGPS:
 
     @staticmethod
     def test_sky_model_gaussian3(cat):
-        models = cat["HESS J1825-137"].sky_model()
+        models = cat["HESS J1825-137"].components_models()
 
         p = models[0].parameters
         assert_allclose(p["amplitude"].value, 1.8952104218765842e-11)
@@ -234,7 +234,7 @@ class TestSourceCatalogObjectHGPS:
     @staticmethod
     def test_sky_model_gaussian_extern(cat):
         # special test for the only extern source with a gaussian morphology
-        model = cat["HESS J1801-233"].sky_model()
+        model = cat["HESS J1801-233"].components_models()
         p = model.parameters
         assert_allclose(p["amplitude"].value, 7.499999970031479e-13)
         assert_allclose(p["lon_0"].value, 6.656888961791992)

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -791,7 +791,7 @@ class DatasetModels(collections.abc.Sequence):
         models = [m.reassign(dataset_name, new_dataset_name) for m in self]
         return self.__class__(models)
 
-    def to_template_spatial_model(self, geom, spectral_model=None, name=None):
+    def to_template_sky_model(self, geom, spectral_model=None, name=None):
         """Merge a list of models into a single `~gammapy.modeling.models.SkyModel`
     
         Parameters

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -9,7 +9,7 @@ from astropy.table import Table
 import yaml
 from gammapy.modeling import Covariance, Parameter, Parameters
 from gammapy.utils.scripts import make_name, make_path
-from gammapy.maps import RegionGeom
+from gammapy.maps import RegionGeom, Map, WcsGeom
 
 log = logging.getLogger(__name__)
 
@@ -791,6 +791,26 @@ class DatasetModels(collections.abc.Sequence):
         models = [m.reassign(dataset_name, new_dataset_name) for m in self]
         return self.__class__(models)
 
+    def to_template_spatial_model(self, geom, spectral_model=None, name=None):
+        """Merge a list of models into a single `~gammapy.modeling.models.SkyModel`
+    
+        Parameters
+        ----------
+        spectral_model : `~gammapy.modeling.models.SpectralModel`
+            One of the NormSpectralMdel 
+        name : str
+            Name of the new model
+                           
+        """
+        from . import SkyModel, TemplateSpatialModel, PowerLawNormSpectralModel
+
+        map_ = Map.from_geom(geom)
+        for m in self:
+            map_ += m.evaluate_geom(geom)
+        spatial_model = TemplateSpatialModel(map_)
+        if spectral_model is None:
+            spectral_model = PowerLawNormSpectralModel()
+        return SkyModel(spectral_model=spectral_model, spatial_model=spatial_model, name=name)
 
 class Models(DatasetModels, collections.abc.MutableSequence):
     """Sky model collection.

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -9,7 +9,7 @@ from astropy.table import Table
 import yaml
 from gammapy.modeling import Covariance, Parameter, Parameters
 from gammapy.utils.scripts import make_name, make_path
-from gammapy.maps import RegionGeom, Map, WcsGeom
+from gammapy.maps import RegionGeom, Map
 
 log = logging.getLogger(__name__)
 
@@ -810,7 +810,10 @@ class DatasetModels(collections.abc.Sequence):
         spatial_model = TemplateSpatialModel(map_)
         if spectral_model is None:
             spectral_model = PowerLawNormSpectralModel()
-        return SkyModel(spectral_model=spectral_model, spatial_model=spatial_model, name=name)
+        return SkyModel(
+            spectral_model=spectral_model, spatial_model=spatial_model, name=name
+        )
+
 
 class Models(DatasetModels, collections.abc.MutableSequence):
     """Sky model collection.

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -804,10 +804,11 @@ class DatasetModels(collections.abc.Sequence):
         """
         from . import SkyModel, TemplateSpatialModel, PowerLawNormSpectralModel
 
-        map_ = Map.from_geom(geom)
+        unit = u.Unit("1 / (cm2 s sr TeV)")
+        map_ = Map.from_geom(geom, unit=unit)
         for m in self:
-            map_ += m.evaluate_geom(geom)
-        spatial_model = TemplateSpatialModel(map_)
+            map_ += m.evaluate_geom(geom).to(unit)
+        spatial_model = TemplateSpatialModel(map_, normalize=False)
         if spectral_model is None:
             spectral_model = PowerLawNormSpectralModel()
         return SkyModel(

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -252,7 +252,7 @@ class SkyModel(Model):
         try:
             mask_cutout = mask.cutout(
                 position=self.position,
-                width=(2 * self.evaluation_radius + CUTOUT_MARGIN) + margin
+                width=(2 * self.evaluation_radius + CUTOUT_MARGIN) + margin,
             )
             contributes = np.any(mask_cutout.data)
         except (NoOverlapError, ValueError):

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -5,6 +5,7 @@ import astropy.units as u
 from gammapy.modeling.models import Model, Models, Parameter, Parameters
 from gammapy.utils.testing import requires_data
 
+
 class MyModel(Model):
     """Simple model example"""
 
@@ -171,25 +172,26 @@ def test_parameter_link():
     m1.y.value = 100
     assert_allclose(m2.y.value, 100)
 
+
 @requires_data()
 def test_set_parameters_from_table():
-    #read gammapy models
+    # read gammapy models
     models = Models.read("$GAMMAPY_DATA/tests/models/gc_example_models.yaml")
 
-    tab=models.to_parameters_table()
-    tab['value'][0]=3.0
-    tab['min'][0]=-10
-    tab['max'][0]=10
-    tab['frozen'][0]=True
-    tab['name'][0]='index2'
-    tab['frozen'][1]=True
+    tab = models.to_parameters_table()
+    tab["value"][0] = 3.0
+    tab["min"][0] = -10
+    tab["max"][0] = 10
+    tab["frozen"][0] = True
+    tab["name"][0] = "index2"
+    tab["frozen"][1] = True
 
     models.update_parameters_from_table(tab)
 
-    d=models.parameters.to_dict()
-    assert d[0]['value'] == 3.0
-    assert d[0]['min'] == -10
-    assert d[0]['max'] == 10
-    assert d[0]['frozen'] == True
-    assert d[0]['name'] == 'index'
-    assert d[1]['frozen'] == True    
+    d = models.parameters.to_dict()
+    assert d[0]["value"] == 3.0
+    assert d[0]["min"] == -10
+    assert d[0]["max"] == 10
+    assert d[0]["frozen"] == True
+    assert d[0]["name"] == "index"
+    assert d[1]["frozen"] == True

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -631,17 +631,17 @@ def test_sky_model_create():
 
 
 def test_integrate_geom():
-    model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1*u.deg, frame='icrs')
+    model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1 * u.deg, frame="icrs")
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     sky_model = SkyModel(spectral_model=spectral_model, spatial_model=model)
 
-    center = SkyCoord("0d", "0d", frame='icrs')
+    center = SkyCoord("0d", "0d", frame="icrs")
     radius = 0.3 * u.deg
     square = CircleSkyRegion(center, radius)
 
-    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3, name='energy_true')
+    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3, name="energy_true")
     geom = RegionGeom(region=square, axes=[axis], binsz_wcs="0.01deg")
 
     integral = sky_model.integrate_geom(geom).data
 
-    assert_allclose(integral/1e-12, [[[5.299]], [[2.460]], [[1.142]]], rtol=1e-3)
+    assert_allclose(integral / 1e-12, [[[5.299]], [[2.460]], [[1.142]]], rtol=1e-3)

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -99,7 +99,9 @@ def test_select_mask(models_gauss):
     inside = models_gauss.select_mask(mask, use_evaluation_region=False)
     assert inside.names == ["source-1"]
 
-    contribute_margin = models_gauss.select_mask(mask, margin=0.6 * u.deg, use_evaluation_region=True)
+    contribute_margin = models_gauss.select_mask(
+        mask, margin=0.6 * u.deg, use_evaluation_region=True
+    )
     assert contribute_margin.names == ["source-1", "source-2", "source-3"]
 
 
@@ -119,7 +121,7 @@ def test_contributes(models):
         spectral_model=PowerLawSpectralModel(),
         name="source-4",
     )
-    assert model4.contributes(mask, margin=0*u.deg)
+    assert model4.contributes(mask, margin=0 * u.deg)
 
 
 def test_select(models):

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -402,7 +402,7 @@ def test_to_from_dict():
 
     model_dict = model.to_dict()
     # Here we reverse the order of parameters list to ensure assignment is correct
-    model_dict['parameters'].reverse()
+    model_dict["parameters"].reverse()
 
     model_class = SPECTRAL_MODEL_REGISTRY.get_cls(model_dict["type"])
     new_model = model_class.from_dict(model_dict)
@@ -424,8 +424,8 @@ def test_to_from_dict_partial_input(caplog):
 
     model_dict = model.to_dict()
     # Here we remove the reference energy
-    model_dict['parameters'].remove(model_dict['parameters'][2])
-    print(model_dict['parameters'][0])
+    model_dict["parameters"].remove(model_dict["parameters"][2])
+    print(model_dict["parameters"][0])
 
     model_class = SPECTRAL_MODEL_REGISTRY.get_cls(model_dict["type"])
     new_model = model_class.from_dict(model_dict)
@@ -440,7 +440,10 @@ def test_to_from_dict_partial_input(caplog):
     desired = [par.frozen for par in model.parameters]
     assert_allclose(actual, desired)
     assert caplog.records[-1].levelname == "WARNING"
-    assert caplog.records[-1].message =="Parameter reference not defined. Using default value: 1.0 TeV"
+    assert (
+        caplog.records[-1].message
+        == "Parameter reference not defined. Using default value: 1.0 TeV"
+    )
 
 
 def test_to_from_dict_compound():


### PR DESCRIPTION
This PR implements several of the proposals discussed in #3268
- add option components_status : {'independent', 'linked', 'merged'} to SourceCatalogObjectHGPS.sky_model():
-- Default is "independent" so it preserves the current behavior. 
-- "linked" adds spectral parameters links (except for the normalisations) .
--  "merged" creates a single model given as a TemplateSpatialModel with a PowerLawNormSpectralModel
- Implement Models.to_template_spatial_model()
- implement SourceCatalog.to_models()
- add support for boolean array on getitem of SourceCatalog so one can use subcat = cat[mask]
