### PR TITLE
Create an Observation object from a single file

### DIFF
--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -33,19 +33,6 @@ class HDUIndexTable(Table):
     ]
     """Valid values for `HDU_CLASS`."""
 
-    HDU_CLASS_IMPLEMENTATION = {
-        "events" : "EventList",
-        "gti" : "GTI",
-        "aeff_2d" : "EffectiveAreaTable2D",
-        "edisp_2d" : "EnergyDispersion2D",
-        "psf_table" : "PSF3D",
-        "psf_3gauss" : "EnergyDependentMultiGaussPSF",
-        "psf_king" : "PSFKing",
-        "bkg_2d" : "Background2D",
-        "bkg_3d" : "Background3D"
-    }
-    """Names of Gammapy classes implementing each specific HDUCLASS."""
-
     @classmethod
     def read(cls, filename, **kwargs):
         """Read :ref:`gadf:hdu-index`.

--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -33,6 +33,19 @@ class HDUIndexTable(Table):
     ]
     """Valid values for `HDU_CLASS`."""
 
+    HDU_CLASS_IMPLEMENTATION = {
+        "events" : "EventList",
+        "gti" : "GTI",
+        "aeff_2d" : "EffectiveAreaTable2D",
+        "edisp_2d" : "EnergyDispersion2D",
+        "psf_table" : "PSF3D",
+        "psf_3gauss" : "EnergyDependentMultiGaussPSF",
+        "psf_king" : "PSFKing",
+        "bkg_2d" : "Background2D",
+        "bkg_3d" : "Background3D"
+    }
+    """Names of Gammapy classes implementing each specific HDUCLASS."""
+
     @classmethod
     def read(cls, filename, **kwargs):
         """Read :ref:`gadf:hdu-index`.

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -49,7 +49,7 @@ def load_irf_from_hdu_class(irf_file, hdu_class):
             if (read_hdu_class.lower() == hdu_class.lower()):
                 # we have found a hdu with this specific HDUCLAS4 hedaer keyword
                 extname = hdu.header["EXTNAME"]
-                component = IRF_REGISTRY.getattr(hdu_class)
+                component = IRF_REGISTRY.get_cls(hdu_class)
                 return component.read(irf_file, extname)
         except KeyError:
             # no 'HDUCLAS4' header keyword in this HDU (probably EVENTS or GTI)

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -421,7 +421,7 @@ class Observation:
         if "aeff" in irf_dict.keys():
             aeff = irf_dict["aeff"]
         
-        if "edsip" in irf_dict.keys():
+        if "edisp" in irf_dict.keys():
             edisp = irf_dict["edisp"]
         
         if "psf" in irf_dict.keys():

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -8,7 +8,7 @@ from astropy.time import Time
 from astropy.units import Quantity
 from gammapy.utils.fits import LazyFitsData, earth_location_from_dict
 from gammapy.utils.testing import Checker
-from gammapy.irf.io import load_irf_dict_from_file
+from gammapy.irf import load_irf_dict_from_file
 from .event_list import EventList, EventListChecker
 from .filters import ObservationFilter
 from .gti import GTI

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -6,17 +6,57 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
+from astropy.io import fits
+from gammapy.utils.scripts import make_path
 from gammapy.utils.fits import LazyFitsData, earth_location_from_dict
 from gammapy.utils.testing import Checker
-from .event_list import EventListChecker
+from .event_list import EventList, EventListChecker
 from .filters import ObservationFilter
 from .gti import GTI
 from .pointing import FixedPointingInfo
+from .hdu_index_table import HDUIndexTable
+from gammapy import irf
+import matplotlib.pyplot as plt
 
-__all__ = ["Observation", "Observations"]
+__all__ = ["Observation", "Observations", "read_irf_with_hdu_class"]
 
 log = logging.getLogger(__name__)
 
