### PR TITLE
Add simple installation instructions using conda

### DIFF
--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -11,7 +11,15 @@ Installation using Anaconda
 
 The easiest and recommended way to install Gammapy is to install the Anaconda
 distribution from https://www.anaconda.com/download/ and then to install
-Gammapy and it's dependencies by executing these commands in a terminal:
+Gammapy and it's dependencies by executing this command in a terminal:
+
+.. code-block:: bash
+
+    conda install -c conda-forge gammapy
+
+
+Alternatively, we also provide an environment definition file, so you can
+get additional useful packages together with gammapy in an isolated environment:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Add simplified instructions for just installing `gammapy` into the current conda environment to the `quickstart` docs.