### PR TITLE
Add sparse option to get_coord() methods

### DIFF
--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -953,8 +953,9 @@ def get_map_dataset_onoff(images, **kwargs):
     gti = GTI.create([0 * u.s], [1 * u.h], reference_time="2010-01-01T00:00:00")
     energy_axis = mask_geom.axes["energy"]
     energy_axis_true = energy_axis.copy(name="energy_true")
+
     psf = PSFMap.from_gauss(
-        energy_axis_true=energy_axis_true, sigma=0.2 * u.deg, geom=mask_geom
+        energy_axis_true=energy_axis_true, sigma=0.2 * u.deg, geom=mask_geom.to_image()
     )
 
     edisp = EDispKernelMap.from_diagonal_response(

--- a/gammapy/irf/edisp_map.py
+++ b/gammapy/irf/edisp_map.py
@@ -158,7 +158,6 @@ class EDispMap(IRFMap):
 
         coords = geom.get_coord(sparse=True, mode="edges", axis_name="energy")
 
-        print(coords)
         migra = coords["energy"] / coords["energy_true"]
 
         coords = {

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -242,10 +242,13 @@ class EffectiveAreaTable2D(IRF):
 
         g1, g2, g3 = pars[instrument]
 
-        energy = energy_axis_true.center.to_value("MeV")
-        data = g1 * energy ** (-g2) * np.exp(-g3 / energy)
+        offset_axis = MapAxis.from_edges([0., 5.] * u.deg, name="offset")
+        axes = MapAxes([energy_axis_true, offset_axis])
+        coords = axes.get_coord()
+
+        energy, offset = coords["energy_true"].to_value("MeV"), coords["offset"]
+        data = np.ones_like(offset.value) * g1 * energy ** (-g2) * np.exp(-g3 / energy)
 
         # TODO: fake offset dependence?
-        offset_axis = MapAxis.from_edges([0., 5.] * u.deg, name="offset")
         meta = {"TELESCOP": instrument}
-        return cls(axes=[energy_axis_true, offset_axis], data=data[:, np.newaxis], unit="cm2", meta=meta)
+        return cls(axes=axes, data=data, unit="cm2", meta=meta)

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -133,20 +133,23 @@ class EnergyDispersion2D(IRF):
                 energy_true, name="energy_true",
             )
 
+        axes = MapAxes([energy_axis_true, energy_axis])
+        coords = axes.get_coord(mode="edges", axis_name="energy")
+
         # migration value of energy bounds
-        migra = energy_axis.edges / energy_axis_true.center[:, np.newaxis]
+        migra = coords["energy"] / coords["energy_true"]
 
         values = self.integral(
             axis_name="migra",
             offset=offset,
-            energy_true=energy_axis_true.center[:, np.newaxis],
+            energy_true=coords["energy_true"],
             migra=migra,
         )
 
         data = np.diff(values)
 
         return EDispKernel(
-            axes=[energy_axis_true, energy_axis],
+            axes=axes,
             data=data.to_value(""),
         )
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -90,7 +90,7 @@ class EnergyDispersion2D(IRF):
         pdf = pdf / (migra_max - migra_min)
 
         # no offset dependence
-        data = pdf * np.ones(coords["offset"].shape) * np.ones(coords["energy_true"].shape)
+        data = pdf * np.ones(axes.shape)
         data[data < pdf_threshold] = 0
 
         return cls(

--- a/gammapy/irf/psf/kernel.py
+++ b/gammapy/irf/psf/kernel.py
@@ -183,7 +183,9 @@ class PSFKernel:
 
         if exposure is None:
             exposure = np.ones(map.geom.axes[0].center.shape)
+
         exposure = u.Quantity(exposure)
+
         if exposure.shape != map.geom.axes[0].center.shape:
             raise ValueError("Incorrect exposure_array shape")
 

--- a/gammapy/irf/psf/psf_map.py
+++ b/gammapy/irf/psf/psf_map.py
@@ -246,14 +246,11 @@ class PSFMap(IRFMap):
             max_radius = np.max(radii)
 
         geom = geom.to_odd_npix(max_radius=max_radius)
-
         geom_upsampled = geom.upsample(factor=factor)
-        rad = geom_upsampled.separation(geom.center_skydir)
+        coords = geom_upsampled.get_coord(sparse=True)
+        rad = coords.skycoord.separation(geom.center_skydir)
 
-        energy_axis = geom.axes["energy_true"]
-
-        energy = energy_axis.center[:, np.newaxis, np.newaxis]
-        coords = {"energy_true": energy, "rad": rad, "skycoord": position}
+        coords = {"energy_true": coords["energy_true"], "rad": rad, "skycoord": position}
 
         data = self.psf_map.interp_by_coord(coords=coords, method="linear",)
 

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -116,7 +116,7 @@ class TestEnergyDispersion2D:
         migra_axis = MapAxis.from_bounds(0, 4, nbin=1000, node_type="edges", name="migra")
         offset_axis = MapAxis.from_bounds(0, 2.5, nbin=5, unit="deg", name="offset")
 
-        energy_true = energy_axis_true.edges[:-1]
+        energy_true = energy_axis_true.edges[:-1].reshape((-1, 1, 1))
         sigma = 0.15 / (energy_true / (1 * u.TeV)).value ** 0.3
         bias = 1e-3 * (energy_true - 1 * u.TeV).value
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -285,21 +285,19 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None, use_region_center=T
             "migra": migra[:, np.newaxis]
         })
     else:
