### PR TITLE
Support HpxGeom in MapDataset.create

### DIFF
--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1580,6 +1580,7 @@ def test_map_dataset_region_geom_npred():
     assert_allclose(npred_ref.data, npred.data, rtol=1e-2)
 
 
+@requires_dependency("healpy")
 def test_map_dataset_create_hpx_geom(geom_hpx):
 
     dataset = MapDataset.create(**geom_hpx, binsz_irf=10 * u.deg)
@@ -1600,6 +1601,7 @@ def test_map_dataset_create_hpx_geom(geom_hpx):
     assert dataset.psf.psf_map.data.shape == (4, 66, 768)
 
 
+@requires_dependency("healpy")
 def test_map_dataset_create_hpx_geom_partial(geom_hpx_partial):
 
     dataset = MapDataset.create(**geom_hpx_partial, binsz_irf=2 * u.deg)
@@ -1620,6 +1622,7 @@ def test_map_dataset_create_hpx_geom_partial(geom_hpx_partial):
     assert dataset.psf.psf_map.data.shape == (4, 66, 24)
 
 
+@requires_dependency("healpy")
 def test_map_dataset_stack_hpx_geom(geom_hpx_partial, geom_hpx):
 
     dataset_all = MapDataset.create(**geom_hpx, binsz_irf=5 * u.deg)
@@ -1636,4 +1639,3 @@ def test_map_dataset_stack_hpx_geom(geom_hpx_partial, geom_hpx):
     assert_allclose(dataset_all.counts.data.sum(), 3 * 90)
     assert_allclose(dataset_all.background.data.sum(), 3 * 90)
     assert_allclose(dataset_all.exposure.data.sum(), 4 * 90)
-

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1618,3 +1618,22 @@ def test_map_dataset_create_hpx_geom_partial(geom_hpx_partial):
 
     assert isinstance(dataset.psf.psf_map.geom, HpxGeom)
     assert dataset.psf.psf_map.data.shape == (4, 66, 24)
+
+
+def test_map_dataset_stack_hpx_geom(geom_hpx_partial, geom_hpx):
+
+    dataset_all = MapDataset.create(**geom_hpx, binsz_irf=5 * u.deg)
+
+    gti = GTI.create(start=0 * u.s, stop=30 * u.min)
+    dataset_cutout = MapDataset.create(**geom_hpx_partial, binsz_irf=5 * u.deg, gti=gti)
+    dataset_cutout.counts.data += 1
+    dataset_cutout.background.data += 1
+    dataset_cutout.exposure.data += 1
+    dataset_cutout.mask_safe.data[...] = True
+
+    dataset_all.stack(dataset_cutout)
+
+    assert_allclose(dataset_all.counts.data.sum(), 3 * 90)
+    assert_allclose(dataset_all.background.data.sum(), 3 * 90)
+    assert_allclose(dataset_all.exposure.data.sum(), 4 * 90)
+

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -51,6 +51,19 @@ def geom_hpx():
 
 
 @pytest.fixture
