### PR TITLE
Enable reading psf and edisp for MapDatasetOnOff

### DIFF
--- a/gammapy/irf/psf/psf_map.py
+++ b/gammapy/irf/psf/psf_map.py
@@ -61,6 +61,7 @@ class PSFMap(IRFMap):
         geom=exposure_geom.upsample(factor=10).drop("rad")
         psf_kernel = psf_map.get_psf_kernel(geom=geom)
     """
+
     tag = "psf_map"
     required_axes = ["rad", "energy_true"]
 
@@ -108,7 +109,7 @@ class PSFMap(IRFMap):
         return IRFLikePSF(
             axes=[geom.axes["energy_true"], geom.axes["rad"], axis_lat, axis_lon],
             data=self.psf_map.data,
-            unit=self.psf_map.unit
+            unit=self.psf_map.unit,
         )
 
     def _get_irf_coords(self, **kwargs):
@@ -150,11 +151,7 @@ class PSFMap(IRFMap):
         if position is None:
             position = self.psf_map.geom.center_skydir
 
-        coords = {
-            "skycoord": position,
-            "rad": rad,
-            "energy_true": energy_true
-        }
+        coords = {"skycoord": position, "rad": rad, "energy_true": energy_true}
 
         return self.psf_map.integral(axis_name="rad", coords=coords).to("")
 
@@ -178,9 +175,7 @@ class PSFMap(IRFMap):
         if position is None:
             position = self.psf_map.geom.center_skydir
 
-        coords = self._get_irf_coords(
-            energy_true=energy_true, skycoord=position
-        )
+        coords = self._get_irf_coords(energy_true=energy_true, skycoord=position)
 
         return self._psf_irf.containment_radius(fraction, **coords)
 
@@ -204,15 +199,11 @@ class PSFMap(IRFMap):
         data = self.containment_radius(
             fraction=fraction,
             energy_true=energy_true,
-            position=geom.get_coord().skycoord
+            position=geom.get_coord().skycoord,
         )
-        return Map.from_geom(
-            geom=geom,
-            data=data.value,
-            unit=data.unit
-        )
+        return Map.from_geom(geom=geom, data=data.value, unit=data.unit)
 
-    def get_psf_kernel(self,  geom, position=None, max_radius=None, factor=4):
+    def get_psf_kernel(self, geom, position=None, max_radius=None, factor=4):
         """Returns a PSF kernel at the given position.
 
         The PSF is returned in the form a WcsNDMap defined by the input Geom.
@@ -255,9 +246,7 @@ class PSFMap(IRFMap):
         energy = energy_axis.center[:, np.newaxis, np.newaxis]
         coords = {"energy_true": energy, "rad": rad, "skycoord": position}
 
-        data = self.psf_map.interp_by_coord(
-            coords=coords, method="linear",
-        )
+        data = self.psf_map.interp_by_coord(coords=coords, method="linear",)
 
         kernel_map = Map.from_geom(geom=geom_upsampled, data=np.clip(data, 0, np.inf))
         kernel_map = kernel_map.downsample(factor, preserve_counts=True)
@@ -340,11 +329,7 @@ class PSFMap(IRFMap):
             rad_axis = RAD_AXIS_DEFAULT.copy()
 
         if geom is None:
-            geom = WcsGeom.create(
-                npix=(2, 1),
-                proj="CAR",
-                binsz=180,
-            )
+            geom = WcsGeom.create(npix=(2, 1), proj="CAR", binsz=180,)
 
         geom = geom.to_image().to_cube([rad_axis, energy_axis_true])
 
@@ -355,7 +340,9 @@ class PSFMap(IRFMap):
         data = gauss(coords["rad"])
 
         psf_map = Map.from_geom(geom=geom, data=data.to_value("sr-1"), unit="sr-1")