-        coords = geom.get_coord(sparse=True)
+        coords, weights = geom.get_coord(sparse=True), None
 
     offset = coords.skycoord.separation(pointing)
 
     # Compute EDisp values
-    edisp_values = edisp.evaluate(
+    data = edisp.evaluate(
         offset=offset,
         energy_true=coords["energy_true"],
         migra=coords["migra"],
     ).to_value("")
 
     if not use_region_center:
-        data = np.average(edisp_values, axis=2, weights=weights)
-    else:
-        data = edisp_values
+        data = np.average(data, axis=2, weights=weights)
 
     # Create Map and fill relevant entries
     edisp_map = Map.from_geom(geom, data=data, unit="")

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -188,12 +188,10 @@ def make_map_background_irf(pointing, ontime, bkg, geom, oversampling=None, use_
 
     bkg_de = bkg.integrate_log_log(**coords, axis_name="energy")
 
-    values = (bkg_de * d_omega * ontime).to_value("")
+    data = (bkg_de * d_omega * ontime).to_value("")
 
     if not use_region_center:
-        data = np.sum(weights * values, axis=2)
-    else:
-        data = values
+        data = np.sum(weights * data, axis=2)
 
     bkg_map = Map.from_geom(geom, data=data)
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -57,14 +57,15 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, use_region_cen
         offset=offset, energy_true=coords["energy_true"]
     )
 
-    exposure = (exposure * livetime).to("m2 s")
-    meta = {"livetime": livetime,
-            "is_pointlike": aeff.is_pointlike}
+    data = (exposure * livetime).to("m2 s")
+    meta = {
+        "livetime": livetime,
+        "is_pointlike": aeff.is_pointlike
+    }
 
     if not use_region_center:
         data = np.average(data, axis=1, weights=weights)
 
-    meta = {"livetime": livetime}
     return Map.from_geom(
         geom=geom, data=data.value, unit=data.unit, meta=meta
     )

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -38,7 +38,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, use_region_cen
     use_region_center: bool
         If geom is a RegionGeom, whether to just
         consider the values at the region center
-        or the insted the average over the whole region
+        or the instead the average over the whole region
 
     Returns
     -------
@@ -46,11 +46,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, use_region_cen
         Exposure map
     """
     if not use_region_center:
-        region_coord, weights = geom.get_wcs_coord_and_weights()
-        coords = MapCoord.create({
-            "skycoord": region_coord.skycoord,
-            "energy_true": geom.axes["energy_true"].center[:, np.newaxis]
-        })
+        coords, weights = geom.get_wcs_coord_and_weights()
     else:
         coords, weights = geom.get_coord(sparse=True), None
 
@@ -271,15 +267,7 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None, use_region_center=T
     """
     # Compute separations with pointing position
     if not use_region_center:
-        # TODO: simplify
-        energy_true = geom.axes["energy_true"].center
-        migra = geom.axes["migra"].center
-        region_coord, weights = geom.get_wcs_coord_and_weights()
-        coords = MapCoord.create({
-            "skycoord": region_coord.skycoord,
-            "energy_true": energy_true[:, np.newaxis, np.newaxis],
-            "migra": migra[:, np.newaxis]
-        })
+        coords, weights = geom.get_wcs_coord_and_weights()
     else:
         coords, weights = geom.get_coord(sparse=True), None
 
@@ -290,13 +278,13 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None, use_region_center=T
         offset=offset,
         energy_true=coords["energy_true"],
         migra=coords["migra"],
-    ).to_value("")
+    )
 
     if not use_region_center:
         data = np.average(data, axis=2, weights=weights)
 
     # Create Map and fill relevant entries
