### PR TITLE
Add optimizer option to estimators

### DIFF
--- a/docs/tutorials/analysis/3D/analysis_3d.ipynb
+++ b/docs/tutorials/analysis/3D/analysis_3d.ipynb
@@ -307,8 +307,8 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "fit = Fit([dataset_stacked])\n",
-    "result = fit.run(optimize_opts={\"print_level\": 1})"
+    "fit = Fit([dataset_stacked], optimize_opts={\"print_level\": 1})\n",
+    "result = fit.run()"
    ]
   },
   {

--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -421,8 +421,8 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "fit = Fit([dataset])\n",
-    "result = fit.run(optimize_opts={\"print_level\": 1})\n",
+    "fit = Fit([dataset], optimize_opts={\"print_level\": 1})\n",
+    "result = fit.run()\n",
     "print(result)"
    ]
   },

--- a/docs/tutorials/analysis/3D/mcmc_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/mcmc_sampling.ipynb
@@ -196,8 +196,8 @@
    "outputs": [],
    "source": [
     "# If you want to fit the data for comparison with MCMC later\n",
-    "# fit = Fit(dataset)\n",
-    "# result = fit.run(optimize_opts={\"print_level\": 1})"
+    "# fit = Fit(dataset, optimize_opts={\"print_level\": 1})\n",
+    "# result = fit.run()"
    ]
   },
   {

--- a/docs/tutorials/analysis/3D/simulate_3d.ipynb
+++ b/docs/tutorials/analysis/3D/simulate_3d.ipynb
@@ -279,8 +279,8 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "fit = Fit([dataset])\n",
-    "result = fit.run(optimize_opts={\"print_level\": 1})"
+    "fit = Fit([dataset], optimize_opts={\"print_level\": 1})\n",
+    "result = fit.run()"
    ]
   },
   {

--- a/docs/tutorials/api/fitting.ipynb
+++ b/docs/tutorials/api/fitting.ipynb
@@ -142,7 +142,8 @@
    "source": [
     "%%time\n",
     "scipy_opts = {\"method\": \"L-BFGS-B\", \"options\": {\"ftol\": 1e-4, \"gtol\": 1e-05}}\n",
-    "result_scipy = fit.run(backend=\"scipy\", optimize_opts=scipy_opts)"
+    "fit = Fit([dataset_hess], store_trace=True, backend=\"scipy\", optimize_opts=scipy_opts)\n",
+    "result_scipy = fit.run()"
    ]
   },
   {
@@ -162,7 +163,8 @@
    "source": [
     "%%time\n",
     "sherpa_opts = {\"method\": \"simplex\", \"ftol\": 1e-3, \"maxfev\": int(1e4)}\n",
-    "results_simplex = fit.run(backend=\"sherpa\", optimize_opts=sherpa_opts)"
+    "fit = Fit([dataset_hess], store_trace=True, backend=\"sherpa\", optimize_opts=sherpa_opts)\n",
+    "results_simplex = fit.run()"
    ]
   },
   {
@@ -181,7 +183,9 @@
    "source": [
     "%%time\n",
     "minuit_opts = {\"tol\": 0.001, \"strategy\": 1}\n",
-    "result_minuit = fit.run(backend=\"minuit\", optimize_opts=minuit_opts)"
+    "fit.backend = \"minuit\"\n",
+    "fit.optimize_opts = minuit_opts\n",
+    "result_minuit = fit.run()"
    ]
   },
   {

--- a/docs/tutorials/starting/analysis_2.ipynb
+++ b/docs/tutorials/starting/analysis_2.ipynb
@@ -396,8 +396,8 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "fit = Fit([stacked])\n",
-    "result = fit.run(optimize_opts={\"print_level\": 1})"
+    "fit = Fit([stacked], optimize_opts={\"print_level\": 1})\n",
+    "result = fit.run()"
    ]
   },
   {

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -186,8 +186,8 @@ class Analysis:
                 dataset.mask_fit = geom.energy_mask(energy_min, energy_max)
 
         log.info("Fitting datasets.")
-        self.fit = Fit(self.datasets)
-        self.fit_result = self.fit.run(optimize_opts=optimize_opts)
+        self.fit = Fit(self.datasets, optimize_opts=optimize_opts)
+        self.fit_result = self.fit.run()
         log.info(self.fit_result)
 
     def get_flux_points(self):

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -12,7 +12,7 @@ from gammapy.utils.testing import mpl_plot_check, requires_data, requires_depend
 
 @pytest.fixture()
 def fit(dataset):
-    return Fit([dataset])
+    return Fit([dataset], backend="minuit")
 
 
 @pytest.fixture()
@@ -81,12 +81,13 @@ def test_flux_point_dataset_str(dataset):
 class TestFluxPointFit:
     @requires_dependency("iminuit")
     def test_fit_pwl_minuit(self, fit):
-        result = fit.run(backend="minuit")
+        result = fit.run()
         self.assert_result(result)
 
     @requires_dependency("sherpa")
     def test_fit_pwl_sherpa(self, fit):
-        result = fit.optimize(backend="sherpa", method="simplex")
+        fit.backend = backend="sherpa"
+        result = fit.optimize(method="simplex")
         self.assert_result(result)
 
     @staticmethod
@@ -106,8 +107,8 @@ class TestFluxPointFit:
     @staticmethod
     @requires_dependency("iminuit")
     def test_stat_profile(fit):
-
-        result = fit.run(backend="minuit")
+        fit.backend = "minuit"
+        result = fit.run()
 
         profile = fit.stat_profile("amplitude", nvalues=3, bounds=1)
 

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -38,6 +38,12 @@ class FluxEstimator(Estimator):
         Sigma to use for asymmetric error computation.
     n_sigma_ul : int
         Sigma to use for upper limit computation.
+    backend : str
+        Backend used for fitting, default : minuit
+    optimize_opts : dict
+        Options passed to `Fit.optimize`.
+    covariance_opts : dict
+        Options passed to `Fit.covariance`.
     reoptimize : bool
         Re-optimize other free model parameters.
     selection_optional : list of str
@@ -65,6 +71,9 @@ class FluxEstimator(Estimator):
         norm_values=None,
         n_sigma=1,
         n_sigma_ul=3,
+        backend="minuit",
+        optimize_opts=None,
+        covariance_opts=None,
         reoptimize=True,
         selection_optional=None,
     ):
