### PR TITLE
Fix TSMapEstimator norm error boundary handling

### DIFF
--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -82,10 +82,8 @@ class ExcessMapEstimator(Estimator):
         correlation radius to use
     n_sigma : float
         Confidence level for the asymmetric errors expressed in number of sigma.
-        Default is 1.
     n_sigma_ul : float
         Confidence level for the upper limits expressed in number of sigma.
-        Default is 3.
     selection_optional : list of str
         Which additional maps to estimate besides delta TS, significance and symmetric error.
         Available options are:
@@ -114,7 +112,7 @@ class ExcessMapEstimator(Estimator):
         self,
         correlation_radius="0.1 deg",
         n_sigma=1,
-        n_sigma_ul=3,
+        n_sigma_ul=2,
         selection_optional=None,
         energy_edges=None,
         apply_mask_fit=False,

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -118,7 +118,7 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
     assert_allclose(result["err"].data[0, 10, 10], 12.727922, atol=1e-3)
     assert_allclose(result["errp"].data[0, 10, 10], 13.063328, atol=1e-3)
     assert_allclose(result["errn"].data[0, 10, 10], -12.396716, atol=1e-3)
-    assert_allclose(result["ul"].data[0, 10, 10], 122.240837, atol=1e-3)
+    assert_allclose(result["ul"].data[0, 10, 10], 107.806275, atol=1e-3)
 
     simple_dataset.exposure += 1e10 * u.cm ** 2 * u.s
     axis = simple_dataset.exposure.geom.axes[0]

--- a/gammapy/estimators/tests/test_ts_map.py
+++ b/gammapy/estimators/tests/test_ts_map.py
@@ -227,13 +227,14 @@ def test_ts_map_with_model(fake_dataset):
     estimator = TSMapEstimator(
         model,
         kernel_width="0.3 deg",
-        selection_optional=[],
+        selection_optional=["all"],
         energy_edges=[200, 3500] * u.GeV,
     )
     maps = estimator.run(fake_dataset)
 
     assert_allclose(maps["sqrt_ts"].data[:, 25, 25], 18.369942, atol=0.1)
     assert_allclose(maps["flux"].data[:, 25, 25], 3.513e-10, atol=1e-12)
+    assert_allclose(maps["flux_err"].data[0, 0, 0], 2.494462e-11, rtol=1e-4)
 
     fake_dataset.models = [model]
     maps = estimator.run(fake_dataset)

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -523,11 +523,12 @@ class SimpleMapDataset:
     def stat_2nd_derivative(self, norm):
         """Stat 2nd derivative"""
         with np.errstate(invalid="ignore", divide="ignore"):
+            mask = self.background > 0
             return (
                 self.model ** 2
                 * self.counts
                 / (self.background + norm * self.model) ** 2
-            ).sum()
+            )[mask].sum()
 
     @classmethod
     def from_arrays(cls, counts, background, exposure, norm, position, kernel):

--- a/gammapy/estimators/ts_map.py
+++ b/gammapy/estimators/ts_map.py
@@ -261,31 +261,22 @@ class TSMapEstimator(Estimator):
         flux = flux.convolve(kernel)
         return flux.sum_over_axes()
 
-    def estimate_mask_default(self, dataset, kernel=None):
+    def estimate_mask_default(self, dataset):
         """Compute default mask where to estimate TS values.
 
         Parameters
         ----------
         dataset : `~gammapy.datasets.MapDataset`
             Input dataset.
-        kernel : `WcsNDMap`
-            Source model kernel.
 
         Returns
         -------
         mask : `WcsNDMap`
             Mask map.
         """
-        if kernel is None:
-            kernel = self.estimate_kernel(dataset=dataset)
-
         geom = dataset.counts.geom.to_image()
 
-        # mask boundary
-        mask = np.zeros(geom.data_shape, dtype=bool)
-        slice_x = slice(kernel.data.shape[2] // 2, -kernel.data.shape[2] // 2 + 1)
-        slice_y = slice(kernel.data.shape[1] // 2, -kernel.data.shape[1] // 2 + 1)
-        mask[slice_y, slice_x] = 1
+        mask = np.ones(geom.data_shape, dtype=bool)
 
         if dataset.mask is not None:
             mask &= dataset.mask.reduce_over_axes(func=np.logical_or, keepdims=False)
@@ -347,9 +338,11 @@ class TSMapEstimator(Estimator):
 
         kernel = self.estimate_kernel(dataset)
 
-        mask = self.estimate_mask_default(dataset, kernel=kernel)
+        mask = self.estimate_mask_default(dataset=dataset)
 
-        flux = self.estimate_flux_default(dataset, kernel=kernel, exposure=exposure)
+        flux = self.estimate_flux_default(
+            dataset=dataset, kernel=kernel, exposure=exposure
+        )
 
         energy_axis = counts.geom.axes["energy"]
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fix the boundary behaviour for errors computed by the `TSMapEstimator` mentioned in #3491. The for the failure was that the background was padded with zero, which resulted in `NaN` values for the second derivative with respect to the norm. It also removes the boundary mask, which is not needed anymore after padding is the default. 

It also changes the `n_sigma_ul` default for `ExcessMapEstimator` for consistency with all the other estimators.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
