### PR TITLE
Safer TemplateSpatialModel init

### DIFF
--- a/examples/models/spatial/plot_template.py
+++ b/examples/models/spatial/plot_template.py
@@ -24,7 +24,7 @@ filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_
 
 m = Map.read(filename)
 m.unit = "sr^-1"
-model = TemplateSpatialModel(m)
+model = TemplateSpatialModel(m, filename=filename)
 
 model.plot(add_cbar=True)
 

--- a/examples/models/spatial/plot_template.py
+++ b/examples/models/spatial/plot_template.py
@@ -34,7 +34,7 @@ model.plot(add_cbar=True)
 # Here is an example YAML file using the model:
 
 pwl = PowerLawSpectralModel()
-template = TemplateSpatialModel(m)
+template = TemplateSpatialModel(m, filename=filename)
 
 model = SkyModel(spectral_model=pwl, spatial_model=template, name="pwl-template-model")
 models = Models([model])

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -385,7 +385,7 @@ class DatasetModels(collections.abc.Sequence):
                 shared_register = _set_link(shared_register, model)
         return models
 
-    def write(self, path, overwrite=False, overwrite_templates=False, full_output=False, write_covariance=True):
+    def write(self, path, overwrite=False, full_output=False, overwrite_templates=False, write_covariance=True):
         """Write to YAML file.
 
         Parameters
@@ -418,11 +418,11 @@ class DatasetModels(collections.abc.Sequence):
             self.write_covariance(base_path / filecovar, **kwargs)
             self._covar_file = filecovar
 
-        path.write_text(self.to_yaml(full_output))
+        path.write_text(self.to_yaml(full_output, overwrite_templates))
 
-    def to_yaml(self, full_output=False):
+    def to_yaml(self, full_output=False, overwrite_templates=False):
         """Convert to YAML string."""
-        data = self.to_dict(full_output)
+        data = self.to_dict(full_output, overwrite_templates)
         return yaml.dump(
             data, sort_keys=False, indent=4, width=80, default_flow_style=False
         )
@@ -445,8 +445,8 @@ class DatasetModels(collections.abc.Sequence):
         for model in self._models:
             model_data = model.to_dict(full_output)
             models_data.append(model_data)
-            if "template" in model.tag:
-                model.write(self, overwrite=overwrite_templates)
+            if model.spatial_model is not None and "template" in model.spatial_model.tag:
+                model.spatial_model.write(overwrite=overwrite_templates)
 
         if self._covar_file is not None:
             return {

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -7,7 +7,7 @@ import yaml
 import numpy as np
 import astropy.units as u
 from astropy.table import Table
-from astropy.coordinates import  SkyCoord
+from astropy.coordinates import SkyCoord
 from regions import PointSkyRegion
 from gammapy.modeling import Covariance, Parameter, Parameters
 from gammapy.utils.scripts import make_name, make_path
@@ -55,10 +55,10 @@ class Model:
 
     def __getattribute__(self, name):
         value = object.__getattribute__(self, name)
-        
+
         if isinstance(value, Parameter):
             return value.__get__(self, None)
-    
+
         return value
 
     @property
@@ -385,7 +385,14 @@ class DatasetModels(collections.abc.Sequence):
                 shared_register = _set_link(shared_register, model)
         return models
 
-    def write(self, path, overwrite=False, full_output=False, overwrite_templates=False, write_covariance=True):
+    def write(
+        self,
+        path,
+        overwrite=False,
+        full_output=False,
+        overwrite_templates=False,
+        write_covariance=True,
+    ):
         """Write to YAML file.
 
         Parameters
@@ -445,7 +452,10 @@ class DatasetModels(collections.abc.Sequence):
         for model in self._models:
             model_data = model.to_dict(full_output)
             models_data.append(model_data)
-            if model.spatial_model is not None and "template" in model.spatial_model.tag:
+            if (
+                model.spatial_model is not None
+                and "template" in model.spatial_model.tag
+            ):
                 model.spatial_model.write(overwrite=overwrite_templates)
 
         if self._covar_file is not None:
@@ -949,7 +959,7 @@ class DatasetModels(collections.abc.Sequence):
 
         kwargs.setdefault("marker", "*")
         kwargs.setdefault("color", "tab:blue")
-        path_effects = kwargs.get('path_effects', None)
+        path_effects = kwargs.get("path_effects", None)
 
         xp, yp = self.positions.to_pixel(ax.wcs)
         p = ax.scatter(xp, yp, **kwargs)

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -453,7 +453,8 @@ class DatasetModels(collections.abc.Sequence):
             model_data = model.to_dict(full_output)
             models_data.append(model_data)
             if (
-                model.spatial_model is not None
+                hasattr(model, "spatial_model")
+                and model.spatial_model is not None
                 and "template" in model.spatial_model.tag
             ):
                 model.spatial_model.write(overwrite=overwrite_templates)

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -385,7 +385,7 @@ class DatasetModels(collections.abc.Sequence):
                 shared_register = _set_link(shared_register, model)
         return models
 
