### PR TITLE
Change UL threshold condition to sqrt TS

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -48,7 +48,7 @@ class SourceCatalogObjectFermiBase(SourceCatalogObject, abc.ABC):
     flux_points_meta = {
         "sed_type_init": "flux",
         "n_sigma": 1,
-        "ts_threshold_ul": 1,
+        "sqrt_ts_threshold_ul": 1,
         "n_sigma_ul": 2
     }
 

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -613,7 +613,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         table.meta["sed_type_init"] = "dnde"
         table.meta["n_sigma_ul"] = 2
         table.meta["n_sigma"] = 1
-        table.meta["ts_threshold_ul"] = 1
+        table.meta["sqrt_ts_threshold_ul"] = 1
         mask = ~np.isnan(self.data["Flux_Points_Energy"])
 
         table["e_ref"] = self.data["Flux_Points_Energy"][mask]

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -223,7 +223,7 @@ class TestFermi4FGLObject:
         source = self.cat["4FGL J0000.3-7355"]
         fp = source.flux_points
 
-        assert_allclose(fp.ts_threshold_ul, 1)
+        assert_allclose(fp.sqrt_ts_threshold_ul, 1)
         assert_allclose(fp.n_sigma, 1)
         assert_allclose(fp.n_sigma_ul, 2)
 

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -256,7 +256,7 @@ class TestSourceCatalogObjectHGPS:
         source = cat['HESS J1843-033']
         fp = source.flux_points
 
-        assert fp.ts_threshold_ul == 1
+        assert fp.sqrt_ts_threshold_ul == 1
         assert fp.n_sigma == 1
         assert fp.n_sigma_ul == 2
 

--- a/gammapy/estimators/flux_map.py
+++ b/gammapy/estimators/flux_map.py
@@ -388,7 +388,8 @@ class FluxMaps:
             return self._data["sqrt_ts"]
         else:
             with np.errstate(invalid="ignore", divide="ignore"):
-                data = np.where(self.norm > 0, np.sqrt(self.ts), -np.sqrt(self.ts))
+                ts = np.clip(self.ts.data, 0, None)
+                data = np.where(self.norm > 0, np.sqrt(ts), -np.sqrt(ts))
                 return Map.from_geom(geom=self.geom, data=data)
 
     @property

--- a/gammapy/estimators/flux_map.py
+++ b/gammapy/estimators/flux_map.py
@@ -216,9 +216,9 @@ class FluxMaps:
         return self.meta.get("n_sigma_ul")
 
     @property
-    def ts_threshold_ul(self):
-        """TS threshold for upper limits"""
-        return self.meta.get("ts_threshold_ul", 4)
+    def sqrt_ts_threshold_ul(self):
+        """qsrt TS threshold for upper limits"""
+        return self.meta.get("sqrt_ts_threshold_ul", 2)
 
     @property
     def sed_type_init(self):
@@ -302,8 +302,8 @@ class FluxMaps:
         # TODO: make this a well defined behaviour
         is_ul = self.norm.copy()
 
-        if "ts" in self._data and "norm_ul" in self._data:
-            is_ul.data = self.ts.data < self.ts_threshold_ul
+        if any([_ in self._data for _ in ["ts", "sqrt_ts"]]) and "norm_ul" in self._data:
+            is_ul.data = self.sqrt_ts.data < self.sqrt_ts_threshold_ul
         elif "norm_ul" in self._data:
             is_ul.data = np.isfinite(self.norm_ul)
         else:
@@ -872,13 +872,13 @@ class FluxMaps:
         str_ = f"{self.__class__.__name__}\n"
         str_ += "-" * len(self.__class__.__name__)
         str_ += "\n\n"
-        str_ += "\t" + f"geom            : {self.geom.__class__.__name__}\n"
-        str_ += "\t" + f"axes            : {self.geom.axes_names}\n"
-        str_ += "\t" + f"shape           : {self.geom.data_shape[::-1]}\n"
-        str_ += "\t" + f"quantities      : {list(self.available_quantities)}\n"
-        str_ += "\t" + f"ref. model      : {self.reference_spectral_model.tag[-1]}\n"
-        str_ += "\t" + f"n_sigma         : {self.n_sigma}\n"
-        str_ += "\t" + f"n_sigma_ul      : {self.n_sigma_ul}\n"
-        str_ += "\t" + f"ts_threshold_ul : {self.ts_threshold_ul}\n"
-        str_ += "\t" + f"sed type init   : {self.sed_type_init}\n"
+        str_ += "\t" + f"geom                   : {self.geom.__class__.__name__}\n"
+        str_ += "\t" + f"axes                   : {self.geom.axes_names}\n"
+        str_ += "\t" + f"shape                  : {self.geom.data_shape[::-1]}\n"
+        str_ += "\t" + f"quantities             : {list(self.available_quantities)}\n"
+        str_ += "\t" + f"ref. model             : {self.reference_spectral_model.tag[-1]}\n"
+        str_ += "\t" + f"n_sigma                : {self.n_sigma}\n"
+        str_ += "\t" + f"n_sigma_ul             : {self.n_sigma_ul}\n"
+        str_ += "\t" + f"sqrt_ts_threshold_ul   : {self.sqrt_ts_threshold_ul}\n"
+        str_ += "\t" + f"sed type init          : {self.sed_type_init}\n"
         return str_.expandtabs(tabsize=2)

--- a/gammapy/estimators/flux_map.py
+++ b/gammapy/estimators/flux_map.py
@@ -217,7 +217,7 @@ class FluxMaps:
 
     @property
     def sqrt_ts_threshold_ul(self):
-        """qsrt TS threshold for upper limits"""
+        """sqrt(TS) threshold for upper limits"""
         return self.meta.get("sqrt_ts_threshold_ul", 2)
 
     @property

--- a/gammapy/estimators/tests/test_flux_map.py
+++ b/gammapy/estimators/tests/test_flux_map.py
@@ -223,7 +223,7 @@ def test_flux_map_str(wcs_flux_map, reference_model):
     assert "pl" in fm_str
     assert "n_sigma" in fm_str
     assert "n_sigma_ul" in fm_str
-    assert "ts_threshold" in fm_str
+    assert "sqrt_ts_threshold" in fm_str
 
 
 @pytest.mark.parametrize("sed_type", ["likelihood", "dnde", "flux", "eflux", "e2dnde"])


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request proposes a change in the definition of the UL threshold relying on arts TS rather than TS. It is more natural as it is directly sigmas and it also provides a way to deal with negative fluctuations. Using TS only works if non negative values are forbidden.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
