### PR TITLE
Implement HpxNDMap.convolve()

### DIFF
--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -564,7 +564,7 @@ class HpxGeom(Geom):
         position : `~astropy.coordinates.SkyCoord`
             Center position of the cutout region.
         width : `~astropy.coordinates.Angle` or `~astropy.units.Quantity`
-            Radius of the circular cutout region.
+            Diameter of the circular cutout region.
 
         Returns
         -------

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1864,7 +1864,7 @@ class HpxToWcsMapping:
         return wcs_data
 
     def fill_hpx_map_from_wcs_data(
-        self, wcs_data, hpx_data, normalize=True, fill_nan=True
+        self, wcs_data, hpx_data, normalize=True
     ):
         """Fill the HPX map from the WCS data using the pre-calculated mappings.
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1862,3 +1862,39 @@ class HpxToWcsMapping:
             wcs_data[~valid] = np.nan
 
         return wcs_data
+
+    def fill_hpx_map_from_wcs_data(
+        self, wcs_data, hpx_data, normalize=True, fill_nan=True
+    ):
+        """Fill the HPX map from the WCS data using the pre-calculated mappings.
+
+        Parameters
+        ----------
+        wcs_data : `~numpy.ndarray`
+            The input WCS data
+        hpx_data : `~numpy.ndarray`
+            The data array being filled
+        normalize : bool
+            True -> preserve integral by splitting HEALPIX values between bins
+        """
+
+        shape = tuple([t.flat[0] for t in self._npix])
+        if self.valid.ndim != 1:
+            shape = hpx_data.shape[:-1] + shape
+
+        valid = np.where(self.valid.reshape(shape))
+        lmap = self.lmap[self.valid]
+        mult_val = self._mult_val[self.valid]
+
+        wcs_slice = [slice(None) for _ in range(wcs_data.ndim - 2)]
+        wcs_slice = tuple(wcs_slice + list(valid)[::-1][:2])
+
+        hpx_slice = [slice(None) for _ in range(wcs_data.ndim - 2)]
+        hpx_slice = tuple(hpx_slice + [lmap])
+
+        if normalize:
+            hpx_data[hpx_slice] = 1/mult_val * wcs_data[wcs_slice]
+        else:
+            hpx_data[hpx_slice] = wcs_data[wcs_slice]
+
+        return hpx_data

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -496,7 +496,7 @@ class HpxNDMap(HpxMap):
         map : `HpxNDMap`
             Convolved map.
         """
-        return convolve_wcs(self, kernel, use_fft=True, **kwargs)
+        return self.convolve_wcs(kernel, use_fft, **kwargs)
 
     def convolve_wcs(self, kernel, use_fft=True, **kwargs):
         """

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -220,6 +220,7 @@ class HpxNDMap(HpxMap):
         oversample=2,
         width_pix=None,
         hpx2wcs=None,
+        fill_nan=True
     ):
         from .wcsnd import WcsNDMap
 
@@ -257,7 +258,7 @@ class HpxNDMap(HpxMap):
             wcs = hpx2wcs.wcs.to_cube(self.geom.axes)
 
         # FIXME: Should reimplement instantiating map first and fill data array
-        hpx2wcs.fill_wcs_map_from_hpx_data(hpx_data, wcs_data, normalize)
+        hpx2wcs.fill_wcs_map_from_hpx_data(hpx_data, wcs_data, normalize, fill_nan)
         return WcsNDMap(wcs, wcs_data, unit=self.unit)
 
     def _pad_spatial(self, pad_width, mode="constant", cval=0):
@@ -330,7 +331,7 @@ class HpxNDMap(HpxMap):
         position : `~astropy.coordinates.SkyCoord`
             Center position of the cutout region.
         width : `~astropy.coordinates.Angle` or `~astropy.units.Quantity`
-            Radius of the circular cutout region.
+            Diameter of the circular cutout region.
 
         Returns
         -------

--- a/gammapy/maps/tests/test_hpxnd.py
+++ b/gammapy/maps/tests/test_hpxnd.py
@@ -495,9 +495,12 @@ def test_smooth(kernel):
     assert_allclose(actual_ring, desired_ring)
     assert smoothed_ring.data.dtype == float
 
-    with pytest.raises(NotImplementedError):
-        cutout = m_nest.cutout(position=(0,0), width=5*u.deg)
-        cutout.smooth(0.2 * u.deg, kernel)
+    # with pytest.raises(NotImplementedError):
+    cutout = m_nest.cutout(position=(0,0), width=15*u.deg)
+    smoothed_cutout = cutout.smooth(0.1 * u.deg, kernel)
+    actual_cutout = cutout.data.sum()
+    desired_cutout = smoothed_cutout.data.sum()
+    assert_allclose(actual_cutout, desired_cutout, rtol=0.01)
 
     with pytest.raises(ValueError):
         m_nest.smooth(0.2 * u.deg, "box")


### PR DESCRIPTION
This pull requests implements several methods required for the convolution of a HealPix map with a kernel. There are several options to do this: the kernel being a WCS or Hpx map, the convolution happening in a small cutout or in the full sky map.

For now, I've implemented `convolve_wcs()` which is the "simplest" of these approaches in my opinion. For a "small map" (I set a limit of 10 degree width, but we can also refine that), it uses the `HpxToWcsMapping` to project the initial `HpxNDMap` into a `WcsNDMap`, convolves with a kernel using the existing `WcsNDMap.convolve()` and makes use of the mapping to go back to the inital `HpxGeom`. To make this work this I implemented a method `HpxToWcsMapping.fill_hpx_map_from_wcs_data()` which just does the inverse as the existing `HpxToWcsMapping.fill_wcs_map_from_hpx_data()`. Testing for this is not implemented yet. (**TO DO**)

The caveat is that the geometry of the kernel has to be compatible with the intermediate `WcsGeom`, and so the kernel has to be extracted using `hpx_geom.to_wcs_geom()` where `hpx_geom` is the inital map geometry. That means, that if this was used for PSF convolution in a `MapDataset` with Healpix geometry, the geometry of the `PSFKernel` (and Map?) would need to be different than the rest of components.

**TO DO**: The next step would be to, from an inital kernel in an unspecified geometry, extract the radial profile of the kernel in angular space (assumed symmetric), convert to a beam function using `healpy.sphtfunc.beam2bl()` and then make use of `healpy.sphtfunc.smoothing`. This happens in a full-sky map, which would require a cutout to be stacked in a full-sky map as an initial step. I suspect this will be much slower than the case above, but I have to check. For a kernel also in an `HpxMap`,  there might be faster options.