### PR TITLE
Catch Runtime Exception from iminuit_confidence

### DIFF
--- a/gammapy/modeling/iminuit.py
+++ b/gammapy/modeling/iminuit.py
@@ -131,7 +131,7 @@ def confidence_iminuit(parameters, function, parameter, reoptimize, sigma, maxca
     try:
         result = minuit.minos(var=var, sigma=sigma, maxcall=maxcall)
         info = result[var]
-    except AttributeError as error:
+    except (AttributeError, RuntimeError) as error:
         message, success = str(error), False
         info = {"is_valid": False, "lower": np.nan, "upper": np.nan, "nfcn": 0}
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds `RuntimeException` to the exception caught in `iminuit_confidence`. This avoids flux points failing when the iminuit minos does not properly converges.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
