### PR TITLE
Improve documentation in gammapy.data and gammapy.irf

### DIFF
--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -146,9 +146,9 @@ their associated GTIs together in the same FITS file.
     # Save together
     from astropy.io import fits
     primary_hdu = fits.PrimaryHDU(np.ones((4,4)))
-    EVENTS = fits.BinTableHDU(data=events.table, name='events')
-    GTI_table = fits.BinTableHDU(gti.table,name='gti')
-    hdul = fits.HDUList([primary_hdu, EVENTS, GTI_table])
+    events_hdu = fits.BinTableHDU(data=events.table, name='events')
+    gti_hdu = fits.BinTableHDU(gti.table,name='gti')
+    hdul = fits.HDUList([primary_hdu, events_hdu, gti_hdu])
     hdul.writeto('test_together.fits.gz')
 
 

--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -56,6 +56,102 @@ to load IACT data. E.g. an alternative way to load the events for observation ID
     data_store = DataStore.from_dir('$GAMMAPY_DATA/hess-dl3-dr1')
     events = data_store.obs(23523).events
 
+Working with event lists
+========================
+To take a quick look at the events inside the list, one can use `~gammapy.data.EventList.peek()`
+
+.. plot::
+    :include-source:
+
+    from gammapy.data import EventList
+    filename = '$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
+    events = EventList.read(filename)
+    events.peek()
+
+Events can be selected based on any of their properties, with dedicated functions existing
+for energy, time, offset from pointing position and the selection of events in a particular region
+of the sky.
+
+.. testcode::
+
+    import astropy.units as u
+    from gammapy.data import EventList
+    filename = '$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
+    events = EventList.read(filename)
+
+    # Select events based on energy
+    selected_energy = events.select_energy([1*u.TeV, 1.2*u.TeV])
+
+    # Select events based on time
+    t_start = Time(57185, format='mjd')
+    t_stop = Time(57185.5, format='mjd')
+
+    selected_time = events.select_time([t_start, t_stop])
+
+    # Select events based on offset
+    selected_offset = events.select_offset([1*u.deg, 2*u.deg])
+
+    # Select events from a region in the sky
+    selected_region =  events.select_region("icrs;circle(86.3,22.01,3)")
+
+    # Finally one can select events based on any other of the columns of the `EventList.table`
+    selected_id = events.select_parameter('EVENT_ID', (5407363826067,5407363826070))
+
+
+Combining event lists and GTIs
+==============================
+Both event lists and GTIs can be stacked into a larger one. An `~gammapy.data.EventList` can also be created `~gammapy.data..EventList.from_stack`, that is,
+from a list of `~gammapy.data.EventList` objects.
+
+.. testcode::
+
+    from gammapy.data import EventList, GTI
+
+    filename_1 = '$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
+    filename_2 = '$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023526.fits.gz'
+
+    events_1 = EventList.read(filename_1)
+    events_2 = EventList.read(filename_2)
+
+    gti_1 = GTI.read(filename_1)
+    gti_2 = GTI.read(filename_2)
+
+    # stack in place, now the _1 object contains the information of both
+    gti_1.stack(gti_2)
+    events_1.stack(events_2)
+
+    # or instead create a new event list from the other two
+    combined_events = EventList.from_stack([events_1, events_2])
+
+Writing event lists and GTIs to file
+====================================
+To write the events or GTIs separately, one can just save the underlying
+`astropy.table.Table`. However, it is usually best to save the events and
+their associated GTIs together in the same FITS file.
+
+.. testcode::
+
+    from gammapy.data import EventList, GTI
+
+    filename = '$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
+
+    events = EventList.read(filename)
+    gti = GTI.read(filename)
+
+    # Save separately
+    events.table.write('test_events.fits.gz',hdu="EVENTS")
+    gti.write('test_gti.fits.gz')
+
+    # Save together
+    from astropy.io import fits
+    primary_hdu = fits.PrimaryHDU(np.ones((4,4)))
+    EVENTS = fits.BinTableHDU(data=events.table, name='events')
+    GTI_table = fits.BinTableHDU(gti.table,name='gti')
+    hdul = fits.HDUList([primary_hdu, EVENTS, GTI_table])
+    hdul.writeto('test_together.fits.gz')
+
+
+
 Using `gammapy.data`
 ====================
 

--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -100,7 +100,7 @@ of the sky.
 
 Combining event lists and GTIs
 ==============================
-Both event lists and GTIs can be stacked into a larger one. An `~gammapy.data.EventList` can also be created `~gammapy.data..EventList.from_stack`, that is,
+Both event lists and GTIs can be stacked into a larger one. An `~gammapy.data.EventList` can also be created `~gammapy.data.EventList.from_stack`, that is,
 from a list of `~gammapy.data.EventList` objects.
 
 .. testcode::

--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -75,6 +75,7 @@ of the sky.
 .. testcode::
 
     import astropy.units as u
+    from astropy.time import Time
     from gammapy.data import EventList
     filename = '$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
     events = EventList.read(filename)

