### PR TITLE
Add sample_time to model.temporal.ExpDecayTemporalModel

### DIFF
--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -77,6 +77,8 @@
     "from pathlib import Path\n",
     "import astropy.units as u\n",
     "from astropy.io import fits\n",
+    "from astropy.table import Table\n",
+    "from astropy.time import Time\n",
     "from astropy.coordinates import SkyCoord\n",
     "from gammapy.data import DataStore, Observation\n",
     "from gammapy.datasets import MapDataset, MapDatasetEventSampler\n",
@@ -92,6 +94,8 @@
     "    PowerLawNormSpectralModel,\n",
     "    PointSpatialModel,\n",
     "    TemplateSpatialModel,\n",
+    "    ExpDecayTemporalModel,\n",
+    "    LightCurveTemplateTemporalModel,\n",
     "    FoVBackgroundModel,\n",
     ")"
    ]
@@ -442,6 +446,109 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Time variable source using a lightcurve\n",
+    "\n",
+    "The event sampler can also handle temporal variability of the simulated sources. In this example, we show how \n",
+    "to sample a source characterized by an exponential decay, with decay time of 200 seconds, during the observation. \n",
+    "\n",
+    "First of all, let's create a lightcurve:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t0 = 200 * u.s\n",
+    "t_ref = Time(\"2000-01-01T00:01:04.184\")\n",
+    "\n",
+    "times = t_ref + livetime * np.linspace(0, 1, 1000)\n",
+    "expdecay_model = ExpDecayTemporalModel(t_ref=t_ref.mjd * u.d, t0=t0)\n",
+    "\n",
+    "lc = Table()\n",
+    "lc.meta[\"MJDREFI\"] = t_ref.mjd\n",
+    "lc.meta[\"MJDREFF\"] = 0.0\n",
+    "lc.meta[\"TIMEUNIT\"] = 's'\n",
+    "\n",
+    "lc[\"TIME\"] = livetime.to('s') * np.linspace(0, 1, 1000)\n",
+    "lc[\"NORM\"] = expdecay_model(times)\n",
+    "\n",
+    "lc.write(\"./event_sampling/lc.fits\", overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we can define the sky model including the temporal model component. The latter is passed as `~gammapy.modeling.models.TemporalModel.LightCurveTemplateTemporalModel` model: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temporal_model = LightCurveTemplateTemporalModel.read(\"./event_sampling/lc.fits\")\n",
+    "\n",
+    "sky_model_pntpwl = SkyModel(\n",
+    "    spectral_model=spectral_model_pwl,\n",
+    "    spatial_model=spatial_model_point,\n",
+    "    temporal_model=temporal_model,\n",
+    "    name=\"point-pwl\",\n",
+    ")\n",
+    "\n",
+    "bkg_model = FoVBackgroundModel(dataset_name=\"my-dataset\")\n",
+    "\n",
+    "models = Models([sky_model_pntpwl, bkg_model])\n",
+    "\n",
+    "file_model = \"./event_sampling/point-pwl_decay.yaml\"\n",
+    "models.write(file_model, overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.models = models\n",
+    "print(dataset.models)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now, let's simulate the variable source:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "sampler = MapDatasetEventSampler(random_state=0)\n",
+    "events = sampler.run(dataset, observation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Source events: {(events.table['MC_ID'] == 1).sum()}\")\n",
+    "print(f\"Background events: {(events.table['MC_ID'] == 0).sum()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Extended source using a template\n",
     "The event sampler can also work with a template model.\n",
     "Here we use the interstellar emission model map of the Fermi 3FHL, which can be found in the GAMMAPY data repository.\n",
@@ -606,7 +713,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -75,6 +75,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "from pathlib import Path\n",
+    "import numpy as np\n",
     "import astropy.units as u\n",
     "from astropy.io import fits\n",
     "from astropy.table import Table\n",
@@ -82,6 +83,7 @@
     "from astropy.coordinates import SkyCoord\n",
     "from gammapy.data import DataStore, Observation\n",
     "from gammapy.datasets import MapDataset, MapDatasetEventSampler\n",
+    "from gammapy.estimators import LightCurveEstimator\n",
     "from gammapy.maps import MapAxis, WcsGeom, Map\n",
     "from gammapy.irf import load_cta_irfs\n",
     "from gammapy.makers import MapDatasetMaker\n",
@@ -421,8 +423,8 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "fit = Fit(optimize_opts={\"print_level\": 1})\n",
-    "result = fit.run([dataset])\n",
+    "fit = Fit()\n",
+    "result = fit.run(dataset)\n",
     "print(result)"
    ]
   },
@@ -432,7 +434,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result[\"optimize_result\"].parameters.to_table()"
+    "result.parameters.to_table()"
    ]
   },
   {
@@ -449,7 +451,7 @@
     "## Time variable source using a lightcurve\n",
     "\n",
     "The event sampler can also handle temporal variability of the simulated sources. In this example, we show how \n",
-    "to sample a source characterized by an exponential decay, with decay time of 200 seconds, during the observation. \n",
+    "to sample a source characterized by an exponential decay, with decay time of 2800 seconds, during the observation. \n",
     "\n",
     "First of all, let's create a lightcurve:"
    ]
@@ -460,10 +462,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t0 = 200 * u.s\n",
+    "t0 = 2800 * u.s\n",
     "t_ref = Time(\"2000-01-01T00:01:04.184\")\n",
     "\n",
-    "times = t_ref + livetime * np.linspace(0, 1, 1000)\n",
+    "times = t_ref + livetime * np.linspace(0, 1, 50)\n",
     "expdecay_model = ExpDecayTemporalModel(t_ref=t_ref.mjd * u.d, t0=t0)\n",
     "\n",
     "lc = Table()\n",
@@ -471,7 +473,7 @@
     "lc.meta[\"MJDREFF\"] = 0.0\n",
     "lc.meta[\"TIMEUNIT\"] = 's'\n",
     "\n",
-    "lc[\"TIME\"] = livetime.to('s') * np.linspace(0, 1, 1000)\n",
+    "lc[\"TIME\"] = livetime.to('s') * np.linspace(0, 1, 50)\n",
     "lc[\"NORM\"] = expdecay_model(times)\n",
     "\n",
     "lc.write(\"./event_sampling/lc.fits\", overwrite=True)"
