### PR TITLE
Use FluxPoints as lightcurve in gammapy.catalog

### DIFF
--- a/docs/tutorials/api/catalog.ipynb
+++ b/docs/tutorials/api/catalog.ipynb
@@ -635,7 +635,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lightcurve.table[:3]"
+    "lightcurve.to_table(format=\"lightcurve\", sed_type=\"flux\")"
    ]
   },
   {

--- a/docs/tutorials/api/mask_maps.ipynb
+++ b/docs/tutorials/api/mask_maps.ipynb
@@ -83,9 +83,8 @@
     "import numpy as np\n",
     "from astropy.coordinates import SkyCoord, Angle\n",
     "import astropy.units as u\n",
-    "from regions import CircleSkyRegion\n",
+    "from regions import CircleSkyRegion, Regions\n",
     "from gammapy.maps import Map, WcsGeom, MapAxis\n",
-    "from gammapy.utils.regions import make_region\n",
     "from gammapy.catalog import CATALOG_REGISTRY\n",
     "from gammapy.datasets import Datasets\n",
     "from gammapy.estimators import ExcessMapEstimator\n",
@@ -191,7 +190,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "box_region = make_region(\"galactic;box(184.55, -5.78, 3.0, 3.0)\")"
+    "box_region = Regions.parse(\"galactic;box(184.55, -5.78, 3.0, 3.0)\", format=\"ds9\")[0]"
    ]
   },
   {
@@ -302,7 +301,7 @@
     "\n",
     "We can rely on known sources positions and properties to build a list of regions (here `~regions.SkyRegions`) enclosing most of the signal that our detector would see from these objects.\n",
     "\n",
-    "A useful function to create region objects is `~gammapy.utils.regions.make_region`. It can take strings defining regions following the \"ds9\" format and convert them to `regions`. \n",
+    "A useful function to create region objects is `~regions.regions.parse`. It can take strings defining regions e.g. following the \"ds9\" format and convert them to `regions`. \n",
     "\n",
     "Here we use a region enclosing the Crab nebula with 0.3 degrees. The actual region size should depend on the expected PSF of the data used. We also add another region with a different shape as en example."
    ]
@@ -313,9 +312,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "some_region = make_region(\"galactic;box(185,-4,1.0,0.5, 45)\")\n",
-    "crab_region = make_region(\"icrs;circle(83.633083, 22.0145, 0.3)\")\n",
-    "regions = [some_region, crab_region]\n",
+    "regions_ds9 = \"galactic;box(185,-4,1.0,0.5, 45);icrs;circle(83.633083, 22.0145, 0.3)\"\n",
+    "regions = Regions.parse(regions_ds9, format=\"ds9\")\n",
     "print(regions)"
    ]
   },