@@ -83,6 +92,13 @@ class FluxEstimator(Estimator):
 
         self.n_sigma = n_sigma
         self.n_sigma_ul = n_sigma_ul
+        self.backend = backend
+        if optimize_opts is None:
+            optimize_opts = {}
+        if covariance_opts is None:
+            covariance_opts = {}
+        self.optimize_opts = optimize_opts
+        self.covariance_opts = covariance_opts
         self.reoptimize = reoptimize
         self.selection_optional = selection_optional
 
@@ -93,6 +109,9 @@ class FluxEstimator(Estimator):
             scan_values=self.norm_values,
             n_sigma=self.n_sigma,
             n_sigma_ul=self.n_sigma_ul,
+            backend = self.backend,
+            optimize_opts = self.optimize_opts,
+            covariance_opts = self.covariance_opts,
             reoptimize=self.reoptimize,
             selection_optional=self.selection_optional,
         )
@@ -145,21 +164,13 @@ class FluxEstimator(Estimator):
         scale_model.norm.frozen = False
         return scale_model
 
-    def run(
-        self, datasets, backend="minuit", optimize_opts=None, covariance_opts=None,
-    ):
+    def run(self, datasets):
         """Estimate flux for a given energy range.
 
         Parameters
         ----------
         datasets : list of `~gammapy.datasets.SpectrumDataset`
             Spectrum datasets.
-        backend : str
-            Backend used for fitting, default : minuit
-        optimize_opts : dict
-            Options passed to `Fit.optimize`.
-        covariance_opts : dict
-            Options passed to `Fit.covariance`.
 
         Returns
         -------
@@ -203,13 +214,7 @@ class FluxEstimator(Estimator):
 
             datasets_sliced.models = models
             result.update(
-                self._parameter_estimator.run(
-                    datasets_sliced,
-                    model.norm,
-                    backend=backend,
-                    optimize_opts=optimize_opts,
-                    covariance_opts=covariance_opts,
-                )
+                self._parameter_estimator.run(datasets_sliced,model.norm)
             )
             result["sqrt_ts"] = self.get_sqrt_ts(result["ts"], result["norm"])
 

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -109,9 +109,9 @@ class FluxEstimator(Estimator):
             scan_values=self.norm_values,
             n_sigma=self.n_sigma,
             n_sigma_ul=self.n_sigma_ul,
-            backend = self.backend,
-            optimize_opts = self.optimize_opts,
-            covariance_opts = self.covariance_opts,
+            backend=self.backend,
+            optimize_opts=self.optimize_opts,
+            covariance_opts=self.covariance_opts,
             reoptimize=self.reoptimize,
             selection_optional=self.selection_optional,
         )
@@ -213,9 +213,7 @@ class FluxEstimator(Estimator):
             models[self.source].spectral_model = model
 
             datasets_sliced.models = models
-            result.update(
-                self._parameter_estimator.run(datasets_sliced,model.norm)
-            )
+            result.update(self._parameter_estimator.run(datasets_sliced, model.norm))
             result["sqrt_ts"] = self.get_sqrt_ts(result["ts"], result["norm"])
 
         return result

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -839,13 +839,19 @@ class FluxPointsEstimator(Estimator):
             selection_optional=self.selection_optional,
         )
 
-    def run(self, datasets):
+    def run(self, datasets, backend="minuit", optimize_opts=None, covariance_opts=None):
         """Run the flux point estimator for all energy groups.
 
         Parameters
         ----------
         datasets : list of `~gammapy.datasets.Dataset`
             Datasets
+        backend : str
+            Backend used for fitting, default : minuit
+        optimize_opts : dict
+            Options passed to `Fit.optimize`.
+        covariance_opts : dict
+            Options passed to `Fit.covariance`.
 
         Returns
         -------
@@ -860,7 +866,12 @@ class FluxPointsEstimator(Estimator):
             self.energy_edges[:-1], self.energy_edges[1:]
         ):
             row = self.estimate_flux_point(
-                datasets, energy_min=energy_min, energy_max=energy_max
+                datasets,
+                energy_min=energy_min,
+                energy_max=energy_max,
+                backend=backend,
+                optimize_opts=optimize_opts,
+                covariance_opts=covariance_opts,
             )
             rows.append(row)
 
@@ -869,7 +880,15 @@ class FluxPointsEstimator(Estimator):
         # TODO: this should be changed once likelihood is fully supported
         return FluxPoints(table).to_sed_type("dnde")
 
