### PR TITLE
Add support for ExcessMapEstimator on HLI

### DIFF
--- a/docs/tutorials/starting/analysis_1.ipynb
+++ b/docs/tutorials/starting/analysis_1.ipynb
@@ -191,7 +191,9 @@
    "metadata": {},
    "source": [
     "### Setting modeling and fitting parameters\n",
-    "`Analysis` can perform a few modeling and fitting tasks besides data reduction. Parameters have then to be passed to the configuration object."
+    "`Analysis` can perform a few modeling and fitting tasks besides data reduction. Parameters have then to be passed to the configuration object.\n",
+    "\n",
+    "Here we define the energy range on which to perform the fit. We also set the energy edges used for flux point computation as well as the correlation radius to compute excess and significance maps. "
    ]
   },
   {
@@ -202,7 +204,8 @@
    "source": [
     "config.fit.fit_range.min = 1 * u.TeV\n",
     "config.fit.fit_range.max = 10 * u.TeV\n",
-    "config.flux_points.energy = {\"min\": \"1 TeV\", \"max\": \"10 TeV\", \"nbins\": 3}"
+    "config.flux_points.energy = {\"min\": \"1 TeV\", \"max\": \"10 TeV\", \"nbins\": 3}\n",
+    "config.excess_map.correlation_radius = 0.1 * u.deg"
    ]
   },
   {
@@ -352,6 +355,23 @@
    "source": [
     "counts = analysis.datasets[\"stacked\"].counts\n",
     "counts.smooth(\"0.05 deg\").plot_interactive()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also compute the map of the sqrt_ts (significance) of the excess counts above the background. The correlation radius to sum counts is defined in the config file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis.get_excess_map()\n",
+    "analysis.excess_maps[\"sqrt_ts\"].plot(add_cbar=True)"
    ]
   },
   {
@@ -547,6 +567,23 @@
    "source": [
     "filename = path / \"flux-points.fits\"\n",
     "analysis.flux_points.write(filename, overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To check the fit is correct, we compute the map of the sqrt_ts of the excess counts above the current model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis.get_excess_map()\n",
+    "analysis.excess_maps[\"sqrt_ts\"].plot(add_cbar=True)"
    ]
   },
   {

--- a/docs/tutorials/starting/analysis_1.ipynb
+++ b/docs/tutorials/starting/analysis_1.ipynb
@@ -371,7 +371,7 @@
    "outputs": [],
    "source": [
     "analysis.get_excess_map()\n",
-    "analysis.excess_maps[\"sqrt_ts\"].plot(add_cbar=True)"
+    "analysis.excess_map[\"sqrt_ts\"].plot(add_cbar=True)"
    ]
   },
   {
@@ -583,7 +583,7 @@
    "outputs": [],
    "source": [
     "analysis.get_excess_map()\n",
-    "analysis.excess_maps[\"sqrt_ts\"].plot(add_cbar=True)"
+    "analysis.excess_map[\"sqrt_ts\"].plot(add_cbar=True)"
    ]
   },
   {
@@ -714,7 +714,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 1,
+       "index": 1.0,
        "layout": "IPY_MODEL_4dec76e5bf084cf490b298615ce29203",
        "style": "IPY_MODEL_c360071495e048b2aca6c16a6568fd96"
       }
@@ -766,7 +766,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0,
+       "index": 0.0,
        "layout": "IPY_MODEL_4346fce106fc4236b9ba5f0ef7eac4ab",
        "orientation": "horizontal",
        "readout": true,
@@ -969,8 +969,8 @@
       }
      }
     },
-    "version_major": 2,
-    "version_minor": 0
+    "version_major": 2.0,
+    "version_minor": 0.0
    }
   }
  },

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -139,8 +139,8 @@ class FitConfig(GammapyBaseConfig):
 
 
 class ExcessMapConfig(GammapyBaseConfig):
