### PR TITLE
Allow to choose scaling method per parameter 

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -334,9 +334,7 @@ class SpectralModel(Model):
             flux_unit = DEFAULT_UNIT[sed_type]
 
         energy_min, energy_max = energy_bounds
-        axis = MapAxis.from_energy_bounds(
-            energy_min, energy_max, n_points, energy_unit
-        )
+        axis = MapAxis.from_energy_bounds(energy_min, energy_max, n_points, energy_unit)
 
         energy = axis.center
         if sed_type == "dnde":
@@ -427,9 +425,7 @@ class SpectralModel(Model):
         kwargs.setdefault("linewidth", 0)
 
         energy_min, energy_max = energy_bounds
-        axis = MapAxis.from_energy_bounds(
-            energy_min, energy_max, n_points, energy_unit
-        )
+        axis = MapAxis.from_energy_bounds(energy_min, energy_max, n_points, energy_unit)
 
         energy = axis.center
 
@@ -645,8 +641,8 @@ class PowerLawSpectralModel(SpectralModel):
 
     tag = ["PowerLawSpectralModel", "pl"]
     index = Parameter("index", 2.0)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
-    reference = Parameter("reference", "1 TeV", frozen=True)
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
 
     @staticmethod
     def evaluate(energy, index, amplitude, reference):
@@ -763,7 +759,7 @@ class PowerLawNormSpectralModel(SpectralModel):
     tag = ["PowerLawNormSpectralModel", "pl-norm"]
     norm = Parameter("norm", 1, unit="")
     tilt = Parameter("tilt", 0, frozen=True)
-    reference = Parameter("reference", "1 TeV", frozen=True)
+    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
 
     @staticmethod
     def evaluate(energy, tilt, norm, reference):
@@ -858,10 +854,10 @@ class PowerLaw2SpectralModel(SpectralModel):
     """
     tag = ["PowerLaw2SpectralModel", "pl-2"]
 
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1", scaler="scale10")
     index = Parameter("index", 2)
-    emin = Parameter("emin", "0.1 TeV", frozen=True)
-    emax = Parameter("emax", "100 TeV", frozen=True)
+    emin = Parameter("emin", "0.1 TeV", frozen=True, scaler="scale10")
+    emax = Parameter("emax", "100 TeV", frozen=True, scaler="scale10")
 
     @staticmethod
     def evaluate(energy, amplitude, index, emin, emax):
@@ -940,8 +936,8 @@ class BrokenPowerLawSpectralModel(SpectralModel):
     tag = ["BrokenPowerLawSpectralModel", "bpl"]
     index1 = Parameter("index1", 2.0)
     index2 = Parameter("index2", 2.0)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
-    ebreak = Parameter("ebreak", "1 TeV")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
+    ebreak = Parameter("ebreak", "1 TeV", scaler="scale10")
 
     @staticmethod
     def evaluate(energy, index1, index2, amplitude, ebreak):
@@ -982,9 +978,9 @@ class SmoothBrokenPowerLawSpectralModel(SpectralModel):
     tag = ["SmoothBrokenPowerLawSpectralModel", "sbpl"]
     index1 = Parameter("index1", 2.0)
     index2 = Parameter("index2", 2.0)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
-    ebreak = Parameter("ebreak", "1 TeV")
-    reference = Parameter("reference", "1 TeV", frozen=True)
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
+    ebreak = Parameter("ebreak", "1 TeV", scaler="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
     beta = Parameter("beta", 1, frozen=True)
 
     @staticmethod
@@ -1104,9 +1100,9 @@ class ExpCutoffPowerLawSpectralModel(SpectralModel):
     tag = ["ExpCutoffPowerLawSpectralModel", "ecpl"]
 
     index = Parameter("index", 1.5)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
-    reference = Parameter("reference", "1 TeV", frozen=True)
-    lambda_ = Parameter("lambda_", "0.1 TeV-1")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
+    lambda_ = Parameter("lambda_", "0.1 TeV-1", scaler="scale10")
     alpha = Parameter("alpha", "1.0", frozen=True)
 
     @staticmethod
@@ -1161,7 +1157,7 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
 
     index = Parameter("index", 1.5)
     norm = Parameter("norm", 1, unit="")
-    reference = Parameter("reference", "1 TeV", frozen=True)
+    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
     alpha = Parameter("alpha", "1.0", frozen=True)
 
@@ -1193,9 +1189,9 @@ class ExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
 
     tag = ["ExpCutoffPowerLaw3FGLSpectralModel", "ecpl-3fgl"]
     index = Parameter("index", 1.5)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
-    reference = Parameter("reference", "1 TeV", frozen=True)
-    ecut = Parameter("ecut", "10 TeV")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
+    ecut = Parameter("ecut", "10 TeV", scaler="scale10")
 
     @staticmethod
     def evaluate(energy, index, amplitude, reference, ecut):
@@ -1231,9 +1227,9 @@ class SuperExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
     """
 
     tag = ["SuperExpCutoffPowerLaw3FGLSpectralModel", "secpl-3fgl"]
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
-    reference = Parameter("reference", "1 TeV", frozen=True)
-    ecut = Parameter("ecut", "10 TeV")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
+    ecut = Parameter("ecut", "10 TeV", scaler="scale10")
     index_1 = Parameter("index_1", 1.5)
     index_2 = Parameter("index_2", 2)
 