+irf_dictionary = HDUIndexTable.HDU_CLASS_IMPLEMENTATION
+
+def read_irf_with_hdu_class(irf_file, hdu_class):
+    """Search for an IRF component with the specified HDUCLAS4 keyword within
+    the irf_file. Return an instance of the corresponding IRF class implemented 
+    in Gammapy.
+    
+    Parameters
+    ----------
+    irf_file : str, path
+        path to the file containing the IRF components, does not matter if also
+        EVENTS and GTI HDUs are included in the file, these are avoided
+    hdu_class : str
+        one of the allowed HDUCLAS4 header keyword in VALID_HDU_CLASS
+    
+    Returns
+    -------
+    one of the IRF component implementated in `~gammapy.irf`;
+    if the specified HDUCLAS4 is not available, `None` is returned
+    """
+    if hdu_class not in HDUIndexTable.VALID_HDU_CLASS:
+        raise KeyError(f"{hdu_class} is not a valid HDU CLASS.")
+    
+    for hdu in fits.open(irf_file):
+        try: 
+            read_hdu_class = hdu.header["HDUCLAS4"]
+            if (read_hdu_class.lower() == hdu_class.lower()):
+                # we have found a hdu with this specific HDUCLAS4 hedaer keyword
+                extname = hdu.header["EXTNAME"]
+                component = getattr(irf, irf_dictionary[hdu_class])
+                return component.read(irf_file, extname)
+        except KeyError:
+            # no 'HDUCLAS4' header keyword in this HDU (probably EVENTS or GTI)
+            continue
+    
 
 class Observation:
     """In-memory observation.
@@ -341,6 +381,56 @@ class Observation:
         obs = copy.deepcopy(self)
         obs.obs_filter = new_obs_filter
         return obs
+
+    @classmethod
+    def from_file(cls, event_file, irf_file):
+        """Create an Observation from a Event List and IRF file.
+        Ease the creation of a single Observation without creating an entire `DataStore`
+        that is without the need of HDU and OBS index files
+        """
+        log.info(f"reading the Event List and GTI from {event_file}")
+        event_file = make_path(event_file)
+        if not event_file.exists():
+            raise OSError(f"File not found: {event_file}")
+        log.debug(f"Reading {event_file}")
+        events = EventList.read(event_file)
+        gti = GTI.read(event_file) 
+        log.info(f"reading the IRF components in {irf_file}")
+        irf_file = make_path(irf_file)
+        if not irf_file.exists():
+            raise OSError(f"File not found: {irf_file}")
+        aeff = read_irf_with_hdu_class(irf_file, "aeff_2d")
+        edisp = read_irf_with_hdu_class(irf_file, "edisp_2d")
+        aeff.peek()
+        plt.show()
+        # non-mandatory IRF components
+        psf = None
+        bkg = None
+        # there are different options for the PSF, the first not None is returned
+        # we assume a single PSF class is saved in the file
+        for hdu_class in HDUIndexTable.VALID_HDU_CLASS:
+            if hdu_class.startswith("psf"): 
+                psf_tmp = read_irf_with_hdu_class(irf_file, hdu_class)
+                if psf_tmp is not None: 
+                    psf = psf_tmp
+        # there are different options for the BKG, the first not None is returned
+        for hdu_class in HDUIndexTable.VALID_HDU_CLASS:
+            if hdu_class.startswith("bkg"): 
+                bkg_tmp = read_irf_with_hdu_class(irf_file, hdu_class)
+                if bkg_tmp is not None: 
+                    bkg = bkg_tmp
+        
+        return cls(
+            gti=gti,
+            aeff=aeff,
+            bkg=bkg,
+            edisp=edisp,
+            psf=psf,
+            events=events,
+        )
+        
+        
+
 
 
 class Observations(collections.abc.MutableSequence):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -432,7 +432,7 @@ class Observation:
             
         obs_info = events.table.meta
         return cls(
-            obs_id = obs_info.get("OBS_ID"),
+            obs_id=obs_info.get("OBS_ID"),
             obs_info=obs_info,
             gti=gti,
             aeff=aeff,

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -8,7 +8,6 @@ from astropy.time import Time
 from astropy.units import Quantity
 from gammapy.utils.fits import LazyFitsData, earth_location_from_dict
 from gammapy.utils.testing import Checker
-from gammapy.irf import load_irf_dict_from_file
 from .event_list import EventList, EventListChecker
 from .filters import ObservationFilter
 from .gti import GTI
@@ -360,6 +359,8 @@ class Observation:
         observation : `~gammapy.data.Observation` 
             observation with the events and the irf read from the file
         """
+        from gammapy.irf.io import load_irf_dict_from_file
+
         events = EventList.read(event_file)
         
         gti = GTI.read(event_file) 

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -16,13 +16,11 @@ from .filters import ObservationFilter
 from .gti import GTI
 from .pointing import FixedPointingInfo
 from .hdu_index_table import HDUIndexTable
-from gammapy import irf
+from gammapy.irf import IRF_REGISTRY
 
 __all__ = ["Observation", "Observations"]
 
 log = logging.getLogger(__name__)
