### PR TITLE
Modify FoVBackgroundMaker to take spectral model as argument

### DIFF
--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -11,6 +11,7 @@ from gammapy.modeling.models import (
     FoVBackgroundModel,
     GaussianSpatialModel,
     PowerLawSpectralModel,
+    PowerLawNormSpectralModel,
     SkyModel,
 )
 from gammapy.utils.testing import requires_data, requires_dependency
@@ -101,14 +102,18 @@ def test_fov_bkg_maker_scale_nocounts(obs_dataset, exclusion_mask, caplog):
 @requires_data()
 @requires_dependency("iminuit")
 def test_fov_bkg_maker_fit(obs_dataset, exclusion_mask):
-    fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
+    spectral_model = PowerLawNormSpectralModel()
+    spectral_model.tilt.frozen = False
+    fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask, spectral_model=spectral_model)
 
     test_dataset = obs_dataset.copy(name="test-fov")
     dataset = fov_bkg_maker.run(test_dataset)
 
     model = dataset.models[f"{dataset.name}-bkg"].spectral_model
-    assert_allclose(model.norm.value, 0.830789, rtol=1e-4)
-    assert_allclose(model.tilt.value, 0.0, rtol=1e-4)
+    assert_allclose(model.norm.value, 0.901523, rtol=1e-4)
+    assert_allclose(model.tilt.value, 0.071069, rtol=1e-4)
+    assert_allclose(fov_bkg_maker.default_spectral_model.tilt.value, 0.0)
+    assert_allclose(fov_bkg_maker.default_spectral_model.norm.value, 1.0)
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request solves #3311  by changing the `spectral_model_tag` argument to `spectral_model`. It can now take either a tag such as `"pl-norm"` (still the default). 
On init a `fov_maker.default_spectral_model` is created and is applied if no `FoVBavkgroundModel` is predefined on the `Dataset`.

This has the advantage of being more configurable than manually creating a `FoVBackgroundModel` if one wants to unfreeze one parameter or change its boundaries. 
This is also probably preferable to changing the class default on the fly.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
