### PR TITLE
Fix stacking of cutouts 

### DIFF
--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -241,24 +241,14 @@ def test_cutout_info():
     geom = WcsGeom.create(skydir=(0, 0), npix=10)
     position = SkyCoord(0, 0, unit="deg")
     cutout_geom = geom.cutout(position=position, width="2 deg")
-    assert cutout_geom.cutout_info["parent-slices"][0].start == 3
-    assert cutout_geom.cutout_info["parent-slices"][1].start == 3
 
-    assert cutout_geom.cutout_info["cutout-slices"][0].start == 0
-    assert cutout_geom.cutout_info["cutout-slices"][1].start == 0
+    cutout_info = cutout_geom.cutout_slices(geom)
 
-    header = cutout_geom.to_header()
-    assert "PSLICE1" in header
-    assert "PSLICE2" in header
-    assert "CSLICE1" in header
-    assert "CSLICE2" in header
+    assert cutout_info["parent-slices"][0].start == 3
+    assert cutout_info["parent-slices"][1].start == 3
 
-    geom = WcsGeom.from_header(header)
-    assert geom.cutout_info["parent-slices"][0].start == 3
-    assert geom.cutout_info["parent-slices"][1].start == 3
-
-    assert geom.cutout_info["cutout-slices"][0].start == 0
-    assert geom.cutout_info["cutout-slices"][1].start == 0
+    assert cutout_info["cutout-slices"][0].start == 0
+    assert cutout_info["cutout-slices"][1].start == 0
 
 
 def test_wcsgeom_get_coord():

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -856,3 +856,18 @@ def test_memory_usage():
     assert geom.data_nbytes().unit == u.MB
     assert_allclose(geom.data_nbytes(dtype="float32").value, 1.0368)
     assert_allclose(geom.data_nbytes(dtype="b").value, 0.2592)
+
+
+def test_double_cutout():
+    # regression test for https://github.com/gammapy/gammapy/issues/3368
+    m = Map.create(width="10 deg")
+    m.data = np.arange(10_000, dtype="float")
+
+    position = SkyCoord("1d", "1d")
+    m_c = m.cutout(position=position, width="3 deg")
+    m_cc = m_c.cutout(position=position, width="2 deg")
+
+    m_new = Map.create(width="10 deg")
+    m_new.stack(m_cc)
+    m_c_new = m_new.cutout(position=position, width="2 deg")
+    np.testing.assert_allclose(m_c_new.data, m_cc.data)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -119,8 +119,6 @@ class WcsGeom(Geom):
         Reference pixel coordinate in each image plane.
     axes : list
         Axes for non-spatial dimensions
-    cutout_info : dict
-        Dict with cutout info, if the `WcsGeom` was created by `WcsGeom.cutout()`
     """
 
     _slice_spatial_axes = slice(0, 2)
@@ -128,7 +126,7 @@ class WcsGeom(Geom):
     is_hpx = False
     is_region = False
 
-    def __init__(self, wcs, npix, cdelt=None, crpix=None, axes=None, cutout_info=None):
+    def __init__(self, wcs, npix, cdelt=None, crpix=None, axes=None):
         self._wcs = wcs
         self._frame = wcs_to_celestial_frame(wcs).name
         self._projection = wcs.wcs.ctype[0][5:]
@@ -147,7 +145,6 @@ class WcsGeom(Geom):
             crpix = tuple(1.0 + (np.array(self._npix) - 1.0) / 2.0)
 
         self._crpix = crpix
-        self._cutout_info = cutout_info
 
         # define cached methods
         self.get_coord = lru_cache()(self.get_coord)
@@ -499,20 +496,7 @@ class WcsGeom(Geom):
             npix = (header["NAXIS1"], header["NAXIS2"])
             cdelt = None
 
-        if "PSLICE1" in header:
-            cutout_info = {}
-            cutout_info["parent-slices"] = (
-                str_to_slice(header["PSLICE2"]),
-                str_to_slice(header["PSLICE1"]),
-            )
-            cutout_info["cutout-slices"] = (
-                str_to_slice(header["CSLICE2"]),
-                str_to_slice(header["CSLICE1"]),
-            )
-        else:
-            cutout_info = None
-
-        return cls(wcs, npix, cdelt=cdelt, axes=axes, cutout_info=cutout_info)
+        return cls(wcs, npix, cdelt=cdelt, axes=axes)
 
     def _make_bands_cols(self):
 
@@ -554,17 +538,8 @@ class WcsGeom(Geom):
         shape = "{},{}".format(np.max(self.npix[0]), np.max(self.npix[1]))
         for ax in self.axes:
             shape += f",{ax.nbin}"
+
         header["WCSSHAPE"] = f"({shape})"
-
-        if self.cutout_info is not None:
-            slices_parent = self.cutout_info["parent-slices"]
-            slices_cutout = self.cutout_info["cutout-slices"]
-
-            header["PSLICE1"] = (slice_to_str(slices_parent[1]), "Parent slice")
-            header["PSLICE2"] = (slice_to_str(slices_parent[0]), "Parent slice")
-            header["CSLICE1"] = (slice_to_str(slices_cutout[1]), "Cutout slice")
-            header["CSLICE2"] = (slice_to_str(slices_cutout[0]), "Cutout slice")
-
         return header
 
     def get_idx(self, idx=None, flat=False):
@@ -705,7 +680,7 @@ class WcsGeom(Geom):
         npix = (np.max(self._npix[0]), np.max(self._npix[1]))
         cdelt = (np.max(self._cdelt[0]), np.max(self._cdelt[1]))
         return self.__class__(
-            self._wcs, npix, cdelt=cdelt, cutout_info=self.cutout_info
+            self._wcs, npix, cdelt=cdelt
         )
 
     def to_cube(self, axes):
@@ -717,7 +692,6 @@ class WcsGeom(Geom):
             npix,
             cdelt=cdelt,
             axes=axes,
-            cutout_info=self.cutout_info,
         )
 
     def _pad_spatial(self, pad_width):
@@ -888,15 +862,7 @@ class WcsGeom(Geom):
             size=width[::-1] * u.deg,
             mode=mode,
         )
-
-        cutout_info = {
-            "parent-slices": c2d.slices_original,
-            "cutout-slices": c2d.slices_cutout,
-        }
-
-        return self._init_copy(
-            wcs=c2d.wcs, npix=c2d.shape[::-1], cutout_info=cutout_info
-        )
+        return self._init_copy(wcs=c2d.wcs, npix=c2d.shape[::-1])
 
     def boundary_mask(self, width):
         """Create a mask applying binary erosion with a given width from geom edges

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -454,6 +454,12 @@ class WcsGeom(Geom):
         wcs.wcs.datfix()
         return cls(wcs, npix, cdelt=binsz, axes=axes)
 