-
-irf_dictionary = HDUIndexTable.HDU_CLASS_IMPLEMENTATION
 
 def load_irf_from_hdu_class(irf_file, hdu_class):
     """Search for an IRF component with the specified HDUCLAS4 keyword within
@@ -51,7 +49,7 @@ def load_irf_from_hdu_class(irf_file, hdu_class):
             if (read_hdu_class.lower() == hdu_class.lower()):
                 # we have found a hdu with this specific HDUCLAS4 hedaer keyword
                 extname = hdu.header["EXTNAME"]
-                component = getattr(irf, irf_dictionary[hdu_class])
+                component = IRF_REGISTRY.getattr(hdu_class)
                 return component.read(irf_file, extname)
         except KeyError:
             # no 'HDUCLAS4' header keyword in this HDU (probably EVENTS or GTI)

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -383,7 +383,7 @@ class Observation:
         return obs
 
     @classmethod
-    def from_file(cls, event_file, irf_file=None):
+    def read(cls, event_file, irf_file=None):
         """Create an Observation from a Event List and an (optional) IRF file.
 
         Parameters

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -398,7 +398,6 @@ class Observation:
         -------
         `~gammapy.data.Observation` with the event and irf read from the file
         """
-        log.info(f"reading the Event List and GTI from {event_file}")
         event_file = make_path(event_file)
         irf_file = make_path(irf_file) if irf_file is not None else event_file
         events = EventList.read(event_file)

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -22,7 +22,19 @@ __all__ = ["Observation", "Observations"]
 log = logging.getLogger(__name__)
 
 def load_irf_dict_from_file(filename):
-    """
+    """Open a fits file and generate a dictionary
+    
+    Parameters
+    ----------
+    filename : str, Path
+        path to the file containing the IRF components, if EVENTS and GTI HDUs 
+        are included in the file, they are ignored
+
+    Returns
+    -------
+    irf_dict : dict
+        dictionary with instances of the Gammapy obejcts corresponding 
+        to the IRF components        
     """
     filename = make_path(filename)
 
@@ -391,7 +403,8 @@ class Observation:
 
         Returns
         -------
-        `~gammapy.data.Observation` with the event and irf read from the file
+        observation : `~gammapy.data.Observation` 
+            observation with the events and the irf read from the file
         """
         events = EventList.read(event_file)
         

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -372,8 +372,6 @@ class Observation:
         return cls(events=events, gti=gti, obs_info=obs_info, obs_id=obs_info.get("OBS_ID"), **irf_dict)
         
 
-
-
 class Observations(collections.abc.MutableSequence):
     """Container class that holds a list of observations.
 

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 irf_dictionary = HDUIndexTable.HDU_CLASS_IMPLEMENTATION
 
