### PR TITLE
Cleanup reflected regions finder

### DIFF
--- a/docs/makers/make_reflected_regions.py
+++ b/docs/makers/make_reflected_regions.py
@@ -1,4 +1,3 @@
-import numpy as np
 import matplotlib.pyplot as plt
 from astropy.coordinates import Angle, SkyCoord
 from regions import CircleSkyRegion

--- a/docs/makers/make_reflected_regions.py
+++ b/docs/makers/make_reflected_regions.py
@@ -1,17 +1,16 @@
-"""Example how to compute and plot reflected regions."""
 import numpy as np
+import matplotlib.pyplot as plt
 from astropy.coordinates import Angle, SkyCoord
 from regions import CircleSkyRegion
-import matplotlib.pyplot as plt
 from gammapy.makers import ReflectedRegionsFinder
-from gammapy.maps import WcsNDMap
+from gammapy.maps import WcsNDMap, RegionGeom
 
 # Exclude a rectangular region
 exclusion_mask = WcsNDMap.create(npix=(801, 701), binsz=0.01, skydir=(83.6, 23.0))
 
 coords = exclusion_mask.geom.get_coord().skycoord
-mask = (Angle("23 deg") < coords.dec) & (coords.dec < Angle("24 deg"))
-exclusion_mask.data = np.invert(mask)
+data = (Angle("23 deg") < coords.dec) & (coords.dec < Angle("24 deg"))
+exclusion_mask.data = ~data
 
 pos = SkyCoord(83.633, 22.014, unit="deg")
 radius = Angle(0.3, "deg")
@@ -25,34 +24,59 @@ finder = ReflectedRegionsFinder(
     exclusion_mask=exclusion_mask,
     min_distance_input="0.2 rad",
 )
-finder.run()
+regions = finder.run()
 
-fig1 = plt.figure(1)
-finder.plot(fig=fig1)
+fig, axes = plt.subplots(
+    ncols=3,
+    subplot_kw={"projection": exclusion_mask.geom.wcs},
+    figsize=(12, 3),
+)
+
+
+def plot_regions(ax, regions, on_region, exclusion_mask):
+    """Little helper function to plot off regions"""
+    exclusion_mask.plot_mask(ax=ax, colors="gray")
+    on_region.to_pixel(ax.wcs).plot(ax=ax, edgecolor="tab:orange")
+    geom = RegionGeom.from_regions(regions)
+    geom.plot_region(ax=ax, color="tab:blue")
+
+
+ax = axes[0]
+ax.set_title("Min. distance first region")
+plot_regions(
+    ax=ax, regions=regions, on_region=on_region, exclusion_mask=exclusion_mask
+)
+
 
 # One can impose a minimal distance between two adjacent regions
 finder = ReflectedRegionsFinder(
     region=on_region,
     center=center,
     exclusion_mask=exclusion_mask,
-    min_distance_input="0.2 rad",
     min_distance="0.1 rad",
 )
-finder.run()
-fig2 = plt.figure(2)
-finder.plot(fig=fig2)
+regions = finder.run()
+
+ax = axes[1]
+ax.set_title("Min. distance all regions")
+plot_regions(
+    ax=ax, regions=regions, on_region=on_region, exclusion_mask=exclusion_mask
+)
+
 
 # One can impose a maximal number of regions to be extracted
 finder = ReflectedRegionsFinder(
     region=on_region,
     center=center,
     exclusion_mask=exclusion_mask,
-    min_distance_input="0.2 rad",
     max_region_number=5,
     min_distance="0.1 rad",
 )
-finder.run()
-fig3 = plt.figure(3)
-finder.plot(fig=fig3)
+regions = finder.run()
 
+ax = axes[2]
+ax.set_title("Max. number of regions")
+plot_regions(
+    ax=ax, regions=regions, on_region=on_region, exclusion_mask=exclusion_mask
+)
 plt.show()

