### PR TITLE
Change default kernel_size to None in TSMapEstimator

### DIFF
--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -112,6 +112,10 @@ def test_compute_ts_map(input_dataset):
     ts_estimator = TSMapEstimator(
         model=model, threshold=1, kernel_width="1 deg", selection_optional=[]
     )
+
+    kernel = ts_estimator.estimate_kernel(dataset=input_dataset)
+    assert_allclose(kernel.geom.width, 1.02 * u.deg)
+
     result = ts_estimator.run(input_dataset)
 
     assert_allclose(result["ts"].data[0, 99, 99], 1704.23, rtol=1e-2)

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -110,20 +110,20 @@ def test_compute_ts_map(input_dataset):
     spectral_model = PowerLawSpectralModel(index=2)
     model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
     ts_estimator = TSMapEstimator(
-        model=model, threshold=1, kernel_width="1 deg", selection_optional=[]
+        model=model, threshold=1, selection_optional=[]
     )
 
     kernel = ts_estimator.estimate_kernel(dataset=input_dataset)
-    assert_allclose(kernel.geom.width, 1.02 * u.deg)
+    assert_allclose(kernel.geom.width, 1.22 * u.deg)
 
     result = ts_estimator.run(input_dataset)
 
     assert_allclose(result["ts"].data[0, 99, 99], 1704.23, rtol=1e-2)
-    assert_allclose(result["niter"].data[0, 99, 99], 8)
+    assert_allclose(result["niter"].data[0, 99, 99], 7)
     assert_allclose(result["flux"].data[0, 99, 99], 1.02e-09, rtol=1e-2)
     assert_allclose(result["flux_err"].data[0, 99, 99], 3.84e-11, rtol=1e-2)
-    assert_allclose(result["npred"].data[0, 99, 99], 3627.874063, rtol=1e-2)
-    assert_allclose(result["npred_null"].data[0, 99, 99], 2601, rtol=1e-2)
+    assert_allclose(result["npred"].data[0, 99, 99], 4744.020361, rtol=1e-2)
+    assert_allclose(result["npred_null"].data[0, 99, 99], 3721, rtol=1e-2)
     assert_allclose(result["npred_excess"].data[0, 99, 99], 1026.874063, rtol=1e-2)
 
     assert result["flux"].unit == u.Unit("cm-2s-1")

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -138,7 +138,9 @@ def test_compute_ts_map_psf(fermi_dataset):
     spectral_model = PowerLawSpectralModel(amplitude="1e-22 cm-2 s-1 keV-1")
     model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
 
-    estimator = TSMapEstimator(model=model, kernel_width="1 deg", selection_optional="all")
+    estimator = TSMapEstimator(
+        model=model, kernel_width="1 deg", selection_optional="all"
+    )
     result = estimator.run(fermi_dataset)
 
     assert_allclose(result["ts"].data[0, 29, 29], 833.38, rtol=2e-3)
@@ -192,7 +194,10 @@ def test_compute_ts_map_downsampled(input_dataset):
     model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
 
     ts_estimator = TSMapEstimator(
-        model=model, downsampling_factor=2, kernel_width="1 deg", selection_optional=["ul"]
+        model=model,
+        downsampling_factor=2,
+        kernel_width="1 deg",
+        selection_optional=["ul"]
     )
     result = ts_estimator.run(input_dataset)
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -875,7 +875,7 @@ class WcsGeom(Geom):
         coord = self.to_image().get_coord()
         return center.separation(coord.skycoord)
 
-    def cutout(self, position, width, mode="trim"):
+    def cutout(self, position, width, mode="trim", odd_npix=False):
         """
         Create a cutout around a given position.
 
@@ -888,20 +888,28 @@ class WcsGeom(Geom):
             If only one value is passed, a square region is extracted.
         mode : {'trim', 'partial', 'strict'}
             Mode option for Cutout2D, for details see `~astropy.nddata.utils.Cutout2D`.
+        odd_npix : bool
+            Force width to odd number of pixels.
 
         Returns
         -------
         cutout : `~gammapy.maps.WcsNDMap`
             Cutout map
         """
-        width = _check_width(width)
+        width = _check_width(width) * u.deg
+
+        if odd_npix:
+            binsz = self.pixel_scales
+            width_npix = (width / binsz).to_value("")
+            width = round_up_to_odd(width_npix)
+
         dummy_data = np.empty(self.to_image().data_shape)
         c2d = Cutout2D(
             data=dummy_data,
             wcs=self.wcs,
             position=position,
             # Cutout2D takes size with order (lat, lon)
-            size=width[::-1] * u.deg,
+            size=width[::-1],
             mode=mode,
         )
         return self._init_copy(wcs=c2d.wcs, npix=c2d.shape[::-1])

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -747,7 +747,7 @@ class WcsNDMap(WcsMap):
 
         return self._init_copy(data=smoothed_data)
 
-    def cutout(self, position, width, mode="trim"):
+    def cutout(self, position, width, mode="trim", odd_npix=False):
         """
         Create a cutout around a given position.
 
@@ -760,13 +760,17 @@ class WcsNDMap(WcsMap):
             If only one value is passed, a square region is extracted.
         mode : {'trim', 'partial', 'strict'}
             Mode option for Cutout2D, for details see `~astropy.nddata.utils.Cutout2D`.
+        odd_npix : bool
+            Force width to odd number of pixels.
 
         Returns
         -------
         cutout : `~gammapy.maps.WcsNDMap`
             Cutout map
         """
-        geom_cutout = self.geom.cutout(position=position, width=width, mode=mode)
+        geom_cutout = self.geom.cutout(
+            position=position, width=width, mode=mode, odd_npix=odd_npix
+        )
         cutout_info = geom_cutout.cutout_slices(self.geom, mode=mode)
 
         slices = cutout_info["parent-slices"]


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the default behavior of the `TSMapEstimator`. The `kernel_size` default value of 0.2 deg can be very underestimated in a number of cases.

Here we change the default `kernel_size` to `None`. By default, it will use the `MapEvaluator.cutout_width` which is the sum of the PSF kernel width with the model `evaluation_radius`. 
While this avoids grossly underestimated kernel sizes, this can also yield very large sizes since the PSF kernel is by default computed until `rad_max`.

The issue was raised in #3004 .


**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
Another option would be to impose a containment fraction on the kernel itself (directly in the reco space).