### PR TITLE
Implement HpxGeom.to_binsz()

### DIFF
--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -956,6 +956,36 @@ class HpxGeom(Geom):
         order = nside_to_order(nside=nside)
         return self.to_ud_graded(order=order)
 
+    def to_binsz(self, binsz):
+        """Change pixel size of the geometry.
+
+        Parameters
+        ----------
+        binsz : float or `~astropy.units.Quantity`
+            New pixel size. A float is assumed to be in degree.
+
+        Returns
+        -------
+        geom : `WcsGeom`
+            Geometry with new pixel size.
+        """
+        binsz = u.Quantity(binsz, "deg").value
+
+        if self.is_allsky:
+            return self.create(
+                binsz=binsz,
+                frame=self.frame,
+                axes=copy.deepcopy(self.axes),
+            )
+        else:
+            return self.create(
+                skydir=self.center_skydir,
+                binsz=binsz,
+                width=self._get_region_size(),
+                frame=self.frame,
+                axes=copy.deepcopy(self.axes),
+            )
+
     def to_swapped(self):
         """Geometry copy with swapped ORDERING (NEST->RING or vice versa).
 

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -802,3 +802,25 @@ def test_hpxgeom_equal(nside, nested, frame, region, result):
 
     assert (geom0 == geom1) is result
     assert (geom0 != geom1) is not result
+
+
+def test_hpx_geom_to_binsz():
+    geom = HpxGeom.create(nside=32, frame="galactic", nest=True)
+
+    geom_new = geom.to_binsz(1 * u.deg)
+
+    assert geom_new.nside[0] == 64
+    assert geom_new.frame == "galactic"
+    assert geom_new.nest
+
+    geom = HpxGeom.create(nside=32, frame="galactic", nest=True, region="DISK(110.,75.,10.)")
+
+    geom_new = geom.to_binsz(1 * u.deg)
+    assert geom_new.nside[0] == 64
+
+    center = geom_new.center_skydir.galactic
+
+    assert_allclose(center.l.deg, 110)
+    assert_allclose(center.b.deg, 75)
+
+


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request implements `HpxGeom.to_binsz()`, which can be convenient to change the bin size to an existing HEALPix geometry. This makes it compatible in API with `WcsGeom.to_binsz()`

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
