### PR TITLE
Use FluxMaps as return type for ExcessMapEstimator

### DIFF
--- a/docs/estimators/index.rst
+++ b/docs/estimators/index.rst
@@ -152,7 +152,7 @@ This how to compute flux maps with the `ExcessMapEstimator`:
         shape : (320, 240, 2)
         ndim  : 3
         unit  : 1 / (cm2 s)
-        dtype : >f4
+        dtype : float64
     <BLANKLINE>
 
 Flux points

--- a/docs/tutorials/analysis/2D/ring_background.ipynb
+++ b/docs/tutorials/analysis/2D/ring_background.ipynb
@@ -309,7 +309,7 @@
    "outputs": [],
    "source": [
     "significance_map = lima_maps[\"sqrt_ts\"]\n",
-    "excess_map = lima_maps[\"excess\"]"
+    "excess_map = lima_maps[\"npred_excess\"]"
    ]
   },
   {

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -321,7 +321,7 @@ def test_analysis_ring_background():
         analysis.datasets[0].npred_background().data[0, 10, 10], 0.091799, rtol=1e-2
     )
     assert isinstance(analysis.excess_map["sqrt_ts"], WcsNDMap)
-    assert_allclose(analysis.excess_map["excess"].data[0, 62, 62], 134.12389)
+    assert_allclose(analysis.excess_map.npred_excess.data[0, 62, 62], 134.12389)
 
 
 @requires_data()

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -183,8 +183,8 @@ class ExcessMapEstimator(Estimator):
         else:
             resampled_dataset.background = dataset.npred().resample_axis(axis=axis)
             resampled_dataset.models = None
-        result = self.estimate_excess_map(resampled_dataset)
 
+        result = self.estimate_excess_map(resampled_dataset)
         return result
 
     def estimate_excess_map(self, dataset):
@@ -224,7 +224,7 @@ class ExcessMapEstimator(Estimator):
         maps["sqrt_ts"] = Map.from_geom(geom, data=counts_stat.sqrt_ts)
 
         if dataset.exposure:
-            reco_exposure = estimate_exposure_reco_energy(dataset, self.spectral_model, normalize=True)
+            reco_exposure = estimate_exposure_reco_energy(dataset, self.spectral_model, normalize=False)
             with np.errstate(invalid="ignore", divide="ignore"):
                 reco_exposure = reco_exposure.convolve(kernel.array) / mask.convolve(kernel.array)
         else:

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -6,9 +6,10 @@ from astropy.convolution import Tophat2DKernel
 from astropy.coordinates import Angle
 from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.maps import Map
-from gammapy.modeling.models import PowerLawSpectralModel
+from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.stats import CashCountsStatistic, WStatCountsStatistic
 from .core import Estimator
