### PR TITLE
Fix typo in light curve tutorial

### DIFF
--- a/docs/tutorials/analysis/time/light_curve.ipynb
+++ b/docs/tutorials/analysis/time/light_curve.ipynb
@@ -517,7 +517,7 @@
    "source": [
     "## What next?\n",
     "\n",
-    "When sources are bight enough to look for variability at small time scales, the per-observation time binning is no longer relevant. One can easily extend the light curve estimation approach presented above to any time binning. This is demonstrated in the [following tutorial](light_curve_flare.ipynb) which shows the extraction of the lightcurve of an AGN flare."
+    "When sources are bright enough to look for variability at small time scales, the per-observation time binning is no longer relevant. One can easily extend the light curve estimation approach presented above to any time binning. This is demonstrated in the [following tutorial](light_curve_flare.ipynb) which shows the extraction of the lightcurve of an AGN flare."
    ]
   },
   {


### PR DESCRIPTION
Just a tiny typo fix