### PR TITLE
Add sed_type keyword to SpectralModel.plot

### DIFF
--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -351,9 +351,9 @@ class SourceCatalogGammaCat(SourceCatalog):
 
     >>> energy_range = [1, 10] * u.TeV
     >>> source.spectral_model().plot(energy_range)
-    <AxesSubplot:xlabel='Energy [TeV]', ylabel='Flux [1 / (cm2 s TeV)]'>
+    <AxesSubplot:xlabel='Energy [TeV]', ylabel='dnde [1 / (cm2 s TeV)]'>
     >>> source.spectral_model().plot_error(energy_range)
-    <AxesSubplot:xlabel='Energy [TeV]', ylabel='Flux [1 / (cm2 s TeV)]'>
+    <AxesSubplot:xlabel='Energy [TeV]', ylabel='dnde [1 / (cm2 s TeV)]'>
     >>> source.flux_points.plot()
     <AxesSubplot:xlabel='Energy (TeV)', ylabel='dnde (1 / (cm2 s TeV))'>
     """

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -343,7 +343,7 @@ class SpectralModel(Model):
             else:
                 raise ValueError(f"Not a valid SED type {sed_type}")
 
-            y = self._plot_scale_flux(energy, flux, energy_power)
+        y = self._plot_scale_flux(energy, flux, energy_power)
 
         ax.plot(energy.value, y.value, **kwargs)
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -273,6 +273,7 @@ class SpectralModel(Model):
         energy_unit="TeV",
         flux_unit="cm-2 s-1 TeV-1",
         energy_power=0,
+        sed_type = "",
         n_points=100,
         **kwargs,
     ):
@@ -302,6 +303,8 @@ class SpectralModel(Model):
             Unit of the flux axis
         energy_power : int, optional
             Power of energy to multiply flux axis with
+        sed_type : str, optional
+            Evaluation methods of the model
         n_points : int, optional
             Number of evaluation nodes
 
@@ -316,13 +319,35 @@ class SpectralModel(Model):
 
         energy_min, energy_max = energy_range
         energy = MapAxis.from_energy_bounds(
-            energy_min, energy_max, n_points, energy_unit
-        ).edges
+                                            energy_min, energy_max, n_points, energy_unit
+                                            ).edges
 
-        # evaluate model
-        flux = self(energy).to(flux_unit)
+        if sed_type:
+            if sed_type == "dnde":
+                energy_power = 0
+                flux = self(energy).to(flux_unit)
 
-        y = self._plot_scale_flux(energy, flux, energy_power)
+            if sed_type == "e2dnde":
+                energy_power = 2
+                flux = self(energy).to(flux_unit)
+
+            if sed_type == "flux":
+                energy_power = 0
+                flux = self.integral(energy[:-1], energy[1:]).to("cm-2 s-1")
+                energy = (energy[:-1] + energy[1:]) / 2.
+
+            if sed_type == "eflux":
+                energy_power = 0
+                flux = self.energy_flux(energy[:-1], energy[1:]).to("TeV cm-2 s-1")
+                energy = (energy[:-1] + energy[1:]) / 2.
+
+            y = self._plot_scale_flux(energy, flux, energy_power)
+
+        else:
+            # evaluate model
+            flux = self(energy).to(flux_unit)
+
+            y = self._plot_scale_flux(energy, flux, energy_power)
 
         ax.plot(energy.value, y.value, **kwargs)
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -273,7 +273,7 @@ class SpectralModel(Model):
         energy_unit="TeV",
         flux_unit="cm-2 s-1 TeV-1",
         energy_power=0,
-        sed_type = "",
+        sed_type = "dnde",
         n_points=100,
         **kwargs,
     ):
@@ -303,7 +303,7 @@ class SpectralModel(Model):
             Unit of the flux axis
         energy_power : int, optional
             Power of energy to multiply flux axis with
-        sed_type : str, optional
+        sed_type : {"dnde", "flux", "eflux", "e2dnde"}
             Evaluation methods of the model
         n_points : int, optional
             Number of evaluation nodes
@@ -324,28 +324,24 @@ class SpectralModel(Model):
 
         if sed_type:
             if sed_type == "dnde":
-                energy_power = 0
                 flux = self(energy).to(flux_unit)
 
-            if sed_type == "e2dnde":
+            elif sed_type == "e2dnde":
                 energy_power = 2
                 flux = self(energy).to(flux_unit)
 
-            if sed_type == "flux":
+            elif sed_type == "flux":
                 energy_power = 0
                 flux = self.integral(energy[:-1], energy[1:]).to("cm-2 s-1")
                 energy = (energy[:-1] + energy[1:]) / 2.
 
-            if sed_type == "eflux":
+            elif sed_type == "eflux":
                 energy_power = 0
                 flux = self.energy_flux(energy[:-1], energy[1:]).to("TeV cm-2 s-1")
                 energy = (energy[:-1] + energy[1:]) / 2.
 
-            y = self._plot_scale_flux(energy, flux, energy_power)
-
-        else:
-            # evaluate model
-            flux = self(energy).to(flux_unit)
+            else:
+                raise ValueError(f"Not a valid SED type {sed_type}")
 
             y = self._plot_scale_flux(energy, flux, energy_power)
 

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -396,6 +396,27 @@ def test_model_plot():
         pwl.plot_error((1 * u.TeV, 10 * u.TeV))
 
 
+@requires_dependency("matplotlib")
+def test_model_plot_sed_type():
+    pwl = PowerLawSpectralModel(
+                                amplitude=1e-12 * u.Unit("TeV-1 cm-2 s-1"), reference=1 * u.Unit("TeV"), index=2
+                                )
+    pwl.amplitude.error = 0.1e-12 * u.Unit("TeV-1 cm-2 s-1")
+                                
+    with mpl_plot_check():
+        ax = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="dnde")
+        assert(ax.axes.axes.get_ylabel() == "Flux [1 / (cm2 s TeV)]")
+    with mpl_plot_check():
+        ax = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="e2dnde")
+        assert(ax.axes.axes.get_ylabel() == "E2 * Flux [TeV / (cm2 s)]")
+    with mpl_plot_check():
+        ax = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="flux")
+        assert(ax.axes.axes.get_ylabel() == "Flux [1 / (cm2 s)]")
+    with mpl_plot_check():
+        ax = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="eflux")
+        assert(ax.axes.axes.get_ylabel() == "Flux [TeV / (cm2 s)]")
+
+
 def test_to_from_dict():
     spectrum = TEST_MODELS[0]
     model = spectrum["model"]

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -404,17 +404,25 @@ def test_model_plot_sed_type():
     pwl.amplitude.error = 0.1e-12 * u.Unit("TeV-1 cm-2 s-1")
                                 
     with mpl_plot_check():
-        ax = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="dnde")
-        assert(ax.axes.axes.get_ylabel() == "Flux [1 / (cm2 s TeV)]")
+        ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="dnde")
+        ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="dnde")
+        assert(ax1.axes.axes.get_ylabel() == "Flux [1 / (cm2 s TeV)]")
+        assert(ax2.axes.axes.get_ylabel() == "Flux [1 / (cm2 s TeV)]")
     with mpl_plot_check():
-        ax = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="e2dnde")
-        assert(ax.axes.axes.get_ylabel() == "E2 * Flux [TeV / (cm2 s)]")
+        ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="e2dnde")
+        ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="e2dnde")
+        assert(ax1.axes.axes.get_ylabel() == "E2 * Flux [TeV / (cm2 s)]")
+        assert(ax2.axes.axes.get_ylabel() == "E2 * Flux [TeV / (cm2 s)]")
     with mpl_plot_check():
-        ax = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="flux")
-        assert(ax.axes.axes.get_ylabel() == "Flux [1 / (cm2 s)]")
+        ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="flux")
+        ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="flux")
+        assert(ax1.axes.axes.get_ylabel() == "Flux [1 / (cm2 s)]")
+        assert(ax2.axes.axes.get_ylabel() == "Flux [1 / (cm2 s)]")
     with mpl_plot_check():
-        ax = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="eflux")
-        assert(ax.axes.axes.get_ylabel() == "Flux [TeV / (cm2 s)]")
+        ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="eflux")
+        ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="eflux")
+        assert(ax1.axes.axes.get_ylabel() == "Flux [TeV / (cm2 s)]")
+        assert(ax2.axes.axes.get_ylabel() == "Flux [TeV / (cm2 s)]")
 
 
 def test_to_from_dict():

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -406,23 +406,23 @@ def test_model_plot_sed_type():
     with mpl_plot_check():
         ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="dnde")
         ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="dnde")
-        assert(ax1.axes.axes.get_ylabel() == "Flux [1 / (cm2 s TeV)]")
-        assert(ax2.axes.axes.get_ylabel() == "Flux [1 / (cm2 s TeV)]")
+        assert(ax1.axes.axes.get_ylabel() == "dnde [1 / (cm2 s TeV)]")
+        assert(ax2.axes.axes.get_ylabel() == "dnde [1 / (cm2 s TeV)]")
     with mpl_plot_check():
         ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="e2dnde")
         ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="e2dnde")
-        assert(ax1.axes.axes.get_ylabel() == "E2 * Flux [TeV / (cm2 s)]")
-        assert(ax2.axes.axes.get_ylabel() == "E2 * Flux [TeV / (cm2 s)]")
+        assert(ax1.axes.axes.get_ylabel() == "e2dnde [TeV / (cm2 s)]")
+        assert(ax2.axes.axes.get_ylabel() == "e2dnde [TeV / (cm2 s)]")
     with mpl_plot_check():
         ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="flux")
         ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="flux")
-        assert(ax1.axes.axes.get_ylabel() == "Flux [1 / (cm2 s)]")
-        assert(ax2.axes.axes.get_ylabel() == "Flux [1 / (cm2 s)]")
+        assert(ax1.axes.axes.get_ylabel() == "flux [1 / (cm2 s)]")
+        assert(ax2.axes.axes.get_ylabel() == "flux [1 / (cm2 s)]")
     with mpl_plot_check():
         ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="eflux")
         ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="eflux")
-        assert(ax1.axes.axes.get_ylabel() == "Flux [TeV / (cm2 s)]")
-        assert(ax2.axes.axes.get_ylabel() == "Flux [TeV / (cm2 s)]")
+        assert(ax1.axes.axes.get_ylabel() == "eflux [TeV / (cm2 s)]")
+        assert(ax2.axes.axes.get_ylabel() == "eflux [TeV / (cm2 s)]")
 
 
 def test_to_from_dict():


### PR DESCRIPTION
This PR solves the issue #3324. A `sed_type` keyword is added to `SpectralModel.plot` and it allows to plot the corresponding evaluation methods of the model.

TO DO: add the `sed_type` keyword to `SpectralModel.plot_error`