### PR TITLE
Support binned time series format in FluxPoints.to_table()

### DIFF
--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -278,10 +278,30 @@ class FluxPoints(FluxMaps):
         sed_type : {"likelihood", "dnde", "e2dnde", "flux", "eflux"}
             sed type to convert to. Default is `likelihood`
         format : {"gadf-sed", "lightcurve", "binned-time-series"}
-            Format specification.
+            Format specification. The following formats are supported:
+            * "gadf-sed": format for sed flux points see :ref:`gadf:flux-points`
+              for details
+            * "lightcurve": Gammapy internal format to store energy dependent
+              lightcurves. Basically a generalisation of the "gadf" format, but
+              currently there is no detailed documentation available.
+            * "binned-time-series": table format support by Astropy's
+             `~astropy.timeseries.BinnedTimeSeries`.
         formatted : bool
             Formatted version with column formats applied. Numerical columns are
             formatted to .3f and .3e respectively.
+
+        Examples
+        --------
+
+        >>> from gammapy.estimators import FluxPoints
+        >>> fp = FluxPoints.read("$GAMMAPY_DATA/hawc_crab/HAWC19_flux_points.fits")
+        >>> table = fp.to_table(sed_type="flux", format="gadf-sed", formatted=True)
+        >>> print(table[:2])
+        e_ref e_min e_max     flux      flux_err    flux_ul      ts    sqrt_ts
+         TeV   TeV   TeV  1 / (cm2 s) 1 / (cm2 s) 1 / (cm2 s)
+        ----- ----- ----- ----------- ----------- ----------- -------- -------
+        1.334 1.001 1.779   1.419e-11   3.128e-13         nan 2734.000  52.288
+        2.372 1.779 3.161   5.792e-12   1.085e-13         nan 4112.000  64.125
 
         Returns
         -------

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Column, Table
 from astropy.time import Time
+from astropy.timeseries import BinnedTimeSeries, BoxLeastSquares
 from gammapy.data import GTI
 from gammapy.datasets import Datasets
 from gammapy.estimators import FluxPoints, LightCurveEstimator
@@ -118,6 +119,34 @@ def test_lightcurve_plot(lc, lc_2d):
 
     with mpl_plot_check():
         lc_2d.plot(axis_name="time")
+
+
+def test_lightcurve_to_time_series():
+    from gammapy.catalog import SourceCatalog4FGL
+
+    catalog_4fgl = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v20.fit.gz")
+    lightcurve = catalog_4fgl["FGES J1553.8-5325"].lightcurve()
+
+    table = lightcurve.to_table(sed_type="flux", format="binned-time-series")
+
+    timeseries = BinnedTimeSeries(data=table)
+
+    assert_allclose(timeseries.time_bin_center.mjd[0], 54863.97885336907)
+    assert_allclose(timeseries.time_bin_end.mjd[0], 55045.301668796295)
+
+    time_axis = lightcurve.geom.axes["time"]
+    assert_allclose(timeseries.time_bin_end.mjd[0], time_axis.time_max.mjd[0])
+
+    # assert that it interfaces with periodograms
+
+    p = BoxLeastSquares.from_timeseries(
+        timeseries=timeseries,
+        signal_column_name="flux",
+        uncertainty="flux_errp"
+    )
+
+    result = p.power(1 * u.year, 0.5 * u.year)
+    assert_allclose(result.duration, 182.625 * u.d)
 
 
 def get_spectrum_datasets():

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -121,6 +121,7 @@ def test_lightcurve_plot(lc, lc_2d):
         lc_2d.plot(axis_name="time")
 
 
+@requires_data()
 def test_lightcurve_to_time_series():
     from gammapy.catalog import SourceCatalog4FGL
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request implements a `binned-time-series` format for `FluxPoints.to_table()` to support interaction with the `BinnedTimeSeries` object in Astropy, like so:
```python3
from gammapy.estimators import FluxPoints
from astropy.timeseries import BinnedTimeSeries

fp = FluxPoints.read()
data = fp.to_table(sed_type="flux", format="binned-time-series")
series = BinnedTimeSeries(data=data)
```

This PR also improves the docstring  of `FluxPoints.to_table()`, but in general some more documentation is required.
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