-    edisp_map = Map.from_geom(geom, data=data, unit="")
+    edisp_map = Map.from_geom(geom, data=data.to_value(""), unit="")
     edisp_map.normalize(axis_name="migra")
     return EDispMap(edisp_map, exposure_map)
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -221,27 +221,22 @@ def make_psf_map(psf, pointing, geom, exposure_map=None):
     exposure_map : `~gammapy.maps.Map`, optional
         the associated exposure map.
         default is None
-    use_region_center: bool
-        If geom is a RegionGeom, whether to just
-        consider the values at the region center
-        or the insted the average over the whole region
 
     Returns
     -------
     psfmap : `~gammapy.irf.PSFMap`
         the resulting PSF map
     """
-    energy_true = geom.axes["energy_true"].center
-    rad = geom.axes["rad"].center
+    coords = geom.get_coord(sparse=True)
 
     # Compute separations with pointing position
-    offset = geom.separation(pointing)
+    offset = coords.skycoord.separation(pointing)
 
     # Compute PSF values
     data = psf.evaluate(
-            energy_true=energy_true[:, np.newaxis, np.newaxis, np.newaxis],
+            energy_true=coords["energy_true"],
             offset=offset,
-            rad=rad[:, np.newaxis, np.newaxis],
+            rad=coords["rad"],
     )
 
     # Create Map and fill relevant entries

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -181,7 +181,6 @@ def make_map_background_irf(pointing, ontime, bkg, geom, oversampling=None, use_
         coords["fov_lat"] = fov_lat
 
     bkg_de = bkg.integrate_log_log(**coords, axis_name="energy")
-
     data = (bkg_de * d_omega * ontime).to_value("")
 
     if not use_region_center:

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -2056,8 +2056,9 @@ class MapCoord:
     @property
     def flat(self):
         """Return flattened, valid coordinates"""
-        is_finite = np.isfinite(self[0])
-        return self.apply_mask(is_finite)
+        coords = self.broadcasted
+        is_finite = np.isfinite(coords[0])
+        return coords.apply_mask(is_finite)
 
     @property
     def broadcasted(self):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -2058,6 +2058,13 @@ class MapCoord:
         is_finite = np.isfinite(self[0])
         return self.apply_mask(is_finite)
 
+    @property
+    def broadcasted(self):
+        """Return broadcasted coords"""
+        vals = np.broadcast_arrays(*self._data.values(), subok=True)
+        data = dict(zip(self._data.keys(), vals))
+        return self.__class__(data=data, frame=self.frame, match_by_name=self._match_by_name)
+
     def copy(self):
         """Copy `MapCoord` object."""
         return copy.deepcopy(self)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1863,11 +1863,12 @@ class MapCoord:
     @property
     def shape(self):
         """Coordinate array shape."""
-        return self[0].shape
+        shapes = [_.shape for _ in self._data.values()]
+        return np.broadcast_shapes(*shapes)
 
     @property
     def size(self):
-        return self[0].size
+        return np.prod(self.shape)
 
     @property
     def lon(self):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1876,8 +1876,8 @@ class MapCoord:
     @property
     def shape(self):
         """Coordinate array shape."""
-        shapes = [_.shape for _ in self._data.values()]
-        return np.broadcast_shapes(*shapes)
+        arrays = [_ for _ in self._data.values()]
+        return np.broadcast(*arrays).shape
 
     @property
     def size(self):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1839,13 +1839,10 @@ class MapCoord:
     """
 
     def __init__(self, data, frame=None, match_by_name=True):
