### PR TITLE
Change Estimator optional default selection

### DIFF
--- a/docs/tutorials/analysis/1D/spectral_analysis.ipynb
+++ b/docs/tutorials/analysis/1D/spectral_analysis.ipynb
@@ -511,7 +511,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fpe = FluxPointsEstimator(energy_edges=energy_edges, source=\"crab\")\n",
+    "fpe = FluxPointsEstimator(energy_edges=energy_edges, source=\"crab\", selection_optional=\"all\")\n",
     "flux_points = fpe.run(datasets=datasets)"
    ]
   },

--- a/docs/tutorials/analysis/2D/detect.ipynb
+++ b/docs/tutorials/analysis/2D/detect.ipynb
@@ -183,7 +183,6 @@
     "estimator = TSMapEstimator(\n",
     "    model,\n",
     "    kernel_width=\"1 deg\",\n",
-    "    selection_optional=[],\n",
     "    energy_edges=[10, 500] * u.GeV,\n",
     ")\n",
     "maps = estimator.run(dataset)"

--- a/docs/tutorials/analysis/time/pulsar_analysis.ipynb
+++ b/docs/tutorials/analysis/time/pulsar_analysis.ipynb
@@ -475,7 +475,7 @@
     "\n",
     "dataset.models = model\n",
     "\n",
-    "fpe = FluxPointsEstimator(energy_edges=energy_edges, source=\"vela psr\")\n",
+    "fpe = FluxPointsEstimator(energy_edges=energy_edges, source=\"vela psr\", selection_optional=\"all\")\n",
     "\n",
     "flux_points = fpe.run(datasets=[dataset])\n",
     "flux_points.table[\"is_ul\"] = flux_points.table[\"ts\"] < 1\n",

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -131,7 +131,7 @@ class TimeRangeConfig(GammapyBaseConfig):
 class FluxPointsConfig(GammapyBaseConfig):
     energy: EnergyAxisConfig = EnergyAxisConfig()
     source: str = "source"
-    parameters: dict = {}
+    parameters: dict = {"selection_optional": "all"}
 
 
 class FitConfig(GammapyBaseConfig):

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -99,7 +99,7 @@ class ExcessMapEstimator(Estimator):
         correlation_radius="0.1 deg",
         n_sigma=1,
         n_sigma_ul=3,
-        selection_optional="all",
+        selection_optional=None,
         energy_edges=None,
         apply_mask_fit=False,
         correlate_off=False

--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -88,7 +88,7 @@ class ExcessProfileEstimator(Estimator):
         spectrum=None,
         n_sigma=1.0,
         n_sigma_ul=3.0,
-        selection_optional="all",
+        selection_optional=None,
     ):
         self.regions = regions
         self.n_sigma = n_sigma

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -65,7 +65,7 @@ class FluxEstimator(Estimator):
         n_sigma=1,
         n_sigma_ul=3,
         reoptimize=True,
-        selection_optional="all",
+        selection_optional=None,
     ):
 
         if norm_values is None:

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -813,7 +813,7 @@ class FluxPointsEstimator(Estimator):
         n_sigma=1,
         n_sigma_ul=2,
         reoptimize=False,
-        selection_optional="all",
+        selection_optional=None,
     ):
         self.energy_edges = energy_edges
         self.source = source

--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -463,7 +463,7 @@ class LightCurveEstimator(Estimator):
         # TODO: remove once FluxPointsEstimator returns object with all energies in one row
         result = {}
         for colname in fp.table.colnames:
-            if colname is not "counts":
+            if colname != "counts":
                 result[colname] = fp.table[colname].quantity
             else:
                 result[colname] = np.atleast_1d(fp.table[colname].quantity.sum(axis=1))

--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -362,7 +362,7 @@ class LightCurveEstimator(Estimator):
         n_sigma=1,
         n_sigma_ul=2,
         reoptimize=False,
-        selection_optional="all",
+        selection_optional=None,
     ):
 
         self.source = source

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -59,7 +59,7 @@ class ParameterEstimator(Estimator):
         scan_n_values=30,
         scan_values=None,
         reoptimize=True,
-        selection_optional="all",
+        selection_optional=None,
     ):
         self.n_sigma = n_sigma
         self.n_sigma_ul = n_sigma_ul

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -58,7 +58,7 @@ def test_compute_lima_image():
     background = image_to_cube(background, "1 GeV", "100 GeV")
     dataset = MapDataset(counts=counts, background=background)
 
