### PR TITLE
Fix region geom width computation

### DIFF
--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -124,7 +124,7 @@ the code as well as the output value produced.
         >>> from gammapy.utils.regions import make_pixel_region
         >>> wcs = WcsGeom.create().wcs
         >>> region = make_pixel_region("galactic;circle(10,20,3)", wcs)
-        >>> region
+        >>> print(region)
         <CirclePixelRegion(PixCoord(x=570.9301128316974, y=159.935542455567), radius=6.061376992149382)>
 
 In order to perform tests of these snippets of code present in the docstrings of the Python files, you may run the

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -122,7 +122,7 @@ class SourceCatalog(abc.ABC):
             name = row[self._source_name_key]
             names[name.strip()] = idx
             for alias_column in self._source_name_alias:
-                for alias in row[alias_column].split(","):
+                for alias in str(row[alias_column]).split(","):
                     if not alias == "":
                         names[alias.strip()] = idx
         return names
@@ -146,7 +146,7 @@ class SourceCatalog(abc.ABC):
 
         possible_names = [row[self._source_name_key]]
         for alias_column in self._source_name_alias:
-            possible_names += row[alias_column].split(",")
+            possible_names += str(row[alias_column]).split(",")
 
         if name not in possible_names:
             self.__dict__.pop("_name_to_index_cache")

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -87,7 +87,7 @@ class SourceCatalogObjectFermiBase(SourceCatalogObject, abc.ABC):
             ss += "{:<20s} : {}\n".format("Extended name", d["Extended_Source_Name"])
 
         def get_nonentry_keys(keys):
-            vals = [d[_].strip() for _ in keys]
+            vals = [str(d[_]).strip() for _ in keys]
             return ", ".join([_ for _ in vals if _ != ""])
 
         associations = get_nonentry_keys(keys)
@@ -256,11 +256,11 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
 
         elif spec_type == "PLSuperExpCutoff":
             tag = "PLEC"
-            fmt = "{:<45s} : {} +- {}\n"
+            fmt = "{:<45s} : {:.4f} +- {:.4f}\n"
             ss += fmt.format(
                 "Exponential factor", d["PLEC_Expfactor"], d["Unc_PLEC_Expfactor"]
             )