-
         if "lon" not in data or "lat" not in data:
             raise ValueError("data dictionary must contain axes named 'lon' and 'lat'.")
 
-        data = {k: np.atleast_1d(np.asanyarray(v)) for k, v in data.items()}
-        vals = np.broadcast_arrays(*data.values(), subok=True)
-        self._data = dict(zip(data.keys(), vals))
+        self._data = {k: np.atleast_1d(v) for k, v in data.items()}
         self._frame = frame
         self._match_by_name = match_by_name
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -136,8 +136,15 @@ class MapAxes(Sequence):
             shape[idx] = -1
             yield tuple(shape), axis
 
-    def get_coord(self):
+    def get_coord(self, mode="center", axis_name=None):
         """Get axes coordinates
+
+        Parameters
+        ----------
+        mode : {"center", "edges"}
+            Coordinate center or edges
+        axis_name : str
+            Axis name
 
         Returns
         -------
@@ -147,8 +154,11 @@ class MapAxes(Sequence):
         coords = {}
 
         for shape, axis in self.iter_with_reshape:
-            coord = axis.center.reshape(shape)
-            coords[axis.name] = coord
+            if mode == "edges" and axis.name == axis_name:
+                coord = axis.edges
+            else:
+                coord = axis.center
+            coords[axis.name] = coord.reshape(shape)
 
         return coords
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -587,7 +587,7 @@ class HpxGeom(Geom):
     def coord_to_pix(self, coords):
         import healpy as hp
 
-        coords = MapCoord.create(coords, frame=self.frame, axis_names=self.axes.names)
+        coords = MapCoord.create(coords, frame=self.frame, axis_names=self.axes.names).broadcasted
         theta, phi = coords.theta, coords.phi
 
         if self.axes:
@@ -827,7 +827,7 @@ class HpxGeom(Geom):
         """
         import healpy as hp
 
-        coords = MapCoord.create(coords, frame=self.frame)
+        coords = MapCoord.create(coords, frame=self.frame).broadcasted
 
         if idxs is None:
             idxs = self.coord_to_idx(coords, clip=True)[1:]

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1642,7 +1642,7 @@ class HpxGeom(Geom):
         mask = geom.contains(coords)
         return Map.from_geom(self, data=mask)
 
-    def get_coord(self, idx=None, flat=False):
+    def get_coord(self, idx=None, flat=False, sparse=False):
         pix = self.get_idx(idx=idx, flat=flat)
         coords = self.pix_to_coord(pix)
         cdict = {"lon": coords[0], "lat": coords[1]}

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1535,7 +1535,7 @@ class HpxGeom(Geom):
             if idx is None:
                 for ax in self.axes:
                     if mode == "edges" and ax.name == axis_name:
-                        pix += [np.arange(-0.5, ax.nbin, dtype=int)]
+                        pix += [np.arange(-0.5, ax.nbin, dtype=float)]
                     else:
                         pix += [np.arange(ax.nbin, dtype=int)]
             else:

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1520,19 +1520,19 @@ class HpxGeom(Geom):
 
         return wcs_tiles
 
-    def get_idx(self, idx=None, local=False, flat=False):
+    def get_idx(self, idx=None, local=False, flat=False, sparse=False):
+        # TODO: simplify this!!!
         if idx is not None and np.any(np.array(idx) >= np.array(self.shape_axes)):
             raise ValueError(f"Image index out of range: {idx!r}")
 
         # Regular all- and partial-sky maps
         if self.is_regular:
-
             pix = [np.arange(np.max(self._npix))]
             if idx is None:
                 pix += [np.arange(ax.nbin, dtype=int) for ax in self.axes]
             else:
                 pix += [t for t in idx]
