### PR TITLE
Fix npred after energy resampling in ExcessMapEstimator

### DIFF
--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -166,11 +166,14 @@ class ExcessMapEstimator(Estimator):
 
         axis = MapAxis.from_energy_edges(energy_edges)
 
-        resampled_dataset = dataset.resample_energy_axis(energy_axis=axis)
-
-        # Beware we rely here on the correct npred background in MapDataset.resample_energy_axis
-        resampled_dataset.models = dataset.models
-
+        resampled_dataset = dataset.resample_energy_axis(
+            energy_axis=axis, name=dataset.name
+        )
+        if isinstance(dataset, MapDatasetOnOff):
+            resampled_dataset.models = dataset.models
+        else:
+            resampled_dataset.background = dataset.npred().resample_axis(axis=axis)
+            resampled_dataset.models = None
         result = self.estimate_excess_map(resampled_dataset)
 
         return result

--- a/gammapy/estimators/excess_profile.py
+++ b/gammapy/estimators/excess_profile.py
@@ -257,9 +257,9 @@ class ExcessProfileEstimator(Estimator):
         """
         if self.energy_edges is not None:
             axis = MapAxis.from_energy_edges(self.energy_edges)
-            dataset = dataset.resample_energy_axis(energy_axis=axis)
+            dataset = dataset.resample_energy_axis(energy_axis=axis, name=dataset.name)
         else:
-            dataset = dataset.to_image()
+            dataset = dataset.to_image(name=dataset.name)
 
         spectrum_datasets = self.get_spectrum_datasets(dataset)
 


### PR DESCRIPTION
Issue #3273 pointed out that the ExcessMapEstimator.run() ignores the models that have a datasets_names attribute set, and that in order to preserve the predicted number of background counts during the energy axis resampling, we have to resample the npred_background. This PR implement the solution discussed.