### PR TITLE
Adapt caplog tests 

### DIFF
--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -379,8 +379,8 @@ with the expected logging level:
         ----------
         caplog : caplog fixture that give you access to the log level, the logger, etc.,
         """
-        assert caplog.records[-1].levelname == "WARNING"
-        assert "warning message" in caplog.records[-1].message
+        assert "WARNING" in [_.levelname for _ in caplog.records]
+        assert "warning message" in [_.message for _ in caplog.records]
 
 Random numbers
 --------------

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -118,6 +118,7 @@ def test_get_observations_obs_time(tmp_path):
     with pytest.raises(KeyError):
         analysis.get_observations()
 
+
 @requires_data()
 def test_get_observations_missing_irf():
     config = AnalysisConfig()
@@ -127,6 +128,7 @@ def test_get_observations_missing_irf():
     analysis.config.observations.required_irf = ["aeff", "edisp"]
     analysis.get_observations()
     assert len(analysis.observations) == 1
+
 
 @requires_data()
 def test_set_models():
@@ -319,7 +321,7 @@ def test_analysis_ring_background():
         analysis.datasets[0].npred_background().data[0, 10, 10], 0.091799, rtol=1e-2
     )
     assert isinstance(analysis.excess_map["sqrt_ts"], WcsNDMap)
-    assert_allclose(analysis.excess_map["excess"].data[0,62,62],134.12389)
+    assert_allclose(analysis.excess_map["excess"].data[0, 62, 62], 134.12389)
 
 
 @requires_data()
@@ -340,8 +342,10 @@ def test_analysis_no_bkg_1d(caplog):
     analysis.get_observations()
     analysis.get_datasets()
     assert isinstance(analysis.datasets[0], SpectrumDatasetOnOff) is False
-    assert caplog.records[-1].levelname == "WARNING"
-    assert caplog.records[-1].message == "No background maker set. Check configuration."
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert "No background maker set. Check configuration." in [
+        _.message for _ in caplog.records
+    ]
 
 
 @requires_data()
@@ -352,8 +356,10 @@ def test_analysis_no_bkg_3d(caplog):
     analysis.get_observations()
     analysis.get_datasets()
     assert isinstance(analysis.datasets[0], MapDataset) is True
-    assert caplog.records[-1].levelname == "WARNING"
-    assert caplog.records[-1].message == "No background maker set. Check configuration."
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert "No background maker set. Check configuration." in [
+        _.message for _ in caplog.records
+    ]
 
 
 @requires_dependency("iminuit")

--- a/gammapy/estimators/tests/test_flux_map.py
+++ b/gammapy/estimators/tests/test_flux_map.py
@@ -7,49 +7,72 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from gammapy.data import GTI
 from gammapy.maps import MapAxis, WcsNDMap, RegionGeom, Maps
-from gammapy.modeling.models import SkyModel, PowerLawSpectralModel, PointSpatialModel, LogParabolaSpectralModel
+from gammapy.modeling.models import (
+    SkyModel,
+    PowerLawSpectralModel,
+    PointSpatialModel,
+    LogParabolaSpectralModel,
+)
 from gammapy.estimators import FluxMaps
 from gammapy.utils.testing import mpl_plot_check, requires_dependency
 
 
 @pytest.fixture(scope="session")
 def reference_model():
-    return SkyModel(spatial_model=PointSpatialModel(), spectral_model=PowerLawSpectralModel(index=2))
+    return SkyModel(
+        spatial_model=PointSpatialModel(), spectral_model=PowerLawSpectralModel(index=2)
+    )
 
 
 @pytest.fixture(scope="session")
 def logpar_reference_model():
-    logpar = LogParabolaSpectralModel(amplitude="2e-12 cm-2s-1TeV-1", alpha=1.5, beta=0.5)
+    logpar = LogParabolaSpectralModel(
+        amplitude="2e-12 cm-2s-1TeV-1", alpha=1.5, beta=0.5
+    )
     return SkyModel(spatial_model=PointSpatialModel(), spectral_model=logpar)
 
 
 @pytest.fixture(scope="session")
 def wcs_flux_map():
-    energy_axis = MapAxis.from_energy_bounds(0.1,10, 2, unit='TeV')
+    energy_axis = MapAxis.from_energy_bounds(0.1, 10, 2, unit="TeV")
 
     map_dict = {}
 
-    map_dict["norm"]= WcsNDMap.create(npix=10, frame='galactic', axes=[energy_axis], unit='')
+    map_dict["norm"] = WcsNDMap.create(
+        npix=10, frame="galactic", axes=[energy_axis], unit=""
+    )
     map_dict["norm"].data += 1.0
 
-    map_dict["norm_err"] = WcsNDMap.create(npix=10, frame='galactic', axes=[energy_axis], unit='')
+    map_dict["norm_err"] = WcsNDMap.create(
+        npix=10, frame="galactic", axes=[energy_axis], unit=""
+    )
     map_dict["norm_err"].data += 0.1
 
-    map_dict["norm_errp"] = WcsNDMap.create(npix=10, frame='galactic', axes=[energy_axis], unit='')
+    map_dict["norm_errp"] = WcsNDMap.create(
+        npix=10, frame="galactic", axes=[energy_axis], unit=""
+    )
     map_dict["norm_errp"].data += 0.2
 
-    map_dict["norm_errn"] = WcsNDMap.create(npix=10, frame='galactic', axes=[energy_axis], unit='')
+    map_dict["norm_errn"] = WcsNDMap.create(
+        npix=10, frame="galactic", axes=[energy_axis], unit=""
+    )
     map_dict["norm_errn"].data += 0.2
 
-    map_dict["norm_ul"] = WcsNDMap.create(npix=10, frame='galactic', axes=[energy_axis], unit='')
+    map_dict["norm_ul"] = WcsNDMap.create(
+        npix=10, frame="galactic", axes=[energy_axis], unit=""
+    )
     map_dict["norm_ul"].data += 2.0
 
     # Add another map
-    map_dict["sqrt_ts"] = WcsNDMap.create(npix=10, frame='galactic', axes=[energy_axis], unit='')
+    map_dict["sqrt_ts"] = WcsNDMap.create(
+        npix=10, frame="galactic", axes=[energy_axis], unit=""
+    )
     map_dict["sqrt_ts"].data += 1.0
 
     # Add another map
-    map_dict["ts"] = WcsNDMap.create(npix=10, frame='galactic', axes=[energy_axis], unit='')
+    map_dict["ts"] = WcsNDMap.create(
+        npix=10, frame="galactic", axes=[energy_axis], unit=""
+    )
     map_dict["ts"].data[1] += 3.0
 
     return map_dict
@@ -57,18 +80,24 @@ def wcs_flux_map():
 
 @pytest.fixture(scope="session")
 def partial_wcs_flux_map():
-    energy_axis = MapAxis.from_energy_bounds(0.1,10, 2, unit='TeV')
+    energy_axis = MapAxis.from_energy_bounds(0.1, 10, 2, unit="TeV")
 
     map_dict = {}
 
-    map_dict["norm"]= WcsNDMap.create(npix=10, frame='galactic', axes=[energy_axis], unit='')
+    map_dict["norm"] = WcsNDMap.create(
+        npix=10, frame="galactic", axes=[energy_axis], unit=""
+    )
     map_dict["norm"].data += 1.0
 
-    map_dict["norm_err"] = WcsNDMap.create(npix=10, frame='galactic', axes=[energy_axis], unit='')
+    map_dict["norm_err"] = WcsNDMap.create(
+        npix=10, frame="galactic", axes=[energy_axis], unit=""
+    )
     map_dict["norm_err"].data += 0.1
 
     # Add another map
-    map_dict["sqrt_ts"] = WcsNDMap.create(npix=10, frame='galactic', axes=[energy_axis], unit='')
+    map_dict["sqrt_ts"] = WcsNDMap.create(
+        npix=10, frame="galactic", axes=[energy_axis], unit=""
+    )
     map_dict["sqrt_ts"].data += 1.0
 
     return map_dict
@@ -77,13 +106,10 @@ def partial_wcs_flux_map():
 @pytest.fixture(scope="session")
 def region_map_flux_estimate():
     axis = MapAxis.from_energy_edges((0.1, 1.0, 10.0), unit="TeV")
-    geom = RegionGeom.create(
-        "galactic;circle(0, 0, 0.1)", axes=[axis]
-    )
+    geom = RegionGeom.create("galactic;circle(0, 0, 0.1)", axes=[axis])
 
     maps = Maps.from_geom(
-        geom=geom,
-        names=["norm", "norm_err", "norm_errn", "norm_errp", "norm_ul"]
+        geom=geom, names=["norm", "norm_err", "norm_errn", "norm_errp", "norm_ul"]
     )
 
     maps["norm"].data = np.array([1.0, 1.0])
@@ -168,12 +194,8 @@ def test_map_properties(map_flux_estimate):
 
     assert fe.eflux.unit == u.Unit("TeV cm-2s-1")
     assert_allclose(fe.eflux.quantity.value[:, 2, 2], [2.302585e-10, 2.302585e-10])
-    assert_allclose(
-        fe.eflux_err.quantity.value[:, 2, 2], [2.302585e-11, 2.302585e-11]
-    )
-    assert_allclose(
-        fe.eflux_errn.quantity.value[:, 2, 2], [4.60517e-11, 4.60517e-11]
-    )
+    assert_allclose(fe.eflux_err.quantity.value[:, 2, 2], [2.302585e-11, 2.302585e-11])
+    assert_allclose(fe.eflux_errn.quantity.value[:, 2, 2], [4.60517e-11, 4.60517e-11])
     assert_allclose(
         fe.eflux_errp.quantity.value[:, 2, 2], [3.4538775e-11, 3.4538775e-11]
     )
@@ -183,24 +205,24 @@ def test_map_properties(map_flux_estimate):
 def test_flux_map_properties(wcs_flux_map, reference_model):
     fluxmap = FluxMaps(wcs_flux_map, reference_model)
 
-    assert_allclose(fluxmap.dnde.data[:,0,0],[1e-11, 1e-13])
-    assert_allclose(fluxmap.dnde_err.data[:,0,0],[1e-12, 1e-14])
-    assert_allclose(fluxmap.dnde_err.data[:,0,0],[1e-12, 1e-14])
-    assert_allclose(fluxmap.dnde_errn.data[:,0,0],[2e-12, 2e-14])
-    assert_allclose(fluxmap.dnde_errp.data[:,0,0],[2e-12, 2e-14])
-    assert_allclose(fluxmap.dnde_ul.data[:,0,0],[2e-11, 2e-13])
+    assert_allclose(fluxmap.dnde.data[:, 0, 0], [1e-11, 1e-13])
+    assert_allclose(fluxmap.dnde_err.data[:, 0, 0], [1e-12, 1e-14])
+    assert_allclose(fluxmap.dnde_err.data[:, 0, 0], [1e-12, 1e-14])
+    assert_allclose(fluxmap.dnde_errn.data[:, 0, 0], [2e-12, 2e-14])
+    assert_allclose(fluxmap.dnde_errp.data[:, 0, 0], [2e-12, 2e-14])
+    assert_allclose(fluxmap.dnde_ul.data[:, 0, 0], [2e-11, 2e-13])
 
-    assert_allclose(fluxmap.flux.data[:,0,0],[9e-12, 9e-13])
-    assert_allclose(fluxmap.flux_err.data[:,0,0],[9e-13, 9e-14])
-    assert_allclose(fluxmap.flux_errn.data[:,0,0],[18e-13, 18e-14])
-    assert_allclose(fluxmap.flux_errp.data[:,0,0],[18e-13, 18e-14])
-    assert_allclose(fluxmap.flux_ul.data[:,0,0],[18e-12, 18e-13])
+    assert_allclose(fluxmap.flux.data[:, 0, 0], [9e-12, 9e-13])
+    assert_allclose(fluxmap.flux_err.data[:, 0, 0], [9e-13, 9e-14])
+    assert_allclose(fluxmap.flux_errn.data[:, 0, 0], [18e-13, 18e-14])
+    assert_allclose(fluxmap.flux_errp.data[:, 0, 0], [18e-13, 18e-14])
+    assert_allclose(fluxmap.flux_ul.data[:, 0, 0], [18e-12, 18e-13])
 
-    assert_allclose(fluxmap.eflux.data[:,0,0],[2.302585e-12, 2.302585e-12])
-    assert_allclose(fluxmap.eflux_err.data[:,0,0],[2.302585e-13, 2.302585e-13])
-    assert_allclose(fluxmap.eflux_errp.data[:,0,0],[4.60517e-13, 4.60517e-13])
-    assert_allclose(fluxmap.eflux_errn.data[:,0,0],[4.60517e-13, 4.60517e-13])
-    assert_allclose(fluxmap.eflux_ul.data[:,0,0],[4.60517e-12, 4.60517e-12])
+    assert_allclose(fluxmap.eflux.data[:, 0, 0], [2.302585e-12, 2.302585e-12])
+    assert_allclose(fluxmap.eflux_err.data[:, 0, 0], [2.302585e-13, 2.302585e-13])
+    assert_allclose(fluxmap.eflux_errp.data[:, 0, 0], [4.60517e-13, 4.60517e-13])
+    assert_allclose(fluxmap.eflux_errn.data[:, 0, 0], [4.60517e-13, 4.60517e-13])
+    assert_allclose(fluxmap.eflux_ul.data[:, 0, 0], [4.60517e-12, 4.60517e-12])
 
     assert_allclose(fluxmap.e2dnde.data[:, 0, 0], [1e-12, 1e-12])
     assert_allclose(fluxmap.e2dnde_err.data[:, 0, 0], [1e-13, 1e-13])
@@ -209,7 +231,7 @@ def test_flux_map_properties(wcs_flux_map, reference_model):
     assert_allclose(fluxmap.e2dnde_ul.data[:, 0, 0], [2e-12, 2e-12])
 
     assert_allclose(fluxmap.sqrt_ts.data, 1)
-    assert_allclose(fluxmap.ts.data[:,0,0], [0, 3])
+    assert_allclose(fluxmap.ts.data[:, 0, 0], [0, 3])
 
 
 def test_flux_map_str(wcs_flux_map, reference_model):
@@ -233,13 +255,15 @@ def test_flux_map_read_write(tmp_path, wcs_flux_map, logpar_reference_model, sed
     fluxmap.write(tmp_path / "tmp.fits", sed_type=sed_type)
     new_fluxmap = FluxMaps.read(tmp_path / "tmp.fits")
 
-    assert_allclose(new_fluxmap.norm.data[:,0,0], [1, 1])
-    assert_allclose(new_fluxmap.norm_err.data[:,0,0], [0.1, 0.1])
-    assert_allclose(new_fluxmap.norm_errn.data[:,0,0], [0.2, 0.2])
-    assert_allclose(new_fluxmap.norm_ul.data[:,0,0], [2, 2])
+    assert_allclose(new_fluxmap.norm.data[:, 0, 0], [1, 1])
+    assert_allclose(new_fluxmap.norm_err.data[:, 0, 0], [0.1, 0.1])
+    assert_allclose(new_fluxmap.norm_errn.data[:, 0, 0], [0.2, 0.2])
+    assert_allclose(new_fluxmap.norm_ul.data[:, 0, 0], [2, 2])
 
     # check model
-    assert new_fluxmap.reference_model.spectral_model.tag[0] == "LogParabolaSpectralModel"
+    assert (
+        new_fluxmap.reference_model.spectral_model.tag[0] == "LogParabolaSpectralModel"
+    )
     assert new_fluxmap.reference_model.spectral_model.alpha.value == 1.5
     assert new_fluxmap.reference_model.spectral_model.beta.value == 0.5
     assert new_fluxmap.reference_model.spectral_model.amplitude.value == 2e-12
@@ -249,14 +273,16 @@ def test_flux_map_read_write(tmp_path, wcs_flux_map, logpar_reference_model, sed
 
 
 @pytest.mark.parametrize("sed_type", ["likelihood", "dnde", "flux", "eflux", "e2dnde"])
-def test_partial_flux_map_read_write(tmp_path, partial_wcs_flux_map, reference_model, sed_type):
+def test_partial_flux_map_read_write(
+    tmp_path, partial_wcs_flux_map, reference_model, sed_type
+):
     fluxmap = FluxMaps(partial_wcs_flux_map, reference_model)
 
     fluxmap.write(tmp_path / "tmp.fits", sed_type=sed_type)
     new_fluxmap = FluxMaps.read(tmp_path / "tmp.fits")
 
-    assert_allclose(new_fluxmap.norm.data[:,0,0], [1, 1])
-    assert_allclose(new_fluxmap.norm_err.data[:,0,0], [0.1, 0.1])
+    assert_allclose(new_fluxmap.norm.data[:, 0, 0], [1, 1])
+    assert_allclose(new_fluxmap.norm_err.data[:, 0, 0], [0.1, 0.1])
 
     # check model
     assert new_fluxmap.reference_model.spectral_model.tag[0] == "PowerLawSpectralModel"
@@ -277,7 +303,7 @@ def test_flux_map_read_write_gti(tmp_path, partial_wcs_flux_map, reference_model
 
     fluxmap = FluxMaps(partial_wcs_flux_map, reference_model, gti=gti)
 
-    fluxmap.write(tmp_path / "tmp.fits", sed_type='dnde')
+    fluxmap.write(tmp_path / "tmp.fits", sed_type="dnde")
     new_fluxmap = FluxMaps.read(tmp_path / "tmp.fits")
 
     assert len(new_fluxmap.gti.table) == 2
@@ -292,11 +318,15 @@ def test_flux_map_read_write_no_reference_model(tmp_path, wcs_flux_map, caplog):
     new_fluxmap = FluxMaps.read(tmp_path / "tmp.fits")
 
     assert new_fluxmap.reference_model.spectral_model.tag[0] == "PowerLawSpectralModel"
-    assert caplog.records[-1].levelname == "WARNING"
-    assert f"No reference model set for FluxMaps." in caplog.records[-1].message
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert f"No reference model set for FluxMaps." in [
+        _.message for _ in caplog.records
+    ]
 
 
-def test_flux_map_read_write_missing_reference_model(tmp_path, wcs_flux_map, reference_model):
+def test_flux_map_read_write_missing_reference_model(
+    tmp_path, wcs_flux_map, reference_model
+):
     fluxmap = FluxMaps(wcs_flux_map, reference_model)
     fluxmap.write(tmp_path / "tmp.fits")
 
@@ -315,22 +345,24 @@ def test_flux_map_init_no_reference_model(wcs_flux_map, caplog):
     assert fluxmap.reference_model.spatial_model.tag[0] == "PointSpatialModel"
     assert fluxmap.reference_model.spectral_model.index.value == 2
 
-    assert caplog.records[-1].levelname == "WARNING"
-    assert f"No reference model set for FluxMaps." in caplog.records[-1].message
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert f"No reference model set for FluxMaps." in [
+        _.message for _ in caplog.records
+    ]
 
 
 @requires_dependency("matplotlib")
 def test_get_flux_point(wcs_flux_map, reference_model):
     fluxmap = FluxMaps(wcs_flux_map, reference_model)
 
-    coord = SkyCoord(0., 0., unit="deg", frame="galactic")
+    coord = SkyCoord(0.0, 0.0, unit="deg", frame="galactic")
     fp = fluxmap.get_flux_points(coord)
     table = fp.to_table()
 
     assert_allclose(table["e_min"], [0.1, 1.0])
-    assert_allclose(table["norm"], [1, 1] )
-    assert_allclose(table["norm_err"], [0.1, 0.1] )
-    assert_allclose(table["norm_errn"], [0.2, 0.2] )
+    assert_allclose(table["norm"], [1, 1])
+    assert_allclose(table["norm_err"], [0.1, 0.1])
+    assert_allclose(table["norm_errn"], [0.2, 0.2])
     assert_allclose(table["norm_errp"], [0.2, 0.2])
     assert_allclose(table["norm_ul"], [2, 2])
     assert_allclose(table["sqrt_ts"], [1, 1])
@@ -349,7 +381,7 @@ def test_get_flux_point_missing_map(wcs_flux_map, reference_model):
     other_data.pop("norm_errp")
     fluxmap = FluxMaps(other_data, reference_model)
 
-    coord = SkyCoord(0., 0., unit="deg", frame="galactic")
+    coord = SkyCoord(0.0, 0.0, unit="deg", frame="galactic")
     table = fluxmap.get_flux_points(coord).to_table()
 
     assert_allclose(table["e_min"], [0.1, 1.0])
@@ -373,4 +405,3 @@ def test_flux_map_from_dict_inconsistent_units(wcs_flux_map, reference_model):
     assert flux_map.norm.unit == ""
     assert_allclose(flux_map.norm_err.data, 0.1)
     assert flux_map.norm_err.unit == ""
-

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -95,12 +95,9 @@ def test_fov_bkg_maker_scale_nocounts(obs_dataset, exclusion_mask, caplog):
     model = dataset.models[f"{dataset.name}-bkg"].spectral_model
     assert_allclose(model.norm.value, 1, rtol=1e-4)
     assert_allclose(model.tilt.value, 0.0, rtol=1e-2)
-    assert caplog.records[-1].levelname == "WARNING"
-    assert (
-        "Only 0 counts outside exclusion mask for test-fov"
-        in caplog.records[-1].message
-    )
-    assert "FoVBackgroundMaker failed" in caplog.records[-1].message
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    message1 = "FoVBackgroundMaker failed. Only 0 counts outside exclusion mask for test-fov. Setting mask to False."
+    assert message1 in [_.message for _ in caplog.records]
 
 
 @requires_data()
@@ -153,8 +150,10 @@ def test_fov_bkg_maker_fit_nocounts(obs_dataset, exclusion_mask, caplog):
     assert_allclose(model.norm.value, 1, rtol=1e-4)
     assert_allclose(model.tilt.value, 0.0, rtol=1e-4)
 
-    assert caplog.records[-1].levelname == "WARNING"
-    assert f"Fit did not converge for {dataset.name}" in caplog.records[-1].message
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert f"Fit did not converge for {dataset.name}" in [
+        _.message for _ in caplog.records
+    ]
 
 
 @requires_data()
@@ -218,8 +217,9 @@ def test_fov_bkg_maker_fit_fail(obs_dataset, exclusion_mask, caplog):
 
     model = dataset.models[f"{dataset.name}-bkg"].spectral_model
     assert_allclose(model.norm.value, 1, rtol=1e-4)
-    assert caplog.records[-1].levelname == "WARNING"
-    assert f"Fit did not converge for {dataset.name}" in caplog.records[-1].message
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    message1 = f"FoVBackgroundMaker failed. Fit did not converge for {dataset.name}. Setting mask to False."
+    assert message1 in [_.message for _ in caplog.records]
 
 
 @requires_data()
@@ -233,9 +233,6 @@ def test_fov_bkg_maker_scale_fail(obs_dataset, exclusion_mask, caplog):
 
     model = dataset.models[f"{dataset.name}-bkg"].spectral_model
     assert_allclose(model.norm.value, 1, rtol=1e-4)
-    assert caplog.records[-1].levelname == "WARNING"
-    assert (
-        f"Only -1940 background counts outside exclusion mask for test-fov"
-        in caplog.records[-1].message
-    )
-    assert "FoVBackgroundMaker failed" in caplog.records[-1].message
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    message1 = "FoVBackgroundMaker failed. Only -1940 background counts outside exclusion mask for test-fov. Setting mask to False."
+    assert message1 in [_.message for _ in caplog.records]

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -74,8 +74,9 @@ def test_safe_mask_maker(observations, caplog):
 
     mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
     assert_allclose(mask_bkg_peak.data.sum(), 1815)
-    assert caplog.records[-1].levelname == "WARNING"
-    assert caplog.records[-1].message == "No default thresholds defined for obs 110380"
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    message1 = "No default thresholds defined for obs 110380"
+    assert message1 in [_.message for _ in caplog.records]
 
     safe_mask_maker_noroot = SafeMaskMaker(
         offset_max="3 deg", aeff_percent=-10, bias_percent=-10
@@ -110,7 +111,6 @@ def test_safe_mask_maker_bkg_invalid(observations_hess_dl3):
     mask_nonan = safe_mask_maker_nonan.make_mask_bkg_invalid(dataset)
 
     assert mask_nonan[0, 0, 0] == False
-
 
     assert_allclose(bkg[mask_nonan].max(), 20.656366)
 

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -219,7 +219,7 @@ def test_plot_models(caplog):
     models = Models([m1, m2])
 
     models.plot_regions()
-    assert caplog.records[-1].levelname == "WARNING"
-    assert (
-        caplog.records[-1].message == "Skipping model m2 - no spatial component present"
-    )
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert "Skipping model m2 - no spatial component present" in [
+        _.message for _ in caplog.records
+    ]

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -118,9 +118,7 @@ def test_generalized_gaussian(eta, r_0, e):
     )
 
     width = np.maximum(2 * model.evaluation_radius.to_value("deg"), 0.5)
-    geom = WcsGeom.create(
-        skydir=(0, 0), binsz=0.02, width=width, frame="galactic",
-    )
+    geom = WcsGeom.create(skydir=(0, 0), binsz=0.02, width=width, frame="galactic",)
 
     integral = model.integrate_geom(geom)
     assert integral.unit.is_equivalent("")
@@ -200,9 +198,7 @@ def test_sky_disk():
 
 def test_sky_disk_edge():
     r_0 = 2 * u.deg
-    model = DiskSpatialModel(
-        lon_0="0 deg", lat_0="0 deg", r_0=r_0, e=0.5, phi="0 deg",
-    )
+    model = DiskSpatialModel(lon_0="0 deg", lat_0="0 deg", r_0=r_0, e=0.5, phi="0 deg",)
     value_center = model(0 * u.deg, 0 * u.deg)
     value_edge = model(0 * u.deg, r_0)
     assert_allclose((value_edge / value_center).to_value(""), 0.5)
@@ -269,8 +265,10 @@ def test_sky_diffuse_map(caplog):
     lat = -39.8 * u.deg
     val = model(lon, lat)
 
-    assert caplog.records[-1].levelname == "WARNING"
-    assert caplog.records[-1].message == "Missing spatial template unit, assuming sr^-1"
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert "Missing spatial template unit, assuming sr^-1" in [
+        _.message for _ in caplog.records
+    ]
 
     assert val.unit == "sr-1"
     desired = [3269.178107, 0]
@@ -385,7 +383,10 @@ def test_integrate_region_geom():
     radius_small = 0.1 * u.deg
     circle_small = CircleSkyRegion(center, radius_small)
 
-    geom_large, geom_small = RegionGeom(region=circle_large), RegionGeom(region=circle_small, binsz_wcs="0.01d")
+    geom_large, geom_small = (
+        RegionGeom(region=circle_large),
+        RegionGeom(region=circle_small, binsz_wcs="0.01d"),
+    )
 
     integral_large, integral_small = (
         model.integrate_geom(geom_large).data,
@@ -395,10 +396,15 @@ def test_integrate_region_geom():
     assert_allclose(integral_large[0], 1, rtol=0.001)
     assert_allclose(integral_small[0], 0.3953, rtol=0.001)
 
+
 def test_integrate_wcs_geom():
     center = SkyCoord("0d", "0d", frame="icrs")
-    model_0_01d = GaussianSpatialModel(lon="0.234d", lat="-0.172d", sigma=0.01 * u.deg, frame="icrs")
-    model_0_005d = GaussianSpatialModel(lon="0.234d", lat="-0.172d", sigma=0.005 * u.deg, frame="icrs")
+    model_0_01d = GaussianSpatialModel(
+        lon="0.234d", lat="-0.172d", sigma=0.01 * u.deg, frame="icrs"
+    )
+    model_0_005d = GaussianSpatialModel(
+        lon="0.234d", lat="-0.172d", sigma=0.005 * u.deg, frame="icrs"
+    )
 
     geom = WcsGeom.create(skydir=center, npix=100, binsz=0.02)
 
@@ -407,6 +413,7 @@ def test_integrate_wcs_geom():
 
     assert_allclose(integrated_0_01d.data.sum(), 1, atol=2e-4)
     assert_allclose(integrated_0_005d.data.sum(), 1, atol=2e-4)
+
 
 def test_integrate_geom_energy_axis():
     center = SkyCoord("0d", "0d", frame="icrs")

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -323,10 +323,10 @@ TEST_MODELS.append(
 def test_models(spectrum):
     model = spectrum["model"]
     for p in model.parameters:
-        assert p._type == 'spectral'
+        assert p._type == "spectral"
     energy = 2 * u.TeV
     value = model(energy)
-    energies =  [2, 3] * u.TeV
+    energies = [2, 3] * u.TeV
     values = model(energies)
     assert_quantity_allclose(value, spectrum["val_at_2TeV"], rtol=1e-7)
     if "val_at_3TeV" in spectrum:
@@ -362,7 +362,6 @@ def test_models(spectrum):
         inverse = model.inverse_all(values)
         for ke, ener in enumerate(energies):
             assert_quantity_allclose(inverse[ke], energies[ke], rtol=0.01)
-
 
     if "integral_infinity" in spectrum:
         energy_min = 0 * u.TeV
@@ -407,33 +406,33 @@ def test_model_plot():
 @requires_dependency("matplotlib")
 def test_model_plot_sed_type():
     pwl = PowerLawSpectralModel(
-                                amplitude=1e-12 * u.Unit("TeV-1 cm-2 s-1"), reference=1 * u.Unit("TeV"), index=2
-                                )
+        amplitude=1e-12 * u.Unit("TeV-1 cm-2 s-1"), reference=1 * u.Unit("TeV"), index=2
+    )
     pwl.amplitude.error = 0.1e-12 * u.Unit("TeV-1 cm-2 s-1")
-                                
+
     with mpl_plot_check():
         ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="dnde")
         ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="dnde")
-        assert(ax1.axes.axes.get_ylabel() == "dnde [1 / (cm2 s TeV)]")
-        assert(ax2.axes.axes.get_ylabel() == "dnde [1 / (cm2 s TeV)]")
+        assert ax1.axes.axes.get_ylabel() == "dnde [1 / (cm2 s TeV)]"
+        assert ax2.axes.axes.get_ylabel() == "dnde [1 / (cm2 s TeV)]"
 
     with mpl_plot_check():
         ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="e2dnde")
         ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="e2dnde")
-        assert(ax1.axes.axes.get_ylabel() == "e2dnde [erg / (cm2 s)]")
-        assert(ax2.axes.axes.get_ylabel() == "e2dnde [erg / (cm2 s)]")
+        assert ax1.axes.axes.get_ylabel() == "e2dnde [erg / (cm2 s)]"
+        assert ax2.axes.axes.get_ylabel() == "e2dnde [erg / (cm2 s)]"
 
     with mpl_plot_check():
         ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="flux")
         ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="flux")
-        assert(ax1.axes.axes.get_ylabel() == "flux [1 / (cm2 s)]")
-        assert(ax2.axes.axes.get_ylabel() == "flux [1 / (cm2 s)]")
+        assert ax1.axes.axes.get_ylabel() == "flux [1 / (cm2 s)]"
+        assert ax2.axes.axes.get_ylabel() == "flux [1 / (cm2 s)]"
 
     with mpl_plot_check():
         ax1 = pwl.plot((1 * u.TeV, 100 * u.TeV), sed_type="eflux")
         ax2 = pwl.plot_error((1 * u.TeV, 100 * u.TeV), sed_type="eflux")
-        assert(ax1.axes.axes.get_ylabel() == "eflux [erg / (cm2 s)]")
-        assert(ax2.axes.axes.get_ylabel() == "eflux [erg / (cm2 s)]")
+        assert ax1.axes.axes.get_ylabel() == "eflux [erg / (cm2 s)]"
+        assert ax2.axes.axes.get_ylabel() == "eflux [erg / (cm2 s)]"
 
 
 def test_to_from_dict():
@@ -478,11 +477,10 @@ def test_to_from_dict_partial_input(caplog):
     actual = [par.frozen for par in new_model.parameters]
     desired = [par.frozen for par in model.parameters]
     assert_allclose(actual, desired)
-    assert caplog.records[-1].levelname == "WARNING"
-    assert (
-        caplog.records[-1].message
-        == "Parameter reference not defined. Using default value: 1.0 TeV"
-    )
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert "Parameter reference not defined. Using default value: 1.0 TeV" in [
+        _.message for _ in caplog.records
+    ]
 
 
 def test_to_from_dict_compound():
@@ -644,7 +642,7 @@ class TestNaimaModel:
         )
         model = NaimaSpectralModel(radiative_model)
         for p in model.parameters:
-            assert p._type == 'spectral'
+            assert p._type == "spectral"
 
         val_at_2TeV = 9.725347355450884e-14 * u.Unit("cm-2 s-1 TeV-1")
         integral_1_10TeV = 3.530537143620737e-13 * u.Unit("cm-2 s-1")
@@ -685,7 +683,7 @@ class TestNaimaModel:
 
         model = NaimaSpectralModel(radiative_model)
         for p in model.parameters:
-            assert p._type == 'spectral'
+            assert p._type == "spectral"
 
         val_at_2TeV = 4.347836316893546e-12 * u.Unit("cm-2 s-1 TeV-1")
         integral_1_10TeV = 1.595813e-11 * u.Unit("cm-2 s-1")
@@ -716,7 +714,7 @@ class TestNaimaModel:
 
         model = NaimaSpectralModel(radiative_model)
         for p in model.parameters:
-            assert p._type == 'spectral'
+            assert p._type == "spectral"
 
         val_at_2TeV = 1.0565840392550432e-24 * u.Unit("cm-2 s-1 TeV-1")
         integral_1_10TeV = 4.449186e-13 * u.Unit("cm-2 s-1")

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -31,11 +31,9 @@ def test_parameter_init():
 def test_parameter_outside_limit(caplog):
     par = Parameter("spam", 50, min=0, max=40)
     par.check_limits()
-    assert caplog.records[-1].levelname == "WARNING"
-    assert (
-        caplog.records[-1].message
-        == "Value 50.0 is outside bounds [0.0, 40.0] for parameter 'spam'"
-    )
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    message1 = "Value 50.0 is outside bounds [0.0, 40.0] for parameter 'spam'"
+    assert message1 in [_.message for _ in caplog.records]
 
 
 def test_parameter_scale():
@@ -173,8 +171,12 @@ def test_parameters_set_parameter_factors(pars):
 
 
 def test_parameters_s():
-    pars = Parameters([Parameter("", 20, scale_method="scale10"),
-                       Parameter("", 20, scale_method=None)])
+    pars = Parameters(
+        [
+            Parameter("", 20, scale_method="scale10"),
+            Parameter("", 20, scale_method=None),
+        ]
+    )
     pars_dict = pars.to_dict()
     pars.autoscale()
     assert_allclose(pars[0].factor, 2)
@@ -189,8 +191,7 @@ def test_parameters_s():
     assert pars[1].scale_method is None
     pars.autoscale()
     assert_allclose(pars[1].factor, 20)
-    assert_allclose(pars[1].scale, 1)    
-
+    assert_allclose(pars[1].scale, 1)
 
 
 def test_parameter_scan_values():


### PR DESCRIPTION
Presently the tests search for a specific string in the latest warning, but there maybe other ones. eg, I get
```
assert caplog.records[-1].message == "No default thresholds defined for obs 110380"
E       AssertionError: assert 'AstropyDepre...a ValueError.' == 'No default t...or obs 110380'
E         - No default thresholds defined for obs 110380
E         + AstropyDeprecationWarning: The truth value of a Quantity is ambiguous. In the future this will raise a ValueError.
```

The present PR checks that there is at least one such warning in the list of `caplog.records`