### PR TITLE
Clean up region nd map plotting and adapt flux points plotting

### DIFF
--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -363,7 +363,7 @@ class SourceCatalogGammaCat(SourceCatalog):
     >>> source.spectral_model().plot_error(energy_range)
     <AxesSubplot:xlabel='Energy [TeV]', ylabel='dnde [1 / (cm2 s TeV)]'>
     >>> source.flux_points.plot()
-    <AxesSubplot:xlabel='Energy (TeV)', ylabel='dnde (1 / (cm2 s TeV))'>
+    <AxesSubplot:xlabel='Energy [TeV]', ylabel='dnde (1 / (cm2 s TeV))'>
     """
 
     tag = "gamma-cat"

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -762,7 +762,7 @@ class SourceCatalogHGPS(SourceCatalog):
     >>> source.spectral_model().plot_error(source.energy_range)
     <AxesSubplot:xlabel='Energy [TeV]', ylabel='dnde [1 / (cm2 s TeV)]'>
     >>> source.flux_points.plot()
-    <AxesSubplot:xlabel='Energy (TeV)', ylabel='dnde (1 / (cm2 s TeV))'>
+    <AxesSubplot:xlabel='Energy [TeV]', ylabel='dnde (1 / (cm2 s TeV))'>
 
     Gaussian component information can be accessed as well,
     either via the source, or via the catalog:

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -848,9 +848,9 @@ class MapDataset(Dataset):
                 )
             elif self.stat_type == "cash":
                 stat = CashCountsStatistic(counts_spec.data, npred_spec.data)
-            yerr = stat.error.flatten()
+            yerr = stat.error
         elif method == "diff/sqrt(model)":
-            yerr = np.ones_like(residuals.data.flatten())
+            yerr = np.ones_like(residuals.data)
         else:
             raise ValueError(
                 'Invalid method, choose between "diff" and "diff/sqrt(model)"'

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -147,7 +147,7 @@ class PlotMixin:
         plot_kwargs.update(kwargs_excess)
         plot_kwargs.setdefault("label", "Excess counts")
         ax = self.excess.plot(
-            ax, yerr=np.sqrt(np.abs(self.excess.data.flatten())), **plot_kwargs
+            ax, yerr=np.sqrt(np.abs(self.excess.data)), **plot_kwargs
         )
 
         plot_kwargs = kwargs.copy()

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -116,7 +116,7 @@ class RegionNDMap(Map):
         if axis.interp == "log":
             ax.set_xscale("log")
 
-        xlabel = axis.name.capitalize() + f" [{axis.unit}]"
+        xlabel = axis.name.capitalize() + f" [{ax.xaxis.units}]"
 
         if isinstance(axis, TimeMapAxis):
             xlabel = axis.name.capitalize() + f" [{axis.time_format}]"

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -81,6 +81,7 @@ class RegionNDMap(Map):
 
         kwargs.setdefault("marker", "+")
         kwargs.setdefault("ls", "None")
+        kwargs.setdefault("xerr", axis.as_xerr)
 
         if isinstance(axis, TimeMapAxis):
             if axis.time_format == "iso":
@@ -106,7 +107,6 @@ class RegionNDMap(Map):
                 ax.errorbar(
                     x=center,
                     y=quantity,
-                    xerr=axis.as_xerr,
                     yerr=yerr,
                     uplims=uplims,
                     label=" ".join(label),

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -59,8 +59,8 @@ class RegionNDMap(Map):
         ax : `~matplotlib.pyplot.Axis`
             Axis used for plotting
         axis_name : str
-            Which axis to plot on the x axis. Extra axes will be plotted as additional lines.
-
+            Which axis to plot on the x axis. Extra axes will be plotted as
+            additional lines.
         **kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.errorbar`
 
@@ -93,15 +93,20 @@ class RegionNDMap(Map):
 
         yerr_nd, yerr = kwargs.pop("yerr", None), None
         uplims_nd, uplims = kwargs.pop("uplims", None), None
+        label_default = kwargs.pop("label", None)
 
         labels = product(*[ax.as_labels for ax in self.geom.axes if ax.name != axis_name])
 
-        for label, (idx, quantity) in zip(labels, self.iter_by_axis(axis_name=axis.name)):
-            if yerr_nd is not None:
+        for label_axis, (idx, quantity) in zip(labels, self.iter_by_axis(axis_name=axis.name)):
+            if isinstance(yerr_nd, tuple):
                 yerr = yerr_nd[0][idx], yerr_nd[1][idx]
+            elif isinstance(yerr_nd, np.ndarray):
+                yerr = yerr_nd[idx]
 
             if uplims_nd is not None:
                 uplims = uplims_nd[idx]
+
+            label = " ".join(label_axis) if label_default is None else label_default
 
             with quantity_support():
                 ax.errorbar(
@@ -109,7 +114,7 @@ class RegionNDMap(Map):
                     y=quantity,
                     yerr=yerr,
                     uplims=uplims,
-                    label=" ".join(label),
+                    label=label,
                     **kwargs
                 )
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -329,13 +329,12 @@ class SpectralModel(Model):
         if self.is_norm_spectral_model:
             sed_type = "norm"
 
-        # TODO: remove energy_power option completely and just suppord sed_type?
-        kwargs.setdefault("yunits", DEFAULT_UNIT[sed_type] * energy_bounds[0].unit ** energy_power)
-
         energy_min, energy_max = energy_bounds
         energy = MapAxis.from_energy_bounds(
             energy_min, energy_max, n_points
         )
+
+        kwargs.setdefault("yunits", DEFAULT_UNIT[sed_type] * energy.unit ** energy_power)
 
         if sed_type in ["dnde", "norm"]:
             flux = self(energy.center)
@@ -412,16 +411,15 @@ class SpectralModel(Model):
         if self.is_norm_spectral_model:
             sed_type = "norm"
 
-        kwargs.setdefault("facecolor", "black")
-        kwargs.setdefault("alpha", 0.2)
-        kwargs.setdefault("linewidth", 0)
-        # TODO: remove energy_power option completely and just suppord sed_type?
-        kwargs.setdefault("yunits", DEFAULT_UNIT[sed_type] * energy_bounds[0].unit ** energy_power)
-
         energy_min, energy_max = energy_bounds
         energy = MapAxis.from_energy_bounds(
             energy_min, energy_max, n_points,
         )
+
+        kwargs.setdefault("facecolor", "black")
+        kwargs.setdefault("alpha", 0.2)
+        kwargs.setdefault("linewidth", 0)
+        kwargs.setdefault("yunits", DEFAULT_UNIT[sed_type] * energy.unit ** energy_power)
 
         if sed_type in ["dnde", "norm"]:
             flux, flux_err = self.evaluate_error(energy.center)
@@ -441,10 +439,8 @@ class SpectralModel(Model):
         y_lo = scale_plot_flux(energy.center, (flux - flux_err), energy_power)
         y_hi = scale_plot_flux(energy.center, (flux + flux_err), energy_power)
 
-        where = (energy.center >= energy_bounds[0]) & (energy.center <= energy_bounds[1])
-
         with quantity_support():
-            ax.fill_between(energy.center, y_lo, y_hi, where=where, **kwargs)
+            ax.fill_between(energy.center, y_lo, y_hi, **kwargs)
 
         self._plot_format_ax(ax, energy_power, sed_type)
         return ax

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -21,14 +21,28 @@ from .core import Model
 from gammapy.utils.roots import find_roots
 
 
-def scale_plot_flux(energy, flux, energy_power):
-    """Scale flux to plot"""
+def scale_plot_flux(flux, energy_power=0):
+    """Scale flux to plot
+
+    Parameters
+    ----------
+    flux : `Map`
+        Flux map
+    energy_power : int, optional
+        Power of energy to multiply flux axis with
+
+    Returns
+    -------
+    flux : `Map`
+        Scaled flux map
+    """
+    energy = flux.geom.get_coord(sparse=True)["energy"]
     try:
         eunit = [_ for _ in flux.unit.bases if _.physical_type == "energy"][0]
     except IndexError:
         eunit = energy.unit
     y = flux * np.power(energy, energy_power)
-    return y.to(flux.unit * eunit ** energy_power)
+    return y.to_unit(flux.unit * eunit ** energy_power)
 
 
 def integrate_spectrum(func, energy_min, energy_max, ndecade=100):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request improves the `RegionNDMap.plot()` method and uses it in `FluxPoints.plot` to reduce code duplication. It include the following changes:

- Add a legend of multiple lines are plotted in `RegionNDMap.plot` (see example below)
- Use `RegionNDMap.plot` in `FluxPoint.plot()` to reduce code duplication
- For now I removed the `energy_power` option. This part I am not sure about. There is the option to provide the `sed_type` which already includes the most common `e2dnde` scaling. I feel like keeping the `energy_power` is maybe too much configuration and a simple handling with the `sed_type` is sufficient and preferable. Another reason is that the arbitrary energy scaling does not easily generalise to the plotting of TS profiles.

**Examples**
The following code shows the minimal example for the new label handling:
```python3
from gammapy.maps import MapAxis, TimeMapAxis, RegionNDMap
from astropy import units as u
from astropy.time import Time
import numpy as np

energy_axis = MapAxis.from_energy_edges([1, 3, 10] * u.TeV)

time_ref =  Time('1999-01-01T00:00:00.123456789')

time_axis = TimeMapAxis(
    edges_min=[0, 1, 3] * u.d,
    edges_max=[0.8, 1.9, 5.4] * u.d,
    reference_time=time_ref
)
time_axis.time_format = "iso"

m = RegionNDMap.create("icrs;circle(0, 0, 1)", axes=[energy_axis, time_axis], unit="cm-2 s-1")
m.data = 10 + np.random.random(m.data.size)
```
The plotting of the time/energy map using `m.plot(axis_name="time")` results now in:
<img width="550" alt="image" src="https://user-images.githubusercontent.com/3715928/127178730-fd5b62e1-bcb8-4a68-9baf-22087db8ad49.png">

So showing the lines and labels per energy...


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