-def read_irf_with_hdu_class(irf_file, hdu_class):
+def load_irf_from_hdu_class(irf_file, hdu_class):
     """Search for an IRF component with the specified HDUCLAS4 keyword within
     the irf_file. Return an instance of the corresponding IRF class implemented 
     in Gammapy.
@@ -402,8 +402,8 @@ class Observation:
         irf_file = make_path(irf_file) if irf_file is not None else event_file
         events = EventList.read(event_file)
         gti = GTI.read(event_file) 
-        aeff = read_irf_with_hdu_class(irf_file, "aeff_2d")
-        edisp = read_irf_with_hdu_class(irf_file, "edisp_2d")
+        aeff = load_irf_from_hdu_class(irf_file, "aeff_2d")
+        edisp = load_irf_from_hdu_class(irf_file, "edisp_2d")
         # non-mandatory IRF components
         psf = None
         bkg = None
@@ -412,7 +412,7 @@ class Observation:
         # - we assume only one PSF type per file is stored
         for hdu_class in HDUIndexTable.VALID_HDU_CLASS:
             if hdu_class.startswith("psf"): 
-                psf_tmp = read_irf_with_hdu_class(irf_file, hdu_class)
+                psf_tmp = load_irf_from_hdu_class(irf_file, hdu_class)
                 if psf_tmp is not None: 
                     psf = psf_tmp
                     break
@@ -421,7 +421,7 @@ class Observation:
         # - we assume only one PSF type per file is stored
         for hdu_class in HDUIndexTable.VALID_HDU_CLASS:
             if hdu_class.startswith("bkg"): 
-                bkg_tmp = read_irf_with_hdu_class(irf_file, hdu_class)
+                bkg_tmp = load_irf_from_hdu_class(irf_file, hdu_class)
                 if bkg_tmp is not None: 
                     bkg = bkg_tmp
                     break

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from gammapy.data.observations import load_irf_dict_from_file
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -226,6 +227,15 @@ def test_observation():
     assert_allclose(obs.target_radec.ra, np.nan)
     assert_allclose(obs.pointing_zen, np.nan)
     assert_allclose(obs.muoneff, 1)
+
+
+@requires_data()
+def test_observation_read():
+    obs = Observation.read(
+        "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+    )
+    assert obs.obs_id == 20136
+    assert obs.available_irfs == ["aeff", "edisp", "psf", "bkg"]
 
 
 @requires_data()

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -231,9 +231,10 @@ def test_observation():
 
 @requires_data()
 def test_observation_read():
+    """read event list and irf components from different DL3 files"""
     obs = Observation.read(
         event_file="$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz",
-        irf_file="$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+        irf_file="$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020137.fits.gz"
     )
 
     energy = Quantity(1, "TeV")
@@ -243,18 +244,26 @@ def test_observation_read():
     assert obs.obs_id == 20136
     assert len(obs.events.energy) == 11243
     assert obs.available_irfs == ["aeff", "edisp", "psf", "bkg"]
-    assert_allclose(val.value, 273372.44851054, rtol=1e-5)
+    assert_allclose(val.value, 278000.54120855, rtol=1e-5)
     assert val.unit == "m2"
 
 
 @requires_data()
 def test_observation_read_single_file():
+    """read event list and irf components from the same DL3 files"""
     obs = Observation.read(
         "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
     )
 
+    energy = Quantity(1, "TeV")
+    offset = Quantity(0.5, "deg")
+    val = obs.aeff.evaluate(energy_true=energy, offset=offset)
+    
     assert obs.obs_id == 20136
+    assert len(obs.events.energy) == 11243
     assert obs.available_irfs == ["aeff", "edisp", "psf", "bkg"]
+    assert_allclose(val.value, 273372.44851054, rtol=1e-5)
+    assert val.unit == "m2"
 
 
 @requires_data()

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
+from astropy.units import Quantity
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from gammapy.data import DataStore, Observation
@@ -231,8 +232,27 @@ def test_observation():
 @requires_data()
 def test_observation_read():
     obs = Observation.read(
+        event_file="$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz",
+        irf_file="$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+    )
+
+    energy = Quantity(1, "TeV")
+    offset = Quantity(0.5, "deg")
+    val = obs.aeff.evaluate(energy_true=energy, offset=offset)
+
+    assert obs.obs_id == 20136
+    assert len(obs.events.energy) == 11243
+    assert obs.available_irfs == ["aeff", "edisp", "psf", "bkg"]
+    assert_allclose(val.value, 273372.44851054, rtol=1e-5)
+    assert val.unit == "m2"
+
+
+@requires_data()
+def test_observation_read_single_file():
+    obs = Observation.read(
         "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
     )
+
     assert obs.obs_id == 20136
     assert obs.available_irfs == ["aeff", "edisp", "psf", "bkg"]
 

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from gammapy.data.observations import load_irf_dict_from_file
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import logging
 from astropy.io import fits
 from gammapy.utils.scripts import make_path
 from gammapy.utils.fits import HDULocation
 from gammapy.data.hdu_index_table import HDUIndexTable
 
 __all__ = ["load_cta_irfs", "load_irf_dict_from_file"]
+
+log = logging.getLogger(__name__)
 
 
 IRF_DL3_AXES_SPECIFICATION = {
@@ -168,6 +171,10 @@ def load_irf_dict_from_file(filename):
             
             for name in HDUIndexTable.VALID_HDU_TYPE:
                 if name in hdu_class:
+                    if name in irf_dict.keys():
+                        log.warning(f"more than one HDU of {name} type found")
+                        log.warning(f"loaded the {irf_dict[name].meta['EXTNAME']} HDU in the dictionary")
+                        continue
                     data = loc.load()
                     # TODO: maybe introduce IRF.type attribute...
                     irf_dict[name] = data

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -181,4 +181,3 @@ def load_irf_dict_from_file(filename):
         else : # not an IRF component
             continue
     return irf_dict
-    

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -143,8 +143,8 @@ def load_irf_dict_from_file(filename):
 
     Returns
     -------
-    irf_dict : dict
-        dictionary with instances of the Gammapy obejcts corresponding 
+    irf_dict : dict of `~gammapy.irf.IRF`
+        dictionary with instances of the Gammapy objects corresponding 
         to the IRF components        
     """
     filename = make_path(filename)

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -174,3 +174,4 @@ def load_irf_dict_from_file(filename):
         else : # not an IRF component
             continue
     return irf_dict