-        return cls(psf_map=psf_map)
+        geom_exposure = geom.squash(axis_name="rad")
+        exposure_psf = Map.from_geom(geom_exposure, unit="m2 s")
+        return cls(psf_map=psf_map, exposure_map=exposure_psf)
 
     def to_image(self, spectrum=None, keepdims=True):
         """Reduce to a 2-D map after weighing
@@ -393,7 +380,7 @@ class PSFMap(IRFMap):
         return self.__class__(psf_map=psf, exposure_map=exposure)
 
     def plot_containment_radius_vs_energy(
-            self, ax=None, fraction=[0.68, 0.95], **kwargs
+        self, ax=None, fraction=[0.68, 0.95], **kwargs
     ):
         """Plot containment fraction as a function of energy.
 
@@ -426,9 +413,7 @@ class PSFMap(IRFMap):
             radius = self.containment_radius(
                 energy_true=energy_true, position=position, fraction=frac
             )
-            plot_kwargs.setdefault(
-                "label", f"Containment: {100 * frac:.1f}%"
-            )
+            plot_kwargs.setdefault("label", f"Containment: {100 * frac:.1f}%")
             ax.plot(energy_true, radius, **plot_kwargs)
 
         ax.semilogx()
@@ -437,7 +422,7 @@ class PSFMap(IRFMap):
         ax.set_ylabel(f"Containment radius ({radius.unit})")
         return ax
 