--- a/docs/maps/regionmap.rst
+++ b/docs/maps/regionmap.rst
@@ -337,7 +337,7 @@ created from an existing `~RegionGeom`, this can be done in the same step:
     # Create another region map with the same RegionGeom but different data,
     # with the same value for each of the 12 energy bins
     geom = region_map.geom
-    region_map_1 = RegionNDMap.from_geom(geom, data = 1)
+    region_map_1 = RegionNDMap.from_geom(geom, data=1.)
 
     # Access the data
     print(region_map_1.data)

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -193,7 +193,7 @@ If you are interested in 68% (1 :math:`\sigma`) and 95% (2 :math:`\sigma`) confi
     excess = count_statistic.n_sig
     errn = count_statistic.compute_errn(1.)
     errp = count_statistic.compute_errp(1.)
-    print(f"68% confidence range: {excess+errn:.3f} < mu < {excess+errp:.3f}")
+    print(f"68% confidence range: {excess + errn:.3f} < mu < {excess + errp:.3f}")
 
 .. testoutput::
 
@@ -203,7 +203,7 @@ If you are interested in 68% (1 :math:`\sigma`) and 95% (2 :math:`\sigma`) confi
 
     errn_2sigma = count_statistic.compute_errn(2.)
     errp_2sigma = count_statistic.compute_errp(2.)
-    print(f"95% confidence range: {excess+errn_2sigma:.3f} < mu < {excess+errp_2sigma:.3f}")
+    print(f"95% confidence range: {excess + errn_2sigma:.3f} < mu < {excess + errp_2sigma:.3f}")
 
 .. testoutput::
 
@@ -239,13 +239,13 @@ Here's how you compute the statistical significance of your detection:
 
     from gammapy.stats import WStatCountsStatistic
     stat = WStatCountsStatistic(n_on=13, n_off=11, alpha=1./2)
-    print(stat.n_sig)
-    print(stat.sqrt_ts)
+    print(f"Excess  : {stat.n_sig:.2f}")
+    print(f"sqrt(TS): {stat.sqrt_ts:.2f}")
 
 .. testoutput::
 
-    7.5
-    2.09283236849328
+    Excess  : 7.50
+    sqrt(TS): 2.09
 
 .. plot:: stats/plot_wstat_significance.py
 
@@ -256,13 +256,13 @@ the Cash statistic and obtain the :math:`\sqrt TS` or Li & Ma significance for k
 
     from gammapy.stats import CashCountsStatistic
     stat = CashCountsStatistic(n_on=13, mu_bkg=5.5)
-    print(stat.n_sig)
-    print(stat.sqrt_ts)
+    print(f"Excess  : {stat.n_sig:.2f}")
+    print(f"sqrt(TS): {stat.sqrt_ts:.2f}")
 
 .. testoutput::
 
-    7.5
-    2.7138962573762653
+    Excess  : 7.50
+    sqrt(TS): 2.71
 
 .. plot:: stats/plot_cash_significance.py
 
@@ -277,17 +277,17 @@ If you are interested in 68% (1 :math:`\sigma`) and 95% (1 :math:`\sigma`) confi
 
     from gammapy.stats import CashCountsStatistic
     stat = CashCountsStatistic(n_on=13, mu_bkg=5.5)
-    print(stat.compute_errn(1.))
-    print(stat.compute_errp(1.))
-    print(stat.compute_errn(2.))
-    print(stat.compute_errp(2.))
+    print(f"{stat.compute_errn(1.):.2f}")
+    print(f"{stat.compute_errp(1.):.2f}")
+    print(f"{stat.compute_errn(2.):.2f}")
+    print(f"{stat.compute_errp(2.):.2f}")
 
 .. testoutput::
 
-    -3.280211558352333
-    3.9463091246231023
-    -5.94409080573643
-    8.60168631791818
+    -3.28
+    3.95
+    -5.94
+    8.60
 
 The 68% confidence interval (1 :math:`\sigma`) is obtained by finding the expected signal values for which the TS
 variation is 1. The 95% confidence interval (2 :math:`\sigma`) is obtained by finding the expected signal values