+from .flux_map import FluxMaps
 from .utils import estimate_exposure_reco_energy
 
 __all__ = [
@@ -217,37 +218,45 @@ class ExcessMapEstimator(Estimator):
         maps = {}
         maps["npred"] = Map.from_geom(geom, data=counts_stat.n_on)
         maps["npred_null"] = Map.from_geom(geom, data=counts_stat.n_on - counts_stat.n_sig)
-        maps["npred_excess"] = Map.from_geom(geom, data=counts_stat.n_sig)
+        maps["counts"] = maps["npred"]
 
         maps["ts"] = Map.from_geom(geom, data=counts_stat.ts)
         maps["sqrt_ts"] = Map.from_geom(geom, data=counts_stat.sqrt_ts)
 
-        maps["npred_err"] = Map.from_geom(geom, data=counts_stat.error * self.n_sigma)
-
         if dataset.exposure:
-            reco_exposure = estimate_exposure_reco_energy(dataset, self.spectral_model)
+            reco_exposure = estimate_exposure_reco_energy(dataset, self.spectral_model, normalize=True)
             with np.errstate(invalid="ignore", divide="ignore"):
                 reco_exposure = reco_exposure.convolve(kernel.array) / mask.convolve(kernel.array)
-                flux = maps["npred_excess"] / reco_exposure
-                flux.quantity = flux.quantity.to("1 / (cm2 s)").astype(dataset.exposure.data.dtype)
         else:
-            flux = Map.from_geom(
-                geom=dataset.counts.geom, data=np.nan * np.ones(dataset.data_shape)
-            )
-            
-        maps["flux"] = flux
+            reco_exposure = 1
 
-        if "errn-errp" in self.selection_optional:
-            maps["npred_errn"] = Map.from_geom(geom, data=counts_stat.compute_errn(self.n_sigma))
-            maps["npred_errp"] = Map.from_geom(geom, data=counts_stat.compute_errp(self.n_sigma))
+        with np.errstate(invalid="ignore", divide="ignore"):
+            maps["norm"] = (maps["npred"] - maps["npred_null"]) / reco_exposure
+            maps["norm_err"] = Map.from_geom(geom, data=counts_stat.error * self.n_sigma) / reco_exposure
 
-        if "ul" in self.selection_optional:
-            maps["npred_ul"] = Map.from_geom(
-                geom, data=counts_stat.compute_upper_limit(self.n_sigma_ul)
-            )
+            if "errn-errp" in self.selection_optional:
+                maps["norm_errn"] = Map.from_geom(geom, data=-counts_stat.compute_errn(self.n_sigma)) / reco_exposure
+                maps["norm_errp"] = Map.from_geom(geom, data=counts_stat.compute_errp(self.n_sigma)) / reco_exposure
+
+            if "ul" in self.selection_optional:
+                maps["norm_ul"] = Map.from_geom(
+                    geom, data=counts_stat.compute_upper_limit(self.n_sigma_ul)
+                ) / reco_exposure
 
         # return nan values outside mask
         for name in maps:
             maps[name].data[~mask] = np.nan
 
-        return maps
+        meta = {
+            "n_sigma": self.n_sigma,
+            "n_sigma_ul": self.n_sigma_ul,
+            "sed_type_init": "likelihood"
+        }
+
+        return FluxMaps.from_maps(
+            maps=maps,
+            meta=meta,
+            reference_model=SkyModel(self.spectral_model),
+            sed_type="likelihood"
+
+        )

--- a/gammapy/estimators/flux_map.py
+++ b/gammapy/estimators/flux_map.py
@@ -365,7 +365,7 @@ class FluxMaps:
 
     def _expand_dims(self, data):
         # instead make map support broadcasting
-        axes = self.counts.geom.axes
+        axes = self.npred.geom.axes
         # here we need to rely on broadcasting
         if "dataset" in axes.names:
             idx = axes.index_data("dataset")

--- a/gammapy/estimators/flux_map.py
+++ b/gammapy/estimators/flux_map.py
@@ -361,7 +361,32 @@ class FluxMaps:
         """Predicted excess counts"""
         self._check_quantity("npred")
         self._check_quantity("npred_null")
-        return self._filter_convergence_failure(self._data["npred"] - self._data["npred_null"])
+        return self.npred - self.npred_null
+
+    @property
+    def npred_ref(self):
+        """Predicted excess reference counts"""
+        return self.npred_excess / self.norm
+
+    @property
+    def npred_err(self):
+        """Predicted excess counts error"""
+        return self.npred_ref * self.norm_err
+
+    @property
+    def npred_errp(self):
+        """Predicted excess counts positive error"""
+        return self.npred_ref * self.norm_errp
+
+    @property
+    def npred_errn(self):
+        """Predicted excess counts negative error"""
+        return self.npred_ref * self.norm_errn
+
+    @property
+    def npred_ul(self):
+        """Predicted excess counts upper limits"""
+        return self.npred_ref * self.norm_ul
 
     @property
     def stat_scan(self):

--- a/gammapy/estimators/flux_map.py
+++ b/gammapy/estimators/flux_map.py
@@ -373,29 +373,29 @@ class FluxMaps:
         return data
 
     @property
-    def npred_ref(self):
+    def npred_excess_ref(self):
         """Predicted excess reference counts"""
         return self.npred_excess / self._expand_dims(self.norm.data)
 
     @property
-    def npred_err(self):
+    def npred_excess_err(self):
         """Predicted excess counts error"""
-        return self.npred_ref * self._expand_dims(self.norm_err.data)
+        return self.npred_excess_ref * self._expand_dims(self.norm_err.data)
 
     @property
-    def npred_errp(self):
+    def npred_excess_errp(self):
         """Predicted excess counts positive error"""
-        return self.npred_ref * self._expand_dims(self.norm_errp.data)
+        return self.npred_excess_ref * self._expand_dims(self.norm_errp.data)
 
     @property
-    def npred_errn(self):
+    def npred_excess_errn(self):
         """Predicted excess counts negative error"""
-        return self.npred_ref * self._expand_dims(self.norm_errn.data)
+        return self.npred_excess_ref * self._expand_dims(self.norm_errn.data)
 
     @property
-    def npred_ul(self):
+    def npred_excess_ul(self):
         """Predicted excess counts upper limits"""
-        return self.npred_ref * self._expand_dims(self.norm_ul.data)
+        return self.npred_excess_ref * self._expand_dims(self.norm_ul.data)
 
     @property
     def stat_scan(self):

--- a/gammapy/estimators/flux_map.py
+++ b/gammapy/estimators/flux_map.py
@@ -363,30 +363,39 @@ class FluxMaps:
         self._check_quantity("npred_null")
         return self.npred - self.npred_null
 
+    def _expand_dims(self, data):
+        # instead make map support broadcasting
+        axes = self.counts.geom.axes
+        # here we need to rely on broadcasting
+        if "dataset" in axes.names:
+            idx = axes.index_data("dataset")
+            data = np.expand_dims(data, axis=idx)
+        return data
+
     @property
     def npred_ref(self):
         """Predicted excess reference counts"""
-        return self.npred_excess / self.norm
+        return self.npred_excess / self._expand_dims(self.norm.data)
 
     @property
     def npred_err(self):
         """Predicted excess counts error"""
-        return self.npred_ref * self.norm_err
+        return self.npred_ref * self._expand_dims(self.norm_err.data)
 
     @property
     def npred_errp(self):
         """Predicted excess counts positive error"""
-        return self.npred_ref * self.norm_errp
+        return self.npred_ref * self._expand_dims(self.norm_errp.data)
 
     @property
     def npred_errn(self):
         """Predicted excess counts negative error"""
-        return self.npred_ref * self.norm_errn
+        return self.npred_ref * self._expand_dims(self.norm_errn.data)
 
     @property
     def npred_ul(self):
         """Predicted excess counts upper limits"""
-        return self.npred_ref * self.norm_ul
+        return self.npred_ref * self._expand_dims(self.norm_ul.data)
 
     @property
     def stat_scan(self):

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -117,10 +117,10 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
     assert_allclose(result["npred_null"].data[0, 10, 10], 81)
     assert_allclose(result["sqrt_ts"].data[0, 10, 10], 7.910732, atol=1e-5)
 
-    assert_allclose(result["npred_err"].data[0, 10, 10], 12.727922, atol=1e-3)
-    assert_allclose(result["npred_errp"].data[0, 10, 10], 13.063328, atol=1e-3)
-    assert_allclose(result["npred_errn"].data[0, 10, 10], 12.396716, atol=1e-3)
-    assert_allclose(result["npred_ul"].data[0, 10, 10], 107.806275, atol=1e-3)
+    assert_allclose(result["npred_excess_err"].data[0, 10, 10], 12.727922, atol=1e-3)
+    assert_allclose(result["npred_excess_errp"].data[0, 10, 10], 13.063328, atol=1e-3)
+    assert_allclose(result["npred_excess_errn"].data[0, 10, 10], 12.396716, atol=1e-3)
+    assert_allclose(result["npred_excess_ul"].data[0, 10, 10], 107.806275, atol=1e-3)
 
 
 def test_significance_map_estimator_map_dataset_exposure(simple_dataset):

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -108,6 +108,7 @@ def test_compute_lima_on_off_image():
 
 
 def test_significance_map_estimator_map_dataset(simple_dataset):
+    simple_dataset.exposure = None
     estimator = ExcessMapEstimator(0.1 * u.deg, selection_optional=["all"])
     result = estimator.run(simple_dataset)
 
@@ -115,11 +116,14 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
     assert_allclose(result["npred_excess"].data[0, 10, 10], 81)
     assert_allclose(result["npred_null"].data[0, 10, 10], 81)
     assert_allclose(result["sqrt_ts"].data[0, 10, 10], 7.910732, atol=1e-5)
+
     assert_allclose(result["npred_err"].data[0, 10, 10], 12.727922, atol=1e-3)
     assert_allclose(result["npred_errp"].data[0, 10, 10], 13.063328, atol=1e-3)
-    assert_allclose(result["npred_errn"].data[0, 10, 10], -12.396716, atol=1e-3)
+    assert_allclose(result["npred_errn"].data[0, 10, 10], 12.396716, atol=1e-3)
     assert_allclose(result["npred_ul"].data[0, 10, 10], 107.806275, atol=1e-3)
 
+
+def test_significance_map_estimator_map_dataset_exposure(simple_dataset):
     simple_dataset.exposure += 1e10 * u.cm ** 2 * u.s
     axis = simple_dataset.exposure.geom.axes[0]
     simple_dataset.psf = PSFMap.from_gauss(axis, sigma="0.05 deg")

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -93,7 +93,7 @@ def test_compute_lima_on_off_image():
     results = estimator.run(dataset)
 
     # Reproduce safe significance threshold from HESS software
-    results["sqrt_ts"].data[results["counts"].data < 5] = 0
+    results["sqrt_ts"].data[results["npred"].data < 5] = 0
 
     # crop the image at the boundaries, because the reference image
     # is cut out from a large map, there is no way to reproduce the
@@ -111,14 +111,14 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
     estimator = ExcessMapEstimator(0.1 * u.deg, selection_optional=["all"])
     result = estimator.run(simple_dataset)
 
-    assert_allclose(result["counts"].data[0, 10, 10], 162)
-    assert_allclose(result["excess"].data[0, 10, 10], 81)
-    assert_allclose(result["background"].data[0, 10, 10], 81)
+    assert_allclose(result["npred"].data[0, 10, 10], 162)
+    assert_allclose(result["npred_excess"].data[0, 10, 10], 81)
+    assert_allclose(result["npred_null"].data[0, 10, 10], 81)
     assert_allclose(result["sqrt_ts"].data[0, 10, 10], 7.910732, atol=1e-5)
-    assert_allclose(result["err"].data[0, 10, 10], 12.727922, atol=1e-3)
-    assert_allclose(result["errp"].data[0, 10, 10], 13.063328, atol=1e-3)
-    assert_allclose(result["errn"].data[0, 10, 10], -12.396716, atol=1e-3)
-    assert_allclose(result["ul"].data[0, 10, 10], 107.806275, atol=1e-3)
+    assert_allclose(result["npred_err"].data[0, 10, 10], 12.727922, atol=1e-3)
+    assert_allclose(result["npred_errp"].data[0, 10, 10], 13.063328, atol=1e-3)
+    assert_allclose(result["npred_errn"].data[0, 10, 10], -12.396716, atol=1e-3)
+    assert_allclose(result["npred_ul"].data[0, 10, 10], 107.806275, atol=1e-3)
 
     simple_dataset.exposure += 1e10 * u.cm ** 2 * u.s
     axis = simple_dataset.exposure.geom.axes[0]
@@ -138,8 +138,8 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
     estimator = ExcessMapEstimator(0.1 * u.deg, selection_optional="all")
     result = estimator.run(simple_dataset)
 
-    assert_allclose(result["excess"].data.sum(), 19733.602, rtol=1e-3)
-    assert_allclose(result["background"].data.sum(), 31818.398, rtol=1e-3)
+    assert_allclose(result["npred_excess"].data.sum(), 19733.602, rtol=1e-3)
+    assert_allclose(result["npred_null"].data.sum(), 31818.398, rtol=1e-3)
     assert_allclose(result["sqrt_ts"].data[0, 10, 10], 4.217129, rtol=1e-3)
 
 
@@ -156,10 +156,10 @@ def test_significance_map_estimator_map_dataset_on_off_no_correlation(
     )
 
     result_image = estimator_image.run(simple_dataset_on_off)
-    assert result_image["counts"].data.shape == (1, 20, 20)
-    assert_allclose(result_image["counts"].data[0, 10, 10], 194)
-    assert_allclose(result_image["excess"].data[0, 10, 10], 97)
-    assert_allclose(result_image["background"].data[0, 10, 10], 97)
+    assert result_image["npred"].data.shape == (1, 20, 20)
+    assert_allclose(result_image["npred"].data[0, 10, 10], 194)
+    assert_allclose(result_image["npred_excess"].data[0, 10, 10], 97)
+    assert_allclose(result_image["npred_null"].data[0, 10, 10], 97)
     assert_allclose(result_image["sqrt_ts"].data[0, 10, 10], 0.780125, atol=1e-3)
     assert_allclose(result_image["flux"].data[:, 10, 10], 9.7e-9, atol=1e-5)
 
@@ -178,12 +178,11 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
     )
     result = estimator.run(simple_dataset_on_off)
 