-    estimator = ExcessMapEstimator("0.1 deg", selection_optional=None)
+    estimator = ExcessMapEstimator("0.1 deg")
     result_lima = estimator.run(dataset)
 
     assert_allclose(result_lima["sqrt_ts"].data[:, 100, 100], 30.814916, atol=1e-3)
@@ -88,7 +88,7 @@ def test_compute_lima_on_off_image():
 
     significance = Map.read(filename, hdu="SIGNIFICANCE")
     significance = image_to_cube(significance, "1 TeV", "10 TeV")
-    estimator = ExcessMapEstimator("0.1 deg", selection_optional=None)
+    estimator = ExcessMapEstimator("0.1 deg")
     results = estimator.run(dataset)
 
     # Reproduce safe significance threshold from HESS software
@@ -107,7 +107,7 @@ def test_compute_lima_on_off_image():
 
 
 def test_significance_map_estimator_map_dataset(simple_dataset):
-    estimator = ExcessMapEstimator(0.1 * u.deg)
+    estimator = ExcessMapEstimator(0.1 * u.deg, selection_optional="all")
     result = estimator.run(simple_dataset)
 
     assert_allclose(result["counts"].data[0, 10, 10], 162)
@@ -145,7 +145,7 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(simple_d
     simple_dataset_on_off.exposure = None
 
     estimator = ExcessMapEstimator(
-        0.11 * u.deg, selection_optional=None, energy_edges=[0.1, 1, 10] * u.TeV, correlate_off=True
+        0.11 * u.deg, energy_edges=[0.1, 1, 10] * u.TeV, correlate_off=True
     )
     result = estimator.run(simple_dataset_on_off)
 

--- a/gammapy/estimators/tests/test_excess_profile.py
+++ b/gammapy/estimators/tests/test_excess_profile.py
@@ -47,7 +47,9 @@ def test_profile_content():
     wcs = mapdataset_onoff.counts.geom.wcs
     boxes = make_horizontal_boxes(wcs)
 
-    prof_maker = ExcessProfileEstimator(boxes, energy_edges=[0.1, 1, 10] * u.TeV)
+    prof_maker = ExcessProfileEstimator(
+        boxes, energy_edges=[0.1, 1, 10] * u.TeV, selection_optional="all"
+    )
     imp_prof = prof_maker.run(mapdataset_onoff)
 
     assert_allclose(imp_prof[7]["x_min"], 0.1462, atol=1e-4)
@@ -67,7 +69,9 @@ def test_radial_profile():
         center=geom.center_skydir, radius_max=0.2 * u.deg,
     )
 
-    prof_maker = ExcessProfileEstimator(regions, energy_edges=[0.1, 1, 10] * u.TeV)
+    prof_maker = ExcessProfileEstimator(
+        regions, energy_edges=[0.1, 1, 10] * u.TeV, selection_optional="all"
+    )
     imp_prof = prof_maker.run(dataset)
 
     assert_allclose(imp_prof[7]["x_min"], 0.14, atol=1e-4)
@@ -88,7 +92,7 @@ def test_radial_profile_one_interval():
         center=geom.center_skydir, radius_max=0.2 * u.deg,
     )
 
-    prof_maker = ExcessProfileEstimator(regions)
+    prof_maker = ExcessProfileEstimator(regions, selection_optional="all")
     imp_prof = prof_maker.run(dataset)
 
     assert_allclose(imp_prof[7]["counts"], [1960], atol=1e-5)

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -44,6 +44,7 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
         norm_min=0.5,
         norm_max=2,
         reoptimize=False,
+        selection_optional="all"
     )
 
     result = estimator.run(fermi_datasets)

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -80,7 +80,7 @@ def create_fpe(model):
     energy_edges = [0.1, 1, 10, 100] * u.TeV
     dataset.models = model
     fpe = FluxPointsEstimator(
-        energy_edges=energy_edges, norm_n_values=11, source="source"
+        energy_edges=energy_edges, norm_n_values=11, source="source", selection_optional="all"
     )
     datasets = [dataset]
     return datasets, fpe
@@ -128,7 +128,7 @@ def fpe_map_pwl():
     energy_edges = [0.1, 1, 10, 100] * u.TeV
     datasets = [dataset_1, dataset_2]
     fpe = FluxPointsEstimator(
-        energy_edges=energy_edges, norm_n_values=3, source="source"
+        energy_edges=energy_edges, norm_n_values=3, source="source", selection_optional="allgi"
     )
     return datasets, fpe
 
