### PR TITLE
Implement TimeMapAxis class

### DIFF
--- a/gammapy/maps/__init__.py
+++ b/gammapy/maps/__init__.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Sky maps."""
 from .core import *
+from .axes import *
 from .geom import *
 from .hpx import *
 from .hpxmap import *

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -63,9 +63,6 @@ class TimeMapAxis:
             delta = self._edges_min[1:] - self._edges_max[:-1]
             if np.any(delta.to_value("s")<0):
                 raise ValueError("TimeMapAxis: time intervals must not overlap.")
-#        else:
-#            self._edges_min.reshape((1,))
-#            self._edges_max.reshape((1,))
 
         if interp != "lin":
             raise ValueError("TimeMapAxis: non-linear scaling scheme are not supported yet.")
@@ -199,10 +196,9 @@ class TimeMapAxis:
         idx = np.atleast_1d(self.coord_to_idx(coord))
 
         valid_pix = np.where(idx!=INVALID_INDEX.int)
-        pix = np.asarray(idx, dtype = 'float')
-        if pix.shape == ():
-            pix = pix.reshape((1,))
+        pix = np.atleast_1d(idx).astype('float')
 
+        # TODO: is there the equivalent of np.atleast1d for astropy.time.Time?
         if coord.shape == ():
             coord = coord.reshape((1,))
         relative_time = coord[valid_pix]-self.reference_time

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -39,8 +39,7 @@ class TimeMapAxis:
         edges_min = u.Quantity(edges_min, ndmin=1)
         edges_max = u.Quantity(edges_max, ndmin=1)
 
-        if not isinstance(reference_time, Time):
-            raise TypeError(f"TimeAxis reference time must be Time object. Got {type(reference_time).__name__}.")
+        reference_time = Time(reference_time)
 
         invalid = [_.unit.name for _ in (edges_min, edges_max) if not _.unit.is_equivalent("d")]
         if len(invalid)>0:

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -123,6 +123,7 @@ class TimeAxis:
     def upsample(self):
         raise NotImplementedError
 
+    #TODO: how configurable should that be? column names?
     @classmethod
     def from_table(cls, table, name="time"):
         if "TIMESYS" not in table.meta:
@@ -131,6 +132,15 @@ class TimeAxis:
         else:
             scale = table.meta["TIMESYS"]
         format = "mjd"
+
         tmin = Time(table["time_min"], scale=scale, format=format)
         tmax = Time(table["time_max"], scale=scale, format=format)
+        return cls(tmin, tmax, name)
+
+    @classmethod
+    def from_gti(cls, gti, name="time"):
+        """Create a time axis from an input GTI."""
+        tmin = gti.time_start
+        tmax = gti.time_stop
+
         return cls(tmin, tmax, name)

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -208,7 +208,6 @@ class TimeMapAxis:
             coord = coord.reshape((1,))
         relative_time = coord[valid_pix]-self.reference_time
 
-        print(valid_pix)
         scale = interpolation_scale(self._interp)
         valid_idx = idx[valid_pix]
         s_min = scale(self._edges_min[valid_idx])

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -5,6 +5,7 @@ import numpy as np
 from astropy.time import Time
 import astropy.units as u
 from gammapy.utils.interpolation import interpolation_scale
+from .utils import INVALID_INDEX
 
 __all__ = ["TimeMapAxis"]
 
@@ -167,7 +168,7 @@ class TimeMapAxis:
         mask = np.logical_and(delta_plus, delta_minus)
 
         idx = np.asanyarray(np.argmax(mask, axis=-1))
-        idx[~np.any(mask, axis=-1)] = -1
+        idx[~np.any(mask, axis=-1)] = INVALID_INDEX.int
         return idx
 
     def coord_to_pix(self, coord):
@@ -188,7 +189,7 @@ class TimeMapAxis:
         """
         idx = self.coord_to_idx(coord)
 
-        valid_pix = np.where(idx!=-1)
+        valid_pix = np.where(idx!=INVALID_INDEX.int)
         pix = np.asarray(idx, dtype = 'float')
         if pix.shape == ():
             pix = pix.reshape((1,))

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -179,6 +179,32 @@ class TimeMapAxis(MapAxis):
             name=self._name,
         )
 
