### PR TITLE
Prevents spatial model integration if no psf is present and add test

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2756,13 +2756,14 @@ class MapEvaluator:
             Psf-corrected, integrated flux over a given region.
         """
         if self.geom.is_region:
-            if self.geom.region is None:
+            # We don't estimate spatial contributions if no psf are defined
+            if self.geom.region is None or self.psf is None:
                 return 1
 
             wcs_geom = self.geom.to_wcs_geom(width_min=self.cutout_width).to_image()
             values = self.model.spatial_model.integrate_geom(wcs_geom)
 
-            if self.psf and self.model.apply_irf["psf"]:
+            if self.model.apply_irf["psf"]:
                 values = self.apply_psf(values)
             else:
                 axes = [self.geom.axes["energy_true"].squash()]

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1516,6 +1516,32 @@ def test_compute_flux_spatial():
     reference = g.containment_fraction(0.1)
     assert_allclose(flux.value, reference, rtol=0.003)
 
+def test_compute_flux_spatial_no_psf():
+    # check that spatial integration is not performed in the absence of a psf
+    center = SkyCoord("0 deg", "0 deg", frame="galactic")
+    region = CircleSkyRegion(center=center, radius=0.1 * u.deg)
+
+    nbin = 2
+    energy_axis_true = MapAxis.from_energy_bounds(
+        ".1 TeV", "10 TeV", nbin=nbin, name="energy_true"
+    )
+
+    spectral_model = ConstantSpectralModel()
+    spatial_model = GaussianSpatialModel(
+        lon_0=0 * u.deg, lat_0=0 * u.deg, frame="galactic", sigma="0.1 deg"
+    )
+
+    models = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)
+    model = Models(models)
+
+    exposure_region = RegionNDMap.create(region, axes=[energy_axis_true])
+    exposure_region.data += 1.0
+    exposure_region.unit = "m2 s"
+
+    evaluator = MapEvaluator(model=model[0], exposure=exposure_region)
+    flux = evaluator.compute_flux_spatial()
+
+    assert_allclose(flux, 1.0)
 
 @requires_data()
 def test_source_outside_geom(sky_model, geom, geom_etrue):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request change the behavior of the `MapEvaluator.compute_flux_spatial` for `RegionGeom` datasets.

At present it can lead to undesired behavior because the spatial integration follows the `binsz_wcs` of the `RegionGeom`. By default the latter is set to 0.1 deg. In this condition, the integration will be incorrect for many situations where the region geom size is comparable.

A priori, `SpectrumDataset` objects have no PSF defined. It is unclear whether the option of  spatial evaluation is meaningful is this case. Hence the choice made here to not perform the spatial evaluation in the absence of a psf.

Note that this issue might be alleviated once a correct/adaptive `SpatialModel.integrate_geom` is in place. See e.g. #3440 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