--- a/docs/tutorials/api/makers.ipynb
+++ b/docs/tutorials/api/makers.ipynb
@@ -337,7 +337,7 @@
    "source": [
     "# on region is given by the CircleSkyRegion previously defined\n",
     "geom = RegionGeom.create(region=circle, axes=[energy_axis])\n",
-    "exclusion_mask_2d = exclusion_mask.sum_over_axes(keepdims=False)\n",
+    "exclusion_mask_2d = exclusion_mask.reduce_over_axes(np.logical_or, keepdims=False)\n",
     "\n",
     "spectrum_dataset_empty = SpectrumDataset.create(\n",
     "    geom=geom, energy_axis_true=energy_axis_true\n",
@@ -393,9 +393,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1,
+   "current_citInitial": 1.0,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1,
+   "eqNumInitial": 1.0,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"

--- a/docs/tutorials/api/makers.ipynb
+++ b/docs/tutorials/api/makers.ipynb
@@ -34,9 +34,10 @@
     ")\n",
     "from gammapy.datasets import MapDataset, SpectrumDataset, Datasets\n",
     "from gammapy.data import DataStore\n",
-    "from gammapy.maps import MapAxis, WcsGeom, Map, RegionGeom\n",
+    "from gammapy.maps import MapAxis, WcsGeom, RegionGeom\n",
     "from regions import CircleSkyRegion\n",
-    "from astropy import units as u"
+    "from astropy import units as u\n",
+    "import numpy as np"
    ]
   },
   {

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -78,7 +78,6 @@ class Analysis:
         else:
             raise FileNotFoundError(f"Datastore not found: {path}")
 
-
     def _make_obs_table_selection(self):
         """Return list of obs_ids after filtering on datastore observation table."""
         obs_settings = self.config.observations
@@ -348,7 +347,6 @@ class Analysis:
         else:
             return MapDataset.create(geom, name=name, **geom_irf)
 
-
     def _create_dataset_maker(self):
         """Create the Dataset Maker."""
         log.debug("Creating the target Dataset Maker.")
@@ -385,8 +383,9 @@ class Analysis:
         bkg_maker_config = {}
         if datasets_settings.background.exclusion:
             path = make_path(datasets_settings.background.exclusion)
-            exclusion_region = Map.read(path)
-            bkg_maker_config["exclusion_mask"] = exclusion_region
+            exclusion_mask = Map.read(path)
+            exclusion_mask.data = exclusion_mask.data.astype(bool)
+            bkg_maker_config["exclusion_mask"] = exclusion_mask
         bkg_maker_config.update(datasets_settings.background.parameters)
 
         bkg_method = datasets_settings.background.method
@@ -410,7 +409,6 @@ class Analysis:
         else:
             log.warning(f"No background maker set. Check configuration.")
         return bkg_maker
-
 
     def _map_making(self):
         """Make maps and datasets for 3d analysis"""
@@ -465,8 +463,7 @@ class Analysis:
         """Run all steps for the spectrum extraction."""
         log.info("Reducing spectrum datasets.")
         datasets_settings = self.config.datasets
-
-        dataset_maker =  self._create_dataset_maker()
+        dataset_maker = self._create_dataset_maker()
         safe_mask_maker = self._create_safe_mask_maker()
         bkg_maker = self._create_background_maker()
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1074,7 +1074,6 @@ def test_map_dataset_onoff_str(images):
 def test_stack_onoff(images):
     dataset = get_map_dataset_onoff(images)
     stacked = dataset.copy()
-
     stacked.stack(dataset)
 
     assert_allclose(stacked.counts.data.sum(), 2 * dataset.counts.data.sum())

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -349,7 +349,7 @@ class PSFMap(IRFMap):
         psf_map = Map.from_geom(geom=geom, data=data.to_value("sr-1"), unit="sr-1")
 
         exposure_map = Map.from_geom(
-            geom=geom.squash(axis_name="rad"), unit="m2 s", data=1
+            geom=geom.squash(axis_name="rad"), unit="m2 s", data=1.
         )
         return cls(psf_map=psf_map, exposure_map=exposure_map)
 

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -199,22 +199,25 @@ class ReflectedRegionsFinder:
             Reflected regions
         """
         self.reset_cache()
-        curr_angle = self.angle_min + self.min_distance_input
-        reflected_regions = []
+        regions = []
 
-        while curr_angle < self.angle_max:
-            test_reg = self.region_pix.rotate(self.center_pix, curr_angle)
-            if not np.any(test_reg.contains(self.excluded_pix_coords)):
-                region = test_reg.to_sky(self.geom_ref.wcs)
-                reflected_regions.append(region)
+        angle = self.angle_min + self.min_distance_input
 
-                curr_angle += self.angle_min
-                if self.max_region_number <= len(reflected_regions):
+        while angle < self.angle_max:
+            region_test = self.region_pix.rotate(self.center_pix, angle)
+
+            if not np.any(region_test.contains(self.excluded_pix_coords)):
+                region = region_test.to_sky(self.geom_ref.wcs)
+                regions.append(region)
+
+                if len(regions) >= self.max_region_number:
                     break
-            else:
-                curr_angle = curr_angle + self.angle_increment
 
-        return reflected_regions
+                angle += self.angle_min
+            else:
+                angle += self.angle_increment
+
+        return regions
 
 
 class ReflectedRegionsBackgroundMaker(Maker):

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -216,29 +216,6 @@ class ReflectedRegionsFinder:
 
         return reflected_regions
 
-    def plot(self, fig=None, ax=None):
-        """Standard debug plot.
-
-        See example here: :ref:'regions_reflected'.
-        """
-        fig, ax, cbar = self.reference_map.plot(
-            fig=fig, ax=ax, cmap="gray", vmin=0, vmax=1
-        )
-        wcs = self.reference_map.geom.wcs
-
-        on_patch = self.region.to_pixel(wcs=wcs).as_artist(edgecolor="red", alpha=0.6)
-        ax.add_patch(on_patch)
-
-        for off in self.reflected_regions:
-            tmp = off.to_pixel(wcs=wcs)
-            off_patch = tmp.as_artist(edgecolor="blue", alpha=0.6)
-            ax.add_patch(off_patch)
-
-            xx, yy = self.center.to_pixel(wcs)
-            ax.plot(xx, yy, marker="+", color="green", markersize=20, linewidth=5)
-
-        return fig, ax
-
 
 class ReflectedRegionsBackgroundMaker(Maker):
     """Reflected regions background maker.

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -87,7 +87,7 @@ class ReflectedRegionsFinder:
         self.min_distance = Angle(min_distance)
         self.min_distance_input = Angle(min_distance_input)
 
-        if not exclusion_mask.is_mask:
+        if exclusion_mask and not exclusion_mask.is_mask:
             raise ValueError("Exclusion mask must contain boolean values")
 
         self.exclusion_mask = exclusion_mask

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -86,6 +86,10 @@ class ReflectedRegionsFinder:
 
         self.min_distance = Angle(min_distance)
         self.min_distance_input = Angle(min_distance_input)
+
+        if not exclusion_mask.is_mask:
+            raise ValueError("Exclusion mask must contain boolean values")
+
         self.exclusion_mask = exclusion_mask
         self.max_region_number = max_region_number
         self.binsz = Angle(binsz)
@@ -144,8 +148,8 @@ class ReflectedRegionsFinder:
 
         pixels = PixCoord(pix_x, pix_y)
 
-        newX, newY = self.center_pix.x - pixels.x, self.center_pix.y - pixels.y
-        angles = Angle(np.arctan2(newX, newY), "rad")
+        dx, dy = self.center_pix.x - pixels.x, self.center_pix.y - pixels.y
+        angles = Angle(np.arctan2(dx, dy), "rad")
         angular_size = np.max(angles) - np.min(angles)
 
         if angular_size.value > np.pi:
@@ -157,12 +161,12 @@ class ReflectedRegionsFinder:
 
     @lazyproperty
     def exclusion_mask_ref(self):
-        """Exlcusion mask reprojected"""
+        """Exclusion mask reprojected"""
         if self.exclusion_mask:
-            mask = self.exclusion_mask.interp_to_geom(self.geom_ref)
+            mask = self.exclusion_mask.interp_to_geom(self.geom_ref, fill_value=True)
         else:
             mask = WcsNDMap.from_geom(geom=self.geom_ref, data=1)
-
+            mask.data = mask.data.astype(bool)
         return mask
 
     @lazyproperty

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -57,8 +57,8 @@ class ReflectedRegionsFinder:
     >>> theta = Angle(0.4, 'deg')
     >>> on_region = CircleSkyRegion(target_position, theta)
     >>> finder = ReflectedRegionsFinder(min_distance_input='1 rad', region=on_region, center=pointing)
-    >>> finder.run()
-    >>> print(finder.reflected_regions[0])
+    >>> regions = finder.run()
+    >>> print(regions[0])
     Region: CircleSkyRegion
     center: <SkyCoord (ICRS): (ra, dec) in deg
         (83.19879005, 25.57300957)>

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -165,8 +165,7 @@ class ReflectedRegionsFinder:
         if self.exclusion_mask:
             mask = self.exclusion_mask.interp_to_geom(self.geom_ref, fill_value=True)
         else:
-            mask = WcsNDMap.from_geom(geom=self.geom_ref, data=1)
-            mask.data = mask.data.astype(bool)
+            mask = WcsNDMap.from_geom(geom=self.geom_ref, data=True)
         return mask
 
     @lazyproperty

--- a/gammapy/makers/background/tests/test_reflected.py
+++ b/gammapy/makers/background/tests/test_reflected.py
@@ -118,10 +118,10 @@ center = SkyCoord(0.5, 0.0, unit="deg")
 other_region_finder_param = [
     (RectangleSkyRegion(center, 0.5 * u.deg, 0.5 * u.deg, angle=0 * u.deg), 3),
     (RectangleSkyRegion(center, 0.5 * u.deg, 1 * u.deg, angle=0 * u.deg), 1),
-    (RectangleSkyRegion(center, 0.5 * u.deg, 1 * u.deg, angle=90 * u.deg), 0),
+    (RectangleSkyRegion(center, 0.5 * u.deg, 1 * u.deg, angle=90 * u.deg), 1),
     (EllipseSkyRegion(center, 0.1 * u.deg, 1 * u.deg, angle=0 * u.deg), 2),
     (EllipseSkyRegion(center, 0.1 * u.deg, 1 * u.deg, angle=60 * u.deg), 3),
-    (EllipseSkyRegion(center, 0.1 * u.deg, 1 * u.deg, angle=90 * u.deg), 0),
+    (EllipseSkyRegion(center, 0.1 * u.deg, 1 * u.deg, angle=90 * u.deg), 2),
 ]
 
 

--- a/gammapy/makers/background/tests/test_reflected.py
+++ b/gammapy/makers/background/tests/test_reflected.py
@@ -132,8 +132,7 @@ def test_non_circular_regions(region, nreg):
     finder = ReflectedRegionsFinder(
         center=pointing, region=region, min_distance_input="0 deg"
     )
-    finder.run()
-    regions = finder.reflected_regions
+    regions = finder.run()
     assert len(regions) == nreg
 
 
@@ -146,13 +145,8 @@ def test_bad_on_region(exclusion_mask, on_region):
         exclusion_mask=exclusion_mask,
         min_distance_input="0 deg",
     )
