### PR TITLE
Add option full to WcsNDMap.convolve

### DIFF
--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -506,7 +506,7 @@ class HpxNDMap(HpxMap):
 
         return self._init_copy(data=smoothed_data)
 
-    def convolve(self, kernel, method="wcs-tan", **kwargs):
+    def convolve(self, kernel, convolution_method="wcs-tan", **kwargs):
         """Convolve map with a WCS kernel.
 
         It projects the map into a WCS geometry, convolves with a WCS kernel and
@@ -521,6 +521,10 @@ class HpxNDMap(HpxMap):
         kernel : `~gammapy.irf.PSFKernel`
             Convolution kernel. The pixel size must be upsampled by a factor 2 or bigger
             with respect to the input map to prevent artifacts in the projection.
+        convolution_method : str
+            Supported methods are :
+            'wcs-tan': project on WCS geometry and convolve with WCS kernel.
+            See `~gammapy.maps.HpxNDMap.convolve_wcs`.
         **kwargs : dict
             Keyword arguments passed to `~gammapy.maps.WcsNDMap.convolve`.
 
@@ -529,12 +533,12 @@ class HpxNDMap(HpxMap):
         map : `HpxNDMap`
             Convolved map.
         """
-        if method == "wcs-tan":
+        if convolution_method == "wcs-tan":
             return self.convolve_wcs(kernel, **kwargs)
-        elif method == "":
+        elif convolution_method == "":
             return self.convolve_full(kernel)
         else:
-            raise ValueError(f"Not a valid method for HPX convolution {method}")
+            raise ValueError(f"Not a valid method for HPX convolution: {convolution_method}")
 
     def convolve_wcs(self, kernel, **kwargs):
         """Convolve map with a WCS kernel.

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -506,7 +506,7 @@ class HpxNDMap(HpxMap):
 
         return self._init_copy(data=smoothed_data)
 
-    def convolve(self, kernel, use_fft=True, method="wcs-tan", **kwargs):
+    def convolve(self, kernel, method="wcs-tan", **kwargs):
         """Convolve map with a WCS kernel.
 
         It projects the map into a WCS geometry, convolves with a WCS kernel and
@@ -534,13 +534,13 @@ class HpxNDMap(HpxMap):
             Convolved map.
         """
         if method == "wcs-tan":
-            return self.convolve_wcs(kernel, use_fft, **kwargs)
+            return self.convolve_wcs(kernel, **kwargs)
         elif method == "":
             return self.convolve_full(kernel)
         else:
             raise ValueError(f"Not a valid method for HPX convolution {method}")
 
-    def convolve_wcs(self, kernel, use_fft=True, **kwargs):
+    def convolve_wcs(self, kernel, **kwargs):
         """Convolve map with a WCS kernel.
 
         It projects the map into a WCS geometry, convolves with a WCS kernel and
@@ -557,9 +557,6 @@ class HpxNDMap(HpxMap):
         kernel : `~gammapy.irf.PSFKernel`
             Convolution kernel. The pixel size must be upsampled by a factor 2 or bigger
             with respect to the input map to prevent artifacts in the projection.
-        use_fft : bool
-            Use `scipy.signal.fftconvolve` if True (default)
-            and `ndi.convolve` otherwise.
         kwargs : dict
             Keyword arguments passed to `scipy.signal.fftconvolve` or
             `ndi.convolve`.
@@ -595,7 +592,7 @@ class HpxNDMap(HpxMap):
 
         # Project to WCS and convolve
         wcs_map = self.to_wcs(hpx2wcs=hpx2wcs, fill_nan=False)
-        conv_wcs_map = wcs_map.convolve(kernel=kernel, use_fft=use_fft, **kwargs)
+        conv_wcs_map = wcs_map.convolve(kernel=kernel, **kwargs)
 
         if self.geom.is_image and geom_kernel.ndim > 2:
             target_geom = self.geom.to_cube(geom_kernel.axes)

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -521,12 +521,8 @@ class HpxNDMap(HpxMap):
         kernel : `~gammapy.irf.PSFKernel`
             Convolution kernel. The pixel size must be upsampled by a factor 2 or bigger
             with respect to the input map to prevent artifacts in the projection.
-        use_fft : bool
-            Use `scipy.signal.fftconvolve` if True (default)
-            and `ndi.convolve` otherwise.
         **kwargs : dict
-            Keyword arguments passed to `scipy.signal.fftconvolve` or
-            `ndi.convolve`.
+            Keyword arguments passed to `~gammapy.maps.WcsNDMap.convolve`.
 
         Returns
         -------
@@ -557,9 +553,8 @@ class HpxNDMap(HpxMap):
         kernel : `~gammapy.irf.PSFKernel`
             Convolution kernel. The pixel size must be upsampled by a factor 2 or bigger
             with respect to the input map to prevent artifacts in the projection.
-        kwargs : dict
-            Keyword arguments passed to `scipy.signal.fftconvolve` or
-            `ndi.convolve`.
+        **kwargs : dict
+            Keyword arguments passed to `~gammapy.maps.WcsNDMap.convolve`.
 
         Returns
         -------

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -9,7 +9,7 @@ from astropy.io import fits
 from astropy.table import Table
 from regions import CircleSkyRegion, PointSkyRegion, RectangleSkyRegion
 from gammapy.datasets.map import MapEvaluator