@@ -481,7 +483,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we can define the sky model including the temporal model component. The latter is passed as `~gammapy.modeling.models.TemporalModel.LightCurveTemplateTemporalModel` model: "
+    "Now, we can define the sky model including the temporal model component. The latter is passed as `~gammapy.modeling.models.TemporalModel.LightCurveTemplateTemporalModel` model. Here we consider an extremely bright source, so to make more evident its temporal properties: "
    ]
   },
   {
@@ -491,6 +493,8 @@
    "outputs": [],
    "source": [
     "temporal_model = LightCurveTemplateTemporalModel.read(\"./event_sampling/lc.fits\")\n",
+    "\n",
+    "spectral_model_pwl.amplitude.value = 2e-10\n",
     "\n",
     "sky_model_pntpwl = SkyModel(\n",
     "    spectral_model=spectral_model_pwl,\n",
@@ -505,6 +509,13 @@
     "\n",
     "file_model = \"./event_sampling/point-pwl_decay.yaml\"\n",
     "models.write(file_model, overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For simplicity"
    ]
   },
   {
@@ -543,6 +554,50 @@
    "source": [
     "print(f\"Source events: {(events.table['MC_ID'] == 1).sum()}\")\n",
     "print(f\"Background events: {(events.table['MC_ID'] == 0).sum()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now inspect the properties of the simulated source. To do that, we adopt the `select_region` function that extracts only the events into a given `SkyRegion` of a `~gammapy.data.event_list.EventList` object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "src_position = SkyCoord(0.0, 0.5, frame=\"galactic\", unit=\"deg\")\n",
+    "\n",
+    "on_region_radius = Angle(\"0.15 deg\")\n",
+    "on_region = CircleSkyRegion(center=src_position, radius=on_region_radius)\n",
+    "\n",
+    "src_events = events.select_region(on_region)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we can have a quick look to the data with the `peek` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "src_events.peek()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the right figure of the bottom panel, it is shown the source lightcurve that follows a decay trend as expected."
    ]
   },
   {

--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,9 +138,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Invalid unit found in background table! Assuming (s-1 MeV-1 sr-1)\n"
+     ]
+    }
+   ],
    "source": [
     "irfs = load_cta_irfs(filename)\n",
     "observation = Observation.create(\n",
@@ -163,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,9 +203,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.08 s, sys: 343 ms, total: 1.42 s\n",
+      "Wall time: 1.5 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "empty = MapDataset.create(\n",
@@ -224,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,9 +282,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DatasetModels\n",
+      "\n",
+      "Component 0: SkyModel\n",
+      "\n",
+      "  Name                      : point-pwl\n",
+      "  Datasets names            : None\n",
+      "  Spectral model type       : PowerLawSpectralModel\n",
+      "  Spatial  model type       : PointSpatialModel\n",
+      "  Temporal model type       : \n",
+      "  Parameters:\n",
+      "    index                   :   2.000              \n",
+      "    amplitude               :   1.00e-12  1 / (cm2 s TeV)\n",
+      "    reference    (frozen)   :   1.000  TeV         \n",
+      "    lon_0                   :   0.000  deg         \n",
+      "    lat_0                   :   0.500  deg         \n",
+      "\n",
+      "Component 1: FoVBackgroundModel\n",
+      "\n",
+      "  Name                      : my-dataset-bkg\n",
+      "  Datasets names            : ['my-dataset']\n",
+      "  Spectral model type       : PowerLawNormSpectralModel\n",
+      "  Parameters:\n",
+      "    norm                    :   1.000              \n",
+      "    tilt         (frozen)   :   0.000              \n",
+      "    reference    (frozen)   :   1.000  TeV         \n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "dataset.models = models\n",
     "print(dataset.models)"
@@ -282,9 +333,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.78 s, sys: 721 ms, total: 3.5 s\n",
+      "Wall time: 3.53 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "sampler = MapDatasetEventSampler(random_state=0)\n",
@@ -300,9 +360,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source events: 175\n",
+      "Background events: 11804\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"Source events: {(events.table['MC_ID'] == 1).sum()}\")\n",
     "print(f\"Background events: {(events.table['MC_ID'] == 0).sum()}\")"
@@ -317,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,13 +439,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "nbsphinx-thumbnail": {
      "tooltip": "Check out the process of sampling events from a given sky model and obtain a simulated events list."
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUsAAAEMCAYAAABN6pRKAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABNG0lEQVR4nO19e5xkVXXut5iRx/CGQXkKo3JFNArToxINXgIqiA8MYgQTBCX2TALGaLwqJvfampvEZ4yJJENrEByfEYki10gIiI+oSPWIIlEjAZSRlwOICCE4sO4fZ+/Tu1attc8+3VXVVVPr+/36V1Xn7LPPOo8+59trrf0tYmY4HA6HI49tltoAh8PhGAf4w9LhcDgK4A9Lh8PhKIA/LB0Oh6MA/rB0OByOAvjD0uFwOAow1IclEZ1HRHcQ0feSZfsS0RVE9Dki2iks246IPkVE1xPRVUR0UNL+NCL6Ufg7LVl+ZdrO4XA4+olhM8vzARwnlv0hgNcA+BCA3w3LzgBwNzM/DsD7ALwTAIhoDwBvBfB0AE8D8FYi2r2NAUS0YaHGjzK21uMCtt5j8+MaDgyStgcRXRZI12Ulz5GhPiyZ+SsA7hKLlwF4OPxRWHYCgAvC9wsBHENEBOBYAJcx813MfDeAyzD/8L0LwEMFZpy48CMYaWytxwVsvcfmxzUcnI9ekvZmAJcz88EALg+/s1jef7ta4wMANgC4B8DLw7L9ANwMAMy8hYjuAbBnujxgU1gGZh61C+RwOEYAzPwVxUV3AoCjwvcLAFwJ4E25fpb8YcnMPwbwLLGYtKaZ5VmEYUF8mK4gInWbqX2qz7lbm3qcx6PDGdy8pfpcKX7fn7Rdge5lctu4fkVyVbR+0rYp4nGtFPuJbffatfr82T1J/+FzpfH7fvFp7RsADgz9fz/p37JF9pv2GZfF6wFUx7Yi09aCvB7pNvL8a4ht5XHIfnM2WX0A89fMgnWuc/1rdjTdP+n6R4unwk/E+ZHXUPa3zTbbgIjuSxZdxMynogWOO+443rx5c3NDAHNzc9cBeCBZNMvMsw2bPYqZbwUAZr6ViB7ZtJ8lf1ga2ATgAACbiGg5gF1RDbM3Yf5tAAD7o3ojZBEu1KlA/ubsrK0+aabc0LeEO3T2tupzWvzemLQ9BN3L5LZrwvLVyV2v9ZP2FZGuj2+FDrr7nT4y9HlJ0r/YRv6OfWjHITEb+l+T9G/ZIvtN+4zL5PWIbdYkbTvIQ16PtH95/jXEtvI4ZL85m6w+5DXVYJ3rXP+aHW3un7eIp+46cX7kfSz7o8MPR6fT2VE1thCbN29Gp9N0dcP+iB5g5jXNLReHUX1YXgzgNADfAHASgCuYmYnoUgB/kThjnwvg7DYdr0R1U2mvnakZfZvp8Cn/4YHeh5n1cEuXrRZt677il2R5bGvZoN1Osk3sN31Iyv4j5H6izTwz3yaeJ3l3xoek7DPtx9p/uj7aEB+Sso3WNkKej/iPntoUv68RJ1Fra52PjeIhOf2CxAZxnq0+UqzfW7dba6udX61/eW60/taIz3Tf2vZpH6uVZQAwZWzXHg/3rScFtxPRPoFV7gPgjqYNhp069AlUD8DHE9EmIjrDaPoPAPYkousBvB7B+crMdwH4MwBXh7+3h2UOh2OrAgPYUvi3IERChvD5uaYNaNIk2nYk4pKhDdDL3jSeH1lbJzCL6cAq4ps2ZQzWcG9asIq0nWSHq43lKSQTy7Ev2SZ3rBLWIEkbkkpGk7OxaZsSxHO6MTPEludUY0wLgezHuoYlmOM5AMAUzfO1eGw590G633TfksFqfchzJ6/HemX/6XWcm5pCp9PR4gvFWLNmijudfytqS7TDXG4YHkjaUagGlrejSj/8LIB/BPBoAD8B8NIm4jWqw3CHwzHRYPRrGM7MpxirjmnTjz8sHQ7HiGKgPsvWmLiH5f2ohgxy2An0Dm/ksEkbosZ+rOH3RmWoIodhMqKaDj/rAEJsq7SR6AkkGfvNtZHDe22YbO03F5SYDe6K2UvsthHacK9pmwgtWCO3l8NkKL+b3B+5IbU8H/IcpMFea0idDr8lmlw06XWSQcV6qC3WA/P37Oo4ZBe2xXNb4mJaOPrHLPuFiXtYOhyOcYE/LEcKKUuxGJ58U+eyXa20IGA+CLSmIbUkfctbLE5LubHWtQkKWTaldli5kiUpQ/HYO4JhakGnyGBi2lJMJdJYrjy22GZ1huFbTDiXmhRThDqCGWupSZJF1zmaCquWI4fc9W1CjvVawSFtP7MGO4+2asGzWfQrdShGw0cHE/+wdDgcowpnlksKmZSuvX0l85JttWRc6aPUGM20YJQRsW1HSUS23upy/2k7K4dCY5QWo5EMLddPLjXJYkjxXMhUFmA+WTy2kcnpOZbbY2vmnMq0pXgd0hkrkj3LhHNpR9cykaQv23SNagzbtPtTzqiR/csRUdc+Dd+i5n+UI6H6/leuWcdgoQuH+ywdDoejEKP1sJy4pPQ4N1yyCUCZfih8TvXy5Lt8kzZFWoF2SdeWfzBCMsN0mdyf5q+ybChJfLZ8oF3TBQVbazpfmk0SkfEANnuTzD61cb1hk7RVs1f2rx2XPCYr8T9Fk39ZY+Dy2GT2QDrZYZ1gi9YoJ2eLxrwl+peU/mTudL5Q1JbogGxSer/gzNLhcIwoRivAM3HMci8iTn2WbabZ5RiPZCBzM9WnJs4hGYz0d6bMY1YwAWtqZI7B5tAU2W4j5JCLtsttrSl1GmRbjUWvFqwqd62aREm0PEsJKwc0heVPLTlPEdrIwWK7EiVTYRcSMddGTen/U3+Y5a9xp9M4XRsAQPRYZ5YOh2OS4T7LJUX0WUqGA/RKU1lsy3qjar9XK/3Lt3vMI1w7073fdF+W/FaOkVnsQYsMy9eyZGoaShiSdV4icv47i73lhDpKorFW25xQSpNPVIP0JVojiRSWFmZuBCTPU0nurcZYrbYROam51AbqC7N8Enc6FxW1JXq8M0uHwzHJGC1m6Q9Lh8MxovCH5ZLi0csr2fw4JEqHeE1DRi2VyBKiqKdGKv1LWMrjWr9tht/W8pwoRr2/zHS4Jhu01J56W5HoPC2WA/Pn10o30qZGyumT0o2Qulus4WrJUL6+N5RgU4ScvLBRuHc0IQor0Tx3rmUaUG4cKteVBJeaAnlaxYD+wac7OhwORwF8Bs+SY/OW6i2YSxrvkVAzVNDTttKJHxmBFoxoSvUoqZ0i048s1prur64TlGkr96exC8lyelJxFOYd7Y3nUDJyrT6QnG6nsay6fylskWE6bQRGrOmlPfvPMFd5/+Sk8iJyNtXBFEPmriTSkUsNs9LHrICPXDcmNXhaY+Ielg6HY1zgD8slxcrlVRlTrXpeLT0VPqWPUvPVRJZjTQFLU4c6ws9lJQhr20jmUcIoZTJ3LvVpVrC4nr6S73Lam2SuJYK4knlrPjk5JU9LWbFEMCTz1qYwlrBE67rKUUDarkfWzfApqhJnxhRbbbtp4/6UNqbomRIZlufK5pZM28ylIi0MPgx3OByOAoxegGfiktJldUeNRUj/o0QJc9LaWtUWc2IJMspoCVOUiCZofrCYEC8j8tYUvXRdm+qLTW1zfrY2iedNkm2aTdp5r9sYUe82U2DbTA6Q67T9WKMJ6RNPRyhN00pzvnXrelvyemtv7UdS+iHc6XyoqC3RkZ6U7nA4Jhk+DB8paHmQuWJXgChYZkQ6NTECGQGu8xEj8wsdp37DnkJlBmvUfGZSvkyLts81UDDtdS2PLVeorM6jNIQzcrJo0heqMaqm4mk5n5y83rkiduvjtg1+53SZRXVysnTSby77lPal+5HbdIyRUbqNdv5yIsVAck9qPtdLgEyNtRZwn6XD4XAUwh+WDofD0QBnlkuOmDqkakeKtnI4UpLeEpFTk66HaTI1RkvMtn4XTHGz6vekxxnTTiyFH23oHt0F68S22jHX1SEN5SAZjALmz0tsI23rSn0S7girlpBaY0a0lbWQUljTEReSLqW5LZpqLeWCNU21zXP2tdEglW1LaskvDqMVDZ+4h6XD4RgHjB6znLjUIVmDR3v75qZ1NW3TRiNR9l/ydm+jZC6DKhqa0oByaShWXyms1JoSJtZGgxGiTUm6kZUao7FQaZtErgaP3E9JrR9po3bPyUCbvFa5Wks5bUrrXssFhdK2/dGzPJg7nfcVtSV6oacOORyOScXoMcuJfVhq7MSa8nfuTPiM+SPKG9uqGFjiN5K+Mw1Wekiub0uZWzt2KXHWI6WWHHNTgnZqi3VeIjS2IplM/JTT+zQbShTl5T57hEYU5ryQio0RPWr6Sv9NowCN7Vr+5Sgikht1WCOK1BZtSnDX/gw/85zRvj38YelwOBwF8IflSECrg9IR9CAygVgbpyeZHEkU1hCr0EQrpA2SdWlTz+S2JVFYSzZO869JNr1anIuSaKcabTeS6CHaqjbJ/hSJM4v15HxyElbdG8COxNeiw0p/TXWAaqasTFE1/bKKf9Oq9Kkl8Vv3j+wz7cdKro99aZMnOgAW5aysMXpzwyf2YelwOEYZ7rNccqwAcAiMqVoZf2PX8uSN2iQkq7EMyVZy0UZr6llJFcOYDxkZmcaCopAGzXQvl7bloqU5llKzqIyYR7pcayPzILUppE3ZCJp/rSnqC8yPPJqEQDQ2KkcMPTmzyhTVeIzTyv1Zbxc+JdvN5QVbIsYl0zWl3Tmpv5L7shz+sHQ4HI4C+MNypKAxDhnhlhHKNOcQ1roMM7Dqh0dIXxRgMz3Nx1WLV2QEZCOiNFuTRFjO/2VtA9gzkKTdGuuVDDx+5qTsJNuNvtLUHy2PNceUm0qMaO0sYV0rCg8k59TIYEjRVGhNY4Tx+9xMaLu+29YUktnL8y1FnweD/g7Dieh1AH4vdHwtgFcy8wNt+timb9Y4HA5H3xADPCV/eRDRfgD+EMAaZn4SgGUATm5r0cQzS4fDMaro6zB8OYAdiOhXqEIXt7TtYOKnO2rahVYah+a8bjMVr0ldO9dHj9BCRrwip6mZLte2L0kaN/UNw2duuqCFtE++perx3NVVj5YGZtq/NcTNXTuZCN4mSFGS9N5T8z3sLwbe0qG8FXDJaWNa91rOJoh1WjJ8TqszXa5hbgZY8/l+THc8kDudPylqS7T2xwA2J4tmmXm2uw29FsCfA/gvAP/CzL/T1iZnlg6HY0RRzCw35+aGE9HuAE4AsArAzwF8moh+l5k/2saaiX1YagGFnro2MTggAj+5/krqMUv0yHEl36U4Qj0FTSaaK2zLSntJWYQVFJAVLlP5OFnPu0cWLTMdVLI4qaQOAFP7zvYsS3+n/eeCJqlNKjMTrFcelwbJqrT7yJJMq++vAnm9iJIaP/K8aDZZyfmaVKHFHEtEYqZm+qWUDvRxGP5sADcy888AgIguAvAMAP6wdDgc446+RsN/AuAIIlqBahh+DBYgwTlxD8sn7ApsOHLeXxRTKYDexOzpAkZppdzk/I8yFSMnoSbFEax+Vyt9WL4nTdzDYma1kEayLJc2k+4n3U76ga3EfACYCz7LyDDrvhQHamlFzq5+Qtu6jruRDiTt0pCrOyRrss+K+6kr+T18WiLM2hTYOtUpnttMupEURukRTsn4gS3/uGVTf4hl/6Y7MvNVRHQhKvO2APg2FlDifOIelg6HY1zQv2g4M78VwFsX08fERcMPfATxW1bmo8gRMiKpSbg1MZoSIVnJJnJTC2W/JcK+cn8pSqLf6XKg199YMp6xShJEX+uaZAdT4XuUxFu7rruvWioP88evTYWUdjeha7JBtFdcE3mtND9qU51w7Z5pynbQ/NiWwHHtZ04uTE6eT6JUCEQ7X+tuA6b6Iv57AHc6ry1qS/S/hiL+O9SkdCI6joh+SETXE9Gbw7J9iegKIvocEe0Ulq0jomuJ6Boi+hoRHZr0cRoR/Sj8nZYsv5KIDhrm8TgcjkEh+ixL/oaDoTFLIloG4D8APAfAJgBXAzgFwCsAbADwGAD7MfN6ItqFmX8RtnsRgD9g5uOIaA9UL9Q1qM7mHIApZr6biK4EcDoz35SzYy8iPjH5nb5prYitjDqmjMBieLKeOKBLZwG2YG1qg8VgtVracttcRLhH5FfY1KYEgpximKJHAk7YlLLTOZ4TrSqcu09FVlIWGn1uFrvN5RHmyoVISIZv+RZT5HzdTf3n/MCyLV9cLZl6UbVEO6dyVJQbFVijCwnNpum9gQ/u1w9muT93OmcVtSU6e6tjlk8DcD0z38DMDwL4JKrcp2WYf0UQAMQHZcCOqB6MAHAsgMuY+S5mvhvAZQCOC+vuAvDQwI/C4XAMAaPHLIcZ4NkPwM3J700Ang7g3aiY5T0AXh5XEtGZAF4PYFsAR2f62A8AmLsIo8PhGHtMrvivRsuZmX8M4FnKinMAnENELwfwpwBOs/po3DHRBgD1w3QW+lCyZ1pg+JT6genwzXKcy3rc6fZNCdSaqpGWYpO21QIM1nA/3e+0MSyrAzLGflPIoXqq9xn7awqMqGOot4XL/dbqEq/dGKxMIherO9XRxjSgkqCZ5W6R6TTpuoh4nqIrYGPUxswE8mQqkeY6aarDlKseuTYMv+Wwvyso16BQn0tNsrRaU9RpabcBNz14I4jovmT1Rcx8qrJZBqMn/jvMYfgmAAckv/dH2WT2TwJ48WL6YOZTmXlHZt6xzFSHw7FQrFq1CvH/Lfy1fFAGPPxw2d+QMExmeTWAg4loFYCfopJIernWkIgOZuYfhZ/PBxC/XwrgL8JcTwB4LoCzF2KM5kgvca5L1Mm8goGlb1rZT1PKTUl1wQiZ7J22LYGljZjrSzKlnCK4ZJCWuEcX3hbSmqfFngKjjIGMtD8J2b/G2OT51yYh9Iwu4qdg5FoAzJpAoDHMnHJ5ulx+T23LTbVdY7TR2OK0aGOlraXHnLLyvlR3ZB7qg7AEQ3tYMvMWIjoL1QNvGYDzmPk6o/lZRPRsAL8CcDeqITiY+S4i+jNUD14AeDsz3zVg0x0Ox1JgxB6WE5eUviMRH4K89JglUKD5AheSXpFLTpYoTRDWUqBK5NHkeWiSqdNssiTb0n7rdYZtqWJ9dElGv+Cs8AvmhDSa9pMi54NrgvTjaQnalsK+5qddjA11H8Lnql0zS5glJz9o7c9q25ek9NV7c+erryhqSzu9eyipQz7d0eFwjCZ4tJjlxD0sV6B6u2qRYclSrEhtjk1KdprziUbmYdX3BpoFabUoaum0SmCeYdTR5Nv0tlpU3xKz1fxf1jk9d6b6jLWAuuwO/Z0bkq61qK8UxYjrcnWOehLvxe8uG2D3AyT+RyXpvSfRPDc1VUxRLEl278koiAzc3tQUZmkzZTVC22Ya7rN0OByO4cIflkuLzejOs0x9TZLZdcRnRBqBleKpbeomy7e85sO0pjPKaYo5BitzA7vyCKU/VtigTee0xGw1NDEWjVHWtsXPwChroeC0jZFfGZETGrGQ8zNblSFzy0rKk0RoeaFpH0BvDqyVZVFim1aN1Nreyr+U9vUFDH9YOhwORzN8GD4y0KKlpUXBNFEG2Ufu7WvlxWmzZUxBiwybk6gZckE5AzlLSTJMrY11DjTICHQuCtsT7UX3frW2kknmZptY/rqsn9mwTZvB0yYrQeZ4WseerqvPpSEu3GUf9HW562sds3bd0+vaF/FfZuBXkzvd0eFwOMrhzNLhcDgawBjP1CEiOhDAwcz8r0S0A4DlzHzvYE0bLGTdkhT1sMlI2NWGRHL6GJTflniBnFaWDolqsQdhS06UwRrqasMza9gHsVzTkIyQgSktTSfaYiX+54JaMb0o1kjKBY2sKoYlgiZaOpm8NtZ5mlXsb6rJnqIpo1pzDdT7NlKGtBQ0bZ2EFZAqmXzQt9ShEfRZNgppENGrAVwI4NywaH8Anx2gTQ6HwzGWQhpnohLuvQoAmPlHRPTIgVo1QMTqjrVytyEGALSrldmUNK7BenPnVL2t36k6uWQalmRb1z7F8p4EZOVA6sBRJgHcsrfej0hoT/uNiIwyx4bkND7ZryZ0YU131FKHrGCfmu4Vlk0bDDZCS94vCYDJ/WRl7kQ/8jrLa5i2sabnyrpHAOalBNHHAM+IMcuSh+V/M/ODRNVUTyJajgINSYfD4VgwGMCW8YuGf5mI3gJgByJ6DoA/APD5wZo1ONx3X8WSNNFTWSdmIakxdV/hM2VJkqXIhPaSVJPIIGWNa63mtWQeGsOxWFZPZUglKd1ijVolwromUWwbJc6UdBcrZUVLA+pZJ1KrpNxYapOVfK35mS3Jt42CVWtt5f4037HFJLVRgZzSaQmyaEyzpC65RLSpxwer3BP9AwMPjRazLBH/fTOAnwG4FsBaAF9ApVzucDgcg0GcwTNOPktmfhjAB8Pf2GPzluqtqvmrmkRVNbbYI74RPjVGEyEZpWSaXcxGym4JBqkx5GhD9NutEz7M3DHXNor12jZW9LWrqmBcJuyWmQCaHRazz/kuLZ9cF/MT/SzGN53LSpAyaBFaW2v0olWnlG2skYiWKB/7afJR55DLruhrNHxcUoeI6FpkfJPM/OSBWORwOBzAWAV4Ynz1zPC5IXz+DoD7B2bRkJATG7Dy7jQGIiXGcnmQkn02MQOgd4qiVctcYx5SZENra9mUK01hsWkNlg8uJ30mfXA9EnZK5D/aZIkZtxHU0KK8jWUftDzO+Cn8zJp/0hScFqOQFCXTEHv6j1Jwwldcwq5L8zgXpfobwTw+AZ5QdRFE9Exmfmay6s1E9G8A3j5o4xwOxwRjjJhlxI5E9BvM/DUAIKJnABj7Kom5EhGSUUbWoDHBtTPdbSW0t7z0WU0bEe60X8lUS8oCyD40iTbLbmuWETAvxktBOq2pzAQw73uVx6j5LK0yG/X5T/qwzoPMWbVyAjVoTL8pz1UrTBcZsYz4a77SuG7tuupz3UxoK+49oPma50YsdeljwbhL7lMJayZb3/IsRywaXvKwPAPAeUS0a/j9cwCvGphFDofDAYwfs2TmOQBPIaJdUBU4u2fwZjkcjonGCM7gaazuSET/R1vOzGPps9yLiE9MfufSgCJy6S1yXS4YJLeJyA1jraFQbjpc05S5tH8ZfGgzhc6qnzOtBDssEYaSaX09ie0F7gpLmxToHcbm+i+9Vul00zg1NFcHCCirgqlNB7WuSe78SMiUNDXNyNhWO570vFA/qjsesgt3PvS0orZ05OUjU93xvuT79qii5N8fjDkOh8OBkYyGt64bTkTbAbiYmY8djEmDRawbLt+sgM0oZeW9XBqKFLbQWEpueh2Qf8svhJH1pCopLEimqDRJkqX9l2zT1DY33VEuL6EQbdKZIjT7G1OGlOVScKKE4VupQxpksMwSSsnVl5Jt0ntaq8+e7kfamva/Gn1ilo/fmTt/f3hRWzrmq0NhliXTHSVWAHhMvw1xOByOGtFn2afpjkS0GxFdSEQ/IKLvE9GvtzWpcRguZvIsA7AXgD9ru6NRwf2o3pCaDJuV5Bvf4Nqry3oLR2jbSJYlxW21+tJSPi7nI5WJ3zJVJRUMsVKE2kzxjGhTnbIkUd7aNt2vFG9uqh9jLdO2sZZp6OpfpisZohXpvSHrqkt0CYGE6ydFMXKTHWTKmRSV7vJji2myEfJcaP23mTraiP4GeN4P4IvMfBIRbYuK9LVCic8yGbRhC4DbmXm0nAkOh2PrAqNveZYhk+dZAE4HAGZ+EMCDrfspiIZvYOZTm5aNC4io64BzPjnLT5jbPhc9bZLq0mp0RzT5BUsEa0sEHJqSr7V919sq9jfJ28nEf7l9ipIpf9byEgk4zRYrol3COEt9l1q/uawEy7ceUdJ/ThA6oknco6ttcs364rM8eEfuvO8JRW3phXM/BrA5NYeZa/OJ6DBUh/PvAJ6CSuvjtcycBq8bUcIsn9hlWCX+25ckfYfD4VDRLs9yc0OAZzmqZ/1rmPkqIno/KunJ/93GpJzq0NkAoujvL+JiVPQ1F2wcaawAcAh0RmBNLYzIyaFZsmUpar+UlF2LyzMsQvq55DS/1FbpA5W+RM3GnpIB1kHAZsi5CK7FxOpzrmzblOcH2GK2lj8yZ5Nmi+XrK/HNNeUrptdZtpHXVStB0QZNgsrp+amZo5SWy/jnU/v7xqT657PcBGATM18Vfl+I6mHZCmY0nJn/kpl3BvBuZt4l/O3MzHsy89kLs9nhcDgK0adoODPfBuBmInp8WHQMqiF5K+SY5SHM/AMAnyainhczMzcFCB0Oh2Nh6P90x9cA+FiIhN8A4JVtO8j5LF+PivG/V1nHAI5uu7NRwApUw5/awZ1x5sthJs9Un1FpKIV0mGhBnDq9IqyMQ7tYBbBWOFfslsNAGQRJh4Vx+B0h02k0SBfAXOgjTmVMp/PJVCo5jG2jjZir21OSAF46nTJnQ4/6eXKssgqoNezXqmtKyJQuLZF91hh+a9fOCvS0GbprQZu6RryRoqQFhyxVqUWhj6pDzHwNFlkqKKdnGc/F85j5gXQdEW2/mJ06HA5HFiM43bEkGv519L7YtGVjgfshasSk07zCZ4/advg8d33YJtnemj7WuU1fD8xrFkoGmGMETYEFLVhgpenkUnAiQ4iMsg4sJYzBCnxpaJrGx0Ebc+pF8zyr1g8tSOaOsAIXuXPak8Qdf3fstpL51aOD9PwYAbVsorw41ri/9XujB7lAWrqtdu9ZKUlpnzEZXd57OfSVUUaMUQ2evQHshyoafjjm1eJ3wQKy3x0Oh6MYIyjRlmOWx6LKeN8fwF8ly+9FlVI0lojTHSNUn6JYJ9++2URe4dfRomCzM9WnZLKaf03WkoFgmJIVpcvq/YlUpVxkTjIEjYVK1tMRNmn9S5YVjydllLJthOVDTtdZqUltpt/lrqs1tRDiuIBeJtYkH5dC2q+xuiZRFclsU8ipjJrEnDYVOLffdNnqvftYBnZcHpbMfAGAC4joJcz8mSHa5HA4Jh1jxiwBAMz8GSJ6PqqZPNsny8dS/DcmpWs+tCYWokX8pHAsCnw3FvvRxAhiVDr6S0vk0CQDyAqBiN+adJ20uWYWkWlnpmlavsrcFEyLaZfkqlmR25jJAMyfSysLQaunE/2n0m86K9ppKGGUlp9RWx77iZMPMIMuaD7NehQjrqu8RwA7ZGxlAqR24jZgaj+jg7YYt4clEa1H9Yz5TQAfAnASgG8N2C6HwzHJYAZ+NX7R8Gcw85OJ6LvM/DYiei+AiwZt2KAQ8yzVt2NgVWtENLD2D0ah3GSb2udj+AO1aWTrbtPbatFeGTGX0BimZAZyiqQmAVeXMRDHXuJHtYSDNRua+gLssg9p/mO9vTEc6MnVnJ7nZrMzs13rSqaD9uRxZs5liQCL7LNmeEJoWk45TLeLGQvWPZe7JyK0a2bZv/E2fX3az3S/fJaM8WOWAP4rfN5PRPsCuBPAqsGZ5HA4HDw+qUMJLiGi3QC8G9VLhdHHgNewsRnVm1KTQ5OiqpJp5OpJS8hIetqfhZzPtKnoVbqtKfqQ2X9PBNoQU0htkD5LLbe0J59P9BWPK92/9I3VAiRC+Djtt95fr7kAANp3fk2PnFtmdk70dUaGb0WaVaEOMUNL2qjNipoV96CW7WDdc9I/3IbhqxkGC8jAWDfJPktmjqronyGiS1AFeQ4ZqFUOh2OyMabD8BrM/N8A/puIPg3g0YMxyeFwOMZzuqOGRakgF++E6DhUtTOWAfgQM7+DiPYA8CkABwG4CcBvM/PdRHQUgNOZ+fQ2+9CGvmaAIbO9DM5sFOuB3oqPbVS3I2RbuX+gd+grE+TT4Z+VSiLFN9IAjFT+juerIwJkQO/QVqvTI7FR2C+RUw23Um9yepZ1eo5iUwyi1OfdOA51CqZMYBc2alMELZfP+sz5r+/TYIQcyqfbRJQk668Tx5rTDE2DfXMFfTeCua9CGv3AQqo7AvMFzAYGIloG4BwAzwNwKIBTiOhQVKKdlzPzwQAuxwJEPB0Oxxigj9Ud+4Hc3PDPQ38oEoA9B2bRPJ4G4HpmviHY80kAJ4S/o0KbCwBcCeBNqBTc72nqNCala8ymKdVDU0rviM+Y3qKlEsV0EJncXqftrOlenu5LVpGUtmrMxmIPWUYjfueUzGUbGSADes+zVGIvqZNtBRq6+m34XaJuX1JjSQY5pKBGaqd5LpX9yH5k0r5W/VLWs69rwKO7j9QGCU0OT46SrDpEKYtPK1r2h1lirHyW71ngun5hPwA3J783AXg6gEcx860AwMy3EtEjw/evo1JDcjgcY48xSh1i5i8P0xAFml90QcN/ItoA4ESgcn4CZWKqTYm8aZtawisz3TGyJ1mPuWZVHXu/Mk0nYnWGbdVtxO9c7Re5XFtv+QXr3wqjsdJatETwHuZV4D+VyDHXJqanMWPpt+tJHWoxUtF81DVbVNKvgG7mWt8LYmRSIqUmkbtvJIuWSfzWaOPGG28EEaWVEy9aUDXYMWKWS41NAA5Ifu8P4BYAtxPRPoFV7gPgjqaOwoU6FQB2FKVwHQ5Hf7Fq1SrceeedOy6qEwYe2jJa/6qj/LC8GsDBRLQKwE8BnAzg5QD2AHAagHeEz88tZicac8qVPOhpK/xpkkVo0leWCEaTqKvWVvMf1ftGdxsNmh9Wg+bzk33ktpP25phfTASX0/lq/5rG4hqYqzY1z2JVGxUWak3104Q05LWw6sFbUoEppN8wtQli3bSxPu1fignn7jlLWi6X9N6vpHRm4OGHFt9PPzGyD0tm3kJEZwG4FNXo+Txmvo6I3gHgH4noDAA/AfDSpbTT4XAMBg+PFrEsUh26DMBLmfnn4ffuAD7JzMcO2DYw8xcAfEEsuxNVKcsFIYr/1lFGpY2VnxiRq7sdUeffKeUYenIljfzLdBspZmCJWGj2SxaXMhwZTbcY5nTCkKMMnWSYmg+wxwZ026uxlDi1sKf2d8Y3V4vyinPZxJi7+he2dfUv2kRo002jdFqUgpP+TW0U0JS3ybfMb7U2TN20ph/mSlFYtpSMHHKiwjk/5kIwgsHwIma5Mj4oASAkgD9ycCY5HI6Jx5gOwx8mokcz808AgIgOxBCS0h0Ox2Rj1JglMeefe2HK4SyAmEr0LADTzHzpgG0bCHYkYksFxJp+WKJ3aPWVomcIZwxdNAWYJrUhbRjVRqcxl3Cc9qntu16eGf5ZyAWfZGBEGx7L4WrJNL6cyry0qal+t1qpUWwrkau+KK+dqnRlBLNy02YtV4xmS4kav9xPGiicm5pCp9NZ1JTowx9FfMUpZW33eD/mmLmNx2VBKFEd+iIRrQZwBKrcx9cx8+ZBG+ZwOCYXY+WzJKJDmPkH4UEJVDmOAPDoMCwv0X0YWeSSrXtqTmfYkWQRsp6OFuyI6yzBDm06pcXmZLsUFqNMj10yGBnkqKdbKv3Lc9jGuV9SQ6hJ/xPorYVekmgu7cxVX2xTGydCipxYQa4U8vrlahTJRHkraKMGqgQb1YJBHeP8WKIxQPf57ovKzpj5LF+P6ry/V1nHAI4eiEUOh2PiwRij1CFmji+o5zHzA+k6Itp+oFYNELEGj8ZsJIuLqSpyClqXKrmxH5nWoa3rSaMRy1NYYhJN/rG0jWaLlPWS/rBcGo08TxqzbFLmLvHtym1yFSEtZt9GqEOzxWKJ2vmxzktOKi8Kr0RIxp/6g+XUSskwczVyetLijMkUQH5EIm1KK2VOKX21xuhVwi2SaNPEKVywwuFwDAzMwJZflf0NCzmf5d6olH92IKLDMe+K2AUVQdsqoDGb+s0fXsNS+CJ9o85m3sxAXrS1JPLcMyUy2iaEdkuENCKr6LJfJMJbkfmcn60jGE1OXNhKTm8jMacl4EvmJ32tueqROf+g7NeauqgKQxvTAusk8oxUnpxemV4XOe1T3hN1PZ+kX8u/qZ3jJjHqNtdqMRibYTiAYwGcjkrA4r2Yf1j+AsBbBmuWw+GYZIxVNJyZLwBwARG9hJk/M0SbBopY3THHOCIkK4ooEcKV0/nSfa2WTExsm0M9Pe2S7t8WswV62VBJdF/uL9e/hMaYLP9s1qdbIEBh5apKRqhNkZT+R206pTwfVgaDBrlOCjlr+5G+0Fwuppw+W48yAsNMr4Ms/TErRiS53GFrdLFRubdLMhiKMKY+y6lQChdANTeciP7v4ExyOByOKnWo5G9YKJnB821mPlws28jMJRNZRg4U9Cxz/ikr707z4VizTHIRyTazcaaFb7KHoSlFwiRys1CsPNGePjK+VwmtrrcVMc/NgLHYW84/ZvkH0z6i0IUU7Kh9uorPVV5neV3UTAPDxtysmbosSViwdrbqmV40f2R1wbPQdirsKAp3aCMH656T+89B/l9Y0fZ+zOB50p7EnymU6jnkEyMygwfAMiLaLpTBBRHtAGC7wZrlcDgmGTEaPkooeVh+FMDlRPRhVH7XV6EqFOZwOByDQZ99lqFabAfAT5n5BU3t1T6ahuFhR89DpSFJAP5lXEU0AGAvIj4R+pBXDkUsgYLckKsksVzW9ZZI7bBs0Gp0Q7QtEeqwUHLMESXOfStQpA3/5T5nRVCiJNhkBdxSlIzbLHvlem06peVO0Nwx8jyUaKjK6yvdCFoVT8uloQU6ZWK8dPlYLqapPgzDn7g78cd/s6ztYf/UPAwnotejOvxdFvqwLFJKZ+Z/BvDPC9mBw+FwtAX3kVkS0f4Ang/gz1FN415YPwUBniMA/C2AJwDYFlWJh/uYeZeF7nQpEQM8uRrgVlBCE2mwAiNa21K2VqJaLW3UarRIRqahKegk26UoYd4WQ8oxJ+v8WCIZaVvJcttEIedmqs+1M3Ybawpjer6aAoMloiRNUw1L2uSuQ47JlgbWtG0AgPrALA/djXjDs8rarvk8fowqKzBilpnr24SILgTwlwB2BvCGQTLLD6AqFvZpVOfvFQAet5CdORwORwlaFizbbA3DiegFAO5g5jkiOmoxNpUOw68nomXM/BCADxPR2M4NXwHgkOR3jiXWAhqCrZQIpeaSfUsEZKVNad3o1BZeV33OzsyvqyW0hG9JS9+RUyB76mHHRHpl3xZyPlGr7lAKK9VJ8w9KWzaKa6Qds+Xri9UkU1iJ5Llr1jRdUNu2ZJRh9WPtP0WPsIhoq0m1RZEVrTaUtZ+N6JOQBoAt/cmhfCaAFxHR8QC2B7ALEX2UmX+3bUclD8v7iWhbANcQ0bsA3ApgcTWBHQ6HI4N+lcJl5rMBnA0AgVm+YSEPSqDsYXkqKj/lWQBeB+AAAC9ZyM7GBT3R2IxoQo94gUgqTrdtSrbW+rcEEGIfsra2/A70stx0v5KxSmbcZmqntBmYZycyai8ZpWZ/rB8uk61Tmyx5stpWTTbOEEjRbKntbdhG297yo+bk9CTjUyXyGiYqaNfl3IurHmdDcntu6mJ97YVsnzZlVKKfiuCjNt2xpKzEj8PX/wLwtsGa43A4HIMR/2XmKwFcudDtzWg4EV2LTBVHZn7yQne6lIjR8Ij0DStZVnyTSn9V2q5JWCFt2zTVT2OaTTmFmn9MMo0Y5Y3T+zRY0W8rVxMoK+nQJORbUm86d55yEVpr/1aUt6TUiLQhd3165PUEI9RyM2W/ufNjTVXVfKJWPfXcsVsF75qucz+i4Y/fmXh9ofPz6C8v/XTHBYXXHQ6HY7EYq+mOyfDb4XA4ho5RE/+duKT0WDc8l+RrTV3MJWbLPiI0VfU20yibggUarKFbblvLbq1mtxzvWInzOZTYIofqWqK5DAbFhPI2ykRNUw1zKDnWpmmPKUpcBNbU0aZprrn+NcjzIK/DIKc7HrwT8d88qazt8Vct/TA8wpPSHQ7HcDFmpXBrbG1J6Wugp0N0xGcuxUNCagzWibwZ1e014rPkLT8r3uoa89goggUyDShXIyenLC5hBT1SSJ3GmI4S03dWi/QUwK6RI21MEVOoYj+y9nUKyVxLhDmsFK5cYMS6ViUMtj4fynHEe0xWhIz9lYwcSqcuAr117q1zEdvO9S5eEMYudQielO5wOIYM5vH0WR4I4HZU/srXAdgVwN8x8/WDN6//iD7LCM2nGCFTMzQGklMhT/vIIZeS0dS/xkotpfeStnK/bXxa2hTGJoGO3DktFfmw+gHKWG+b9KgSyTrLpytHHymrl2w3p54v+8vVM7JsK0l5so61SdSjH6lDj11B/K5CZ99J146IzzKJij8AT0p3OBzDwDj5LInoBAD7M/M54fdVAPYKq9/IzBcOwb6BI8cm6jdrxn8kmZdkKSVyZRJdycSx3/gpfH+a/6oN05BTIa2pbRoD7/FtKYILHKbZrQ3T7KRtWlK9xWZLEthLZN3kPnOZBVL4oyOM07IFeqT+xPLV4YsWTS6ppimZdcloo24bhVFEZkbqx5ZTUa2RijXFtl9CGqM2DM8xyzeiioJHbAfgqaj8lR8GsFU8LB0Ox+ihn+K//ULuYbktM9+c/P4aM98J4E4iGvsAT8qUImqhBrFc5pXl/HhWLmX6XbK3uD/JaNN91jZd0m1DZJjpfizfmMxbTO21fmtM02IumhBurEoomaTcRqsIKVlvSd5giU8uwpriqQmNWCUt6nOtRPMtf7V2HNaIpE3OZ+7Y6/vIYNGp/7SuTR8+Ldbbxne8EIzNMBzA7ukPZj4r+bkXHA6HY0Bg7pueZd+Qe1heRUSvZuYPpguJaC2Abw3WrMGjRC6rRDRBMgvLn5dCMkrLH6lBsp9avDfxOUW/2rRgnVoOpWSDko3m2JzFAFNY0WhNyLdeJ5hZjtFH5tcRvsMcM5PXKluIThyk9PVFaGU9rOJyGjOXtsi+upYZvtsSxmflUGqCL5agtYY6h/QFwNpbMw0LwRivYfjrAHyWiF6O+fM2hcp3+eIB2+VwOCYZ4+SzZOY7ADyDiI4G8MSw+P8x8xVDsczhcEw0xslnCQAID8et5gG5cjkwvTKZ+pesk0PFjcbydCgj6/XkhAqsyoNxCLRGDJu7+jcU2OuhXjJ0l8PkEkGQujaLYoOElaBdD5uTIV1dx0gI/q0Wx6EF3OQQXZvCWFITRy6XqUIlkw56rpnYRksDWi+ua22LMoyWdrcR6JC2ajY1JbCX6InKwI+WjrXmEmCqD7lD4xYNdzgcjiXDOOVZbpW4f0vFRrSUGBksyEmDRVgyYutFX1o/9Rs6ky5SO9dlMrSwQ1MPtxz0WppLU1pUV6L5TPVp1dfWgh0yYd0KjKVtrGRxjcXJba1UpRTrxT3QUQJsU/HECvvr44q/lQDJrLgXZLXEnN25EYrFAnOBNsko5f2fm3RgTQftSlfLiGssBGMl/utwOBxLCR+GLzHuR3gDx7dnhmVtNBhlyYx9jY1ataxLxH/ltDqrDrTWj2ShueqIJccqK0rKVBWtrrf0P9bnOpPAbYkAp/bLujYl9bclo69TecLJTVmcVbeox94Mo6qPVaQOaSOIEvHf3FTR9HfJfVozTs0fHD9v05d3TctN2HnfUod8GO5wOBwNmOQADxERgPcDOB4VwTudmTeGdSejmov+EWb+67DsiwD2CTZ+FcCZzPwQEW0H4COocj7vBPAyZr6JiA4CcD4zH9XGLs3H0lTJT4v2ShaaEzOwWJzG1CRzzEVha5vEOslku1iWEOEtSURuYj9alNeqe56LJkuoYrOCUTZVMUztlMj5jJui7bmEbattm/rhKaysDWljTuqvJyNAyUZYJ0czxogoRacDYD9lRUswRi91aJsh7ut5AA4Of9MA/j5ZdzIqkY4jiGinsOy3mfkpAJ6EanrlS8PyMwDczcyPA/A+AO8cgu0Oh2OYCMyy5G9YGOYw/ARUzJEBfJOIdiOifZj5VgBRKJTjd2b+RWLjtpivYX4CgJnw/UIAHwis9SEAdzUZcT+634iaf60n5y22icwsebVvFMIWa4xt0jYQbeu+lHYWO5Q5mhrriv3nygF0DEZZIvPVY4vYNt3e8snlBI/r3yKanEar5RRRy3eZE6SQPsycdFpTnfIUsl67NU0x7Sd3LiPklNSeQmIFkemSPM6e8hsF/uXZ2wDqB7NkYMuWxffTTwyTWe4HIFUx2oR5wn4Rqvuww8z3xgZEdCmAOwDci3lJuLofZt4C4B4AezLzzcx84kCPwOFwDA2jxiyH+bDUZOYZAJj5AmY+nJnf27WS+VhUfsvtABzd1I+5Y6INRHQfEd3X3myHw9EGN954I+L/W/jb0LaPKKQxSg/Lxho8i+qc6EwArw4/rwZwBTN/Iqz7IYCjwjC8qZ/TADyVmc8KbHOGmb9BRMtRDXT34sIDkXXDtcTaJgUYLQBQgqbpaRpKUmEkcsEfIB/ssKbFaa6LNko5EnKbVKl7Vrg2csEVK3WoKckb6K3E2aaueoSVPgUA5waV+KkXNatSNt1rmmvAcpXkXCglep9SJankPo0TFaZm+lODZ18ifnVzMwDA2zGcGjwDZZbMfA4zH8bMhwH4LIBXUIUjANxjPSiJaCci2id8X44qgv6DsPpiAKeF7yehegCPWEaWw+FYLB4u/BsWhhng+QKqh971qOIsr8y03RHAxSFNaBkqIY/1Yd0/ANhARNejCuicvBBjVJYiUmssPpB7y0cnvlabRe5bimSUTIOzEpC1/i2GqW1j1bfRWJ1MUs7VkW5K06lFPy7pXSdZlcZsJPuRAa9c5UZZd1trY9mSu851oE4wylxyfY/mqNif1k/p8hTWlMh023gfSoaZu85xokK/wABGLL4zvIdlYH9nFra9HVUqkbbuAcynETkcjq0QjOGyxhJM7AwezXfTk4Ih2uSkqeS0sRIHSs1ABP3M1TKX4g+yr3Tf0t46TUpjgA1251hLTmjEmk4pGZ/G1mV61LRit1UvKedXbUqPKkkWh2K37D+iJ0UsI14hbdDYtOWHLWGW9f4yoxnJ9qVMnWZbeq/1rbpjn/rpFyb2YelwOEYb/rBcYqxA9RbMTUOUyNVptphYzlfZU49GsB9NrsxivZqNct+SjXb5H+M+hY2WFJnWf09dF4UxNUWTc+tK/L/SP2sxtbStde1ybC5Cyq4hYWhNMncyCV6zJVdLyLLbqlap2RBHM/L+AubPt2TnJQLFbbJDchjFYfgw8ywdDoejGP2KhhPRAUT0JSL6PhFdR0SvXYg9E8csN6NiDiVRRoshlAjtajl7FgOT/jyNbeX8gtJW6ausfWQxl1EpQRHRUxdbEViI/jrZVvOnSt9YSU5mk79XO/+Wj1ITlaj3LXy4MsKtQbL/dYrPT17HNgmAVn5oet4skY1cBF32s1GMUDSWa4mfyP0NAn2Ohm8B8MfMvJGIdgYwR0SXMfO/t+lk4h6WDodjPNCvYXjI5741fL+XiL6Patq0PyxzeMKuwIYjganp6j1JyuyKJlmunNBu3SYT5a1ZYGgTZz/UggvJNmaeYoEog9yvVo9cCkTI49H8uJHFyRrami1xn9LnWlSzW9imMTRr3z15nMq2tY3xS8ana9mm/ZbZB7liYBGWqHNk9uuTtvKalGQw1HnAov+I1GeZKx+Rbtsv/6SGlj7LlUTUVXmDmdUJR0HK8XAAV7W1aeIelg6HYzzQ4mG5uWS6Y5B//AyAP0pUzYrhD0uHwzFy6Hc0nIgegepB+TFmvmhBfUzatOoopJGDrHyXEy6whoq5tI2mGs65AJJELigUIYfamiiGDGr0BHoKbCpRGi8R6rC0I+N5SWuQ99Tkho6cTXLInqvLFJEbipYKi2g2yYCatn+ZJiWneJacUyu4mFsnJxJo9+n03sAH91u8kMZKIn5hYdvzG4Q0gt7tBQDuYuY/WqhNnjrkcDhGDjEaXvJXgGcCOBXA0UR0Tfg7vq1NE8cs9yLiE1EmiyaZRk66q02Cs9y2DeR+zp2pPucSGqZNYdO2BWz7coy1qcZ4bt9WPSAtaJZj6bJfyXZ7JhIoAYw2LC6i5Nit0YZkhClDjvXJpSCFFgCz+svZZAmyaPevZM1zt1R7mNp3tqdtRHofrr118cxyTyI+rrDtx4ck0eY+S4fDMXIYxRk8E8ssc/WYLYFUzb9nJTJr6S5NVSM1tEk8lvtu8nNq/Vk2duVlGInm0ocGlFeyLKm+GCXDUuGReN7lOWxi/Ok+cylKJQLEEpbPsoQp5/yCEfJYcxJ/0qYmf7lmZ0lVx4jV6I/47x5E/JzCtv/ozNLhcEwyRo1ZTtzD8n5Ub0zt7WiVOohMRvVZFiQcS0hGmZtGJiPAMfprVpPEfC3zorrhcZsWNkrpLnneclM85bQ7yV40O2uJNi2pXiTIy+PJMfwIaf8aZV3TVL/VynfJyErYnJRv06ZeSp+nPC/1uVWyBuK5XI9u5CY3NE21TdfNvgBY21gophkTLf7rcDgcpXCf5QggV7DMgoyapm9hq2xBzh9pTW/MbWMxNG3ao8UKc5FnKzq62HxCq99pwdo1Wbom4RENPdMFw2dXLXajH62tJTSS84m2yUNtgmZT9BnL6asW08yhJNpuXQeLjU71wWe5GxEfWdj2EvdZOhyOScUoMsuJe1iuXA5Mr9TZiRUFjNDepJY/R8p/pW1iLp1VtiKX59fz1i+IUMq+UtGEKF4bWYq0RStS1cM0DFtT9Jzb8FlHsxX/mozgaue6SVZPK9omxWzb+E9LjlXaPW0wwdy2sqhdCqtUsBQtKWHr2swhmW8q7d+o3HODENXwh6XD4XAUwB+WDofD0YBRjIZPXIAnJqVHlEzZa1ITB+z6Jzkxg6Za1Glbq0aLlvqTc8BbaAoKpalJuZo4Vr+5VCdAH+ZbaU0llRpLgmUlQT6ZgG8laOdcA5aKe67+vFXzPV1nBZm0QE+umqO02To/uYBeuq4fAZ6diYojNld6gMfhcEwyRm0YPnHM8sBHEL9lpS6aYDGYnMSZldIThQWkMIKG3HQyq+62NX0tbSMTm0uSoq1pgzlYTArotdtiyCW2lASbSgJdHSPgUpIm1Sb9p2kKqbZvayKBdk80TT8subdLUsLkNF+Nuab341yfmOVhhW2/5szS4XBMKkYxdWjimCURNR5wE5tL0UauzJITy7GjyILq6Wpxv5kEbUvQt0SQ2BIGSVleiYAvxDprvzmhWivJuoSZ5VJ7rGuWu74RbUSe623ENYxow9o1ti5hCRSn+5L9aX7tJv+1nFCQ9tOvpPSdiPjXCtt+05mlw+GYVIxiNHziHpYrAZwIm0EBdtJyRMoILEYZt4lTG4F5/6UUk8j1byUyy7rPXdPhDFEJjQ3xxdXezp2urJC+XDWpW1mW9q8J7co2khmr/jWRnK4laks6EffN66rPc9f32mFlI7SZhtimOmJkYLkRhDzfcnSQskmrbVNVxq59C8EO7fxIO2vGKSYwpDb1s5b4qA3DJ+5h6XA4Rh/usxwBRCGNWcWPZEW2JTPTCmYtZLqXJTKhMSfJhNuIt7YRDZF9ROTKPkjbchHukuJabfIgrayAnC+5SagjJ0qSy4yQsOzW9tMUbU+Zq7wHSoqpWVN5c1NIreusReHT7fsh/ruCiA8ubPtd91k6HI5JxSgyS39YOhyOkYQHeEYEmtNdDn1qFe7wu1a8zih2y4BFrqqgHE5lE4WNoZc2FJNug3qoKqYYpjZZ0JSK6gCYGJblxkGxn05otPoS3cb0u5U2pQ195dBzIdNYczqZEfGYO2L4mvZlBUislDRtXUR9nRXXgOVq0JbLayWvu6a0VP+OX8Ty3OSDxcKZpcPhcBRi1B6WEx/g0aZsyVSMXAKyVY0vl3Ijq/HlnO3SNgktbaQpqbhkimGuCmCTvSXJ+9KWVM/SqimTS6SOiP3Iukk5jdAcrGDT3Ez1qU1nLZnS2QQrJQqwg3y5yp8lAiMRTWlMTXWN+pGUvh0R71/Y9gYP8DgcjkmGM8slhqwbrkGyCJlmVOKX0d7gFrsqYTrSFuk31epuW4wglwxdUoOnx7crbEhZolT1LjnmkjrY0pbcVD8JeV7a1G2X0I7HSkmqbcsIYFgsUUsnsypyasxPq9WUtsnZb8GSH+xH6tB2RKy42FX8xJmlw+GYVPh0xxFArBseYfldUsg62VK4Fuhlb7FNWlfcEvKV0FhczRpiNUR026RJeFnMSWMOJX7NCMlGe1hjKjortm1ipcA8oyxJ2q8Zd8bedD9Ab8R5MTJ0JUndks2VMMp6uYi+a/20yQCwkLNfQstgSLedWoQdER4NdzgcjkL4w3JEoLE7+Xa33twlb/mcX8rys+Wm/lnQfIo9uZ6iXy2n0fJd5iKrEVapCAB1bl5TDXAtj1MyZM3vtlp8yimpkaVGMWYAmE2+a9B8cfJ+2SiOKzftsURcYo34zAm91PfhC7qXS596yrZjfmtk/dKP2lHOaYSVf7w+WdbvPEvAH5YOh8PRiFEchk9cNDyK/5YI1pYUp9IEOWSbiCaBCy33sylnr0SEVorpSltTGyTjKBEXzvnKSnygaTvAnhmk1fW2BDly19eaLaPNxikV0NCk+Jrun5x4iFyey0Ntg5gfuname3nJ/SPPv5bv2i/x3+VEvHNh2597NNzhcEwqPBrucDgchRi1YfjQHpZEdAiAD6MaWfwJM78nWXcygDcC+Agz/3VYNgXgfAA7APgCgNcyMxPRdgA+gipD4U4AL2Pmm4joIADnM/NROTsevRx4y8r5IaSVWAtkap0kw0BL5KGkel6PGIbifJfiGx3xW7NRBj0iNPEQa5icS6+xxB60AI8MNsn9aEn21jYbxfq0jQzo5JK65bbx/GuBqtXGPSCRTnusU6iMIF+9Xknet5C6TpomEuSS0imxM+1LSz2L0IJwsv86ZQ79wSj6LLcZ4r7uAvCHAN6jrDsZwFMBHEFEO4Vlf4/qWh4c/o4Ly88AcDczPw7A+wC8c5BGOxyOpcHDhX8lIKLjiOiHRHQ9Eb15IfYMPcBDRDMAfimY5edQlcb5KKoH5E4AvsTMh4T1pwA4ipnXEtGlAGaY+RtEtBxVcspeAPYH8H5mPjG3/yik0aYSYUQJW8z1aQVr2vTbJnk8V9vHskkGgXJBj3obYzlgT13MBa7aqIavWaP3X6KyXhKcazqH2n7M1LBMYKxJ/CSHhdQEt6o9AvbIIaZfRXZq3U/9qBtORFw67N3SEOAhomUA/gPAcwBsAnA1gFOY+d/b2DRMZpnDRaiueYeZ7wWwH6qDitgUliF83gwAzLwFwD0A9mTmm5selA6HY3ywpfCvAE8DcD0z38DMDwL4JIAT2tozEsxSafNUAH/JzM8Ov48E8EZmfiERXQfgWGbeFNb9J4CnMfOdmf42oGKu2GabbVYcfvjhfTueUcGNN96IVatWLbUZA8HWemxb63F9+9vfxsMPP3x/sugiZj61TR9E9EVUxVhLsD2AB5Lfs8xcD3SI6CQAxzHz74XfpwJ4OjOf1camgQZ4iOhMAK8OP49n5lsKN92EalgdsT+AW5J1BwDYFIbhu6Lyh5oIF+rUYNN9nU5nx0I7xgZEdN+dd9651R0XsPUe29Z8XMy8qONi5uOaWxVDcwm0ZokDHYYz8znMfFj4K31QgplvBXAvER1BRATgFQA+F1ZfDOC08P0kAFfwpGXWOxyONogEKyIlX8UY2jCciPZG5ZfcBVUQ65cADmXmXxjt12A+deifAbwmpA5tD2ADgMNRMcqTmfmGFnYs+q03ithajwvYeo/Nj2s4CCPQ/wBwDICfogrwvJyZr2vTz9DyLJn5NnQPrZvadwA8SVn+AICXLsKUixax7Shjaz0uYOs9Nj+uIYCZtxDRWQAuBbAMwHltH5TABM4NdzgcjoVgVFKHHA6HY6ThD0uHw+EowNg/LInoPCK6g4i+lyzbl4iuIKLPxemTRLQdEX0qTHe6Kswlj+1PI6Ifhb/TkuVXpu2GCW16lnFc64joWiK6hoi+RkSHJn2M3HFZMI53DyK6LNh/GRHtHpYfRUTnL5Gd2xPRt4joO0R0HRG9LSyfIaKfhutwDREdH5ZvS0QfDtfoO0R0VNLXUUTUIaJ3Jcv+IbT7LhFdmFxnIqK/Cefnu0S0OtnmpiEdfhfG5Zr1Dcw81n8AnoVq5tX3kmXvAPBEAC8EsC4s+wMA68P3kwF8KnzfA8AN4XP38H33sO5KAActwTEtA/CfAB4DYFsA3wFwqHFcuyTbvQjAF0f1uBZwvO8C8ObQ5s0A3hm+H4VKNGUpbCUAO4XvjwBwFYAjAMwAeIPS/kwAHw7fHwlgDsA24fenUGV7vBfAIcr1/Kvk+I9HlRVCYX9XJe1u8ms2+L+xZ5bM/BX0JqUvw/w8+5iQegKAC8L3CwEcE3I4jwVwGTPfxcx3A7gM86IddwF4aIDmW7CmZ/UcF3enXu2I+WTbUTwuC9bxptfsAgAvDt8fRDXNdejgCr8MPx8R/nJR0kMBXB62vQPAzzE/5XsbzAvsdF3PcG/ukPR9AipVLmbmbwLYjYj2Cet+tvgja42xuWb9wtg/LA18AMC5ANahEucAjDnl6fKAeh46M5/IzOm6YcGySTsuENGZYdrnu1ApO+X6WMrjsmDZ+iiuJiggfD4yfP86M7926FYGENEyIroGwB2oXkhXhVVnhSHyeXH4iYpxnUBEy4loFSppwZgg/SEAX0fFNL+f9P9hVAIxhwD427A4dz2f2u9jLMBYXbN+YKt8WDLzj5n5Wcz8Qq6EOQB7ylNfpkL1GapNxnGBq5lSjwXwJgB/mutjALb2A+NkK5j5IWY+DFXe8NOI6EmoJAUfC+AwALeiGloDwHmoHiQdAH+N6uG4JfRzKTOvZuY/Fv2/EsC+AL4P4GVh8aido1GzZ+DYKh+WBuopT9Q9p7wvU6H6jIXa9EnMD3tG8bgsWLbeHoea4fOOJbDNBDP/HJX/9zhmvj08RB8G8EFUw1Qw8xZmfh1XU35PALAbgB8V9P0QKp/mS8KiUbueY3nNFoNJelhac8ovBfBcIto9DJ2eG5YtJa4GcDARrSKibVEFpC7WGhLRwcnP52P+H3EUj8uCdbzpNTsN8/oASwYi2ouIdgvfdwDwbAA/SPyHAPBbAL4X2qwgoh3D9+cA2MKGjmKIeD8ufkcVyPtBWH0xgFeENkcAuCcOd5cIY3PN+oaljjAt9g/AJ1ANe36F6m13htFuewCfBnA9gG8BeEyy7lVh+fUAXrnUxxRsOh7VfNb/RFWGw2r3fgDXAbgGwJcAPHGUj6vN8aLyKV+O6gVwOYA9RsDOJwP4NoDvonog/p+wfAOAa8PyiwHsE5YfBOCHqIbU/wrgwEzf2wD4t9DP9wB8DCE6jmrYe044P9cCWDMC52Isrlm//ny6o8PhcBRgkobhDofDsWD4w9LhcDgK4A9Lh8PhKIA/LB0Oh6MA/rB0OByOAvjD0uFwOArgD8sJAhE9iog+TkQ3ENEcEX2DiH6rYZuDKJG/a7m/04lo3+T3hyiRkGvY9igiumQh+y3sf18iujB8PyxKqrXsY4aI3tB/6xyjCH9YTgjCjJDPAvgKMz+GmadQzboorou0AJyOao4zAICZf4+N2SvDBjPfwswnhZ+HoUqwdjhM+MNycnA0gAeZeX1cwJUwx98CNYP8KhFtDH/PkB3k2hDRGxOB23dQVdh+DYCPUSWGuwNVosNrQvvjQh/fIaLLSw+CiE4J+/keEb0zWf5LIvrz0N83iehRYfljw++riejtRPTL5Fi+F6bqvR3Ay4KdL5OMMbQ7KHz/E6oEb/8VwOOTNo8loi8Gxv5VIjqk9JgcY4KlnkLkf8P5QyXd9r7M+hUAtg/fDwbQCd8PQhBWzrR5Hio1nRXh9x7h80ok0/LibwB7oZL3WpW2F/YcBeASsWxfAD8J2y8HcAWAF4d1DOCF4fu7APxp+H4JgFPC93UAfqkc1+kAPpDsZwaJkC+qqYcHoZJXuzach11QTSN9Q2hzOYCDw/eno9IeWPLr7n/9+xtaKVzHaIGIzgHwG6jY5lNRidh+gIgOQyUM/D+Uzaw2z0alBn4/ADCzFGOWOAKVO+DGwvYRTwVwJTP/LBzDx1Ap5X8Wlbhs9HHOAXhO+P7rmFdi+jiA9xTuS8ORAP4pHicRXRw+dwLwDACfrrwdAIDtFrEfxwjCH5aTg+swL/cFZj6TiFai0lkEgNcBuB3AU1C5Zx5Q+rDaENppGbZtn25n4VccaB2qB/li7u0t6HZRbZ981+zeBsDPudK4dGylcJ/l5OAKANsT0e8ny1Yk33cFcCtXeoynoiphIWG1+RcAryKiFUBVtCosvxfAzko/3wDwP6lSDk/bN+GqsN1KIloG4BQAX27Y5puYf0mcbLSRdt6Eqq4TqCoMtios/wqA3wr+151RSaiBq1IQNxLRS8M2RERPKTwmx5jAH5YTgsC6XozqYXMjEX0LVY2UN4UmfwfgNCL6Jqrh9X1KN2obZv4iKlmyDlXlFmJw5HwA62OAJ7HlZwCmAVxERN9BJXKr4Rgi2hT/UPkNz0YlRfcdABuZuUkv8Y8AvD4c7z7Q68B8CcChMcAD4DMA9gjH8vuoZMjAzBuDrdeENl9N+vgdAGeE47kOVS0ax1YEl2hzbNUIbPe/mJmJ6GRUwR5/kDlaw32Wjq0dU6iCUoSqsuKrltYcx7jCmaXD4XAUwH2WDofDUQB/WDocDkcB/GHpcDgcBfCHpcPhcBTAH5YOh8NRgP8PN2q7wITtHk0AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "counts = Map.create(\n",
     "    frame=\"galactic\", skydir=(0, 0.0), binsz=0.02, npix=(100, 100)\n",
@@ -396,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -418,9 +500,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'optimize_result': OptimizeResult\n",
+      "\n",
+      "\tbackend    : minuit\n",
+      "\tmethod     : minuit\n",
+      "\tsuccess    : True\n",
+      "\tmessage    : Optimization terminated successfully.\n",
+      "\tnfev       : 120\n",
+      "\ttotal stat : 71343.23\n",
+      ", 'covariance_result': CovarianceResult\n",
+      "\n",
+      "\tbackend    : minuit\n",
+      "\tmethod     : hesse\n",
+      "\tsuccess    : True\n",
+      "\tmessage    : Hesse terminated successfully.\n",
+      "}\n",
+      "CPU times: user 43.6 s, sys: 9.89 s, total: 53.5 s\n",
+      "Wall time: 53.9 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "fit = Fit()\n",
@@ -430,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -458,7 +564,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,29 +572,12 @@
     "t_ref = Time(\"2000-01-01T00:01:04.184\")\n",
     "\n",
     "times = t_ref + livetime * np.linspace(0, 1, 50)\n",
-    "expdecay_model = ExpDecayTemporalModel(t_ref=t_ref.mjd * u.d, t0=t0)\n",
-    "\n",
-    "lc = Table()\n",
-    "lc.meta[\"MJDREFI\"] = t_ref.mjd\n",
-    "lc.meta[\"MJDREFF\"] = 0.0\n",
-    "lc.meta[\"TIMEUNIT\"] = 's'\n",
-    "\n",
-    "lc[\"TIME\"] = livetime.to('s') * np.linspace(0, 1, 50)\n",
-    "lc[\"NORM\"] = expdecay_model(times)\n",
-    "\n",
-    "lc.write(\"./event_sampling/lc.fits\", overwrite=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now, we can define the sky model including the temporal model component. The latter is passed as `~gammapy.modeling.models.TemporalModel.LightCurveTemplateTemporalModel` model. Here we consider an extremely bright source, so to make more evident its temporal properties: "
+    "expdecay_model = ExpDecayTemporalModel(t_ref=t_ref.mjd * u.d, t0=t0)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,7 +588,7 @@
     "sky_model_pntpwl = SkyModel(\n",
     "    spectral_model=spectral_model_pwl,\n",
     "    spatial_model=spatial_model_point,\n",
-    "    temporal_model=temporal_model,\n",
+    "    temporal_model=expdecay_model,\n",
     "    name=\"point-pwl\",\n",
     ")\n",
     "\n",
@@ -515,14 +604,50 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For simplicity"
+    "For simplicity, we use the same dataset defined above:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DatasetModels\n",
+      "\n",
+      "Component 0: SkyModel\n",
+      "\n",
+      "  Name                      : point-pwl\n",
+      "  Datasets names            : None\n",
+      "  Spectral model type       : PowerLawSpectralModel\n",
+      "  Spatial  model type       : PointSpatialModel\n",
+      "  Temporal model type       : ExpDecayTemporalModel\n",
+      "  Parameters:\n",
+      "    index                   :   2.000              \n",
+      "    amplitude               :   2.00e-10  1 / (cm2 s TeV)\n",
+      "    reference    (frozen)   :   1.000  TeV         \n",
+      "    lon_0                   :   0.000  deg         \n",
+      "    lat_0                   :   0.500  deg         \n",
+      "    t0                      : 2800.000  s           \n",
+      "    t_ref        (frozen)   : 51544.001  d           \n",
+      "\n",
+      "Component 1: FoVBackgroundModel\n",
+      "\n",
+      "  Name                      : my-dataset-bkg\n",
+      "  Datasets names            : ['my-dataset']\n",
+      "  Spectral model type       : PowerLawNormSpectralModel\n",
+      "  Parameters:\n",
+      "    norm                    :   1.000              \n",
+      "    tilt         (frozen)   :   0.000              \n",
+      "    reference    (frozen)   :   1.000  TeV         \n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "dataset.models = models\n",
     "print(dataset.models)"
@@ -537,9 +662,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 4 µs, sys: 0 ns, total: 4 µs\n",
+      "Wall time: 31.9 µs\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "sampler = MapDatasetEventSampler(random_state=0)\n",

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Time-dependent models."""
 import numpy as np
+from numpy.random import Generator, PCG64
 import scipy.interpolate
 from astropy import units as u
 from astropy.table import Table
@@ -189,6 +190,30 @@ class ExpDecayTemporalModel(TemporalModel):
         t_ref = Time(pars["t_ref"].quantity, format="mjd")
         value = self.evaluate(t_max, t0, t_ref) - self.evaluate(t_min, t0, t_ref)
         return -t0 * value / self.time_sum(t_min, t_max)
+        
+    def sample_time(self, n_events, random_state=0):
+        """Sample arrival times of events.
+
+        Parameters
+        ----------
+        n_events : int
+            Number of events to sample.
+        random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
+            Defines random number generator initialisation.
+            Passed to `~gammapy.utils.random.get_random_state`.
+
+        Returns
+        -------
+        time : `~astropy.units.Quantity`
+            Array with times of the sampled events.
+        """
+        pars = self.parameters
+        t0 = pars["t0"].quantity
+        
+        rng = Generator(PCG64(random_state))
+        time_delta = rng.exponential(scale=t0.value, size=n_events) * u.s
+ 
+        return self.t_ref + time_delta
 
 
 class GaussianTemporalModel(TemporalModel):

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -167,6 +167,14 @@ def test_exponential_temporal_model_integral():
     assert_allclose(np.sum(val), 0.102557, rtol=1e-5)
 
 
+def test_exponential_temporal_model_sample_time():
+    t_ref = Time(55555, format="mjd")
+    temporal_model = ExpDecayTemporalModel(t_ref=t_ref.mjd * u.d)
+    times = temporal_model.sample_time(2)
+
+    assert_allclose(times.value, [55555.00000787, 55555.0000118], rtol=1e-8)
+
+
 def test_gaussian_temporal_model_evaluate():
     t = Time(46301, format="mjd")
     t_ref = 46300 * u.d


### PR DESCRIPTION
The `sample_time` function is generally needed for event sampling of variable sources. This PR aims at introducing such a function into the `~gammapy.model.temporal.ExpDecayTemporalModel`, where it is currently missing. 
The new function is based on the `numpy.random.Generator.exponential`, which allows to generate random numbers following an exponential function. 