+    

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 from astropy.units import Quantity
 import astropy.units as u
 from astropy.io import fits
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_cta_irfs, load_irf_dict_from_file
 from gammapy.utils.testing import requires_data
 from gammapy.irf import Background3D, EffectiveAreaTable2D, EnergyDispersion2D
 from gammapy.maps import MapAxis
@@ -33,6 +33,32 @@ def test_cta_irf():
 
     val = irf["bkg"].evaluate(energy=energy, fov_lon=offset, fov_lat="0 deg")
     assert_allclose(val.value, 9.400071e-05, rtol=1e-5)
+    assert val.unit == "1 / (MeV s sr)"
+
+@requires_data()
+def test_load_irf_dict_from_file():
+    """Test that the IRF components in a dictionary loaded from a DL3 file can 
+    be loaded in a dictionary and correctly used"""
+    irf = load_irf_dict_from_file(
+        "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+    )
+
+    energy = Quantity(1, "TeV")
+    offset = Quantity(0.5, "deg")
+
+    val = irf["aeff"].evaluate(energy_true=energy, offset=offset)
+    assert_allclose(val.value, 273372.44851054, rtol=1e-5)
+    assert val.unit == "m2"
+
+    val = irf["edisp"].evaluate(offset=offset, energy_true=energy, migra=1)
+    assert_allclose(val.value, 1.84269482, rtol=1e-5)
+    assert val.unit == ""
+
+    val = irf["psf"].evaluate(rad=Quantity(0.1, "deg"), energy_true=energy, offset=offset)
+    assert_allclose(val, 6.75981573 * u.Unit("deg-2"), rtol=1e-5)
+
+    val = irf["bkg"].evaluate(energy=energy, fov_lon=offset, fov_lat="0.1 deg")
+    assert_allclose(val.value, 0.00031552, rtol=1e-5)
     assert val.unit == "1 / (MeV s sr)"
 
 


### PR DESCRIPTION
**Description**

It is a bit impractical to create a `DataStore` object each time we want to manipulate / check `Observation`s, without having the possibility of reading them directly from DL3 files.

`Observations` are what actually goes into the spectral analysis and it seems to me that the `DataStore` provides a class for organising a list of them: **but often I want to quickly check if the information in a single (or few) test DL3 files I am producing is correct, without having to create the `hdu` and `obs` index files each time!**

Note that there is a `from_event_files` method in `DataStore`, but the IRF components - quoting the docstring - "are found only if you have a ``CALDB`` environment variable set"...

*what changes are done?*

I added a `.from_file(cls, event_file, irf_file)` method in `Observation`. It takes different arguments for event and IRF files, in case they are not in the same file.

To search for IRF components in the file I added a function searching for the allowed `HDUCLAS4` keywords by the GADF and returning the corresponding IRF component implemented in gammapy. There is a 1:1 correspondence between them (keyword and IRF class / component). The same is not true for `EXTNAME`, for example, as this can change from production to production (e.g. `AEFF` vs `EFFECTIVE AREA`) and does not identify the class of IRF component produced.

**Dear reviewer**

Let me know if you agree with the changes proposed - @AtreyeeS, @LauraOlivera, @bkhelifi and @maxnoe agreed with (or did not protest) my proposal in slack, I assumed it was a good basis for a PR.

This is roughly what is available now:
```python
from gammapy.data import Observation
obs = Observation.from_file(
    event_file="$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz", 
    irf_file="$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
)
print(obs.events)
print(obs.available_irfs)
```
that gives 
```
EventList
---------

  Instrument       : H.E.S.S. Phase I
  Telescope        : HESS
  Obs. ID          : 20136

  Number of events : 11243
  Event rate       : 6.684 1 / s

  Time start       : 53090.123451203704
  Time stop        : 53090.14291879629

  Min. energy      : 2.23e-01 TeV
  Max. energy      : 1.04e+02 TeV
  Median energy    : 5.37e-01 TeV

  Max. offset      : 36.3 deg

['aeff', 'edisp', 'psf', 'bkg']
```

*P.S.* I seem to have a problem with the `peek` functions, though I changed nothing in the `EventList` or `irf` class. 
Will take a deeper look tomorrow.