### PR TITLE
Implement Parameter.conf_min and Parameter.conf_max

### DIFF
--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -283,6 +283,30 @@ class Parameter:
         self.value = val.value
         self.unit = val.unit
 
+    # TODO: possibly allow to set this independently
+    @property
+    def conf_min(self):
+        """Confidence min value (`float`)
+
+        Returns parameter minimum if defined else the scan_min
+        """
+        if not np.isnan(self.min):
+            return self.min
+        else:
+            return self.scan_min
+
+    # TODO: possibly allow to set this independently
+    @property
+    def conf_max(self):
+        """Confidence max value (`float`)
+
+        Returns parameter maximum if defined else the scan_max
+        """
+        if not np.isnan(self.max):
+            return self.max
+        else:
+            return self.scan_max
+
     @property
     def scan_min(self):
         """Stat scan min"""

--- a/gammapy/modeling/scipy.py
+++ b/gammapy/modeling/scipy.py
@@ -69,14 +69,11 @@ def _confidence_scipy_brentq(
     )
 
     lower_bound = parameter.factor
-    upper_bound = parameter.factor_max if upper else parameter.factor_min
-    if np.isnan(upper_bound):
-        # TODO: remove hard coded limits here...
-        upper_bound = parameter.factor
-        if upper:
-            upper_bound += 1e2 * parameter.error / parameter.scale
-        else:
-            upper_bound -= 1e2 * parameter.error / parameter.scale
+
+    if upper:
+        upper_bound = parameter.scan_max / parameter.scale
+    else:
+        upper_bound = parameter.scan_min / parameter.scale
 
     message, success = "Confidence terminated successfully.", True
     kwargs.setdefault("nbin", 1)
@@ -85,11 +82,13 @@ def _confidence_scipy_brentq(
         ts_diff.fcn, lower_bound=lower_bound, upper_bound=upper_bound, **kwargs
     )
     result = (roots[0], res[0])
+
     if np.isnan(roots[0]):
         message = (
             "Confidence estimation failed. Try to set the parameter.min/max by hand."
         )
         success = False
+
     suffix = "errp" if upper else "errn"
 
     return {

--- a/gammapy/modeling/scipy.py
+++ b/gammapy/modeling/scipy.py
@@ -71,9 +71,9 @@ def _confidence_scipy_brentq(
     lower_bound = parameter.factor
 
     if upper:
-        upper_bound = parameter.scan_max / parameter.scale
+        upper_bound = parameter.conf_max / parameter.scale
     else:
-        upper_bound = parameter.scan_min / parameter.scale
+        upper_bound = parameter.conf_min / parameter.scale
 
     message, success = "Confidence terminated successfully.", True
     kwargs.setdefault("nbin", 1)

--- a/gammapy/modeling/tests/test_scipy.py
+++ b/gammapy/modeling/tests/test_scipy.py
@@ -89,7 +89,7 @@ def test_scipy_confidence(pars):
     assert_allclose(ds.fcn(), 0, atol=1e-5)
 
     par = pars["x"]
-    par.min, par.max = 0, 10
+    par.scan_min, par.scan_max = 0, 10
 
     result = confidence_scipy(function=ds.fcn, parameters=pars, parameter=par, sigma=1)
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies the boundary handling for the confidence estimation for the Scipy backend. I noticed that in the current version of the `spectral_analysis.ipynb` tutorial, the UL of the highest flux point is not computed properly. This is because there are hard-coded bounds for the confidence intervals which also depend on the error. There is also a remaining TODO (see https://github.com/gammapy/gammapy/blob/master/gammapy/modeling/scipy.py#L74 ).  

For now I adjusted the boundaries to rely on `scan_min` and `scan_max`. We could keep the behaviour and document it. Maybe you have better proposal for choosing default boundaries @registerrier?

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