-            pix = np.meshgrid(*pix[::-1], indexing="ij", sparse=False)[::-1]
+            pix = np.meshgrid(*pix[::-1], indexing="ij", sparse=sparse)[::-1]
             pix = self.local_to_global(pix)
 
         # Non-regular all-sky
@@ -1642,8 +1642,8 @@ class HpxGeom(Geom):
         mask = geom.contains(coords)
         return Map.from_geom(self, data=mask)
 
-    def get_coord(self, idx=None, flat=False, sparse=False):
-        pix = self.get_idx(idx=idx, flat=flat)
+    def get_coord(self, idx=None, flat=False, sparse=False, mode="center", axis_name=None):
+        pix = self.get_idx(idx=idx, flat=flat, sparse=sparse)
         coords = self.pix_to_coord(pix)
         cdict = {"lon": coords[0], "lat": coords[1]}
 

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -244,16 +244,13 @@ class RegionGeom(Geom):
         """
         # TODO: support mode=edges?
         cdict = {}
+        
         cdict["skycoord"] = self.center_skydir.reshape((1, 1))
 
         if self.axes is not None:
-            coords = []
-            for ax in self.axes:
-                coords.append(ax.center)  # .reshape((-1, 1, 1)))
-
-            coords = np.meshgrid(*coords)
-            for idx, ax in enumerate(self.axes):
-                cdict[ax.name] = coords[idx].reshape(self.data_shape)
+            for shape, ax in self.axes.iter_with_reshape:
+                shape = shape[::-1] + (1, 1)
+                cdict[ax.name] = ax.center.reshape(shape)
 
         if frame is None:
             frame = self.frame
@@ -462,10 +459,10 @@ class RegionGeom(Geom):
         else:
             in_region = self.region.contains(coords.skycoord, wcs=self.wcs)
 
-            x = np.zeros(coords.shape)
+            x = np.zeros(coords.skycoord.shape)
             x[~in_region] = np.nan
 
-            y = np.zeros(coords.shape)
+            y = np.zeros(coords.skycoord.shape)
             y[~in_region] = np.nan
 
             pix = (x, y)

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -234,7 +234,7 @@ class RegionGeom(Geom):
         """
         return tuple((1, 1) + self.axes.shape)
 
