### PR TITLE
Implement padding for TSMapEstimator

### DIFF
--- a/gammapy/estimators/asmooth_map.py
+++ b/gammapy/estimators/asmooth_map.py
@@ -153,10 +153,7 @@ class ASmoothMapEstimator(Estimator):
                 * 'scales'
                 * 'sqrt_ts'.
         """
-        if self.energy_edges is None:
-            energy_axis = dataset.counts.geom.axes["energy"].squash()
-        else:
-            energy_axis = MapAxis.from_energy_edges(self.energy_edges)
+        energy_axis = self._get_energy_axis(dataset)
 
         results = []
 

--- a/gammapy/estimators/asmooth_map.py
+++ b/gammapy/estimators/asmooth_map.py
@@ -1,11 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Implementation of adaptive smoothing algorithms."""
 import numpy as np
-from astropy import units as u
 from astropy.convolution import Gaussian2DKernel, Tophat2DKernel
 from astropy.coordinates import Angle
-from gammapy.datasets import Datasets, MapDatasetOnOff
-from gammapy.maps import Map, WcsNDMap
+from gammapy.datasets import MapDatasetOnOff
+from gammapy.maps import Map, WcsNDMap, MapAxis
 from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.stats import CashCountsStatistic
 from gammapy.utils.array import scale_cube
@@ -143,6 +142,7 @@ class ASmoothMapEstimator(Estimator):
         ----------
         dataset : `~gammapy.datasets.MapDataset` or `~gammapy.datasets.MapDatasetOnOff`
             the input dataset (with one bin in energy at most)
+
         Returns
         -------
         images : dict of `~gammapy.maps.WcsNDMap`
@@ -155,20 +155,22 @@ class ASmoothMapEstimator(Estimator):
         """
         if self.energy_edges is None:
             energy_axis = dataset.counts.geom.axes["energy"]
-            energy_edges = u.Quantity([energy_axis.edges[0], energy_axis.edges[-1]])
         else:
-            energy_edges = self.energy_edges
+            energy_axis = MapAxis.from_energy_edges(self.energy_edges)
 
         results = []
 
         for energy_min, energy_max in progress_bar(
-            zip(energy_edges[:-1], energy_edges[1:]),
+            energy_axis.iter_by_edges,
             desc="Energy bins"
         ):
-            dataset_sliced = dataset.slice_by_energy(energy_min, energy_max, name=dataset.name)
+            dataset_sliced = dataset.slice_by_energy(
+                energy_min=energy_min, energy_max=energy_max, name=dataset.name
+            )
             dataset_sliced.models = dataset.models
             result = self.estimate_maps(dataset_sliced)
             results.append(result)
+
         result_all = {}
 
         for name in results[0].keys():

--- a/gammapy/estimators/asmooth_map.py
+++ b/gammapy/estimators/asmooth_map.py
@@ -154,7 +154,7 @@ class ASmoothMapEstimator(Estimator):
                 * 'sqrt_ts'.
         """
         if self.energy_edges is None:
-            energy_axis = dataset.counts.geom.axes["energy"]
+            energy_axis = dataset.counts.geom.axes["energy"].squash()
         else:
             energy_axis = MapAxis.from_energy_edges(self.energy_edges)
 

--- a/gammapy/estimators/core.py
+++ b/gammapy/estimators/core.py
@@ -121,6 +121,15 @@ class Estimator(abc.ABC):
         with np.errstate(invalid="ignore", divide="ignore"):
             return np.where(norm > 0, np.sqrt(ts), -np.sqrt(ts))
 
+    def _get_energy_axis(self, dataset):
+        """Energy axis"""
+        if self.energy_edges is None:
+            energy_axis = dataset.counts.geom.axes["energy"].squash()
+        else:
+            energy_axis = MapAxis.from_energy_edges(self.energy_edges)
+
+        return energy_axis
+
     def copy(self):
         """Copy estimator"""
         return deepcopy(self)

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -165,13 +165,7 @@ class ExcessMapEstimator(Estimator):
         if not isinstance(dataset, MapDataset):
             raise ValueError("Unsupported dataset type. Excess map is not applicable to 1D datasets.")
 