+    # TODO: if we are to allow log or sqrt bins the reference time should always
+    # be strictly lower than all times
+    # Should we define a mechanism to ensure this is always correct?
+    @classmethod
+    def from_time_edges(cls, time_min, time_max, interp="lin", name="time"):
+        """Create TimeMapAxis from the time interval edges defined as `~astropy.time.Time`.
+
+        The reference time is defined as the lower edge of the first interval.
+
+        Parameters
+        ----------
+        time_min : `~astropy.time.Time`
+            Array of lower edge times.
+        time_max : ``~astropy.time.Time`
+            Array of lower edge times.
+        interp : str
+            Interpolation method used to transform between axis and pixel
+            coordinates.  Valid options are 'log', 'lin', and 'sqrt'.
+        name : str
+            Axis name
+        """
+        reference_time = time_min[0]
+        edges_min = time_min - reference_time
+        edges_max = time_max - reference_time
+
+        return cls(edges_min, edges_max, reference_time, interp=interp, name=name)
 
     #TODO: how configurable should that be? column names?
     @classmethod

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -57,37 +57,37 @@ class TimeMapAxis:
 
     @property
     def reference_time(self):
-        """The reference time used for the axis."""
+        """Return reference time used for the axis."""
         return self._reference_time
 
     @property
     def name(self):
-        """The axis name."""
+        """Return axis name."""
         return self._name
 
     @property
     def nbin(self):
-        """The number of bins in the axis."""
+        """Return number of bins in the axis."""
         return self._nbin
 
     @property
     def time_min(self):
-        """Axis lower edges as Time objects."""
+        """Return axis lower edges as Time objects."""
         return self._edges_min + self.reference_time
 
     @property
     def time_max(self):
-        """Axis upper edges as Time objects."""
+        """Return axis upper edges as Time objects."""
         return self._edges_max + self.reference_time
 
     @property
     def time_delta(self):
-        """Axis time bin width (`~astropy.time.TimeDelta`)."""
+        """Return axis time bin width (`~astropy.time.TimeDelta`)."""
         return self._edges_max - self._edges_min
 
     @property
     def time_mid(self):
-        """Time bin center (`~astropy.time.Time`)."""
+        """Return time bin center (`~astropy.time.Time`)."""
         return self.time_min + 0.5 * self.time_delta
 
     def coord_to_idx(self, time):
@@ -124,10 +124,12 @@ class TimeMapAxis:
 
     @property
     def center(self):
+        """Return `~astropy.time.Time` at interval centers."""
         return self.time_mid
 
     @property
     def bin_width(self):
+        """Return time interval width."""
         return self.time_delta
 
     def __repr__(self):

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -5,7 +5,9 @@ import numpy as np
 from astropy.time import Time
 import astropy.units as u
 from gammapy.utils.interpolation import interpolation_scale
