### PR TITLE
Modify Analysis to support missing irfs

### DIFF
--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -64,6 +64,11 @@ class FrameEnum(str, Enum):
     icrs = "icrs"
     galactic = "galactic"
 
+class RequiredIRFEnum(str, Enum):
+    aeff = "aeff"
+    bkg = "bkg"
+    edisp = "edisp"
+    psf = "psf"
 
 class BackgroundMethodEnum(str, Enum):
     reflected = "reflected"
@@ -206,7 +211,7 @@ class ObservationsConfig(GammapyBaseConfig):
     obs_file: Path = None
     obs_cone: SpatialCircleConfig = SpatialCircleConfig()
     obs_time: TimeRangeConfig = TimeRangeConfig()
-
+    required_irf: List[RequiredIRFEnum] = ["aeff", "edisp", "psf", "bkg"]
 
 class LogConfig(GammapyBaseConfig):
     level: str = "info"

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -120,7 +120,8 @@ class Analysis:
         log.info("Fetching observations.")
         ids = self._make_obs_table_selection()
 
-        self.observations = self.datastore.get_observations(ids, skip_missing=True)
+        self.observations = self.datastore.get_observations(ids, skip_missing=True,
+                                                            required_irf=observations_settings.required_irf)
 
         if observations_settings.obs_time.start is not None:
             start = observations_settings.obs_time.start

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -118,6 +118,15 @@ def test_get_observations_obs_time(tmp_path):
     with pytest.raises(KeyError):
         analysis.get_observations()
 
+@requires_data()
+def test_get_observations_missing_irf():
+    config = AnalysisConfig()
+    analysis = Analysis(config)
+    analysis.config.observations.datastore = "$GAMMAPY_DATA/joint-crab/dl3/magic/"
+    analysis.config.observations.obs_ids = ["05029748"]
+    analysis.config.observations.required_irf = ["aeff", "edisp"]
+    analysis.get_observations()
+    assert len(analysis.observations) == 1
 
 @requires_data()
 def test_set_models():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a required_irf entry in `AnalysisConfig.observations` to be used in `Analysis.get_observations`. This is necessary to support datastore without e.g. background IRFs defined.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
