### PR TITLE
Fix MapDataset.npred_signal for single model evaluation at first

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -435,10 +435,11 @@ class MapDataset(Dataset):
         """
         npred_total = Map.from_geom(self._geom, dtype=float)
 
+        evaluators = self.evaluators
         if model_name is not None:
-            return self.evaluators[model_name].compute_npred()
+            evaluators = {model_name: self.evaluators[model_name]} 
 
-        for evaluator in self.evaluators.values():
+        for evaluator in evaluators.values():
             if evaluator.needs_update:
                 evaluator.update(
                     self.exposure,

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -875,11 +875,12 @@ def test_npred_sig(sky_model, geom, geom_etrue):
     bkg = FoVBackgroundModel(dataset_name=dataset.name)
     dataset.models = [bkg, sky_model, model1]
 
-    assert_allclose(dataset.npred().data.sum(), 9676.047906, rtol=1e-3)
-    assert_allclose(dataset.npred_signal().data.sum(), 5676.04790, rtol=1e-3)
     assert_allclose(
         dataset.npred_signal(model_name=model1.name).data.sum(), 150.7487, rtol=1e-3
     )
+    assert_allclose(dataset.npred().data.sum(), 9676.047906, rtol=1e-3)
+    assert_allclose(dataset.npred_signal().data.sum(), 5676.04790, rtol=1e-3)
+ 
     with pytest.raises(
         KeyError, match="m2",
     ):


### PR DESCRIPTION
Currently single model evaluation with `MapDataset.npred_signal(model_name) ` fails on the first call,  because the default case `MapDataset.npred_signal()`  have to be called first in order to initialize the evaluators. This PR fix this issue and change the order of the tests to cover this problem.

Solves #3490