### PR TITLE
Add Npred formula to dataset docs

### DIFF
--- a/docs/datasets/index.rst
+++ b/docs/datasets/index.rst
@@ -64,10 +64,11 @@ The total number of predicted counts from a `MapDataset` are computed per bin li
 
 	N_{Pred} = N_{Bkg} + \sum_{Src} N_{Src}
 
-Where :math:`N_{Bkg}` is the expected residual hadronic background model and :math:`N_{Src}`
-the predicted counts from a given source model component.
-
-The predicted counts from a source are given by:
+Where :math:`N_{Bkg}` is the expected counts from the residual hadronic background
+model and :math:`N_{Src}` the predicted counts from a given source model component.
+The predicted counts from the hadronic background are computed directly from
+the model in reconstructed energy and spatial coordinates, while the predicted counts
+from a source are obtained by forward folding with the instrument response:
 
 .. math::
 

--- a/docs/datasets/index.rst
+++ b/docs/datasets/index.rst
@@ -52,9 +52,27 @@ Note that in Gammapy, 2D image analyses are done with 3D cubes with a single
 energy bin, e.g. for modeling and fitting,
 see the `2D map analysis tutorial <./tutorials/image_analysis.html>`__.
 
-
 To analyse multiple runs, you can either stack the datasets together, or perform
 a joint fit across multiple datasets.
+
+
+Predicted counts
+================
+Predicted counts are computed like:
+
+.. math::
+
+	N_{Pred} = N_{Bkg} + \mathrm{PSF} \circledast \mathrm{EDISP(\mathcal{E} \cdot F_{Src}(l, b, E_{True}))}
+
+
+Where :math:`$N_{Bkg}$` is the expected residual hadronic background,
+:math:`$F_{Src}$` the integrated flux of the source model,
+:math:`$\mathrm{EDISP}$` the energy dispersion matrix and
+:math:`$\mathrm{PSF}$` the PSF convolution kernel. Predicted counts are computed
+per model component, where the corresponding IRFs are extracted
+at the current position of the model component and assumed to be
+constant across the size of the source.
+
 
 .. _stack:
 
@@ -129,6 +147,7 @@ The following plot shows the individual and stacked energy dispersion kernel and
 
 
 .. _joint:
+
 Joint Analysis
 ==============
 

--- a/docs/datasets/index.rst
+++ b/docs/datasets/index.rst
@@ -78,7 +78,8 @@ Where :math:`F_{Src}` is the integrated flux of the source model,
 :math:`\mathrm{EDISP}` the energy dispersion matrix and
 :math:`\mathrm{PSF}` the PSF convolution kernel. The corresponding IRFs are extracted
 at the current position of the model component defined by :math:`(l, b)` and assumed
-to be constant across the size of the source.
+to be constant across the size of the source. The detailed expressions to compute the
+predicted number of counts from a source and corresponding IRFs are given in `irf-theory`_.
 
 
 .. _stack:

--- a/docs/datasets/index.rst
+++ b/docs/datasets/index.rst
@@ -58,20 +58,27 @@ a joint fit across multiple datasets.
 
 Predicted counts
 ================
-Predicted counts are computed like:
+The total number of predicted counts from a `MapDataset` are computed per bin like:
 
 .. math::
 
-	N_{Pred} = N_{Bkg} + \mathrm{PSF} \circledast \mathrm{EDISP(\mathcal{E} \cdot F_{Src}(l, b, E_{True}))}
+	N_{Pred} = N_{Bkg} + \sum_{Src} N_{Src}
 
+Where :math:`N_{Bkg}` is the expected residual hadronic background model and :math:`N_{Src}`
+the predicted counts from a given source model component.
 
-Where :math:`$N_{Bkg}$` is the expected residual hadronic background,
-:math:`$F_{Src}$` the integrated flux of the source model,
-:math:`$\mathrm{EDISP}$` the energy dispersion matrix and
-:math:`$\mathrm{PSF}$` the PSF convolution kernel. Predicted counts are computed
-per model component, where the corresponding IRFs are extracted
-at the current position of the model component and assumed to be
-constant across the size of the source.
+The predicted counts from a source are given by:
+
+.. math::
+
+	N_{Src} = \mathrm{PSF_{Src}} \circledast \mathrm{EDISP_{Src}}(\mathcal{E} \cdot F_{Src}(l, b, E_{True}))
+
+Where :math:`F_{Src}` is the integrated flux of the source model,
+:math:`\mathcal{E}` the exposure,
+:math:`\mathrm{EDISP}` the energy dispersion matrix and
+:math:`\mathrm{PSF}` the PSF convolution kernel. The corresponding IRFs are extracted
+at the current position of the model component defined by :math:`(l, b)` and assumed
+to be constant across the size of the source.
 
 
 .. _stack:


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

I noticed we don't show the standard formula of our npred data model. So this pull request add the formula how the predicted counts are computed to the datasets docs page. Another good place would the analysis overview page, but for now it does not matter this much. We can move around the content later...

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