-    finder.run()
-    regions = finder.reflected_regions
+    regions = finder.run()
     assert len(regions) == 0
-
-    # try plotting
-    with mpl_plot_check():
-        finder.plot()
 
 
 @requires_data()

--- a/gammapy/makers/background/tests/test_reflected.py
+++ b/gammapy/makers/background/tests/test_reflected.py
@@ -79,28 +79,24 @@ def test_find_reflected_regions(
         exclusion_mask=exclusion_mask,
         min_distance_input="0 deg",
     )
-    finder.run()
-    regions = finder.reflected_regions
+    regions = finder.run()
     assert len(regions) == nreg1
     assert_quantity_allclose(regions[3].center.icrs.ra, reg3_ra, rtol=1e-2)
 
     # Test without exclusion
     finder.exclusion_mask = None
-    finder.run()
-    regions = finder.reflected_regions
+    regions = finder.run()
     assert len(regions) == nreg2
 
     # Test with too small exclusion
     small_mask = exclusion_mask.cutout(pointing, Angle("0.1 deg"))
     finder.exclusion_mask = small_mask
-    finder.run()
-    regions = finder.reflected_regions
+    regions = finder.run()
     assert len(regions) == nreg3
 
     # Test with maximum number of regions
     finder.max_region_number = 5
