### PR TITLE
Impose WcsGeom.cutout to have at least one bin.

### DIFF
--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -303,6 +303,14 @@ def test_cutout_info():
     assert cutout_info["cutout-slices"][0].start == 0
     assert cutout_info["cutout-slices"][1].start == 0
 
+def test_cutout_min_size(caplog):
+    geom = WcsGeom.create(skydir=(0, 0), npix=10, binsz=0.5)
+    position = SkyCoord(0, 0, unit="deg")
+    cutout_geom = geom.cutout(position=position, width=["2 deg", "0.1 deg"])
+
+    assert cutout_geom.data_shape == (1, 4)
+    assert caplog.records[-1].levelname == "WARNING"
+    assert f"Cutout size smaller than bin size." in caplog.records[-1].message
 
 def test_wcsgeom_get_coord():
     geom = WcsGeom.create(

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -303,14 +303,12 @@ def test_cutout_info():
     assert cutout_info["cutout-slices"][0].start == 0
     assert cutout_info["cutout-slices"][1].start == 0
 
-def test_cutout_min_size(caplog):
+def test_cutout_min_size():
     geom = WcsGeom.create(skydir=(0, 0), npix=10, binsz=0.5)
     position = SkyCoord(0, 0, unit="deg")
     cutout_geom = geom.cutout(position=position, width=["2 deg", "0.1 deg"])
 
     assert cutout_geom.data_shape == (1, 4)
-    assert caplog.records[-1].levelname == "WARNING"
-    assert f"Cutout size smaller than bin size." in caplog.records[-1].message
 
 def test_wcsgeom_get_coord():
     geom = WcsGeom.create(

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import copy
 from functools import lru_cache
-import logging
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
@@ -27,8 +26,6 @@ from .axes import MapAxes
 from .utils import INVALID_INDEX
 
 __all__ = ["WcsGeom"]
-
-log = logging.getLogger(__name__)
 
 def _check_width(width):
     """Check and normalise width argument.

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -916,13 +916,9 @@ class WcsGeom(Geom):
         width = _check_width(width) * u.deg
 
         binsz = self.pixel_scales
-        width_npix = (width / binsz).to_value("")
+        width_npix = np.clip((width / binsz).to_value(""), 1, None)
+        width = width_npix*binsz
 
-        invalid_size = width_npix<1
-        if np.any(invalid_size):
-            width_npix[invalid_size] = 1
-            width[invalid_size] = binsz[invalid_size]
-            log.warning("Cutout size smaller than bin size. Setting size to {width}.")
         if odd_npix:
             width = round_up_to_odd(width_npix)
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies the behavior of `WcsGeom.cutout` for small cutout sizes. Currently if the size is smaller than the pixel the resulting cutout has no pixels. Here we force the cutout to have at least one pixel. A warning is raised to warn the user.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