-from gammapy.utils.testing import assert_time_allclose
+
+__all__ = ["TimeMapAxis"]
+
 
 class TimeMapAxis:
     """Class representing a time axis.

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -26,10 +26,9 @@ class TimeAxis:
     def __init__(self, time_min, time_max, name="", interp="lin",):
         self._name = name
 
-        if not isinstance(time_min, Time):
-            raise TypeError(f"TimeAxis time_min must be Time object. Got {time_min.__class__}")
-        if not isinstance(time_max, Time):
-            raise TypeError(f"TimeAxis time_max must be Time object. Got {time_max.__class__}")
+        invalid = [type(_).__name__ for _ in (time_min, time_max) if not isinstance(_, Time)]
+        if len(invalid)>0:
+            raise TypeError(f"TimeAxis edges must be Time objects. Got {invalid}")
 
         if not len(time_min) == len(time_max):
             raise ValueError("Time min and time max must have the same length.")

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1,0 +1,136 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from astropy.time import Time
+
+
+class TimeAxis:
+    """Class representing a time axis.
+
+    Provides methods for transforming to/from axis and pixel coordinates.
+    A time axis can represent non-contiguous sequences of time intervals.
+
+    Parameters
+    ----------
+    time_min : `~astropy.time.Time`
+        Array of edge time values.
+    time_max : `~astropy.time.Time`
+        Array of edge time values.
+    interp : str
+        Interpolation method used to transform between axis and pixel
+        coordinates.  Valid options are 'log', 'lin', and 'sqrt'.
+    name : str
+        Axis name
+    """
+    node_type = "edges"
+    def __init__(self, time_min, time_max, name="", interp="lin",):
+        self._name = name
+
+        if not isinstance(time_min, Time):
+            raise TypeError(f"TimeAxis time_min must be Time object. Got {time_min.__class__}")
+        if not isinstance(time_max, Time):
+            raise TypeError(f"TimeAxis time_max must be Time object. Got {time_max.__class__}")
+
+        if not len(time_min) == len(time_max):
+            raise ValueError("Time min and time max must have the same length.")
+
+        if not (np.all(time_min == time_min.sort()) and np.all(time_max == time_max.sort()) ):
+            raise ValueError("TimeAxis: edge values must be sorted")
+
+        self._time_min = Time(time_min)
+        self._time_max = Time(time_max)
+
+        self._interp = interp
+
+        self._pix_offset = -0.5
+        self._nbin = len(time_min)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def nbin(self):
+        return len(self._time_min)
+
+    @property
+    def time_min(self):
+        return self._time_min
+
+    @property
+    def time_max(self):
+        return self._time_max
+
+    @property
+    def time_delta(self):
+        """Time bin width (`~astropy.time.TimeDelta`)."""
+        return self.time_max - self.time_min
+
+    @property
+    def time_mid(self):
+        """Time bin center (`~astropy.time.Time`)."""
+        return self.time_min + 0.5 * self.time_delta
+
+    def coord_to_idx(self, time):
+        """Transform from axis time coordinate to bin index.
+
+        Indices of time values falling outside time bins will be
+        set to -1.
+
+        Parameters
+        ----------
+        coord : `~astropy.time.Time`
+            Array of axis coordinate values.
+
+        Returns
+        -------
+        idx : `~numpy.ndarray`
+            Array of bin indices.
+        """
+
+        time = Time(time[..., np.newaxis])
+        delta_plus = (time - self.time_min).value > 0.
+        delta_minus = (time - self.time_max).value <= 0.
+        mask = np.logical_and(delta_plus, delta_minus)
+
+        idx = np.asanyarray(np.argmax(mask, axis=-1))
+        idx[~np.any(mask, axis=-1)] = -1
+        return idx
+
+    def time_to_pix(self, coord):
+        return self.coord_to_idx(coord)
+
+    def pix_to_idx(self, pix, clip=False):
+        return pix
+
+    @property
+    def center(self):
+        return self.time_mid
+
+    @property
+    def bin_width(self):
+        return self.time_delta
+
+    def __repr__(self):
+        str_ = self.__class__.__name__ + "\n"
+        str_ += "-" * len(self.__class__.__name__) + "\n\n"
+        fmt = "\t{:<10s} : {:<10s}\n"
+        str_ += fmt.format("name", self.name)
+        str_ += fmt.format("nbins", str(self.nbin))
+        str_ += fmt.format("node type", self.node_type)
+        return str_.expandtabs(tabsize=2)
+
+    def upsample(self):
+        raise NotImplementedError
+
+    @classmethod
+    def from_table(cls, table, name="time"):
+        if "TIMESYS" not in table.meta:
+            print("No TIMESYS information. Assuming UTC scale.")
+            scale = "utc"
+        else:
+            scale = table.meta["TIMESYS"]
+        format = "mjd"
+        tmin = Time(table["time_min"], scale=scale, format=format)
+        tmax = Time(table["time_max"], scale=scale, format=format)
+        return cls(tmin, tmax, name)

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -5,7 +5,7 @@ from astropy.time import Time
 import astropy.units as u
 from gammapy.maps import MapAxis
 
-class TimeMapAxis(MapAxis):
+class TimeMapAxis:
     """Class representing a time axis.
 
     Provides methods for transforming to/from axis and pixel coordinates.
