### PR TITLE
Implement WcsGeom.from_aligned

### DIFF
--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -152,6 +152,25 @@ def test_wcs_geom_from_aligned(npix, binsz, frame, proj, skydir, axes):
     assert aligned_geom.is_aligned(geom)
 
 
+def test_from_aligned_vs_cutout():
+    skydir = SkyCoord(0.12, -0.34, unit="deg", frame="galactic")
+
+    geom = WcsGeom.create(
+        binsz=0.1, skydir=skydir, proj="TAN", frame="galactic"
+    )
+
+    position = SkyCoord("2.23d", "3.102d", frame="galactic")
+
+    width = ("89 deg", "79 deg")
+    aligned_geom = WcsGeom.from_aligned(
+        geom=geom, skydir=position, width=width
+    )
+
+    geom_cutout = geom.cutout(position=position, width=width)
+
+    assert geom_cutout == aligned_geom
+
+
 def test_wcsgeom_solid_angle():
     # Test using a CAR projection map with an extra axis
     binsz = 1.0 * u.deg

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -365,7 +365,16 @@ def test_geom_repr():
     geom = WcsGeom.create(
         skydir=(0, 0), npix=(10, 4), binsz=50, frame="galactic", proj="AIT"
     )
-    assert geom.__class__.__name__ in repr(geom)
+
+    str_info = repr(geom)
+    assert geom.__class__.__name__ in str_info
+    assert "wcs ref" in str_info
+    assert "center" in str_info
+    assert "projection" in str_info
+    assert "axes" in str_info
+    assert "shape" in str_info
+    assert "ndim" in str_info
+    assert "width" in str_info
 
 
 def test_geom_refpix():
@@ -451,6 +460,7 @@ def test_check_width(width, out):
 
     geom = WcsGeom.create(width=width, binsz=1.0)
     assert tuple(geom.npix) == out
+
 
 def test_check_binsz():
     # float

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -156,12 +156,31 @@ def test_from_aligned_vs_cutout():
     skydir = SkyCoord(0.12, -0.34, unit="deg", frame="galactic")
 
     geom = WcsGeom.create(
-        binsz=0.1, skydir=skydir, proj="TAN", frame="galactic"
+        binsz=0.1, skydir=skydir, proj="AIT", frame="galactic"
     )
 
     position = SkyCoord("2.23d", "3.102d", frame="galactic")
 
     width = ("89 deg", "79 deg")
+    aligned_geom = WcsGeom.from_aligned(
+        geom=geom, skydir=position, width=width
+    )
+
+    geom_cutout = geom.cutout(position=position, width=width)
+
+    assert geom_cutout == aligned_geom
+
+
+def test_from_aligned_vs_cutout_tan():
+    skydir = SkyCoord(0.12, -0.34, unit="deg", frame="galactic")
+
+    geom = WcsGeom.create(
+        binsz=0.1, skydir=skydir, proj="TAN", frame="galactic"
+    )
+
+    position = SkyCoord("165.23d", "74.102d", frame="galactic")
+    width = ("89 deg", "79 deg")
+
     aligned_geom = WcsGeom.from_aligned(
         geom=geom, skydir=position, width=width
     )

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -172,23 +172,23 @@ def test_from_aligned_vs_cutout():
 
 
 def test_from_aligned_vs_cutout_tan():
-    skydir = SkyCoord(0.12, -0.34, unit="deg", frame="galactic")
+    skydir = SkyCoord(0, 0, unit="deg", frame="galactic")
 
     geom = WcsGeom.create(
-        binsz=0.1, skydir=skydir, proj="TAN", frame="galactic"
+        binsz=1, skydir=skydir, proj="TAN", frame="galactic", width=("180d", "90d")
     )
 
-    position = SkyCoord("165.23d", "74.102d", frame="galactic")
-    width = ("89 deg", "79 deg")
+    position = SkyCoord("53.23d", "22.102d", frame="galactic")
+    width = ("17 deg", "15 deg")
+
+    geom_cutout = geom.cutout(position=position, width=width, mode="partial")
 
     aligned_geom = WcsGeom.from_aligned(
         geom=geom, skydir=position, width=width
     )
 
