### PR TITLE
Implement LabelMapAxis

### DIFF
--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -445,7 +445,7 @@ class FluxPoints(FluxMaps):
             raise ValueError("Plotting only supported for region based flux points")
 
         if not self.geom.axes.is_unidimensional:
-            raise ValueError("Profile plotting is only support for unidimensional maps")
+            raise ValueError("Profile plotting is only supported for unidimensional maps")
 
         axis = self.geom.axes.primary_axis
 

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2712,6 +2712,17 @@ class LabelMapAxis:
         str_ += fmt.format(f"labels", "{0}".format(list(self._labels)))
         return str_.expandtabs(tabsize=2)
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+
+        name_equal = self.name.upper() == other.name.upper()
+        labels_equal = np.all(self.center == other.center)
+        return name_equal & labels_equal
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     # TODO: could create sub-labels here using dashes like "label-1-a", etc.
     def upsample(self, *args, **kwargs):
         """Upsample axis"""

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1684,7 +1684,8 @@ class MapAxes(Sequence):
 
         Parameters
         ----------
-        format : {"gadf", "gadf-dl3", "fgst-ccube", "fgst-template", "ogip", "ogip-sherpa", "ogip-arf", "ogip-arf-sherpa"}
+        format : {"gadf", "gadf-dl3", "fgst-ccube", "fgst-template", "ogip",
+                  "ogip-sherpa", "ogip-arf", "ogip-arf-sherpa"}
             Format to use.
 
         Returns
@@ -2337,8 +2338,8 @@ class TimeMapAxis:
         )
 
     # TODO: if we are to allow log or sqrt bins the reference time should always
-    # be strictly lower than all times
-    # Should we define a mechanism to ensure this is always correct?
+    #  be strictly lower than all times
+    #  Should we define a mechanism to ensure this is always correct?
     @classmethod
     def from_time_edges(cls, time_min, time_max, unit="d", interp="lin", name="time"):
         """Create TimeMapAxis from the time interval edges defined as `~astropy.time.Time`.

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2589,6 +2589,11 @@ class LabelMapAxis:
         return np.ones(self.nbin)
 
     @property
+    def as_plot_xerr(self):
+        """Plot labels"""
+        return 0.5 * np.ones(self.nbin)
+
+    @property
     def as_plot_labels(self):
         """Plot labels"""
         return self._labels.tolist()
@@ -2603,8 +2608,7 @@ class LabelMapAxis:
         """Plot labels"""
         return np.arange(self.nbin + 1) - 0.5
 
-    @staticmethod
-    def format_plot_axis(ax):
+    def format_plot_axis(self, ax):
         """Format plot axis.
 
         Parameters
@@ -2618,6 +2622,13 @@ class LabelMapAxis:
             Formatted plot axis.
         """
         # TODO: tilt labels 30 deg?
+        ax.set_xticks(self.as_plot_center)
+        ax.set_xticklabels(
+            self.as_plot_labels,
+            rotation=30,
+            ha="right",
+            rotation_mode="anchor",
+        )
         return ax
 
     def __repr__(self):

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2172,7 +2172,7 @@ class TimeMapAxis:
         for time_min, time_max in zip(self.time_min, self.time_max):
             yield (time_min, time_max)
 
-    def coord_to_idx(self, coord):
+    def coord_to_idx(self, coord,**kwargs):
         """Transform from axis time coordinate to bin index.
 
         Indices of time values falling outside time bins will be
@@ -2201,7 +2201,7 @@ class TimeMapAxis:
         idx[~np.any(mask, axis=-1)] = INVALID_INDEX.int
         return idx
 
-    def coord_to_pix(self, coord):
+    def coord_to_pix(self, coord, **kwargs):
         """Transform from time to coordinate to pixel position.
 
         Pixels of time values falling outside time bins will be

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2441,6 +2441,7 @@ class TimeMapAxis:
 
         return header
 
+
 class LabelMapAxis:
     """Map axis using labels
 
@@ -2462,6 +2463,11 @@ class LabelMapAxis:
 
         self._labels = np.array(labels)
         self._name = name
+
+    @property
+    def unit(self):
+        """Unit"""
+        return u.Unit("")
 
     @property
     def name(self):
@@ -2581,6 +2587,38 @@ class LabelMapAxis:
     def bin_width(self):
         """Bin width is unity """
         return np.ones(self.nbin)
+
+    @property
+    def as_plot_labels(self):
+        """Plot labels"""
+        return self._labels.tolist()
+
+    @property
+    def as_plot_center(self):
+        """Plot labels"""
+        return np.arange(self.nbin)
+
+    @property
+    def as_plot_edges(self):
+        """Plot labels"""
+        return np.arange(self.nbin + 1) - 0.5
+
+    @staticmethod
+    def format_plot_axis(ax):
+        """Format plot axis.
+
+        Parameters
+        ----------
+        ax : `~matplotlib.pyplot.Axis`
+            Plot axis to format.
+
+        Returns
+        -------
+        ax : `~matplotlib.pyplot.Axis`
+            Formatted plot axis.
+        """
+        # TODO: tilt labels 30 deg?
+        return ax
 
     def __repr__(self):
         str_ = self.__class__.__name__ + "\n"

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2468,6 +2468,20 @@ class LabelMapAxis:
         """Name of the axis"""
         return self._name
 