@@ -323,7 +321,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Equivalently the regions can be read from a ds9 file, this time using `regions.read_ds9`. "
+    "Equivalently the regions can be read from a ds9 file, this time using `Regions.read`. "
    ]
   },
   {
@@ -332,8 +330,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#from regions import read_ds9\n",
-    "#regions = read_ds9('ds9.reg')"
+    "#regions = Regions.read('ds9.reg', format=\"ds9\")"
    ]
   },
   {
@@ -699,9 +696,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1,
+   "current_citInitial": 1.0,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1,
+   "eqNumInitial": 1.0,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -8,6 +8,7 @@ from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
 from gammapy.utils.table import table_from_row_data, table_row_to_dict
 from gammapy.modeling.models import Models
+from gammapy.maps import TimeMapAxis
 
 __all__ = ["SourceCatalog", "SourceCatalogObject"]
 
@@ -207,6 +208,15 @@ class SourceCatalog(abc.ABC):
         """
         data = table_row_to_dict(self.table[index])
         data[SourceCatalogObject._row_index_key] = index
+
+        hist_table = getattr(self, "hist_table", None)
+        hist2_table = getattr(self, "hist2_table", None)
+
+        if hist_table:
+            data["time_axis"] = TimeMapAxis.from_table(hist_table, format="fermi-4fgl")
+
+        if hist2_table:
+            data["time_axis_2"] = TimeMapAxis.from_table(hist2_table, format="fermi-4fgl")
 
         if "Extended_Source_Name" in data:
             name_extended = data["Extended_Source_Name"].strip()

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -213,10 +213,10 @@ class SourceCatalog(abc.ABC):
         hist2_table = getattr(self, "hist2_table", None)
 
         if hist_table:
-            data["time_axis"] = TimeMapAxis.from_table(hist_table, format="fermi-4fgl")
+            data["time_axis"] = TimeMapAxis.from_table(hist_table, format="fermi-fgl")
 
         if hist2_table:
-            data["time_axis_2"] = TimeMapAxis.from_table(hist2_table, format="fermi-4fgl")
+            data["time_axis_2"] = TimeMapAxis.from_table(hist2_table, format="fermi-fgl")
 
         if "Extended_Source_Name" in data:
             name_extended = data["Extended_Source_Name"].strip()

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -4,10 +4,9 @@ import abc
 import warnings
 import numpy as np
 import astropy.units as u
-from astropy.table import Column, Table
-from astropy.time import Time
+from astropy.table import Table
 from astropy.wcs import FITSFixedWarning
-from gammapy.estimators import FluxPoints, LightCurve
+from gammapy.estimators import FluxPoints
 from gammapy.modeling.models import (
     DiskSpatialModel,
     GaussianSpatialModel,
@@ -496,7 +495,7 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
             raise ValueError("Time intervals available are '1-year' or '2-month'")
 
         energy_axis = MapAxis.from_energy_edges([50, 300000] * u.MeV)
-        geom = RegionGeom(region=None, axes=[energy_axis, time_axis])
+        geom = RegionGeom.create(region=self.position, axes=[energy_axis, time_axis])
 
         names = ["flux", "flux_errp", "flux_errn", "flux_ul", "ts"]
         maps = Maps.from_geom(geom=geom, names=names)
@@ -798,7 +797,7 @@ class SourceCatalogObject3FGL(SourceCatalogObjectFermiBase):
         tag = "Flux_History"
 
         energy_axis = MapAxis.from_energy_edges(self.energy_range)
-        geom = RegionGeom(region=None, axes=[energy_axis, time_axis])
+        geom = RegionGeom.create(region=self.position, axes=[energy_axis, time_axis])
 
         names = ["flux", "flux_errp", "flux_errn", "flux_ul"]
         maps = Maps.from_geom(geom=geom, names=names)

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -485,12 +485,13 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
             tag_sqrt_ts = "Sqrt_TS_History"
         elif interval == "2-month":
             tag = "Flux2_History"
-            time_axis = self.data["time_axis_2"]
-            tag_sqrt_ts = "Sqrt_TS2_History"
             if tag not in self.data:
                 raise ValueError(
                     "Only '1-year' interval is available for this catalogue version"
                 )
+
+            time_axis = self.data["time_axis_2"]
+            tag_sqrt_ts = "Sqrt_TS2_History"
         else:
             raise ValueError("Time intervals available are '1-year' or '2-month'")
 
@@ -1270,7 +1271,10 @@ class SourceCatalog4FGL(SourceCatalog):
 
         self.extended_sources_table = Table.read(filename, hdu="ExtendedSources")
         self.hist_table = Table.read(filename, hdu="Hist_Start")
-        self.hist2_table = Table.read(filename, hdu="Hist2_Start")
+        try:
+            self.hist2_table = Table.read(filename, hdu="Hist2_Start")
+        except KeyError:
+            pass
 
 
 class SourceCatalog2FHL(SourceCatalog):

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -236,22 +236,28 @@ class TestFermi4FGLObject:
 
     def test_lightcurve_dr1(self):
         lc = self.source.lightcurve(interval="1-year")
-        table = lc.table
+        table = lc.to_table(format="lightcurve", sed_type="flux")
 
         assert len(table) == 8
         assert table.colnames == [
             "time_min",
             "time_max",
+            "e_ref",
+            "e_min",
+            "e_max",
             "flux",
             "flux_errp",
             "flux_errn",
+            "flux_ul",
+            "ts",
+            "sqrt_ts"
         ]
+        axis = lc.geom.axes["time"]
+        expected = Time(54682.6552835, format="mjd", scale="utc")
+        assert_time_allclose(axis.time_min[0].utc, expected)
 
-        expected = Time(54682.655277777776, format="mjd", scale="utc")
-        assert_time_allclose(lc.time_min[0], expected)
-
-        expected = Time(55047.603239293836, format="mjd", scale="utc")
-        assert_time_allclose(lc.time_max[0], expected)
+        expected = Time(55045.30090278, format="mjd", scale="utc")
+        assert_time_allclose(axis.time_max[0].utc, expected)
 
         assert table["flux"].unit == "cm-2 s-1"
         assert_allclose(table["flux"][0], 2.2122326e-06, rtol=1e-3)
@@ -262,7 +268,9 @@ class TestFermi4FGLObject:
         assert table["flux_errn"].unit == "cm-2 s-1"
         assert_allclose(table["flux_errn"][0], 2.3099371e-08, rtol=1e-3)
 
-        table = self.source.lightcurve(interval="2-month").table
+        table = self.source.lightcurve(interval="2-month").to_table(
+            format="lightcurve", sed_type="flux"
+        )
         assert len(table) == 48  # (12 month/year / 2month) * 8 years
 
         assert table["flux"].unit == "cm-2 s-1"
@@ -277,7 +285,9 @@ class TestFermi4FGLObject:
     def test_lightcurve_dr2(self):
         dr2 = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v27.fit.gz")
         source_dr2 = dr2[self.source_name]
-        table = source_dr2.lightcurve(interval="1-year").table
+        table = source_dr2.lightcurve(interval="1-year").to_table(
+            format="lightcurve", sed_type="flux"
+        )
 
         assert table["flux"].unit == "cm-2 s-1"
         assert_allclose(table["flux"][0], 2.196788e-6, rtol=1e-3)
@@ -390,22 +400,27 @@ class TestFermi3FGLObject:
 
     def test_lightcurve(self):
         lc = self.source.lightcurve()
-        table = lc.table
+        table = lc.to_table(format="lightcurve", sed_type="flux")
 
         assert len(table) == 48
         assert table.colnames == [
             "time_min",
             "time_max",
+            "e_ref",
+            "e_min",
+            "e_max",
             "flux",
             "flux_errp",
             "flux_errn",
+            "flux_ul"
         ]
 
         expected = Time(54680.02313657408, format="mjd", scale="utc")
-        assert_time_allclose(lc.time_min[0], expected)
+        axis = lc.geom.axes["time"]
+        assert_time_allclose(axis.time_min[0].utc, expected)
 
-        expected = Time(54710.43824797454, format="mjd", scale="utc")
-        assert_time_allclose(lc.time_max[0], expected)
+        expected = Time(54710.46295139, format="mjd", scale="utc")
+        assert_time_allclose(axis.time_max[0].utc, expected)
 
         assert table["flux"].unit == "cm-2 s-1"
         assert_allclose(table["flux"][0], 2.384e-06, rtol=1e-3)

--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -277,9 +277,13 @@ class FluxPoints(FluxMaps):
         """
         if format == "gadf-sed":
             # TODO: what to do with GTI info?
-            if self.geom.axes.names == ["energy"]:
-                idx = (Ellipsis, 0, 0)
+            if not self.geom.axes.names == ["energy"]:
+                raise ValueError(
+                    "Only flux points with a single energy axis "
+                    "can be converted to 'gadf-sed'"
+                )
 
+            idx = (Ellipsis, 0, 0)
             table = self.energy_axis.to_table(format="gadf-sed")
             table.meta["SED_TYPE"] = sed_type
 

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2384,7 +2384,7 @@ class TimeMapAxis:
         ----------
         table : `~astropy.table.Table`
             Bin table HDU
-        format : {"gadf"}
+        format : {"gadf", "fermi-4fgl"}
             Format to use.
 
         Returns
@@ -2400,6 +2400,11 @@ class TimeMapAxis:
             reference_time = time_ref_from_dict(table.meta)
             edges_min = np.unique(table[colnames[0]].quantity)
             edges_max = np.unique(table[colnames[1]].quantity)
+        elif format == "fermi-4fgl":
+            reference_time = Time("2001-01-01T00:00:00")
+            name = "time"
+            edges_min = table["Hist_Start"][:-1]
+            edges_max = table["Hist_Start"][1:]
         else:
             raise ValueError(f"Not a supported format: {format}")
 

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2400,7 +2400,7 @@ class TimeMapAxis:
             reference_time = time_ref_from_dict(table.meta)
             edges_min = np.unique(table[colnames[0]].quantity)
             edges_max = np.unique(table[colnames[1]].quantity)
-        elif format == "fermi-4fgl":
+        elif format == "fermi-fgl":
             reference_time = Time("2001-01-01T00:00:00")
             name = "time"
             edges_min = table["Hist_Start"][:-1]

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2401,7 +2401,9 @@ class TimeMapAxis:
             edges_min = np.unique(table[colnames[0]].quantity)
             edges_max = np.unique(table[colnames[1]].quantity)
         elif format == "fermi-fgl":
-            reference_time = Time("2001-01-01T00:00:00")
+            meta = table.meta.copy()
+            meta["MJDREFF"] = str(meta["MJDREFF"]).replace("D-4", "e-4")
+            reference_time = time_ref_from_dict(meta=meta)
             name = "time"
             edges_min = table["Hist_Start"][:-1]
             edges_max = table["Hist_Start"][1:]

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -6,7 +6,7 @@ from astropy.coordinates import SkyCoord, Angle
 from astropy.io import fits
 from astropy.table import Table
 from astropy.wcs.utils import proj_plane_pixel_area, wcs_to_celestial_frame, proj_plane_pixel_scales
-from regions import FITSRegionParser, fits_region_objects_to_table, SkyRegion, CompoundSkyRegion, PixCoord
+from regions import FITSRegionParser, fits_region_objects_to_table, SkyRegion, CompoundSkyRegion, PixCoord, PointSkyRegion
 from gammapy.utils.regions import (
     compound_region_to_list,
     list_to_compound_region,
@@ -509,6 +509,8 @@ class RegionGeom(Geom):
         """
         if isinstance(region, str):
             region = make_region(region)
+        elif isinstance(region, SkyCoord):
+            region = PointSkyRegion(center=region)
 
         return cls(region, **kwargs)
 

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -74,9 +74,13 @@ class RegionNDMap(Map):
         ax = ax or plt.gca()
 
         if axis_name is None:
-            # set longest axis as default
-            idx = np.argmax(self.geom.axes.shape)
-            axis_name = self.geom.axes.names[idx]
+            if self.geom.axes.is_unidimensional:
+                axis_name = self.geom.axes.primary_axis.name
+            else:
+                raise ValueError(
+                    "Plotting a region map with multiple extra axes requires "
+                    "specifying the 'axis_name' keyword."
+                )
 
         axis = self.geom.axes[axis_name]
 
@@ -484,7 +488,7 @@ class RegionNDMap(Map):
         ----------
         table : `~astropy.table.Table`
             Table with input data
-        format : {"gadf-sed}
+        format : {"gadf-sed", "lightcurve"}
             Format to use
         colname : str
             Column name to take the data from.
@@ -511,6 +515,10 @@ class RegionNDMap(Map):
             else:
                 axes = [axes["energy"]]
 
+            data = table[colname].data
+            unit = table[colname].unit or ""
+        elif format == "lightcurve":
+            axes = MapAxes.from_table(table=table, format=format)
             data = table[colname].data
             unit = table[colname].unit or ""
         else:

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -74,15 +74,11 @@ class RegionNDMap(Map):
         ax = ax or plt.gca()
 
         if axis_name is None:
-            if self.geom.axes.is_unidimensional:
-                axis = self.geom.axes.primary_axis
-            else:
-                raise ValueError(
-                    "Plotting a region map with multiple extra axes requires "
-                    "specifying the 'axis_name' keyword."
-                )
-        else:
-            axis = self.geom.axes[axis_name]
+            # set longest axis as default
+            idx = np.argmax(self.geom.axes.shape)
+            axis_name = self.geom.axes.names[idx]
+
+        axis = self.geom.axes[axis_name]
 
         kwargs.setdefault("marker", "o")
         kwargs.setdefault("markersize", 4)
@@ -117,6 +113,9 @@ class RegionNDMap(Map):
                 )
 
         axis.format_plot_axis(ax=ax)
+
+        if "energy" in axis_name:
+            ax.set_yscale("log", nonpositive="clip")
 
         if len(self.geom.axes) > 1:
             plt.legend()


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request refactors `gammapy.catalog` to use `FluxPoints` to represent lightcurves of sources. For this it introduces the `fermi-fgl` format for `TimeMapAxis` to support the `Hist_Start` HDU in the Fermi catalogs.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
