### PR TITLE
Change `energy_range` to `energy_bounds` in `SpectralModel.plot()`

### DIFF
--- a/docs/tutorials/analysis/1D/sed_fitting.ipynb
+++ b/docs/tutorials/analysis/1D/sed_fitting.ipynb
@@ -236,8 +236,8 @@
    "outputs": [],
    "source": [
     "ax = flux_points.plot(energy_power=2)\n",
-    "pwl.plot(energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2)\n",
-    "pwl.plot_error(energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2)\n",
+    "pwl.plot(energy_bounds=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2)\n",
+    "pwl.plot_error(energy_bounds=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2)\n",
     "ax.set_ylim(1e-13, 1e-11);"
    ]
   },
@@ -301,8 +301,8 @@
    "outputs": [],
    "source": [
     "ax = flux_points.plot(energy_power=2)\n",
-    "ecpl.plot(energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2)\n",
-    "ecpl.plot_error(energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2)\n",
+    "ecpl.plot(energy_bounds=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2)\n",
+    "ecpl.plot_error(energy_bounds=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2)\n",
     "ax.set_ylim(1e-13, 1e-11)"
    ]
   },
@@ -345,9 +345,9 @@
    "outputs": [],
    "source": [
     "ax = flux_points.plot(energy_power=2)\n",
-    "log_parabola.plot(energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2)\n",
+    "log_parabola.plot(energy_bounds=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2)\n",
     "log_parabola.plot_error(\n",
-    "    energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2\n",
+    "    energy_bounds=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2\n",
     ")\n",
     "ax.set_ylim(1e-13, 1e-11);"
    ]

--- a/docs/tutorials/analysis/1D/spectral_analysis.ipynb
+++ b/docs/tutorials/analysis/1D/spectral_analysis.ipynb
@@ -662,7 +662,7 @@
    "outputs": [],
    "source": [
     "plot_kwargs = {\n",
-    "    \"energy_range\": [0.1, 30] * u.TeV,\n",
+    "    \"energy_bounds\": [0.1, 30] * u.TeV,\n",
     "    \"energy_power\": 2,\n",
     "    \"flux_unit\": \"erg-1 cm-2 s-1\",\n",
     "}\n",

--- a/docs/tutorials/analysis/3D/analysis_3d.ipynb
+++ b/docs/tutorials/analysis/3D/analysis_3d.ipynb
@@ -674,11 +674,11 @@
    "source": [
     "def plot_spectrum(model, result, label, color):\n",
     "    spec = model.spectral_model\n",
-    "    energy_range = [0.3, 10] * u.TeV\n",
+    "    energy_bounds = [0.3, 10] * u.TeV\n",
     "    spec.plot(\n",
-    "        energy_range=energy_range, energy_power=2, label=label, color=color\n",
+    "        energy_bounds=energy_bounds, energy_power=2, label=label, color=color\n",
     "    )\n",
-    "    spec.plot_error(energy_range=energy_range, energy_power=2, color=color)"
+    "    spec.plot_error(energy_bounds=energy_bounds, energy_power=2, color=color)"
    ]
   },
   {

--- a/docs/tutorials/analysis/3D/analysis_mwl.ipynb
+++ b/docs/tutorials/analysis/3D/analysis_mwl.ipynb
@@ -340,10 +340,10 @@
    "outputs": [],
    "source": [
     "# display spectrum and flux points\n",
-    "energy_range = [0.01, 120] * u.TeV\n",
+    "energy_bounds = [0.01, 120] * u.TeV\n",
     "plt.figure(figsize=(8, 6))\n",
-    "ax = crab_spec.plot(energy_range=energy_range, energy_power=2, label=\"Model\")\n",
-    "crab_spec.plot_error(ax=ax, energy_range=energy_range, energy_power=2)\n",
+    "ax = crab_spec.plot(energy_bounds=energy_bounds, energy_power=2, label=\"Model\")\n",
+    "crab_spec.plot_error(ax=ax, energy_bounds=energy_bounds, energy_power=2)\n",
     "flux_points_fermi.plot(ax=ax, energy_power=2, label=\"Fermi-LAT\")\n",
     "flux_points_hess.plot(ax=ax, energy_power=2, label=\"HESS\")\n",
     "flux_points_hawc.plot(ax=ax, energy_power=2, label=\"HAWC\")\n",

--- a/docs/tutorials/analysis/3D/mcmc_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/mcmc_sampling.ipynb
@@ -359,7 +359,7 @@
     "        spectral_model = dataset.models[\"source\"].spectral_model\n",
     "\n",
     "        spectral_model.plot(\n",
-    "            energy_range=(emin, emax),\n",
+    "            energy_bounds=(emin, emax),\n",
     "            ax=ax,\n",
     "            energy_power=2,\n",
     "            alpha=0.02,\n",
@@ -368,7 +368,7 @@
     "\n",
     "\n",
     "sky_model_simu.spectral_model.plot(\n",
-    "    energy_range=(emin, emax), energy_power=2, ax=ax, color=\"red\"\n",
+    "    energy_bounds=(emin, emax), energy_power=2, ax=ax, color=\"red\"\n",
     ");"
    ]
   },