-    finder.run()
-    regions = finder.reflected_regions
+    regions = finder.run()
     assert len(regions) == 5
 
     # Test with an other type of region
@@ -114,8 +110,7 @@ def test_find_reflected_regions(
     )
     finder.region = on_ellipse_annulus
     finder.reference_map = None
-    finder.run()
-    regions = finder.reflected_regions
+    regions = finder.run()
     assert len(regions) == 5
 
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -831,7 +831,7 @@ class Map(abc.ABC):
         """
         pass
 
-    def interp_to_geom(self, geom, preserve_counts=False, **kwargs):
+    def interp_to_geom(self, geom, preserve_counts=False, fill_value=0, **kwargs):
         """Interpolate map to input geometry.
 
         Parameters
@@ -861,7 +861,7 @@ class Map(abc.ABC):
         if map_copy.is_mask:
             # TODO: check this NaN handling is needed
             data = map_copy.get_by_coord(coords)
-            data = np.nan_to_num(data).astype(bool)
+            data = np.nan_to_num(data, nan=fill_value).astype(bool)
         else:
             data = map_copy.interp_by_coord(coords, **kwargs)
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -76,7 +76,7 @@ class Map(abc.ABC):
     @data.setter
     def data(self, value):
         if np.isscalar(value):
-            value = value * np.ones(self.geom.data_shape)
+            value = value * np.ones(self.geom.data_shape, dtype=type(value))
 
         if isinstance(value, u.Quantity):
             raise TypeError("Map data must be a Numpy array. Set unit separately")

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -122,6 +122,28 @@ class RegionGeom(Geom):
         rectangle = rectangle_pix.to_sky(self.wcs)
         return u.Quantity([rectangle.width, rectangle.height])
 
