### PR TITLE
Compile extensions against oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
 	"setuptools >= 40.6.0",
 	"wheel",
 	"Cython",
-	'numpy >= 1.16',
+	'oldest-supported-numpy',
 	'setuptools_scm[toml]'
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
As discussed in the #dev channel in slack, to support older releases of numpy, compilation of the c-extensions must happen against the oldest still supported version of numpy.

See https://pypi.org/project/oldest-supported-numpy/