--- a/docs/tutorials/analysis/time/pulsar_analysis.ipynb
+++ b/docs/tutorials/analysis/time/pulsar_analysis.ipynb
@@ -508,7 +508,7 @@
     "\n",
     "spec_model_true.plot(\n",
     "    ax=ax_spectrum,\n",
-    "    energy_range=(emin_fit, emax_fit),\n",
+    "    energy_bounds=(emin_fit, emax_fit),\n",
     "    label=\"Reference model\",\n",
     "    c=\"black\",\n",
     "    linestyle=\"dashed\",\n",

--- a/docs/tutorials/api/astro_dark_matter.ipynb
+++ b/docs/tutorials/api/astro_dark_matter.ipynb
@@ -202,7 +202,7 @@
     "    for channel in [\"tau\", \"mu\", \"b\", \"Z\"]:\n",
     "        fluxes.channel = channel\n",
     "        fluxes.table_model.plot(\n",
-    "            energy_range=[mDM / 100, mDM],\n",
+    "            energy_bounds=[mDM / 100, mDM],\n",
     "            ax=ax,\n",
     "            label=channel,\n",
     "            flux_unit=\"1/GeV\",\n",

--- a/docs/tutorials/api/catalog.ipynb
+++ b/docs/tutorials/api/catalog.ipynb
@@ -479,10 +479,10 @@
    },
    "outputs": [],
    "source": [
-    "energy_range = (100 * u.MeV, 100 * u.GeV)\n",
+    "energy_bounds = (100 * u.MeV, 100 * u.GeV)\n",
     "opts = dict(energy_power=2, flux_unit=\"erg-1 cm-2 s-1\")\n",
-    "model.spectral_model.plot(energy_range, **opts);\n",
-    "model.spectral_model.plot_error(energy_range, **opts);"
+    "model.spectral_model.plot(energy_bounds, **opts);\n",
+    "model.spectral_model.plot_error(energy_bounds, **opts);"
    ]
   },
   {

--- a/docs/tutorials/api/fitting.ipynb
+++ b/docs/tutorials/api/fitting.ipynb
@@ -324,9 +324,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "energy_range = [1, 10] * u.TeV\n",
-    "crab_spectrum.plot(energy_range=energy_range, energy_power=2)\n",
-    "ax = crab_spectrum.plot_error(energy_range=energy_range, energy_power=2)"
+    "energy_bounds = [1, 10] * u.TeV\n",
+    "crab_spectrum.plot(energy_bounds=energy_bounds, energy_power=2)\n",
+    "ax = crab_spectrum.plot_error(energy_bounds=energy_bounds, energy_power=2)"
    ]
   },
   {
@@ -522,9 +522,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    ""
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",

--- a/docs/tutorials/api/models.ipynb
+++ b/docs/tutorials/api/models.ipynb
@@ -229,7 +229,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pwl.plot(energy_range=[1, 100] * u.TeV)"
+    "pwl.plot(energy_bounds=[1, 100] * u.TeV)"
    ]
   },
   {
@@ -329,10 +329,10 @@
     "energy = [0.3, 1, 3, 10, 30] * u.TeV\n",
     "values = [40, 30, 20, 10, 1] * u.Unit(\"TeV-1 s-1 cm-2\")\n",
     "template = TemplateSpectralModel(energy, values)\n",
-    "template.plot(energy_range=[0.2, 50] * u.TeV, label=\"template model\")\n",
+    "template.plot(energy_bounds=[0.2, 50] * u.TeV, label=\"template model\")\n",
     "normed_template = template * pwl_norm\n",
     "normed_template.plot(\n",
-    "    energy_range=[0.2, 50] * u.TeV, label=\"normed_template model\"\n",
+    "    energy_bounds=[0.2, 50] * u.TeV, label=\"normed_template model\"\n",
     ")\n",
     "plt.legend();"
    ]
