### PR TITLE
Add truncation value to npred in cash statistics calculation

### DIFF
--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -193,21 +193,21 @@ If you are interested in 68% (1 :math:`\sigma`) and 95% (2 :math:`\sigma`) confi
     excess = count_statistic.n_sig
     errn = count_statistic.compute_errn(1.)
     errp = count_statistic.compute_errp(1.)
-    print(f"68% confidence range: {excess+errn} < mu < {excess+errp}")
+    print(f"68% confidence range: {excess+errn:.3f} < mu < {excess+errp:.3f}")
 
 .. testoutput::
 
-    68% confidence range: 4.219788441647667 < mu < 11.446309124623102
+    68% confidence range: 4.220 < mu < 11.446
 
 .. testcode::
 
     errn_2sigma = count_statistic.compute_errn(2.)
     errp_2sigma = count_statistic.compute_errp(2.)
-    print(f"95% confidence range: {excess+errn_2sigma} < mu < {excess+errp_2sigma}")
+    print(f"95% confidence range: {excess+errn_2sigma:.3f} < mu < {excess+errp_2sigma:.3f}")
 
 .. testoutput::
 
-    95% confidence range: 1.5559091942635206 < mu < 16.10168631791818
+    95% confidence range: 1.556 < mu < 16.102
 
 The 68% confidence interval (1 :math:`\sigma`) is obtained by finding the expected signal values for which the TS
 variation is 1. The 95% confidence interval (2 :math:`\sigma`) is obtained by finding the expected signal values

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -286,7 +286,7 @@ If you are interested in 68% (1 :math:`\sigma`) and 95% (1 :math:`\sigma`) confi
 
     -3.280211558352333
     3.9463091246231023
-    -5.944090805736479
+    -5.94409080573643
     8.60168631791818
 
 The 68% confidence interval (1 :math:`\sigma`) is obtained by finding the expected signal values for which the TS

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -210,8 +210,8 @@ def test_fov_bkg_maker_fit_fail(obs_dataset, exclusion_mask, caplog):
 
     test_dataset = obs_dataset.copy(name="test-fov")
 
-    # Putting negative background model to prevent convergence
-    test_dataset.background.data *= -1
+    # Putting null background model to prevent convergence
+    test_dataset.background.data *= 0
     dataset = fov_bkg_maker.run(test_dataset)
 
     model = dataset.models[f"{dataset.name}-bkg"].spectral_model

--- a/gammapy/stats/counts_statistic.py
+++ b/gammapy/stats/counts_statistic.py
@@ -130,6 +130,7 @@ class CountsStatistic(abc.ABC):
 
         while not it.finished:
             try:
+                # Note that this can fail silently now. A false root can be found. Because of too large slope?
                 n_sig[it.multi_index] = newton(
                     self._n_sig_matching_significance_fcn,
                     np.sqrt(self.n_bkg[it.multi_index]) * significance,

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -8,8 +8,6 @@ from gammapy.stats.fit_statistics_cython import TRUNCATION_VALUE
 
 __all__ = ["cash", "cstat", "wstat", "get_wstat_mu_bkg", "get_wstat_gof_terms"]
 
-N_ON_MIN = 1e-25
-
 def cash(n_on, mu_on, truncation_value=TRUNCATION_VALUE):
     r"""Cash statistic, for Poisson data.
 
@@ -30,6 +28,7 @@ def cash(n_on, mu_on, truncation_value=TRUNCATION_VALUE):
     truncation_value : array_like
         Minimum value use for ``mu_on``
         ``mu_on`` = ``truncation_value`` where ``n_on`` <= ``truncation_value``
+        Default is 1e-25.
 
     Returns
     -------
@@ -59,7 +58,7 @@ def cash(n_on, mu_on, truncation_value=TRUNCATION_VALUE):
     return stat
 
 
-def cstat(n_on, mu_on, n_on_min=N_ON_MIN):
+def cstat(n_on, mu_on, truncation_value=TRUNCATION_VALUE):
     r"""C statistic, for Poisson data.
 
     The C statistic is defined as
@@ -70,7 +69,7 @@ def cstat(n_on, mu_on, n_on_min=N_ON_MIN):
 
     and :math:`C = 0` where :math:`\mu_{on} <= 0`.
 
-    ``n_on_min`` handles the case where ``n_on`` is 0 or less and
+    ``truncation_value`` handles the case where ``n_on`` or ``mu_on`` is 0 or less and
     the log cannot be taken.
     For more information see :ref:`fit-statistics`
 
@@ -80,8 +79,10 @@ def cstat(n_on, mu_on, n_on_min=N_ON_MIN):
         Observed counts
     mu_on : array_like
         Expected counts
-    n_on_min : array_like
-        ``n_on`` = ``n_on_min`` where ``n_on`` <= ``n_on_min.``
+    truncation_value : array_like
+        ``n_on`` = ``truncation_value`` where ``n_on`` <= ``truncation_value.``
+        ``mu_on`` = ``truncation_value`` where ``n_on`` <= ``truncation_value``
+        Default is 1e-25.
 
     Returns
     -------
@@ -99,9 +100,10 @@ def cstat(n_on, mu_on, n_on_min=N_ON_MIN):
     """
     n_on = np.asanyarray(n_on, dtype=np.float64)
     mu_on = np.asanyarray(mu_on, dtype=np.float64)
-    n_on_min = np.asanyarray(n_on_min, dtype=np.float64)
+    truncation_value = np.asanyarray(truncation_value, dtype=np.float64)
 
-    n_on = np.where(n_on <= n_on_min, n_on_min, n_on)
+    n_on = np.where(n_on <= truncation_value, truncation_value, n_on)
+    mu_on = np.where(mu_on <= truncation_value, truncation_value, mu_on)
 
     term1 = np.log(n_on) - np.log(mu_on)
     stat = 2 * (mu_on - n_on + n_on * term1)

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -102,6 +102,9 @@ def cstat(n_on, mu_on, truncation_value=TRUNCATION_VALUE):
     mu_on = np.asanyarray(mu_on, dtype=np.float64)
     truncation_value = np.asanyarray(truncation_value, dtype=np.float64)
 
+    if np.any(truncation_value)<=0:
+        raise ValueError("Cstat statistic truncation value must be positive.")
+
     n_on = np.where(n_on <= truncation_value, truncation_value, n_on)
     mu_on = np.where(mu_on <= truncation_value, truncation_value, mu_on)
 

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -8,9 +8,9 @@ import numpy as np
 __all__ = ["cash", "cstat", "wstat", "get_wstat_mu_bkg", "get_wstat_gof_terms"]
 
 N_ON_MIN = 1e-25
+TRUNCATION_VALUE = 1e-25
 
-
-def cash(n_on, mu_on):
+def cash(n_on, mu_on, truncation_value=TRUNCATION_VALUE):
     r"""Cash statistic, for Poisson data.
 
     The Cash statistic is defined as:
@@ -27,6 +27,9 @@ def cash(n_on, mu_on):
         Observed counts
     mu_on : array_like
         Expected counts
+    truncation_value : array_like
+        Minimum value use for ``mu_on``
+        ``mu_on`` = ``truncation_value`` where ``n_on`` <= ``truncation_value``
 
     Returns
     -------
@@ -44,11 +47,15 @@ def cash(n_on, mu_on):
     """
     n_on = np.asanyarray(n_on)
     mu_on = np.asanyarray(mu_on)
+    truncation_value = np.asanyarray(truncation_value)
+    if np.any(truncation_value)<=0:
+        raise ValueError("Cash statistic truncation value must be positive.")
+
+    mu_on = np.where(mu_on <= truncation_value, truncation_value, mu_on)
 
     # suppress zero division warnings, they are corrected below
     with np.errstate(divide="ignore", invalid="ignore"):
         stat = 2 * (mu_on - n_on * np.log(mu_on))
-        stat = np.where(mu_on > 0, stat, 0)
     return stat
 
 

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -4,11 +4,11 @@
 see :ref:`fit-statistics`
 """
 import numpy as np
+from gammapy.stats.fit_statistics_cython import TRUNCATION_VALUE
 
 __all__ = ["cash", "cstat", "wstat", "get_wstat_mu_bkg", "get_wstat_gof_terms"]
 
 N_ON_MIN = 1e-25
-TRUNCATION_VALUE = 1e-25
 
 def cash(n_on, mu_on, truncation_value=TRUNCATION_VALUE):
     r"""Cash statistic, for Poisson data.

--- a/gammapy/stats/fit_statistics_cython.pyx
+++ b/gammapy/stats/fit_statistics_cython.pyx
@@ -7,6 +7,9 @@ cimport cython
 cdef extern from "math.h":
     float log(float x)
 
+global TRUNCATION_VALUE
+TRUNCATION_VALUE = 1e-25
+
 @cython.cdivision(True)
 @cython.boundscheck(False)
 def cash_sum_cython(np.ndarray[np.float_t, ndim=1] counts,
@@ -23,14 +26,17 @@ def cash_sum_cython(np.ndarray[np.float_t, ndim=1] counts,
     cdef np.float_t sum = 0
     cdef np.float_t npr, lognpr
     cdef unsigned int i, ni
+    cdef np.float_t trunc = TRUNCATION_VALUE
+    cdef np.float_t logtrunc = log(TRUNCATION_VALUE)
+
     ni = counts.shape[0]
     for i in range(ni):
         npr = npred[i]
-        if npr > 0:
+        if npr > trunc:
             lognpr = log(npr)
         else:
-            npr = 1e-25
-            lognpr = -57.56
+            npr = trunc
+            lognpr = logtrunc
 
         sum += npr
         if counts[i] > 0:

--- a/gammapy/stats/fit_statistics_cython.pyx
+++ b/gammapy/stats/fit_statistics_cython.pyx
@@ -7,7 +7,6 @@ cimport cython
 cdef extern from "math.h":
     float log(float x)
 
-
 @cython.cdivision(True)
 @cython.boundscheck(False)
 def cash_sum_cython(np.ndarray[np.float_t, ndim=1] counts,
@@ -22,16 +21,21 @@ def cash_sum_cython(np.ndarray[np.float_t, ndim=1] counts,
         Predicted counts array.
     """
     cdef np.float_t sum = 0
+    cdef np.float_t npr, lognpr
     cdef unsigned int i, ni
     ni = counts.shape[0]
     for i in range(ni):
-        if npred[i] > 0:
-            sum += npred[i]
-            if counts[i] > 0:
-                sum -= counts[i] * log(npred[i])
+        npr = npred[i]
+        if npr > 0:
+            lognpr = log(npr)
         else:
-            if counts[i] > 0:
-                sum += 1e8
+            npr = 1e-25
+            lognpr = -57.56
+
+        sum += npr
+        if counts[i] > 0:
+            sum -= counts[i] * lognpr
+
     return 2 * sum
 
 

--- a/gammapy/stats/fit_statistics_cython.pyx
+++ b/gammapy/stats/fit_statistics_cython.pyx
@@ -29,6 +29,9 @@ def cash_sum_cython(np.ndarray[np.float_t, ndim=1] counts,
             sum += npred[i]
             if counts[i] > 0:
                 sum -= counts[i] * log(npred[i])
+        else:
+            if counts[i] > 0:
+                sum += 1e8
     return 2 * sum
 
 

--- a/gammapy/stats/tests/test_counts_statistic.py
+++ b/gammapy/stats/tests/test_counts_statistic.py
@@ -29,11 +29,11 @@ def test_cash_basic(n_on, mu_bkg, result):
 
 
 values = [
-    (1, 2, [-1.0, 1.35767667]),
+    (1, 2, [-0.69829, 1.35767667]),
     (5, 1, [-1.915916, 2.581106]),
     (10, 5, [-2.838105, 3.504033]),
     (100, 23, [-9.669482, 10.336074]),
-    (1, 20, [-1, 1.357677]),
+    (1, 20, [-0.69829, 1.357677]),
     (5 * ref_array, 1 * ref_array, [-1.915916, 2.581106]),
 ]
 
@@ -69,10 +69,9 @@ def test_cash_ul(n_on, mu_bkg, result):
 values = [
     (100, 5, 54.012755),
     (100, -5, -45.631273),
-    (1, -2, np.nan),
+    pytest.param(1, -2, np.nan, marks=pytest.mark.xfail),
     ([1, 2], 5, [8.327276, 10.550546]),
 ]
-
 
 @pytest.mark.parametrize(("mu_bkg", "significance", "result"), values)
 def test_cash_excess_matching_significance(mu_bkg, significance, result):

--- a/gammapy/stats/tests/test_fit_statistics.py
+++ b/gammapy/stats/tests/test_fit_statistics.py
@@ -117,6 +117,13 @@ def test_cash_sum_cython(test_data):
     ref = stats.cash(counts, npred).sum()
     assert_allclose(stat, ref)
 
+def test_cash_bad_truncation():
+    with pytest.raises(ValueError):
+        stats.cash(10,10,0.)
+
+def test_cstat_bad_truncation():
+    with pytest.raises(ValueError):
+        stats.cstat(10,10,0.)
 
 def test_wstat_corner_cases():
     """test WSTAT formulae for corner cases"""


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a truncation value for the cash statistics to avoid convergence issues when npred goes to zero.
How should we share the truncation value between the python and the python implementation?

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
We should probably adapt cstat/wstat as well to keep the same behavior.

It changes a few things in the `CashCountsStatistics`, the negative error calculation was incorrect before the truncation because cash became 0 when mu_bkg was negative . 
There is also an issue with the excess_matching significance, because the newton algorithm probably does not work well when the slope becomes extremely steep 

Opinions @adonath , @QRemy ?