-    assert result["counts"].data.shape == (2, 20, 20)
-    assert_allclose(result["counts"].data[:, 10, 10], 194)
-    assert_allclose(result["excess"].data[:, 10, 10], 97)
-    assert_allclose(result["background"].data[:, 10, 10], 97)
+    assert result["npred"].data.shape == (2, 20, 20)
+    assert_allclose(result["npred"].data[:, 10, 10], 194)
+    assert_allclose(result["npred_excess"].data[:, 10, 10], 97)
+    assert_allclose(result["npred_null"].data[:, 10, 10], 97)
     assert_allclose(result["sqrt_ts"].data[:, 10, 10], 5.741116, atol=1e-5)
-    assert_allclose(result["flux"].data[:, 10, 10], np.nan)
 
     # Test with exposure
     simple_dataset_on_off.exposure = exposure
@@ -192,10 +191,10 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
     )
 
     result_image = estimator_image.run(simple_dataset_on_off)
-    assert result_image["counts"].data.shape == (1, 20, 20)
-    assert_allclose(result_image["counts"].data[0, 10, 10], 194)
-    assert_allclose(result_image["excess"].data[0, 10, 10], 97)
-    assert_allclose(result_image["background"].data[0, 10, 10], 97)
+    assert result_image["npred"].data.shape == (1, 20, 20)
+    assert_allclose(result_image["npred"].data[0, 10, 10], 194)
+    assert_allclose(result_image["npred_excess"].data[0, 10, 10], 97)
+    assert_allclose(result_image["npred_null"].data[0, 10, 10], 97)
     assert_allclose(result_image["sqrt_ts"].data[0, 10, 10], 5.741116, atol=1e-3)
     assert_allclose(result_image["flux"].data[:, 10, 10], 9.7e-9, atol=1e-5)
 