@@ -1266,9 +1262,9 @@ class SuperExpCutoffPowerLaw4FGLSpectralModel(SpectralModel):
     """
 
     tag = ["SuperExpCutoffPowerLaw4FGLSpectralModel", "secpl-4fgl"]
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
-    reference = Parameter("reference", "1 TeV", frozen=True)
-    expfactor = Parameter("expfactor", "1e-2")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
+    expfactor = Parameter("expfactor", "1e-2", scaler="scale10")
     index_1 = Parameter("index_1", 1.5)
     index_2 = Parameter("index_2", 2)
 
@@ -1306,8 +1302,8 @@ class LogParabolaSpectralModel(SpectralModel):
 
     """
     tag = ["LogParabolaSpectralModel", "lp"]
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1")
-    reference = Parameter("reference", "10 TeV", frozen=True)
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
+    reference = Parameter("reference", "10 TeV", frozen=True, scaler="scale10")
     alpha = Parameter("alpha", 2)
     beta = Parameter("beta", 1)
 
@@ -1359,7 +1355,7 @@ class LogParabolaNormSpectralModel(SpectralModel):
     """
     tag = ["LogParabolaNormSpectralModel", "lp-norm"]
     norm = Parameter("norm", 1, unit="")
-    reference = Parameter("reference", "10 TeV", frozen=True)
+    reference = Parameter("reference", "10 TeV", frozen=True, scaler="scale10")
     alpha = Parameter("alpha", 2)
     beta = Parameter("beta", 1)
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1762,6 +1762,9 @@ class NaimaSpectralModel(SpectralModel):
             parameters.append(Parameter("B", B))
             parameters.append(Parameter("radius", radius, frozen=True))
 
+        for p in parameters:
+            p.scaler = "scale10"
+
         self.default_parameters = Parameters(parameters)
         super().__init__()
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -641,8 +641,8 @@ class PowerLawSpectralModel(SpectralModel):
 
     tag = ["PowerLawSpectralModel", "pl"]
     index = Parameter("index", 2.0)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
-    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scale_method="scale10")
 
     @staticmethod
     def evaluate(energy, index, amplitude, reference):
@@ -759,7 +759,7 @@ class PowerLawNormSpectralModel(SpectralModel):
     tag = ["PowerLawNormSpectralModel", "pl-norm"]
     norm = Parameter("norm", 1, unit="")
     tilt = Parameter("tilt", 0, frozen=True)
-    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scale_method="scale10")
 
     @staticmethod
     def evaluate(energy, tilt, norm, reference):
@@ -854,10 +854,10 @@ class PowerLaw2SpectralModel(SpectralModel):
     """
     tag = ["PowerLaw2SpectralModel", "pl-2"]
 
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1", scaler="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1", scale_method="scale10")
     index = Parameter("index", 2)
-    emin = Parameter("emin", "0.1 TeV", frozen=True, scaler="scale10")
-    emax = Parameter("emax", "100 TeV", frozen=True, scaler="scale10")
+    emin = Parameter("emin", "0.1 TeV", frozen=True, scale_method="scale10")
+    emax = Parameter("emax", "100 TeV", frozen=True, scale_method="scale10")
 
     @staticmethod
     def evaluate(energy, amplitude, index, emin, emax):