-    def get_coord(self, frame=None):
+    def get_coord(self, frame=None, sparse=False):
         """Get map coordinates from the geometry.
 
         Returns
@@ -255,7 +255,12 @@ class RegionGeom(Geom):
         if frame is None:
             frame = self.frame
 
-        return MapCoord.create(cdict, frame=self.frame).to_frame(frame)
+        coord = MapCoord.create(cdict, frame=self.frame).to_frame(frame)
+
+        if sparse:
+            return coord
+
+        return coord.broadcasted
 
     def _pad_spatial(self, pad_width):
         raise NotImplementedError("Spatial padding of `RegionGeom` not supported")

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -98,7 +98,7 @@ def test_get_coord(region, energy_axis, test_axis):
     )
 
     geom = RegionGeom.create(region, axes=[energy_axis, test_axis])
-    coords = geom.get_coord()
+    coords = geom.get_coord(sparse=True)
     assert coords["lon"].shape == (1, 1)
     assert coords["test"].shape == (2, 1, 1, 1)
     assert coords["energy"].shape == (1, 3, 1, 1)

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -100,11 +100,14 @@ def test_get_coord(region, energy_axis, test_axis):
     geom = RegionGeom.create(region, axes=[energy_axis, test_axis])
     coords = geom.get_coord()
     assert coords["lon"].shape == (1, 1)
-    assert coords["test"].shape == (2, 3, 1, 1)
+    assert coords["test"].shape == (2, 1, 1, 1)
+    assert coords["energy"].shape == (1, 3, 1, 1)
+
     assert_allclose(
-        coords["energy"].value[1].squeeze(), [1.467799, 3.162278, 6.812921], rtol=1e-5
+        coords["energy"].value[0, :, 0, 0], [1.467799, 3.162278, 6.812921], rtol=1e-5
     )
-    assert_allclose(coords["test"].value[:, 1].squeeze(), [1, 2], rtol=1e-5)
+
+    assert_allclose(coords["test"].value[:, 0, 0, 0].squeeze(), [1, 2], rtol=1e-5)
 
 
 def test_get_idx(region, energy_axis, test_axis):

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -99,7 +99,7 @@ def test_get_coord(region, energy_axis, test_axis):
 
     geom = RegionGeom.create(region, axes=[energy_axis, test_axis])
     coords = geom.get_coord()
-    assert coords["lon"].shape == (2, 3, 1, 1)
+    assert coords["lon"].shape == (1, 1)
     assert coords["test"].shape == (2, 3, 1, 1)
     assert_allclose(
         coords["energy"].value[1].squeeze(), [1.467799, 3.162278, 6.812921], rtol=1e-5

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -630,7 +630,7 @@ class WcsGeom(Geom):
         coords = self.pix_to_coord(pix)
         m = np.isfinite(coords[0])
         for _ in pix:
-            _[~m] = INVALID_INDEX.floatgit s
+            _[~m] = INVALID_INDEX.float
         return pix
 
     def get_coord(self, idx=None, mode="center", frame=None, sparse=False, axis_name=None):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -597,17 +597,21 @@ class WcsGeom(Geom):
 
     def _get_pix_all(self, idx=None, mode="center", sparse=False, axis_name=("lon", "lat")):
         """Get idx coordinate array without footprint of the projection applied"""
-        pix = []
+        pix_all = []
 
         for name, nbin in zip(self.axes_names, self._shape):
             if mode == "edges" and name in axis_name:
-                pix_coords = np.arange(-0.5, nbin, dtype=float)
+                pix = np.arange(-0.5, nbin, dtype=float)
             else:
-                pix_coords = np.arange(nbin, dtype=float)
+                pix = np.arange(nbin, dtype=float)
 
-            pix.append(pix_coords)
+            pix_all.append(pix)
 
-        return np.meshgrid(*pix[::-1], indexing="ij", sparse=sparse)[::-1]
+        # TODO: improve varying bin size coordinate handling
+        if idx is not None:
+            pix_all = pix_all[self._slice_spatial_axes] + [float(t) for t in idx]
+
+        return np.meshgrid(*pix_all[::-1], indexing="ij", sparse=sparse)[::-1]
 
     def get_pix(self, idx=None, mode="center"):
         """Get map pix coordinates from the geometry.
@@ -626,7 +630,7 @@ class WcsGeom(Geom):
         coords = self.pix_to_coord(pix)
         m = np.isfinite(coords[0])
         for _ in pix:
-            _[~m] = INVALID_INDEX.float
+            _[~m] = INVALID_INDEX.floatgit s
         return pix
 
     def get_coord(self, idx=None, mode="center", frame=None, sparse=False, axis_name=None):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -590,7 +590,7 @@ class WcsGeom(Geom):
             pix = tuple([p[np.isfinite(p)] for p in pix])
         return pix_tuple_to_idx(pix)
 
-    def _get_pix_all(self, idx=None, mode="center"):
+    def _get_pix_all(self, idx=None, mode="center", sparse=sparse):
         """Get idx coordinate array without footprint of the projection applied"""
         if mode == "edges":
             shape = self._shape_edges
@@ -607,7 +607,7 @@ class WcsGeom(Geom):
             for pix_array in pix[self._slice_spatial_axes]:
                 pix_array -= 0.5
 
-        return np.meshgrid(*pix[::-1], indexing="ij")[::-1]
+        return np.meshgrid(*pix[::-1], indexing="ij", sparse=sparse)[::-1]
 
     def get_pix(self, idx=None, mode="center"):
         """Get map pix coordinates from the geometry.
@@ -629,20 +629,24 @@ class WcsGeom(Geom):
             _[~m] = INVALID_INDEX.float
         return pix
 
-    def get_coord(self, idx=None, mode="center", frame=None):
+    def get_coord(self, idx=None, mode="center", frame=None, sparse=False):
         """Get map coordinates from the geometry.
 
         Parameters
         ----------
         mode : {'center', 'edges'}
             Get center or edge coordinates for the spatial axes.