-from gammapy.irf import EnergyDependentMultiGaussPSF, PSFKernel, PSFMap
+from gammapy.irf import PSFKernel, PSFMap
 from gammapy.maps import Map, MapAxis, MapCoord, WcsGeom, WcsNDMap
 from gammapy.modeling.models import (
     GaussianSpatialModel,

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -550,6 +550,17 @@ def test_convolve_nd():
     assert_allclose(mc.data[0, :, :].sum(), 0, atol=1e-5)
     assert_allclose(mc.data[1, :, :].sum(), 9, atol=1e-5)
 
+    kernel_2d = Gaussian2DKernel(15, mode="center")
+    kernel_2d.normalize("peak")
+    mc_full = m.convolve(kernel_2d.array, mode="full")
+    mc_same = m.convolve(kernel_2d.array, mode="same")
+    coords = [[0.2, 0.1, 0.4, 0.44, -1.3], [-0.1, -0.13, 0.6, 0.57, 0.91], [0.5, 0.5, 3.6, 3.6, 0.5]]
+    values_full = mc_full.get_by_coord(coords)
+    values_same = mc_same.get_by_coord(coords)
+
+    assert mc_same.data.shape == (3, 200, 200)
+    assert mc_full.data.shape == (3, 320, 320)
+    assert_allclose(values_full, values_same, rtol=1e-5)
 
 def test_convolve_pixel_scale_error():
     m = WcsNDMap.create(binsz=0.05 * u.deg, width=5 * u.deg)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -590,7 +590,7 @@ class WcsNDMap(WcsMap):
         structure = self.geom.binary_structure(width=width, kernel=kernel)
 
         if use_fft:
-            return self.convolve(structure.squeeze(), convolve_method="fft") > (structure.sum() - 1)
+            return self.convolve(structure.squeeze(), method="fft") > (structure.sum() - 1)
 
         data = ndi.binary_erosion(self.data, structure=structure)
         return self._init_copy(data=data)
@@ -620,12 +620,12 @@ class WcsNDMap(WcsMap):
         structure = self.geom.binary_structure(width=width, kernel=kernel)
 
         if use_fft:
-            return self.convolve(structure.squeeze(), convolve_method="fft") > 1
+            return self.convolve(structure.squeeze(), method="fft") > 1
 
         data = ndi.binary_dilation(self.data, structure=structure)
         return self._init_copy(data=data)
 
-    def convolve(self, kernel, convolve_method="fft", mode="same"):
+    def convolve(self, kernel, method="fft", mode="same"):
         """Convolve map with a kernel.
 
         If the kernel is two dimensional, it is applied to all image planes likewise.
@@ -638,7 +638,7 @@ class WcsNDMap(WcsMap):
         ----------
         kernel : `~gammapy.irf.PSFKernel` or `numpy.ndarray`
             Convolution kernel.
-        convolve_method : str
+        method : str
             The method used by `~scipy.signal.convolve`. Default is 'fft'.
         mode : str
             The convolution mode used by `~scipy.signal.convolve`. Default is 'same'.
@@ -689,13 +689,13 @@ class WcsNDMap(WcsMap):
         if self.geom.is_image and kernel.ndim == 3:
             for idx in range(kernel.shape[0]):
                 data[idx] = convolve(
-                    self.data.astype(np.float32), kernel[idx], method=convolve_method, mode=mode
+                    self.data.astype(np.float32), kernel[idx], method=method, mode=mode
                 )
         else:
             for img, idx in self.iter_by_image():
                 ikern = Ellipsis if kernel.ndim == 2 else idx
                 data[idx] = convolve(
-                    img.astype(np.float32), kernel[ikern],  method=convolve_method, mode=mode
+                    img.astype(np.float32), kernel[ikern],  method=method, mode=mode
                 )
         return self._init_copy(data=data, geom=geom)
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -669,6 +669,12 @@ class WcsNDMap(WcsMap):
             if self.geom.is_image:
                 geom = geom.to_cube(kmap.geom.axes)
 
+        if mode == "full":
+            pad_width = [0.5*(width-1) for width in kernel.shape[-2:]]
+            geom = geom.pad(pad_width, axis_name=None)
+        elif mode == "valid":
+            raise NotImplementedError("WcsNDMap.convolve: mode='valid' is not supported.")
+
         data = np.empty(geom.data_shape, dtype=np.float32)
 
         shape_axes_kernel = kernel.shape[slice(0, -2)]

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -638,9 +638,10 @@ class WcsNDMap(WcsMap):
         ----------
         kernel : `~gammapy.irf.PSFKernel` or `numpy.ndarray`
             Convolution kernel.
-        kwargs : dict
-            Keyword arguments passed to `scipy.signal.convolve`
-            Default values are method = 'fft' and mode = 'same'
+        convolve_method : str
+            The method used by `~scipy.signal.convolve`. Default is 'fft'.
+        mode : str
+            The convolution mode used by `~scipy.signal.convolve`. Default is 'same'.
 
         Returns
         -------


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adapts `WcsNDMap.convolve` to use `spicy.signal.convolve`. The `use_fft` flag is replaced with a `convolve_method` to allow `auto` as a possible argument. 
The `mode` is now better taken into account. In particular, `mode='full'` is now supported by padding the map `geom` object with the size of the kernel. 

This will allow evaluating the models on smaller cutouts before applying the psf convolution in `MapEvaluator`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