-    def estimate_flux_point(self, datasets, energy_min, energy_max):
+    def estimate_flux_point(
+        self,
+        datasets,
+        energy_min,
+        energy_max,
+        backend="minuit",
+        optimize_opts=None,
+        covariance_opts=None,
+    ):
         """Estimate flux point for a single energy group.
 
         Parameters
@@ -878,6 +897,12 @@ class FluxPointsEstimator(Estimator):
             Datasets
         energy_min, energy_max : `~astropy.units.Quantity`
             Energy bounds to compute the flux point for.
+        backend : str
+            Backend used for fitting, default : minuit
+        optimize_opts : dict
+            Options passed to `Fit.optimize`.
+        covariance_opts : dict
+            Options passed to `Fit.covariance`.
 
         Returns
         -------
@@ -889,7 +914,14 @@ class FluxPointsEstimator(Estimator):
         )
         fe = self._flux_estimator(energy_min=energy_min, energy_max=energy_max)
 
-        result.update(fe.run(datasets=datasets))
+        result.update(
+            fe.run(
+                datasets=datasets,
+                backend=backend,
+                optimize_opts=optimize_opts,
+                covariance_opts=covariance_opts,
+            )
+        )
 
         return result
 

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -851,9 +851,9 @@ class FluxPointsEstimator(Estimator):
             norm_values=self.norm_values,
             n_sigma=self.n_sigma,
             n_sigma_ul=self.n_sigma_ul,
-            backend = self.backend,
-            optimize_opts = self.optimize_opts,
-            covariance_opts = self.covariance_opts,
+            backend=self.backend,
+            optimize_opts=self.optimize_opts,
+            covariance_opts=self.covariance_opts,
             reoptimize=self.reoptimize,
             selection_optional=self.selection_optional,
         )
@@ -879,9 +879,7 @@ class FluxPointsEstimator(Estimator):
             self.energy_edges[:-1], self.energy_edges[1:]
         ):
             row = self.estimate_flux_point(
-                datasets,
-                energy_min=energy_min,
-                energy_max=energy_max,
+                datasets, energy_min=energy_min, energy_max=energy_max,
             )
             rows.append(row)
 

--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -424,7 +424,14 @@ class LightCurveEstimator(Estimator):
                 continue
 
             row = {"time_min": t_min.mjd, "time_max": t_max.mjd}
-            row.update(self.estimate_time_bin_flux(datasets_to_fit))
+            row.update(
+                self.estimate_time_bin_flux(
+                    datasets_to_fit,
+                    backend=backend,
+                    optimize_opts=optimize_opts,
+                    covariance_opts=covariance_opts,
+                )
+            )
             rows.append(row)
 
         if len(rows) == 0:

--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -408,13 +408,13 @@ class LightCurveEstimator(Estimator):
             norm_values=self.norm_values,
             n_sigma=self.n_sigma,
             n_sigma_ul=self.n_sigma_ul,
-            backend = self.backend,
-            optimize_opts = self.optimize_opts,
-            covariance_opts = self.covariance_opts,
+            backend=self.backend,
+            optimize_opts=self.optimize_opts,
+            covariance_opts=self.covariance_opts,
             reoptimize=self.reoptimize,
             selection_optional=self.selection_optional,
         )
-        
+
     def run(self, datasets):
         """Run light curve extraction.
 
@@ -451,8 +451,7 @@ class LightCurveEstimator(Estimator):
                 continue
 
             row = {"time_min": t_min.mjd, "time_max": t_max.mjd}
-            row.update(
-                self.estimate_time_bin_flux(datasets_to_fit))
+            row.update(self.estimate_time_bin_flux(datasets_to_fit))
             rows.append(row)
 
         if len(rows) == 0:

--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -382,7 +382,7 @@ class LightCurveEstimator(Estimator):
         self.reoptimize = reoptimize
         self.selection_optional = selection_optional
 
-    def run(self, datasets):
+    def run(self, datasets, backend="minuit", optimize_opts=None, covariance_opts=None):
         """Run light curve extraction.
 
         Normalize integral and energy flux between emin and emax.
@@ -391,6 +391,12 @@ class LightCurveEstimator(Estimator):
         ----------
         datasets : list of `~gammapy.datasets.SpectrumDataset` or `~gammapy.datasets.MapDataset`
             Spectrum or Map datasets.
+        backend : str
+            Backend used for fitting, default : minuit
+        optimize_opts : dict
+            Options passed to `Fit.optimize`.
+        covariance_opts : dict
+            Options passed to `Fit.covariance`.
 
         Returns
         -------
@@ -428,13 +434,21 @@ class LightCurveEstimator(Estimator):
         table = FluxPoints(table).to_sed_type("flux").table
         return LightCurve(table)
 
-    def estimate_time_bin_flux(self, datasets):
+    def estimate_time_bin_flux(
+        self, datasets, backend="minuit", optimize_opts=None, covariance_opts=None
+    ):
         """Estimate flux point for a single energy group.
 
         Parameters
         ----------
         datasets : `~gammapy.modeling.Datasets`
             the list of dataset object
+        backend : str
+            Backend used for fitting, default : minuit
+        optimize_opts : dict
+            Options passed to `Fit.optimize`.
+        covariance_opts : dict
+            Options passed to `Fit.covariance`.
 
         Returns
         -------
@@ -459,7 +473,12 @@ class LightCurveEstimator(Estimator):
             reoptimize=self.reoptimize,
             selection_optional=self.selection_optional,
         )
-        fp = fe.run(datasets)
+        fp = fe.run(
+            datasets,
+            backend=backend,
+            optimize_opts=optimize_opts,
+            covariance_opts=covariance_opts,
+        )
 
         # TODO: remove once FluxPointsEstimator returns object with all energies in one row
         result = {}

--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -398,6 +398,23 @@ class LightCurveEstimator(Estimator):
         self.reoptimize = reoptimize
         self.selection_optional = selection_optional
 