+        frame : str or `~astropy.coordinates.Frame`
+            Coordinate frame
+        sparse : bool
+            Compute sparse coordinates
 
         Returns
         -------
         coord : `~MapCoord`
             Map coordinate object.
         """
-        pix = self._get_pix_all(idx=idx, mode=mode)
+        pix = self._get_pix_all(idx=idx, mode=mode, sparse=sparse)
         coords = self.pix_to_coord(pix)
 
         axes_names = ["lon", "lat"] + self.axes.names

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -590,7 +590,7 @@ class WcsGeom(Geom):
             pix = tuple([p[np.isfinite(p)] for p in pix])
         return pix_tuple_to_idx(pix)
 
-    def _get_pix_all(self, idx=None, mode="center", sparse=sparse):
+    def _get_pix_all(self, idx=None, mode="center", sparse=False):
         """Get idx coordinate array without footprint of the projection applied"""
         if mode == "edges":
             shape = self._shape_edges

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -529,7 +529,6 @@ class WcsNDMap(WcsMap):
 
         return RegionNDMap(geom=geom, data=data, unit=self.unit, meta=self.meta.copy())
 
-
     def mask_contains_region(self, region):
         """Check if input region is contained in a boolean mask map.
 
@@ -838,7 +837,6 @@ class WcsNDMap(WcsMap):
         coords = self.geom.pix_to_coord(coords_pix[::-1])
 
         # TODO: pix_to_coord should return a MapCoord object
-        axes_names = ["lon", "lat"] + self.geom.axes.names
-        cdict = OrderedDict(zip(axes_names, coords))
+        cdict = OrderedDict(zip(self.geom.axes_names, coords))
 
         return MapCoord.create(cdict, frame=self.geom.frame)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -305,8 +305,8 @@ class SkyModel(Model):
 
     def evaluate_geom(self, geom, gti=None):
         """Evaluate model on `~gammapy.maps.Geom`."""
-        energy = geom.axes["energy_true"].center[:, np.newaxis, np.newaxis]
-        value = self.spectral_model(energy)
+        coords = geom.get_coord(sparse=True)
+        value = self.spectral_model(coords["energy_true"])
 
         if self.spatial_model:
             value = value * self.spatial_model.evaluate_geom(geom)
@@ -598,8 +598,8 @@ class FoVBackgroundModel(Model):
 
     def evaluate_geom(self, geom):
         """Evaluate map"""
-        energy = geom.axes["energy"].center[:, np.newaxis, np.newaxis]
-        return self.evaluate(energy=energy)
+        coords = geom.get_coord(sparse=True)
+        return self.evaluate(energy=coords["energy_true"])
 
     def evaluate(self, energy):
         """Evaluate model"""

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -599,7 +599,7 @@ class FoVBackgroundModel(Model):
     def evaluate_geom(self, geom):
         """Evaluate map"""
         coords = geom.get_coord(sparse=True)
-        return self.evaluate(energy=coords["energy_true"])
+        return self.evaluate(energy=coords["energy"])
 
     def evaluate(self, energy):
         """Evaluate model"""

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -147,11 +147,10 @@ class SpatialModel(Model):
         `~gammapy.maps.Map`
 
         """
-        coords = geom.to_image().get_coord(frame=self.frame)
+        coords = geom.get_coord(frame=self.frame, sparse=True)
 
         if self.is_energy_dependent:
-            energy = geom.axes["energy_true"].center
-            return self(coords.lon, coords.lat, energy[:, np.newaxis, np.newaxis])
+            return self(coords.lon, coords.lat, energy=coords["energy_true"])
         else:
             return self(coords.lon, coords.lat)
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
This PR adds a `get_coord(sparse=)` option to be able to work with sparse coordinate arrays and rely on broadcasting instead. This simplifies the code in a few places (just adapt a few places so far) and makes sure it is always the fastest option.

<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