-    def plot_psf_vs_rad(self, ax=None, energy_true=[0.1, 1, 10] * u.TeV,  **kwargs):
+    def plot_psf_vs_rad(self, ax=None, energy_true=[0.1, 1, 10] * u.TeV, **kwargs):
         """Plot PSF vs radius.
 
         The method plots the profile at the center of the map.
@@ -468,7 +453,7 @@ class PSFMap(IRFMap):
                 {
                     "skycoord": self.psf_map.geom.center_skydir,
                     "energy_true": value,
-                    "rad": rad
+                    "rad": rad,
                 }
             )
             label = f"{value:.0f}"

--- a/gammapy/irf/psf/tests/test_psf_map.py
+++ b/gammapy/irf/psf/tests/test_psf_map.py
@@ -41,7 +41,7 @@ def fake_psf3d(sigma=0.15 * u.deg, shape="gauss"):
     return PSF3D(
         axes=[energy_axis_true, offset_axis, rad_axis],
         data=psf_value.T.value,
-        unit=psf_value.unit
+        unit=psf_value.unit,
     )
 
 
@@ -50,13 +50,11 @@ def fake_aeff2d(area=1e6 * u.m ** 2):
         "0.1 TeV", "10 TeV", nbin=4, name="energy_true"
     )
 
-    offset_axis = MapAxis.from_edges(
-        [0.0, 1.0, 2.0, 3.0] * u.deg, name="offset"
-    )
+    offset_axis = MapAxis.from_edges([0.0, 1.0, 2.0, 3.0] * u.deg, name="offset")
 
     return EffectiveAreaTable2D(
         axes=[energy_axis_true, offset_axis], data=area.value, unit=area.unit
-     )
+    )
 
 
 def test_make_psf_map():
@@ -114,27 +112,21 @@ def test_psf_map_containment_radius():
         psf_map.containment_radius(
             energy_true=1 * u.TeV, position=position, fraction=0.9
         ),
-        psf.containment_radius(
-            energy_true=1 * u.TeV, offset=0 * u.deg, fraction=0.9
-        ),
+        psf.containment_radius(energy_true=1 * u.TeV, offset=0 * u.deg, fraction=0.9),
         rtol=1e-2,
     )
     assert_allclose(
         psf_map.containment_radius(
             energy_true=1 * u.TeV, position=position, fraction=0.5
         ),
-        psf.containment_radius(
-            energy_true=1 * u.TeV, offset=0 * u.deg, fraction=0.5
-        ),
+        psf.containment_radius(energy_true=1 * u.TeV, offset=0 * u.deg, fraction=0.5),
         rtol=1e-2,
     )
 
 
 def test_psf_map_containment():
     psf_map = make_test_psfmap(0.15 * u.deg)
-    assert_allclose(
-        psf_map.containment(rad=10 * u.deg, energy_true=[10] * u.TeV), 1
-    )
+    assert_allclose(psf_map.containment(rad=10 * u.deg, energy_true=[10] * u.TeV), 1)
 
 
 def test_psfmap_to_psf_kernel():
@@ -356,10 +348,7 @@ def test_make_mean_psf(data_store):
     psf = observations[0].psf
 
     geom = WcsGeom.create(
-        skydir=position,
-        npix=(3, 3),
-        axes=psf.axes[["rad", "energy_true"]],
-        binsz=0.2,
+        skydir=position, npix=(3, 3), axes=psf.axes[["rad", "energy_true"]], binsz=0.2,
     )
 
     psf_map_1 = make_psf_map_obs(geom, observations[0])
@@ -381,9 +370,7 @@ def test_psf_map_read(position):
     filename = "$GAMMAPY_DATA/fermi_3fhl/fermi_3fhl_psf_gc.fits.gz"
     psf = PSFMap.read(filename, format="gtpsf")
 
-    value = psf.containment(
-        position=position, energy_true=100 * u.GeV, rad=0.1 * u.deg
-    )
+    value = psf.containment(position=position, energy_true=100 * u.GeV, rad=0.1 * u.deg)
 
     assert_allclose(value, 0.682022, rtol=1e-5)
     assert psf.psf_map.unit == "sr-1"
@@ -404,9 +391,7 @@ def test_psf_map_write_gtpsf(tmpdir):
 
     psf = PSFMap.read(filename, format="gtpsf")
 
-    value = psf.containment_radius(
-        energy_true=energy_axis_true.center, fraction=0.394
-    )
+    value = psf.containment_radius(energy_true=energy_axis_true.center, fraction=0.394)
 
     assert_allclose(value, [0.1, 0.2, 0.3] * u.deg, rtol=1e-5)
     assert psf.psf_map.unit == "sr-1"
@@ -436,12 +421,12 @@ def test_psf_map_from_gauss():
 
     assert psfmap.psf_map.geom.axes[0] == rad_axis
     assert psfmap.psf_map.geom.axes[1] == energy_axis
+    assert psfmap.exposure_map.geom.axes["rad"].nbin == 1
+    assert psfmap.exposure_map.geom.axes["energy_true"] == psfmap.psf_map.geom.axes[1]
     assert psfmap.psf_map.unit == "sr-1"
     assert psfmap.psf_map.data.shape == (3, 100, 1, 2)
 
-    radius = psfmap.containment_radius(
-        fraction=0.394, energy_true=[1, 3, 10] * u.TeV
-    )
+    radius = psfmap.containment_radius(fraction=0.394, energy_true=[1, 3, 10] * u.TeV)
     assert_allclose(radius, sigma, rtol=0.01)
 
     # test that it won't work with different number of sigmas and energies
@@ -463,9 +448,7 @@ def test_psf_map_from_gauss_const_sigma():
     assert psfmap.psf_map.unit == Unit("sr-1")
     assert psfmap.psf_map.data.shape == (3, 100, 1, 2)
 
-    radius = psfmap.containment_radius(
-        energy_true=[1, 3, 10] * u.TeV, fraction=0.394
-    )
+    radius = psfmap.containment_radius(energy_true=[1, 3, 10] * u.TeV, fraction=0.394)
     assert_allclose(radius, 0.1 * u.deg, rtol=0.01)
 
 
@@ -487,4 +470,3 @@ def test_psf_map_plot_psf_vs_rad():
 
     with mpl_plot_check():
         psf.plot_psf_vs_rad()
-


### PR DESCRIPTION
PSF and EDISP maps were dropped during `MapDataset.read()` This PR fixes that.
While adapting the tests, I saw that `PSFMap.from_gauss()` does not create a default exposure map, which breaks stacking. Now, a default exposure map is created as in `EDispKernelMap.from_diagonal_response()`