### PR TITLE
Add documentation on the index tables

### DIFF
--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -61,26 +61,10 @@ The index tables
 A typical way to organize the files relevant to the observation are the index tables.
 There are two relevant tables:
 
-- Observation index table: this table has information on specifics of each observation or run, meta data about each observation run,
-such as the pointing direction, the duration, the run ID...
-- HDU index table: this table links each of the observations listed in the observation
-index table to the relevant data and instrument response files.
+* Observation index table: this table has information on specifics of each observation or run, meta data about each observation run, such as the pointing direction, the duration, the run ID...
+* HDU index table: this table links each of the observations listed in the observation index table to the relevant data and instrument response files.
 
-A `~gammapy.data.DataStore` can be created by giving each of these two tables separately, as well as the directory that they can be found in:
-
-.. testcode::
-
-    from gammapy.data import DataStore
-    directory = "$GAMMAPY_DATA/hess-dl3-dr1"
-    hdu_table_path = directory + "/hdu-index.fits.gz"
-    obs_table_path = directory + "/obs-index.fits.gz"
-
-    # separate tables
-    data_store = DataStore(hdu_table=hdu_table_path, obs_table=obs_table_path)
-
-    # directly from directory
-    data_store = DataStore.from_dir(directory)
-
+A `~gammapy.data.DataStore` can then be created by giving each of these two tables separately, or instead by the directory that they can be found in as shown above.
 
 More details on these tables and their content can be found in https://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/index.html.
 

--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -56,6 +56,35 @@ to load IACT data. E.g. an alternative way to load the events for observation ID
     data_store = DataStore.from_dir('$GAMMAPY_DATA/hess-dl3-dr1')
     events = data_store.obs(23523).events
 
+The index tables
+================
+A typical way to organize the files relevant to the observation are the index tables.
+There are two relevant tables:
+
+- Observation index table: this table has information on specifics of each observation or run, meta data about each observation run,
+such as the pointing direction, the duration, the run ID...
+- HDU index table: this table links each of the observations listed in the observation
+index table to the relevant data and instrument response files.
+
+A `~gammapy.data.DataStore` can be created by giving each of these two tables separately, as well as the directory that they can be found in:
+
+.. testcode::
+
+    from gammapy.data import DataStore
+    directory = "$GAMMAPY_DATA/hess-dl3-dr1"
+    hdu_table_path = directory + "/hdu-index.fits.gz"
+    obs_table_path = directory + "/obs-index.fits.gz"
+
+    # separate tables
+    data_store = DataStore(hdu_table=hdu_table_path, obs_table=obs_table_path)
+
+    # directly from directory
+    data_store = DataStore.from_dir(directory)
+
+
+More details on these tables and their content can be found in https://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/index.html.
+
+
 Working with event lists
 ========================
 To take a quick look at the events inside the list, one can use `~gammapy.data.EventList.peek()`

--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -58,13 +58,14 @@ to load IACT data. E.g. an alternative way to load the events for observation ID
 
 The index tables
 ================
-A typical way to organize the files relevant to the observation are the index tables.
-There are two relevant tables:
+A typical way to organize the files relevant to the data we are interested in are the index tables.
+There are two tables:
 
-* Observation index table: this table has information on specifics of each observation or run, meta data about each observation run, such as the pointing direction, the duration, the run ID...
-* HDU index table: this table links each of the observations listed in the observation index table to the relevant data and instrument response files.
+* **Observation index table:** this table collects the information on each observation or run, with meta data about each of them, such as the pointing direction, the duration, the run ID...
 
-A `~gammapy.data.DataStore` can then be created by giving each of these two tables separately, or instead by the directory that they can be found in as shown above.
+* **HDU index table:** this table links each of the observations listed in the observation index table to the corresponding data and instrument response files.
+
+A `~gammapy.data.DataStore` can then be created by providing each of these two tables separately, or instead by the directory that they can be found in as shown above.
 
 More details on these tables and their content can be found in https://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/index.html.
 

--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -63,9 +63,9 @@ There are two tables:
 
 * **Observation index table:** this table collects the information on each observation or run, with meta data about each of them, such as the pointing direction, the duration, the run ID...
 
-* **HDU index table:** this table links each of the observations listed in the observation index table to the corresponding data and instrument response files.
+* **HDU index table:** this table provides, for each observation listed in the index table, the location of the corresponding data and instrument response files.
 