@@ -213,16 +212,16 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
     )
 
     result_image = estimator_image.run(simple_dataset_on_off)
-    assert result_image["counts"].data.shape == (1, 20, 20)
+    assert result_image["npred"].data.shape == (1, 20, 20)
 
     assert_allclose(result_image["sqrt_ts"].data[0, 10, 10], np.nan, atol=1e-3)
-    assert_allclose(result_image["counts"].data[0, 10, 10], np.nan)
-    assert_allclose(result_image["excess"].data[0, 10, 10], np.nan)
-    assert_allclose(result_image["background"].data[0, 10, 10], np.nan)
+    assert_allclose(result_image["npred"].data[0, 10, 10], np.nan)
+    assert_allclose(result_image["npred_excess"].data[0, 10, 10], np.nan)
+    assert_allclose(result_image["npred_null"].data[0, 10, 10], np.nan)
     assert_allclose(result_image["sqrt_ts"].data[0, 9, 9], 7.186745, atol=1e-3)
-    assert_allclose(result_image["counts"].data[0, 9, 9], 304)
-    assert_allclose(result_image["excess"].data[0, 9, 9], 152)
-    assert_allclose(result_image["background"].data[0, 9, 9], 152)
+    assert_allclose(result_image["npred"].data[0, 9, 9], 304)
+    assert_allclose(result_image["npred_excess"].data[0, 9, 9], 152)
+    assert_allclose(result_image["npred_null"].data[0, 9, 9], 152)
 
     assert result_image["flux"].unit == u.Unit("cm-2s-1")
     assert_allclose(result_image["flux"].data[0, 9, 9], 1.190928e-08, rtol=1e-3)