-            ss += "{:<45s} : {} +- {}\n".format(
+            ss += "{:<45s} : {:.4f} +- {:.4f}\n".format(
                 "Super-exponential cutoff index",
                 d["PLEC_Exp_Index"],
                 d["Unc_PLEC_Exp_Index"],
@@ -415,7 +415,7 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
             errs = {
                 "amplitude": self.data["Unc_PLEC_Flux_Density"],
                 "index_1": self.data["Unc_PLEC_Index"],
-                "index_2": np.nan_to_num(self.data["Unc_PLEC_Exp_Index"]),
+                "index_2": np.nan_to_num(float(self.data["Unc_PLEC_Exp_Index"])),
                 "expfactor": self.data["Unc_PLEC_Expfactor"],
             }
         else:

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -194,7 +194,8 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         elif spec_type == "pl2":
             e_max = data["spec_pl2_e_max"]
             DEFAULT_E_MAX = u.Quantity(1e5, "TeV")
-            if np.isnan(e_max.value):
+
+            if np.isnan(e_max.value) or e_max.value == 0:
                 e_max = DEFAULT_E_MAX
 
             tag = "PowerLaw2SpectralModel"

--- a/gammapy/catalog/tests/data/2fhl_j0822.6-4250e.txt
+++ b/gammapy/catalog/tests/data/2fhl_j0822.6-4250e.txt
@@ -3,9 +3,9 @@
 
 Catalog row index (zero-based) : 134
 Source name          : 2FHL J0822.6-4250e
-Associations     : Puppis A, 3FGL J0822.6-4250e, 1FHL J0822.6-4250e
-ASSOC_PROB_BAY   : nan
-ASSOC_PROB_LR    : nan
+Associations     : Puppis A, 3FGL J0822.6-4250e, 1FHL J0822.6-4250e, --
+ASSOC_PROB_BAY   : --
+ASSOC_PROB_LR    : --
 Class            : snr
 TeVCat flag      : N/A
 

--- a/gammapy/catalog/tests/data/2fhl_j1445.1-0329.txt
+++ b/gammapy/catalog/tests/data/2fhl_j1445.1-0329.txt
@@ -3,7 +3,7 @@
 
 Catalog row index (zero-based) : 221
 Source name          : 2FHL J1445.1-0329
-Associations     : RBS 1424, 3FGL J1445.0-0328
+Associations     : RBS 1424, 3FGL J1445.0-0328, --, --
 ASSOC_PROB_BAY   : 0.997
 ASSOC_PROB_LR    : 0.944
 Class            : bll

--- a/gammapy/catalog/tests/data/3fhl_j2301.9+5855e.txt
+++ b/gammapy/catalog/tests/data/3fhl_j2301.9+5855e.txt
@@ -5,8 +5,8 @@ Catalog row index (zero-based) : 1500
 Source name          : 3FHL J2301.9+5855e
 Extended name        : FGES J2301.9+5855 
 Associations     : CTB 109, 3FGL J2301.2+5853
-ASSOC_PROB_BAY   : nan
-ASSOC_PROB_LR    : nan
+ASSOC_PROB_BAY   : --
+ASSOC_PROB_LR    : --
 Class            : SNR    
 TeVCat flag      : N
 
@@ -18,8 +18,8 @@ Npred                            : 53.1
 HEP Energy       : 364.828 GeV
 HEP Probability  : 0.849
 Bayesian Blocks  : 1
-Redshift         : nan
-NuPeak_obs       : nan Hz
+Redshift         : --
+NuPeak_obs       : 0.0 Hz
 
 *** Position info ***
 
@@ -28,9 +28,9 @@ DEC                  : 58.920 deg
 GLON                 : 109.203 deg
 GLAT                 : -1.003 deg
 
-Semimajor (95%)      : nan deg
-Semiminor (95%)      : nan deg
-Position angle (95%) : nan deg
+Semimajor (95%)      : 0.0000 deg
+Semiminor (95%)      : 0.0000 deg
+Position angle (95%) : 0.00 deg
 ROI number           : 479
 
 *** Extended source information ***

--- a/gammapy/catalog/tests/data/4fgl_J0002.8+6217.txt
+++ b/gammapy/catalog/tests/data/4fgl_J0002.8+6217.txt
@@ -37,8 +37,8 @@ ROI number           : 1389
 
 Spectrum type                                 : PLSuperExpCutoff 
 Detection significance (100 MeV - 1 TeV)      : 27.669
-Exponential factor                            : 0.013006397522985935 +- 0.0018857797840610147
-Super-exponential cutoff index                : 0.6666666865348816 +- nan
+Exponential factor                            : 0.0130 +- 0.0019
+Super-exponential cutoff index                : 0.6667 +- --
 Significance curvature                        : 9.7
 Pivot energy                                  : 1327 MeV
 Spectral index                                : 1.181 +- 0.191

--- a/gammapy/catalog/tests/data/4fgl_J1409.1-6121e.txt
+++ b/gammapy/catalog/tests/data/4fgl_J1409.1-6121e.txt
@@ -5,8 +5,8 @@ Catalog row index (zero-based) : 2718
 Source name          : 4FGL J1409.1-6121e
 Extended name        : FGES J1409.1-6121 
 Associations     : 3FGL J1405.4-6119, 3FHL J1409.1-6121e, J1407-6136c
-ASSOC_PROB_BAY   : nan
-ASSOC_PROB_LR    : nan
+ASSOC_PROB_BAY   : --
+ASSOC_PROB_LR    : --
 Class1           :      
 Class2           :      
 TeVCat flag      : N
@@ -25,12 +25,12 @@ DEC                  : -61.353 deg
 GLON                 : 312.111 deg
 GLAT                 : 0.126 deg
 
-Semimajor (68%)      : nan deg
-Semiminor (68%)      : nan deg
-Position angle (68%) : nan deg
-Semimajor (95%)      : nan deg
-Semiminor (95%)      : nan deg
-Position angle (95%) : nan deg
+Semimajor (68%)      : 0.0000 deg
+Semiminor (68%)      : 0.0000 deg
+Position angle (68%) : 0.00 deg
+Semimajor (95%)      : 0.0000 deg
+Semiminor (95%)      : 0.0000 deg
+Position angle (95%) : 0.00 deg
 ROI number           : 280
 
 *** Extended source information ***

--- a/gammapy/catalog/tests/data/gammacat_hess_j1813-178.txt
+++ b/gammapy/catalog/tests/data/gammacat_hess_j1813-178.txt
@@ -4,7 +4,7 @@
 Catalog row index (zero-based): 118
 Common name: HESS J1813-178
 Gamma names: HESS J1813-178
-Fermi names: 
+Fermi names: --
 Other names: G12.82-0.02,PSR J1813-1749,CXOU J181335.1-174957,IGR J18135-1751,W33
 Location: gal
 Class: pwn
@@ -41,11 +41,11 @@ Position error: 0.005 deg
 Morphology model type: gauss
 Sigma: 0.036 deg
 Sigma error: 0.006 deg
-Sigma2: nan deg
-Sigma2 error: nan deg
-Position angle: nan deg
-Position angle error: nan deg
-Position angle frame: 
+Sigma2: 0.000 deg
+Sigma2 error: 0.000 deg
+Position angle: 0.000 deg
+Position angle error: 0.000 deg
+Position angle frame: --
 
 *** Spectral info ***
 
@@ -56,9 +56,9 @@ Spectrum type: pl2
 flux: 1.42e-11 +- 1.1e-12 (stat) +- 3e-13 (sys) cm-2 s-1
 index: 2.09 +- 0.08 (stat) +- 0.2 (sys)
 e_min: 0.2 TeV
-e_max: nan TeV
+e_max: 0.0 TeV
 
-Energy range: (nan, nan) TeV
+Energy range: (0.0, 0.0) TeV
 theta: 0.15 deg
 
 

--- a/gammapy/catalog/tests/data/gammacat_hess_j1848-018.txt
+++ b/gammapy/catalog/tests/data/gammacat_hess_j1848-018.txt
@@ -4,7 +4,7 @@
 Catalog row index (zero-based): 134
 Common name: HESS J1848-018
 Gamma names: HESS J1848-018,1HWC J1849-017c
-Fermi names: 
+Fermi names: --
 Other names: WR121a,W43
 Location: gal
 Class: unid
@@ -34,18 +34,18 @@ RA: 282.121 deg
 DEC: -1.792 deg
 GLON: 31.000 deg
 GLAT: -0.160 deg
-Position error: nan deg
+Position error: 0.000 deg
 
 *** Morphology info ***
 
 Morphology model type: gauss
 Sigma: 0.320 deg
 Sigma error: 0.020 deg
-Sigma2: nan deg
-Sigma2 error: nan deg
-Position angle: nan deg
-Position angle error: nan deg
-Position angle frame: 
+Sigma2: 0.000 deg
+Sigma2 error: 0.000 deg
+Position angle: 0.000 deg
+Position angle error: 0.000 deg
+Position angle frame: --
 
 *** Spectral info ***
 

--- a/gammapy/catalog/tests/data/gammacat_vela_x.txt
+++ b/gammapy/catalog/tests/data/gammacat_vela_x.txt
@@ -4,8 +4,8 @@
 Catalog row index (zero-based): 36
 Common name: Vela X
 Gamma names: HESS J0835-455
-Fermi names: 
-Other names: 
+Fermi names: --
+Other names: --
 Location: gal
 Class: pwn
 
@@ -34,7 +34,7 @@ RA: 128.750 deg
 DEC: -45.600 deg
 GLON: 263.856 deg
 GLAT: -3.089 deg
-Position error: nan deg
+Position error: 0.000 deg
 
 *** Morphology info ***
 
@@ -58,7 +58,7 @@ index: 1.32 +- 0.06 (stat) +- 0.12 (sys)
 e_cut: 14.0 +- 1.6 (stat) +- 2.6 (sys) TeV
 reference: 1.0 TeV
 
-Energy range: (0.75, nan) TeV
+Energy range: (0.75, 0.0) TeV
 theta: 1.2 deg
 
 

--- a/gammapy/catalog/tests/data/hess_j1713-397.txt
+++ b/gammapy/catalog/tests/data/hess_j1713-397.txt
@@ -13,52 +13,52 @@ Gamma-Cat id         : 96
 
 RA                   :  258.355 deg = 17h13m25s
 DEC                  :  -39.771 deg = -39d46m16s
-GLON                 :  347.311 +/- nan deg
-GLAT                 :   -0.457 +/- nan deg
-Position Error (68%) : nan deg
-Position Error (95%) : nan deg
+GLON                 :  347.311 +/- 0.000 deg
+GLAT                 :   -0.457 +/- 0.000 deg
+Position Error (68%) : 0.000 deg
+Position Error (95%) : 0.000 deg
 ROI number           : -1
 Spatial model        : Shell
-Spatial components   : 
-TS                   : nan
-sqrt(TS)             : nan
-Size                 : 0.500 +/- nan (UL: nan) deg
-R70                  : nan deg
+Spatial components   : --
+TS                   : --
+sqrt(TS)             : --
+Size                 : 0.500 +/- 0.000 (UL: 0.000) deg
+R70                  : 0.000 deg
 RSpec                : 0.600 deg
-Total model excess   : nan
-Excess in RSpec      : nan
-Model Excess in RSpec : nan
-Background in RSpec  : nan
+Total model excess   : --
+Excess in RSpec      : --
+Model Excess in RSpec : --
+Background in RSpec  : --
 Livetime             : 164.0 hours
-Energy threshold     : nan TeV
+Energy threshold     : 0.00 TeV
 Source flux (>1 TeV) : (16.879 +/- 0.824) x 10^-12 cm^-2 s^-1 = (74.69 +/- 3.64) % Crab
 
 Fluxes in RSpec (> 1 TeV):
-Map measurement                : nan x 10^-12 cm^-2 s^-1 =   nan % Crab
-Source model                   : nan x 10^-12 cm^-2 s^-1 =   nan % Crab
-Other component model          : nan x 10^-12 cm^-2 s^-1 =   nan % Crab
-Large scale component model    : nan x 10^-12 cm^-2 s^-1 =   nan % Crab
-Total model                    : nan x 10^-12 cm^-2 s^-1 =   nan % Crab
-Containment in RSpec                :   nan %
-Contamination in RSpec              :   nan %
-Flux correction (RSpec -> Total)    :   nan %
-Flux correction (Total -> RSpec)    :   nan %
+Map measurement                : 0.000 x 10^-12 cm^-2 s^-1 =  0.00 % Crab
+Source model                   : 0.000 x 10^-12 cm^-2 s^-1 =  0.00 % Crab
+Other component model          : 0.000 x 10^-12 cm^-2 s^-1 =  0.00 % Crab
+Large scale component model    : 0.000 x 10^-12 cm^-2 s^-1 =  0.00 % Crab
+Total model                    : 0.000 x 10^-12 cm^-2 s^-1 =  0.00 % Crab
+Containment in RSpec                : -- %
+Contamination in RSpec              : -- %
+Flux correction (RSpec -> Total)    : -- %
+Flux correction (Total -> RSpec)    : -- %
 
 *** Info from spectral analysis ***
 
 Livetime             : 164.0 hours
 Energy range:        : 0.20 to 40.00 TeV
-Background           : nan
-Excess               : nan
+Background           : --
+Excess               : --
 Spectral model       : ECPL
-TS ECPL over PL      : nan
+TS ECPL over PL      : --
 Best-fit model flux(> 1 TeV) : (16.879 +/- 0.824) x 10^-12 cm^-2 s^-1  = (74.69 +/- 3.64) % Crab
 Best-fit model energy flux(1 to 10 TeV) : (59.996 +/- 3.173) x 10^-12 erg cm^-2 s^-1
-Pivot energy         : nan TeV
-Flux at pivot energy : (nan +/- nan) x 10^-12 cm^-2 s^-1 TeV^-1  = (nan +/- nan) % Crab
-PL   Flux(> 1 TeV)   : (nan +/- nan) x 10^-12 cm^-2 s^-1  = (nan +/- nan) % Crab
-PL   Flux(@ 1 TeV)   : (nan +/- nan) x 10^-12 cm^-2 s^-1 TeV^-1  = (nan +/- nan) % Crab
-PL   Index           : nan +/- nan
+Pivot energy         : 0.00 TeV
+Flux at pivot energy : (0.000 +/- 0.000) x 10^-12 cm^-2 s^-1 TeV^-1  = (0.00 +/- 0.00) % Crab
+PL   Flux(> 1 TeV)   : (0.000 +/- 0.000) x 10^-12 cm^-2 s^-1  = (0.00 +/- 0.00) % Crab
+PL   Flux(@ 1 TeV)   : (0.000 +/- 0.000) x 10^-12 cm^-2 s^-1 TeV^-1  = (0.00 +/- 0.00) % Crab
+PL   Index           : -- +/- --
 ECPL   Flux(@ 1 TeV) : (21.284 +/- 0.936) x 10^-12 cm^-2 s^-1 TeV^-1  = (94.18 +/- 2.67) % Crab
 ECPL   Flux(> 1 TeV) : (16.879 +/- 0.824) x 10^-12 cm^-2 s^-1  = (74.69 +/- 3.64) % Crab
 ECPL Index           : 2.06 +/- 0.02

--- a/gammapy/catalog/tests/data/hess_j1825-137.txt
+++ b/gammapy/catalog/tests/data/hess_j1825-137.txt
@@ -22,7 +22,7 @@ Spatial model        : 3-Gaussian
 Spatial components   : HGPSC 065, HGPSC 066, HGPSC 067
 TS                   : 5846.8
 sqrt(TS)             : 76.5
-Size                 : 0.461 +/- 0.032 (UL: nan) deg
+Size                 : 0.461 +/- 0.032 (UL: 0.000) deg
 R70                  : 0.709 deg
 RSpec                : 0.500 deg
 Total model excess   : 18291.5

--- a/gammapy/catalog/tests/data/hess_j1930+188.txt
+++ b/gammapy/catalog/tests/data/hess_j1930+188.txt
@@ -22,7 +22,7 @@ Spatial model        : Gaussian
 Spatial components   : HGPSC 097
 TS                   : 33.6
 sqrt(TS)             : 5.8
-Size                 : nan +/- nan (UL: 0.072) deg
+Size                 : 0.000 +/- 0.000 (UL: 0.072) deg
 R70                  : 0.083 deg
 RSpec                : 0.150 deg
 Total model excess   : 64.6
@@ -51,7 +51,7 @@ Energy range:        : 0.46 to 90.85 TeV
 Background           : 611.9
 Excess               : 155.1
 Spectral model       : PL
-TS ECPL over PL      : nan
+TS ECPL over PL      : --
 Best-fit model flux(> 1 TeV) : (0.318 +/- 0.068) x 10^-12 cm^-2 s^-1  = (1.41 +/- 0.30) % Crab
 Best-fit model energy flux(1 to 10 TeV) : (1.019 +/- 0.236) x 10^-12 erg cm^-2 s^-1
 Pivot energy         : 1.70 TeV
@@ -59,11 +59,11 @@ Flux at pivot energy : (0.128 +/- 0.027) x 10^-12 cm^-2 s^-1 TeV^-1  = (0.57 +/-
 PL   Flux(> 1 TeV)   : (0.318 +/- 0.068) x 10^-12 cm^-2 s^-1  = (1.41 +/- 0.30) % Crab
 PL   Flux(@ 1 TeV)   : (0.506 +/- 0.124) x 10^-12 cm^-2 s^-1 TeV^-1  = (2.24 +/- 0.35) % Crab
 PL   Index           : 2.59 +/- 0.26
-ECPL   Flux(@ 1 TeV) : (nan +/- nan) x 10^-12 cm^-2 s^-1 TeV^-1  = (nan +/- nan) % Crab
-ECPL   Flux(> 1 TeV) : (nan +/- nan) x 10^-12 cm^-2 s^-1  = (nan +/- nan) % Crab
-ECPL Index           : nan +/- nan
-ECPL Lambda          : nan +/- nan TeV^-1
-ECPL E_cut           : nan +/- nan TeV
+ECPL   Flux(@ 1 TeV) : (0.000 +/- 0.000) x 10^-12 cm^-2 s^-1 TeV^-1  = (0.00 +/- 0.00) % Crab
+ECPL   Flux(> 1 TeV) : (0.000 +/- 0.000) x 10^-12 cm^-2 s^-1  = (0.00 +/- 0.00) % Crab
+ECPL Index           : -- +/- --
+ECPL Lambda          : 0.000 +/- 0.000 TeV^-1
+ECPL E_cut           : inf +/- nan TeV
 
 *** Flux points info ***
 

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -624,7 +624,7 @@ class TestSourceCatalog3FHL:
         assert len(table) == 55
 
     def test_to_models(self):
-        mask = self.cat.table["GLAT"].data.data > 80
+        mask = self.cat.table["GLAT"].quantity > 80 * u.deg
         subcat = self.cat[mask]
         models = subcat.to_models()
         assert len(models) == 17

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -107,6 +107,7 @@ class TestSourceCatalogObjectGammaCat:
             "erg cm-2 s-1"
         )
 
+        print(spectral_model)
         assert_quantity_allclose(dne, ref["dnde_1TeV"], rtol=1e-3)
         assert_quantity_allclose(flux, ref["flux_1TeV"], rtol=1e-3)
         assert_quantity_allclose(eflux, ref["eflux_1_10TeV"], rtol=1e-3)

--- a/gammapy/irf/edisp/tests/test_map.py
+++ b/gammapy/irf/edisp/tests/test_map.py
@@ -253,7 +253,7 @@ def test_edispkernel_from_diagonal_response():
         "0.3 TeV", "10 TeV", nbin=11, name="energy"
     )
 
-    geom = RegionGeom.create("fk5;circle(0.,0., 10.")
+    geom = RegionGeom.create("fk5;circle(0, 0, 10)")
     region_edisp = EDispKernelMap.from_diagonal_response(
         energy_axis, energy_axis_true, geom=geom
     )
@@ -274,7 +274,7 @@ def test_edispkernel_from_1d():
 
     edisp = EDispKernel.from_gauss(energy_axis_true, energy_axis, 0.1, 0.0)
 
-    geom = RegionGeom.create("fk5;circle(0.,0., 10.")
+    geom = RegionGeom.create("fk5;circle(0, 0, 10)")
     region_edisp = EDispKernelMap.from_edisp_kernel(edisp, geom=geom)
 
     sum_kernel = np.sum(region_edisp.edisp_map.data[..., 0, 0], axis=1)

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -62,7 +62,7 @@ class ReflectedRegionsFinder:
     Region: CircleSkyRegion
     center: <SkyCoord (ICRS): (ra, dec) in deg
         (83.19879005, 25.57300957)>
-    radius: 0.39953342830756855 deg
+    radius: 1438.3203418953717 arcsec
     """
 
     def __init__(

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -60,6 +60,7 @@ class RegionGeom(Geom):
         if wcs is None and region is not None:
             if isinstance(region, CompoundSkyRegion):
                 center = compound_region_center(region)
+                print(f"Center: {center}")
             else:
                 center = region.center
 
@@ -98,15 +99,7 @@ class RegionGeom(Geom):
         return Angle(proj_plane_pixel_scales(self.wcs), unit="deg")
 
     @property
-    def width(self):
-        """Width of bounding box of the region.
-
-        Returns
-        -------
-        width : `~astropy.units.Quantity`
-            Dimensions of the region in both spatial dimensions.
-            Units: ``deg``
-        """
+    def _rectangle_bbox(self):
         if self.region is None:
             raise ValueError("Region definition required.")
 
@@ -119,8 +112,20 @@ class RegionGeom(Geom):
             bbox = bbox.union(region_pix.bounding_box)
 
         rectangle_pix = bbox.to_region()
-        rectangle = rectangle_pix.to_sky(self.wcs)
-        return u.Quantity([rectangle.width, rectangle.height])
+        return rectangle_pix.to_sky(self.wcs)
+
+    @property
+    def width(self):
+        """Width of bounding box of the region.
+
+        Returns
+        -------
+        width : `~astropy.units.Quantity`
+            Dimensions of the region in both spatial dimensions.
+            Units: ``deg``
+        """
+        rectangle = self._rectangle_bbox
+        return u.Quantity([rectangle.width.to("deg"), rectangle.height.to("deg")])
 
     @property
     def region(self):
@@ -158,11 +163,8 @@ class RegionGeom(Geom):
         """Sky coordinate of the center of the region"""
         if self.region is None:
             return SkyCoord(np.nan * u.deg, np.nan * u.deg)
-        try:
-            return self.region.center
-        except AttributeError:
-            xp, yp = self.wcs.wcs.crpix
-            return SkyCoord.from_pixel(xp=xp, yp=yp, wcs=self.wcs)
+
+        return self._rectangle_bbox.center
 
     @property
     def npix(self):

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -60,7 +60,6 @@ class RegionGeom(Geom):
         if wcs is None and region is not None:
             if isinstance(region, CompoundSkyRegion):
                 center = compound_region_center(region)
-                print(f"Center: {center}")
             else:
                 center = region.center
 

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -65,9 +65,9 @@ def make_region(region):
 
     >>> from gammapy.utils.regions import make_region
     >>> make_region("image;circle(10,20,3)")
-    <CirclePixelRegion(PixCoord(x=9.0, y=19.0), radius=3.0)>
+    <CirclePixelRegion(center=PixCoord(x=9.0, y=19.0), radius=3.0)>
     >>> make_region("galactic;circle(10,20,3)")
-    <CircleSkyRegion(<SkyCoord (Galactic): (l, b) in deg
+    <CircleSkyRegion(center=<SkyCoord (Galactic): (l, b) in deg
         (10., 20.)>, radius=3.0 deg)>
 
     If a region object is passed in, it is returned unchanged:
@@ -107,7 +107,7 @@ def make_pixel_region(region, wcs=None):
     >>> wcs = WcsGeom.create().wcs
     >>> region = make_pixel_region("galactic;circle(10,20,3)", wcs)
     >>> region
-    <CirclePixelRegion(PixCoord(x=570.9301128316974, y=159.935542455567), radius=6.061376992149382)>
+    <CirclePixelRegion(center=PixCoord(x=570.9301128316974, y=159.935542455567), radius=6.061376991980699)>
     """
     if isinstance(region, str):
         region = make_region(region)

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -148,14 +148,16 @@ def compound_region_center(compound_region):
         center = SkyCoord(lon * u.deg, lat * u.deg)
         return np.sum(center.separation(coords).deg)
 
-    eps = 1e-5
+    ra, dec = positions.icrs.ra.wrap_at("180d").deg, positions.icrs.dec.deg
+
     result = minimize(
         f,
-        x0=[0, 0],
+        x0=[np.mean(ra), np.mean(dec)],
         args=(positions,),
-        bounds=[(-180 + eps, 180 - eps), (-90 + eps, 90 - eps)],
+        bounds=[(np.min(ra), np.max(ra)), (np.min(dec), np.max(dec))],
         method="L-BFGS-B",
     )
+
     return SkyCoord(result.x[0], result.x[1], frame="icrs", unit="deg")
 
 

--- a/gammapy/utils/tests/test_regions.py
+++ b/gammapy/utils/tests/test_regions.py
@@ -78,6 +78,14 @@ def test_compound_region_center():
     assert_allclose(center.galactic.b, 0 * u.deg, atol=1e-6)
 
 
+def test_compound_region_center_single():
+    region = make_region("galactic;circle(1,1,0.1)")
+    center = compound_region_center(region)
+
+    assert_allclose(center.galactic.l.wrap_at("180d"), 1 * u.deg, atol=1e-6)
+    assert_allclose(center.galactic.b, 1 * u.deg, atol=1e-6)
+
+
 class TestSphericalCircleSkyRegion:
     def setup(self):
         self.region = SphericalCircleSkyRegion(


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes a number of test fails that recently appeared in the CI builds:
- In `regions=0.5` the unit returned in `geom.width` change from `deg` to `arcsec`.
- The `compound_region_center` didn't behave stably and I added better boundary handling
- Adapt tests...

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
