### PR TITLE
Mask invalid background values in SafeMaskMaker

### DIFF
--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -59,7 +59,6 @@ class SafeMaskMaker(Maker):
         position=None,
         fixed_offset=None,
         offset_max="3 deg",
-        n_95percentile=None,
     ):
         methods = set(methods)
 
@@ -73,7 +72,6 @@ class SafeMaskMaker(Maker):
         self.position = position
         self.fixed_offset = fixed_offset
         self.offset_max = Angle(offset_max)
-        self.n_95percentile = n_95percentile
         if self.position and self.fixed_offset:
             raise ValueError(
                 "`position` and `fixed_offset` attributes are mutually exclusive"
@@ -261,7 +259,7 @@ class SafeMaskMaker(Maker):
         """
 
         bkg = dataset.background.data
-        mask = np.isfinite(bkg) | (bkg == 0.0)
+        mask = np.isfinite(bkg) & (bkg > 0.0)
         return mask
 
     def run(self, dataset, observation=None):

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -45,7 +45,7 @@ class SafeMaskMaker(Maker):
         `n_95percentile` times the 95% percentile value.
         Default is None then only non-finite values are masked.
     force_clipping : bool
-       If True the aberrant value found by `bkg-clip` method will be set to zero.
+       If True (default), the aberrant value found by `bkg-clip` method will be set to zero.
     """
 
     tag = "SafeMaskMaker"
@@ -67,7 +67,7 @@ class SafeMaskMaker(Maker):
         fixed_offset=None,
         offset_max="3 deg",
         n_95percentile=None,
-        force_clipping=False,
+        force_clipping=True,
     ):
         methods = set(methods)
 

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -274,8 +274,10 @@ class SafeMaskMaker(Maker):
         bkg[bkg == 0.0] = np.nan
         mask = np.isfinite(bkg)
         if self.n_95percentile is not None:
-            thr = self.n_95percentile * np.nanpercentile(bkg, 95, axis=(1,2))
-            mask = np.abs(bkg) < thr[:, None, None]
+            thr = self.n_95percentile * np.nanpercentile(
+                bkg, 95, axis=(1, 2), keepdims=True
+            )
+            mask = np.abs(bkg) < thr
         if np.any(~mask):
             bad_values = np.unique(bkg[~mask & np.isfinite(bkg)])
             log.warning(f"Invalid values found in background masked \n {bad_values}")

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -249,7 +249,7 @@ class SafeMaskMaker(Maker):
  
         Parameters
         ----------
-        dataset : `~gammapy.datasets.MapDataset`
+        dataset : `~gammapy.datasets.MapDataset` or `~gammapy.datasets.SpectrumDataset`
             Dataset to compute mask for.
 
         Returns