+    def _flux_poins_estimator(self, energy_edges):
+        return FluxPointsEstimator(
+            source=self.source,
+            energy_edges=energy_edges,
+            norm_min=self.norm_min,
+            norm_max=self.norm_max,
+            norm_n_values=self.norm_n_values,
+            norm_values=self.norm_values,
+            n_sigma=self.n_sigma,
+            n_sigma_ul=self.n_sigma_ul,
+            backend = self.backend,
+            optimize_opts = self.optimize_opts,
+            covariance_opts = self.covariance_opts,
+            reoptimize=self.reoptimize,
+            selection_optional=self.selection_optional,
+        )
+        
     def run(self, datasets):
         """Run light curve extraction.
 
@@ -470,21 +487,7 @@ class LightCurveEstimator(Estimator):
         else:
             energy_edges = self.energy_edges
 
-        fe = FluxPointsEstimator(
-            source=self.source,
-            energy_edges=energy_edges,
-            norm_min=self.norm_min,
-            norm_max=self.norm_max,
-            norm_n_values=self.norm_n_values,
-            norm_values=self.norm_values,
-            n_sigma=self.n_sigma,
-            n_sigma_ul=self.n_sigma_ul,
-            backend = self.backend,
-            optimize_opts = self.optimize_opts,
-            covariance_opts = self.covariance_opts,
-            reoptimize=self.reoptimize,
-            selection_optional=self.selection_optional,
-        )
+        fe = self._flux_poins_estimator(energy_edges)
         fp = fe.run(datasets)
 
         # TODO: remove once FluxPointsEstimator returns object with all energies in one row

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -98,11 +98,12 @@ class ParameterEstimator(Estimator):
 
     def fit(self, datasets):
         if self._fit is None or datasets is not self._fit.datasets:
-            self._fit = Fit(datasets,
-                            backend=self.backend,
-                            optimize_opts=self.optimize_opts,
-                            covariance_opts=self.covariance_opts,
-                            )
+            self._fit = Fit(
+                datasets,
+                backend=self.backend,
+                optimize_opts=self.optimize_opts,
+                covariance_opts=self.covariance_opts,
+            )
         return self._fit
 
     def estimate_best_fit(self, datasets, parameter):
@@ -242,9 +243,7 @@ class ParameterEstimator(Estimator):
         """
         self.fit(datasets)
         self._fit.optimize(**self.optimize_opts)
-        res = self._fit.confidence(
-            parameter=parameter, sigma=self.n_sigma_ul
-        )
+        res = self._fit.confidence(parameter=parameter, sigma=self.n_sigma_ul)
         return {f"{parameter.name}_ul": res["errp"] + parameter.value}
 
     def run(self, datasets, parameter):
@@ -281,6 +280,6 @@ class ParameterEstimator(Estimator):
                 result.update(self.estimate_ul(datasets, parameter))
 
             if "scan" in self.selection_optional:
-                result.update(self.estimate_scan(datasets,parameter))
+                result.update(self.estimate_scan(datasets, parameter))
 
         return result

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -103,6 +103,7 @@ class ParameterEstimator(Estimator):
                             optimize_opts=self.optimize_opts,
                             covariance_opts=self.covariance_opts,
                             )
+        return self._fit
 
     def estimate_best_fit(self, datasets, parameter):
         """Estimate parameter assymetric errors
@@ -153,7 +154,7 @@ class ParameterEstimator(Estimator):
 
             if self.reoptimize:
                 parameter.frozen = True
-                _ = self._fit.optimize(backend=self.backend, **self.optimize_opts)
+                _ = self._fit.optimize(**self.optimize_opts)
 
             ts = datasets.stat_sum() - stat
 
@@ -175,8 +176,8 @@ class ParameterEstimator(Estimator):
             Dict with the various parameter estimation values.
         """
         # TODO: make Fit stateless and configurable
-        self._setup_fit(datasets)
-        self._fit.optimize(backend=self.backend, **self.optimize_opts)
+        self.fit(datasets)
+        self._fit.optimize(**self.optimize_opts)
 
         res = self._fit.confidence(
             parameter=parameter, sigma=self.n_sigma, reoptimize=self.reoptimize
@@ -202,8 +203,8 @@ class ParameterEstimator(Estimator):
             Dict with the various parameter estimation values.
 
         """
-        self._setup_fit(datasets)
-        self._fit.optimize(backend=self.backend, **self.optimize_opts)
+        self.fit(datasets)
+        self._fit.optimize(**self.optimize_opts)
 
         if self.scan_min and self.scan_max:
             bounds = (self.scan_min, self.scan_max)
@@ -239,10 +240,10 @@ class ParameterEstimator(Estimator):
             Dict with the various parameter estimation values.
 
         """
-        self._setup_fit(datasets)
-        self._fit.optimize(backend=self.backend, **self.optimize_opts)
+        self.fit(datasets)
+        self._fit.optimize(**self.optimize_opts)
         res = self._fit.confidence(
-            parameter=parameter, sigma=self.n_sigma_ul, backend="scipy"
+            parameter=parameter, sigma=self.n_sigma_ul
         )
         return {f"{parameter.name}_ul": res["errp"] + parameter.value}
 

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -61,6 +61,9 @@ class ParameterEstimator(Estimator):
         scan_n_values=30,
         scan_values=None,
         reoptimize=True,
+        backend="minuit",
+        optimize_opts=None,
+        covariance_opts=None,
         selection_optional=None,
     ):
         self.n_sigma = n_sigma
@@ -83,7 +86,14 @@ class ParameterEstimator(Estimator):
         if self._fit is None or datasets is not self._fit.datasets:
             self._fit = Fit(datasets)
 
