### PR TITLE
Fix and cleanup 3HAWC catalogue object

### DIFF
--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -16,10 +16,7 @@ __all__ = [
 
 
 class SourceCatalogObjectHWCBase(SourceCatalogObject, abc.ABC):
-    """One source from the HAWC 2HWC catalog.
-
-    Catalog is represented by `~gammapy.catalog.SourceCatalog2HWC`.
-    """
+    """Base class for the HAWC catalogs objects"""
 
     _source_name_key = "source_name"
 
@@ -90,6 +87,13 @@ class SourceCatalogObjectHWCBase(SourceCatalogObject, abc.ABC):
 
         return ss
 
+
+class SourceCatalogObject2HWC(SourceCatalogObjectHWCBase):
+    """One source from the HAWC 2HWC catalog.
+
+    Catalog is represented by `~gammapy.catalog.SourceCatalog2HWC`.
+    """
+
     @property
     def n_models(self):
         """Number of models (1 or 2)."""
@@ -108,6 +112,33 @@ class SourceCatalogObjectHWCBase(SourceCatalogObject, abc.ABC):
                 raise ValueError(f"No extended source analysis available: {self.name}")
         else:
             raise ValueError(f"Invalid which: {which!r}")
+
+    def spectral_model(self, which="point"):
+        """Spectral model (`~gammapy.modeling.models.PowerLawSpectralModel`).
+
+        * ``which="point"`` -- Spectral model under the point source assumption.
+        * ``which="extended"`` -- Spectral model under the extended source assumption.
+          Only available for some sources. Raise ValueError if not available.
+        """
+        idx = self._get_idx(which)
+
+        pars = {
+            "reference": "7 TeV",
+            "amplitude": self.data[f"spec{idx}_dnde"],
+            "index": -self.data[f"spec{idx}_index"],
+        }
+
+        errs = {
+            "amplitude": self.data[f"spec{idx}_dnde_err"],
+            "index": self.data[f"spec{idx}_index_err"],
+        }
+
+        model = Model.create("PowerLawSpectralModel", "spectral", **pars)
+
+        for name, value in errs.items():
+            model.parameters[name].error = value
+
+        return model
 
     def spatial_model(self, which="point"):
         """Spatial model (`~gammapy.modeling.models.SpatialModel`).
@@ -154,35 +185,6 @@ class SourceCatalogObjectHWCBase(SourceCatalogObject, abc.ABC):
         )
 
 
-class SourceCatalogObject2HWC(SourceCatalogObjectHWCBase):
-    def spectral_model(self, which="point"):
-        """Spectral model (`~gammapy.modeling.models.PowerLawSpectralModel`).
-
-        * ``which="point"`` -- Spectral model under the point source assumption.
-        * ``which="extended"`` -- Spectral model under the extended source assumption.
-          Only available for some sources. Raise ValueError if not available.
-        """
-        idx = self._get_idx(which)
-
-        pars = {
-            "reference": "7 TeV",
-            "amplitude": self.data[f"spec{idx}_dnde"],
-            "index": -self.data[f"spec{idx}_index"],
-        }
-
-        errs = {
-            "amplitude": self.data[f"spec{idx}_dnde_err"],
-            "index": self.data[f"spec{idx}_index_err"],
-        }
-
-        model = Model.create("PowerLawSpectralModel", "spectral", **pars)
-
-        for name, value in errs.items():
-            model.parameters[name].error = value
-
-        return model
-
-
 class SourceCatalog2HWC(SourceCatalog):
     """HAWC 2HWC catalog.
 
@@ -218,29 +220,29 @@ class SourceCatalog2HWC(SourceCatalog):
 
 
 class SourceCatalogObject3HWC(SourceCatalogObjectHWCBase):
-    def spectral_model(self, which="point"):
-        """Spectral model (`~gammapy.modeling.models.PowerLawSpectralModel`).
+    """One source from the HAWC 3HWC catalog.
 
-        * ``which="point"`` -- Spectral model under the point source assumption.
-        * ``which="extended"`` -- Spectral model under the extended source assumption.
-          Only available for some sources. Raise ValueError if not available.
-        """
-        idx = self._get_idx(which)
+    Catalog is represented by `~gammapy.catalog.SourceCatalog3HWC`.
+    """
+
+    @property
+    def n_models(self):
+        return 1
+
+    def spectral_model(self):
+        """Spectral model (`~gammapy.modeling.models.PowerLawSpectralModel`)."""
 
         pars = {
             "reference": "7 TeV",
-            "amplitude": self.data[f"spec{idx}_dnde"],
-            "index": -self.data[f"spec{idx}_index"],
+            "amplitude": self.data[f"spec0_dnde"],
+            "index": -self.data[f"spec0_index"],
         }
 
         errs = {
-            "index_err": 0.5
-            * (
-                self.data[f"spec_{idx}_index_errp"]
-                + self.data[f"spec_{idx}_index_errn"]
-            ),
-            "amplitude_err": 0.5
-            * (self.data[f"spec_{idx}_dnde_errp"] + self.data[f"spec_{idx}_dnde_errp"]),
+            "index": 0.5
+            * (self.data[f"spec0_index_errp"] + self.data[f"spec0_index_errn"]),
+            "amplitude": 0.5
+            * (self.data[f"spec0_dnde_errp"] + self.data[f"spec0_dnde_errp"]),
         }
 
         model = Model.create("PowerLawSpectralModel", "spectral", **pars)
@@ -249,6 +251,36 @@ class SourceCatalogObject3HWC(SourceCatalogObjectHWCBase):
             model.parameters[name].error = value
 
         return model
+
+    def spatial_model(self):
+        """Spatial model (`~gammapy.modeling.models.SpatialModel`)."""
+        pars = {"lon_0": self.data.glon, "lat_0": self.data.glat, "frame": "galactic"}
+
+        if self.data[f"spec0_radius"] == 0.0:
+            tag = "PointSpatialModel"
+        else:
+            tag = "DiskSpatialModel"
+            pars["r_0"] = self.data[f"spec0_radius"]
+
+        errs = {
+            "lat_0": self.data.pos_err,
+            "lon_0": self.data.pos_err / np.cos(self.data.glat),
+        }
+
+        model = Model.create(tag, "spatial", **pars)
+
+        for name, value in errs.items():
+            model.parameters[name].error = value
+
+        return model
+
+    def sky_model(self):
+        """Sky model (`~gammapy.modeling.models.SkyModel`)."""
+        return SkyModel(
+            spatial_model=self.spatial_model(),
+            spectral_model=self.spectral_model(),
+            name=self.name,
+        )
 
 
 class SourceCatalog3HWC(SourceCatalog):

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -72,7 +72,7 @@ class SourceCatalogObjectHWCBase(SourceCatalogObject, abc.ABC):
         if self.n_models == 2:
             ss += self._info_spectrum_one(1)
         else:
-            ss += "No second spectrum available for this source"
+            ss += "No second spectrum available"
 
         return ss
 

--- a/gammapy/catalog/tests/data/2hwc_j0534+220.txt
+++ b/gammapy/catalog/tests/data/2hwc_j0534+220.txt
@@ -19,4 +19,4 @@ Flux at 7 TeV: 1.85e-13 +- 2.38e-15 cm-2 s-1 TeV-1
 Spectral index: -2.580 +- 0.010
 Test Radius: 0.0 deg
 
-No second spectrum available for this source
+No second spectrum available

--- a/gammapy/catalog/tests/test_hawc.py
+++ b/gammapy/catalog/tests/test_hawc.py
@@ -136,8 +136,10 @@ class TestSourceCatalog3HWC:
 class TestSourceCatalogObject3HWC:
     @staticmethod
     def test_data(ca_3hwc):
+
         assert ca_3hwc[0].data["source_name"] == "3HWC J0534+220"
         assert ca_3hwc[0].n_models == 1
+        ca_3hwc[0].info()
 
         assert ca_3hwc[1].data["source_name"] == "3HWC J0540+228"
         assert ca_3hwc[1].n_models == 1


### PR DESCRIPTION
This PR fix SourceCatalog3HWC.sky_model() and solves #3292.
The methods .spectral_model(), .spatial_model(), .sky_model() were all broken because they wrongly assumed the same catalog structure for 3HWAC than for 2HWC. The changes include the following:
- As there is only one model per source in 3HAWC we can  set `n_models = 1`, remove `._get_idx() `and remove the `which` options  in the model functions.
- moved specific cases from base class to 2HWAC class
- corrected several typos in parameters and table column names.
- added missing tests for 3HAWC