### PR TITLE
Add containment option to PSFMap.get_psf_kernel()

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -50,6 +50,7 @@ BINSZ_IRF_DEFAULT = 0.2
 
 EVALUATION_MODE = "local"
 USE_NPRED_CACHE = True
+PSF_CONTAINMENT = 0.999
 
 
 def create_map_dataset_geoms(
@@ -2671,11 +2672,15 @@ class MapEvaluator:
 
                 if geom.is_hpx:
                     self.psf = psf.get_psf_kernel(
-                        position=self.model.position, geom=geom.to_wcs_geom()
+                        position=self.model.position,
+                        geom=geom.to_wcs_geom(),
+                        containment=PSF_CONTAINMENT
                     )
                 else:
                     self.psf = psf.get_psf_kernel(
-                        position=self.model.position, geom=geom
+                        position=self.model.position,
+                        geom=geom,
+                        containment=PSF_CONTAINMENT
                     )
 
         if self.evaluation_mode == "local":

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -138,9 +138,9 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
     estimator = ExcessMapEstimator(0.1 * u.deg, selection_optional="all")
     result = estimator.run(simple_dataset)
 
-    assert_allclose(result["excess"].data.sum(), 19733.602)
-    assert_allclose(result["background"].data.sum(), 31818.398)
-    assert_allclose(result["sqrt_ts"].data[0, 10, 10], 4.217129, atol=1e-5)
+    assert_allclose(result["excess"].data.sum(), 19733.602, rtol=1e-3)
+    assert_allclose(result["background"].data.sum(), 31818.398, rtol=1e-3)
+    assert_allclose(result["sqrt_ts"].data[0, 10, 10], 4.217129, rtol=1e-3)
 
 
 def test_significance_map_estimator_map_dataset_on_off_no_correlation(

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -51,7 +51,7 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
     result = estimator.run(fermi_datasets)
 
     assert_allclose(result["norm"], 0.98949, atol=1e-3)
-    assert_allclose(result["ts"], 25083.75408, atol=1e-3)
+    assert_allclose(result["ts"], 25083.75408, rtol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
     assert_allclose(result["norm_errn"], 0.0199, atol=1e-3)
     assert_allclose(result["norm_errp"], 0.0199, atol=1e-3)
@@ -75,7 +75,7 @@ def test_flux_estimator_fermi_with_reoptimization(fermi_datasets):
     result = estimator.run(fermi_datasets)
 
     assert_allclose(result["norm"], 0.989989, atol=1e-3)
-    assert_allclose(result["ts"], 18729.907481, atol=1e-3)
+    assert_allclose(result["ts"], 18729.907481, rtol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
 
 

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -141,14 +141,13 @@ def test_compute_ts_map_psf(fermi_dataset):
     estimator = TSMapEstimator(model=model, kernel_width="1 deg", selection_optional="all")
     result = estimator.run(fermi_dataset)
 
-    assert_allclose(result["ts"].data[0, 29, 29], 833.38, atol=0.1)
+    assert_allclose(result["ts"].data[0, 29, 29], 833.38, rtol=2e-3)
     assert_allclose(result["niter"].data[0, 29, 29], 7)
-    assert_allclose(result["flux"].data[0, 29, 29], 1.34984e-09, rtol=1e-3)
-
-    assert_allclose(result["flux_err"].data[0, 29, 29], 7.93751176e-11, rtol=1e-3)
-    assert_allclose(result["flux_errp"].data[0, 29, 29], 7.948953e-11, rtol=1e-3)
-    assert_allclose(result["flux_errn"].data[0, 29, 29], 7.508168e-11, rtol=1e-3)
-    assert_allclose(result["flux_ul"].data[0, 29, 29], 1.63222157e-10, rtol=1e-3)
+    assert_allclose(result["flux"].data[0, 29, 29], 1.34984e-09, rtol=2e-3)
+    assert_allclose(result["flux_err"].data[0, 29, 29], 7.93751176e-11, rtol=2e-3)
+    assert_allclose(result["flux_errp"].data[0, 29, 29], 7.948953e-11, rtol=2e-3)
+    assert_allclose(result["flux_errn"].data[0, 29, 29], 7.508168e-11, rtol=2e-3)
+    assert_allclose(result["flux_ul"].data[0, 29, 29], 1.63222157e-10, rtol=2e-3)
 
     assert result["flux"].unit == u.Unit("cm-2s-1")
     assert result["flux_err"].unit == u.Unit("cm-2s-1")
@@ -170,7 +169,7 @@ def test_compute_ts_map_energy(fermi_dataset):
 
     result = estimator.run(fermi_dataset)
 
-    assert_allclose(result.ts.data[1, 43, 30], 0.199291, rtol=1e-5)
+    assert_allclose(result.ts.data[1, 43, 30], 0.199291, atol=0.01)
 
     assert_allclose(result["ts"].data[:, 29, 29], [804.86171, 16.988756], rtol=1e-2)
     assert_allclose(

--- a/gammapy/irf/psf/tests/test_psf_map.py
+++ b/gammapy/irf/psf/tests/test_psf_map.py
@@ -141,6 +141,12 @@ def test_psfmap_to_psf_kernel():
     assert_allclose(psfkernel.psf_kernel_map.geom.width, 2.02 * u.deg)
     assert_allclose(psfkernel.psf_kernel_map.data.sum(axis=(1, 2)), 1.0, atol=1e-7)
 
+    psfkernel = psfmap.get_psf_kernel(
+        position=SkyCoord(1, 1, unit="deg"), geom=kern_geom,
+    )
+    assert_allclose(psfkernel.psf_kernel_map.geom.width, 1.14 * u.deg)
+    assert_allclose(psfkernel.psf_kernel_map.data.sum(axis=(1, 2)), 1.0, atol=1e-7)
+
 
 def test_psfmap_to_from_hdulist():
     psfmap = make_test_psfmap(0.15 * u.deg)

--- a/gammapy/irf/psf/tests/test_psf_map.py
+++ b/gammapy/irf/psf/tests/test_psf_map.py
@@ -138,6 +138,7 @@ def test_psfmap_to_psf_kernel():
     psfkernel = psfmap.get_psf_kernel(
         position=SkyCoord(1, 1, unit="deg"), geom=kern_geom, max_radius=1 * u.deg
     )
+    assert_allclose(psfkernel.psf_kernel_map.geom.width, 2.02 * u.deg)
     assert_allclose(psfkernel.psf_kernel_map.data.sum(axis=(1, 2)), 1.0, atol=1e-7)
 
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a containment option to `PSFMap.get_psf_kernel()`. This option allows users to choose the `max_radius` based on the containment fraction of the kernel. The option can be overwritten with `max_radius` option.
For now I set the default to 99.9% containment, with a lower default I saw bigger changes in the test reference values. However we could optimise this in future. I also introduce a `PSF_CONTAINMENT` variable which allows users to modify the value for fitting if needed.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
