### PR TITLE
Cleanup and fix light curve read

### DIFF
--- a/gammapy/estimators/flux_map.py
+++ b/gammapy/estimators/flux_map.py
@@ -75,7 +75,6 @@ OPTIONAL_QUANTITIES_COMMON = [
     "ts",
     "sqrt_ts",
     "npred",
-    "npred_excess",
     "npred_null",
     "stat",
     "stat_null",

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -176,7 +176,8 @@ def test_str(fpe_pwl):
 def test_run_pwl(fpe_pwl):
     datasets, fpe = fpe_pwl
 
-    table = fpe.run(datasets).to_table()
+    fp = fpe.run(datasets)
+    table = fp.to_table()
 
     actual = table["e_min"].data
     assert_allclose(actual, [0.316228, 1.0, 10.0], rtol=1e-5)

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -277,10 +277,13 @@ def test_lightcurve_estimator_spectrum_datasets():
         table[0]["stat_scan"], [[224.058304, 19.074405, 2063.75636]], rtol=1e-5,
     )
 
-    fp = FluxPoints.from_table(table=table)
-    assert fp.norm.axes.names == ["energy", "time"]
-    assert fp.counts.axes.names == ["energy", "time", "dataset"]
-    assert fp.stat_scan.axes.names == ["energy", "time", "norm"]
+    # TODO: fix reference model I/O
+    fp = FluxPoints.from_table(
+        table=table, format="lightcurve", reference_model=PowerLawSpectralModel()
+    )
+    assert fp.norm.geom.axes.names == ["energy", "time"]
+    assert fp.counts.geom.axes.names == ["dataset", "energy", "time"]
+    assert fp.stat_scan.geom.axes.names == ["norm", "energy", "time"]
 
 
 @requires_data()
@@ -359,6 +362,13 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
         [[153.880281, 10.701492, 1649.609684], [70.178023, 8.372913, 414.146676]],
         rtol=1e-5,
     )
+
+    fp = FluxPoints.from_table(
+        table=table, format="lightcurve", reference_model=PowerLawSpectralModel()
+    )
+    assert fp.norm.geom.axes.names == ["energy", "time"]
+    assert fp.counts.geom.axes.names == ["dataset", "energy", "time"]
+    assert fp.stat_scan.geom.axes.names == ["norm", "energy", "time"]
 
 
 @requires_data()

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -277,6 +277,11 @@ def test_lightcurve_estimator_spectrum_datasets():
         table[0]["stat_scan"], [[224.058304, 19.074405, 2063.75636]], rtol=1e-5,
     )
 
+    fp = FluxPoints.from_table(table=table)
+    assert fp.norm.axes.names == ["energy", "time"]
+    assert fp.counts.axes.names == ["energy", "time", "dataset"]
+    assert fp.stat_scan.axes.names == ["energy", "time", "norm"]
+
 
 @requires_data()
 @requires_dependency("iminuit")

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1227,7 +1227,8 @@ class MapAxis:
                                  "names are required")
         elif format == "gadf-sed-norm":
             # TODO: guess interp here
-            axis = MapAxis.from_nodes(table["norm_scan"][0], name="norm")
+            nodes = flat_if_equal(table["norm_scan"][0])
+            axis = MapAxis.from_nodes(nodes, name="norm")
         elif format == "gadf-sed-counts":
             if "datasets" in table.colnames:
                 labels = np.unique(table["datasets"])

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1225,10 +1225,17 @@ class MapAxis:
             else:
                 raise ValueError("Either 'e_ref', 'e_min' or 'e_max' column "
                                  "names are required")
-
         elif format == "gadf-sed-norm":
             # TODO: guess interp here
             axis = MapAxis.from_nodes(table["norm_scan"][0], name="norm")
+        elif format == "gadf-sed-counts":
+            if "datasets" in table.colnames:
+                labels = np.unique(table["datasets"])
+                axis = LabelMapAxis(labels=labels, name="dataset")
+            else:
+                shape = table["counts"].shape
+                edges = np.arange(shape[-1] + 1) - 0.5
+                axis = MapAxis.from_edges(edges, name="dataset")
         else:
             raise ValueError(f"Format '{format}' not supported")
 
@@ -1874,7 +1881,7 @@ class MapAxes(Sequence):
                     continue
                 axes.append(axis)
         elif format == "gadf-sed":
-            for axis_format in ["gadf-sed-norm", "gadf-sed-energy"]:
+            for axis_format in ["gadf-sed-norm", "gadf-sed-energy", "gadf-sed-counts"]:
                 try:
                     axis = MapAxis.from_table(table=table, format=axis_format)
                 except KeyError:

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -518,6 +518,16 @@ class RegionNDMap(Map):
             unit = table[colname].unit or ""
         elif format == "lightcurve":
             axes = MapAxes.from_table(table=table, format=format)
+
+            if colname == "stat_scan":
+                names = ["norm", "energy", "time"]
+            # TODO: this is not officially supported by GADF...
+            elif colname in ["counts", "npred", "npred_null"]:
+                names = ["dataset", "energy", "time"]
+            else:
+                names = ["energy", "time"]
+
+            axes = axes[names]
             data = table[colname].data
             unit = table[colname].unit or ""
         else:

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -506,19 +506,14 @@ class RegionNDMap(Map):
             axes = MapAxes.from_table(table=table, format=format)
 
             if colname == "stat_scan":
-                axes = axes
+                names = ["norm", "energy"]
             # TODO: this is not officially supported by GADF...
             elif colname in ["counts", "npred", "npred_null"]:
-                if "datasets" in table.colnames:
-                    labels = np.unique(table["datasets"])
-                    axis = LabelMapAxis(labels=labels, name="dataset")
-                else:
-                    edges = np.arange(table[colname].shape[1] + 1) - 0.5
-                    axis = MapAxis.from_edges(edges, name="dataset-idx")
-                axes = [axis, axes["energy"]]
+                names = ["dataset", "energy"]
             else:
-                axes = [axes["energy"]]
+                names = ["energy"]
 
+            axes = axes[names]
             data = table[colname].data
             unit = table[colname].unit or ""
         elif format == "lightcurve":


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request cleans up and fixes the light curve `.from_table()`. So far we didn't have a test with all the optional data such as `stat_scan` etc. For now I added an additional  `FluxPoints.from_table()` call for some of our existing tests. Long-term once the serialisation format has been settled, it would be good to add an example file to `$GAMMAPY_DATA` instead. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
