### PR TITLE
Add spatial model evaluation on oversampled geom for MapEvaluator

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2770,7 +2770,7 @@ class MapEvaluator:
             binz = self.model.spatial_model.evaluation_bin_size_min
         else:
             binz = 0 * u.deg
-        res_scale = np.sqrt(binz.value ** 2 + self._psf_r68_min.value ** 2)
+        res_scale = np.sqrt(binz ** 2 + self._psf_r68_min ** 2).to_value("deg")
         if res_scale != 0:
             if geom.is_region or geom.is_hpx:
                 geom = geom.to_wcs_geom()

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2827,14 +2827,15 @@ class MapEvaluator:
                 return 1
 
             wcs_geom = self.geom.to_wcs_geom(width_min=self.cutout_width).to_image()
-            values = self.model.spatial_model.integrate_geom(wcs_geom)
 
             if self.model.apply_irf["psf"]:
                 values = self.apply_psf(values)
+#            if self.psf and self.model.apply_irf["psf"]:
+#                values = self._compute_flux_spatial_geom(wcs_geom)
             else:
+                values = self.model.spatial_model.integrate_geom(wcs_geom, oversampling_factor=1)
                 axes = [self.geom.axes["energy_true"].squash()]
                 values = values.to_cube(axes=axes)
-#            values = self._compute_flux_spatial_geom(wcs_geom)
 
             weights = wcs_geom.region_weights(regions=[self.geom.region])
             value = (values.quantity * weights).sum(axis=(1, 2), keepdims=True)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2747,7 +2747,7 @@ class MapEvaluator:
 
         if self.evaluation_mode == "local":
             self.contributes = self.model.contributes(mask=mask, margin=self.psf_width)
