### PR TITLE
Fix dtype for npred quantities

### DIFF
--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -274,7 +274,7 @@ class ParameterEstimator(Estimator):
             mask = dataset.mask
             npred.append(dataset.npred().data[mask].sum())
 
-        return {"npred": np.array(npred, dtype=int), "datasets": datasets.names}
+        return {"npred": np.array(npred), "datasets": datasets.names}
 
     def run(self, datasets, parameter):
         """Run the parameter estimator.

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -109,8 +109,8 @@ def test_flux_estimator_1d(hess_datasets):
     assert_allclose(result["norm_ul"], 1.418475, atol=1e-3)
     assert_allclose(result["e_min"], 1 * u.TeV, atol=1e-3)
     assert_allclose(result["e_max"], 10 * u.TeV, atol=1e-3)
-    assert_allclose(result["npred"], [93, 93], atol=1e-3)
-    assert_allclose(result["npred_null"], [13, 11], atol=1e-3)
+    assert_allclose(result["npred"], [93.209263, 93.667283], atol=1e-3)
+    assert_allclose(result["npred_null"], [14., 11.384615], atol=1e-3)
 
 
 @requires_data()

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -228,13 +228,14 @@ def test_run_pwl(fpe_pwl):
     assert_allclose(actual, [220.368653, 4.301011, 1881.626454], rtol=1e-2)
 
     actual = table["npred"].data
-    assert_allclose(actual, [[1492.], [749.], [43.]])
+    assert_allclose(actual, [[1492.96638], [749.4587], [43.104823]])
 
     actual = table["npred_null"].data
-    assert_allclose(actual, [[942.], [398.], [14.]])
+    assert_allclose(actual, [[942.5], [398.166667], [14.5]])
 
     actual = table.meta["UL_CONF"]
     assert_allclose(actual, 0.9544997)
+
 
 @requires_dependency("iminuit")
 def test_run_ecpl(fpe_ecpl):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes the type for spread quantities returned by the `FluxEstimator`.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