-        if self.energy_edges is None:
-            energy_axis = dataset.counts.geom.axes["energy"]
-            energy_edges = u.Quantity([energy_axis.edges[0], energy_axis.edges[-1]])
-        else:
-            energy_edges = self.energy_edges
-
-        axis = MapAxis.from_energy_edges(energy_edges)
+        axis = self._get_energy_axis(dataset)
 
         resampled_dataset = dataset.resample_energy_axis(
             energy_axis=axis, name=dataset.name

--- a/gammapy/estimators/flux_map.py
+++ b/gammapy/estimators/flux_map.py
@@ -68,6 +68,13 @@ class FluxMaps(FluxEstimate):
         """Reference map geometry (`Geom`)"""
         return self.data["norm"].geom
 
+    @property
+    def sqrt_ts(self):
+        """Sqrt TS"""
+        with np.errstate(invalid="ignore", divide="ignore"):
+            data = np.where(self.norm > 0, np.sqrt(self.ts), -np.sqrt(self.ts))
+            return Map.from_geom(geom=self.geom, data=data)
+
     def __str__(self):
         str_ = f"{self.__class__.__name__}\n"
         str_ += "-" * len(self.__class__.__name__)

--- a/gammapy/estimators/flux_map.py
+++ b/gammapy/estimators/flux_map.py
@@ -71,9 +71,12 @@ class FluxMaps(FluxEstimate):
     @property
     def sqrt_ts(self):
         """Sqrt TS"""
-        with np.errstate(invalid="ignore", divide="ignore"):
-            data = np.where(self.norm > 0, np.sqrt(self.ts), -np.sqrt(self.ts))
-            return Map.from_geom(geom=self.geom, data=data)
+        if "sqrt_ts" in self.data:
+            return self.data["sqrt_ts"]
+        else:
+            with np.errstate(invalid="ignore", divide="ignore"):
+                data = np.where(self.norm > 0, np.sqrt(self.ts), -np.sqrt(self.ts))
+                return Map.from_geom(geom=self.geom, data=data)
 
     def __str__(self):
         str_ = f"{self.__class__.__name__}\n"

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -242,5 +242,5 @@ def test_ts_map_with_model(fake_dataset):
         energy_edges=[200, 3500] * u.GeV,
     )
     maps = estimator.run(fake_dataset)
-    assert_allclose(maps["sqrt_ts"].data[:, 25, 25], -0.378473, atol=0.1)
-    assert_allclose(maps["flux"].data[:, 25, 25], -6.627532e-12, atol=1e-12)
+    assert_allclose(maps["sqrt_ts"].data[:, 25, 25], 0.323203, atol=0.1)
+    assert_allclose(maps["flux"].data[:, 25, 25], 1.015509e-12, atol=1e-12)

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -211,15 +211,6 @@ def test_compute_ts_map_downsampled(input_dataset):
     assert np.isnan(result["ts"].data[0, 30, 40])
 
 
-@requires_data()
-def test_large_kernel(input_dataset):
-    """Minimal test of compute_ts_image"""
-    ts_estimator = TSMapEstimator(kernel_width="4 deg")
-
-    with pytest.raises(ValueError):
-        ts_estimator.run(input_dataset)
-
-
 def test_ts_map_with_model(fake_dataset):
     model = fake_dataset.models["source"]
 
@@ -251,5 +242,5 @@ def test_ts_map_with_model(fake_dataset):
         energy_edges=[200, 3500] * u.GeV,
     )
     maps = estimator.run(fake_dataset)
-    assert_allclose(maps["sqrt_ts"].data[:, 25, 25], 0.323, atol=0.1)
-    assert_allclose(maps["flux"].data[:, 25, 25], 1.015417e-12, atol=1e-12)
+    assert_allclose(maps["sqrt_ts"].data[:, 25, 25], -0.378473, atol=0.1)
+    assert_allclose(maps["flux"].data[:, 25, 25], -6.627532e-12, atol=1e-12)

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -331,7 +331,7 @@ class TSMapEstimator(Estimator):
         )
 
         exposure_npred = (exposure * flux_ref * mask.data).to_unit("")