-
+            print(self.contributes)
             if self.contributes:
                 self.exposure = exposure.cutout(
                     position=self.model.position, width=self.cutout_width, odd_npix=True
@@ -2755,7 +2755,8 @@ class MapEvaluator:
         else:
             self.exposure = exposure
 
-        self.update_spatial_oversampling_factor(geom)
+        if self.contributes:
+            self.update_spatial_oversampling_factor(self.geom)
 
         self._compute_npred.cache_clear()
         self._compute_flux_spatial.cache_clear()

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2624,7 +2624,6 @@ class MapEvaluator:
         self._computation_cache = None
         self._neval = 0  # for debugging
         self._renorm = 1
-        self._psf_r68_min = 0 * u.deg
         self._spatial_oversampling_factor = 1
         self._upsampled_geom = self.exposure.geom if self.exposure else None
 
@@ -2740,12 +2739,7 @@ class MapEvaluator:
                 self.psf = psf.get_psf_kernel(
                     position=self.model.position, geom=geom, containment=PSF_CONTAINMENT
                 )
-            self._psf_r68_min = psf.containment_radius(
-                fraction=0.68,
-                energy_true=geom.axes["energy_true"].center,
-                position=self.model.position,
-            ).min()
-
+     
         if self.evaluation_mode == "local":
             self.contributes = self.model.contributes(mask=mask, margin=self.psf_width)
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2747,7 +2747,7 @@ class MapEvaluator:
 
         if self.evaluation_mode == "local":
             self.contributes = self.model.contributes(mask=mask, margin=self.psf_width)
-            print(self.contributes)
+
             if self.contributes:
                 self.exposure = exposure.cutout(
                     position=self.model.position, width=self.cutout_width, odd_npix=True
@@ -2772,7 +2772,7 @@ class MapEvaluator:
             binz = self.model.spatial_model.evaluation_bin_size_min
         else:
             binz = 0 * u.deg
-#        res_scale = np.sqrt(binz ** 2 + self._psf_r68_min ** 2).to_value("deg")
+
         res_scale = binz.to_value("deg")
 
         if res_scale != 0:

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2761,15 +2761,9 @@ class MapEvaluator:
 
     def update_spatial_oversampling_factor(self, geom):
         """Update spatial oversampling_factor for model evaluation"""
-        if (
-            self.model.spatial_model is not None
-            and self.model.spatial_model.evaluation_bin_size_min is not None
-        ):
-            binz = self.model.spatial_model.evaluation_bin_size_min
-        else:
-            binz = 0 * u.deg
+        res_scale = self.model.evaluation_bin_size_min
 
-        res_scale = binz.to_value("deg")
+        res_scale = res_scale.to_value("deg") if res_scale is not None else 0
 
         if geom.is_region or geom.is_hpx:
             geom = geom.to_wcs_geom()

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2626,7 +2626,8 @@ class MapEvaluator:
         self._renorm = 1
         self._psf_r68_min = 0 * u.deg
         self._spatial_oversampling_factor = 1
-        self._upsampled_geom = None
+        self._upsampled_geom = self.exposure.geom if self.exposure else None
+
 
     # workaround for the lru_cache pickle issue
     # see e.g. https://github.com/cloudpipe/cloudpickle/issues/178
@@ -2856,7 +2857,6 @@ class MapEvaluator:
     def _compute_flux_spatial_geom(self, geom):
         """Compute spatial flux oversampling geom if necessary"""
         factor = self._spatial_oversampling_factor
-
         # for now we force the oversampling factor to be 1
         value = self.model.spatial_model.integrate_geom(geom, oversampling_factor=1)
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2781,9 +2781,9 @@ class MapEvaluator:
             self._spatial_oversampling_factor = factor
 
         if  self._spatial_oversampling_factor > 1:
-            self._upsampled_geom = self.geom.upsample(self._spatial_oversampling_factor)
+            self._upsampled_geom = geom.upsample(self._spatial_oversampling_factor)
         else:
-            self._upsampled_geom = self.geom
+            self._upsampled_geom = geom
 
     def compute_dnde(self):
         """Compute model differential flux at map pixel centers.

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2851,7 +2851,10 @@ class MapEvaluator:
 
         value = self.model.spatial_model.integrate_geom(geom)
         if self.psf and self.model.apply_irf["psf"]:
+            psf_kernel_map = self.psf._psf_kernel_map.copy()
+            self.psf._psf_kernel_map = self.psf._psf_kernel_map.upsample(factor)
             value = self.apply_psf(value)
+            self.psf._psf_kernel_map = psf_kernel_map
 
         if factor > 1:
             value = value.downsample(factor)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2849,7 +2849,8 @@ class MapEvaluator:
         if factor > 1:
             geom = geom.upsample(factor)
 
-        value = self.model.spatial_model.integrate_geom(geom)
+        # for now we force the oversampling factor to be 1
+        value = self.model.spatial_model.integrate_geom(geom, oversampling_factor=1)
         if self.psf and self.model.apply_irf["psf"]:
             psf_kernel_map = self.psf._psf_kernel_map.copy()
             self.psf._psf_kernel_map = self.psf._psf_kernel_map.upsample(factor)

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -54,7 +54,7 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
     result = estimator.run(datasets)
 
     assert_allclose(result["norm"], 0.98949, atol=1e-3)
-    assert_allclose(result["ts"], 24662.234134, rtol=1e-3)
+    assert_allclose(result["ts"], 25083.75408, rtol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
     assert_allclose(result["norm_errn"], 0.0199, atol=1e-3)
     assert_allclose(result["norm_errp"], 0.0199, atol=1e-3)
@@ -82,7 +82,7 @@ def test_flux_estimator_fermi_with_reoptimization(fermi_datasets):
     result = estimator.run(datasets)
 
     assert_allclose(result["norm"], 0.989989, atol=1e-3)
-    assert_allclose(result["ts"], 18308.368105, rtol=1e-3)
+    assert_allclose(result["ts"], 18729.368105, rtol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
 
 
@@ -134,7 +134,7 @@ def test_inhomogeneous_datasets(fermi_datasets, hess_datasets):
     result = estimator.run(datasets)
 
     assert_allclose(result["norm"], 1.190622, atol=1e-3)
-    assert_allclose(result["ts"], 602.201947, atol=1e-3)
+    assert_allclose(result["ts"], 612.50171, atol=1e-3)
     assert_allclose(result["norm_err"], 0.090744, atol=1e-3)
     assert_allclose(result["e_min"], 0.693145 * u.TeV, atol=1e-3)
     assert_allclose(result["e_max"], 10 * u.TeV, atol=1e-3)

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -54,7 +54,7 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
     result = estimator.run(datasets)
 
     assert_allclose(result["norm"], 0.98949, atol=1e-3)
-    assert_allclose(result["ts"], 25083.75408, rtol=1e-3)
+    assert_allclose(result["ts"], 24662.234134, rtol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
     assert_allclose(result["norm_errn"], 0.0199, atol=1e-3)
     assert_allclose(result["norm_errp"], 0.0199, atol=1e-3)
@@ -82,7 +82,7 @@ def test_flux_estimator_fermi_with_reoptimization(fermi_datasets):
     result = estimator.run(datasets)
 
     assert_allclose(result["norm"], 0.989989, atol=1e-3)
-    assert_allclose(result["ts"], 18729.907481, rtol=1e-3)
+    assert_allclose(result["ts"], 18308.368105, rtol=1e-3)
     assert_allclose(result["norm_err"], 0.01998, atol=1e-3)
 
 
@@ -134,7 +134,7 @@ def test_inhomogeneous_datasets(fermi_datasets, hess_datasets):
     result = estimator.run(datasets)
 
     assert_allclose(result["norm"], 1.190622, atol=1e-3)
-    assert_allclose(result["ts"], 612.50171, atol=1e-3)
+    assert_allclose(result["ts"], 602.201947, atol=1e-3)
     assert_allclose(result["norm_err"], 0.090744, atol=1e-3)
     assert_allclose(result["e_min"], 0.693145 * u.TeV, atol=1e-3)
     assert_allclose(result["e_max"], 10 * u.TeV, atol=1e-3)

--- a/gammapy/irf/psf/kernel.py
+++ b/gammapy/irf/psf/kernel.py
@@ -112,7 +112,7 @@ class PSFKernel:
         model.position = geom.center_skydir
 
         geom = geom.upsample(factor=factor)
-        map = model.integrate_geom(geom)
+        map = model.integrate_geom(geom, oversampling_factor=1)
         return cls(psf_kernel_map=map.downsample(factor=factor))
 
     @classmethod

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -338,7 +338,7 @@ class SkyModel(Model):
         )
 
         if self.spatial_model:
-            value = value * self.spatial_model.integrate_geom(geom).quantity
+            value = value * self.spatial_model.integrate_geom(geom, oversampling_factor=None).quantity
 
         if self.temporal_model:
             integral = self.temporal_model.integral(gti.time_start, gti.time_stop)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -191,6 +191,17 @@ class SkyModel(Model):
         return getattr(self.spatial_model, "position_lonlat", None)
 
     @property
+    def evaluation_bin_size_min(self):
+        """Minimal spatial bin size for spatial model evaluation."""
+        if (
+            self.spatial_model is not None
+            and self.spatial_model.evaluation_bin_size_min is not None
+        ):
+            return self.spatial_model.evaluation_bin_size_min
+        else:
+            return None
+
+    @property
     def evaluation_radius(self):
         """`~astropy.coordinates.Angle`"""
         return self.spatial_model.evaluation_radius

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -317,8 +317,11 @@ class SkyModel(Model):
 
         return value
 
-    def integrate_geom(self, geom, gti=None):
+    def integrate_geom(self, geom, gti=None, oversampling_factor=None):
         """Integrate model on `~gammapy.maps.Geom`.
+
+        See `~gammapy.modeling.models.SpatialModel.integrate_geom` and
+        `~gammapy.modeling.models.SpectralModel.integral`.
 
         Parameters
         ----------
@@ -326,6 +329,9 @@ class SkyModel(Model):
             Map geometry
         gti : `GTI`
             GIT table
+        oversampling_factor : int or None
+            The oversampling factor to use for spatial integration.
+            Default is None: the factor is estimated from the model minimal bin size
 
         Returns
         -------
@@ -338,7 +344,7 @@ class SkyModel(Model):
         )
 
         if self.spatial_model:
-            value = value * self.spatial_model.integrate_geom(geom, oversampling_factor=None).quantity
+            value = value * self.spatial_model.integrate_geom(geom, oversampling_factor=oversampling_factor).quantity
 
         if self.temporal_model:
             integral = self.temporal_model.integral(gti.time_start, gti.time_stop)

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -188,9 +188,12 @@ class SpatialModel(Model):
             wcs_geom = geom.to_wcs_geom().to_image()
 
         result = Map.from_geom(geom=wcs_geom, unit='1/sr')
-        if oversampling_factor is None:
+
+        if oversampling_factor is None and self.evaluation_bin_size_min:
             res_scale = self.evaluation_bin_size_min.to_value("deg")
             oversampling_factor = int(np.ceil(np.max(wcs_geom.pixel_scales.deg) / res_scale))
+        else:
+            oversampling_factor=1
 
         if oversampling_factor > 1:
             if self.evaluation_radius is not None:
@@ -670,7 +673,7 @@ class DiskSpatialModel(SpatialModel):
     @property
     def evaluation_bin_size_min(self):
         """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
-        return self.r_0.quantity * (1 - self.edge_width.quantity)
+        return self.r_0.quantity * (1 - self.edge_width.quantity) /10.
 
     @property
     def evaluation_radius(self):
@@ -678,7 +681,7 @@ class DiskSpatialModel(SpatialModel):
     
         Set to the length of the semi-major axis plus the edge width.
         """
-        return self.r_0.quantity * (1 + self.edge_width.quantity)
+        return 1.1*self.r_0.quantity * (1 + self.edge_width.quantity)
 
     @staticmethod
     def _evaluate_norm_factor(r_0, e):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -198,7 +198,6 @@ class SpatialModel(Model):
             else:
                 oversampling_factor=1
 
-        print(oversampling_factor)
         if oversampling_factor > 1:
             if self.evaluation_radius is not None:
                 # Is it still needed?

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -594,7 +594,7 @@ class GeneralizedGaussianSpatialModel(SpatialModel):
     @property
     def evaluation_bin_size_min(self):
         """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
-        return self.r_0.quantity / (1 + 8 * self.eta.value)
+        return self.r_0.quantity / (3 + 8 * self.eta.value) / (self.e.value + 1)
 
 
     @property

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -191,12 +191,14 @@ class SpatialModel(Model):
         result = Map.from_geom(geom=wcs_geom)#, unit='1/sr')
 
         pix_scale = np.max(wcs_geom.pixel_scales.to_value("deg"))
-        if oversampling_factor is None and self.evaluation_bin_size_min is not None:
-            res_scale = self.evaluation_bin_size_min.to_value("deg")
-            oversampling_factor = int(np.ceil( pix_scale/ res_scale))
-        else:
-            oversampling_factor=1
+        if oversampling_factor is None:
+            if self.evaluation_bin_size_min is not None:
+                res_scale = self.evaluation_bin_size_min.to_value("deg")
+                oversampling_factor = int(np.ceil( pix_scale/ res_scale))
+            else:
+                oversampling_factor=1
 
+        print(oversampling_factor)
         if oversampling_factor > 1:
             if self.evaluation_radius is not None:
                 # Is it still needed?
@@ -950,7 +952,7 @@ class ConstantFluxSpatialModel(SpatialModel):
         return 1 / geom.solid_angle()
 
     @staticmethod
-    def integrate_geom(geom):
+    def integrate_geom(geom, oversampling_factor=None):
         """Evaluate model."""
         return Map.from_geom(geom=geom, data=1)
 

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -61,6 +61,10 @@ class SpatialModel(Model):
 
         return self.evaluate(lon, lat, **kwargs)
 
+    @property
+    def evaluation_bin_size_min(self):
+        return None
+
     # TODO: make this a hard-coded class attribute?
     @lazyproperty
     def is_energy_dependent(self):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -158,12 +158,25 @@ class SpatialModel(Model):
         else:
             return self(coords.lon, coords.lat)
 
-    def integrate_geom(self, geom):
+    def integrate_geom(self, geom, oversampling_factor=None):
         """Integrate model on `~gammapy.maps.Geom` or `~gammapy.maps.RegionGeom`.
-        
+
+        Integration is performed by simple rectangle approximation, the pixel center model value
+        is multiplied by the pixel solid angle.
+        An oversampling factor can be used for precision. By default, this parameter is set to None
+        and an oversampling factor is automatically estimated based on the model estimation maximal
+        bin width.
+
+        For a RegionGeom, the model is estimated at the center of the region and mutliplied by
+        the region solid angle.
+
         Parameters
         ----------
         geom : `~gammapy.maps.WcsGeom` or `~gammapy.maps.RegionGeom`
+            The geom on which the integration is performed
+        oversampling_factor : int or None
+            The oversampling factor to use for integration.
+            Default is None: the factor is estimated from the model minimimal bin size
 
         Returns
         ---------

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -630,7 +630,7 @@ class DiskSpatialModel(SpatialModel):
     @property
     def evaluation_bin_size_min(self):
         """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
-        return self.r_0.quantity / 2.
+        return self.r_0.quantity * (1 - self.edge_width.quantity)
 
     @property
     def evaluation_radius(self):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -188,7 +188,7 @@ class SpatialModel(Model):
         if geom.is_region:
             wcs_geom = geom.to_wcs_geom().to_image()
 
-        result = Map.from_geom(geom=wcs_geom, unit='1/sr')
+        result = Map.from_geom(geom=wcs_geom)#, unit='1/sr')
 
         pix_scale = np.max(wcs_geom.pixel_scales.to_value("deg"))
         if oversampling_factor is None and self.evaluation_bin_size_min is not None:
@@ -216,9 +216,12 @@ class SpatialModel(Model):
             integrated = upsampled.downsample(oversampling_factor, preserve_counts=True, weights=mask)
 
             # Finally stack result
+            result.unit = integrated.unit
             result.stack(integrated)
         else:
-            result.quantity += self.evaluate_geom(wcs_geom)
+            values = self.evaluate_geom(wcs_geom)
+            result.unit = values.unit
+            result += values
 
         result *= result.geom.solid_angle()
 

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -360,6 +360,11 @@ class PointSpatialModel(SpatialModel):
     is_energy_dependent = False
 
     @property
+    def evaluation_bin_size_min(self):
+        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
+        return 0 * u.deg
+
+    @property
     def evaluation_radius(self):
         """Evaluation radius (`~astropy.coordinates.Angle`).
 
@@ -439,6 +444,12 @@ class GaussianSpatialModel(SpatialModel):
     sigma = Parameter("sigma", "1 deg", min=0)
     e = Parameter("e", 0, min=0, max=1, frozen=True)
     phi = Parameter("phi", "0 deg", frozen=True)
+
+    @property
+    def evaluation_bin_size_min(self):
+        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
+        return self.parameters["sigma"].quantity / 3.
+
 
     @property
     def evaluation_radius(self):
@@ -538,6 +549,12 @@ class GeneralizedGaussianSpatialModel(SpatialModel):
         return (norm * np.exp(-(z ** (1 / eta)))).to("sr-1")
 
     @property
+    def evaluation_bin_size_min(self):
+        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
+        return self.r_0.quantity / (1 + 8 * self.eta.value)
+
+
+    @property
     def evaluation_radius(self):
         r"""Evaluation radius (`~astropy.coordinates.Angle`).
         The evaluation radius is defined as r_eval = r_0*(1+8*eta) so it verifies:
@@ -609,6 +626,11 @@ class DiskSpatialModel(SpatialModel):
     e = Parameter("e", 0, min=0, max=1, frozen=True)
     phi = Parameter("phi", "0 deg", frozen=True)
     edge_width = Parameter("edge_width", value=0.01, min=0, max=1, frozen=True)
+
+    @property
+    def evaluation_bin_size_min(self):
+        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
+        return self.r_0.quantity / 2.
 
     @property
     def evaluation_radius(self):
@@ -698,6 +720,11 @@ class ShellSpatialModel(SpatialModel):
     width = Parameter("width", "0.2 deg")
 
     @property
+    def evaluation_bin_size_min(self):
+        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
+        return self.width.quantity
+
+    @property
     def evaluation_radius(self):
         r"""Evaluation radius (`~astropy.coordinates.Angle`).
 
@@ -759,6 +786,11 @@ class Shell2SpatialModel(SpatialModel):
     lat_0 = Parameter("lat_0", "0 deg", min=-90, max=90)
     r_0 = Parameter("r_0", "1 deg")
     eta = Parameter("eta", 0.2, min=0.02, max=1)
+
+    @property
+    def evaluation_bin_size_min(self):
+        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
+        return self.eta.value * self.r_0
 
     @property
     def evaluation_radius(self):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -497,7 +497,7 @@ class GaussianSpatialModel(SpatialModel):
 
     @property
     def evaluation_bin_size_min(self):
-        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
+        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`) chosen as sigma/3."""
         return self.parameters["sigma"].quantity / 3.
 
 
@@ -600,7 +600,10 @@ class GeneralizedGaussianSpatialModel(SpatialModel):
 
     @property
     def evaluation_bin_size_min(self):
-        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
+        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`).
+
+        The bin min size is defined as r_0/(3+8*eta)/(e+1).
+        """
         return self.r_0.quantity / (3 + 8 * self.eta.value) / (self.e.value + 1)
 
 
@@ -679,7 +682,10 @@ class DiskSpatialModel(SpatialModel):
 
     @property
     def evaluation_bin_size_min(self):
-        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
+        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`).
+
+        The bin min size is defined as r_0*(1-edge_width)/10.
+        """
         return self.r_0.quantity * (1 - self.edge_width.quantity) /10.
 
     @property