@@ -244,13 +243,13 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
         0.11 * u.deg, apply_mask_fit=False, correlate_off=True
     )
     result_mod = estimator_mod.run(simple_dataset_on_off)
-    assert result_mod["counts"].data.shape == (1, 20, 20)
+    assert result_mod["npred"].data.shape == (1, 20, 20)
 
     assert_allclose(result_mod["sqrt_ts"].data[0, 10, 10], 8.899278, atol=1e-3)
 
-    assert_allclose(result_mod["counts"].data[0, 10, 10], 388)
-    assert_allclose(result_mod["excess"].data[0, 10, 10], 190.68057)
-    assert_allclose(result_mod["background"].data[0, 10, 10], 197.31943)
+    assert_allclose(result_mod["npred"].data[0, 10, 10], 388)
+    assert_allclose(result_mod["npred_excess"].data[0, 10, 10], 190.68057)
+    assert_allclose(result_mod["npred_null"].data[0, 10, 10], 197.31943)
 
     assert result_mod["flux"].unit == "cm-2s-1"
     assert_allclose(result_mod["flux"].data[0, 10, 10], 1.906806e-08, rtol=1e-3)

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -236,20 +236,20 @@ def test_run_pwl(fpe_pwl, tmpdir):
     actual = table.meta["UL_CONF"]
     assert_allclose(actual, 0.9544997)
 
-    npred_err = fp.npred_excess.data.squeeze()
-    assert_allclose(npred_err, [550.466, 351.292,  28.604], rtol=1e-3)
+    npred_excess_err = fp.npred_excess.data.squeeze()
+    assert_allclose(npred_excess_err, [550.466, 351.292,  28.604], rtol=1e-3)
 
-    npred_err = fp.npred_err.data.squeeze()
-    assert_allclose(npred_err, [33.784, 23.536,  5.575], rtol=1e-3)
+    npred_excess_err = fp.npred_excess_err.data.squeeze()
+    assert_allclose(npred_excess_err, [33.784, 23.536,  5.575], rtol=1e-3)
 
-    npred_errp = fp.npred_errp.data.squeeze()
-    assert_allclose(npred_errp, [34.032, 23.792,  5.844], rtol=1e-3)
+    npred_excess_errp = fp.npred_excess_errp.data.squeeze()
+    assert_allclose(npred_excess_errp, [34.032, 23.792,  5.844], rtol=1e-3)
 
-    npred_errn = fp.npred_errn.data.squeeze()
-    assert_allclose(npred_errn, [33.539, 23.277,  5.315], rtol=1e-3)
+    npred_excess_errn = fp.npred_excess_errn.data.squeeze()
+    assert_allclose(npred_excess_errn, [33.539, 23.277,  5.315], rtol=1e-3)
 
-    npred_ul = fp.npred_ul.data.squeeze()
-    assert_allclose(npred_ul, [619.060, 399.318,  40.849], rtol=1e-3)
+    npred_excess_ul = fp.npred_excess_ul.data.squeeze()
+    assert_allclose(npred_excess_ul, [619.060, 399.318,  40.849], rtol=1e-3)
 
     # test GADF I/O
     fp.write(tmpdir / "test.fits", format="gadf-sed")

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -236,6 +236,18 @@ def test_run_pwl(fpe_pwl, tmpdir):
     actual = table.meta["UL_CONF"]
     assert_allclose(actual, 0.9544997)
 