-    
+
         norm = (flux / flux_ref).to_unit("")
         return {
             "counts": counts,
@@ -453,7 +453,7 @@ class TSMapEstimator(Estimator):
             )
 
             if self.sum_over_energy_groups:
-                sliced_dataset = sliced_dataset.to_image()
+                sliced_dataset = sliced_dataset.to_image(name=dataset.name)
 
             sliced_dataset.models = dataset_models
             result = self.estimate_flux_map(sliced_dataset)

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -182,15 +182,6 @@ class TSMapEstimator(Estimator):
 
         return selection
 
-    def energy_edges_axis(self, dataset):
-        """Energy axis"""
-        if self.energy_edges is None:
-            energy_axis = dataset.counts.geom.axes["energy"].squash()
-        else:
-            energy_axis = MapAxis.from_energy_edges(self.energy_edges)
-
-        return energy_axis
-
     def estimate_kernel(self, dataset):
         """Get the convolution kernel for the input dataset.
 
@@ -441,7 +432,7 @@ class TSMapEstimator(Estimator):
         dataset = dataset.pad(pad_width, name=dataset.name)
         dataset = dataset.downsample(self.downsampling_factor, name=dataset.name)
 
-        energy_axis = self.energy_edges_axis(dataset=dataset)
+        energy_axis = self._get_energy_axis(dataset=dataset)
 
         results = []
 

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -7,12 +7,11 @@ import warnings
 from multiprocessing import Pool
 import numpy as np
 import scipy.optimize
-from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.utils import lazyproperty
 from gammapy.datasets import Datasets
 from gammapy.datasets.map import MapEvaluator
-from gammapy.maps import Map, MapCoord
+from gammapy.maps import Map, MapCoord, MapAxis
 from gammapy.modeling.models import PointSpatialModel, PowerLawSpectralModel, SkyModel
 from gammapy.stats import cash_sum_cython, f_cash_root_cython, norm_bounds_cython
 from gammapy.utils.array import shape_2N, symmetric_crop_pad_width
@@ -407,15 +406,13 @@ class TSMapEstimator(Estimator):
 
         if self.energy_edges is None:
             energy_axis = dataset.counts.geom.axes["energy"]
-            energy_edges = u.Quantity([energy_axis.edges[0], energy_axis.edges[-1]])
         else:
-            energy_edges = self.energy_edges
+            energy_axis = MapAxis.from_energy_edges(self.energy_edges)
 
         results = []
 
         for energy_min, energy_max in progress_bar(
-            zip(energy_edges[:-1], energy_edges[1:]),
-            desc="Energy bins"
+                energy_axis.iter_by_edges, desc="Energy bins"
         ):
             sliced_dataset = datasets.slice_by_energy(energy_min, energy_max)[0]
 

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -407,7 +407,7 @@ class TSMapEstimator(Estimator):
 
         if self.downsampling_factor and self.downsampling_factor > 1:
             shape = tuple(np.array(geom.data_shape) + 2 * pad_width)
-            pad_width = symmetric_crop_pad_width(shape, shape_2N(shape))[0]
+            pad_width = symmetric_crop_pad_width(geom.data_shape, shape_2N(shape))[0]
 
         return tuple(pad_width)
 

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -405,7 +405,7 @@ class TSMapEstimator(Estimator):
         datasets = Datasets(dataset)
 
         if self.energy_edges is None:
-            energy_axis = dataset.counts.geom.axes["energy"]
+            energy_axis = dataset.counts.geom.axes["energy"].squash()
         else:
             energy_axis = MapAxis.from_energy_edges(self.energy_edges)
 

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -9,9 +9,8 @@ import numpy as np
 import scipy.optimize
 from astropy.coordinates import Angle
 from astropy.utils import lazyproperty
-from gammapy.datasets import Datasets
 from gammapy.datasets.map import MapEvaluator
-from gammapy.maps import Map, MapCoord, MapAxis
+from gammapy.maps import Map, MapCoord, MapAxis, Maps
 from gammapy.modeling.models import PointSpatialModel, PowerLawSpectralModel, SkyModel
 from gammapy.stats import cash_sum_cython, f_cash_root_cython, norm_bounds_cython
 from gammapy.utils.array import shape_2N, symmetric_crop_pad_width
@@ -209,17 +208,12 @@ class TSMapEstimator(Estimator):
 
         # Creating exposure map with exposure at map center
         exposure = Map.from_geom(geom_kernel, unit="cm2 s1")
-        coord = MapCoord.create(
-            dict(
-                skycoord=geom.center_skydir, energy_true=geom.axes["energy_true"].center
-            )
-        )
-        exposure.data[...] = dataset.exposure.get_by_coord(coord)[
-            :, np.newaxis, np.newaxis
-        ]
+
+        exposure.data[...] = dataset.exposure.to_region_nd_map(geom.center_skydir).data
 
         # We use global evaluation mode to not modify the geometry
         evaluator = MapEvaluator(model, evaluation_mode="global")
+
         evaluator.update(
             exposure, dataset.psf, dataset.edisp, dataset.counts.geom, dataset.mask_fit,
         )
@@ -253,8 +247,10 @@ class TSMapEstimator(Estimator):
             exposure = estimate_exposure_reco_energy(dataset, self.model.spectral_model)
 
         kernel = kernel / np.sum(kernel ** 2)
+
         with np.errstate(invalid="ignore", divide="ignore"):
             flux = (dataset.counts - dataset.npred()) / exposure
+
         flux.quantity = flux.quantity.to("1 / (cm2 s)")
         flux = flux.convolve(kernel)
         return flux.sum_over_axes()
@@ -292,23 +288,6 @@ class TSMapEstimator(Estimator):
         background = dataset.npred().sum_over_axes(keepdims=False)
         mask[background.data == 0] = False
         return Map.from_geom(data=mask, geom=geom)
-
-    def estimate_sqrt_ts(self, map_ts, norm):
-        r"""Compute sqrt(TS) map.
-
-
-        Parameters
-        ----------
-        map_ts : `gammapy.maps.WcsNDMap`
-            Input TS map.
-
-        Returns
-        -------
-        sqrt_ts : `gammapy.maps.WcsNDMap`
-            Sqrt(TS) map.
-        """
-        sqrt_ts = self.get_sqrt_ts(map_ts.data, norm.data)
-        return map_ts.copy(data=sqrt_ts)
 
     def estimate_flux_map(self, dataset):
         """Estimate flux and ts maps for single dataset