-    def write(self, path, overwrite=False, full_output=False, write_covariance=True):
+    def write(self, path, overwrite=False, overwrite_templates=False, full_output=False, write_covariance=True):
         """Write to YAML file.
 
         Parameters
@@ -393,7 +393,9 @@ class DatasetModels(collections.abc.Sequence):
         path : `pathlib.Path` or str
             path to write files
         overwrite : bool
-            overwrite files
+            overwrite YAML files
+        overwrite_templates : bool
+            overwrite templates FITS files
         write_covariance : bool
             save covariance or not
         """
@@ -425,7 +427,7 @@ class DatasetModels(collections.abc.Sequence):
             data, sort_keys=False, indent=4, width=80, default_flow_style=False
         )
 
-    def to_dict(self, full_output=False):
+    def to_dict(self, full_output=False, overwrite_templates=False):
         """Convert to dict."""
         # update linked parameters labels
         params_list = []
@@ -443,6 +445,9 @@ class DatasetModels(collections.abc.Sequence):
         for model in self._models:
             model_data = model.to_dict(full_output)
             models_data.append(model_data)
+            if "template" in model.tag:
+                model.write(self, overwrite=overwrite_templates)
+
         if self._covar_file is not None:
             return {
                 "components": models_data,

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1010,7 +1010,7 @@ class TemplateSpatialModel(SpatialModel):
         self, map, meta=None, normalize=True, interp_kwargs=None, filename=None,
     ):
         if (map.data < 0).any():
-            log.warning("Diffuse map has negative values. Check and fix this!")
+            log.warning("Map has negative values. Check and fix this!")
 
         if filename is not None:
             filename = str(make_path(filename))

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1014,12 +1014,6 @@ class TemplateSpatialModel(SpatialModel):
 
         if filename is not None:
             filename = str(make_path(filename))
-            if not os.path.isfile(filename):
-                raise IOError("File not found")
-        else:
-            log.warning(
-                "filename is not set, model serialisation will not be possible if map is not written to disk beforehand"
-            )
 
         self.normalize = normalize
 
@@ -1051,6 +1045,7 @@ class TemplateSpatialModel(SpatialModel):
 
     @property
     def map(self):
+        """Template map  (`~gammapy.maps.Map`)"""
         return self._map
 
     @property
@@ -1122,6 +1117,12 @@ class TemplateSpatialModel(SpatialModel):
         data["filename"] = self.filename
         data["normalize"] = self.normalize
         data["unit"] = str(self.map.unit)
+        if self.filename is None:
+            raise IOError("Missing filename")
+        elif os.path.isfile(self.filename) :
+            log.warning("Template file already exits, it will not be overwritten")
+        else:
+            self.map.write(self.filename)
         return data
 
     def to_region(self, **kwargs):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -21,6 +21,7 @@ from gammapy.modeling import Parameter
 from gammapy.utils.gauss import Gauss2DPDF
 from gammapy.utils.scripts import make_path
 from .core import Model
+import os
 
 log = logging.getLogger(__name__)
 
@@ -188,20 +189,22 @@ class SpatialModel(Model):
         if geom.is_region:
             wcs_geom = geom.to_wcs_geom().to_image()
 
-        result = Map.from_geom(geom=wcs_geom)#, unit='1/sr')
+        result = Map.from_geom(geom=wcs_geom)  # , unit='1/sr')
 
         pix_scale = np.max(wcs_geom.pixel_scales.to_value("deg"))
         if oversampling_factor is None:
             if self.evaluation_bin_size_min is not None:
                 res_scale = self.evaluation_bin_size_min.to_value("deg")
-                oversampling_factor = int(np.ceil( pix_scale/ res_scale))
+                oversampling_factor = int(np.ceil(pix_scale / res_scale))
             else:
-                oversampling_factor=1
+                oversampling_factor = 1
 
         if oversampling_factor > 1:
             if self.evaluation_radius is not None:
                 # Is it still needed?
-                width = 2*np.maximum(self.evaluation_radius.to_value("deg"),pix_scale)
+                width = 2 * np.maximum(
+                    self.evaluation_radius.to_value("deg"), pix_scale
+                )
                 wcs_geom = wcs_geom.cutout(self.position, width)
 
             upsampled_geom = wcs_geom.upsample(oversampling_factor)
@@ -212,9 +215,11 @@ class SpatialModel(Model):
             upsampled += values
 
             if geom.is_region:
-                mask = geom.contains(upsampled_geom.get_coord()).astype('int')
+                mask = geom.contains(upsampled_geom.get_coord()).astype("int")
 
-            integrated = upsampled.downsample(oversampling_factor, preserve_counts=True, weights=mask)
+            integrated = upsampled.downsample(
+                oversampling_factor, preserve_counts=True, weights=mask
+            )
 
             # Finally stack result
             result.unit = integrated.unit
@@ -228,7 +233,9 @@ class SpatialModel(Model):
 
         if geom.is_region:
             mask = result.geom.region_mask([geom.region])
-            result = Map.from_geom(geom, data=np.sum(result.data[mask]), unit=result.unit)
+            result = Map.from_geom(
+                geom, data=np.sum(result.data[mask]), unit=result.unit
+            )
         return result
 
     def to_dict(self, full_output=False):
@@ -498,8 +505,7 @@ class GaussianSpatialModel(SpatialModel):
     @property
     def evaluation_bin_size_min(self):
         """ Minimal evaluation bin size (`~astropy.coordinates.Angle`) chosen as sigma/3."""
-        return self.parameters["sigma"].quantity / 3.
-
+        return self.parameters["sigma"].quantity / 3.0
 
     @property
     def evaluation_radius(self):
@@ -606,7 +612,6 @@ class GeneralizedGaussianSpatialModel(SpatialModel):
         """
         return self.r_0.quantity / (3 + 8 * self.eta.value) / (self.e.value + 1)
 
-
     @property
     def evaluation_radius(self):
         r"""Evaluation radius (`~astropy.coordinates.Angle`).
@@ -686,7 +691,7 @@ class DiskSpatialModel(SpatialModel):
 
         The bin min size is defined as r_0*(1-edge_width)/10.
         """
-        return self.r_0.quantity * (1 - self.edge_width.quantity) /10.
+        return self.r_0.quantity * (1 - self.edge_width.quantity) / 10.0
 
     @property
     def evaluation_radius(self):
@@ -694,7 +699,7 @@ class DiskSpatialModel(SpatialModel):
     
         Set to the length of the semi-major axis plus the edge width.
         """
-        return 1.1*self.r_0.quantity * (1 + self.edge_width.quantity)
+        return 1.1 * self.r_0.quantity * (1 + self.edge_width.quantity)
 
     @staticmethod
     def _evaluate_norm_factor(r_0, e):
@@ -733,7 +738,9 @@ class DiskSpatialModel(SpatialModel):
 
         norm = DiskSpatialModel._evaluate_norm_factor(r_0, e)
 
-        in_ellipse = DiskSpatialModel._evaluate_smooth_edge(sep - sigma_eff, sigma_eff * edge_width)
+        in_ellipse = DiskSpatialModel._evaluate_smooth_edge(
+            sep - sigma_eff, sigma_eff * edge_width
+        )
         return u.Quantity(norm * in_ellipse, "sr-1", copy=False)
 
     def to_region(self, **kwargs):
@@ -1007,6 +1014,12 @@ class TemplateSpatialModel(SpatialModel):
 
         if filename is not None:
             filename = str(make_path(filename))
+            if not os.path.isfile(filename):
+                raise IOError("File not found")
+        else:
+            log.warning(
+                "filename is not set, model serialisation will not be possible if map is not written to disk beforehand"
+            )
 
         self.normalize = normalize
 
@@ -1026,7 +1039,7 @@ class TemplateSpatialModel(SpatialModel):
             map = map.copy(unit="sr-1")
             log.warning("Missing spatial template unit, assuming sr^-1")
 
-        self.map = map
+        self._map = map.copy()
 
         self.meta = dict() if meta is None else meta
         interp_kwargs = {} if interp_kwargs is None else interp_kwargs
@@ -1035,6 +1048,10 @@ class TemplateSpatialModel(SpatialModel):
         self._interp_kwargs = interp_kwargs
         self.filename = filename
         super().__init__()
+
+    @property
+    def map(self):
+        return self._map
 
     @property
     def is_energy_dependent(self):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1118,7 +1118,7 @@ class TemplateSpatialModel(SpatialModel):
         data["normalize"] = self.normalize
         data["unit"] = str(self.map.unit)
         return data
-    
+
     def write(self, overwrite=False):
         if self.filename is None:
             raise IOError("Missing filename")
@@ -1126,7 +1126,6 @@ class TemplateSpatialModel(SpatialModel):
             log.warning("Template file already exits, and overwrite is False")
         else:
             self.map.write(self.filename)
-
 
     def to_region(self, **kwargs):
         """Model outline from template map boundary (`~regions.RectangleSkyRegion`)."""

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1117,13 +1117,16 @@ class TemplateSpatialModel(SpatialModel):
         data["filename"] = self.filename
         data["normalize"] = self.normalize
         data["unit"] = str(self.map.unit)