+    npred_err = fp.npred_err.data.squeeze()
+    assert_allclose(npred_err, [0, 0, 0])
+
+    npred_errp = fp.npred_errp.data.squeeze()
+    assert_allclose(npred_errp, [0, 0, 0])
+
+    npred_errn = fp.npred_errn.data.squeeze()
+    assert_allclose(npred_errn, [0, 0, 0])
+
+    npred_ul = fp.npred_ul.data.squeeze()
+    assert_allclose(npred_ul, [0, 0, 0])
+
     # test GADF I/O
     fp.write(tmpdir / "test.fits", format="gadf-sed")
     fp_new = FluxPoints.read(tmpdir / "test.fits")

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -236,17 +236,20 @@ def test_run_pwl(fpe_pwl, tmpdir):
     actual = table.meta["UL_CONF"]
     assert_allclose(actual, 0.9544997)
 
+    npred_err = fp.npred_excess.data.squeeze()
+    assert_allclose(npred_err, [550.46638 , 351.292033,  28.604823])
+
     npred_err = fp.npred_err.data.squeeze()
-    assert_allclose(npred_err, [0, 0, 0])
+    assert_allclose(npred_err, [33.783979, 23.535834,  5.575055])
 
     npred_errp = fp.npred_errp.data.squeeze()
-    assert_allclose(npred_errp, [0, 0, 0])
+    assert_allclose(npred_errp, [34.032192, 23.791832,  5.844476])
 
     npred_errn = fp.npred_errn.data.squeeze()
-    assert_allclose(npred_errn, [0, 0, 0])
+    assert_allclose(npred_errn, [33.539282, 23.277257,  5.315383])
 
     npred_ul = fp.npred_ul.data.squeeze()
-    assert_allclose(npred_ul, [0, 0, 0])
+    assert_allclose(npred_ul, [619.059717, 399.317749,  40.849236])
 
     # test GADF I/O
     fp.write(tmpdir / "test.fits", format="gadf-sed")

--- a/gammapy/estimators/tests/test_flux_point_estimator.py
+++ b/gammapy/estimators/tests/test_flux_point_estimator.py
@@ -225,31 +225,31 @@ def test_run_pwl(fpe_pwl, tmpdir):
     assert_allclose(actual, [0.2, 1., 5.])
 
     actual = table["stat_scan"][0][[0, 5, -1]]
-    assert_allclose(actual, [220.368653, 4.301011, 1881.626454], rtol=1e-2)
+    assert_allclose(actual, [220.369, 4.301, 1881.626], rtol=1e-2)
 
     actual = table["npred"].data
-    assert_allclose(actual, [[1492.96638], [749.4587], [43.104823]])
+    assert_allclose(actual, [[1492.966], [749.459], [43.105]], rtol=1e-3)
 
     actual = table["npred_null"].data
-    assert_allclose(actual, [[942.5], [398.166667], [14.5]])
+    assert_allclose(actual, [[942.5], [398.167], [14.5]], rtol=1e-3)
 
     actual = table.meta["UL_CONF"]
     assert_allclose(actual, 0.9544997)
 
     npred_err = fp.npred_excess.data.squeeze()
-    assert_allclose(npred_err, [550.46638 , 351.292033,  28.604823])
+    assert_allclose(npred_err, [550.466, 351.292,  28.604], rtol=1e-3)
 
     npred_err = fp.npred_err.data.squeeze()
-    assert_allclose(npred_err, [33.783979, 23.535834,  5.575055])
+    assert_allclose(npred_err, [33.784, 23.536,  5.575], rtol=1e-3)
 
     npred_errp = fp.npred_errp.data.squeeze()
-    assert_allclose(npred_errp, [34.032192, 23.791832,  5.844476])
+    assert_allclose(npred_errp, [34.032, 23.792,  5.844], rtol=1e-3)
 
     npred_errn = fp.npred_errn.data.squeeze()
-    assert_allclose(npred_errn, [33.539282, 23.277257,  5.315383])
+    assert_allclose(npred_errn, [33.539, 23.277,  5.315], rtol=1e-3)
 
     npred_ul = fp.npred_ul.data.squeeze()
-    assert_allclose(npred_ul, [619.059717, 399.317749,  40.849236])
+    assert_allclose(npred_ul, [619.060, 399.318,  40.849], rtol=1e-3)
 
     # test GADF I/O
     fp.write(tmpdir / "test.fits", format="gadf-sed")

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -369,17 +369,17 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
     npred = lightcurve.npred.data.squeeze()
     assert_allclose(npred, [[[669.36, np.nan], [121.66, np.nan]], [[np.nan, 664.41], [np.nan, 115.09]]], rtol=1e-3)
 
-    npred_err = lightcurve.npred_err.data.squeeze()
-    assert_allclose(npred_err, [[[22.34, np.nan], [9.42, np.nan]], [[np.nan, 22.38], [np.nan, 9.29]]], rtol=1e-3)
+    npred_excess_err = lightcurve.npred_excess_err.data.squeeze()
+    assert_allclose(npred_excess_err, [[[22.34, np.nan], [9.42, np.nan]], [[np.nan, 22.38], [np.nan, 9.29]]], rtol=1e-3)
 