@@ -371,6 +350,30 @@ class TSMapEstimator(Estimator):
 
         return result
 
+    def estimate_pad_width(self, dataset):
+        """Estimate pad width of the dataset
+
+        Parameters
+        ----------
+        dataset : `~gammapy.datasets.MapDataset`
+            Input MapDataset.
+
+        Returns
+        -------
+        pad_width : tuple
+            Padding width
+        """
+        geom = dataset.counts.geom.to_image()
+        geom_kernel = geom.to_odd_npix(max_radius=self.kernel_width / 2)
+
+        pad_width = np.array(geom_kernel.data_shape) // 2
+
+        if self.downsampling_factor and self.downsampling_factor > 1:
+            shape = tuple(np.array(geom.data_shape) + 2 * pad_width)
+            pad_width = symmetric_crop_pad_width(shape, shape_2N(shape))[0]
+
+        return tuple(pad_width)
+
     def run(self, dataset):
         """
         Run TS map estimation.
@@ -382,6 +385,7 @@ class TSMapEstimator(Estimator):
         ----------
         dataset : `~gammapy.datasets.MapDataset`
             Input MapDataset.
+
         Returns
         -------
         maps : dict
@@ -396,13 +400,9 @@ class TSMapEstimator(Estimator):
         """
         dataset_models = dataset.models
 
-        if self.downsampling_factor:
-            shape = dataset.counts.geom.to_image().data_shape
-            pad_width = symmetric_crop_pad_width(shape, shape_2N(shape))[0]
-            dataset = dataset.pad(pad_width).downsample(self.downsampling_factor)
-
-        # TODO: add support for joint likelihood fitting to TSMapEstimator
-        datasets = Datasets(dataset)
+        pad_width = self.estimate_pad_width(dataset=dataset)
+        dataset = dataset.pad(pad_width, name=dataset.name)
+        dataset = dataset.downsample(self.downsampling_factor, name=dataset.name)
 
         if self.energy_edges is None:
             energy_axis = dataset.counts.geom.axes["energy"].squash()
