### PR TITLE
Implement WcsNDMap.plot_mask()

### DIFF
--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1111,6 +1111,38 @@ class Map(abc.ABC):
                 fig, ax, cbar = img.plot(stretch=stretch, **kwargs)
                 plt.show()
 
+    def plot_mask(self, ax=None, **kwargs):
+        """Plot the mask as a shaded area
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axis`
+            Axis instance to be used for the plot.
+        **kwargs : dict
+            Keyword arguments passed to `~matplotlib.pyplot.axvspan`
+
+        Returns
+        -------
+        ax : `~matplotlib.pyplot.Axis`
+            Axis used for plotting
+        """
+        import matplotlib.pyplot as plt
+
+        if not self.is_mask:
+            raise ValueError("This is not a mask and cannot be plotted")
+
+        kwargs.setdefault("alpha", 0.05)
+        kwargs.setdefault("colors", "k")
+
+        ax = plt.gca() if ax is None else ax
+
+        data = self.data.astype(float)
+
+        cs = ax.contourf(data, level=[0, 0.5], **kwargs)
+        ax.contour(cs)
+
+        return ax
+
     def copy(self, **kwargs):
         """Copy map instance and overwrite given attributes, except for geometry.
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1111,44 +1111,6 @@ class Map(abc.ABC):
                 fig, ax, cbar = img.plot(stretch=stretch, **kwargs)
                 plt.show()
 
-    def plot_mask(self, ax=None, **kwargs):
-        """Plot the mask as a shaded area
-
-        Parameters
-        ----------
-        ax : `~matplotlib.axis`
-            Axis instance to be used for the plot.
-        **kwargs : dict
-            Keyword arguments passed to `~matplotlib.pyplot.axvspan`
-
-        Returns
-        -------
-        ax : `~matplotlib.pyplot.Axis`
-            Axis used for plotting
-        """
-        import matplotlib.pyplot as plt
-
-        if not self.is_mask:
-            raise ValueError("This is not a mask and cannot be plotted")
-
-        kwargs.setdefault("alpha", 0.5)
-        kwargs.setdefault("colors", "w")
-
-        if ax is None:
-            fig = plt.gcf()
-            if self.geom.projection in ["AIT"]:
-                ax = fig.add_subplot(
-                                 1, 1, 1, projection=self.geom.wcs,
-                                 frame_class=EllipticalFrame
-                                 )
-            else:
-                ax = fig.add_subplot(1, 1, 1, projection=self.geom.wcs)
-
-        data = self.data.astype(float)
-
-        ax.contourf(data, level=[0, 0.5], **kwargs)
-
-        return ax
 
     def copy(self, **kwargs):
         """Copy map instance and overwrite given attributes, except for geometry.

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1131,15 +1131,22 @@ class Map(abc.ABC):
         if not self.is_mask:
             raise ValueError("This is not a mask and cannot be plotted")
 
-        kwargs.setdefault("alpha", 0.05)
-        kwargs.setdefault("colors", "k")
+        kwargs.setdefault("alpha", 0.5)
+        kwargs.setdefault("colors", "w")
 
-        ax = plt.gca() if ax is None else ax
+        if ax is None:
+            fig = plt.gcf()
+            if self.geom.projection in ["AIT"]:
+                ax = fig.add_subplot(
+                                 1, 1, 1, projection=self.geom.wcs,
+                                 frame_class=EllipticalFrame
+                                 )
+            else:
+                ax = fig.add_subplot(1, 1, 1, projection=self.geom.wcs)
 
         data = self.data.astype(float)
 
-        cs = ax.contourf(data, level=[0, 0.5], **kwargs)
-        ax.contour(cs)
+        ax.contourf(data, level=[0, 0.5], **kwargs)
 
         return ax
 

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -6,6 +6,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.units import Quantity, Unit
 from gammapy.maps import HpxGeom, HpxNDMap, Map, MapAxis, WcsGeom, WcsNDMap
+from gammapy.utils.testing import mpl_plot_check, requires_dependency
 
 pytest.importorskip("healpy")
 
@@ -421,3 +422,25 @@ def test_interp_to_geom():
     geom_target = WcsGeom.create(skydir=(20, 20), width=(5, 5), binsz=0.1 * u.deg,)
     new_map = test_map.interp_to_geom(geom_target, preserve_counts=True)
     assert np.floor(np.sum(new_map.data)) == np.sum(test_map.data)
+
+
+@requires_dependency("matplotlib")
+def test_map_plot_mask():
+    from regions import CircleSkyRegion
+
+    skydir = SkyCoord(0, 0, frame='galactic', unit='deg')
+
+    m_wcs = Map.create(
+                   map_type='wcs',
+                   binsz=0.02,
+                   skydir=skydir,
+                   width=2.0,
+                   )
+
+    exclusion_region = CircleSkyRegion(center=SkyCoord(0.0, 0.0, unit="deg", frame="galactic"),
+                                       radius=0.6 * u.deg)
+
+    mask = ~m_wcs.geom.region_mask([exclusion_region])
+
+    with mpl_plot_check():
+        mask.plot_mask()


### PR DESCRIPTION
This PR adds a new functionality, `plot_mask`, in `~gammapy.Map` as requested in the issue #3271. It allows to plot a `mask` as shaded areas above a given map. 