### PR TITLE
Correct correlate_off option in ExcessMapEstimator

### DIFF
--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -246,15 +246,15 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
     result_mod = estimator_mod.run(simple_dataset_on_off)
     assert result_mod["counts"].data.shape == (1, 20, 20)
 
-    assert_allclose(result_mod["sqrt_ts"].data[0, 10, 10], 6.240846, atol=1e-3)
+    assert_allclose(result_mod["sqrt_ts"].data[0, 10, 10], 8.899278, atol=1e-3)
 
     assert_allclose(result_mod["counts"].data[0, 10, 10], 388)
-    assert_allclose(result_mod["excess"].data[0, 10, 10], 148.68057)
-    assert_allclose(result_mod["background"].data[0, 10, 10], 239.31943)
+    assert_allclose(result_mod["excess"].data[0, 10, 10], 190.68057)
+    assert_allclose(result_mod["background"].data[0, 10, 10], 197.31943)
 
     assert result_mod["flux"].unit == "cm-2s-1"
-    assert_allclose(result_mod["flux"].data[0, 10, 10], 1.486806e-08, rtol=1e-3)
-    assert_allclose(result_mod["flux"].data.sum(), 5.254442192077636e-06, rtol=1e-8)
+    assert_allclose(result_mod["flux"].data[0, 10, 10], 1.906806e-08, rtol=1e-3)
+    assert_allclose(result_mod["flux"].data.sum(), 5.920642e-06 , rtol=1e-3)
 
     spectral_model=PowerLawSpectralModel(index=15)
     estimator_mod = ExcessMapEstimator(
@@ -266,7 +266,7 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
     result_mod = estimator_mod.run(simple_dataset_on_off)
 
     assert result_mod["flux"].unit == "cm-2s-1"
-    assert_allclose(result_mod["flux"].data.sum(), 5.254442192077636e-06, rtol=1e-8)
+    assert_allclose(result_mod["flux"].data.sum(),5.920642e-06, rtol=1e-3)
 
     reco_exposure=estimate_exposure_reco_energy(simple_dataset_on_off, spectral_model=spectral_model)
     assert_allclose(reco_exposure.data.sum(), 7.977796e+12, rtol=0.001)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects a bug in the correlated OFF calculation of the `ExcessMapEstimator`

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