@@ -936,8 +936,8 @@ class BrokenPowerLawSpectralModel(SpectralModel):
     tag = ["BrokenPowerLawSpectralModel", "bpl"]
     index1 = Parameter("index1", 2.0)
     index2 = Parameter("index2", 2.0)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
-    ebreak = Parameter("ebreak", "1 TeV", scaler="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    ebreak = Parameter("ebreak", "1 TeV", scale_method="scale10")
 
     @staticmethod
     def evaluate(energy, index1, index2, amplitude, ebreak):
@@ -978,9 +978,9 @@ class SmoothBrokenPowerLawSpectralModel(SpectralModel):
     tag = ["SmoothBrokenPowerLawSpectralModel", "sbpl"]
     index1 = Parameter("index1", 2.0)
     index2 = Parameter("index2", 2.0)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
-    ebreak = Parameter("ebreak", "1 TeV", scaler="scale10")
-    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    ebreak = Parameter("ebreak", "1 TeV", scale_method="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scale_method="scale10")
     beta = Parameter("beta", 1, frozen=True)
 
     @staticmethod
@@ -1100,9 +1100,9 @@ class ExpCutoffPowerLawSpectralModel(SpectralModel):
     tag = ["ExpCutoffPowerLawSpectralModel", "ecpl"]
 
     index = Parameter("index", 1.5)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
-    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
-    lambda_ = Parameter("lambda_", "0.1 TeV-1", scaler="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scale_method="scale10")
+    lambda_ = Parameter("lambda_", "0.1 TeV-1", scale_method="scale10")
     alpha = Parameter("alpha", "1.0", frozen=True)
 
     @staticmethod
@@ -1157,7 +1157,7 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
 
     index = Parameter("index", 1.5)
     norm = Parameter("norm", 1, unit="")
-    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scale_method="scale10")
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
     alpha = Parameter("alpha", "1.0", frozen=True)
 
@@ -1189,9 +1189,9 @@ class ExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
 
     tag = ["ExpCutoffPowerLaw3FGLSpectralModel", "ecpl-3fgl"]
     index = Parameter("index", 1.5)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
-    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
-    ecut = Parameter("ecut", "10 TeV", scaler="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scale_method="scale10")
+    ecut = Parameter("ecut", "10 TeV", scale_method="scale10")
 
     @staticmethod
     def evaluate(energy, index, amplitude, reference, ecut):
@@ -1227,9 +1227,9 @@ class SuperExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
     """
 
     tag = ["SuperExpCutoffPowerLaw3FGLSpectralModel", "secpl-3fgl"]
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
-    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
-    ecut = Parameter("ecut", "10 TeV", scaler="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scale_method="scale10")
+    ecut = Parameter("ecut", "10 TeV", scale_method="scale10")
     index_1 = Parameter("index_1", 1.5)
     index_2 = Parameter("index_2", 2)
 
@@ -1262,9 +1262,9 @@ class SuperExpCutoffPowerLaw4FGLSpectralModel(SpectralModel):
     """
 
     tag = ["SuperExpCutoffPowerLaw4FGLSpectralModel", "secpl-4fgl"]
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
-    reference = Parameter("reference", "1 TeV", frozen=True, scaler="scale10")
-    expfactor = Parameter("expfactor", "1e-2", scaler="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    reference = Parameter("reference", "1 TeV", frozen=True, scale_method="scale10")
+    expfactor = Parameter("expfactor", "1e-2", scale_method="scale10")
     index_1 = Parameter("index_1", 1.5)
     index_2 = Parameter("index_2", 2)
 
@@ -1302,8 +1302,8 @@ class LogParabolaSpectralModel(SpectralModel):
 
     """
     tag = ["LogParabolaSpectralModel", "lp"]
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scaler="scale10")
-    reference = Parameter("reference", "10 TeV", frozen=True, scaler="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    reference = Parameter("reference", "10 TeV", frozen=True, scale_method="scale10")
     alpha = Parameter("alpha", 2)
     beta = Parameter("beta", 1)
 
@@ -1355,7 +1355,7 @@ class LogParabolaNormSpectralModel(SpectralModel):
     """
     tag = ["LogParabolaNormSpectralModel", "lp-norm"]
     norm = Parameter("norm", 1, unit="")
-    reference = Parameter("reference", "10 TeV", frozen=True, scaler="scale10")
+    reference = Parameter("reference", "10 TeV", frozen=True, scale_method="scale10")
     alpha = Parameter("alpha", 2)
     beta = Parameter("beta", 1)
 
@@ -1763,7 +1763,7 @@ class NaimaSpectralModel(SpectralModel):
             parameters.append(Parameter("radius", radius, frozen=True))
 
         for p in parameters:
-            p.scaler = "scale10"
+            p.scale_method = "scale10"
 
         self.default_parameters = Parameters(parameters)
         super().__init__()

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -372,12 +372,14 @@ class Parameter:
             "name": self.name,
             "value": self.value,
             "unit": self.unit.to_string("fits"),
+            "error": self.error,
             "min": self.min,
             "max": self.max,
             "frozen": self.frozen,
-            "scale_method": self.scale_method,
-            "error": self.error,
+            "interp": self.interp
         }
+        if self.scale_method is not None:
+            output["scale_method"] = self.scale_method
 
         if self._link_label_io is not None:
             output["link"] = self._link_label_io
@@ -561,6 +563,9 @@ class Parameters(collections.abc.Sequence):
         rows = []
         for p in self._parameters:
             d = p.to_dict()
+            for key in ["scale_method", "interp"]:
+                if key in d:
+                    del d[key]
             rows.append({**dict(type=p.type), **d})
         table = table_from_row_data(rows)
 

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -78,7 +78,7 @@ class Parameter:
         Number of sigmas to scan.
     scan_values: `numpy.array`
         Scan values. Overwrites all of the scan keywords before.
-    scaler : {'scale10', 'factor1', None}
+    scale_method : {'scale10', 'factor1', None}
         Method used to set ``factor`` and ``scale``
     interp : {"lin", "sqrt", "log"}
         Parameter scaling to use for the scan.
@@ -100,7 +100,7 @@ class Parameter:
         scan_n_values=11,
         scan_n_sigma=2,
         scan_values=None,
-        scaler=None,
+        scale_method=None,
         interp="lin",
     ):
         self.name = name
@@ -109,7 +109,7 @@ class Parameter:
         self.min = min
         self.max = max
         self.frozen = frozen
-        self.scaler = scaler
+        self.scale_method = scale_method
         self._error = error
         self._type = None
 
@@ -237,15 +237,15 @@ class Parameter:
         return self.max / self.scale
 
     @property
-    def scaler(self):
+    def scale_method(self):
         """Method used to set ``factor`` and ``scale``"""
-        return self._scaler
+        return self._scale_method
 
-    @scaler.setter
-    def scaler(self, val):
+    @scale_method.setter
+    def scale_method(self, val):
         if val not in ["scale10", "factor1"] and val is not None:
             raise ValueError(f"Invalid method: {val}")
-        self._scaler = val
+        self._scale_method = val
 
     @property
     def frozen(self):
@@ -375,6 +375,7 @@ class Parameter:
             "min": self.min,
             "max": self.max,
             "frozen": self.frozen,
+            "scale_method": self.scale_method,
             "error": self.error,
         }
 
@@ -385,9 +386,9 @@ class Parameter:
     def autoscale(self):
         """Autoscale the parameters.
 
-        Set ``factor`` and ``scale`` according to ``scaler`` attribute
+        Set ``factor`` and ``scale`` according to ``scale_method`` attribute
 
-        Available ``scaler``
+        Available ``scale_method``
 
         * ``scale10`` sets ``scale`` to power of 10,
           so that abs(factor) is in the range 1 to 10
@@ -395,17 +396,17 @@ class Parameter:
 
         In both cases the sign of value is stored in ``factor``,
         i.e. the ``scale`` is always positive. 
-        If ``scaler`` is None the scaling is ignored.
+        If ``scale_method`` is None the scaling is ignored.
 
         """
-        if self.scaler == "scale10":
+        if self.scale_method == "scale10":
             value = self.value
             if value != 0:
                 exponent = np.floor(np.log10(np.abs(value)))
                 scale = np.power(10.0, exponent)
                 self.factor = value / scale
                 self.scale = scale
-        elif self.scaler == "factor1":
+        elif self.scale_method == "factor1":
             self.factor, self.scale = 1, self.value
 
 

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -78,6 +78,8 @@ class Parameter:
         Number of sigmas to scan.
     scan_values: `numpy.array`
         Scan values. Overwrites all of the scan keywords before.
+    scaler : {'scale10', 'factor1', None}
+        Method used to set ``factor`` and ``scale``
     interp : {"lin", "sqrt", "log"}
         Parameter scaling to use for the scan.
 
@@ -98,6 +100,7 @@ class Parameter:
         scan_n_values=11,
         scan_n_sigma=2,
         scan_values=None,
+        scaler=None,
         interp="lin",
     ):
         self.name = name
