### PR TITLE
Fix SpectrumDataset spatial model handling

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2764,6 +2764,9 @@ class MapEvaluator:
 
             if self.psf and self.model.apply_irf["psf"]:
                 values = self.apply_psf(values)
+            else:
+                axes = [self.geom.axes["energy_true"].squash()]
+                values = values.to_cube(axes=axes)
 
             weights = wcs_geom.region_weights(regions=[self.geom.region])
             value = (values.quantity * weights).sum(axis=(1, 2), keepdims=True)

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -130,6 +130,16 @@ def test_npred_models():
     assert_allclose(npred_sig_model1.data.sum(), 32.4)
 
 
+def test_npred_spatial_model(spectrum_dataset):
+    model = SkyModel.create("pl", "point")
+
+    spectrum_dataset.models = [model]
+
+    npred = spectrum_dataset.npred()
+
+    assert_allclose(npred.data.sum(), 12)
+
+
 @requires_dependency("iminuit")
 def test_fit(spectrum_dataset):
     """Simple CASH fit to the on vector"""

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -131,13 +131,14 @@ def test_npred_models():
 
 
 def test_npred_spatial_model(spectrum_dataset):
-    model = SkyModel.create("pl", "point")
+    model = SkyModel.create("pl", "point", name="test")
 
     spectrum_dataset.models = [model]
 
     npred = spectrum_dataset.npred()
 
-    assert_allclose(npred.data.sum(), 12)
+    assert_allclose(npred.data.sum(), 3000)
+    assert spectrum_dataset.evaluators["test"].psf is None
 
 
 @requires_dependency("iminuit")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes a bug reported by @registerrier in private. When there is no PSF defined the model evaluation fails for the `SpectrumDataset` if a spatial model is defined. This PR fixes the behaviour. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