-    npred_errp = lightcurve.npred_errp.data.squeeze()
-    assert_allclose(npred_errp, [[[22.59, np.nan], [9.69, np.nan]], [[np.nan, 22.63], [np.nan, 9.55]]], rtol=1e-3)
+    npred_excess_errp = lightcurve.npred_excess_errp.data.squeeze()
+    assert_allclose(npred_excess_errp, [[[22.59, np.nan], [9.69, np.nan]], [[np.nan, 22.63], [np.nan, 9.55]]], rtol=1e-3)
 
-    npred_errn = lightcurve.npred_errn.data.squeeze()
-    assert_allclose(npred_errn, [[[22.08, np.nan], [9.17, np.nan]], [[np.nan, 22.12], [np.nan, 9.03]]], rtol=1e-3)
+    npred_excess_errn = lightcurve.npred_excess_errn.data.squeeze()
+    assert_allclose(npred_excess_errn, [[[22.08, np.nan], [9.17, np.nan]], [[np.nan, 22.12], [np.nan, 9.03]]], rtol=1e-3)
 
-    npred_ul = lightcurve.npred_ul.data.squeeze()
-    assert_allclose(npred_ul, [[[348.90, np.nan], [95.15, np.nan]], [[np.nan, 355.62], [np.nan, 88.22]]], rtol=1e-3)
+    npred_excess_ul = lightcurve.npred_excess_ul.data.squeeze()
+    assert_allclose(npred_excess_ul, [[[348.90, np.nan], [95.15, np.nan]], [[np.nan, 355.62], [np.nan, 88.22]]], rtol=1e-3)
 
     fp = FluxPoints.from_table(
         table=table, format="lightcurve", reference_model=PowerLawSpectralModel()

--- a/gammapy/estimators/tests/test_lightcurve.py
+++ b/gammapy/estimators/tests/test_lightcurve.py
@@ -305,6 +305,7 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
     )
     lightcurve = estimator.run(datasets)
     table = lightcurve.to_table(format="lightcurve")
+
     assert_allclose(table["time_min"], [55197.0, 55197.041667])
     assert_allclose(table["time_max"], [55197.041667, 55197.083333])
     assert_allclose(
@@ -364,6 +365,22 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
         rtol=1e-5,
     )
 
+    # those quantities are currently not part of the table so we test separately
+    npred = lightcurve.npred.data.squeeze()
+    assert_allclose(npred, [[[669.36, np.nan], [121.66, np.nan]], [[np.nan, 664.41], [np.nan, 115.09]]], rtol=1e-3)
+
+    npred_err = lightcurve.npred_err.data.squeeze()
+    assert_allclose(npred_err, [[[22.34, np.nan], [9.42, np.nan]], [[np.nan, 22.38], [np.nan, 9.29]]], rtol=1e-3)
+
+    npred_errp = lightcurve.npred_errp.data.squeeze()
+    assert_allclose(npred_errp, [[[22.59, np.nan], [9.69, np.nan]], [[np.nan, 22.63], [np.nan, 9.55]]], rtol=1e-3)
+
+    npred_errn = lightcurve.npred_errn.data.squeeze()
+    assert_allclose(npred_errn, [[[22.08, np.nan], [9.17, np.nan]], [[np.nan, 22.12], [np.nan, 9.03]]], rtol=1e-3)
+
+    npred_ul = lightcurve.npred_ul.data.squeeze()
+    assert_allclose(npred_ul, [[[348.90, np.nan], [95.15, np.nan]], [[np.nan, 355.62], [np.nan, 88.22]]], rtol=1e-3)
+
     fp = FluxPoints.from_table(
         table=table, format="lightcurve", reference_model=PowerLawSpectralModel()
     )
@@ -374,7 +391,7 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
 
 @requires_data()
 @requires_dependency("iminuit")