@@ -25,7 +25,7 @@ class TimeMapAxis(MapAxis):
     name : str
         Axis name
     """
-    _node_type = "edges"
+    node_type = "edges"
     def __init__(self, edges_min, edges_max, reference_time, name="time", interp="lin",):
         self._name = name
 
@@ -183,7 +183,7 @@ class TimeMapAxis(MapAxis):
     # be strictly lower than all times
     # Should we define a mechanism to ensure this is always correct?
     @classmethod
-    def from_time_edges(cls, time_min, time_max, interp="lin", name="time"):
+    def from_time_edges(cls, time_min, time_max, unit="d", interp="lin", name="time"):
         """Create TimeMapAxis from the time interval edges defined as `~astropy.time.Time`.
 
         The reference time is defined as the lower edge of the first interval.
@@ -194,17 +194,20 @@ class TimeMapAxis(MapAxis):
             Array of lower edge times.
         time_max : ``~astropy.time.Time`
             Array of lower edge times.
+        unit : `~astropy.units.Unit` or str
+            The unit to convert the edges to. Default is 'd' (day).
         interp : str
             Interpolation method used to transform between axis and pixel
             coordinates.  Valid options are 'log', 'lin', and 'sqrt'.
         name : str
             Axis name
         """
+        unit = u.Unit(unit)
         reference_time = time_min[0]
         edges_min = time_min - reference_time
         edges_max = time_max - reference_time
 
-        return cls(edges_min, edges_max, reference_time, interp=interp, name=name)
+        return cls(edges_min.to(unit), edges_max.to(unit), reference_time, interp=interp, name=name)
 
     #TODO: how configurable should that be? column names?
     @classmethod

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -30,7 +30,7 @@ class TimeMapAxis:
         Interpolation method used to transform between axis and pixel
         coordinates.  For now only 'lin' is supported.
     """
-    node_type = "edges"
+    node_type = "intervals"
     def __init__(self, edges_min, edges_max, reference_time, name="time", interp="lin"):
         self._name = name
 
@@ -225,7 +225,8 @@ class TimeMapAxis:
         fmt = "\t{:<10s} : {:<10s}\n"
         str_ += fmt.format("name", self.name)
         str_ += fmt.format("nbins", str(self.nbin))
-        str_ += fmt.format("node type", self.node_type)
+        str_ += fmt.format("reference time", self.reference_time.iso)
+        str_ += fmt.format("total time", self.time_delta.sum())
         return str_.expandtabs(tabsize=2)
 
     def upsample(self):

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -1,0 +1,26 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import pytest
+import numpy as np
+from astropy.time import Time
+import astropy.units as u
+from gammapy.maps.axes import TimeAxis
+from gammapy.utils.testing import assert_allclose
+
+@pytest.fixture
+def time_intervals():
+    t0 = Time("2020-03-19")
+    t_min = t0 + np.linspace(0, 10, 20) * u.d
+    t_max = t_min + 1 * u.h
+    return {"t_min" : t_min, "t_max" : t_max}
+
+def test_time_axis(time_intervals):
+    axis = TimeAxis(time_intervals["t_min"], time_intervals["t_max"], name="time")
+
+    assert axis.nbin == 20
+    assert axis.name == "time"
+    assert axis.node_type == "edges"
+    assert_allclose(axis.time_delta.to_value("min"), 60)
+
+
+

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -21,6 +21,8 @@ def time_intervals():
 def test_time_axis(time_intervals):
     axis = TimeMapAxis(time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"])
 
+    axis_copy = axis.copy()
+
     assert axis.nbin == 20
     assert axis.name == "time"
     assert axis.node_type == "edges"
@@ -28,6 +30,21 @@ def test_time_axis(time_intervals):
     assert_allclose(axis.center[0].mjd, 58927.020833333336)
     assert "time" in axis.__str__()
     assert "20" in axis.__str__()
+    with pytest.raises(ValueError):
+        axis.assert_name("bad")
+    assert axis_copy == axis
+
+def test_slice_squash_time_axis(time_intervals):
+    axis = TimeMapAxis(time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"])
+    axis_squash = axis.squash()
+    axis_slice = axis.slice(slice(1,5))
+
+    assert axis_squash.nbin ==1
+    assert_allclose(axis_squash.time_min[0].mjd, 58927)
+    assert_allclose(axis_squash.time_delta.to_value("d"), 10.04166666)
+    assert axis_slice.nbin == 4
+    assert_allclose(axis_slice.time_delta.to_value("d")[0], 0.04166666666)
+    assert axis_squash != axis_slice
 
 def test_from_time_edges_time_axis():
     t0 = Time("2020-03-19")
@@ -44,6 +61,7 @@ def test_from_time_edges_time_axis():
     assert_allclose(axis.center[0].mjd, 58927.020833333336)
     assert_allclose(axis_h.time_delta.to_value("h"), 1)
     assert_allclose(axis_h.center[0].mjd, 58927.020833333336)
+    assert axis == axis_h
 
 def test_incorrect_time_axis():
     tmin = np.linspace(0,10)*u.h

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -25,7 +25,7 @@ def test_time_axis(time_intervals):
 
     assert axis.nbin == 20
     assert axis.name == "time"
-    assert axis.node_type == "edges"
+    assert axis.node_type == "intervals"
     assert_allclose(axis.time_delta.to_value("min"), 60)
     assert_allclose(axis.center[0].mjd, 58927.020833333336)
     assert "time" in axis.__str__()

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -78,9 +78,14 @@ def test_coord_to_idx_time_axis(time_intervals):
     idx = axis.coord_to_idx(time)
     indices = axis.coord_to_idx(times)
 
+    pix = axis.coord_to_pix(time)
+    pixels = axis.coord_to_pix(times)
+
     assert idx == 0
     assert_allclose(indices[1::2], [1, 3, 5, 7, 9, 11, 13, 15, 17, 19])
     assert_allclose(indices[::2], -1)
+    assert_allclose(pix, 0.5)
+    assert_allclose(pixels[1::2], [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5])
 
 def test_slice_time_axis(time_intervals):
     axis = TimeMapAxis(time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"])

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -21,6 +21,25 @@ def test_time_axis(time_intervals):
     assert axis.name == "time"
     assert axis.node_type == "edges"
     assert_allclose(axis.time_delta.to_value("min"), 60)
+    assert_allclose(axis.center[0].mjd, 58927.020833333336)
+    assert "time" in axis.__str__()
+    assert "20" in axis.__str__()
 
 
+def test_incorrect_time_axis():
+    tmin = np.linspace(0,10)*u.h
+    tmax = np.linspace(1,11)*u.h
+    with pytest.raises(TypeError):
+        TimeAxis(tmin, tmax, name="time")
+
+def test_bad_length_sort_time_axis(time_intervals):
+    tmin = time_intervals["t_min"]
+
+    tmax = time_intervals["t_max"][::-1]
+    with pytest.raises(ValueError):
+        TimeAxis(tmin, tmax, name="time")
+
+    tmax = time_intervals["t_max"][:-1]
+    with pytest.raises(ValueError):
+        TimeAxis(tmin, tmax, name="time")
 

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -5,7 +5,8 @@ import numpy as np
 from astropy.time import Time
 from astropy.table import Table
 import astropy.units as u
-from gammapy.maps.axes import TimeAxis
+from gammapy.maps import RegionNDMap, MapAxis
+from gammapy.maps.axes import TimeMapAxis
 from gammapy.data import GTI
 from gammapy.utils.testing import assert_allclose, requires_data, assert_time_allclose
 from gammapy.utils.scripts import make_path
@@ -18,7 +19,7 @@ def time_intervals():
     return {"t_min" : t_min, "t_max" : t_max}
 
 def test_time_axis(time_intervals):
-    axis = TimeAxis(time_intervals["t_min"], time_intervals["t_max"], name="time")
+    axis = TimeMapAxis(time_intervals["t_min"], time_intervals["t_max"], name="time")
 
     assert axis.nbin == 20
     assert axis.name == "time"
@@ -34,7 +35,7 @@ def test_incorrect_time_axis():
     tmax = np.linspace(1,11)*u.h
 
     with pytest.raises(TypeError):
-        TimeAxis(tmin, tmax, name="time")
+        TimeMapAxis(tmin, tmax, name="time")
 
 def test_bad_length_sort_time_axis(time_intervals):
     tmin = time_intervals["t_min"]
@@ -42,16 +43,16 @@ def test_bad_length_sort_time_axis(time_intervals):
     tmax_short = time_intervals["t_max"][:-1]
 
     with pytest.raises(ValueError):
-        TimeAxis(tmin, tmax_reverse, name="time")
+        TimeMapAxis(tmin, tmax_reverse, name="time")
 
     with pytest.raises(ValueError):
-        TimeAxis(tmin, tmax_short, name="time")
+        TimeMapAxis(tmin, tmax_short, name="time")
 
 
 def test_coord_to_idx_time_axis(time_intervals):
     tmin = time_intervals["t_min"]
     tmax = time_intervals["t_max"]
-    axis = TimeAxis(tmin, tmax, name="time")
+    axis = TimeMapAxis(tmin, tmax, name="time")
 
     time = Time(58927.020833333336, format="mjd")
     times = axis.time_mid
@@ -64,6 +65,16 @@ def test_coord_to_idx_time_axis(time_intervals):
     assert_allclose(indices[1::2], [1, 3, 5, 7, 9, 11, 13, 15, 17, 19])
     assert_allclose(indices[::2], -1)
 
+def test_slice_time_axis(time_intervals):
+    axis = TimeMapAxis(time_intervals["t_min"], time_intervals["t_max"], name="time")
+
+    new_axis = axis.slice([2,6,9])
+    squashed = axis.squash()
+
+    assert new_axis.nbin == 3
+    assert_allclose(squashed.time_max[0].mjd, 1)
+    assert squashed.nbin == 1
+    assert_allclose(squashed.time_max[0].mjd, 1)
 
 def test_from_table_time_axis():
     t0 = Time("2006-02-12", scale='utc')
@@ -75,7 +86,7 @@ def test_from_table_time_axis():
     cols["some_column"] = np.ones(10)
     table = Table(data=cols)
 
-    axis = TimeAxis.from_table(table)
+    axis = TimeMapAxis.from_table(table)
 
     assert axis.nbin == 10
     assert_allclose(axis.center[0].mjd, 53778.25)
@@ -86,7 +97,14 @@ def test_from_gti_time_axis():
     filename = make_path(filename)
     gti = GTI.read(filename)
 
-    axis = TimeAxis.from_gti(gti)
+    axis = TimeMapAxis.from_gti(gti)
     expected = Time(53090.123451203704, format="mjd", scale="tt")
     assert_time_allclose(axis.time_min[0], expected)
     assert axis.nbin == 1
+
+def test_map_with_time_axis(time_intervals):
+    time_axis = TimeMapAxis(time_intervals["t_min"], time_intervals["t_max"], name="time")
+    energy_axis = MapAxis.from_energy_bounds(0.1,10, 2, unit="TeV")
+    region_map = RegionNDMap.create(region="fk5; circle(0,0,0.1)", axes=[energy_axis, time_axis])
+
+    assert region_map.geom.data_shape == (20, 2, 1, 1)

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -3,9 +3,12 @@
 import pytest
 import numpy as np
 from astropy.time import Time
+from astropy.table import Table
 import astropy.units as u
 from gammapy.maps.axes import TimeAxis
-from gammapy.utils.testing import assert_allclose
+from gammapy.data import GTI
+from gammapy.utils.testing import assert_allclose, requires_data, assert_time_allclose
+from gammapy.utils.scripts import make_path
 
 @pytest.fixture
 def time_intervals():
@@ -29,17 +32,61 @@ def test_time_axis(time_intervals):
 def test_incorrect_time_axis():
     tmin = np.linspace(0,10)*u.h
     tmax = np.linspace(1,11)*u.h
+
     with pytest.raises(TypeError):
         TimeAxis(tmin, tmax, name="time")
 
 def test_bad_length_sort_time_axis(time_intervals):
     tmin = time_intervals["t_min"]
+    tmax_reverse = time_intervals["t_max"][::-1]
+    tmax_short = time_intervals["t_max"][:-1]
 
-    tmax = time_intervals["t_max"][::-1]
     with pytest.raises(ValueError):
-        TimeAxis(tmin, tmax, name="time")
+        TimeAxis(tmin, tmax_reverse, name="time")
 
-    tmax = time_intervals["t_max"][:-1]
     with pytest.raises(ValueError):
-        TimeAxis(tmin, tmax, name="time")
+        TimeAxis(tmin, tmax_short, name="time")
 
+
+def test_coord_to_idx_time_axis(time_intervals):
+    tmin = time_intervals["t_min"]
+    tmax = time_intervals["t_max"]
+    axis = TimeAxis(tmin, tmax, name="time")
+
+    time = Time(58927.020833333336, format="mjd")
+    times = axis.time_mid
+    times[::2] += 1*u.h
+
+    idx = axis.coord_to_idx(time)
+    indices = axis.coord_to_idx(times)
+
+    assert idx == 0
+    assert_allclose(indices[1::2], [1, 3, 5, 7, 9, 11, 13, 15, 17, 19])
+    assert_allclose(indices[::2], -1)
+
+
+def test_from_table_time_axis():
+    t0 = Time("2006-02-12", scale='utc')
+    t_min = t0 + np.linspace(0, 10, 10)*u.d
+    t_max = t_min+12*u.h
+    cols = dict()
+    cols["time_min"] = t_min
+    cols["time_max"] = t_max
+    cols["some_column"] = np.ones(10)
+    table = Table(data=cols)
+
+    axis = TimeAxis.from_table(table)
+
+    assert axis.nbin == 10
+    assert_allclose(axis.center[0].mjd, 53778.25)
+
+@requires_data()
+def test_from_gti_time_axis():
+    filename = "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+    filename = make_path(filename)
+    gti = GTI.read(filename)
+
+    axis = TimeAxis.from_gti(gti)
+    expected = Time(53090.123451203704, format="mjd", scale="tt")
+    assert_time_allclose(axis.time_min[0], expected)
+    assert axis.nbin == 1

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -29,6 +29,21 @@ def test_time_axis(time_intervals):
     assert "time" in axis.__str__()
     assert "20" in axis.__str__()
 
+def test_from_time_edges_time_axis():
+    t0 = Time("2020-03-19")
+    t_min = t0 + np.linspace(0, 10, 20) * u.d
+    t_max = t_min + 1 * u.h
+
+    axis = TimeMapAxis.from_time_edges(t_min, t_max)
+    axis_h = TimeMapAxis.from_time_edges(t_min, t_max, unit='h')
+
+    assert axis.nbin == 20
+    assert axis.name == "time"
+    assert_time_allclose(axis.reference_time, t0)
+    assert_allclose(axis.time_delta.to_value("min"), 60)
+    assert_allclose(axis.center[0].mjd, 58927.020833333336)
+    assert_allclose(axis_h.time_delta.to_value("h"), 1)
+    assert_allclose(axis_h.center[0].mjd, 58927.020833333336)
 
 def test_incorrect_time_axis():
     tmin = np.linspace(0,10)*u.h

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -86,7 +86,7 @@ def test_incorrect_time_axis():
     tmax = np.linspace(1,11, 20)*u.h
 
     # incorrect reference time
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         TimeMapAxis(tmin, tmax, reference_time=51000*u.d, name="time")
 
     # overlapping time intervals

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -114,8 +114,11 @@ def test_coord_to_idx_time_axis(time_intervals):
     axis = TimeMapAxis(tmin, tmax, tref, name="time")
 
     time = Time(58927.020833333336, format="mjd")
+
     times = axis.time_mid
     times[::2] += 1*u.h
+    times = times.insert(0, tref-[1,2]*u.yr)
+    print(times)
 
     idx = axis.coord_to_idx(time)
     indices = axis.coord_to_idx(times)
@@ -124,10 +127,10 @@ def test_coord_to_idx_time_axis(time_intervals):
     pixels = axis.coord_to_pix(times)
 
     assert idx == 0
-    assert_allclose(indices[1::2], [1, 3, 5, 7, 9, 11, 13, 15, 17, 19])
+    assert_allclose(indices[1::2], [-1, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19])
     assert_allclose(indices[::2], -1)
     assert_allclose(pix, 0.5)
-    assert_allclose(pixels[1::2], [1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5])
+    assert_allclose(pixels[1::2], [-1, 1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5])
 
 def test_slice_time_axis(time_intervals):
     axis = TimeMapAxis(time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"])


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a `TimeAxis` object that contains sorted time intervals that are not expected to be contiguous.
  
For now, it implements the `coord_to_idx` method and a few `from_something` class methods. 

I have created a new file `gammapy.maps.axes.py` since the `geom.py` file is already very long. The `MapAxis` and `MapAxes` code could be moved here as well to clarify a bit.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This is a draft for discussions.