### PR TITLE
Add fixed_offset attribute to SafeMaskMaker

### DIFF
--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -36,7 +36,7 @@ class SafeMaskMaker(Maker):
         Position at which the `aeff_percent` or `bias_percent` are computed. By default,
         it uses the position of the center of the map.
     fixed_offset : `~astropy.coordinates.Angle`
-        offset, calculated from the coordinates of the center of the map, at which 
+        offset, calculated from the pointing position, at which 
         the `aeff_percent` or `bias_percent` are computed.
     offset_max : str or `~astropy.units.Quantity`
         Maximum offset cut.

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -50,12 +50,12 @@ def test_safe_mask_maker(observations, caplog):
     assert_allclose(mask_energy_aeff_default.data.sum(), 1936)
 
     mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset)
-    mask_aeff_max_offset = safe_mask_maker_offset.make_mask_energy_aeff_max(dataset)
+    mask_aeff_max_offset = safe_mask_maker_offset.make_mask_energy_aeff_max(dataset, obs)
     assert_allclose(mask_aeff_max.data.sum(), 1210)
     assert_allclose(mask_aeff_max_offset.data.sum(), 1210)
 
     mask_edisp_bias = safe_mask_maker.make_mask_energy_edisp_bias(dataset)
-    mask_edisp_bias_offset = safe_mask_maker_offset.make_mask_energy_edisp_bias(dataset)
+    mask_edisp_bias_offset = safe_mask_maker_offset.make_mask_energy_edisp_bias(dataset, obs)
     assert_allclose(mask_edisp_bias.data.sum(), 1815)
     assert_allclose(mask_edisp_bias_offset.data.sum(), 121)
 

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from numpy.testing import assert_allclose
+from astropy import units as u
 from gammapy.data import DataStore
 from gammapy.datasets import MapDataset
 from gammapy.makers import MapDatasetMaker, SafeMaskMaker
@@ -33,6 +34,11 @@ def test_safe_mask_maker(observations, caplog):
         offset_max="3 deg", bias_percent=0.02, position=obs.pointing_radec
     )
 
+    fixed_offset = 1.5 * u.deg
+    safe_mask_maker_offset = SafeMaskMaker(
+                                    offset_max="3 deg", bias_percent=0.02, fixed_offset = fixed_offset
+                                    )
+
     dataset = dataset_maker.run(empty_dataset, obs)
 
     mask_offset = safe_mask_maker.make_mask_offset_max(dataset=dataset, observation=obs)
@@ -44,10 +50,14 @@ def test_safe_mask_maker(observations, caplog):
     assert_allclose(mask_energy_aeff_default.data.sum(), 1936)
 
     mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset)
+    mask_aeff_max_offset = safe_mask_maker_offset.make_mask_energy_aeff_max(dataset)
     assert_allclose(mask_aeff_max.data.sum(), 1210)
+    assert_allclose(mask_aeff_max_offset.data.sum(), 1210)
 
     mask_edisp_bias = safe_mask_maker.make_mask_energy_edisp_bias(dataset)
+    mask_edisp_bias_offset = safe_mask_maker_offset.make_mask_energy_edisp_bias(dataset)
     assert_allclose(mask_edisp_bias.data.sum(), 1815)
+    assert_allclose(mask_edisp_bias_offset.data.sum(), 121)
 
     mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
     assert_allclose(mask_bkg_peak.data.sum(), 1815)      


### PR DESCRIPTION
This PR fixes the issue #2704 . It adds a `fixed_offset` attribute to `SafeMaskMaker` to evaluate the safe energy mask from energy dispersion bias or from effective area maximum value at a given offset with respect to the pointing position.