### PR TITLE
Support serialisation of TimeMapAxis

### DIFF
--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -416,6 +416,7 @@ class LightCurveEstimator(Estimator):
         ----------
         datasets : list of `~gammapy.datasets.SpectrumDataset` or `~gammapy.datasets.MapDataset`
             Spectrum or Map datasets.
+
         Returns
         -------
         lightcurve : `~gammapy.estimators.LightCurve`

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1850,7 +1850,8 @@ class TimeMapAxis:
         self._pix_offset = -0.5
         self._interp = interp
 
-        if np.any(self.time_delta < 0 * u.s):
+        delta = edges_min[1:] - edges_max[:-1]
+        if np.any(delta < 0 * u.s):
             raise ValueError("Time intervals must not overlap.")
 
     @property

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1832,8 +1832,11 @@ class TimeMapAxis:
             raise ValueError(f"Time edges max must have a valid time unit, got {edges_max.unit}")
 
         if not edges_min.shape == edges_max.shape:
-            raise ValueError("Time min and time max must have the same shape,"
+            raise ValueError("Edges min and edges max must have the same shape,"
                              f" got {edges_min.shape} and {edges_max.shape}.")
+
+        if not np.all(edges_max > edges_min):
+            raise ValueError("Edges max must all be larger than edge min")
 
         if not np.all(edges_min == np.sort(edges_min)):
             raise ValueError("Time edges min values must be sorted")
@@ -1896,7 +1899,7 @@ class TimeMapAxis:
     @property
     def time_delta(self):
         """Return axis time bin width (`~astropy.time.TimeDelta`)."""
-        return self._edges_max - self._edges_min
+        return self.time_max - self.time_min
 
     @property
     def time_mid(self):
@@ -2016,13 +2019,13 @@ class TimeMapAxis:
 
     @property
     def center(self):
-        """Return `~astropy.time.Time` at interval centers."""
-        return self.edges_min + 0.5 * self.time_delta
+        """Return `~astropy.units.Quantity` at interval centers."""
+        return self.edges_min + 0.5 * self.bin_width
 
     @property
     def bin_width(self):
-        """Return time interval width."""
-        return self.time_delta
+        """Return time interval width (`~astropy.units.Quantity`)."""
+        return self.time_delta.to("h")
 
     def __repr__(self):
         str_ = self.__class__.__name__ + "\n"
@@ -2034,7 +2037,7 @@ class TimeMapAxis:
         str_ += fmt.format("scale", self.reference_time.scale)
         str_ += fmt.format("time min.", self.time_min.min().iso)
         str_ += fmt.format("time max.", self.time_max.max().iso)
-        str_ += fmt.format("total time", self.time_delta.sum())
+        str_ += fmt.format("total time", np.sum(self.bin_width))
         return str_.expandtabs(tabsize=2)
 
     def upsample(self):

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -207,11 +207,21 @@ class MapAxis:
         return u.Quantity(self.pix_to_coord(pix), self._unit, copy=False)
 
     @property
+    def edges_min(self):
+        """Return array of bin edges max values."""
+        return self.edges[:-1]
+
+    @property
+    def edges_max(self):
+        """Return array of bin edges min values."""
+        return self.edges[1:]
+
+    @property
     def as_xerr(self):
         """Return tuple of xerr to be used with plt.errorbar()"""
         return (
-            self.center - self.edges[:-1],
-            self.edges[1:] - self.center,
+            self.center - self.edges_min,
+            self.edges_max - self.center,
         )
 
     @property
@@ -1604,8 +1614,8 @@ class MapAxes(Sequence):
             table["CHANNEL"] = np.arange(np.prod(self.shape))
 
             axes_ctr = np.meshgrid(*[ax.center for ax in self])
-            axes_min = np.meshgrid(*[ax.edges[:-1] for ax in self])
-            axes_max = np.meshgrid(*[ax.edges[1:] for ax in self])
+            axes_min = np.meshgrid(*[ax.edges_min for ax in self])
+            axes_max = np.meshgrid(*[ax.edges_max for ax in self])
 
             for idx, ax in enumerate(self):
                 name = ax.name.upper()
@@ -1847,6 +1857,16 @@ class TimeMapAxis:
     def nbin(self):
         """Return number of bins in the axis."""
         return self._nbin
+
+    @property
+    def edges_min(self):
+        """Return array of bin edges max values."""
+        return self._edges_min
+
+    @property
+    def edges_max(self):
+        """Return array of bin edges min values."""
+        return self._edges_max
 
     @property
     def time_min(self):

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -483,7 +483,7 @@ class RegionGeom(Geom):
         return np.meshgrid(*idxs[::-1], indexing="ij")[::-1]
 
     def _make_bands_cols(self):
-        pass
+        return []
 
     @classmethod
     def create(cls, region, **kwargs):

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -573,6 +573,11 @@ class RegionNDMap(Map):
             data = self.quantity.flatten()
             table["CHANNEL"] = np.arange(len(data), dtype=np.int16)
             table["DATA"] = data
+        elif format == "gadf-sed":
+            table = self.geom.axes.to_table()
+            data = self.quantity.flatten()
+            table["CHANNEL"] = np.arange(len(data), dtype=np.int16)
+            table["DATA"] = data
         else:
             raise ValueError(f"Unsupported format: '{format}'")
 

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -573,11 +573,6 @@ class RegionNDMap(Map):
             data = self.quantity.flatten()
             table["CHANNEL"] = np.arange(len(data), dtype=np.int16)
             table["DATA"] = data
-        elif format == "gadf-sed":
-            table = self.geom.axes.to_table()
-            data = self.quantity.flatten()
-            table["CHANNEL"] = np.arange(len(data), dtype=np.int16)
-            table["DATA"] = data
         else:
             raise ValueError(f"Unsupported format: '{format}'")
 

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -10,6 +10,8 @@ from gammapy.maps.axes import TimeMapAxis
 from gammapy.data import GTI
 from gammapy.utils.testing import assert_allclose, requires_data, assert_time_allclose
 from gammapy.utils.scripts import make_path
+from gammapy.utils.time import time_ref_to_dict
+
 
 @pytest.fixture
 def time_intervals():
@@ -17,6 +19,7 @@ def time_intervals():
     t_min = np.linspace(0, 10, 20) * u.d
     t_max = t_min + 1 * u.h
     return {"t_min" : t_min, "t_max" : t_max, "t_ref":t0}
+
 
 @pytest.fixture
 def time_interval():
@@ -34,13 +37,18 @@ def test_time_axis(time_intervals):
     assert axis.nbin == 20
     assert axis.name == "time"
     assert axis.node_type == "intervals"
+
     assert_allclose(axis.time_delta.to_value("min"), 60)
-    assert_allclose(axis.center[0].mjd, 58927.020833333336)
+    assert_allclose(axis.time_mid[0].mjd, 58927.020833333336)
+
     assert "time" in axis.__str__()
     assert "20" in axis.__str__()
+
     with pytest.raises(ValueError):
         axis.assert_name("bad")
+
     assert axis_copy == axis
+
 
 def test_single_interval_time_axis(time_interval):
     axis = TimeMapAxis(time_interval["t_min"], time_interval["t_max"], time_interval["t_ref"])
@@ -49,20 +57,22 @@ def test_single_interval_time_axis(time_interval):
 
     assert axis.nbin == 1
     assert_allclose(axis.time_delta.to_value("d"), 10)
-    assert_allclose(axis.center[0].mjd, 58933)
+    assert_allclose(axis.time_mid[0].mjd, 58933)
     assert_allclose(pix, [0.65, 0.85, -1.0])
+
 
 def test_slice_squash_time_axis(time_intervals):
     axis = TimeMapAxis(time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"])
     axis_squash = axis.squash()
     axis_slice = axis.slice(slice(1,5))
 
-    assert axis_squash.nbin ==1
+    assert axis_squash.nbin == 1
     assert_allclose(axis_squash.time_min[0].mjd, 58927)
     assert_allclose(axis_squash.time_delta.to_value("d"), 10.04166666)
     assert axis_slice.nbin == 4
     assert_allclose(axis_slice.time_delta.to_value("d")[0], 0.04166666666)
     assert axis_squash != axis_slice
+
 
 def test_from_time_edges_time_axis():
     t0 = Time("2020-03-19")
@@ -76,18 +86,19 @@ def test_from_time_edges_time_axis():
     assert axis.name == "time"
     assert_time_allclose(axis.reference_time, t0)
     assert_allclose(axis.time_delta.to_value("min"), 60)
-    assert_allclose(axis.center[0].mjd, 58927.020833333336)
+    assert_allclose(axis.time_mid[0].mjd, 58927.020833333336)
     assert_allclose(axis_h.time_delta.to_value("h"), 1)
-    assert_allclose(axis_h.center[0].mjd, 58927.020833333336)
+    assert_allclose(axis_h.time_mid[0].mjd, 58927.020833333336)
     assert axis == axis_h
 
+
 def test_incorrect_time_axis():
-    tmin = np.linspace(0,10, 20)*u.h
-    tmax = np.linspace(1,11, 20)*u.h
+    tmin = np.linspace(0, 10, 20) * u.h
+    tmax = np.linspace(1, 11, 20) * u.h
 
     # incorrect reference time
     with pytest.raises(ValueError):
-        TimeMapAxis(tmin, tmax, reference_time=51000*u.d, name="time")
+        TimeMapAxis(tmin, tmax, reference_time=51000 * u.d, name="time")
 
     # overlapping time intervals
     with pytest.raises(ValueError):
@@ -116,9 +127,8 @@ def test_coord_to_idx_time_axis(time_intervals):
     time = Time(58927.020833333336, format="mjd")
 
     times = axis.time_mid
-    times[::2] += 1*u.h
-    times = times.insert(0, tref-[1,2]*u.yr)
-    print(times)
+    times[::2] += 1 * u.h
+    times = times.insert(0, tref-[1, 2] * u.yr)
 
     idx = axis.coord_to_idx(time)
     indices = axis.coord_to_idx(times)
@@ -132,10 +142,11 @@ def test_coord_to_idx_time_axis(time_intervals):
     assert_allclose(pix, 0.5)
     assert_allclose(pixels[1::2], [-1, 1.5, 3.5, 5.5, 7.5, 9.5, 11.5, 13.5, 15.5, 17.5, 19.5])
 
+
 def test_slice_time_axis(time_intervals):
     axis = TimeMapAxis(time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"])
 
-    new_axis = axis.slice([2,6,9])
+    new_axis = axis.slice([2, 6, 9])
     squashed = axis.squash()
 
     assert new_axis.nbin == 3
@@ -143,20 +154,23 @@ def test_slice_time_axis(time_intervals):
     assert squashed.nbin == 1
     assert_allclose(squashed.time_max[0].mjd, 58937.041667)
 
+
 def test_from_table_time_axis():
     t0 = Time("2006-02-12", scale='utc')
-    t_min = t0 + np.linspace(0, 10, 10)*u.d
-    t_max = t_min+12*u.h
-    cols = dict()
-    cols["time_min"] = t_min
-    cols["time_max"] = t_max
-    cols["some_column"] = np.ones(10)
-    table = Table(data=cols)
+    t_min = np.linspace(0, 10, 10) * u.d
+    t_max = t_min + 12 * u.h
 
-    axis = TimeMapAxis.from_table(table)
+    table = Table()
+    table["TIME_MIN"] = t_min
+    table["TIME_MAX"] = t_max
+    table.meta.update(time_ref_to_dict(t0))
+    table.meta["AXCOLS1"] = "TIME_MIN,TIME_MAX"
+
+    axis = TimeMapAxis.from_table(table, format="gadf")
 
     assert axis.nbin == 10
-    assert_allclose(axis.center[0].mjd, 53778.25)
+    assert_allclose(axis.time_mid[0].mjd, 53778.25)
+
 
 @requires_data()
 def test_from_gti_time_axis():
@@ -168,6 +182,7 @@ def test_from_gti_time_axis():
     expected = Time(53090.123451203704, format="mjd", scale="tt")
     assert_time_allclose(axis.time_min[0], expected)
     assert axis.nbin == 1
+
 
 def test_map_with_time_axis(time_intervals):
     time_axis = TimeMapAxis(time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"])


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a follow-up PR to #3393 to support serialisation of a `TimeMapAxis`. I includes the following changes:

- Add `.edges_min` and `.edges_max` attribute on the axis objects
- Refactor `TimeMapAxis.from_table()` to support the "gadf" format only. I decided to remove the generic format for now, but I'm happy to introduce it later once we have identified and document an internal format.
- Clean up `TimeMapAxis.__init__` 
- Change `TimeMapAxis.center` to **not** return a `Time` object

I think there are a few open points to discuss:
- How to handle Gammapy internal formats for e.g. tables?
- Should we keep the time scale on I/O or always convert to "tt"?

I opened https://github.com/open-gamma-ray-astro/gamma-astro-data-formats/pull/179 to allow for the additional keywords required for time axis serialisation in GADF.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