@@ -106,6 +109,7 @@ class Parameter:
         self.min = min
         self.max = max
         self.frozen = frozen
+        self.scaler = scaler
         self._error = error
         self._type = None
 
@@ -233,14 +237,25 @@ class Parameter:
         return self.max / self.scale
 
     @property
+    def scaler(self):
+        """Method used to set ``factor`` and ``scale``"""
+        return self._scaler
+
+    @scaler.setter
+    def scaler(self, val):
+        if val not in ["scale10", "factor1"] and val is not None:
+            raise ValueError(f"Invalid method: {val}")
+        self._scaler = val
+
+    @property
     def frozen(self):
         """Frozen? (used in fitting) (bool)."""
         return self._frozen
 
     @frozen.setter
     def frozen(self, val):
-        if val in ['True', 'False']:
-            val=bool(val)
+        if val in ["True", "False"]:
+            val = bool(val)
         if not isinstance(val, bool) and not isinstance(val, np.bool_):
             raise TypeError(f"Invalid type: {val}, {type(val)}")
         self._frozen = val
@@ -264,7 +279,9 @@ class Parameter:
         val = u.Quantity(val)
 
         if not val.unit.is_equivalent(self.unit):
-            raise u.UnitConversionError(f"Unit must be equivalent to {self.unit} for parameter {self.name}")
+            raise u.UnitConversionError(
+                f"Unit must be equivalent to {self.unit} for parameter {self.name}"
+            )
 
         self.value = val.value
         self.unit = val.unit