+        return data
+    
+    def write(self, overwrite=False):
         if self.filename is None:
             raise IOError("Missing filename")
-        elif os.path.isfile(self.filename) :
-            log.warning("Template file already exits, it will not be overwritten")
+        elif os.path.isfile(self.filename) and not overwrite:
+            log.warning("Template file already exits, and overwrite is False")
         else:
             self.map.write(self.filename)
-        return data
+
 
     def to_region(self, **kwargs):
         """Model outline from template map boundary (`~regions.RectangleSkyRegion`)."""

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -63,7 +63,7 @@ def diffuse_model():
         npix=(4, 3), binsz=2, axes=[axis], unit="cm-2 s-1 MeV-1 sr-1", frame="galactic"
     )
     m.data += 42
-    spatial_model = TemplateSpatialModel(m, normalize=False)
+    spatial_model = TemplateSpatialModel(m, normalize=False, filename="diffuse_test.fits")
     return SkyModel(PowerLawNormSpectralModel(), spatial_model)
 
 
@@ -373,6 +373,20 @@ class Test_Template_with_cube:
 
         assert q.shape == (5, 3, 4)
         assert_allclose(q.value.mean(), 42)
+
+
+    @staticmethod
+    def test_write(tmpdir, diffuse_model):
+        filename = tmpdir / diffuse_model.spatial_model.filename
+
+        diffuse_model.spatial_model.filename = None
+        with pytest.raises(IOError):
+            diffuse_model.to_dict()
+            
+        diffuse_model.spatial_model.filename = filename
+        diffuse_model.to_dict()
+        TemplateSpatialModel.read(filename)
+        
 
     @staticmethod
     @requires_data()

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -381,12 +381,14 @@ class Test_Template_with_cube:
 
         diffuse_model.spatial_model.filename = None
         with pytest.raises(IOError):
-            diffuse_model.to_dict()
+            diffuse_model.spatial_model.write()
+
+        with pytest.raises(IOError):
+            Models(diffuse_model).to_dict()
             
         diffuse_model.spatial_model.filename = filename
-        diffuse_model.to_dict()
+        diffuse_model.spatial_model.write(overwrite=False)
         TemplateSpatialModel.read(filename)
-        
 
     @staticmethod
     @requires_data()

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -63,7 +63,9 @@ def diffuse_model():
         npix=(4, 3), binsz=2, axes=[axis], unit="cm-2 s-1 MeV-1 sr-1", frame="galactic"
     )
     m.data += 42
-    spatial_model = TemplateSpatialModel(m, normalize=False, filename="diffuse_test.fits")
+    spatial_model = TemplateSpatialModel(
+        m, normalize=False, filename="diffuse_test.fits"
+    )
     return SkyModel(PowerLawNormSpectralModel(), spatial_model)
 
 
@@ -374,7 +376,6 @@ class Test_Template_with_cube:
         assert q.shape == (5, 3, 4)
         assert_allclose(q.value.mean(), 42)
 
-
     @staticmethod
     def test_write(tmpdir, diffuse_model):
         filename = tmpdir / diffuse_model.spatial_model.filename
@@ -385,7 +386,7 @@ class Test_Template_with_cube:
 
         with pytest.raises(IOError):
             Models(diffuse_model).to_dict()
-            
+
         diffuse_model.spatial_model.filename = filename
         diffuse_model.spatial_model.write(overwrite=False)
         TemplateSpatialModel.read(filename)
@@ -626,7 +627,9 @@ class MyCustomGaussianModel(SpatialModel):
 
 def test_energy_dependent_model():
     axis = MapAxis.from_edges(np.logspace(-1, 1, 4), unit=u.TeV, name="energy_true")
-    geom_true = WcsGeom.create(skydir=(0, 0), binsz="0.1 deg", npix=(50, 50), frame="galactic", axes=[axis])
+    geom_true = WcsGeom.create(
+        skydir=(0, 0), binsz="0.1 deg", npix=(50, 50), frame="galactic", axes=[axis]
+    )
 
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     spatial_model = MyCustomGaussianModel(frame="galactic")


### PR DESCRIPTION
This PR add the following changes to TemplateSpatialModel init in order to solve #3503:
- if filename  is not None and not found on disk, add IOError 
- if filename is None, add a log.warning("filename is not set, model serialisation will not be possible if map is not written to disk beforehand")
- map attribute as a property and _map is a copy() of the input so it cannot be changed

Writing the map to disk should remain the responsability of the user  as it is a pre-processing operation that should be done only once. It is not the responsability of Models.write() that come later in the analysis chain and may be repeated multiple times.