-    def estimate_best_fit(self, datasets, parameter):
+    def estimate_best_fit(
+        self,
+        datasets,
+        parameter,
+        backend="minuit",
+        optimize_opts={},
+        covariance_opts={},
+    ):
         """Estimate parameter assymetric errors
 
         Parameters
@@ -92,6 +102,12 @@ class ParameterEstimator(Estimator):
             Datasets
         parameter : `Parameter`
             For which parameter to get the value
+        backend : str
+            Backend used for fitting, default : minuit
+        optimize_opts : dict
+            Options passed to `Fit.optimize`.
+        covariance_opts : dict
+            Options passed to `Fit.covariance`.
 
         Returns
         -------
@@ -99,7 +115,11 @@ class ParameterEstimator(Estimator):
             Dict with the various parameter estimation values.
         """
         self._setup_fit(datasets)
-        result_fit = self._fit.run()
+        result_fit = self._fit.run(
+            backend=backend,
+            optimize_opts=optimize_opts,
+            covariance_opts=covariance_opts,
+        )
 
         return {
             f"{parameter.name}": parameter.value,
@@ -108,7 +128,7 @@ class ParameterEstimator(Estimator):
             f"{parameter.name}_err": parameter.error * self.n_sigma,
         }
 
-    def estimate_ts(self, datasets, parameter):
+    def estimate_ts(self, datasets, parameter, backend="minuit", optimize_opts={}):
         """Estimate parameter ts
 
         Parameters
@@ -117,6 +137,10 @@ class ParameterEstimator(Estimator):
             Datasets
         parameter : `Parameter`
             For which parameter to get the value
+        backend : str
+            Backend used for fitting, default : minuit
+        optimize_opts : dict
+            Options passed to `Fit.optimize`.
 
         Returns
         -------
@@ -132,13 +156,15 @@ class ParameterEstimator(Estimator):
 
             if self.reoptimize:
                 parameter.frozen = True
-                _ = self._fit.optimize()
+                _ = self._fit.optimize(backend=backend, **optimize_opts)
 
             ts = datasets.stat_sum() - stat
 
         return {"ts": ts}
 
-    def estimate_errn_errp(self, datasets, parameter):
+    def estimate_errn_errp(
+        self, datasets, parameter, backend="minuit", optimize_opts={}
+    ):
         """Estimate parameter assymetric errors
 
         Parameters
@@ -147,6 +173,10 @@ class ParameterEstimator(Estimator):
             Datasets
         parameter : `Parameter`
             For which parameter to get the value
+        backend : str
+            Backend used for fitting, default : minuit
+        optimize_opts : dict
+            Options passed to `Fit.optimize`.
 
         Returns
         -------
@@ -155,7 +185,7 @@ class ParameterEstimator(Estimator):
         """
         # TODO: make Fit stateless and configurable
         self._setup_fit(datasets)
-        self._fit.optimize()
+        self._fit.optimize(backend=backend, **optimize_opts)
 
         res = self._fit.confidence(
             parameter=parameter, sigma=self.n_sigma, reoptimize=self.reoptimize
@@ -165,7 +195,7 @@ class ParameterEstimator(Estimator):
             f"{parameter.name}_errn": res["errn"],
         }
 
-    def estimate_scan(self, datasets, parameter):
+    def estimate_scan(self, datasets, parameter, backend="minuit", optimize_opts={}):
         """Estimate parameter stat scan.
 
         Parameters
@@ -174,6 +204,10 @@ class ParameterEstimator(Estimator):
             The datasets used to estimate the model parameter
         parameter : `Parameter`
             For which parameter to get the value
+        backend : str
+            Backend used for fitting, default : minuit
+        optimize_opts : dict
+            Options passed to `Fit.optimize`.
 
         Returns
         -------
@@ -182,7 +216,7 @@ class ParameterEstimator(Estimator):
 
         """
         self._setup_fit(datasets)
-        self._fit.optimize()
+        self._fit.optimize(backend=backend, **optimize_opts)
 
         if self.scan_min and self.scan_max:
             bounds = (self.scan_min, self.scan_max)
@@ -202,7 +236,7 @@ class ParameterEstimator(Estimator):
             "stat_scan": profile["stat_scan"],
         }
 
-    def estimate_ul(self, datasets, parameter):
+    def estimate_ul(self, datasets, parameter, backend="minuit", optimize_opts={}):
         """Estimate parameter ul.
 
         Parameters
@@ -211,6 +245,10 @@ class ParameterEstimator(Estimator):
             The datasets used to estimate the model parameter
         parameter : `Parameter`
             For which parameter to get the value
+        backend : str
+            Backend used for fitting, default : minuit
+        optimize_opts : dict
+            Options passed to `Fit.optimize`.
 
         Returns
         -------
@@ -219,13 +257,20 @@ class ParameterEstimator(Estimator):
 
         """
         self._setup_fit(datasets)
-        self._fit.optimize()
+        self._fit.optimize(backend=backend, **optimize_opts)
         res = self._fit.confidence(
             parameter=parameter, sigma=self.n_sigma_ul, backend="scipy"
         )
         return {f"{parameter.name}_ul": res["errp"] + parameter.value}
 
-    def run(self, datasets, parameter):
+    def run(
+        self,
+        datasets,
+        parameter,
+        backend="minuit",
+        optimize_opts=None,
+        covariance_opts=None,
+    ):
         """Run the parameter estimator.
 
         Parameters
@@ -234,6 +279,12 @@ class ParameterEstimator(Estimator):
             The datasets used to estimate the model parameter
         parameter : `str` or `Parameter`
             For which parameter to run the estimator
+        backend : str
+            Backend used for fitting, default : minuit
+        optimize_opts : dict
+            Options passed to `Fit.optimize`.
+        covariance_opts : dict
+            Options passed to `Fit.covariance`.
 
         Returns
         -------