@@ -259,7 +259,9 @@ class SafeMaskMaker(Maker):
         """
 
         bkg = dataset.background.data
-        mask = np.isfinite(bkg) & (bkg > 0.0)
+        mask = np.isfinite(bkg)
+        if "OnOff" not in dataset.tag:
+            mask &= (bkg > 0.0)
         return mask
 
     def run(self, dataset, observation=None):

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -111,7 +111,10 @@ def test_safe_mask_maker_bkg_invalid(observations_hess_dl3):
 
     assert mask_nonan[0, 0, 0] == False
 
-    assert_allclose(bkg[mask_nonan].max(), 20.656366)
+    assert_allclose(bkg[mask_nonan].max(), 3.615932e+28)
+
+    #TODO: change after disable IRF extrapolation:
+    #assert_allclose(bkg[mask_nonan].max(), 20.656366)
 
     dataset = safe_mask_maker_nonan.run(dataset, obs)
     assert_allclose(dataset.mask_safe, mask_nonan)

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -103,9 +103,6 @@ def test_safe_mask_maker_bkg_clip(observations_hess_dl3):
 
     safe_mask_maker_nonan = SafeMaskMaker(["bkg-clip"])
     safe_mask_maker_nolarge = SafeMaskMaker(["bkg-clip"], n_95percentile=10)
-    safe_mask_maker_clip = SafeMaskMaker(
-        ["bkg-clip"], n_95percentile=10, force_clipping=True
-    )
 
     dataset = dataset_maker.run(empty_dataset, obs)
     bkg = dataset.background.data
@@ -122,7 +119,5 @@ def test_safe_mask_maker_bkg_clip(observations_hess_dl3):
     # using reasonnale parameters for the other masks, n_95percentile may not be needed
     # but this must be checked as aberrant values would bias the fov-bkg-maker scaling.
 
-    dataset = safe_mask_maker_clip.run(dataset)
-
+    dataset = safe_mask_maker_nolarge.run(dataset)
     assert_allclose(dataset.mask_safe, mask_nolarge)
-    assert np.all(np.isfinite(dataset.background.data))

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -103,6 +103,9 @@ def test_safe_mask_maker_bkg_clip(observations_hess_dl3):
 
     safe_mask_maker_nonan = SafeMaskMaker(["bkg-clip"])
     safe_mask_maker_nolarge = SafeMaskMaker(["bkg-clip"], n_95percentile=10)
+    safe_mask_maker_clip = SafeMaskMaker(
+        ["bkg-clip"], n_95percentile=10, force_clipping=True
+    )
 
     dataset = dataset_maker.run(empty_dataset, obs)
     bkg = dataset.background.data
@@ -118,3 +121,8 @@ def test_safe_mask_maker_bkg_clip(observations_hess_dl3):
     # the value of n_95percentile requires some tuning...
     # using reasonnale parameters for the other masks, n_95percentile may not be needed
     # but this must be checked as aberrant values would bias the fov-bkg-maker scaling.
+
+    dataset = safe_mask_maker_clip.run(dataset)
+
+    assert_allclose(dataset.mask_safe, mask_nolarge)
+    assert np.all(np.isfinite(dataset.background.data))

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -7,6 +7,7 @@ from gammapy.datasets import MapDataset
 from gammapy.makers import MapDatasetMaker, SafeMaskMaker
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.utils.testing import requires_data
+import numpy as np
 
 
 @pytest.fixture(scope="session")
@@ -14,6 +15,14 @@ def observations():
     data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps/")
     obs_id = [110380, 111140]
     return data_store.get_observations(obs_id)
+
+
+@pytest.fixture
+def observations_hess_dl3():
+    """HESS DL3 observation list."""
+    datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
+    obs_ids = [23523, 23526]
+    return datastore.get_observations(obs_ids)
 
 
 @requires_data()
@@ -36,8 +45,8 @@ def test_safe_mask_maker(observations, caplog):
 
     fixed_offset = 1.5 * u.deg
     safe_mask_maker_offset = SafeMaskMaker(
-                                    offset_max="3 deg", bias_percent=0.02, fixed_offset = fixed_offset
-                                    )
+        offset_max="3 deg", bias_percent=0.02, fixed_offset=fixed_offset
+    )
 
     dataset = dataset_maker.run(empty_dataset, obs)
 
@@ -50,24 +59,62 @@ def test_safe_mask_maker(observations, caplog):
     assert_allclose(mask_energy_aeff_default.data.sum(), 1936)
 
     mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset)
-    mask_aeff_max_offset = safe_mask_maker_offset.make_mask_energy_aeff_max(dataset, obs)
+    mask_aeff_max_offset = safe_mask_maker_offset.make_mask_energy_aeff_max(
+        dataset, obs
+    )
     assert_allclose(mask_aeff_max.data.sum(), 1210)
     assert_allclose(mask_aeff_max_offset.data.sum(), 1210)
 
     mask_edisp_bias = safe_mask_maker.make_mask_energy_edisp_bias(dataset)
-    mask_edisp_bias_offset = safe_mask_maker_offset.make_mask_energy_edisp_bias(dataset, obs)
+    mask_edisp_bias_offset = safe_mask_maker_offset.make_mask_energy_edisp_bias(
+        dataset, obs
+    )
     assert_allclose(mask_edisp_bias.data.sum(), 1815)
     assert_allclose(mask_edisp_bias_offset.data.sum(), 1694)
 
     mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
-    assert_allclose(mask_bkg_peak.data.sum(), 1815)      
+    assert_allclose(mask_bkg_peak.data.sum(), 1815)
     assert caplog.records[-1].levelname == "WARNING"
     assert caplog.records[-1].message == "No default thresholds defined for obs 110380"
 
     safe_mask_maker_noroot = SafeMaskMaker(
-                                    offset_max="3 deg", aeff_percent = -10, bias_percent=-10
-                                    )
+        offset_max="3 deg", aeff_percent=-10, bias_percent=-10
+    )
     mask_aeff_max_noroot = safe_mask_maker_noroot.make_mask_energy_aeff_max(dataset)
     mask_edisp_bias_noroot = safe_mask_maker_noroot.make_mask_energy_edisp_bias(dataset)
     assert_allclose(mask_aeff_max_noroot.data.sum(), 1815)
     assert_allclose(mask_edisp_bias_noroot.data.sum(), 1936)
+
+
+@requires_data()
+def test_safe_mask_maker_bkg_clip(observations_hess_dl3):
+    obs = observations_hess_dl3[0]
+
+    axis = MapAxis.from_bounds(
+        0.1, 10, nbin=16, unit="TeV", name="energy", interp="log"
+    )
+    axis_true = MapAxis.from_bounds(
+        0.1, 50, nbin=30, unit="TeV", name="energy_true", interp="log"
+    )
+    geom = WcsGeom.create(npix=(11, 11), axes=[axis], skydir=obs.pointing_radec)
+
+    empty_dataset = MapDataset.create(geom=geom, energy_axis_true=axis_true)
+    dataset_maker = MapDatasetMaker()
+
+    safe_mask_maker_nonan = SafeMaskMaker(["bkg-clip"])
+    safe_mask_maker_nolarge = SafeMaskMaker(["bkg-clip"], n_95percentile=10)
+
+    dataset = dataset_maker.run(empty_dataset, obs)
+    bkg = dataset.background.data
+    bkg[0, 0, 0] = np.nan
+
+    mask_nonan = safe_mask_maker_nonan.make_mask_bkg_clip(dataset)
+    mask_nolarge = safe_mask_maker_nolarge.make_mask_bkg_clip(dataset)
+
+    assert mask_nonan[0, 0, 0] == False
+
+    assert_allclose(bkg[mask_nonan].max(), 3.615932095e28)
+    assert_allclose(bkg[mask_nolarge].max(), 20.656366)
+    # the value of n_95percentile requires some tuning...
+    # using reasonnale parameters for the other masks, n_95percentile may not be needed
+    # but this must be checked as aberrant values would bias the fov-bkg-maker scaling.


### PR DESCRIPTION
This PR introduces a bkg-clip method to SafeMaskMaker that adds a mask from the aberrant values in background maps

By default only non-finite values are masked.
If`n_95percentile` option  is not None then the values larger than 
`n_95percentile` times the 95% percentile value will also be masked.