+    def rotate(self, center, angle):
+        """Rotate region geom around a given center.
+
+        Parameters
+        ----------
+        center : `SkyCoord`
+            Rotation center coordinate
+        angle : `Angle`
+            Rotation angle
+
+        Returns
+        -------
+        geom : `RegionGeom`
+            Rotated region geom.
+        """
+        pix_region = self.region.to_pixel(self.wcs)
+        center_pix = center.to_pixel(wcs=self.wcs)
+
+        pix_region = pix_region.rotate(center_pix, angle)
+        region = pix_region.to_sky(wcs=self.wcs)
+        return self.__class__(region=region, wcs=self.wcs, axes=self.axes)
+
     @property
     def region(self):
         """`~regions.SkyRegion` object that defines the spatial component

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -122,28 +122,6 @@ class RegionGeom(Geom):
         rectangle = rectangle_pix.to_sky(self.wcs)
         return u.Quantity([rectangle.width, rectangle.height])
 
-    def rotate(self, center, angle):
-        """Rotate region geom around a given center.
-
-        Parameters
-        ----------
-        center : `SkyCoord`
-            Rotation center coordinate
-        angle : `Angle`
-            Rotation angle
-
-        Returns
-        -------
-        geom : `RegionGeom`
-            Rotated region geom.
-        """
-        pix_region = self.region.to_pixel(self.wcs)
-        center_pix = center.to_pixel(wcs=self.wcs)
-
-        pix_region = pix_region.rotate(center_pix, angle)
-        region = pix_region.to_sky(wcs=self.wcs)
-        return self.__class__(region=region, wcs=self.wcs, axes=self.axes)
-
     @property
     def region(self):
         """`~regions.SkyRegion` object that defines the spatial component

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -60,12 +60,12 @@ def test_to_binsz_wcs(region):
 
 def test_centers(region):
     geom = RegionGeom.create(region)
