### PR TITLE
Implement HpxNDMap.smooth()

### DIFF
--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -429,7 +429,8 @@ class HpxNDMap(HpxMap):
             elif kernel == "disk":
                 lmax = 3*nside-1
                 # create the step function in angular space
-                theta = np.append(np.linspace(0,width), width+1e-7)
+                # (this is not great)
+                theta = np.append(np.linspace(0,width), np.linspace(width+1e-7, width+1, 10))
                 beam = np.ones(len(theta))
                 beam[theta>width]=0
                 # convert to the spherical harmonics space

--- a/gammapy/maps/tests/test_hpxnd.py
+++ b/gammapy/maps/tests/test_hpxnd.py
@@ -499,3 +499,10 @@ def test_smooth(kernel):
     actual_ring = smoothed_ring.data.sum()
     assert_allclose(actual_ring, desired_ring)
     assert smoothed_ring.data.dtype == float
+
+    with pytest.raises(NotImplementedError):
+        cutout = m_nest.cutout(position=(0,0), width=5*u.deg)
+        cutout.smooth(0.2 * u.deg, kernel)
+
+    with pytest.raises(ValueError):
+        m_nest.smooth(0.2 * u.deg, "box")

--- a/gammapy/maps/tests/test_hpxnd.py
+++ b/gammapy/maps/tests/test_hpxnd.py
@@ -471,3 +471,31 @@ def test_hpx_map_to_region_nd_map():
     spec_interp = m.to_region_nd_map(region=circle.center, func=np.mean)
     assert_allclose(spec_interp.data, 1)
 
+@pytest.mark.parametrize("kernel", ["gauss", "disk"])
+def test_smooth(kernel):
+    axes = [
+        MapAxis(np.logspace(0.0, 3.0, 3), interp="log"),
+        MapAxis(np.logspace(1.0, 3.0, 4), interp="lin"),
+    ]
+    geom_nest = HpxGeom.create(
+        nside=256,nest = False, frame="galactic", axes=axes
+    )
+    geom_ring = HpxGeom.create(
+        nside=256,nest = True, frame="galactic", axes=axes
+    )
+    m_nest = HpxNDMap(geom_nest, data=np.ones(geom_nest.data_shape), unit="m2")
+    m_ring = HpxNDMap(geom_ring, data=np.ones(geom_ring.data_shape), unit="m2")
+
+    desired_nest = m_nest.data.sum()
+    desired_ring = m_ring.data.sum()
+
+    smoothed_nest = m_nest.smooth(0.2 * u.deg, kernel)
+    smoothed_ring = m_ring.smooth(0.2 * u.deg, kernel)
+
+    actual_nest = smoothed_nest.data.sum()
+    assert_allclose(actual_nest, desired_nest)
+    assert smoothed_nest.data.dtype == float
+
+    actual_ring = smoothed_ring.data.sum()
+    assert_allclose(actual_ring, desired_ring)
+    assert smoothed_ring.data.dtype == float


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request implements a function to smooth HpxNDMaps for two different choices of the kernel, gaussian and disk.
It relies on `healpy.sphtfunc.smoothing` for the smoothing and on `healpy.sphtfunc.beam2bl()` to construct the beam function in the harmonics space from the angular radial profile of the disk

**Dear reviewer**
I marked it as draft because I am unsure of the normalization for the disk window_beam function. The method `healpy.sphtfunc.smoothing` has a dedicated implementation of a gaussian beam, which looks like this in l-space
![image](https://user-images.githubusercontent.com/22521727/114872152-54802080-9dfa-11eb-99f4-96d1fa21b5b6.png)
When transforming it to angular space via `healpy.sphtfunc.bl2beam()` we get
![image](https://user-images.githubusercontent.com/22521727/114872269-711c5880-9dfa-11eb-8e93-a1c1b27681db.png)
where the x axis are angles in radians.

Analogous to this case, I construct the angular radial disk profile with a step function:
![image](https://user-images.githubusercontent.com/22521727/114872467-a9bc3200-9dfa-11eb-8307-ece1d102af36.png)
and then normalize the corresponding window beam function so that it peaks at 1, like in the Gaussian case:
![image](https://user-images.githubusercontent.com/22521727/114872622-cd7f7800-9dfa-11eb-9a4d-b8599d82d51d.png)


but I am not sure how to test that this is 100% correct.