+    def assert_name(self, required_name):
+        """Assert axis name if a specific one is required.
+
+        Parameters
+        ----------
+        required_name : str
+            Required
+        """
+        if self.name != required_name:
+            raise ValueError(
+                "Unexpected axis name,"
+                f' expected "{required_name}", got: "{self.name}"'
+            )
+
     @property
     def nbin(self):
         """Number of bins"""

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -147,18 +147,24 @@ class RegionNDMap(Map):
         kwargs.setdefault("histtype", "step")
         kwargs.setdefault("lw", 1)
 
+        if not self.geom.axes.is_unidimensional:
+            raise ValueError("Plotting is only supported for unidimensional maps")
+
         axis = self.geom.axes[0]
 
         with quantity_support():
             weights = self.data[:, 0, 0]
-            ax.hist(axis.center.value, bins=axis.edges.value, weights=weights, **kwargs)
-
-        ax.set_xlabel(axis.name.capitalize() + f" [{axis.unit}]")
+            ax.hist(
+                axis.as_plot_center,
+                bins=axis.as_plot_center,
+                weights=weights,
+                **kwargs
+            )
 
         if not self.unit.is_unity():
             ax.set_ylabel(f"Data [{self.unit}]")
 
-        ax.set_xscale("log")
+        axis.format_plot_axis(ax=ax)
         ax.set_yscale("log")
         return ax
 

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -5,12 +5,7 @@ from numpy.testing import assert_allclose, assert_equal
 from astropy.time import Time
 from astropy.table import Table
 import astropy.units as u
-<<<<<<< HEAD
-from gammapy.maps import RegionNDMap, MapAxis, TimeMapAxis, MapAxes
-=======
-from gammapy.maps import RegionNDMap, MapAxis
-from gammapy.maps.axes import TimeMapAxis, LabelMapAxis
->>>>>>> c8727de10... Add basic LabelMapAxis tests
+from gammapy.maps import RegionNDMap, MapAxis, TimeMapAxis, MapAxes, LabelMapAxis
 from gammapy.data import GTI
 from gammapy.utils.testing import assert_allclose, requires_data, assert_time_allclose
 from gammapy.utils.scripts import make_path
@@ -601,8 +596,11 @@ def test_label_map_axis_basics():
     with pytest.raises(ValueError):
         axis.edges
 
+    axis_copy = axis.copy()
+    assert axis_copy.name == "label-axis"
 
-def test_label_map_axis():
+
+def test_label_map_axis_coord_to_idx():
     axis = LabelMapAxis(labels=["label-1", "label-2", "label-3"], name="label-axis")
 
     labels = "label-1"
@@ -622,4 +620,21 @@ def test_label_map_axis():
         _ = axis.coord_to_idx(coord=labels)
 
 
+def test_mixed_axes():
+    label_axis = LabelMapAxis(labels=["label-1", "label-2", "label-3"], name="label")
 
+    time_axis = TimeMapAxis(
+        edges_min=[1, 10] * u.day,
+        edges_max=[2, 13] * u.day,
+        reference_time=Time("2020-03-19")
+    )
+
+    energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=4)
+
+    axes = MapAxes(axes=[energy_axis, time_axis, label_axis])
+
+    coords = axes.get_coord()
+
+    assert coords["label"].shape == (1, 1, 3)
+    assert coords["energy"].shape == (4, 1, 1)
+    assert coords["time"].shape == (1, 2, 1)

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -600,3 +600,26 @@ def test_label_map_axis_basics():
 
     with pytest.raises(ValueError):
         axis.edges
+
+
+def test_label_map_axis():
+    axis = LabelMapAxis(labels=["label-1", "label-2", "label-3"], name="label-axis")
+
+    labels = "label-1"
+    idx = axis.coord_to_idx(coord=labels)
+    assert_allclose(idx, 0)
+
+    labels = ["label-1", "label-3"]
+    idx = axis.coord_to_idx(coord=labels)
+    assert_allclose(idx, [0, 2])
+
+    labels = [["label-1"], ["label-2"]]
+    idx = axis.coord_to_idx(coord=labels)
+    assert_allclose(idx, [[0], [1]])
+
+    with pytest.raises(ValueError):
+        labels = [["bad-label"], ["label-2"]]
+        _ = axis.coord_to_idx(coord=labels)
+
+
+

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -638,3 +638,9 @@ def test_mixed_axes():
     assert coords["label"].shape == (1, 1, 3)
     assert coords["energy"].shape == (4, 1, 1)
     assert coords["time"].shape == (1, 2, 1)