@@ -771,7 +771,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.spectral_model.plot(energy_range=[1, 10] * u.TeV);"
+    "model.spectral_model.plot(energy_bounds=[1, 10] * u.TeV);"
    ]
   },
   {
@@ -1125,7 +1125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_custom_model.plot(energy_range=[1, 10] * u.TeV)"
+    "my_custom_model.plot(energy_bounds=[1, 10] * u.TeV)"
    ]
   },
   {

--- a/docs/tutorials/data/fermi_lat.ipynb
+++ b/docs/tutorials/data/fermi_lat.ipynb
@@ -424,8 +424,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "energy_range = [50, 2000] * u.GeV\n",
-    "diffuse_iso.spectral_model.plot(energy_range, flux_unit=\"1 / (cm2 MeV s)\");"
+    "energy_bounds = [50, 2000] * u.GeV\n",
+    "diffuse_iso.spectral_model.plot(energy_bounds, flux_unit=\"1 / (cm2 MeV s)\");"
    ]
   },
   {

--- a/docs/tutorials/starting/analysis_2.ipynb
+++ b/docs/tutorials/starting/analysis_2.ipynb
@@ -525,9 +525,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "energy_range = [1, 10] * u.TeV\n",
-    "spec.plot(energy_range=energy_range, energy_power=2)\n",
-    "ax = spec.plot_error(energy_range=energy_range, energy_power=2)"
+    "energy_bounds = [1, 10] * u.TeV\n",
+    "spec.plot(energy_bounds=energy_bounds, energy_power=2)\n",
+    "ax = spec.plot_error(energy_bounds=energy_bounds, energy_power=2)"
    ]
   },
   {
@@ -567,7 +567,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = spec.plot_error(energy_range=energy_range, energy_power=2)\n",
+    "ax = spec.plot_error(energy_bounds=energy_bounds, energy_power=2)\n",
     "flux_points.plot(ax=ax, energy_power=2)"
    ]
   },

--- a/docs/tutorials/starting/overview.ipynb
+++ b/docs/tutorials/starting/overview.ipynb
@@ -598,7 +598,7 @@
    "outputs": [],
    "source": [
     "ax_crab_3fhl = crab_3fhl_spec.plot(\n",
-    "    energy_range=[10, 2000] * u.GeV, energy_power=0\n",
+    "    energy_bounds=[10, 2000] * u.GeV, energy_power=0\n",
     ")"
    ]
   },
@@ -719,7 +719,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = crab_3fhl_spec.plot(energy_range=[10, 2000] * u.GeV, energy_power=2)\n",
+    "ax = crab_3fhl_spec.plot(energy_bounds=[10, 2000] * u.GeV, energy_power=2)\n",
     "crab_3fhl.flux_points.plot(ax=ax, sed_type=\"dnde\", energy_power=2);"
    ]
   },

