### PR TITLE
fixing Matplotlib deprecation of nonposx

### DIFF
--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -664,8 +664,8 @@ class FluxPoints:
                 **kwargs,
             )
 
-        ax.set_xscale("log", nonposx="clip")
-        ax.set_yscale("log", nonposy="clip")
+        ax.set_xscale("log", nonpositive="clip")
+        ax.set_yscale("log", nonpositive="clip")
         ax.set_xlabel(f"Energy ({energy_unit})")
         ax.set_ylabel(f"{self.sed_type} ({y_unit})")
         return ax
@@ -740,8 +740,8 @@ class FluxPoints:
         # clipped values are set to NaN so that they appear white on the plot
         z[-z < kwargs["vmin"]] = np.nan
         caxes = ax.pcolormesh(x.value, y_values.value, -z.T, **kwargs)
-        ax.set_xscale("log", nonposx="clip")
-        ax.set_yscale("log", nonposy="clip")
+        ax.set_xscale("log", nonpositive="clip")
+        ax.set_yscale("log", nonpositive="clip")
         ax.set_xlabel(f"Energy ({energy_unit})")
         ax.set_ylabel(f"{self.sed_type} ({y_values.unit})")
 


### PR DESCRIPTION
This pull request  fixes the deprecated kw nonposx in flux_point.py.
It was apparently recently fixed in spectral.py but not everywhere.
Also the doc here mixes description between nonposx and nonpositive kw:
https://github.com/gammapy/gammapy/blob/722cdd53c6f0768a6b8a3d71a4df91fa689c809e/gammapy/modeling/models/spectral.py#L322

For example, is this allowed for matplotlib >3.3 ?
`plt.loglog(nonposx='clip', nonpositive='clip')`

