### PR TITLE
Change HLI default for Fit range

### DIFF
--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -119,8 +119,8 @@ class SpatialCircleConfig(GammapyBaseConfig):
 
 
 class EnergyRangeConfig(GammapyBaseConfig):
-    min: EnergyType = "0.1 TeV"
-    max: EnergyType = "10 TeV"
+    min: EnergyType = None
+    max: EnergyType = None
 
 
 class TimeRangeConfig(GammapyBaseConfig):

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -175,6 +175,7 @@ class Analysis:
 
         fit_settings = self.config.fit
         for dataset in self.datasets:
+            print(fit_settings.fit_range)
             if fit_settings.fit_range:
                 energy_min = fit_settings.fit_range.min
                 energy_max = fit_settings.fit_range.max

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -175,7 +175,6 @@ class Analysis:
 
         fit_settings = self.config.fit
         for dataset in self.datasets:
-            print(fit_settings.fit_range)
             if fit_settings.fit_range:
                 energy_min = fit_settings.fit_range.min
                 energy_max = fit_settings.fit_range.max

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -284,7 +284,6 @@ def test_analysis_1d_stacked_no_fit_range():
             method: reflected
     """
     config = AnalysisConfig.from_yaml(cfg)
-#    config = get_example_config("1d")
     analysis = Analysis(config)
     analysis.update_config(cfg)
     analysis.config.datasets.stack = True

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -236,34 +236,6 @@ def test_exclusion_region(tmp_path):
 
 @requires_dependency("iminuit")
 @requires_data()
-def test_analysis_1d_stacked():
-    cfg = """
-    datasets:
-        geom:
-            axes:
-                energy_true: {min: 0.03 TeV, max: 100 TeV, nbins: 50}
-        background:
-            method: reflected
-    """
-
-    config = get_example_config("1d")
-    analysis = Analysis(config)
-    analysis.update_config(cfg)
-    analysis.config.datasets.stack = True
-    analysis.get_observations()
-    analysis.get_datasets()
-    analysis.read_models(MODEL_FILE_1D)
-    analysis.run_fit()
-
-    assert len(analysis.datasets) == 1
-    assert_allclose(analysis.datasets["stacked"].counts.data.sum(), 184)
-    pars = analysis.fit_result.parameters
-
-    assert_allclose(pars["index"].value, 2.76913, rtol=1e-2)
-    assert_allclose(pars["amplitude"].value, 5.479729e-11, rtol=1e-2)
-
-@requires_dependency("iminuit")
-@requires_data()
 def test_analysis_1d_stacked_no_fit_range():
     cfg = """
     observations:

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -262,6 +262,45 @@ def test_analysis_1d_stacked():
     assert_allclose(pars["index"].value, 2.76913, rtol=1e-2)
     assert_allclose(pars["amplitude"].value, 5.479729e-11, rtol=1e-2)
 
+@requires_dependency("iminuit")
+@requires_data()
+def test_analysis_1d_stacked_no_fit_range():
+    cfg = """
+    observations:
+        datastore: $GAMMAPY_DATA/hess-dl3-dr1
+        obs_cone: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 5 deg}
+        obs_ids: [23592, 23559]
+
+    datasets:
+        type: 1d
+        stack: false
+        geom:
+            axes:
+                energy: {min: 0.01 TeV, max: 100 TeV, nbins: 73}
+                energy_true: {min: 0.03 TeV, max: 100 TeV, nbins: 50}
+        on_region: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 0.1 deg}
+        containment_correction: true
+        background:
+            method: reflected
+    """
+    config = AnalysisConfig.from_yaml(cfg)
+#    config = get_example_config("1d")
+    analysis = Analysis(config)
+    analysis.update_config(cfg)
+    analysis.config.datasets.stack = True
+    analysis.get_observations()
+    analysis.get_datasets()
+    analysis.read_models(MODEL_FILE_1D)
+    analysis.run_fit()
+
+    assert len(analysis.datasets) == 1
+    assert_allclose(analysis.datasets["stacked"].counts.data.sum(), 184)
+    pars = analysis.fit_result.parameters
+    assert_allclose(analysis.datasets[0].mask_fit.data, True)
+
+    assert_allclose(pars["index"].value, 2.76913, rtol=1e-2)
+    assert_allclose(pars["amplitude"].value, 5.479729e-11, rtol=1e-2)
+
 
 @requires_data()
 def test_analysis_ring_background():

--- a/gammapy/analysis/tests/test_config.py
+++ b/gammapy/analysis/tests/test_config.py
@@ -29,8 +29,8 @@ def test_config_default_types():
     assert isinstance(config.datasets.geom.axes.energy_true.min, Quantity)
     assert isinstance(config.datasets.geom.axes.energy_true.max, Quantity)
     assert isinstance(config.datasets.geom.selection.offset_max, Angle)
-    assert isinstance(config.fit.fit_range.min, Quantity)
-    assert isinstance(config.fit.fit_range.max, Quantity)
+    assert config.fit.fit_range.min is None
+    assert config.fit.fit_range.max is None
 
 
 def test_config_not_default_types():
@@ -41,6 +41,7 @@ def test_config_not_default_types():
         "lat": "22.014 deg",
         "radius": "1 deg",
     }
+    config.fit.fit_range = {"min": "0.1 TeV", "max": "10 TeV"}
     assert isinstance(config.observations.obs_cone.frame, FrameEnum)
     assert isinstance(config.observations.obs_cone.lon, Angle)
     assert isinstance(config.observations.obs_cone.lat, Angle)
@@ -49,6 +50,8 @@ def test_config_not_default_types():
     assert isinstance(config.observations.obs_time.start, Time)
     with pytest.raises(ValueError):
         config.flux_points.energy.min = "1 deg"
+    assert isinstance(config.fit.fit_range.min, Quantity)
+    assert isinstance(config.fit.fit_range.max, Quantity)
 
 
 def test_config_basics():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the default fit range min and max of the `AnalysisConfig` to `None` to avoid having a 1-10 TeV range applied silently.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
