### PR TITLE
Fix FoVBackgroundMaker error 

### DIFF
--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -170,14 +170,13 @@ class FoVBackgroundMaker(Maker):
         """
         # freeze all model components not related to background model
 
-        models = dataset.models
+        models = dataset.models.select(tag="sky-model")
 
         with models.restore_status(restore_values=False):
             models.select(tag="sky-model").freeze()
 
             fit = Fit([dataset])
             fit_result = fit.run()
-            #print("fit res \n", fit_result.parameters.to_table())
             if not fit_result.success:
                 log.warning(
                     f"FoVBackgroundMaker failed. Fit did not converge for {dataset.name}. "
@@ -185,7 +184,6 @@ class FoVBackgroundMaker(Maker):
                 )
                 dataset.mask_safe.data[...] = False
 
-        #print("fit res outside \n", fit_result.parameters.to_table())
         return dataset
 
     def make_background_scale(self, dataset):

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -177,6 +177,7 @@ class FoVBackgroundMaker(Maker):
 
             fit = Fit([dataset])
             fit_result = fit.run()
+            #print("fit res \n", fit_result.parameters.to_table())
             if not fit_result.success:
                 log.warning(
                     f"FoVBackgroundMaker failed. Fit did not converge for {dataset.name}. "
@@ -184,6 +185,7 @@ class FoVBackgroundMaker(Maker):
                 )
                 dataset.mask_safe.data[...] = False
 
+        #print("fit res outside \n", fit_result.parameters.to_table())
         return dataset
 
     def make_background_scale(self, dataset):

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -72,19 +72,6 @@ def test_fov_bkg_maker_incorrect_method():
 
 
 @requires_data()
-@requires_dependency("iminuit")
-def test_fov_bkg_maker_fit(obs_dataset, exclusion_mask):
-    fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
-
-    test_dataset = obs_dataset.copy(name="test-fov")
-    dataset = fov_bkg_maker.run(test_dataset)
-
-    model = dataset.models[f"{dataset.name}-bkg"].spectral_model
-    assert_allclose(model.norm.value, 0.830789, rtol=1e-4)
-    assert_allclose(model.tilt.value, 0.0, rtol=1e-4)
-
-
-@requires_data()
 def test_fov_bkg_maker_scale(obs_dataset, exclusion_mask, caplog):
     fov_bkg_maker = FoVBackgroundMaker(method="scale", exclusion_mask=exclusion_mask)
     test_dataset = obs_dataset.copy(name="test-fov")
@@ -119,18 +106,33 @@ def test_fov_bkg_maker_scale_nocounts(obs_dataset, exclusion_mask, caplog):
 @requires_data()
 @requires_dependency("iminuit")
 def test_fov_bkg_maker_fit(obs_dataset, exclusion_mask):
+    fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
+
+    dataset1 = obs_dataset.copy(name="test-fov")
+    dataset = fov_bkg_maker.run(dataset1)
+
+    model = dataset.models[f"{dataset.name}-bkg"].spectral_model
+    assert_allclose(model.norm.value, 0.83077, rtol=1e-4)
+    assert_allclose(model.norm.error, 0.02069, rtol=1e-2)
+    assert_allclose(model.tilt.value, 0.0, rtol=1e-4)
+    assert_allclose(model.tilt.error, 0.0, rtol=1e-2)
+    assert_allclose(fov_bkg_maker.default_spectral_model.tilt.value, 0.0)
+    assert_allclose(fov_bkg_maker.default_spectral_model.norm.value, 1.0)
+
     spectral_model = PowerLawNormSpectralModel()
     spectral_model.tilt.frozen = False
     fov_bkg_maker = FoVBackgroundMaker(
         method="fit", exclusion_mask=exclusion_mask, spectral_model=spectral_model
     )
 
-    test_dataset = obs_dataset.copy(name="test-fov")
-    dataset = fov_bkg_maker.run(test_dataset)
+    dataset2 = obs_dataset.copy(name="test-fov")
+    dataset = fov_bkg_maker.run(dataset2)
 
     model = dataset.models[f"{dataset.name}-bkg"].spectral_model
     assert_allclose(model.norm.value, 0.901523, rtol=1e-4)
+    assert_allclose(model.norm.error, 0.6088, rtol=1e-2)
     assert_allclose(model.tilt.value, 0.071069, rtol=1e-4)
+    assert_allclose(model.tilt.error, 0.5866, rtol=1e-2)
     assert_allclose(fov_bkg_maker.default_spectral_model.tilt.value, 0.0)
     assert_allclose(fov_bkg_maker.default_spectral_model.norm.value, 1.0)
 


### PR DESCRIPTION
This PR fixes #3375
The covariance is re-written in `Models.restore_status()`, so, the error information would be lost.
Now, restore_status() is applied only on the sky models, so the error on the background model is retained.

`test_fov_bkg_maker_fit` was defined twice, so the first one was not executed. Cleaned up.