--- a/docs/irf/edisp.rst
+++ b/docs/irf/edisp.rst
@@ -38,3 +38,36 @@ Such an energy dispersion can be obtained for example:
 
 .. plot:: irf/plot_edisp_kernel_param.py
     :include-source:
+
+Storing the energy dispersion information as a function of sky position
+-----------------------------------------------------------------------
+The `gammapy.irf.EDispKernelMap` is a four-dimensional `~gammapy.maps.Map` that stores, for each position in the sky,
+an `~gammapy.irf.EDispKernel`, which, as described above, depends on true energy.
+
+The `~gammapy.irf.EDispKernel` at a given position can be extracted with `~gammapy.irf.EDispKernelMap.get_edisp_kernel()` by
+providing a `~astropy.coordinates.SkyCoord` or `~regions.SkyRegion`.
+
+.. plot::
+    :include-source:
+
+    from gammapy.irf import EDispKernelMap
+    from gammapy.maps import MapAxis
+    from astropy.coordinates import SkyCoord
+
+    # Create a test EDispKernelMap from a gaussian distribution
+    energy_axis_true = MapAxis.from_energy_bounds(1,10, 8, unit="TeV", name="energy_true")
+    energy_axis = MapAxis.from_energy_bounds(1,10, 5, unit="TeV", name="energy")
+
+    edisp_map = EDispKernelMap.from_gauss(energy_axis, energy_axis_true, 0.3, 0)
+    position = SkyCoord(ra=83, dec=22, unit='deg', frame='icrs')
+
+    edisp_kernel = edisp_map.get_edisp_kernel(position)
+
+    # We can quickly check the edisp kernel via the peek() method
+    edisp_kernel.peek()
+
+The `gammapy.irf.EDispMap` serves a similar purpose but instead of a true energy axis,
+it contains the information of the energy dispersion as a function of the energy migration (:math:`E/ E_{\rm true}`).
+It can be converted into a `gammapy.irf.EDispKernelMap` with `gammapy.irf.EDispMap.to_edisp_kernel_map()` and the
+`gammapy.irf.EDispKernelMap` at a given position can be extracted in the same way as described above, using `~gammapy.irf.EDispMap.get_edisp_kernel()`
+and providing a `~astropy.coordinates.SkyCoord`.

--- a/docs/irf/psf.rst
+++ b/docs/irf/psf.rst
@@ -26,4 +26,4 @@ The remaining IRF classes implement:
 - `~gammapy.irf.EnergyDependentMultiGaussPSF` a PSF whose probability density is parametrised by the sum of 1 to 3 2-dimensional gaussian (definition at :ref:`gadf:psf_3gauss`);
 - `~gammapy.irf.PSFKing` a PSF whose probability density is parametrised by the King function (definition at :ref:`gadf:psf_king`);
 - `~gammapy.irf.PSFKernel` a PSF that can be used to convolve `~gammapy.maps.WcsNDMap` objects;
-- `~gammapy.irf.PSFMap` a PSF that can be used to convolve `~gammapy.maps.WcsNDMap` objects;
+- `~gammapy.irf.PSFMap` a four-dimensional `~gammapy.maps.Map` storing a `~gammapy.irf.PSFKernel` for each sky position.

--- a/docs/maps/hpxmap.rst
+++ b/docs/maps/hpxmap.rst
@@ -8,6 +8,13 @@ classes. All HEALPix classes inherit from `~gammapy.maps.Map` which provides gen
 interface methods that can be be used to access or update the contents of a map
 without reference to its pixelization scheme.
 
+.. warning::
+
+    Gammapy uses `NEST` as default pixel order scheme, while `healpy`
+    functions have `RING` as the default (see https://healpy.readthedocs.io/en/1.11.0/index.html).
+    If you are interfacing Gammapy HEALPix maps with `healpy` functions, you need to specify the pixelization scheme
+    either while creating the Gammapy object or when using the `healpy` functions.
+
 HEALPix geometry
 ----------------
 

--- a/docs/maps/hpxmap.rst
+++ b/docs/maps/hpxmap.rst
@@ -10,10 +10,10 @@ without reference to its pixelization scheme.
 
 .. warning::
 
-    Gammapy uses `NEST` as default pixel order scheme, while `healpy`
+    Gammapy uses `NEST` as default pixel order scheme, while `~healpy`
     functions have `RING` as the default (see https://healpy.readthedocs.io/en/1.11.0/index.html).
-    If you are interfacing Gammapy HEALPix maps with `healpy` functions, you need to specify the pixelization scheme
-    either while creating the Gammapy object or when using the `healpy` functions.
+    If you are interfacing Gammapy HEALPix maps with `~healpy` functions, you need to specify the pixelization scheme
+    either while creating the Gammapy object or when using the `~healpy` functions.
 
 HEALPix geometry
 ----------------


### PR DESCRIPTION
This pull request expands the documentation in several aspects:

- adds some examples in `gammapy.data` on how to select events from an event list and how to combine and save event lists to file.
- adds a warning in the HEALPix `Map` documentation about the default pixelization scheme used by Gammapy.
- adds information about the `EDispKernelMap` and `EDispMap` classes, which were totally missing before.
- fixes the definition of the `PSFMap` in the psf documentation, which was incorrect before.



