### PR TITLE
Correct for empty time bins in LightCurveEstimator

### DIFF
--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -100,6 +100,7 @@ class LightCurveEstimator(FluxPointsEstimator):
         gti = gti.union(overlap_ok=False, merge_equal=False)
 
         rows = []
+        valid_intervals = []
         for t_min, t_max in progress_bar(
                 gti.time_intervals,
                 desc="Time intervals"
@@ -112,6 +113,7 @@ class LightCurveEstimator(FluxPointsEstimator):
                 log.debug(f"No Dataset for the time interval {t_min} to {t_max}")
                 continue
 
+            valid_intervals.append([t_min, t_max])
             fp = self.estimate_time_bin_flux(datasets=datasets_to_fit)
 
             for name in ["counts", "npred", "npred_null"]:
@@ -123,6 +125,7 @@ class LightCurveEstimator(FluxPointsEstimator):
         if len(rows) == 0:
             raise ValueError("LightCurveEstimator: No datasets in time intervals")
 
+        gti = GTI.from_time_intervals(valid_intervals)
         axis = TimeMapAxis.from_gti(gti=gti)
         return FluxPoints.from_stack(
             maps=rows, axis=axis,

--- a/gammapy/estimators/lightcurve.py
+++ b/gammapy/estimators/lightcurve.py
@@ -26,6 +26,9 @@ class LightCurveEstimator(FluxPointsEstimator):
     To be included in the estimation, the dataset must have their GTI fully
     overlapping a time interval.
 
+    Time intervals without any dataset GTI fully overlapping will be dropped. They will not
+    be stored in the final lightcurve `FluxPoints` object.
+
     Parameters
     ----------
     time_intervals : list of `astropy.time.Time`
@@ -110,7 +113,7 @@ class LightCurveEstimator(FluxPointsEstimator):
             )
 
             if len(datasets_to_fit) == 0:
-                log.debug(f"No Dataset for the time interval {t_min} to {t_max}")
+                log.info(f"No Dataset for the time interval {t_min} to {t_max}. Skipping interval.")
                 continue
 
             valid_intervals.append([t_min, t_max])

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -471,6 +471,24 @@ def test_lightcurve_estimator_spectrum_datasets_largerbin():
     assert_allclose(table["norm_err"][0], [0.040874], rtol=1e-3)
     assert_allclose(table["ts"][0], [742.939324], rtol=1e-4)
 
+@requires_data()
+@requires_dependency("iminuit")
+def test_lightcurve_estimator_spectrum_datasets_emptybin():
+    # Test all dataset in a single LC bin, here two hours
+    datasets = get_spectrum_datasets()
+    time_intervals = [Time(["2010-01-01T00:00:00", "2010-01-01T02:00:00"]),
+                      Time(["2010-02-01T00:00:00", "2010-02-01T02:00:00"])]
+    estimator = LightCurveEstimator(
+        energy_edges=[1, 30] * u.TeV,
+        norm_n_values=3,
+        time_intervals=time_intervals,
+        selection_optional=["scan"],
+    )
+    lightcurve = estimator.run(datasets)
+    table = lightcurve.to_table(format="lightcurve")
+
+    assert_allclose(table["time_min"], [55197.0])
+    assert_allclose(table["time_max"], [55197.083333])
 
 @requires_data()
 @requires_dependency("iminuit")


### PR DESCRIPTION

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request  corrects issue #3477 . 
The choice is here to simply drop empty time intervals rather than filling them with nan values. It seems easier to handle. Possibly the message mentioning empty time bin could be raised from `DEBUG` to `INFO`. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
