### PR TITLE
Correct ParameterEstimator to return npred and npred_null when no dataset contributes

### DIFF
--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -75,6 +75,7 @@ class ParameterEstimator(Estimator):
         -------
         result : dict
             Dict with the various parameter estimation values.
+            (parameter value, total statistic, success flag, parameter error value)
         """
         value, total_stat, success, error = np.nan, 0, False, np.nan
 
@@ -104,10 +105,11 @@ class ParameterEstimator(Estimator):
         Returns
         -------
         result : dict
-            Dict with the various parameter estimation values.
+            Dict with the TS of the best fit value compared to the null hypothesis.
+            (TS, npred, npred_null)
         """
         if not np.any(datasets.contributes_to_stat):
-            return {"ts": np.nan}
+            return {"ts": np.nan, "npred": np.nan, "npred_null": np.nan}
 
         stat = datasets.stat_sum()
         npred = self.estimate_npred(datasets=datasets)
@@ -142,7 +144,8 @@ class ParameterEstimator(Estimator):
         Returns
         -------
         result : dict
-            Dict with the various parameter estimation values.
+            Dict with the parameter asymmetric errors
+            (error_p, error_n)
         """
         if not np.any(datasets.contributes_to_stat):
             return {
@@ -177,7 +180,8 @@ class ParameterEstimator(Estimator):
         Returns
         -------
         result : dict
-            Dict with the various parameter estimation values.
+            Dict with the parameter fit scan values.
+            (parameter values, statistic values)
 
         """
         scan_values = parameter.scan_values
@@ -214,7 +218,8 @@ class ParameterEstimator(Estimator):
         Returns
         -------
         result : dict
-            Dict with the various parameter estimation values.
+            Dict with the parameter ULs.
+            (upper limit)
 
         """
         if not np.any(datasets.contributes_to_stat):

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -108,11 +108,20 @@ class ParameterEstimator(Estimator):
             Dict with the TS of the best fit value compared to the null hypothesis.
             (TS, npred, npred_null)
         """
-        if not np.any(datasets.contributes_to_stat):
-            return {"ts": np.nan, "npred": np.nan, "npred_null": np.nan}
 
-        stat = datasets.stat_sum()
+#        if not np.any(datasets.contributes_to_stat):
+#            npred_null = self.estimate_npred(datasets=datasets)
+#            return {"ts": np.nan,
+#                    "npred": self.estimate_npred(datasets=datasets),
+#                    "npred_null": self.estimate_npred(datasets=datasets)}
+
         npred = self.estimate_npred(datasets=datasets)
+
+        if not np.any(datasets.contributes_to_stat):
+            stat = np.nan
+            npred["npred"][...] = np.nan
+        else:
+            stat = datasets.stat_sum()
 
         with datasets.parameters.restore_status():
             # compute ts value

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -74,8 +74,12 @@ class ParameterEstimator(Estimator):
         Returns
         -------
         result : dict
-            Dict with the various parameter estimation values.
-            (parameter value, total statistic, success flag, parameter error value)
+            Dict with the various parameter estimation values. Entries are:
+
+                * parameter.name: best fit parameter value
+                * "stat": best fit total stat.
+                * "success": boolean flag for fit success
+                * parameter.name_err: covariance-based error estimate on parameter value
         """
         value, total_stat, success, error = np.nan, 0, False, np.nan
 
@@ -105,16 +109,12 @@ class ParameterEstimator(Estimator):
         Returns
         -------
         result : dict
-            Dict with the TS of the best fit value compared to the null hypothesis.
-            (TS, npred, npred_null)
+            Dict with the TS of the best fit value compared to the null hypothesis. Entries are:
+
+                * TS : fit statistic difference with null hypothesis
+                * "npred" : predicted number of counts per dataset
+                * "npred_null" : predicted number of counts per dataset in the null hypothesis
         """
-
-#        if not np.any(datasets.contributes_to_stat):
-#            npred_null = self.estimate_npred(datasets=datasets)
-#            return {"ts": np.nan,
-#                    "npred": self.estimate_npred(datasets=datasets),
-#                    "npred_null": self.estimate_npred(datasets=datasets)}
-
         npred = self.estimate_npred(datasets=datasets)
 
         if not np.any(datasets.contributes_to_stat):
