### PR TITLE
Add min counts options and scale error to FoVBackgroundMaker

### DIFF
--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -2,9 +2,11 @@
 """FoV background estimation."""
 import logging
 import numpy as np
+from gammapy.maps import Map
 from gammapy.modeling import Fit
 from gammapy.modeling.models import FoVBackgroundModel, Model
 from ..core import Maker
+
 
 __all__ = ["FoVBackgroundMaker"]
 

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """FoV background estimation."""
 import logging
-from gammapy.datasets import Datasets
+import numpy as np
 from gammapy.modeling import Fit
 from gammapy.modeling.models import FoVBackgroundModel, Model
 from ..core import Maker
@@ -19,8 +19,11 @@ class FoVBackgroundMaker(Maker):
 
     The normalization is performed outside the exclusion mask that is passed on init.
 
-    If a SkyModel is set on the input dataset and method is 'fit', its are frozen during
-    the fov normalization fit.
+    If a SkyModel is set on the input dataset and method is 'fit', it' parameters
+    are frozen during the fov normalization fit.
+
+    If the requirement of either min_counts or min_bkg is not satisfied, the background will not be
+    normalised
 
     Parameters
     ----------
@@ -31,20 +34,30 @@ class FoVBackgroundMaker(Maker):
     spectral_model : SpectralModel or str
         Reference norm spectral model to use for the `FoVBackgroundModel`, if none is defined
         on the dataset. By default, use pl-norm.
+    min_counts : float
+        Minimum number of counts required outside the exclusion region
+    min_bkg : float
+       Minimum number of predicted background counts required outside the exclusion region
     """
+
     tag = "FoVBackgroundMaker"
     available_methods = ["fit", "scale"]
 
     def __init__(
-        self, method="scale", exclusion_mask=None, spectral_model="pl-norm"
+        self,
+        method="scale",
+        exclusion_mask=None,
+        spectral_model="pl-norm",
+        min_counts=0,
+        min_bkg=0,
     ):
         self.method = method
         self.exclusion_mask = exclusion_mask
+        self.min_counts = min_counts
+        self.min_bkg = min_bkg
 
         if isinstance(spectral_model, str):
-            spectral_model = Model.create(
-                tag=spectral_model, model_type="spectral"
-            )
+            spectral_model = Model.create(tag=spectral_model, model_type="spectral")
 
         if not spectral_model.is_norm_spectral_model:
             raise ValueError("Spectral model must be a norm spectral model")
@@ -60,8 +73,10 @@ class FoVBackgroundMaker(Maker):
     def method(self, value):
         """Method setter"""
         if value not in self.available_methods:
-            raise ValueError(f"Not a valid method for FoVBackgroundMaker: {value}."
-                             f" Choose from {self.available_methods}")
+            raise ValueError(
+                f"Not a valid method for FoVBackgroundMaker: {value}."
+                f" Choose from {self.available_methods}"
+            )
 
         self._method = value
 
@@ -90,6 +105,21 @@ class FoVBackgroundMaker(Maker):
 
         return dataset
 
+    def make_exclusion_mask(self, dataset):
+        """Project input exclusion mask to dataset geom
+
+        Returns
+        -------
+        mask : `~gammapy.maps.WcsNDMap`
+            Projected exclusion mask
+        """
+        geom = dataset._geom
+        if self.exclusion_mask:
+            mask = self.exclusion_mask.interp_to_geom(geom=geom)
+        else:
+            mask = Map.from_geom(geom=geom, data=1)
+        return mask
+
     def run(self, dataset, observation=None):
         """Run FoV background maker.
 
@@ -103,9 +133,7 @@ class FoVBackgroundMaker(Maker):
         """
         mask_fit = dataset.mask_fit
 
-        if self.exclusion_mask:
-            geom = dataset.counts.geom
-            dataset.mask_fit = self.exclusion_mask.interp_to_geom(geom=geom)
+        dataset.mask_fit = self.make_exclusion_mask(dataset)
 
         if dataset.background_model is None:
             dataset = self.make_default_fov_background_model(dataset)
@@ -143,14 +171,15 @@ class FoVBackgroundMaker(Maker):
             fit = Fit([dataset])
             fit_result = fit.run()
             if not fit_result.success:
-                log.warning(f"FoVBackgroundMaker failed. Fit did not converge for {dataset.name}. "\
-                            f"Setting mask to False.")
+                log.warning(
+                    f"FoVBackgroundMaker failed. Fit did not converge for {dataset.name}. "
+                    f"Setting mask to False."
+                )
                 dataset.mask_safe.data[...] = False
 
         return dataset
 
-    @staticmethod
-    def make_background_scale(dataset):
+    def make_background_scale(self, dataset):
         """Fit the FoV background model on the dataset counts data
 
         Parameters
