### PR TITLE
Add find_roots generic function

### DIFF
--- a/gammapy/estimators/tests/test_utils.py
+++ b/gammapy/estimators/tests/test_utils.py
@@ -85,7 +85,7 @@ class TestFindRoots:
                 self.f,
                 lower_bounds=self.lower_bounds,
                 upper_bounds=self.upper_bounds,
-                method="brentq",
+                method=method,
             )
             assert res[0]["roots"].unit == u.rad
             assert_allclose(
@@ -99,7 +99,7 @@ class TestFindRoots:
                 self.h,
                 lower_bounds=self.lower_bounds,
                 upper_bounds=self.upper_bounds,
-                method="brentq",
+                method=method,
             )
             assert_allclose(res[0]["roots"].value, np.array([1.0]))
             assert res[1]["roots"] is None

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -12,6 +12,7 @@ from gammapy.modeling.models import (
     SkyModel,
 )
 from gammapy.utils.interpolation import interpolation_scale
+
 __all__ = ["find_roots", "find_peaks", "estimate_exposure_reco_energy"]
 
 from scipy.optimize import root_scalar
@@ -114,7 +115,7 @@ def find_roots(
     NDouput = np.empty(lower_bounds.shape, dtype=object)
     while not it.finished:
         it_idx = it.multi_index
-        
+
         scale = interpolation_scale(points_scale)
         a = scale(lower_bounds[it_idx].value)
         b = scale(upper_bounds[it_idx].value)


### PR DESCRIPTION
This PR add a generic function find_roots in gammapy.estimators.utils, this function is a thin wrapper around `~scipy.optimize.root_scalar` that select the valid bracketing intervals in which run the solver for the search range defined. This aims to solve a bug in the current calls of the root finding methods where the bracketing interval given are not always valid. The usage of find_roots in the relevant places could be implemented in separate(s) PR.