@@ -771,7 +777,10 @@ class ShellSpatialModel(SpatialModel):
 
     @property
     def evaluation_bin_size_min(self):
-        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
+        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`).
+
+        The bin min size is defined as the shell width.
+        """
         return self.width.quantity
 
     @property
@@ -839,7 +848,10 @@ class Shell2SpatialModel(SpatialModel):
 
     @property
     def evaluation_bin_size_min(self):
-        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`)."""
+        """ Minimal evaluation bin size (`~astropy.coordinates.Angle`).
+
+        The bin min size is defined as r_0*eta.
+        """
         return self.eta.value * self.r_0
 
     @property

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -585,8 +585,8 @@ class MyCustomGaussianModel(SpatialModel):
     lon_0 = Parameter("lon_0", "0 deg")
     lat_0 = Parameter("lat_0", "0 deg", min=-90, max=90)
 
-    sigma_1TeV = Parameter("sigma_1TeV", "1 deg", min=0)
-    sigma_10TeV = Parameter("sigma_10TeV", "0.5 deg", min=0)
+    sigma_1TeV = Parameter("sigma_1TeV", "0.5 deg", min=0)
+    sigma_10TeV = Parameter("sigma_10TeV", "0.1 deg", min=0)
 
     @staticmethod
     def evaluate(lon, lat, energy, lon_0, lat_0, sigma_1TeV, sigma_10TeV):
@@ -607,13 +607,16 @@ class MyCustomGaussianModel(SpatialModel):
         return 5 * self.sigma_1TeV.quantity
 
 
-def test_energy_dependent_model(geom_true):
+def test_energy_dependent_model():
+    axis = MapAxis.from_edges(np.logspace(-1, 1, 4), unit=u.TeV, name="energy_true")
+    geom_true = WcsGeom.create(skydir=(0, 0), binsz="0.1 deg", npix=(50, 50), frame="galactic", axes=[axis])
+
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     spatial_model = MyCustomGaussianModel(frame="galactic")
     sky_model = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)
     model = sky_model.integrate_geom(geom_true)
 
-    assert_allclose(model.data.sum(), 1.678314e-14, rtol=1e-3)
+    assert_allclose(model.data.sum(), 9.9e-11, rtol=1e-3)
 
 
 @requires_dependency("matplotlib")

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -594,6 +594,7 @@ class MyCustomGaussianModel(SpatialModel):
         sigmas = u.Quantity([sigma_1TeV, sigma_10TeV])
         energy_nodes = [1, 10] * u.TeV
         sigma = np.interp(energy, energy_nodes, sigmas)
+        sigma = sigma.to("rad")
 
         sep = angular_separation(lon, lat, lon_0, lat_0)
 

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -109,7 +109,7 @@ def test_sky_gaussian():
 
 
 @pytest.mark.parametrize("eta", np.arange(0.1, 1.01, 0.3))
-@pytest.mark.parametrize("r_0", np.arange(0.1, 1.01, 0.3))
+@pytest.mark.parametrize("r_0", np.arange(0.01, 1.01, 0.3))
 @pytest.mark.parametrize("e", np.arange(0.0, 0.801, 0.4))
 def test_generalized_gaussian(eta, r_0, e):
     # check normalization is robust for a large set of values
@@ -117,8 +117,9 @@ def test_generalized_gaussian(eta, r_0, e):
         eta=eta, r_0=r_0 * u.deg, e=e, frame="galactic"
     )
 
+    width = np.maximum(2 * model.evaluation_radius.to_value("deg"), 0.5)
     geom = WcsGeom.create(
-        skydir=(0, 0), binsz=0.02, width=2 * model.evaluation_radius, frame="galactic",
+        skydir=(0, 0), binsz=0.02, width=width, frame="galactic",
     )
 
     integral = model.integrate_geom(geom)

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -375,7 +375,7 @@ def test_spatial_model_plot():
         model.plot_error(ax=ax)
 
 
-def test_integrate_geom():
+def test_integrate_region_geom():
     center = SkyCoord("0d", "0d", frame="icrs")
     model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1 * u.deg, frame="icrs")
 
@@ -397,6 +397,18 @@ def test_integrate_geom():
     assert_allclose(integral_large[0], 1, rtol=0.01)
     assert_allclose(integral_small[0], 0.3953, rtol=0.01)
 
+def test_integrate_wcs_geom():
+    center = SkyCoord("0d", "0d", frame="icrs")
+    model_0_01d = GaussianSpatialModel(lon="0.234d", lat="-0.172d", sigma=0.01 * u.deg, frame="icrs")
+    model_0_005d = GaussianSpatialModel(lon="0.234d", lat="-0.172d", sigma=0.005 * u.deg, frame="icrs")
+
+    geom = WcsGeom.create(skydir=center, npix=100, binsz=0.02)
+
+    integrated_0_01d = model_0_01d.integrate_geom(geom)
+    integrated_0_005d = model_0_005d.integrate_geom(geom)
+
+    assert_allclose(integrated_0_01d.data.sum(), 1, atol=1e-4)
+    assert_allclose(integrated_0_005d.data.sum(), 1, atol=1e-4)
 
 def test_integrate_geom_energy_axis():
     center = SkyCoord("0d", "0d", frame="icrs")

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -384,18 +384,15 @@ def test_integrate_region_geom():
     radius_small = 0.1 * u.deg
     circle_small = CircleSkyRegion(center, radius_small)
 
-    geom_large, geom_small = (
-        RegionGeom(region=circle_large, binsz_wcs="0.01deg"),
-        RegionGeom(region=circle_small, binsz_wcs="0.01deg"),
-    )
+    geom_large, geom_small = RegionGeom(region=circle_large), RegionGeom(region=circle_small, binsz_wcs="0.01d")
 
     integral_large, integral_small = (
         model.integrate_geom(geom_large).data,
         model.integrate_geom(geom_small).data,
     )
 
-    assert_allclose(integral_large[0], 1, rtol=0.01)
-    assert_allclose(integral_small[0], 0.3953, rtol=0.01)
+    assert_allclose(integral_large[0], 1, rtol=0.001)
+    assert_allclose(integral_small[0], 0.3953, rtol=0.001)
 
 def test_integrate_wcs_geom():
     center = SkyCoord("0d", "0d", frame="icrs")
@@ -418,8 +415,8 @@ def test_integrate_geom_energy_axis():
     square = RectangleSkyRegion(center, radius, radius)
 
     axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=10)
-    geom = RegionGeom(region=square, axes=[axis], binsz_wcs="0.01deg")
+    geom = RegionGeom(region=square, axes=[axis])
 
     integral = model.integrate_geom(geom).data
 
-    assert_allclose(integral, 1, rtol=0.01)
+    assert_allclose(integral, 1, rtol=0.0001)

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -150,7 +150,7 @@ def test_sky_disk():
     assert_allclose(val.value, desired)
     radius = model.evaluation_radius
     assert radius.unit == "deg"
-    assert_allclose(radius, r_0 * (1 + model.edge_width.value))
+    assert_allclose(radius.to_value("deg"), 2.222)
 
     # test the normalization for an elongated ellipse near the Galactic Plane
     m_geom_1 = WcsGeom.create(
@@ -170,7 +170,7 @@ def test_sky_disk():
 
     radius = model_1.evaluation_radius
     assert radius.unit == "deg"
-    assert_allclose(radius, r_0 * (1 + model.edge_width.value))
+    assert_allclose(radius.to_value("deg"), 11.11)
     # test rotation
     r_0 = 2 * u.deg
     semi_minor = 1 * u.deg

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -407,8 +407,8 @@ def test_integrate_wcs_geom():
     integrated_0_01d = model_0_01d.integrate_geom(geom)
     integrated_0_005d = model_0_005d.integrate_geom(geom)
 
-    assert_allclose(integrated_0_01d.data.sum(), 1, atol=1e-4)
-    assert_allclose(integrated_0_005d.data.sum(), 1, atol=1e-4)
+    assert_allclose(integrated_0_01d.data.sum(), 1, atol=2e-4)
+    assert_allclose(integrated_0_005d.data.sum(), 1, atol=2e-4)
 
 def test_integrate_geom_energy_axis():
     center = SkyCoord("0d", "0d", frame="icrs")


### PR DESCRIPTION
Add spatial model evaluation on oversampled geom for MapEvaluator (follow-up of issues discussed in #3229):
- Add SpatialModel.evaluation_bin_size_min property to define a minimal bin size to be used. For now it is set to None in the SpatialModel base class, but it should also be  set as a function of the parameters case by case.
-  within MapEvaluator._compute_flux_spatial(), call geom.upsample() before model evaluation, and then call map.downsample() after PSF convolution