### PR TITLE
Add TELESCOP meta data to EffectiveAreaTabel2D.from_parametrisation()

### DIFF
--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -247,4 +247,5 @@ class EffectiveAreaTable2D(IRF):
 
         # TODO: fake offset dependence?
         offset_axis = MapAxis.from_edges([0., 5.] * u.deg, name="offset")
-        return cls(axes=[energy_axis_true, offset_axis], data=data[:, np.newaxis], unit="cm2")
+        meta = {"TELESCOP": instrument}
+        return cls(axes=[energy_axis_true, offset_axis], data=data[:, np.newaxis], unit="cm2", meta=meta)

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -57,6 +57,7 @@ class TestEffectiveAreaTable2D:
         area = EffectiveAreaTable2D.from_parametrization(axis, "HESS")
         assert_allclose(area.quantity[:, 0], area_ref)
         assert area.unit == area_ref.unit
+        assert area.meta["TELESCOP"] == "HESS"
 
     @staticmethod
     @requires_dependency("matplotlib")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request add `TELESCOP` to the meta data of `EffectiveAreaTable2D.from_parametrisation()`.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
