### PR TITLE
Correct exposure of the TSMapEstimator kernel

### DIFF
--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -145,10 +145,10 @@ def test_compute_ts_map_psf(fermi_dataset):
     assert_allclose(result["niter"].data[0, 29, 29], 7)
     assert_allclose(result["flux"].data[0, 29, 29], 1.34984e-09, rtol=1e-3)
 
-    assert_allclose(result["flux_err"].data[0, 29, 29], 7.93751176e-11, rtol=1e-2)
-    assert_allclose(result["flux_errp"].data[0, 29, 29], 7.9376134e-11, rtol=1e-2)
-    assert_allclose(result["flux_errn"].data[0, 29, 29], 7.5180404579e-11, rtol=1e-2)
-    assert_allclose(result["flux_ul"].data[0, 29, 29], 1.63222157e-10, rtol=1e-2)
+    assert_allclose(result["flux_err"].data[0, 29, 29], 7.93751176e-11, rtol=1e-3)
+    assert_allclose(result["flux_errp"].data[0, 29, 29], 7.948953e-11, rtol=1e-3)
+    assert_allclose(result["flux_errn"].data[0, 29, 29], 7.508168e-11, rtol=1e-3)
+    assert_allclose(result["flux_ul"].data[0, 29, 29], 1.63222157e-10, rtol=1e-3)
 
     assert result["flux"].unit == u.Unit("cm-2s-1")
     assert result["flux_err"].unit == u.Unit("cm-2s-1")

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -141,9 +141,9 @@ def test_compute_ts_map_psf(fermi_dataset):
     estimator = TSMapEstimator(model=model, kernel_width="1 deg", selection_optional="all")
     result = estimator.run(fermi_dataset)
 
-    assert_allclose(result["ts"].data[0, 29, 29], 835.140605, rtol=1e-2)
+    assert_allclose(result["ts"].data[0, 29, 29], 833.38, atol=0.1)
     assert_allclose(result["niter"].data[0, 29, 29], 7)
-    assert_allclose(result["flux"].data[0, 29, 29], 1.351949e-09, rtol=1e-2)
+    assert_allclose(result["flux"].data[0, 29, 29], 1.34984e-09, rtol=1e-3)
 
     assert_allclose(result["flux_err"].data[0, 29, 29], 7.93751176e-11, rtol=1e-2)
     assert_allclose(result["flux_errp"].data[0, 29, 29], 7.9376134e-11, rtol=1e-2)

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -77,7 +77,7 @@ class TSMapEstimator(Estimator):
     threshold : float (None)
         If the TS value corresponding to the initial flux estimate is not above
         this threshold, the optimizing step is omitted to save computing time.
-    rtol : float (0.001)
+    rtol : float (0.01)
         Relative precision of the flux estimate. Used as a stopping criterion for
         the norm fit.
     selection_optional : list of str

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -12,7 +12,7 @@ from astropy.coordinates import Angle
 from astropy.utils import lazyproperty
 from gammapy.datasets import Datasets
 from gammapy.datasets.map import MapEvaluator
-from gammapy.maps import Map
+from gammapy.maps import Map, MapCoord
 from gammapy.modeling.models import PointSpatialModel, PowerLawSpectralModel, SkyModel
 from gammapy.stats import cash_sum_cython, f_cash_root_cython, norm_bounds_cython
 from gammapy.utils.array import shape_2N, symmetric_crop_pad_width, round_up_to_odd
@@ -206,8 +206,10 @@ class TSMapEstimator(Estimator):
 
         geom_kernel = geom.to_odd_npix(max_radius=self.kernel_width / 2)
 
+        # Creating exposure map with exposure at map center
         exposure = Map.from_geom(geom_kernel, unit="cm2 s1")
-        exposure.data += 1.0
+        coord = MapCoord.create(dict(skycoord=geom.center_skydir, energy_true=geom.axes["energy_true"].center))
+        exposure.data[...] = dataset.exposure.get_by_coord(coord)[:, np.newaxis, np.newaxis]
 
         # We use global evaluation mode to not modify the geometry
         evaluator = MapEvaluator(model, evaluation_mode="global")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects the `TSMapEstimator.estimate_kernel` method so that it uses the exposure values at the center of the `dataset.exposure`. This avoids assuming that exposure is independent of true energy. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
