### PR TITLE
corrected axis label units for PSF containment radius

### DIFF
--- a/gammapy/irf/psf/core.py
+++ b/gammapy/irf/psf/core.py
@@ -204,8 +204,8 @@ class PSF(IRF):
 
         # Axes labels and ticks, colobar
         ax.semilogx()
-        ax.set_ylabel(f"Offset ({ax.xaxis.units})")
-        ax.set_xlabel(f"Energy ({ax.yaxis.units})")
+        ax.set_xlabel(f"Energy ({ax.xaxis.units})")
+        ax.set_ylabel(f"Offset ({ax.yaxis.units})")
 
         if add_cbar:
             label = f"Containment radius R{100 * fraction:.0f} ({containment.unit})"


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->
This PR fixes the units for the PSF containment radius plots. The unit of the x-axis was wrongly given in the y-axis label and vice versa.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This seems like a trivial fix but please tell me if I misunderstood something. 