@@ -243,22 +294,59 @@ class ParameterEstimator(Estimator):
         datasets = Datasets(datasets)
         parameter = datasets.parameters[parameter]
 
+        if optimize_opts is None:
+            optimize_opts = {}
+
+        if covariance_opts is None:
+            covariance_opts = {}
+
         with datasets.parameters.restore_status():
 
             if not self.reoptimize:
                 datasets.parameters.freeze_all()
                 parameter.frozen = False
 
-            result = self.estimate_best_fit(datasets, parameter)
-            result.update(self.estimate_ts(datasets, parameter))
+            result = self.estimate_best_fit(
+                datasets,
+                parameter,
+                backend=backend,
+                optimize_opts=optimize_opts,
+                covariance_opts=covariance_opts,
+            )
+            result.update(
+                self.estimate_ts(
+                    datasets, parameter, backend=backend, optimize_opts=optimize_opts
+                )
+            )
 
             if "errn-errp" in self.selection_optional:
-                result.update(self.estimate_errn_errp(datasets, parameter))
+                result.update(
+                    self.estimate_errn_errp(
+                        datasets,
+                        parameter,
+                        backend=backend,
+                        optimize_opts=optimize_opts,
+                    )
+                )
 
             if "ul" in self.selection_optional:
-                result.update(self.estimate_ul(datasets, parameter))
+                result.update(
+                    self.estimate_ul(
+                        datasets,
+                        parameter,
+                        backend=backend,
+                        optimize_opts=optimize_opts,
+                    )
+                )
 
             if "scan" in self.selection_optional:
-                result.update(self.estimate_scan(datasets, parameter))
+                result.update(
+                    self.estimate_scan(
+                        datasets,
+                        parameter,
+                        backend=backend,
+                        optimize_opts=optimize_opts,
+                    )
+                )
 
         return result

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -27,9 +27,7 @@ def simulate_spectrum_dataset(model, random_state=0):
     energy_axis = MapAxis.from_edges(energy_edges, interp="log", name="energy")
     energy_axis_true = energy_axis.copy(name="energy_true")
 
-    aeff = EffectiveAreaTable2D.from_parametrization(
-        energy_axis_true=energy_axis_true
-    )
+    aeff = EffectiveAreaTable2D.from_parametrization(energy_axis_true=energy_axis_true)
 
     bkg_model = SkyModel(
         spectral_model=PowerLawSpectralModel(
@@ -43,14 +41,14 @@ def simulate_spectrum_dataset(model, random_state=0):
     geom = RegionGeom.create(region="icrs;circle(0, 0, 0.1)", axes=[energy_axis])
     acceptance = RegionNDMap.from_geom(geom=geom, data=1)
     edisp = EDispKernelMap.from_diagonal_response(
-        energy_axis=energy_axis,
-        energy_axis_true=energy_axis_true,
-        geom=geom,
+        energy_axis=energy_axis, energy_axis_true=energy_axis_true, geom=geom,
     )
 
-    geom_true= RegionGeom.create(region="icrs;circle(0, 0, 0.1)", axes=[energy_axis_true])
+    geom_true = RegionGeom.create(
+        region="icrs;circle(0, 0, 0.1)", axes=[energy_axis_true]
+    )
     exposure = make_map_exposure_true_energy(
-        pointing=SkyCoord("0d", "0d"), aeff=aeff, livetime=100 *u.h, geom=geom_true
+        pointing=SkyCoord("0d", "0d"), aeff=aeff, livetime=100 * u.h, geom=geom_true
     )
 
     mask_safe = RegionNDMap.from_geom(geom=geom, dtype=bool)
@@ -63,7 +61,7 @@ def simulate_spectrum_dataset(model, random_state=0):
         acceptance=acceptance,
         acceptance_off=acceptance_off,
         edisp=edisp,
-        mask_safe=mask_safe
+        mask_safe=mask_safe,
     )
     dataset.models = bkg_model
     bkg_npred = dataset.npred_signal()
@@ -86,7 +84,7 @@ def create_fpe(model):
         source="source",
         selection_optional="all",
         backend="minuit",
-        optimize_opts = dict(tol=0.2, strategy=1),
+        optimize_opts=dict(tol=0.2, strategy=1),
     )
     datasets = [dataset]
     return datasets, fpe
@@ -134,7 +132,10 @@ def fpe_map_pwl():
     energy_edges = [0.1, 1, 10, 100] * u.TeV
     datasets = [dataset_1, dataset_2]
     fpe = FluxPointsEstimator(
-        energy_edges=energy_edges, norm_n_values=3, source="source", selection_optional="all"
+        energy_edges=energy_edges,
+        norm_n_values=3,
+        source="source",
+        selection_optional="all",
     )
     return datasets, fpe
 
@@ -302,7 +303,7 @@ def test_run_map_pwl(fpe_map_pwl):
     assert_allclose(actual, [0.2, 1, 5])
 
     actual = fp.table["stat_scan"][0] - fp.table["stat"][0]
-    assert_allclose(actual, [1.628398e+02, 1.452456e-01, 2.008018e+03], rtol=1e-2)
+    assert_allclose(actual, [1.628398e02, 1.452456e-01, 2.008018e03], rtol=1e-2)
 
 
 @requires_dependency("iminuit")
@@ -340,12 +341,12 @@ def test_flux_points_estimator_no_norm_scan(fpe_pwl):
 
     assert_allclose(fpe.optimize_opts["tol"], 0.2)
 
