### PR TITLE
Keep infinite values in sparse wcs map serialisation

### DIFF
--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -149,7 +149,7 @@ def test_wcs_nd_map_data_transpose_issue(tmp_path):
     assert_equal(m2.data, data)
 
     # Data should be unmodified after write / read to sparse image format
-    m.write(tmp_path / "sparse.fits.gz")
+    m.write(tmp_path / "sparse.fits.gz", sparse=True)
     m2 = Map.read(tmp_path / "sparse.fits.gz")
     assert_equal(m2.data, data)
 

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -270,18 +270,16 @@ class WcsMap(Map):
 
         if len(shape) == 2:
             data_flat = np.ravel(data)
-            data_flat[~np.isfinite(data_flat)] = 0
-            nonzero = np.where(data_flat > 0)
-            value = data_flat[nonzero].astype(float)
+            non_zero = np.where(~(data_flat == 0))
+            value = data_flat[non_zero].astype(float)
             cols = [
-                fits.Column("PIX", "J", array=nonzero[0]),
+                fits.Column("PIX", "J", array=non_zero[0]),
                 fits.Column("VALUE", "E", array=value),
             ]
         elif npix[0].size == 1:
             shape_flat = shape[:-2] + (shape[-1] * shape[-2],)
             data_flat = np.ravel(data).reshape(shape_flat)
-            data_flat[~np.isfinite(data_flat)] = 0
-            nonzero = np.where(data_flat > 0)
+            nonzero = np.where(~(data_flat == 0))
             channel = np.ravel_multi_index(nonzero[:-1], shape[:-2])
             value = data_flat[nonzero].astype(float)
             cols = [
@@ -295,8 +293,7 @@ class WcsMap(Map):
             pix = []
             for i, _ in np.ndenumerate(npix[0]):
                 data_i = np.ravel(data[i[::-1]])
-                data_i[~np.isfinite(data_i)] = 0
-                pix_i = np.where(data_i > 0)
+                pix_i = np.where(~(data_i == 0))
                 data_i = data_i[pix_i]
                 data_flat += [data_i]
                 pix += pix_i


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes #2465, by keeping the infinite values during the serialisation. For the sparsification only values equivalent to zero are skipped.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
