### PR TITLE
Add the sampling of a variable source in the `Event Sampling` tutorial

### DIFF
--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -77,6 +77,8 @@
     "from pathlib import Path\n",
     "import astropy.units as u\n",
     "from astropy.io import fits\n",
+    "from astropy.table import Table\n",
+    "from astropy.time import Time\n",
     "from astropy.coordinates import SkyCoord\n",
     "from gammapy.data import DataStore, Observation\n",
     "from gammapy.datasets import MapDataset, MapDatasetEventSampler\n",
@@ -92,6 +94,8 @@
     "    PowerLawNormSpectralModel,\n",
     "    PointSpatialModel,\n",
     "    TemplateSpatialModel,\n",
+    "    ExpDecayTemporalModel,\n",
+    "    LightCurveTemplateTemporalModel,\n",
     "    FoVBackgroundModel,\n",
     ")"
    ]
@@ -442,6 +446,109 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Time variable source using a lightcurve\n",
+    "\n",
+    "The event sampler can also handle temporal variability of the simulated sources. In this example, we show how \n",
+    "to sample a source characterized by an exponential decay, with decay time of 200 seconds, during the observation. \n",
+    "\n",
+    "First of all, let's create a lightcurve:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t0 = 200 * u.s\n",
+    "t_ref = Time(\"2000-01-01T00:01:04.184\")\n",
+    "\n",
+    "times = t_ref + livetime * np.linspace(0, 1, 1000)\n",
+    "expdecay_model = ExpDecayTemporalModel(t_ref=t_ref.mjd * u.d, t0=t0)\n",
+    "\n",
+    "lc = Table()\n",
+    "lc.meta[\"MJDREFI\"] = t_ref.mjd\n",
+    "lc.meta[\"MJDREFF\"] = 0.0\n",
+    "lc.meta[\"TIMEUNIT\"] = 's'\n",
+    "\n",
+    "lc[\"TIME\"] = livetime.to('s') * np.linspace(0, 1, 1000)\n",
+    "lc[\"NORM\"] = expdecay_model(times)\n",
+    "\n",
+    "lc.write(\"./event_sampling/lc.fits\", overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we can define the sky model including the temporal model component. The latter is passed as `~gammapy.modeling.models.TemporalModel.LightCurveTemplateTemporalModel` model: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temporal_model = LightCurveTemplateTemporalModel.read(\"./event_sampling/lc.fits\")\n",
+    "\n",
+    "sky_model_pntpwl = SkyModel(\n",
+    "    spectral_model=spectral_model_pwl,\n",
+    "    spatial_model=spatial_model_point,\n",
+    "    temporal_model=temporal_model,\n",
+    "    name=\"point-pwl\",\n",
+    ")\n",
+    "\n",
+    "bkg_model = FoVBackgroundModel(dataset_name=\"my-dataset\")\n",
+    "\n",
+    "models = Models([sky_model_pntpwl, bkg_model])\n",
+    "\n",
+    "file_model = \"./event_sampling/point-pwl_decay.yaml\"\n",
+    "models.write(file_model, overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.models = models\n",
+    "print(dataset.models)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now, let's simulate the variable source:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "sampler = MapDatasetEventSampler(random_state=0)\n",
+    "events = sampler.run(dataset, observation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Source events: {(events.table['MC_ID'] == 1).sum()}\")\n",
+    "print(f\"Background events: {(events.table['MC_ID'] == 0).sum()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Extended source using a template\n",
     "The event sampler can also work with a template model.\n",
     "Here we use the interstellar emission model map of the Fermi 3FHL, which can be found in the GAMMAPY data repository.\n",
@@ -606,7 +713,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,


### PR DESCRIPTION
This PR adds a new example into the `Event Sampling` tutorial. In particular, it shows how to sample the event of a variable source, by taking into account a light curve. 
The example allows the user to create a lightcurve  (fits file) from scratch and save it into the disk. Then, this is passed to `~gammapy.modeling.models.temporal.LightCurveTemplateTemporalModel` and used to create a `SkyModel` with the temporal extension. 
Finally, the source and background are sampled.
Comments and suggestions are welcome.