-def test_lightcurve_estimator_spectrum_datasets_withmaskfit():
+def test_lightcurve_estimator_spectrum_datasets_with_mask_fit():
     # Doing a LC on one hour bin
     datasets = get_spectrum_datasets()
     time_intervals = [
@@ -472,6 +489,7 @@ def test_lightcurve_estimator_spectrum_datasets_largerbin():
     assert_allclose(table["norm_err"][0], [0.040874], rtol=1e-3)
     assert_allclose(table["ts"][0], [742.939324], rtol=1e-4)
 
+
 @requires_data()
 @requires_dependency("iminuit")
 def test_lightcurve_estimator_spectrum_datasets_emptybin():
@@ -490,6 +508,7 @@ def test_lightcurve_estimator_spectrum_datasets_emptybin():
 
     assert_allclose(table["time_min"], [55197.0])
     assert_allclose(table["time_max"], [55197.083333])
+
 
 @requires_data()
 @requires_dependency("iminuit")

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -125,6 +125,7 @@ def test_compute_ts_map(input_dataset):
     assert_allclose(result["npred"].data[0, 99, 99], 4744.020361, rtol=1e-2)
     assert_allclose(result["npred_null"].data[0, 99, 99], 3721, rtol=1e-2)
     assert_allclose(result["npred_excess"].data[0, 99, 99], 1026.874063, rtol=1e-2)
+    assert_allclose(result["npred_err"].data[0, 99, 99], 38.470995, rtol=1e-2)
 
     assert result["flux"].unit == u.Unit("cm-2s-1")
     assert result["flux_err"].unit == u.Unit("cm-2s-1")

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -125,7 +125,7 @@ def test_compute_ts_map(input_dataset):
     assert_allclose(result["npred"].data[0, 99, 99], 4744.020361, rtol=1e-2)
     assert_allclose(result["npred_null"].data[0, 99, 99], 3721, rtol=1e-2)
     assert_allclose(result["npred_excess"].data[0, 99, 99], 1026.874063, rtol=1e-2)
-    assert_allclose(result["npred_err"].data[0, 99, 99], 38.470995, rtol=1e-2)
+    assert_allclose(result["npred_excess_err"].data[0, 99, 99], 38.470995, rtol=1e-2)
 
     assert result["flux"].unit == u.Unit("cm-2s-1")
     assert result["flux_err"].unit == u.Unit("cm-2s-1")

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -120,6 +120,10 @@ def estimate_exposure_reco_energy(dataset, spectral_model=None, normalize=True):
             the input dataset
     spectral_model: `~gammapy.modeling.models.SpectralModel`
             assumed spectral shape. If none, a Power Law of index 2 is assumed
+    normalize : bool
+        Normalize the exposure to the total integrated flux of the spectral model.
+        When not normalized it directly gives the predicted counts from the spectral
+        model.
 
     Returns
     -------

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -111,7 +111,7 @@ def find_peaks(image, threshold, min_distance=1):
     return table
 
 
-def estimate_exposure_reco_energy(dataset, spectral_model=None):
+def estimate_exposure_reco_energy(dataset, spectral_model=None, normalize=True):
     """Estimate an exposure map in reconstructed energy.
 
     Parameters
@@ -135,13 +135,16 @@ def estimate_exposure_reco_energy(dataset, spectral_model=None):
 
     energy_axis = dataset._geom.axes["energy"]
 
-    edisp = None
-
     if dataset.edisp is not None:
         edisp = dataset.edisp.get_edisp_kernel(position=None, energy_axis=energy_axis)
+    else:
+        edisp = None
 
-    meval = MapEvaluator(model=model, exposure=dataset.exposure, edisp=edisp)
-    npred = meval.compute_npred()
-    ref_flux = spectral_model.integral(energy_axis.edges[:-1], energy_axis.edges[1:])
-    reco_exposure = npred / ref_flux[:, np.newaxis, np.newaxis]
+    eval = MapEvaluator(model=model, exposure=dataset.exposure, edisp=edisp)
+    reco_exposure = eval.compute_npred()
+
+    if normalize:
+        ref_flux = spectral_model.integral(energy_axis.edges[:-1], energy_axis.edges[1:])
+        reco_exposure = reco_exposure / ref_flux[:, np.newaxis, np.newaxis]
+
     return reco_exposure


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the `ExcessMapEstimator` to return a `FluxMaps` object as well. This required adding `npred` based quantities to the `FluxMaps` object, such that it can represent the case where there is no exposure and thus no flux estimate present. Here is a list of the quantities:

- `FluxMaps.npred_ref` reference predicted counts, such that `npred_excess = npred_ref * norm`. The definition of `npred_ref` somewhat differs from the other reference spectra, because it needs to vary with position and is represented as a `Map`.
- `FluxMaps.npred_err` error on `npred_excess`
- `FluxMaps.npred_errp` positive error on `npred_excess`
- `FluxMaps.npred_errn` negative error on `npred_excess`
- `FluxMaps.npred_ul` upper limit on `npred_excess`

In the name there is one inconsistency, that I don't like: `npred` already refers to the total counts (including null...), while the npred that relates to the norm is named `npred_excess`. So we might consider renaming either `npred` to e.g. `npred_total` or work with  `npred_excess_err` etc. instead.

Again for illustration I have updated the notebook here https://github.com/adonath/notebooks-public/blob/master/excess-vs-ts-map-estimator.ipynb

In past PRs I have resolved the inconsistencies between the `TSMapEstimator` and `ExcessMapEstimator`:
- #3497
- #3569
- #3519

The results (including the npred quantities defined above) now agree nicely and I propose to use `FluxMaps` as return type for the `ExcessMapEstimator` as well.  The main question is whether `npred` should be introduced as an independent sed type, to be able to represent maps and spectra without knowing the effective area of the instrument.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
