### PR TITLE
Correct for missing UL FluxPoints plot

### DIFF
--- a/gammapy/estimators/flux_point.py
+++ b/gammapy/estimators/flux_point.py
@@ -456,7 +456,7 @@ class FluxPoints(FluxMaps):
         y_errn, y_errp = self._plot_get_flux_err(sed_type=sed_type)
 
         is_ul = self.is_ul.data
-        if y_errn and is_ul.any():
+        if np.isnan(is_ul.data).all() and y_errn and is_ul.any():
             flux_ul = getattr(self, sed_type + "_ul").quantity
             y_errn.data[is_ul] = 0.5 * flux_ul[is_ul].to_value(y_errn.unit)
             y_errp.data[is_ul] = 0

--- a/gammapy/estimators/tests/test_flux_point.py
+++ b/gammapy/estimators/tests/test_flux_point.py
@@ -7,6 +7,7 @@ from astropy.table import Table
 from gammapy.catalog.fermi import SourceCatalog3FGL
 from gammapy.estimators import FluxPoints
 from gammapy.modeling.models import SpectralModel
+from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import (
     assert_quantity_allclose,
     mpl_plot_check,
@@ -240,3 +241,15 @@ def test_compute_flux_points_dnde_fermi():
         actual = table[column].quantity
         desired = getattr(flux_points, column).quantity.squeeze()
         assert_quantity_allclose(actual[:-1], desired[:-1], rtol=0.05)
+
+@requires_data()
+@requires_dependency("matplotlib")
+def test_plot_fp_no_ul():
+    path = make_path("$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits")
+    table = Table.read(path)
+    table.remove_column('dnde_ul')
+    fp = FluxPoints.from_table(table, sed_type='dnde')
+
+    with mpl_plot_check():
+        fp.plot()
+


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects issue #3481  and adds a test for plots with missing UL values in `FluxPoints`. A check that `fp.is_ul` is not fully NaN is added before the UL plot.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