-    correlation_radius: AngleType = '0.1 deg'
-    parameters: dict = {"selection_optional": ""}
+    correlation_radius: AngleType = "0.1 deg"
+    parameters: dict = {}
     energy_edges: EnergyAxisConfig = EnergyAxisConfig()
 
 

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -106,9 +106,9 @@ class SkyCoordConfig(GammapyBaseConfig):
 
 
 class EnergyAxisConfig(GammapyBaseConfig):
-    min: EnergyType = "0.1 TeV"
-    max: EnergyType = "10 TeV"
-    nbins: int = 30
+    min: EnergyType = None
+    max: EnergyType = None
+    nbins: int = None
 
 
 class SpatialCircleConfig(GammapyBaseConfig):
@@ -141,7 +141,7 @@ class FitConfig(GammapyBaseConfig):
 class ExcessMapConfig(GammapyBaseConfig):
     correlation_radius: AngleType = '0.1 deg'
     parameters: dict = {"selection_optional": ""}
-    energy_edges: EnergyAxisConfig = None
+    energy_edges: EnergyAxisConfig = EnergyAxisConfig()
 
 
 class BackgroundConfig(GammapyBaseConfig):
@@ -156,8 +156,8 @@ class SafeMaskConfig(GammapyBaseConfig):
 
 
 class EnergyAxesConfig(GammapyBaseConfig):
-    energy: EnergyAxisConfig = EnergyAxisConfig()
-    energy_true: EnergyAxisConfig = EnergyAxisConfig()
+    energy: EnergyAxisConfig = EnergyAxisConfig(min="1 TeV", max="10 TeV", nbins=5)
+    energy_true: EnergyAxisConfig = EnergyAxisConfig(min="0.5 TeV", max="20 TeV", nbins=16)
 
 
 class SelectionConfig(GammapyBaseConfig):

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -138,6 +138,12 @@ class FitConfig(GammapyBaseConfig):
     fit_range: EnergyRangeConfig = EnergyRangeConfig()
 
 
+class ExcessMapConfig(GammapyBaseConfig):
+    correlation_radius: AngleType = '0.1 deg'
+    parameters: dict = {"selection_optional": ""}
+    energy_edges: EnergyAxisConfig = None
+
+
 class BackgroundConfig(GammapyBaseConfig):
     method: BackgroundMethodEnum = None
     exclusion: FilePath = None
@@ -216,6 +222,7 @@ class AnalysisConfig(GammapyBaseConfig):
     datasets: DatasetsConfig = DatasetsConfig()
     fit: FitConfig = FitConfig()
     flux_points: FluxPointsConfig = FluxPointsConfig()
+    excess_map: ExcessMapConfig = ExcessMapConfig()
 
     def __str__(self):
         """Display settings in pretty YAML format."""

--- a/gammapy/analysis/config/docs.yaml
+++ b/gammapy/analysis/config/docs.yaml
@@ -59,3 +59,10 @@ flux_points:
     energy: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
     source: "source"
     parameters: {}
+
+# Section: excess_map
+# Flux/significance map process /optional
+excess_map:
+    correlation_radius: 0.1 deg
+    energy_edges: {min: None, max: None, nbins: None}
+    parameters: {}

--- a/gammapy/analysis/config/docs.yaml
+++ b/gammapy/analysis/config/docs.yaml
@@ -64,5 +64,5 @@ flux_points:
 # Flux/significance map process /optional
 excess_map:
     correlation_radius: 0.1 deg
-    energy_edges: {min: None, max: None, nbins: None}
+    energy_edges: {min: 0.1 TeV, max: 10 TeV, nbins: 1}
     parameters: {}

--- a/gammapy/analysis/config/example-3d.yaml
+++ b/gammapy/analysis/config/example-3d.yaml
@@ -30,3 +30,8 @@ fit:
 
 flux_points:
     energy: {min: 1 TeV, max: 10 TeV, nbins: 2}