@@ -345,8 +362,9 @@ class Parameter:
     def update_from_dict(self, data):
         """Update parameters from a dict.
            Protection against changing parameter model, type, name."""
-        keys=["value", "unit", "min", "max", "frozen"]
-        for k in keys: setattr(self, k, data[k])
+        keys = ["value", "unit", "min", "max", "frozen"]
+        for k in keys:
+            setattr(self, k, data[k])
 
     def to_dict(self):
         """Convert to dict."""
@@ -364,36 +382,31 @@ class Parameter:
             output["link"] = self._link_label_io
         return output
 
-    def autoscale(self, method="scale10"):
+    def autoscale(self):
         """Autoscale the parameters.
 
-        Set ``factor`` and ``scale`` according to ``method``
+        Set ``factor`` and ``scale`` according to ``scaler`` attribute
 
-        Available methods:
+        Available ``scaler``
 
         * ``scale10`` sets ``scale`` to power of 10,
           so that abs(factor) is in the range 1 to 10
         * ``factor1`` sets ``factor, scale = 1, value``
 
         In both cases the sign of value is stored in ``factor``,
-        i.e. the ``scale`` is always positive.
+        i.e. the ``scale`` is always positive. 
+        If ``scaler`` is None the scaling is ignored.
 
-        Parameters
-        ----------
-        method : {'factor1', 'scale10'}
-            Method to apply
         """
-        if method == "scale10":
+        if self.scaler == "scale10":
             value = self.value
             if value != 0:
                 exponent = np.floor(np.log10(np.abs(value)))
                 scale = np.power(10.0, exponent)
                 self.factor = value / scale
                 self.scale = scale
-        elif method == "factor1":
+        elif self.scaler == "factor1":
             self.factor, self.scale = 1, self.value