-    assert_allclose(geom.center_skydir.l.deg, 0)
-    assert_allclose(geom.center_skydir.b.deg, 0)
+    assert_allclose(geom.center_skydir.l.deg, 0, atol=1e-30)
+    assert_allclose(geom.center_skydir.b.deg, 0, atol=1e-30)
     assert_allclose(geom.center_pix, (0, 0))
 
     values = [_.value for _ in geom.center_coord]
-    assert_allclose(values, (0, 0))
+    assert_allclose(values, (0, 0), atol=1e-30)
 
 
 def test_width(region):
@@ -91,8 +91,8 @@ def test_get_coord(region, energy_axis, test_axis):
     geom = RegionGeom.create(region, axes=[energy_axis])
     coords = geom.get_coord()
 
-    assert_allclose(coords.lon, 0)
-    assert_allclose(coords.lat, 0)
+    assert_allclose(coords.lon, 0, atol=1e-30)
+    assert_allclose(coords.lat, 0, atol=1e-30)
     assert_allclose(
         coords["energy"].value.squeeze(), [1.467799, 3.162278, 6.812921], rtol=1e-5
     )
@@ -153,8 +153,8 @@ def test_pix_to_coord(region, energy_axis):
 
     pix = (0, 0, 0)
     coords = geom.pix_to_coord(pix)
-    assert_allclose(coords[0].value, 0)
-    assert_allclose(coords[1].value, 0)
+    assert_allclose(coords[0].value, 0, atol=1e-30)
+    assert_allclose(coords[1].value, 0, atol=1e-30)
     assert_allclose(coords[2].value, 1.467799, rtol=1e-5)
 
     pix = (1, 1, 1)
@@ -173,8 +173,8 @@ def test_pix_to_coord_2axes(region, energy_axis, test_axis):
 
     pix = (0, 0, 0, 0)
     coords = geom.pix_to_coord(pix)
-    assert_allclose(coords[0].value, 0)
-    assert_allclose(coords[1].value, 0)
+    assert_allclose(coords[0].value, 0, atol=1e-30)
+    assert_allclose(coords[1].value, 0, atol=1e-30)
     assert_allclose(coords[2].value, 1.467799, rtol=1e-5)
     assert_allclose(coords[3].value, 1)
 
@@ -216,7 +216,7 @@ def test_separation(region):
     position = SkyCoord([0, 0], [0, 1.1], frame="galactic", unit="deg")
     separation = geom.separation(position)
 
-    assert_allclose(separation.deg, [0, 1.1])
+    assert_allclose(separation.deg, [0, 1.1], atol=1e-30)
 
 
 def test_upsample(region):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request partly addresses #2267 and cleans up the implementation of the `ReflectedRegionsFinder`. the most relevant change here is to replace the `.setup()` methods by a `lazyproperty` pattern. This allowed me to replace the derived quantities from the finder configuration by lazy properties. I think the resulting implementation is very simple and clean. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