--- a/examples/models/spectral/plot_absorbed.py
+++ b/examples/models/spectral/plot_absorbed.py
@@ -42,14 +42,14 @@ franceschini = EBLAbsorptionNormSpectralModel.read_builtin(
 finke = EBLAbsorptionNormSpectralModel.read_builtin("finke", redshift=redshift)
 
 plt.figure()
-energy_range = [0.08, 3] * u.TeV
-opts = dict(energy_range=energy_range, energy_unit="TeV", flux_unit="")
+energy_bounds = [0.08, 3] * u.TeV
+opts = dict(energy_bounds=energy_bounds, energy_unit="TeV", flux_unit="")
 franceschini.plot(label="Franceschini 2008", **opts)
 finke.plot(label="Finke 2010", **opts)
 dominguez.plot(label="Dominguez 2011", **opts)
 
 plt.ylabel(r"Absorption coefficient [$\exp{(-\tau(E))}$]")
-plt.xlim(energy_range.value)
+plt.xlim(energy_bounds.value)
 plt.ylim(1e-4, 2)
 plt.title(f"EBL models (z={redshift})")
 plt.grid(which="both")
@@ -68,9 +68,9 @@ absorption = EBLAbsorptionNormSpectralModel.read_builtin("dominguez", redshift=r
 
 model = pwl * absorption
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 plt.figure()
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 plt.ylim(1e-24, 1e-8)
 

--- a/examples/models/spectral/plot_broken_powerlaw.py
+++ b/examples/models/spectral/plot_broken_powerlaw.py
@@ -24,11 +24,11 @@ from astropy import units as u
 import matplotlib.pyplot as plt
 from gammapy.modeling.models import BrokenPowerLawSpectralModel, Models, SkyModel
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = BrokenPowerLawSpectralModel(
     index1=1.5, index2=2.5, amplitude="1e-12 TeV-1 cm-2 s-1", ebreak="1 TeV",
 )
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%

--- a/examples/models/spectral/plot_compound.py
+++ b/examples/models/spectral/plot_compound.py
@@ -23,7 +23,7 @@ from gammapy.modeling.models import (
     SkyModel,
 )
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 pwl = PowerLawSpectralModel(
     index=2.0, amplitude="1e-12 cm-2 s-1 TeV-1", reference="1 TeV"
 )
@@ -31,7 +31,7 @@ lp = LogParabolaSpectralModel(
     amplitude="1e-12 cm-2 s-1 TeV-1", reference="10 TeV", alpha=2.0, beta=1.0
 )
 model = CompoundSpectralModel(pwl, lp, operator.add)
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%

--- a/examples/models/spectral/plot_constant_spectral.py
+++ b/examples/models/spectral/plot_constant_spectral.py
@@ -18,9 +18,9 @@ from astropy import units as u
 import matplotlib.pyplot as plt
 from gammapy.modeling.models import ConstantSpectralModel, Models, SkyModel
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = ConstantSpectralModel(const="1 / (cm2 s TeV)")
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%

--- a/examples/models/spectral/plot_exp_cutoff_powerlaw.py
+++ b/examples/models/spectral/plot_exp_cutoff_powerlaw.py
@@ -22,14 +22,14 @@ from astropy import units as u
 import matplotlib.pyplot as plt
 from gammapy.modeling.models import ExpCutoffPowerLawSpectralModel, Models, SkyModel
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = ExpCutoffPowerLawSpectralModel(
     amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
     index=2,
     lambda_=0.1 * u.Unit("TeV-1"),
     reference=1 * u.TeV,
 )
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%

--- a/examples/models/spectral/plot_exp_cutoff_powerlaw_3fgl.py
+++ b/examples/models/spectral/plot_exp_cutoff_powerlaw_3fgl.py
@@ -22,14 +22,14 @@ from astropy import units as u
 import matplotlib.pyplot as plt
 from gammapy.modeling.models import ExpCutoffPowerLaw3FGLSpectralModel, Models, SkyModel
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = ExpCutoffPowerLaw3FGLSpectralModel(
     index=2.3 * u.Unit(""),
     amplitude=4 / u.cm ** 2 / u.s / u.TeV,
     reference=1 * u.TeV,
     ecut=10 * u.TeV,
 )
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%

--- a/examples/models/spectral/plot_gauss_spectral.py
+++ b/examples/models/spectral/plot_gauss_spectral.py
@@ -22,9 +22,9 @@ from astropy import units as u
 import matplotlib.pyplot as plt
 from gammapy.modeling.models import GaussianSpectralModel, Models, SkyModel
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = GaussianSpectralModel(norm="1e-2 cm-2 s-1", mean=2 * u.TeV, sigma=0.2 * u.TeV)
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 plt.ylim(1e-24, 1e-1)
 

--- a/examples/models/spectral/plot_logparabola.py
+++ b/examples/models/spectral/plot_logparabola.py
@@ -33,11 +33,11 @@ from astropy import units as u
 import matplotlib.pyplot as plt
 from gammapy.modeling.models import LogParabolaSpectralModel, Models, SkyModel
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = LogParabolaSpectralModel(
     alpha=2.3, amplitude="1e-12 cm-2 s-1 TeV-1", reference=1 * u.TeV, beta=0.5,
 )
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%

--- a/examples/models/spectral/plot_naima.py
+++ b/examples/models/spectral/plot_naima.py
@@ -45,7 +45,7 @@ radiative_model = naima.radiative.InverseCompton(
 model = NaimaSpectralModel(radiative_model, distance=1.5 * u.kpc)
 
 opts = {
-    "energy_range": [10 * u.GeV, 80 * u.TeV],
+    "energy_bounds": [10 * u.GeV, 80 * u.TeV],
     "energy_power": 2,
     "flux_unit": "erg-1 cm-2 s-1",
 }

--- a/examples/models/spectral/plot_piecewise_norm_spectral.py
+++ b/examples/models/spectral/plot_piecewise_norm_spectral.py
@@ -22,11 +22,11 @@ from gammapy.modeling.models import (
     SkyModel,
 )
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = PiecewiseNormSpectralModel(
     energy=[0.1, 1, 3, 10, 30, 100] * u.TeV, norms=[1, 3, 8, 10, 8, 2],
 )
-model.plot(energy_range, flux_unit="")
+model.plot(energy_bounds, flux_unit="")
 plt.grid(which="both")
 
 

--- a/examples/models/spectral/plot_powerlaw.py
+++ b/examples/models/spectral/plot_powerlaw.py
@@ -22,11 +22,11 @@ from astropy import units as u
 import matplotlib.pyplot as plt
 from gammapy.modeling.models import Models, PowerLawSpectralModel, SkyModel
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = PowerLawSpectralModel(
     index=2, amplitude="1e-12 TeV-1 cm-2 s-1", reference=1 * u.TeV,
 )
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%

--- a/examples/models/spectral/plot_powerlaw2.py
+++ b/examples/models/spectral/plot_powerlaw2.py
@@ -24,11 +24,11 @@ from astropy import units as u
 import matplotlib.pyplot as plt
 from gammapy.modeling.models import Models, PowerLaw2SpectralModel, SkyModel
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = PowerLaw2SpectralModel(
     amplitude=u.Quantity(1e-12, "cm-2 s-1"), index=2.3, emin=1 * u.TeV, emax=10 * u.TeV,
 )
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%

--- a/examples/models/spectral/plot_smooth_broken_powerlaw.py
+++ b/examples/models/spectral/plot_smooth_broken_powerlaw.py
@@ -21,7 +21,7 @@ from astropy import units as u
 import matplotlib.pyplot as plt
 from gammapy.modeling.models import Models, SkyModel, SmoothBrokenPowerLawSpectralModel
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = SmoothBrokenPowerLawSpectralModel(
     index1=1.5,
     index2=2.5,
@@ -30,7 +30,7 @@ model = SmoothBrokenPowerLawSpectralModel(
     reference="1 TeV",
     beta=1,
 )
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%

--- a/examples/models/spectral/plot_super_exp_cutoff_powerlaw_3fgl.py
+++ b/examples/models/spectral/plot_super_exp_cutoff_powerlaw_3fgl.py
@@ -28,7 +28,7 @@ from gammapy.modeling.models import (
     SuperExpCutoffPowerLaw3FGLSpectralModel,
 )
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = SuperExpCutoffPowerLaw3FGLSpectralModel(
     index_1=1,
     index_2=2,
@@ -36,7 +36,7 @@ model = SuperExpCutoffPowerLaw3FGLSpectralModel(
     reference="1 TeV",
     ecut="10 TeV",
 )
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 plt.ylim(1e-24, 1e-10)
 

--- a/examples/models/spectral/plot_super_exp_cutoff_powerlaw_4fgl.py
+++ b/examples/models/spectral/plot_super_exp_cutoff_powerlaw_4fgl.py
@@ -30,7 +30,7 @@ from gammapy.modeling.models import (
     SuperExpCutoffPowerLaw4FGLSpectralModel,
 )
 
-energy_range = [0.1, 100] * u.TeV
+energy_bounds = [0.1, 100] * u.TeV
 model = SuperExpCutoffPowerLaw4FGLSpectralModel(
     index_1=1,
     index_2=2,
@@ -38,7 +38,7 @@ model = SuperExpCutoffPowerLaw4FGLSpectralModel(
     reference="1 TeV",
     expfactor=1e-2,
 )
-model.plot(energy_range)
+model.plot(energy_bounds)
 plt.grid(which="both")
 plt.ylim(1e-24, 1e-10)
 

--- a/examples/models/spectral/plot_template_spectral.py
+++ b/examples/models/spectral/plot_template_spectral.py
@@ -36,11 +36,11 @@ from gammapy.modeling.models import (
     TemplateSpectralModel,
 )
 
-energy_range = [0.1, 1] * u.TeV
+energy_bounds = [0.1, 1] * u.TeV
 energy = np.array([1e6, 3e6, 1e7, 3e7]) * u.MeV
 values = np.array([4.4e-38, 2.0e-38, 8.8e-39, 3.9e-39]) * u.Unit("MeV-1 s-1 cm-2")
 template = TemplateSpectralModel(energy=energy, values=values)
-template.plot(energy_range)
+template.plot(energy_bounds)
 plt.grid(which="both")
 
 

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -291,7 +291,7 @@ class FluxPointsDataset(Dataset):
         return ax_spectrum, ax_residuals
 
     @property
-    def _energy_range(self):
+    def _energy_bounds(self):
         try:
             return u.Quantity([self.data.energy_min.min(), self.data.energy_max.max()])
         except KeyError:
@@ -356,7 +356,7 @@ class FluxPointsDataset(Dataset):
         # format axes
         ax.set_xlabel(f"Energy [{self._energy_unit}]")
         ax.set_xscale("log")
-        ax.set_xlim(self._energy_range.to_value(self._energy_unit))
+        ax.set_xlim(self._energy_bounds.to_value(self._energy_unit))
         label = self._residuals_labels[method]
         ax.set_ylabel(f"Residuals ({label}){f' [{unit}]' if unit else ''}")
         ymin = 1.05 * np.nanmin(residuals.value - yerr[0])
@@ -399,7 +399,7 @@ class FluxPointsDataset(Dataset):
 
         plot_kwargs = kwargs.copy()
         plot_kwargs.update(kwargs_model)
-        plot_kwargs.setdefault("energy_range", self._energy_range)
+        plot_kwargs.setdefault("energy_bounds", self._energy_bounds)
         plot_kwargs.setdefault("label", "Best fit model")
         plot_kwargs.setdefault("zorder", 10)
 
@@ -416,5 +416,5 @@ class FluxPointsDataset(Dataset):
                     model.spectral_model.plot_error(ax=ax, **plot_kwargs)
 
         # format axes
-        ax.set_xlim(self._energy_range.to_value(self._energy_unit))
+        ax.set_xlim(self._energy_bounds.to_value(self._energy_unit))
         return ax

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -297,7 +297,7 @@ class SpectralModel(Model):
         ax : `~matplotlib.axes.Axes`, optional
             Axis
         energy_bounds : `~astropy.units.Quantity`
-            Plot energy bounds
+            Plot energy bounds passed to MapAxis.from_energy_bounds
         energy_unit : str, `~astropy.units.Unit`, optional
             Unit of the energy axis
         flux_unit : str, `~astropy.units.Unit`, optional
@@ -379,7 +379,7 @@ class SpectralModel(Model):
         ax : `~matplotlib.axes.Axes`, optional
             Axis
         energy_bounds : `~astropy.units.Quantity`
-            Plot energy bounds
+            Plot energy bounds passed to MapAxis.from_energy_bounds
         energy_unit : str, `~astropy.units.Unit`, optional
             Unit of the energy axis
         flux_unit : str, `~astropy.units.Unit`, optional

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -269,7 +269,7 @@ class SpectralModel(Model):
 
     def plot(
         self,
-        energy_range,
+        energy_bounds,
         ax=None,
         energy_unit="TeV",
         flux_unit="cm-2 s-1 TeV-1",
@@ -289,15 +289,15 @@ class SpectralModel(Model):
             from astropy import units as u
 
             pwl = ExpCutoffPowerLawSpectralModel()
-            ax = pwl.plot(energy_range=(0.1, 100) * u.TeV)
+            ax = pwl.plot(energy_bounds=(0.1, 100) * u.TeV)
             ax.set_yscale('linear')
 
         Parameters
         ----------
         ax : `~matplotlib.axes.Axes`, optional
             Axis
-        energy_range : `~astropy.units.Quantity`
-            Plot range
+        energy_bounds : `~astropy.units.Quantity`
+            Plot energy bounds
         energy_unit : str, `~astropy.units.Unit`, optional
             Unit of the energy axis
         flux_unit : str, `~astropy.units.Unit`, optional
@@ -318,7 +318,7 @@ class SpectralModel(Model):
 
         ax = plt.gca() if ax is None else ax
 
-        energy_min, energy_max = energy_range
+        energy_min, energy_max = energy_bounds
         energy = MapAxis.from_energy_bounds(
             energy_min, energy_max, n_points, energy_unit
         ).edges
@@ -349,7 +349,7 @@ class SpectralModel(Model):
 
     def plot_error(
         self,
-        energy_range,
+        energy_bounds,
         ax=None,
         energy_unit="TeV",
         flux_unit="cm-2 s-1 TeV-1",
@@ -378,8 +378,8 @@ class SpectralModel(Model):
         ----------
         ax : `~matplotlib.axes.Axes`, optional
             Axis
-        energy_range : `~astropy.units.Quantity`
-            Plot range
+        energy_bounds : `~astropy.units.Quantity`
+            Plot energy bounds
         energy_unit : str, `~astropy.units.Unit`, optional
             Unit of the energy axis
         flux_unit : str, `~astropy.units.Unit`, optional
@@ -406,7 +406,7 @@ class SpectralModel(Model):
         kwargs.setdefault("alpha", 0.2)
         kwargs.setdefault("linewidth", 0)
 
-        energy_min, energy_max = energy_range
+        energy_min, energy_max = energy_bounds
         energy = MapAxis.from_energy_bounds(
             energy_min, energy_max, n_points, energy_unit
         ).edges
@@ -433,7 +433,7 @@ class SpectralModel(Model):
         y_lo = self._plot_scale_flux(energy, flux - flux_err, energy_power)
         y_hi = self._plot_scale_flux(energy, flux + flux_err, energy_power)
 
-        where = (energy >= energy_range[0]) & (energy <= energy_range[1])
+        where = (energy >= energy_bounds[0]) & (energy <= energy_bounds[1])
         ax.fill_between(energy.value, y_lo.value, y_hi.value, where=where, **kwargs)
 
         self._plot_format_ax(ax, energy, y_lo, energy_power, sed_type)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -297,7 +297,7 @@ class SpectralModel(Model):
         ax : `~matplotlib.axes.Axes`, optional
             Axis
         energy_bounds : `~astropy.units.Quantity`
-            Plot energy bounds passed to MapAxis.from_energy_bounds
+            Plot energy bounds
         energy_unit : str, `~astropy.units.Unit`, optional
             Unit of the energy axis
         flux_unit : str, `~astropy.units.Unit`, optional
@@ -379,7 +379,7 @@ class SpectralModel(Model):
         ax : `~matplotlib.axes.Axes`, optional
             Axis
         energy_bounds : `~astropy.units.Quantity`
-            Plot energy bounds passed to MapAxis.from_energy_bounds
+            Plot energy bounds
         energy_unit : str, `~astropy.units.Unit`, optional
             Unit of the energy axis
         flux_unit : str, `~astropy.units.Unit`, optional

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -507,7 +507,7 @@ def test_table_model_from_file():
         filename=filename, param=0.3
     )
     with mpl_plot_check():
-        absorption_z03.plot(energy_range=(0.03, 10), energy_unit=u.TeV, flux_unit="")
+        absorption_z03.plot(energy_bounds=(0.03, 10), energy_unit=u.TeV, flux_unit="")
 
 
 @requires_data()


### PR DESCRIPTION
This PR changes the definition name of the `energy_range` parameter in `SpectralModel.plot()` and `SpectralModel.plot_error()`. This is replaced by `energy_bounds`. 
It solves an issue raised in #3078.