@@ -168,20 +197,22 @@ class FoVBackgroundMaker(Maker):
         count_tot = dataset.counts.data[mask].sum()
         bkg_tot = dataset.npred_background().data[mask].sum()
 
-        if count_tot <= 0.0:
+        if count_tot <= self.min_counts:
             log.warning(
-                f"FoVBackgroundMaker failed. No counts found outside exclusion mask for {dataset.name}. "\
+                f"FoVBackgroundMaker failed. Only {count_tot} counts outside exclusion mask for {dataset.name}. "
                 f"Setting mask to False."
             )
             dataset.mask_safe.data[...] = False
-        elif bkg_tot <= 0.0:
+        elif bkg_tot <= self.min_bkg:
             log.warning(
-                f"FoVBackgroundMaker failed. No positive background found outside exclusion mask for {dataset.name}. "\
+                f"FoVBackgroundMaker failed. Only {bkg_tot} background counts outside exclusion mask for {dataset.name}. "
                 f"Setting mask to False."
             )
             dataset.mask_safe.data[...] = False
         else:
             value = count_tot / bkg_tot
+            err = np.sqrt(count_tot) / bkg_tot
             dataset.models[f"{dataset.name}-bkg"].spectral_model.norm.value = value
+            dataset.models[f"{dataset.name}-bkg"].spectral_model.norm.error = err
 
         return dataset

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -206,13 +206,13 @@ class FoVBackgroundMaker(Maker):
 
         if count_tot <= self.min_counts:
             log.warning(
-                f"FoVBackgroundMaker failed. Only {count_tot} counts outside exclusion mask for {dataset.name}. "
+                f"FoVBackgroundMaker failed. Only {int(count_tot)} counts outside exclusion mask for {dataset.name}. "
                 f"Setting mask to False."
             )
             dataset.mask_safe.data[...] = False
         elif bkg_tot <= self.min_npred_background:
             log.warning(
-                f"FoVBackgroundMaker failed. Only {bkg_tot} background counts outside exclusion mask for {dataset.name}. "
+                f"FoVBackgroundMaker failed. Only {int(bkg_tot)} background counts outside exclusion mask for {dataset.name}. "
                 f"Setting mask to False."
             )
             dataset.mask_safe.data[...] = False

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -110,7 +110,7 @@ def test_fov_bkg_maker_scale_nocounts(obs_dataset, exclusion_mask, caplog):
     assert_allclose(model.tilt.value, 0.0, rtol=1e-2)
     assert caplog.records[-1].levelname == "WARNING"
     assert (
-        "Only 0.0 counts outside exclusion mask for test-fov"
+        "Only 0 counts outside exclusion mask for test-fov"
         in caplog.records[-1].message
     )
     assert "FoVBackgroundMaker failed" in caplog.records[-1].message
@@ -233,7 +233,7 @@ def test_fov_bkg_maker_scale_fail(obs_dataset, exclusion_mask, caplog):
     assert_allclose(model.norm.value, 1, rtol=1e-4)
     assert caplog.records[-1].levelname == "WARNING"
     assert (
-        f"Only -1940.3238771984525 background counts outside exclusion mask for test-fov"
+        f"Only -1940 background counts outside exclusion mask for test-fov"
         in caplog.records[-1].message
     )
     assert "FoVBackgroundMaker failed" in caplog.records[-1].message


### PR DESCRIPTION
This partly solve #3311

- Adds error on the background norm
- Returns the exclusion mask on interpolated geometry
- Allows the user to pass the minimum number of counts/background counts required for scaling.

The ideal option would be to have provenance info as @adonath mentioned, but this can be a temporary solution