+    @property
+    def footprint(self):
+        """Footprint of the geometry"""
+        coords = self.wcs.calc_footprint()
+        return SkyCoord(coords, frame=self.frame, unit="deg")
+
     @classmethod
     def from_header(cls, header, hdu_bands=None, format="gadf"):
         """Create a WCS geometry object from a FITS header.

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -209,13 +209,15 @@ class WcsGeom(Geom):
         """
         return self._frame
 
-    def cutout_slices(self, geom):
-        """Cutout info dict.
+    def cutout_slices(self, geom, mode="partial"):
+        """Compute cutout slices.
 
         Parameters
         ----------
         geom : `WcsGeom`
-            Reference geometry
+            Parent geometry
+        mode : {"trim", "partial", "strict"}
+            Cutout slices mode.
 
         Returns
         -------
@@ -227,7 +229,7 @@ class WcsGeom(Geom):
             large_array_shape=geom.data_shape[-2:],
             small_array_shape=self.data_shape[-2:],
             position=position[::-1],
-            mode="partial"
+            mode=mode
         )
         return {
             "parent-slices": slices[0],

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -761,7 +761,7 @@ class WcsNDMap(WcsMap):
             Cutout map
         """
         geom_cutout = self.geom.cutout(position=position, width=width, mode=mode)
-        cutout_info = geom_cutout.cutout_slices(self.geom)
+        cutout_info = geom_cutout.cutout_slices(self.geom, mode=mode)
 
         slices = cutout_info["parent-slices"]
         parent_slices = Ellipsis, slices[0], slices[1]

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -761,11 +761,12 @@ class WcsNDMap(WcsMap):
             Cutout map
         """
         geom_cutout = self.geom.cutout(position=position, width=width, mode=mode)
+        cutout_info = geom_cutout.cutout_slices(self.geom)
 
-        slices = geom_cutout.cutout_info["parent-slices"]
+        slices = cutout_info["parent-slices"]
         parent_slices = Ellipsis, slices[0], slices[1]
 
-        slices = geom_cutout.cutout_info["cutout-slices"]
+        slices = cutout_info["cutout-slices"]
         cutout_slices = Ellipsis, slices[0], slices[1]
 
         data = np.zeros(shape=geom_cutout.data_shape, dtype=self.data.dtype)
@@ -787,10 +788,12 @@ class WcsNDMap(WcsMap):
         if self.geom == other.geom:
             parent_slices, cutout_slices = None, None
         elif self.geom.is_aligned(other.geom):
-            slices = other.geom.cutout_info["parent-slices"]
+            cutout_slices = other.geom.cutout_slices(self.geom)
+
+            slices = cutout_slices["parent-slices"]
             parent_slices = Ellipsis, slices[0], slices[1]
 
-            slices = other.geom.cutout_info["cutout-slices"]
+            slices = cutout_slices["cutout-slices"]
             cutout_slices = Ellipsis, slices[0], slices[1]
         else:
             raise ValueError(


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes #3368. The fix includes recomputing the slices using `overlap_slices` from `astropy` in a new method called `WcsGeom.cutout_slices()`. This is slightly slower for stacking and cutouts however it should still be fast enough and correct now. This also allows to remove the `cutout_info` completely and simplify the code in this regard.

The PR also adds a unit test, however in general it might be a good idea to improve the testing to cover all cases like partial cutouts etc.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
