### PR TITLE
Change  default correlate_off to True for ExcessMapEstimator

### DIFF
--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -67,10 +67,6 @@ class ExcessMapEstimator(Estimator):
     If a model is set on the dataset the excess map estimator will compute the excess taking into account
     the predicted counts of the model.
 
-    Some background estimation techniques like ring background or adaptive ring background will provide already
-    correlated data for OFF. In the case of already correlated OFF data, the OFF data should not be correlated again,
-    and so the option correlate_off should set to False (default).
-
     Parameters
     ----------
     correlation_radius : ~astropy.coordinate.Angle
@@ -96,7 +92,7 @@ class ExcessMapEstimator(Estimator):
         Apply a mask for the computation.
         A `~gammapy.datasets.MapDataset.mask_fit` must be present on the input dataset
     correlate_off : Bool
-        Correlate OFF events in the case of a MapDatasetOnOff
+        Correlate OFF events in the case of a MapDatasetOnOff. Default is True.
     spectral_model : `~gammapy.modeling.models.SpectralModel`
         Spectral model used for the computation of the flux map. 
         If None, a Power Law of index 2 is assumed (default). 
@@ -113,7 +109,7 @@ class ExcessMapEstimator(Estimator):
         selection_optional=None,
         energy_edges=None,
         apply_mask_fit=False,
-        correlate_off=False,
+        correlate_off=True,
         spectral_model=None,
     ):
         self.correlation_radius = correlation_radius

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -62,10 +62,19 @@ def convolved_map_dataset_counts_statistics(dataset, kernel, mask, correlate_off
 
 
 class ExcessMapEstimator(Estimator):
-    """Computes correlated excess, sqrt TS (i.e. Li-Ma significance) and errors for MapDatasets.
+    """Computes correlated excess, significance and error maps from a map dataset.
 
-    If a model is set on the dataset the excess map estimator will compute the excess taking into account
-    the predicted counts of the model.
+    If a model is set on the dataset the excess map estimator will compute the
+    excess taking into account the predicted counts of the model.
+
+    ..note::
+        By default the excess estimator correlates the off counts as well to avoid
+        artifacts at the edges of the :term:`FoV` for stacked on-off datasets.
+        However when the on-off dataset has been derived from a ring background
+        estimate, this leads to the off counts being correlated twice. To avoid
+        artifacts and the double correlation, the `ExcessMapEstimator` has to
+        be applied per dataset and the resulting maps need to be stacked, taking
+        the :term:`FoV` cut into account.
 
     Parameters
     ----------
@@ -88,11 +97,11 @@ class ExcessMapEstimator(Estimator):
         Default is None so the optionnal steps are not executed.
     energy_edges : `~astropy.units.Quantity`
         Energy edges of the target excess maps bins.
-    apply_mask_fit : Bool
+    apply_mask_fit : bool
         Apply a mask for the computation.
         A `~gammapy.datasets.MapDataset.mask_fit` must be present on the input dataset
-    correlate_off : Bool
-        Correlate OFF events in the case of a MapDatasetOnOff. Default is True.
+    correlate_off : bool
+        Correlate OFF events in the case of a `MapDatasetOnOff`. Default is True.
     spectral_model : `~gammapy.modeling.models.SpectralModel`
         Spectral model used for the computation of the flux map. 
         If None, a Power Law of index 2 is assumed (default). 

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -89,7 +89,7 @@ def test_compute_lima_on_off_image():
 
     significance = Map.read(filename, hdu="SIGNIFICANCE")
     significance = image_to_cube(significance, "1 TeV", "10 TeV")
-    estimator = ExcessMapEstimator("0.1 deg")
+    estimator = ExcessMapEstimator("0.1 deg", correlate_off=False)
     results = estimator.run(dataset)
 
     # Reproduce safe significance threshold from HESS software


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request reverts the change to have by default `correlate_off=False` for `ExcessMApEstimator`. As noted by @AtreyeeS , this leads to poor results when using stacked datasets.
The main situation where this makes sense is when the `ExcessMapEstimator` is applied on  non stacked datasets. We can therefore leave it as an option but change its default.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