+
+excess_map:
+    correlation_radius: 0.1 deg
+    energy_edges: {min: None, max: None, nbins: None}
+    parameters: {}

--- a/gammapy/analysis/config/example-3d.yaml
+++ b/gammapy/analysis/config/example-3d.yaml
@@ -33,5 +33,5 @@ flux_points:
 
 excess_map:
     correlation_radius: 0.1 deg
-    energy_edges: {min: None, max: None, nbins: None}
+    energy_edges: {min: 1 TeV, max: 10 TeV, nbins: 1}
     parameters: {}

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -407,7 +407,9 @@ class Analysis:
 
     @staticmethod
     def _make_energy_axis(axis, name="energy"):
-        if axis.min is None and axis.max is None:
+        if axis.min is None or axis.max is None:
+            return None
+        elif axis.nbins is None or axis.nbins<1:
             return None
         else:
             return MapAxis.from_bounds(

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -7,7 +7,7 @@ from regions import CircleSkyRegion
 from gammapy.analysis.config import AnalysisConfig
 from gammapy.data import DataStore
 from gammapy.datasets import Datasets, FluxPointsDataset, MapDataset, SpectrumDataset
-from gammapy.estimators import FluxPointsEstimator
+from gammapy.estimators import FluxPointsEstimator, ExcessMapEstimator
 from gammapy.makers import (
     FoVBackgroundMaker,
     MapDatasetMaker,
@@ -206,6 +206,29 @@ class Analysis:
         )
         cols = ["e_ref", "ref_flux", "dnde", "dnde_ul", "dnde_err", "is_ul"]
         log.info("\n{}".format(self.flux_points.data.table[cols]))
+
+    def get_excess_map(self):
+        """Calculate excess map with respect to the current model."""
+        excess_settings = self.config.excess_map
+        log.info("Computing excess maps.")
+
+        if self.config.datasets.type == "1d":
+            raise ValueError("Cannot compute excess map for 1D dataset")
+
+        # Here we could possibly stack the datasets if needed.
+        if len(self.datasets)>1:
+            raise ValueError("Datasets must be stacked to compute the excess map")
+
+        energy_edges = None
+        if excess_settings.energy_edges:
+            energy_edges = excess_settings.energy_edges.edges
+
+        excess_map_estimator = ExcessMapEstimator(
+            correlation_radius=excess_settings.correlation_radius,
+            energy_edges=energy_edges,
+            **excess_settings.parameters
+        )
+        self.excess_maps = excess_map_estimator.run(self.datasets[0])
 
     def update_config(self, config):
         self.config = self.config.update(config=config)

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -228,7 +228,7 @@ class Analysis:
             energy_edges=energy_edges,
             **excess_settings.parameters
         )
-        self.excess_maps = excess_map_estimator.run(self.datasets[0])
+        self.excess_map = excess_map_estimator.run(self.datasets[0])
 
     def update_config(self, config):
         self.config = self.config.update(config=config)

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -219,9 +219,9 @@ class Analysis:
         if len(self.datasets)>1:
             raise ValueError("Datasets must be stacked to compute the excess map")
 
