### PR TITLE
Further cleanup Fit class

### DIFF
--- a/docs/tutorials/api/fitting.ipynb
+++ b/docs/tutorials/api/fitting.ipynb
@@ -377,7 +377,7 @@
     "    for sigma in sigmas:\n",
     "        contours = dict()\n",
     "        for par_1, par_2 in combinations([\"alpha\", \"beta\", \"amplitude\"], r=2):\n",
-    "            contour = fit.minos_contour(\n",
+    "            contour = fit.stat_contour(\n",
     "                datasets=datasets,\n",
     "                x=result.parameters[par_1],\n",
     "                y=result.parameters[par_2],\n",

--- a/docs/tutorials/api/fitting.ipynb
+++ b/docs/tutorials/api/fitting.ipynb
@@ -119,8 +119,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scipy_opts = {\"method\": \"L-BFGS-B\", \"options\": {\"ftol\": 1e-4, \"gtol\": 1e-05}}\n",
-    "fit_scipy = Fit(store_trace=True, optimize_opts=scipy_opts, backend=\"scipy\")"
+    "scipy_opts = {\"method\": \"L-BFGS-B\", \"options\": {\"ftol\": 1e-4, \"gtol\": 1e-05}, \"backend\": \"scipy\"}\n",
+    "fit_scipy = Fit(store_trace=True, optimize_opts=scipy_opts)"
    ]
   },
   {

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -106,19 +106,28 @@ class TestFluxPointFit:
         fit = Fit()
         result = fit.run(datasets=dataset)
 
-        profile = fit.stat_profile(datasets=dataset, parameter="amplitude", nvalues=3, bounds=1)
+        profile = fit.stat_profile(
+            datasets=dataset,
+            parameter="amplitude",
+            nvalues=3,
+            bounds=1,
+        )
 
         ts_diff = profile["stat_scan"] - result.total_stat
-        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)
+        assert_allclose(ts_diff, [174.358204, 0., 174.418515], rtol=1e-2, atol=1e-7)
 
         value = result.parameters["amplitude"].value
         err = result.parameters["amplitude"].error
         values = np.array([value - err, value, value + err])
 
-        profile = fit.stat_profile(datasets=dataset, parameter="amplitude", values=values)
+        profile = fit.stat_profile(
+            datasets=dataset,
+            parameter="amplitude",
+            values=values
+        )
 
         ts_diff = profile["stat_scan"] - result.total_stat
-        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)
+        assert_allclose(ts_diff, [174.358204, 0., 174.418515], rtol=1e-2, atol=1e-7)
 
     @staticmethod
     @requires_dependency("matplotlib")

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -130,9 +130,9 @@ def test_fov_bkg_maker_fit(obs_dataset, exclusion_mask):
 
     model = dataset.models[f"{dataset.name}-bkg"].spectral_model
     assert_allclose(model.norm.value, 0.901523, rtol=1e-4)
-    assert_allclose(model.norm.error, 0.6088, rtol=1e-2)
+    assert_allclose(model.norm.error, 0.583411, rtol=1e-2)
     assert_allclose(model.tilt.value, 0.071069, rtol=1e-4)
-    assert_allclose(model.tilt.error, 0.5866, rtol=1e-2)
+    assert_allclose(model.tilt.error, 0.562129, rtol=1e-2)
     assert_allclose(fov_bkg_maker.default_spectral_model.tilt.value, 0.0)
     assert_allclose(fov_bkg_maker.default_spectral_model.norm.value, 1.0)
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -97,6 +97,8 @@ class Fit:
         interval can be adapted by modifying the the upper bound of the interval (``b``) value.
     store_trace : bool
         Whether to store the trace of the fit
+    scale_parameters : bool
+        Whether to scale parameters prior to the fit.
     """
 
     def __init__(
@@ -106,6 +108,7 @@ class Fit:
         covariance_opts=None,
         confidence_opts=None,
         store_trace=False,
+        scale_parameters=True
     ):
         self.store_trace = store_trace
         self.backend = backend
@@ -122,6 +125,7 @@ class Fit:
         self.optimize_opts = optimize_opts
         self.covariance_opts = covariance_opts
         self.confidence_opts = confidence_opts
+        self.scale_parameters = scale_parameters
 
     @staticmethod
     def _parse_datasets(datasets):
@@ -166,8 +170,7 @@ class Fit:
         datasets, parameters = self._parse_datasets(datasets=datasets)
         datasets.parameters.check_limits()
 
-        # TODO: expose options if / when to scale? On the Fit class?
-        if np.all(datasets.models.covariance.data == 0):
+        if self.scale_parameters:
             parameters.autoscale()
 
         kwargs = self.optimize_opts.copy()

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -457,7 +457,7 @@ class Fit:
             "fit_results": fit_results,
         }
 
-    def minos_contour(self, datasets, x, y, numpoints=10, sigma=1):
+    def stat_contour(self, datasets, x, y, numpoints=10, sigma=1):
         """Compute MINOS contour.
 
         Calls ``iminuit.Minuit.mncontour``.

--- a/gammapy/modeling/iminuit.py
+++ b/gammapy/modeling/iminuit.py
@@ -63,13 +63,15 @@ def optimize_iminuit(parameters, function, store_trace=False, **kwargs):
     result : (factors, info, optimizer)
         Tuple containing the best fit factors, some info and the optimizer instance.
     """
+    migrad_opts = kwargs.pop("migrad_opts", {})
+
     minuit, minuit_func = setup_iminuit(
         parameters=parameters,
         function=function,
         store_trace=store_trace,
         **kwargs
     )
-    migrad_opts = kwargs.pop("migrad_opts", {})
+
     minuit.migrad(**migrad_opts)
 
     factors = minuit.args
@@ -94,12 +96,14 @@ def covariance_iminuit(parameters, function, **kwargs):
     minuit.hesse()
 
     message, success = "Hesse terminated successfully.", True
+
     try:
         covariance_factors = minuit.np_covariance()
     except (TypeError, RuntimeError):
         N = len(minuit.args)
         covariance_factors = np.nan * np.ones((N, N))
         message, success = "Hesse failed", False
+
     return covariance_factors, {"success": success, "message": message}
 
 

--- a/gammapy/modeling/iminuit.py
+++ b/gammapy/modeling/iminuit.py
@@ -93,11 +93,11 @@ def covariance_iminuit(parameters, function, **kwargs):
         store_trace=False,
         **kwargs
     )
-    minuit.hesse()
 
     message, success = "Hesse terminated successfully.", True
 
     try:
+        minuit.hesse()
         covariance_factors = minuit.np_covariance()
     except (TypeError, RuntimeError):
         N = len(minuit.args)

--- a/gammapy/modeling/tests/test_iminuit.py
+++ b/gammapy/modeling/tests/test_iminuit.py
@@ -127,7 +127,9 @@ def test_iminuit_confidence():
     par = pars["x"]
     par.min, par.max = 0, 10
 
-    result = confidence_iminuit(minuit=minuit, parameters=pars, parameter=par, sigma=1)
+    result = confidence_iminuit(
+        function=ds.fcn, parameters=pars, parameter=par, sigma=1, reoptimize=True
+    )
 
     assert result["success"]
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request does some more cleanup on the `Fit` class. It includes the following changes:
- Rename `.minos_contour` to `.stat_contour`
- Allow stateless use of the Minuit backend, by re-creating the `Minuit`object
- Allow mixed backends to estimate errors using `minuit` while fitting with `scipy`
- Add `scale_parameters` option to `Fit` to control the parameter scaling
- Make `Fit.minuit` read only


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