@@ -414,7 +414,9 @@ class TSMapEstimator(Estimator):
         for energy_min, energy_max in progress_bar(
                 energy_axis.iter_by_edges, desc="Energy bins"
         ):
-            sliced_dataset = datasets.slice_by_energy(energy_min, energy_max)[0]
+            sliced_dataset = dataset.slice_by_energy(
+                energy_min=energy_min, energy_max=energy_max, name=dataset.name
+            )
 
             if self.sum_over_energy_groups:
                 sliced_dataset = sliced_dataset.to_image()
@@ -423,24 +425,19 @@ class TSMapEstimator(Estimator):
             result = self.estimate_flux_map(sliced_dataset)
             results.append(result)
 
-        result_all = {}
+        maps = Maps()
 
         for name in self.selection_all:
-            map_all = Map.from_images(images=[_[name] for _ in results])
+            m = Map.from_images(images=[_[name] for _ in results])
 
-            if self.downsampling_factor:
-                order = 0 if name == "niter" else 1
-                map_all = map_all.upsample(
-                    factor=self.downsampling_factor, preserve_counts=False, order=order
-                )
-                map_all = map_all.crop(crop_width=pad_width)
+            order = 0 if name == "niter" else 1
+            m = m.upsample(
+                factor=self.downsampling_factor, preserve_counts=False, order=order
+            )
 
-            result_all[name] = map_all
+            maps[name] = m.crop(crop_width=pad_width)
 
-        result_all["sqrt_ts"] = self.estimate_sqrt_ts(
-            result_all["ts"], result_all["norm"]
-        )
-        return FluxMaps(data=result_all, reference_model=self.model, gti=dataset.gti)
+        return FluxMaps(data=maps, reference_model=self.model, gti=dataset.gti)
 
 
 # TODO: merge with MapDataset?

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1467,6 +1467,22 @@ class Map(abc.ABC):
 
         return self.to_region_nd_map(region=region, func=func, weights=weights)
 
+    def to_unit(self, unit):
+        """Convert map to different unit
+
+        Parameters
+        ----------
+        unit : `~astropy.unit.Unit` or str
+            New unit
+
+        Returns
+        -------
+        map : `Map`
+            Map with new unit and converted data
+        """
+        data = self.quantity.to_value(unit)
+        return self.from_geom(self.geom, data=data, unit=unit)
+
     def __repr__(self):
         geom = self.geom.__class__.__name__
         axes = ["skycoord"] if self.geom.is_hpx else ["lon", "lat"]

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -882,6 +882,12 @@ class MapAxis:
             self.edges[1:] - self.center,
         )
 
+    @property
+    def iter_by_edges(self):
+        """Iterate by intervals defined by the edges"""
+        for value_min, value_max in zip(self.edges[:-1], self.edges[1:]):
+            yield (value_min, value_max)
+
     @lazyproperty
     def center(self):
         """Return array of bin centers."""

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -259,6 +259,9 @@ class WcsNDMap(WcsMap):
         return map_out
 
     def upsample(self, factor, order=0, preserve_counts=True, axis_name=None):
+        if factor == 1 or factor is None:
+            return self
+
         geom = self.geom.upsample(factor, axis_name=axis_name)
         idx = geom.get_idx()
 
@@ -285,6 +288,9 @@ class WcsNDMap(WcsMap):
         return self._init_copy(geom=geom, data=data.astype(self.data.dtype))
 
     def downsample(self, factor, preserve_counts=True, axis_name=None, weights=None):
+        if factor == 1 or factor is None:
+            return self
+
         geom = self.geom.downsample(factor, axis_name=axis_name)
 
         if axis_name is None:


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request implement padding for the `TSMapEstimator` too avoid blank boundaries of the result maps and to be able to work with arbitrary kernel sizes. In addition in restructures a bit the implementation and adds some little helper methods, like:
- `Map.to_unit()`
- `MapAxis.iter_by_edges`

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
