### PR TITLE
Expand $GAMMAPY_DATA defined in HLI config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__
 htmlcov
 .coverage*
 .coverage.subprocess
+.hypothesis
 
 # Sphinx
 _build

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -9,7 +9,7 @@ from astropy.coordinates import Angle
 from astropy.time import Time
 from astropy.units import Quantity
 import yaml
-from pydantic import BaseModel, FilePath
+from pydantic import BaseModel
 from pydantic.utils import deep_update
 from gammapy.makers import MapDatasetMaker
 from gammapy.utils.scripts import make_path, read_yaml

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -153,7 +153,7 @@ class ExcessMapConfig(GammapyBaseConfig):
 
 class BackgroundConfig(GammapyBaseConfig):
     method: BackgroundMethodEnum = None
-    exclusion: FilePath = None
+    exclusion: Path = None
     parameters: dict = {}
 
 
@@ -203,7 +203,7 @@ class DatasetsConfig(GammapyBaseConfig):
 class ObservationsConfig(GammapyBaseConfig):
     datastore: Path = Path("$GAMMAPY_DATA/hess-dl3-dr1/")
     obs_ids: List[int] = []
-    obs_file: FilePath = None
+    obs_file: Path = None
     obs_cone: SpatialCircleConfig = SpatialCircleConfig()
     obs_time: TimeRangeConfig = TimeRangeConfig()
 

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -309,7 +309,8 @@ class Analysis:
 
         bkg_maker_config = {}
         if datasets_settings.background.exclusion:
-            exclusion_region = Map.read(datasets_settings.background.exclusion)
+            path = make_path(datasets_settings.background.exclusion)
+            exclusion_region = Map.read(path)
             bkg_maker_config["exclusion_mask"] = exclusion_region
         bkg_maker_config.update(datasets_settings.background.parameters)
 
@@ -383,7 +384,8 @@ class Analysis:
 
         bkg_maker_config = {}
         if datasets_settings.background.exclusion:
-            exclusion_region = Map.read(datasets_settings.background.exclusion)
+            path = make_path(datasets_settings.background.exclusion)
+            exclusion_region = Map.read(path)
             bkg_maker_config["exclusion_mask"] = exclusion_region
         bkg_maker_config.update(datasets_settings.background.parameters)
         bkg_method = datasets_settings.background.method


### PR DESCRIPTION
This PR expands env variables (i.e. `$GAMMAPY_DATA`) in config fields `BackgroundConfig.exclusion` and `ObservationsConfig.obs_file` of the high-level interface. At this moment, it is no possible to use `$GAMMAPY_DATA` when declaring path values in these fields. 

If the path declared does not exist, it will not be Pydantic but Gammapy functions who will raise the exception, as it is already the case for `ObservationsConfig.datastore` 