-A `~gammapy.data.DataStore` can then be created by providing each of these two tables separately, or instead by the directory that they can be found in as shown above.
+A `~gammapy.data.DataStore` can then be created by providing each of these two tables in the same file with `~gammapy.data.Datastore.from_file()`, or instead by the directory where they can be found with `~gammapy.data.Datastore.from_dir()` as shown above.
 
 More details on these tables and their content can be found in https://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/index.html.
 

--- a/docs/tutorials/data/hess.ipynb
+++ b/docs/tutorials/data/hess.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# H.E.S.S. with Gammapy\n",
     "\n",
@@ -17,126 +16,132 @@
     "## DL3 DR1\n",
     "\n",
     "This is how to access data and IRFs from the H.E.S.S. data level 3, data release 1."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "from astropy.coordinates import SkyCoord\n",
     "import astropy.units as u"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "from gammapy.data import DataStore\n",
     "from gammapy.maps import MapAxis\n",
     "from gammapy.makers.utils import make_theta_squared_table\n",
     "from gammapy.visualization import plot_theta_squared_table"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   ],
    "outputs": [],
-   "source": [
-    "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/hess-dl3-dr1\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data_store.info()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data_store.obs_table[:2][[\"OBS_ID\", \"DATE-OBS\", \"RA_PNT\", \"DEC_PNT\", \"OBJECT\"]]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "obs = data_store.obs(23523)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "obs.events.select_offset([0, 2.5] * u.deg).peek()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "obs.aeff.peek()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "obs.edisp.peek()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "obs.psf.peek()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "obs.bkg.to_2d().plot()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "## Theta squared event distribution\n",
-    "As a quick look plot it can be helpful to plot the quadratic offset (theta squared) distribution of the events. "
-   ]
+    "A useful way to organize the relevant files are the index tables. The observation index table contains information on each particular run, such as the pointing, or the run ID. The HDU index table has a row per relevant file (i.e., events, effective area, psf...) and contains the path to said file. Together they can be loaded into a Datastore by indicating the directory in which they can be found, in this case \"$GAMMAPY_DATA/hess-dl3-dr1\":"
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "source": [
+    "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/hess-dl3-dr1\")"
+   ],
    "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "data_store.info()"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "data_store.obs_table[:2][[\"OBS_ID\", \"DATE-OBS\", \"RA_PNT\", \"DEC_PNT\", \"OBJECT\"]]"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "obs = data_store.obs(23523)"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "obs.events.select_offset([0, 2.5] * u.deg).peek()"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "obs.aeff.peek()"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "obs.edisp.peek()"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "obs.psf.peek()"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "obs.bkg.to_2d().plot()"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Theta squared event distribution\n",
+    "As a quick look plot it can be helpful to plot the quadratic offset (theta squared) distribution of the events. "
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "source": [
     "position = SkyCoord(ra=83.63, dec=22.01, unit=\"deg\", frame=\"icrs\")\n",
     "theta2_axis = MapAxis.from_bounds(0, 0.2, nbin=20, interp=\"lin\", unit=\"deg2\")\n",
@@ -147,40 +152,42 @@
     "    position=position,\n",
     "    theta_squared_axis=theta2_axis,\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "plt.figure(figsize=(10, 5))\n",
+    "plot_theta_squared_table(theta2_table)"
+   ],
+   "outputs": [],
    "metadata": {
     "nbsphinx-thumbnail": {
      "tooltip": "Explore H.E.S.S. event lists and IRFs."
     }
-   },
-   "outputs": [],
-   "source": [
-    "plt.figure(figsize=(10, 5))\n",
-    "plot_theta_squared_table(theta2_table)"
-   ]
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Exercises\n",
     "\n",
     "- Find the `OBS_ID` for the runs of the Crab nebula\n",
     "- Compute the expected number of background events in the whole RoI for `OBS_ID=23523` in the 1 TeV to 3 TeV energy band, from the background IRF."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Next steps\n",
     "\n",
     "Now you know how to access and work with H.E.S.S. data. All other tutorials and documentation apply to H.E.S.S. and CTA or any other IACT that provides DL3 data and IRFs in the standard format."
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
This pull request expands the documentation on the observation and HDU index tables in two places:

- The index page of `gammapy.data`.
- The HESS tutorial.

The information in both is mostly repeated, and pretty much summarized from https://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/index.html, but given how many questions people have about the tables, I thought  better to be extra repetitive and clear :wink: 