-    flux_estimator = fpe._flux_estimator(1*u.TeV, 10*u.TeV)
+    flux_estimator = fpe._flux_estimator(1 * u.TeV, 10 * u.TeV)
     assert_allclose(flux_estimator.optimize_opts["tol"], 0.2)
 
     param_estimator = flux_estimator._parameter_estimator
     assert_allclose(param_estimator.optimize_opts["tol"], 0.2)
-    
+
     param_estimator.fit(datasets).run()
     assert_allclose(param_estimator._fit.minuit.tol, 0.2)
 

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -216,22 +216,22 @@ def test_lightcurve_estimator_fit_options():
         time_intervals=time_intervals,
         selection_optional="all",
         backend="minuit",
-        optimize_opts = dict(tol=0.2, strategy=1),
+        optimize_opts=dict(tol=0.2, strategy=1),
     )
-    
+
     fpe = estimator._flux_poins_estimator(energy_edges)
     assert_allclose(fpe.optimize_opts["tol"], 0.2)
 
-    flux_estimator = fpe._flux_estimator(1*u.TeV, 30*u.TeV)
+    flux_estimator = fpe._flux_estimator(1 * u.TeV, 30 * u.TeV)
     assert_allclose(flux_estimator.optimize_opts["tol"], 0.2)
 
     param_estimator = flux_estimator._parameter_estimator
     assert_allclose(param_estimator.optimize_opts["tol"], 0.2)
-    
+
     param_estimator.fit(datasets).run()
     assert_allclose(param_estimator._fit.minuit.tol, 0.2)
-    
-    
+
+
 @requires_data()
 @requires_dependency("iminuit")
 def test_lightcurve_estimator_spectrum_datasets():
@@ -248,7 +248,7 @@ def test_lightcurve_estimator_spectrum_datasets():
         time_intervals=time_intervals,
         selection_optional="all",
     )
-    
+
     lightcurve = estimator.run(datasets)
     assert_allclose(lightcurve.table["time_min"], [55197.0, 55197.041667])
     assert_allclose(lightcurve.table["time_max"], [55197.041667, 55197.083333])
@@ -296,7 +296,7 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
         energy_edges=[1, 5, 30] * u.TeV,
         norm_n_values=3,
         time_intervals=time_intervals,
-        selection_optional="all"
+        selection_optional="all",
     )
     lightcurve = estimator.run(datasets)
     assert_allclose(lightcurve.table["time_min"], [55197.0, 55197.041667])
@@ -373,7 +373,9 @@ def test_lightcurve_estimator_spectrum_datasets_withmaskfit():
     energy_max_fit = 3 * u.TeV
     for dataset in datasets:
         geom = dataset.counts.geom
-        dataset.mask_fit = geom.energy_mask(energy_min=energy_min_fit, energy_max=energy_max_fit)
+        dataset.mask_fit = geom.energy_mask(
+            energy_min=energy_min_fit, energy_max=energy_max_fit
+        )
 
     selection = ["scan"]
     estimator = LightCurveEstimator(

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -201,6 +201,39 @@ def test_group_datasets_in_time_interval_outflows():
 
 @requires_data()
 @requires_dependency("iminuit")
+def test_lightcurve_estimator_fit_options():
+    # Doing a LC on one hour bin
+    datasets = get_spectrum_datasets()
+    time_intervals = [
+        Time(["2010-01-01T00:00:00", "2010-01-01T01:00:00"]),
+        Time(["2010-01-01T01:00:00", "2010-01-01T02:00:00"]),
+    ]
+    energy_edges = [1, 30] * u.TeV
+
+    estimator = LightCurveEstimator(
+        energy_edges=energy_edges,
+        norm_n_values=3,
+        time_intervals=time_intervals,
+        selection_optional="all",
+        backend="minuit",
+        optimize_opts = dict(tol=0.2, strategy=1),
+    )
+    
+    fpe = estimator._flux_poins_estimator(energy_edges)
+    assert_allclose(fpe.optimize_opts["tol"], 0.2)
+
+    flux_estimator = fpe._flux_estimator(1*u.TeV, 30*u.TeV)
+    assert_allclose(flux_estimator.optimize_opts["tol"], 0.2)
+
+    param_estimator = flux_estimator._parameter_estimator
+    assert_allclose(param_estimator.optimize_opts["tol"], 0.2)
+    
+    param_estimator.fit(datasets).run()
+    assert_allclose(param_estimator._fit.minuit.tol, 0.2)
+    
+    
+@requires_data()
+@requires_dependency("iminuit")
 def test_lightcurve_estimator_spectrum_datasets():
     # Doing a LC on one hour bin
     datasets = get_spectrum_datasets()
@@ -213,8 +246,9 @@ def test_lightcurve_estimator_spectrum_datasets():
         energy_edges=[1, 30] * u.TeV,
         norm_n_values=3,
         time_intervals=time_intervals,
-        selection_optional="all"
+        selection_optional="all",
     )
+    
     lightcurve = estimator.run(datasets)
     assert_allclose(lightcurve.table["time_min"], [55197.0, 55197.041667])
     assert_allclose(lightcurve.table["time_max"], [55197.041667, 55197.083333])

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -77,7 +77,14 @@ class Fit:
         Options passed to `Fit.covariance`.
     """
 
-    def __init__(self, datasets,  backend="minuit", optimize_opts=None, covariance_opts=None, store_trace=False):
+    def __init__(
+        self,
+        datasets,
+        backend="minuit",
+        optimize_opts=None,
+        covariance_opts=None,
+        store_trace=False,
+    ):
         from gammapy.datasets import Datasets
 
         # TODO: docstring for store_trace ?
@@ -91,8 +98,6 @@ class Fit:
         self.optimize_opts = optimize_opts
         self.covariance_opts = covariance_opts
 
-
-        
     @lazyproperty
     def _parameters(self):
         return self.datasets.parameters
@@ -217,7 +222,7 @@ class Fit:
             Results
         """
 