@@ -153,8 +153,10 @@ class ParameterEstimator(Estimator):
         Returns
         -------
         result : dict
-            Dict with the parameter asymmetric errors
-            (error_p, error_n)
+            Dict with the parameter asymmetric errors. Entries are:
+
+                * parameter.name_errp : positive error on parameter value
+                * parameter.name_errn : negative error on parameter value
         """
         if not np.any(datasets.contributes_to_stat):
             return {
@@ -189,9 +191,10 @@ class ParameterEstimator(Estimator):
         Returns
         -------
         result : dict
-            Dict with the parameter fit scan values.
-            (parameter values, statistic values)
+            Dict with the parameter fit scan values. Entries are:
 
+                * parameter.name_scan : parameter values scan
+                * "stat_scan" : fit statistic values scan
         """
         scan_values = parameter.scan_values
 
@@ -227,9 +230,9 @@ class ParameterEstimator(Estimator):
         Returns
         -------
         result : dict
-            Dict with the parameter ULs.
-            (upper limit)
-
+            Dict with the parameter ULs. Entries are:
+            
+                * parameter.name_ul : upper limit on parameter value
         """
         if not np.any(datasets.contributes_to_stat):
             return {f"{parameter.name}_ul": np.nan}

--- a/gammapy/estimators/tests/test_parameter_estimator.py
+++ b/gammapy/estimators/tests/test_parameter_estimator.py
@@ -94,7 +94,7 @@ def test_parameter_estimator_no_data(crab_datasets_1d, pwl_model):
     assert np.isnan(result["amplitude_ul"])
     assert np.isnan(result["ts"])
     assert np.isnan(result["npred"])
-    assert np.isnan(result["npred_null"])
+    assert_allclose(result["npred_null"], 0)
     assert_allclose(result["counts"], 0)
 
     # Add test for scan

--- a/gammapy/estimators/tests/test_parameter_estimator.py
+++ b/gammapy/estimators/tests/test_parameter_estimator.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import numpy as np
 from numpy.testing import assert_allclose
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
 from gammapy.estimators.parameter import ParameterEstimator
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
-from gammapy.modeling import Fit
 from gammapy.utils.testing import requires_data
 
 pytest.importorskip("iminuit")
@@ -71,3 +71,33 @@ def test_parameter_estimator_3d_no_reoptimization(crab_datasets_fermi):
     assert_allclose(result["amplitude"], 0.018251, rtol=1e-3)
     assert_allclose(result["amplitude_scan"].shape, 10)
     assert_allclose(result["amplitude_scan"][0], 0.017282, atol=1e-3)
+
+@requires_data()
+def test_parameter_estimator_no_data(crab_datasets_1d, pwl_model):
+    datasets = crab_datasets_1d
+
+    model = SkyModel(spectral_model=pwl_model, name="Crab")
+    model.spectral_model.amplitude.scan_n_values = 10
+
+    for dataset in datasets:
+        dataset.mask_safe.data[...] = False
+        dataset.models = model
+
+    estimator = ParameterEstimator(selection_optional="all")
+
+    result = estimator.run(datasets, parameter="amplitude")
+
+    assert np.isnan(result["amplitude"])
+    assert np.isnan(result["amplitude_err"])
+    assert np.isnan(result["amplitude_errp"])
+    assert np.isnan(result["amplitude_errn"])
+    assert np.isnan(result["amplitude_ul"])
+    assert np.isnan(result["ts"])
+    assert np.isnan(result["npred"])
+    assert np.isnan(result["npred_null"])
+    assert_allclose(result["counts"], 0)
+
+    # Add test for scan
+    assert_allclose(result["amplitude_scan"].shape, 10)
+    assert np.all(np.isnan(result["stat_scan"]))
+


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects the behavior of the `ParameterEstimator` when no datasets contributes. `ParameterEstimator.estimate_ts` did not return `npred` and `npred` entries in the results `dict` when `datasets.contributes_to_stat` is all `False`.

This PR changes this. `npred` are set to `NaN` while `npred_null` are computed (and equal to 0). 
This should resolve #3501 .

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
