### PR TITLE
Fix DEADC definition in datasets.simulate

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -238,7 +238,7 @@ class MapDatasetEventSampler:
         )
         meta["ONTIME"] = observation.observation_time_duration.to("s").value
         meta["LIVETIME"] = observation.observation_live_time_duration.to("s").value
-        meta["DEADC"] = observation.observation_dead_time_fraction
+        meta["DEADC"] = 1 - observation.observation_dead_time_fraction
 
         meta["RA_PNT"] = observation.pointing_radec.icrs.ra.deg
         meta["DEC_PNT"] = observation.pointing_radec.icrs.dec.deg

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -250,7 +250,7 @@ def test_mde_run(dataset, models):
     assert_allclose(meta["TSTOP"], 3600.0)
     assert_allclose(meta["ONTIME"], 3600.0)
     assert_allclose(meta["LIVETIME"], 3600.0)
-    assert_allclose(meta["DEADC"], 0.0)
+    assert_allclose(meta["DEADC"], 1.0)
     assert_allclose(meta["RA_PNT"], 266.4049882865447)
     assert_allclose(meta["DEC_PNT"], -28.936177761791473)
     assert meta["EQUINOX"] == "J2000"


### PR DESCRIPTION
As discussed in the help channel on slack, the definition of DEADC in gammapy.datasets.simulate is inconsistent with the one in Observation and EventList, this PR solves it.