### PR TITLE
Define estimator norm range from amplitude parameter range

### DIFF
--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -115,7 +115,8 @@ class TestFluxPointFit:
 
         model.amplitude.scan_n_values = 3
         model.amplitude.scan_n_sigma = 1
-
+        model.amplitude.interp = "lin"
+        
         profile = fit.stat_profile(
             datasets=dataset,
             parameter="amplitude",

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -94,8 +94,19 @@ class FluxEstimator(ParameterEstimator):
         """
         ref_model = models[self.source].spectral_model
         scale_model = ScaleSpectralModel(ref_model)
+
         scale_model.norm.value = 1.0
         scale_model.norm.frozen = False
+
+        if hasattr(ref_model, "amplitude"):
+            scaled_parameter = ref_model.amplitude
+        else:
+            scaled_parameter = ref_model.norm
+
+        scale_model.norm.min = scaled_parameter.min/scaled_parameter.value
+        scale_model.norm.max = scaled_parameter.max/scaled_parameter.value
+
+        # is log the best case?
         scale_model.norm.interp = "log"
         scale_model.norm.scan_values = self.norm_values
         scale_model.norm.scan_min = self.norm_min

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -105,9 +105,7 @@ class FluxEstimator(ParameterEstimator):
 
         scale_model.norm.min = scaled_parameter.min/scaled_parameter.value
         scale_model.norm.max = scaled_parameter.max/scaled_parameter.value
-
-        # is log the best case?
-        scale_model.norm.interp = "log"
+        scale_model.norm.interp = scaled_parameter.interp
         scale_model.norm.scan_values = self.norm_values
         scale_model.norm.scan_min = self.norm_min
         scale_model.norm.scan_max = self.norm_max

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -161,7 +161,7 @@ def test_flux_estimator_norm_range():
 
     assert_allclose(scale_model.norm.min, 1e-3)
     assert_allclose(scale_model.norm.max, 1e2)
-    assert scale_model.norm.interp == "log"
+    assert scale_model.norm.interp == "lin"
 
 def test_flux_estimator_norm_range_template():
     energy = MapAxis.from_energy_bounds(0.1,10,3., unit='TeV', name="energy_true")
@@ -183,4 +183,4 @@ def test_flux_estimator_norm_range_template():
 
     assert_allclose(scale_model.norm.min, 0)
     assert_allclose(scale_model.norm.max, 10)
-    assert scale_model.norm.interp == "log"
+    assert scale_model.norm.interp == "lin"

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -3,9 +3,9 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from gammapy.datasets import Datasets, SpectrumDatasetOnOff, MapDataset
+from gammapy.datasets import Datasets, SpectrumDatasetOnOff
 from gammapy.estimators.flux import FluxEstimator
-from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
+from gammapy.modeling.models import PowerLawSpectralModel, SkyModel, Models
 from gammapy.modeling import Fit
 from gammapy.utils.testing import requires_data, requires_dependency
 
@@ -152,8 +152,8 @@ def test_flux_estimator_norm_range():
         reoptimize=True
     )
 
-    dataset = MapDataset(models=[model])
+    scale_model = estimator.get_scale_model(Models([model]))
 
-    estimator.run([dataset])
-
-    assert False
+    assert_allclose(scale_model.norm.min, 1e-3)
+    assert_allclose(scale_model.norm.max, 1e2)
+    assert scale_model.norm.interp == "log"

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from gammapy.datasets import Datasets, SpectrumDatasetOnOff
+from gammapy.datasets import Datasets, SpectrumDatasetOnOff, MapDataset
 from gammapy.estimators.flux import FluxEstimator
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.modeling import Fit
@@ -138,3 +138,22 @@ def test_inhomogeneous_datasets(fermi_datasets, hess_datasets):
     assert_allclose(result["norm_err"], 0.090744, atol=1e-3)
     assert_allclose(result["e_min"], 0.693145 * u.TeV, atol=1e-3)
     assert_allclose(result["e_max"], 10 * u.TeV, atol=1e-3)
+
+
+def test_flux_estimator_norm_range():
+    model = SkyModel.create("pl", "gauss", name="test")
+
+    model.spectral_model.amplitude.min = 1e-15
+    model.spectral_model.amplitude.max = 1e-10
+
+    estimator = FluxEstimator(
+        source="test",
+        selection_optional=[],
+        reoptimize=True
+    )
+
+    dataset = MapDataset(models=[model])
+
+    estimator.run([dataset])
+
+    assert False

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -161,7 +161,7 @@ def test_flux_estimator_norm_range():
 
     assert_allclose(scale_model.norm.min, 1e-3)
     assert_allclose(scale_model.norm.max, 1e2)
-    assert scale_model.norm.interp == "lin"
+    assert scale_model.norm.interp == "log"
 
 def test_flux_estimator_norm_range_template():
     energy = MapAxis.from_energy_bounds(0.1,10,3., unit='TeV', name="energy_true")
@@ -183,4 +183,4 @@ def test_flux_estimator_norm_range_template():
 
     assert_allclose(scale_model.norm.min, 0)
     assert_allclose(scale_model.norm.max, 10)
-    assert scale_model.norm.interp == "lin"
+    assert scale_model.norm.interp == "log"

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -402,3 +402,42 @@ def test_mask_shape():
     table = fp.to_table()
 
     assert_allclose(table["counts"], 0)
+
+@requires_dependency("iminuit")
+def test_run_pwl_parameter_range(fpe_pwl):
+    pl = PowerLawSpectralModel(amplitude="1e-16 cm-2s-1TeV-1")
+
+    datasets, fpe = create_fpe(pl)
+
+    fp = fpe.run(datasets)
+    table_no_bounds = fp.to_table()
+
+    pl.amplitude.min=0
+    pl.amplitude.max=1e-8
+
+    fp = fpe.run(datasets)
+    table_with_bounds = fp.to_table()
+
+    actual = table_with_bounds["norm"].data
+    assert_allclose(actual, [3.215947e-02, 3.939055e-02, 5.551115e-09], rtol=1e-3)
+
+    actual = table_with_bounds["norm_err"].data
+    assert_allclose(actual, [251.490704, 280.37361 , 404.162784], rtol=1e-2)
+
+    actual = table_with_bounds["norm_ul"].data
+    assert_allclose(actual, [640.067576,  722.571371, 1414.22209], rtol=1e-2)
+
+    actual = table_with_bounds["sqrt_ts"].data
+    assert_allclose(actual, [0.,0., 0.], rtol=1e-2)
+
+    actual = table_no_bounds["norm"].data
+    assert_allclose(actual, [-511.76675 , -155.75408 , -853.547117], rtol=1e-3)
+
+    actual = table_no_bounds["norm_err"].data
+    assert_allclose(actual, [504.601499, 416.69248 , 851.223077], rtol=1e-2)
+
+    actual = table_no_bounds["norm_ul"].data
+    assert_allclose(actual, [ 514.957128,  707.888477, 1167.105962], rtol=1e-2)
+
+    actual = table_no_bounds["sqrt_ts"].data
+    assert_allclose(actual, [-1.006081, -0.364848, -0.927819], rtol=1e-2)

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -222,10 +222,10 @@ def test_run_pwl(fpe_pwl):
     assert_allclose(actual, [18.568429, 18.054651, 7.057121], rtol=1e-2)
 
     actual = table["norm_scan"][0][[0, 5, -1]]
-    assert_allclose(actual, [0.2, 1, 5])
+    assert_allclose(actual, [0.2, 2.6, 5])
 
     actual = table["stat_scan"][0][[0, 5, -1]]
-    assert_allclose(actual, [220.368653, 4.301011, 1881.626454], rtol=1e-2)
+    assert_allclose(actual, [220.368653, 394.796395, 1881.626454], rtol=1e-2)
 
     actual = table["npred"].data
     assert_allclose(actual, [[1492.96638], [749.4587], [43.104823]])
@@ -309,10 +309,10 @@ def test_run_map_pwl(fpe_map_pwl):
     assert_allclose(actual, [16.681221, 28.408676, 21.91912], rtol=1e-2)
 
     actual = table["norm_scan"][0]
-    assert_allclose(actual, [0.2, 1, 5])
+    assert_allclose(actual, [0.2, 2.6, 5])
 
     actual = table["stat_scan"][0] - table["stat"][0]
-    assert_allclose(actual, [1.628398e02, 1.452456e-01, 2.008018e03], rtol=1e-2)
+    assert_allclose(actual, [1.628398e02, 432.425885, 2.008018e03], rtol=1e-2)
 
 
 @requires_dependency("iminuit")

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -222,10 +222,10 @@ def test_run_pwl(fpe_pwl):
     assert_allclose(actual, [18.568429, 18.054651, 7.057121], rtol=1e-2)
 
     actual = table["norm_scan"][0][[0, 5, -1]]
-    assert_allclose(actual, [0.2, 2.6, 5])
+    assert_allclose(actual, [0.2, 1., 5.])
 
     actual = table["stat_scan"][0][[0, 5, -1]]
-    assert_allclose(actual, [220.368653, 394.796395, 1881.626454], rtol=1e-2)
+    assert_allclose(actual, [220.368653, 4.301011, 1881.626454], rtol=1e-2)
 
     actual = table["npred"].data
     assert_allclose(actual, [[1492.96638], [749.4587], [43.104823]])
@@ -309,10 +309,10 @@ def test_run_map_pwl(fpe_map_pwl):
     assert_allclose(actual, [16.681221, 28.408676, 21.91912], rtol=1e-2)
 
     actual = table["norm_scan"][0]
-    assert_allclose(actual, [0.2, 2.6, 5])
+    assert_allclose(actual, [0.2, 1.0, 5])
 
     actual = table["stat_scan"][0] - table["stat"][0]
-    assert_allclose(actual, [1.628398e02, 432.425885, 2.008018e03], rtol=1e-2)
+    assert_allclose(actual, [1.628398e02, 1.452456e-01, 2.008018e03], rtol=1e-2)
 
 
 @requires_dependency("iminuit")

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -272,9 +272,9 @@ def test_lightcurve_estimator_spectrum_datasets():
     assert_allclose(table["norm_ul"], [[1.029989], [1.025061]], rtol=1e-2)
     assert_allclose(table["sqrt_ts"], [[19.384781], [19.161769]], rtol=1e-2)
     assert_allclose(table["ts"], [[375.769735], [367.173374]], rtol=1e-2)
-    assert_allclose(table[0]["norm_scan"], [[0.2, 1.0, 5.0]])
+    assert_allclose(table[0]["norm_scan"], [[0.2, 2.6, 5.0]])
     assert_allclose(
-        table[0]["stat_scan"], [[224.058304, 19.074405, 2063.75636]], rtol=1e-5,
+        table[0]["stat_scan"], [[224.058304, 545.093991, 2063.75636]], rtol=1e-5,
     )
 
     # TODO: fix reference model I/O
@@ -355,11 +355,11 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
         rtol=1e-2,
     )
     assert_allclose(
-        table[0]["norm_scan"], [[0.2, 1.0, 5.0], [0.2, 1.0, 5.0]]
+        table[0]["norm_scan"], [[0.2, 2.6, 5.0], [0.2, 2.6, 5.0]]
     )
     assert_allclose(
         table[0]["stat_scan"],
-        [[153.880281, 10.701492, 1649.609684], [70.178023, 8.372913, 414.146676]],
+        [[153.880281, 431.655792, 1649.609684], [70.178023, 113.438199, 414.146676]],
         rtol=1e-5,
     )
 

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -272,9 +272,9 @@ def test_lightcurve_estimator_spectrum_datasets():
     assert_allclose(table["norm_ul"], [[1.029989], [1.025061]], rtol=1e-2)
     assert_allclose(table["sqrt_ts"], [[19.384781], [19.161769]], rtol=1e-2)
     assert_allclose(table["ts"], [[375.769735], [367.173374]], rtol=1e-2)
-    assert_allclose(table[0]["norm_scan"], [[0.2, 2.6, 5.0]])
+    assert_allclose(table[0]["norm_scan"], [[0.2, 1.0, 5.0]])
     assert_allclose(
-        table[0]["stat_scan"], [[224.058304, 545.093991, 2063.75636]], rtol=1e-5,
+        table[0]["stat_scan"], [[224.058304, 19.074405, 2063.75636]], rtol=1e-5,
     )
 
     # TODO: fix reference model I/O
@@ -355,11 +355,11 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
         rtol=1e-2,
     )
     assert_allclose(
-        table[0]["norm_scan"], [[0.2, 2.6, 5.0], [0.2, 2.6, 5.0]]
+        table[0]["norm_scan"], [[0.2, 1.0, 5.0], [0.2, 1.0, 5.0]]
     )
     assert_allclose(
         table[0]["stat_scan"],
-        [[153.880281, 431.655792, 1649.609684], [70.178023, 113.438199, 414.146676]],
+        [[153.880281, 10.701492, 1649.609684], [70.178023, 8.372913, 414.146676]],
         rtol=1e-5,
     )
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -635,7 +635,7 @@ class PowerLawSpectralModel(SpectralModel):
 
     tag = ["PowerLawSpectralModel", "pl"]
     index = Parameter("index", 2.0)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log")
     reference = Parameter("reference", "1 TeV", frozen=True)
 
     @staticmethod
@@ -751,7 +751,7 @@ class PowerLawNormSpectralModel(SpectralModel):
     """
 
     tag = ["PowerLawNormSpectralModel", "pl-norm"]
-    norm = Parameter("norm", 1, unit="")
+    norm = Parameter("norm", 1, unit="", interp="log")
     tilt = Parameter("tilt", 0, frozen=True)
     reference = Parameter("reference", "1 TeV", frozen=True)
 
@@ -848,7 +848,7 @@ class PowerLaw2SpectralModel(SpectralModel):
     """
     tag = ["PowerLaw2SpectralModel", "pl-2"]
 
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1", scale_method="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1", scale_method="scale10", interp="log")
     index = Parameter("index", 2)
     emin = Parameter("emin", "0.1 TeV", frozen=True)
     emax = Parameter("emax", "100 TeV", frozen=True)
@@ -930,7 +930,7 @@ class BrokenPowerLawSpectralModel(SpectralModel):
     tag = ["BrokenPowerLawSpectralModel", "bpl"]
     index1 = Parameter("index1", 2.0)
     index2 = Parameter("index2", 2.0)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log")
     ebreak = Parameter("ebreak", "1 TeV")
 
     @staticmethod
@@ -972,7 +972,7 @@ class SmoothBrokenPowerLawSpectralModel(SpectralModel):
     tag = ["SmoothBrokenPowerLawSpectralModel", "sbpl"]
     index1 = Parameter("index1", 2.0)
     index2 = Parameter("index2", 2.0)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log")
     ebreak = Parameter("ebreak", "1 TeV")
     reference = Parameter("reference", "1 TeV", frozen=True)
     beta = Parameter("beta", 1, frozen=True)
@@ -1094,7 +1094,7 @@ class ExpCutoffPowerLawSpectralModel(SpectralModel):
     tag = ["ExpCutoffPowerLawSpectralModel", "ecpl"]
 
     index = Parameter("index", 1.5)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log")
     reference = Parameter("reference", "1 TeV", frozen=True)
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
     alpha = Parameter("alpha", "1.0", frozen=True)
@@ -1150,7 +1150,7 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
     tag = ["ExpCutoffPowerLawNormSpectralModel", "ecpl-norm"]
 
     index = Parameter("index", 1.5)
-    norm = Parameter("norm", 1, unit="")
+    norm = Parameter("norm", 1, unit="", interp="log")
     reference = Parameter("reference", "1 TeV", frozen=True)
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
     alpha = Parameter("alpha", "1.0", frozen=True)
@@ -1183,7 +1183,7 @@ class ExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
 
     tag = ["ExpCutoffPowerLaw3FGLSpectralModel", "ecpl-3fgl"]
     index = Parameter("index", 1.5)
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log")
     reference = Parameter("reference", "1 TeV", frozen=True)
     ecut = Parameter("ecut", "10 TeV")
 
@@ -1221,7 +1221,7 @@ class SuperExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
     """
 
     tag = ["SuperExpCutoffPowerLaw3FGLSpectralModel", "secpl-3fgl"]
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log")
     reference = Parameter("reference", "1 TeV", frozen=True)
     ecut = Parameter("ecut", "10 TeV")
     index_1 = Parameter("index_1", 1.5)
@@ -1256,7 +1256,7 @@ class SuperExpCutoffPowerLaw4FGLSpectralModel(SpectralModel):
     """
 
     tag = ["SuperExpCutoffPowerLaw4FGLSpectralModel", "secpl-4fgl"]
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log")
     reference = Parameter("reference", "1 TeV", frozen=True)
     expfactor = Parameter("expfactor", "1e-2")
     index_1 = Parameter("index_1", 1.5)
@@ -1296,7 +1296,7 @@ class LogParabolaSpectralModel(SpectralModel):
 
     """
     tag = ["LogParabolaSpectralModel", "lp"]
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10")
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log")
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 2)
     beta = Parameter("beta", 1)
