### PR TITLE
Allow for neg. ULs in CountsStatistics

### DIFF
--- a/docs/estimators/index.rst
+++ b/docs/estimators/index.rst
@@ -104,6 +104,20 @@ n_sigma_ul        Number of sigma used for upper limit estimation
 ts_threshold_ul   TS threshold to define the use of an upper limit
 ================= =================================================
 
+A note on negative flux and upper limit values:
+
+.. note::
+
+    Gammapy allows for negative flux values and upper limits by default.
+    While those values are physically not valid solutions, they are still
+    valid statistically. Negative flux values either hint at overestimated
+    background levels or underestimated systematic errors in general. Or in
+    case of many measurements, such as pixels in a flux map, they are even
+    statistically expected. In future versions of Gammapy it will be possible
+    to account for systematic errors in the likelihood as well. For now the
+    correct interpretation of the results is left to the user.
+
+
 Getting started
 ===============
 

--- a/docs/estimators/index.rst
+++ b/docs/estimators/index.rst
@@ -113,9 +113,10 @@ A note on negative flux and upper limit values:
     valid statistically. Negative flux values either hint at overestimated
     background levels or underestimated systematic errors in general. Or in
     case of many measurements, such as pixels in a flux map, they are even
-    statistically expected. In future versions of Gammapy it will be possible
-    to account for systematic errors in the likelihood as well. For now the
-    correct interpretation of the results is left to the user.
+    statistically expected. For flux points and light curves the amplitude
+    limits (if defined) are taken into account. In future versions of Gammapy
+    it will be possible to account for systematic errors in the likelihood as
+    well. For now the correct interpretation of the results is left to the user.
 
 
 Getting started

--- a/gammapy/stats/counts_statistic.py
+++ b/gammapy/stats/counts_statistic.py
@@ -103,19 +103,19 @@ class CountsStatistic(abc.ABC):
 
         ul = np.zeros_like(self.n_on, dtype="float")
 
-        min_range = np.maximum(0, self.n_sig)
-        max_range = min_range + 2 * n_sigma * (self.error + 1)
+        min_range = self.n_sig
+        max_range = self.n_sig + 2 * n_sigma * (self.error + 1)
         it = np.nditer(ul, flags=["multi_index"])
 
         while not it.finished:
-            TS_ref = self._stat_fcn(min_range[it.multi_index], 0.0, it.multi_index)
+            ts_ref = self._stat_fcn(min_range[it.multi_index], 0.0, it.multi_index)
 
             roots, res = find_roots(
                 self._stat_fcn,
                 min_range[it.multi_index],
                 max_range[it.multi_index],
                 nbin=1,
-                args=(TS_ref + n_sigma ** 2, it.multi_index),
+                args=(ts_ref + n_sigma ** 2, it.multi_index),
             )
             ul[it.multi_index] = roots[0]
             it.iternext()

--- a/gammapy/stats/tests/test_counts_statistic.py
+++ b/gammapy/stats/tests/test_counts_statistic.py
@@ -49,11 +49,11 @@ def test_cash_errors(n_on, mu_bkg, result):
 
 
 values = [
-    (1, 2, [5.869898]),
+    (1, 2, [5.517193]),
     (5, 1, [13.98959]),
     (10, 5, [17.696064]),
     (100, 23, [110.07206]),
-    (1, 20, [4.711538]),
+    (1, 20, [-12.482807]),
     (5 * ref_array, 1 * ref_array, [13.98959]),
 ]
 
@@ -72,6 +72,7 @@ values = [
     pytest.param(1, -2, np.nan, marks=pytest.mark.xfail),
     ([1, 2], 5, [8.327276, 10.550546]),
 ]
+
 
 @pytest.mark.parametrize(("mu_bkg", "significance", "result"), values)
 def test_cash_excess_matching_significance(mu_bkg, significance, result):
@@ -151,11 +152,11 @@ def test_wstat_errors(n_on, n_off, alpha, result):
 
 
 values = [
-    (1, 2, 1, [6.272627]),
+    (1, 2, 1, [6.075534]),
     (5, 1, 1, [14.222831]),
     (10, 5, 0.3, [21.309229]),
     (10, 23, 0.1, [20.45803]),
-    (1, 20, 1.0, [4.884418]),
+    (1, 20, 1.0, [-7.078228]),
     (5 * ref_array, 1 * ref_array, 1 * ref_array, [14.222831]),
 ]
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes `compute_upper_limits` top allow for negative upper limits. While physically this doesn't make sense, statistically it is a correct solution and points to underestimated systematics. This change is also done for consistency with the `TSMapEstimator` I noticed the difference in https://github.com/adonath/notebooks-public/blob/master/excess-vs-ts-map-estimator.ipynb.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