-        #TODO: docstring kwargs for covairance
+        # TODO: docstring kwargs for covairance
         self.covariance_opts.update(kwargs)
         compute = registry.get("covariance", self.backend)
         parameters = self._parameters
@@ -250,9 +255,7 @@ class Fit:
             message=info["message"],
         )
 
-    def confidence(
-        self, parameter, sigma=1, reoptimize=True, **kwargs
-    ):
+    def confidence(self, parameter, sigma=1, reoptimize=True, **kwargs):
         """Estimate confidence interval.
 
         Extra ``kwargs`` are passed to the backend.
@@ -284,7 +287,7 @@ class Fit:
         parameters = self._parameters
         parameter = parameters[parameter]
 
-        #TODO: confidence_options on fit for consistancy ?
+        # TODO: confidence_options on fit for consistancy ?
 
         # TODO: wrap MINUIT in a stateless backend
         with parameters.restore_status():

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -57,8 +57,8 @@ class MyDataset(Dataset):
 @pytest.mark.parametrize("backend", ["sherpa", "scipy"])
 def test_warning_no_covariance(backend, caplog):
    dataset = MyDataset()
-   fit = Fit([dataset])
-   result = fit.run(backend=backend)
+   fit = Fit([dataset], backend=backend)
+   result = fit.run()
    assert caplog.records[-1].levelname == "WARNING"
    assert caplog.records[-1].message == "No covariance estimate - not supported by this backend."
 
@@ -66,8 +66,8 @@ def test_warning_no_covariance(backend, caplog):
 @pytest.mark.parametrize("backend", ["minuit"])
 def test_run(backend):
     dataset = MyDataset()
-    fit = Fit([dataset])
-    result = fit.run(backend=backend)
+    fit = Fit([dataset], backend=backend)
+    result = fit.run()
     pars = result.parameters
 
     assert result.success is True

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -56,11 +56,14 @@ class MyDataset(Dataset):
 @requires_dependency("sherpa")
 @pytest.mark.parametrize("backend", ["sherpa", "scipy"])
 def test_warning_no_covariance(backend, caplog):
-   dataset = MyDataset()
-   fit = Fit([dataset], backend=backend)
-   result = fit.run()
-   assert caplog.records[-1].levelname == "WARNING"
-   assert caplog.records[-1].message == "No covariance estimate - not supported by this backend."
+    dataset = MyDataset()
+    fit = Fit([dataset], backend=backend)
+    result = fit.run()
+    assert caplog.records[-1].levelname == "WARNING"
+    assert (
+        caplog.records[-1].message
+        == "No covariance estimate - not supported by this backend."
+    )
 
 
 @pytest.mark.parametrize("backend", ["minuit"])
@@ -118,7 +121,7 @@ def test_optimize(backend):
 @pytest.mark.parametrize("backend", ["minuit"])
 def test_confidence(backend):
     dataset = MyDataset()
-    fit = Fit([dataset],backend=backend)
+    fit = Fit([dataset], backend=backend)
     fit.optimize()
     result = fit.confidence("x")
 
@@ -134,7 +137,7 @@ def test_confidence(backend):
 def test_confidence_frozen(backend):
     dataset = MyDataset()
     dataset.models.parameters["x"].frozen = True
-    fit = Fit([dataset],backend=backend)
+    fit = Fit([dataset], backend=backend)
     fit.optimize()
     result = fit.confidence("y")
 

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -90,14 +90,14 @@ def test_run(backend):
 @pytest.mark.parametrize("backend", ["minuit", "sherpa", "scipy"])
 def test_optimize(backend):
     dataset = MyDataset()
-    fit = Fit([dataset], store_trace=True)
+    fit = Fit([dataset], store_trace=True, backend=backend)
 
     if backend == "scipy":
         kwargs = {"method": "L-BFGS-B"}
     else:
         kwargs = {}
 
-    result = fit.optimize(backend=backend, **kwargs)
+    result = fit.optimize(**kwargs)
     pars = dataset.models.parameters
 
     assert result.success is True
@@ -118,8 +118,8 @@ def test_optimize(backend):
 @pytest.mark.parametrize("backend", ["minuit"])
 def test_confidence(backend):
     dataset = MyDataset()
-    fit = Fit([dataset])
-    fit.optimize(backend=backend)
+    fit = Fit([dataset],backend=backend)
+    fit.optimize()
     result = fit.confidence("x")
 
     assert result["success"] is True
@@ -134,8 +134,8 @@ def test_confidence(backend):
 def test_confidence_frozen(backend):
     dataset = MyDataset()
     dataset.models.parameters["x"].frozen = True
-    fit = Fit([dataset])
-    fit.optimize(backend=backend)
+    fit = Fit([dataset],backend=backend)
+    fit.optimize()
     result = fit.confidence("y")
 
     assert result["success"] is True
@@ -224,8 +224,8 @@ def test_stat_surface_reoptimize():
 def test_minos_contour():
     dataset = MyDataset()
     dataset.models.parameters["x"].frozen = True
-    fit = Fit([dataset])
-    fit.optimize(backend="minuit")
+    fit = Fit([dataset], backend="minuit")
+    fit.optimize()
     result = fit.minos_contour("y", "z")
 
     assert result["success"] is True


### PR DESCRIPTION
This PR add backend, optimize_opts, and covariance_opts options from`Fit.run()` to the `estimators.run()` methods`and their associated evaluate methods. 

Also set FluxEstimator._parameter_estimator as a property