-    geom_cutout = geom.cutout(position=position, width=width)
-
-    assert geom_cutout == aligned_geom
-
+    assert aligned_geom == geom_cutout
+    
 
 def test_wcsgeom_solid_angle():
     # Test using a CAR projection map with an extra axis

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -137,6 +137,21 @@ def test_wcsgeom_contains(npix, binsz, frame, proj, skydir, axes):
         assert_allclose(geom.contains(coords), np.zeros((1,), dtype=bool))
 
 
+@pytest.mark.parametrize(
+    ("npix", "binsz", "frame", "proj", "skydir", "axes"), wcs_test_geoms
+)
+def test_wcs_geom_from_aligned(npix, binsz, frame, proj, skydir, axes):
+    geom = WcsGeom.create(
+        npix=npix, binsz=binsz, skydir=(0, 0), proj=proj, frame=frame, axes=axes
+    )
+
+    aligned_geom = WcsGeom.from_aligned(
+        geom=geom, skydir=(2, 3), width="90 deg"
+    )
+
+    assert aligned_geom.is_aligned(geom)
+
+
 def test_wcsgeom_solid_angle():
     # Test using a CAR projection map with an extra axis
     binsz = 1.0 * u.deg

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -491,7 +491,7 @@ class WcsGeom(Geom):
         return cls.create(
             skydir=tuple(geom.wcs.wcs.crval),
             npix=tuple(npix),
-            refpix=(xref - 1, yref),
+            refpix=(xref - 1, yref),  # TODO: understand why the -1 is required for consistency with .cutout()
             frame=geom.frame,
             binsz=tuple(geom.pixel_scales.deg),
             axes=geom.axes,

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -1048,6 +1048,7 @@ class WcsGeom(Geom):
         axes = ["lon", "lat"] + [_.name for _ in self.axes]
         lon = self.center_skydir.data.lon.deg
         lat = self.center_skydir.data.lat.deg
+        lon_ref, lat_ref = self.wcs.wcs.crval
 
         return (
             f"{self.__class__.__name__}\n\n"
@@ -1058,6 +1059,7 @@ class WcsGeom(Geom):
             f"\tprojection : {self.projection}\n"
             f"\tcenter     : {lon:.1f} deg, {lat:.1f} deg\n"
             f"\twidth      : {self.width[0][0]:.1f} x {self.width[1][0]:.1f}\n"
+            f"\twcs ref    : {lon_ref:.1f} deg, {lat_ref:.1f} deg\n"
         )
 
     def to_odd_npix(self, max_radius=None):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -486,9 +486,9 @@ class WcsGeom(Geom):
         """
         width = _check_width(width) * u.deg
         npix = tuple(np.round(width / geom.pixel_scales).astype(int))
-        xref, yref = skycoord_to_pixel(skydir, geom.wcs, mode='all')
-        xref = np.floor(-xref + npix[0] / 2.) + geom.wcs.wcs.crpix[0]
-        yref = np.floor(-yref + npix[1] / 2.) + geom.wcs.wcs.crpix[1]
+        xref, yref = geom.to_image().coord_to_pix(skydir)
+        xref = int(np.floor(-xref + npix[0] / 2.)) + geom.wcs.wcs.crpix[0]
+        yref = int(np.floor(-yref + npix[1] / 2.)) + geom.wcs.wcs.crpix[1]
         return cls.create(
             skydir=tuple(geom.wcs.wcs.crval),
             npix=npix,


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request implement a `WcsGeom.from_aligned(geom, skydir, width)` method which allows users to create a new aligned geometry for stacking cutouts. This makes it possibly to stack cutouts into and any arbitrary aligned geometry, without needing to know the parent one. I'll add a corresponding `MapDataset.from_aligned()` method. 

This PR also fixes #3384.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