+def geom_hpx_partial():
+    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
+
+    energy_axis_true = MapAxis.from_energy_bounds(
+        "1 TeV", "10 TeV", nbin=4, name="energy_true"
+    )
+
+    geom = HpxGeom.create(nside=32, axes=[axis], frame="galactic", region="DISK(110.,75.,10.)")
+
+    return {"geom": geom, "energy_axis_true": energy_axis_true}
+
+
+@pytest.fixture
 def geom():
     axis = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=2)
     return WcsGeom.create(
@@ -1586,3 +1599,22 @@ def test_map_dataset_create_hpx_geom(geom_hpx):
     assert isinstance(dataset.psf.psf_map.geom, HpxGeom)
     assert dataset.psf.psf_map.data.shape == (4, 66, 768)
 
+
+def test_map_dataset_create_hpx_geom_partial(geom_hpx_partial):
+
+    dataset = MapDataset.create(**geom_hpx_partial, binsz_irf=2 * u.deg)
+
+    assert isinstance(dataset.counts.geom, HpxGeom)
+    assert dataset.counts.data.shape == (3, 90)
+
+    assert isinstance(dataset.background.geom, HpxGeom)
+    assert dataset.background.data.shape == (3, 90)
+
+    assert isinstance(dataset.exposure.geom, HpxGeom)
+    assert dataset.exposure.data.shape == (4, 90)
+
+    assert isinstance(dataset.edisp.edisp_map.geom, HpxGeom)
+    assert dataset.edisp.edisp_map.data.shape == (4, 3, 24)
+
+    assert isinstance(dataset.psf.psf_map.geom, HpxGeom)
+    assert dataset.psf.psf_map.data.shape == (4, 66, 24)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -21,7 +21,7 @@ from gammapy.irf import (
 )
 
 from gammapy.makers.utils import make_map_exposure_true_energy, make_psf_map
-from gammapy.maps import Map, MapAxis, WcsGeom, WcsNDMap, RegionGeom, RegionNDMap
+from gammapy.maps import Map, MapAxis, WcsGeom, WcsNDMap, RegionGeom, RegionNDMap, HpxGeom
 from gammapy.modeling import Fit
 from gammapy.modeling.models import (
     FoVBackgroundModel,
@@ -1552,3 +1552,16 @@ def test_map_dataset_region_geom_npred():
     npred = dataset_spec.npred()
 
     assert_allclose(npred_ref.data, npred.data, rtol=1e-2)
+
+
+def test_map_dataset_create_hpx_geom():
+    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
+    energy_axis_true = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=4, name="energy_true")
+
+    geom = HpxGeom.create(nside=32, axes=[axis], frame="galactic")
+
+    dataset = MapDataset.create(
+        geom=geom, energy_axis_true=energy_axis_true, binsz_irf=10 * u.deg
+    )
+
+    assert isinstance(dataset.counts.geom, HpxGeom)

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -332,7 +332,7 @@ class EDispKernelMap(IRFMap):
         data = get_overlap_fraction(energy_axis, energy_axis_true)
 
         edisp_kernel_map = Map.from_geom(geom, unit="")
-        edisp_kernel_map.quantity += data[:, :, np.newaxis, np.newaxis]
+        edisp_kernel_map.quantity += data.reshape(geom.data_shape_axes)
         return cls(edisp_kernel_map=edisp_kernel_map, exposure_map=exposure)
 
     def get_edisp_kernel(self, position=None, energy_axis=None):

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1281,7 +1281,7 @@ class Map(abc.ABC):
         axis_idx = self.geom.axes.index_data(axis_name)
 
         # TODO: the broadcasting should be done by axis.center, axis.bin_width etc.
-        shape = [1] * self.geom.ndim
+        shape = [1] * len(self.geom.data_shape)
         shape[axis_idx] = -1
 
         values = self.quantity * axis.bin_width.reshape(shape)

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -681,6 +681,11 @@ class HpxGeom(Geom):
         return self.axes.shape
 
     @property
+    def data_shape_axes(self):
+        """Shape of data of the non-spatial axes and unit spatial axes."""
+        return self.axes.shape[::-1] + (1,)
+
+    @property
     def ndim(self):
         """Number of dimensions (int)."""
         return len(self._axes) + 2

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -222,6 +222,11 @@ class RegionGeom(Geom):
         return self._shape[::-1]
 
     @property
+    def data_shape_axes(self):
+        """Shape of data of the non-spatial axes and unit spatial axes."""
+        return self.axes.shape[::-1] + (1, 1)
+
+    @property
     def _shape(self):
         """Number of bins in each dimension.
         The spatial dimension is always (1, 1), as a

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -712,6 +712,7 @@ def test_hpx_geom_cutout():
 
     assert cutout.nside == 8
     assert cutout.data_shape == (2, 14)
+    assert cutout.data_shape_axes == (2, 1)
 
     center = cutout.center_skydir.icrs
     assert_allclose(center.ra.deg, 0, atol=1e-8)

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -79,6 +79,7 @@ def test_create_axis(region, energy_axis, test_axis):
     assert geom.ndim == 3
     assert len(geom.axes) == 1
     assert geom.data_shape == (3, 1, 1)
+    assert geom.data_shape_axes == (3, 1, 1)
 
     geom = RegionGeom.create(region, axes=[energy_axis, test_axis])
     assert geom.ndim == 4

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -234,6 +234,7 @@ def test_cutout():
     assert_allclose(center_coord[2].value, 2.0)
 
     assert cutout_geom.data_shape == (2, 6, 6)
+    assert cutout_geom.data_shape_axes == (2, 1, 1)
 
 
 def test_cutout_info():
@@ -316,6 +317,7 @@ def test_wcsgeom_resample_overflows():
     geom_resample = geom.resample_axis(axis=new_axis)
 
     assert geom_resample.data_shape == (3, 2, 3, 3)
+    assert geom_resample.data_shape_axes == (3, 2, 1, 1)
     assert_allclose(geom_resample.axes[0].edges, [1, 2, 5])
 
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -179,6 +179,11 @@ class WcsGeom(Geom):
         return self._shape[::-1]
 
     @property
+    def data_shape_axes(self):
+        """Shape of data of the non-spatial axes and unit spatial axes."""
+        return self.axes.shape[::-1] + (1, 1)
+
+    @property
     def _shape(self):
         npix_shape = tuple([np.max(self.npix[0]), np.max(self.npix[1])])
         return npix_shape + self.axes.shape


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds the support for `HpxGeom` (all sky as well as partial) to `MapDataset.create`. Right no there is no extensive unit testing, however most of the functionality os covered by the `Map` API anyway. In addition a unit test for `MapDataset.stack()` with a `HpxGeom` has beed added.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