@@ -304,7 +304,7 @@ def test_run_map_pwl(fpe_map_pwl):
 def test_run_map_pwl_reoptimize(fpe_map_pwl_reoptimize):
     datasets, fpe = fpe_map_pwl_reoptimize
     fpe = fpe.copy()
-    fpe.selection = ["scan"]
+    fpe.selection_optional = ["scan"]
 
     fp = fpe.run(datasets)
 
@@ -350,8 +350,6 @@ def test_no_likelihood_contribution():
 
     assert np.isnan(fp.table["norm"]).all()
     assert np.isnan(fp.table["norm_err"]).all()
-    assert np.isnan(fp.table["norm_ul"]).all()
-    assert np.isnan(fp.table["norm_scan"]).all()
     assert_allclose(fp.table["counts"], 0)
 
 

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -128,7 +128,7 @@ def fpe_map_pwl():
     energy_edges = [0.1, 1, 10, 100] * u.TeV
     datasets = [dataset_1, dataset_2]
     fpe = FluxPointsEstimator(
-        energy_edges=energy_edges, norm_n_values=3, source="source", selection_optional="allgi"
+        energy_edges=energy_edges, norm_n_values=3, source="source", selection_optional="all"
     )
     return datasets, fpe
 

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -210,7 +210,10 @@ def test_lightcurve_estimator_spectrum_datasets():
     ]
 
     estimator = LightCurveEstimator(
-        energy_edges=[1, 30] * u.TeV, norm_n_values=3, time_intervals=time_intervals
+        energy_edges=[1, 30] * u.TeV,
+        norm_n_values=3,
+        time_intervals=time_intervals,
+        selection_optional="all"
     )
     lightcurve = estimator.run(datasets)
     assert_allclose(lightcurve.table["time_min"], [55197.0, 55197.041667])
@@ -256,7 +259,10 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
     ]
 
     estimator = LightCurveEstimator(
-        energy_edges=[1, 5, 30] * u.TeV, norm_n_values=3, time_intervals=time_intervals
+        energy_edges=[1, 5, 30] * u.TeV,
+        norm_n_values=3,
+        time_intervals=time_intervals,
+        selection_optional="all"
     )
     lightcurve = estimator.run(datasets)
     assert_allclose(lightcurve.table["time_min"], [55197.0, 55197.041667])

--- a/gammapy/estimators/tests/test_parameter_estimator.py
+++ b/gammapy/estimators/tests/test_parameter_estimator.py
@@ -54,7 +54,7 @@ def test_parameter_estimator_1d(crab_datasets_1d, PLmodel):
 def test_parameter_estimator_3d_no_reoptimization(crab_datasets_fermi):
     datasets = crab_datasets_fermi
     parameter = datasets[0].models.parameters["amplitude"]
-    estimator = ParameterEstimator(reoptimize=False, scan_n_values=10)
+    estimator = ParameterEstimator(reoptimize=False, scan_n_values=10, selection_optional=["scan"])
     alpha_value = datasets[0].models.parameters["alpha"].value
 
     result = estimator.run(datasets, parameter)

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -132,7 +132,7 @@ def test_compute_ts_map(input_dataset):
 
 @requires_data()
 def test_compute_ts_map_psf(fermi_dataset):
-    estimator = TSMapEstimator(kernel_width="1 deg")
+    estimator = TSMapEstimator(kernel_width="1 deg", selection_optional="all")
     result = estimator.run(fermi_dataset)
 
     assert_allclose(result["ts"].data[0, 29, 29], 835.140605, rtol=1e-2)
@@ -178,7 +178,7 @@ def test_compute_ts_map_downsampled(input_dataset):
     model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
 
     ts_estimator = TSMapEstimator(
-        model=model, downsampling_factor=2, kernel_width="1 deg",
+        model=model, downsampling_factor=2, kernel_width="1 deg", selection_optional=["ul"]
     )
     result = ts_estimator.run(input_dataset)
 

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -125,7 +125,7 @@ class TSMapEstimator(Estimator):
         n_sigma_ul=2,
         threshold=None,
         rtol=0.01,
-        selection_optional="all",
+        selection_optional=None,
         energy_edges=None,
         sum_over_energy_groups=True,
         n_jobs=None,


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the optional default selection for `Estimator` to `None`, too avoid that expensive computation such as ULs and assym. error are computed by default. In selected place we now use `selection_optional="all"` explicitly.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