@@ -1348,7 +1348,7 @@ class LogParabolaNormSpectralModel(SpectralModel):
     LogParabolaSpectralModel
     """
     tag = ["LogParabolaNormSpectralModel", "lp-norm"]
-    norm = Parameter("norm", 1, unit="")
+    norm = Parameter("norm", 1, unit="", interp="log")
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 2)
     beta = Parameter("beta", 1)
@@ -1499,7 +1499,7 @@ class ScaleSpectralModel(SpectralModel):
     """
 
     tag = ["ScaleSpectralModel", "scale"]
-    norm = Parameter("norm", 1, unit="")
+    norm = Parameter("norm", 1, unit="", interp="log")
 
     def __init__(self, model, norm=norm.quantity):
         self.model = model
@@ -1863,7 +1863,7 @@ class GaussianSpectralModel(SpectralModel):
     """
 
     tag = ["GaussianSpectralModel", "gauss"]
-    norm = Parameter("norm", 1e-12 * u.Unit("cm-2 s-1"))
+    norm = Parameter("norm", 1e-12 * u.Unit("cm-2 s-1"), interp="log")
     mean = Parameter("mean", 1 * u.TeV)
     sigma = Parameter("sigma", 2 * u.TeV)
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the behavior of the `FluxEstimate` and inherited classes (`FluxPointsEstimator and `LightCurveEstimator`) regarding the `norm` parameter range.
It is currently set by default to `-inf` and `inf`. 

This is a matter of convention. Initially, gammapy used to follow the fermion approach where fluxes are always considered positive quantities and it was forced to be positive. While this makes sense in a number of cases, it can also limit and or bias the results in a number of situation. This is why the interval was changed. 

The latter solution is non-ideal as well. Some users might want to work with always positive fluxes, but flux estimators will impose their own norm range. To avoid this, this PR defines the `norm` parameter range directly from the `amplitude` parameter range (or the `norm` in case of a Norm type spectral model). 

The user now has control over the `norm` range and associated quantities.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
Some documentation is needed here.

This seems a more intuitive and configurable behavior for flux estimators without any specific API change. Opinion @adonath @QRemy @AtreyeeS @bkhelifi ?