-        energy_edges = None
-        if excess_settings.energy_edges:
-            energy_edges = excess_settings.energy_edges.edges
+        energy_edges = self._make_energy_axis(excess_settings.energy_edges)
+        if energy_edges is not None:
+            energy_edges = energy_edges.edges
 
         excess_map_estimator = ExcessMapEstimator(
             correlation_radius=excess_settings.correlation_radius,
@@ -407,12 +407,15 @@ class Analysis:
 
     @staticmethod
     def _make_energy_axis(axis, name="energy"):
-        return MapAxis.from_bounds(
-            name=name,
-            lo_bnd=axis.min.value,
-            hi_bnd=axis.max.to_value(axis.min.unit),
-            nbin=axis.nbins,
-            unit=axis.min.unit,
-            interp="log",
-            node_type="edges",
-        )
+        if axis.min is None and axis.max is None:
+            return None
+        else:
+            return MapAxis.from_bounds(
+                name=name,
+                lo_bnd=axis.min.value,
+                hi_bnd=axis.max.to_value(axis.min.unit),
+                nbin=axis.nbins,
+                unit=axis.min.unit,
+                interp="log",
+                node_type="edges",
+            )

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -289,8 +289,8 @@ def test_analysis_ring_background():
     assert_allclose(
         analysis.datasets[0].npred_background().data[0, 10, 10], 0.091799, rtol=1e-2
     )
-    assert isinstance(analysis.excess_maps["sqrt_ts"], WcsNDMap)
-    assert_allclose(analysis.excess_maps["excess"].data[0,62,62],134.12389)
+    assert isinstance(analysis.excess_map["sqrt_ts"], WcsNDMap)
+    assert_allclose(analysis.excess_map["excess"].data[0,62,62],134.12389)
 
 @requires_data()
 def test_analysis_ring_3d():

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -263,6 +263,8 @@ def test_analysis_1d_stacked_no_fit_range():
     analysis.get_datasets()
     analysis.read_models(MODEL_FILE_1D)
     analysis.run_fit()
+    with pytest.raises(ValueError):
+        analysis.get_excess_map()
 
     assert len(analysis.datasets) == 1
     assert_allclose(analysis.datasets["stacked"].counts.data.sum(), 184)
@@ -282,11 +284,13 @@ def test_analysis_ring_background():
     analysis = Analysis(config)
     analysis.get_observations()
     analysis.get_datasets()
+    analysis.get_excess_map()
     assert isinstance(analysis.datasets[0], MapDataset)
     assert_allclose(
         analysis.datasets[0].npred_background().data[0, 10, 10], 0.091799, rtol=1e-2
     )
-
+    assert isinstance(analysis.excess_maps["sqrt_ts"], WcsNDMap)
+    assert_allclose(analysis.excess_maps["excess"].data[0,62,62],134.12389)
 
 @requires_data()
 def test_analysis_ring_3d():

--- a/gammapy/analysis/tests/test_config.py
+++ b/gammapy/analysis/tests/test_config.py
@@ -32,7 +32,9 @@ def test_config_default_types():
     assert config.fit.fit_range.min is None
     assert config.fit.fit_range.max is None
     assert isinstance(config.excess_map.correlation_radius, Angle)
-    assert config.excess_map.energy_edges is None
+    assert config.excess_map.energy_edges.min is None
+    assert config.excess_map.energy_edges.max is None
+    assert config.excess_map.energy_edges.nbins is None
 
 def test_config_not_default_types():
     config = AnalysisConfig()

--- a/gammapy/analysis/tests/test_config.py
+++ b/gammapy/analysis/tests/test_config.py
@@ -31,7 +31,8 @@ def test_config_default_types():
     assert isinstance(config.datasets.geom.selection.offset_max, Angle)
     assert config.fit.fit_range.min is None
     assert config.fit.fit_range.max is None
-
+    assert isinstance(config.excess_map.correlation_radius, Angle)
+    assert config.excess_map.energy_edges is None
 
 def test_config_not_default_types():
     config = AnalysisConfig()

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -156,7 +156,7 @@ class ExcessMapEstimator(Estimator):
 
         """
         if not isinstance(dataset, MapDataset):
-            raise ValueError("Unsupported dataset type")
+            raise ValueError("Unsupported dataset type. Excess map is not applicable to 1D datasets.")
 
         if self.energy_edges is None:
             energy_axis = dataset.counts.geom.axes["energy"]


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a new config argument for `ExcessMapEstimator` as well as a the corresponding method `Analysis.get_excess_map()`

The default values for `EnergyAxisConfig` arguments is set to None, but default values are added to `EnergyAxesConfig`
**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