+
+    idx = axes.coord_to_idx(coords)
+
+    assert_allclose(idx[0], np.arange(4).reshape((4, 1, 1)))
+    assert_allclose(idx[1], np.arange(2).reshape((1, 2, 1)))
+    assert_allclose(idx[2], np.arange(3).reshape((1, 1, 3)))

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -644,3 +644,10 @@ def test_mixed_axes():
     assert_allclose(idx[0], np.arange(4).reshape((4, 1, 1)))
     assert_allclose(idx[1], np.arange(2).reshape((1, 2, 1)))
     assert_allclose(idx[2], np.arange(3).reshape((1, 1, 3)))
+
+    hdu = axes.to_table_hdu(format="gadf")
+
+    table = Table.read(hdu)
+
+    assert table["LABEL"].dtype == np.dtype("<U7")
+    assert len(table) == 24

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -5,7 +5,12 @@ from numpy.testing import assert_allclose, assert_equal
 from astropy.time import Time
 from astropy.table import Table
 import astropy.units as u
+<<<<<<< HEAD
 from gammapy.maps import RegionNDMap, MapAxis, TimeMapAxis, MapAxes
+=======
+from gammapy.maps import RegionNDMap, MapAxis
+from gammapy.maps.axes import TimeMapAxis, LabelMapAxis
+>>>>>>> c8727de10... Add basic LabelMapAxis tests
 from gammapy.data import GTI
 from gammapy.utils.testing import assert_allclose, requires_data, assert_time_allclose
 from gammapy.utils.scripts import make_path
@@ -574,3 +579,24 @@ def test_axes_basics():
     assert not axes.is_flat
 
     assert axes.primary_axis.name == "time"
+
+def test_label_map_axis_basics():
+    axis = LabelMapAxis(labels=["label-1", "label-2"], name="label-axis")
+
+    axis_str = str(axis)
+    assert "node type" in axis_str
+    assert "labels" in axis_str
+    assert "label-2" in axis_str
+
+    with pytest.raises(ValueError):
+        axis.assert_name("time")
+
+    assert axis.nbin == 2
+    assert axis.node_type == "label"
+
+    assert_allclose(axis.bin_width, 1)
+
+    assert axis.name == "label-axis"
+
+    with pytest.raises(ValueError):
+        axis.edges

--- a/gammapy/maps/tests/test_regionnd.py
+++ b/gammapy/maps/tests/test_regionnd.py
@@ -7,7 +7,7 @@ from astropy import units as u
 from astropy.time import Time
 from gammapy.data import EventList
 from gammapy.irf import EDispKernel
-from gammapy.maps import Map, MapAxis, RegionGeom, RegionNDMap, TimeMapAxis
+from gammapy.maps import Map, MapAxis, RegionGeom, RegionNDMap, TimeMapAxis, LabelMapAxis
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 
@@ -92,6 +92,21 @@ def test_region_nd_map_plot_two_axes():
 
     with pytest.raises(ValueError):
         m.plot()
+
+
+@requires_dependency("matplotlib")
+def test_region_nd_map_plot_label_axis():
+    energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=5)
+    label_axis = LabelMapAxis(labels=["dataset-1", "dataset-2"], name="dataset")
+
+    m = RegionNDMap.create(region=None, axes=[energy_axis, label_axis])
+    m.data = np.random.random(m.data.shape)
+
+    with mpl_plot_check():
+        m.plot(axis_name="energy")
+
+    with mpl_plot_check():
+        m.plot(axis_name="dataset")
 
 
 @requires_dependency("matplotlib")

--- a/gammapy/maps/tests/test_regionnd.py
+++ b/gammapy/maps/tests/test_regionnd.py
@@ -100,13 +100,29 @@ def test_region_nd_map_plot_label_axis():
     label_axis = LabelMapAxis(labels=["dataset-1", "dataset-2"], name="dataset")
 
     m = RegionNDMap.create(region=None, axes=[energy_axis, label_axis])
-    m.data = np.random.random(m.data.shape)
 
     with mpl_plot_check():
         m.plot(axis_name="energy")
 
     with mpl_plot_check():
         m.plot(axis_name="dataset")
+
+
+def test_label_axis_io(tmpdir):
+    energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=5)
+    label_axis = LabelMapAxis(labels=["dataset-1", "dataset-2"], name="dataset")
+
+    m = RegionNDMap.create(region=None, axes=[energy_axis, label_axis])
+    m.data = np.arange(m.data.size)
+
+    filename = tmpdir / "test.fits"
+
+    m.write(filename, format="gadf")
+
+    m_new = RegionNDMap.read(filename, format="gadf")
+
+    assert m.geom.axes["dataset"] == m_new.geom.axes["dataset"]
+    assert m.geom.axes["energy"] == m_new.geom.axes["energy"]
 
 
 @requires_dependency("matplotlib")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a first version of `LabelMapAxis` to allow for handling of labels for map axes. It implements the basic functionality for label to idx conversion and vice versa as well as the basic axis attributes. 

The core of the functionality is to be bale to define an axis like:
```python3
label_axis = LabelMapAxis(labels=["label-1", "label-2", "label-3"], name="label")
```
This allows to include labelled data in a `Map` object. This is useful in the context of e.g. flux points where flux points of multiple sources could be handled with the same object. The same goes for maps, e.g. to include npred maps from multiple datasets.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
