### PR TITLE
Add plot_mask to HpxNDMap

### DIFF
--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -962,7 +962,6 @@ class HpxNDMap(HpxMap):
     def plot_mask(self,
             method="raster",
             ax=None,
-            normalize=False,
             proj="AIT",
             oversample=2,
             width_pix=1000,
@@ -998,29 +997,18 @@ class HpxNDMap(HpxMap):
         ax : `~astropy.visualization.wcsaxes.WCSAxes`
             WCS axis object
         """
-        if not self.geom.is_flat:
-            raise TypeError("Use .plot_interactive() for Map dimension > 2")
-
         if not self.is_mask:
             raise ValueError("`.plot_mask()` only supports maps containing boolean values.")
 
         if method == "raster":
             m = self.to_wcs(
                 sum_bands=True,
-                normalize=normalize,
+                normalize=False,
                 proj=proj,
                 oversample=oversample,
                 width_pix=width_pix,
             )
-
             m.data = np.nan_to_num(m.data).astype(bool)
-
-            kwargs.setdefault("alpha", 0.1)
-            kwargs.setdefault("colors", "r")
-
-            m.plot_mask(**kwargs)
-
+            return m.plot_mask(ax=ax, **kwargs)
         else:
             raise ValueError(f"Invalid method: {method!r}")
-
-        return ax

--- a/gammapy/maps/tests/test_hpxnd.py
+++ b/gammapy/maps/tests/test_hpxnd.py
@@ -589,23 +589,22 @@ def test_hpxmap_read_healpy(tmp_path):
     diff = np.sum(m[1] - m2.data)
     assert_allclose(diff, 0.0)
 
+
 @requires_dependency("matplotlib")
 def test_map_plot_mask():
     from regions import CircleSkyRegion
-    import random
+    from gammapy.maps import HpxGeom
+    from astropy.coordinates import SkyCoord
+    from astropy import units as u
 
     geom = HpxGeom.create(nside=16)
-    map_hp = HpxNDMap.from_geom(geom)
-    wcs_map = map_hp.to_wcs(proj='AIT')
 
-    val = np.array([random.choices(range(0,np.shape(wcs_map)[0]),
-    k=np.shape(wcs_map)[0]) for _ in range(np.shape(wcs_map)[1])])
+    region = CircleSkyRegion(
+        center=SkyCoord("0d", "0d", frame="galactic"),
+        radius=20 * u.deg
+    )
 
-    wcs_map.data = val
-
-    exclusion_region = CircleSkyRegion(center=SkyCoord(0.0, 0.0, unit="deg", frame="galactic"), radius=0.6 * u.deg)
-
-    mask = ~wcs_map.geom.region_mask([exclusion_region])
+    mask = geom.region_mask([region])
 
     with mpl_plot_check():
         mask.plot_mask()

--- a/gammapy/maps/tests/test_hpxnd.py
+++ b/gammapy/maps/tests/test_hpxnd.py
@@ -592,11 +592,6 @@ def test_hpxmap_read_healpy(tmp_path):
 
 @requires_dependency("matplotlib")
 def test_map_plot_mask():
-    from regions import CircleSkyRegion
-    from gammapy.maps import HpxGeom
-    from astropy.coordinates import SkyCoord
-    from astropy import units as u
-
     geom = HpxGeom.create(nside=16)
 
     region = CircleSkyRegion(

--- a/gammapy/maps/tests/test_hpxnd.py
+++ b/gammapy/maps/tests/test_hpxnd.py
@@ -588,3 +588,24 @@ def test_hpxmap_read_healpy(tmp_path):
     assert m2.data.shape[0] == npix
     diff = np.sum(m[1] - m2.data)
     assert_allclose(diff, 0.0)
+
+@requires_dependency("matplotlib")
+def test_map_plot_mask():
+    from regions import CircleSkyRegion
+    import random
+
+    geom = HpxGeom.create(nside=16)
+    map_hp = HpxNDMap.from_geom(geom)
+    wcs_map = map_hp.to_wcs(proj='AIT')
+
+    val = np.array([random.choices(range(0,np.shape(wcs_map)[0]),
+    k=np.shape(wcs_map)[0]) for _ in range(np.shape(wcs_map)[1])])
+
+    wcs_map.data = val
+
+    exclusion_region = CircleSkyRegion(center=SkyCoord(0.0, 0.0, unit="deg", frame="galactic"), radius=0.6 * u.deg)
+
+    mask = ~wcs_map.geom.region_mask([exclusion_region])
+
+    with mpl_plot_check():
+        mask.plot_mask()


### PR DESCRIPTION
This PR adds a new functionality, `plot_mask`, in `~gammapy.HpxNDMap` as an extension of fixing the issue #3271. It allows to plot a mask as shaded areas above a given healpy map.