-        else:
-            raise ValueError(f"Invalid method: {method}")
 
 
 class Parameters(collections.abc.Sequence):
@@ -544,7 +557,7 @@ class Parameters(collections.abc.Sequence):
 
     def to_table(self):
         """Convert parameter attributes to `~astropy.table.Table`."""
-        rows=[]
+        rows = []
         for p in self._parameters:
             d = p.to_dict()
             rows.append({**dict(type=p.type), **d})
@@ -581,18 +594,14 @@ class Parameters(collections.abc.Sequence):
                 parameter.factor = factors[idx]
                 idx += 1
 
-    def autoscale(self, method="scale10"):
+    def autoscale(self):
         """Autoscale all parameters.
 
         See :func:`~gammapy.modeling.Parameter.autoscale`
 
-        Parameters
-        ----------
-        method : {'factor1', 'scale10'}
-            Method to apply
         """
         for par in self._parameters:
-            par.autoscale(method)
+            par.autoscale()
 
     def select(
         self, name=None, type=None, frozen=None,

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -270,7 +270,7 @@ def test_stat_contour():
     y = result["z"]
     assert_allclose(len(y), 10)
     assert_allclose(y[0], 0.04, rtol=1e-5)
-    assert_allclose(y[-1], 0.54, rtol=1e-5)
+    assert_allclose(y[-1], 0.747107, rtol=1e-5)
 
     # Check that original value state wasn't changed
     assert_allclose(dataset.models.parameters["y"].value, 300)

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -266,7 +266,7 @@ def test_stat_contour():
     x = result["y"]
     assert_allclose(len(x), 10)
     assert_allclose(x[0], 299, rtol=1e-5)
-    assert_allclose(x[-1], 299.133975, rtol=1e-5)
+    assert_allclose(x[-1], 299.292893, rtol=1e-5)
     y = result["z"]
     assert_allclose(len(y), 10)
     assert_allclose(y[0], 0.04, rtol=1e-5)

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -94,7 +94,7 @@ def test_parameter_to_dict():
     ],
 )
 def test_parameter_autoscale(method, value, factor, scale):
-    par = Parameter("", value, scaler=method)
+    par = Parameter("", value, scale_method=method)
     par.autoscale()
     assert_allclose(par.factor, factor)
     assert_allclose(par.scale, scale)
@@ -173,7 +173,7 @@ def test_parameters_set_parameter_factors(pars):
 
 
 def test_parameters_s():
-    pars = Parameters([Parameter("", 20, scaler="scale10")])
+    pars = Parameters([Parameter("", 20, scale_method="scale10")])
     pars.autoscale()
     assert_allclose(pars[0].factor, 2)
     assert_allclose(pars[0].scale, 10)
@@ -213,7 +213,7 @@ def test_update_from_dict():
         max="nan",
         frozen=False,
         unit="TeV",
-        scaler="scale10",
+        scale_method="scale10",
     )
     par.autoscale()
     data = {

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -173,10 +173,24 @@ def test_parameters_set_parameter_factors(pars):
 
 
 def test_parameters_s():
-    pars = Parameters([Parameter("", 20, scale_method="scale10")])
+    pars = Parameters([Parameter("", 20, scale_method="scale10"),
+                       Parameter("", 20, scale_method=None)])
+    pars_dict = pars.to_dict()
     pars.autoscale()
     assert_allclose(pars[0].factor, 2)
     assert_allclose(pars[0].scale, 10)
+
+    assert pars_dict[0]["scale_method"] == "scale10"
+    assert "scale_method" not in pars_dict[1]
+    pars = Parameters.from_dict(pars_dict)
+    pars.autoscale()
+    assert_allclose(pars[0].factor, 2)
+    assert_allclose(pars[0].scale, 10)
+    assert pars[1].scale_method is None
+    pars.autoscale()
+    assert_allclose(pars[1].factor, 20)
+    assert_allclose(pars[1].scale, 1)    
+
 
 
 def test_parameter_scan_values():


### PR DESCRIPTION
Add a `scaler` attribute on parameter so the choice of scaling method is not forced to be the same for all parameters. By default `scaler=None` so no scaling is applied. For amplitudes/energies parameters and all Naima parameters  the default is set to `scaler="scale10"`. Should resolve #2434.