### PR TITLE
Add `sample_time` to `model.temporal.GaussianTemporalModel` and `model.temporal.ExpDecayTemporalModel`

### DIFF
--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -167,6 +167,15 @@ def test_exponential_temporal_model_integral():
     assert_allclose(np.sum(val), 0.102557, rtol=1e-5)
 
 
+def test_exponential_temporal_model_sample_time():
+    t_ref = Time(55555, format="mjd")
+    temporal_model = ExpDecayTemporalModel(t_ref=t_ref.mjd * u.d)
+    times = temporal_model.sample_time(2)
+
+    assert times.unit == u.d
+    assert_allclose(times.value, [55555.679932, 55556.019597], rtol=1e-8)
+
+
 def test_gaussian_temporal_model_evaluate():
     t = Time(46301, format="mjd")
     t_ref = 46300 * u.d
@@ -185,6 +194,15 @@ def test_gaussian_temporal_model_integral():
     val = temporal_model.integral(gti.time_start, gti.time_stop)
     assert len(val) == 3
     assert_allclose(np.sum(val), 0.682679, rtol=1e-5)
+
+
+def test_gaussian_temporal_model_sample_time():
+    t_ref = Time(55555, format="mjd")
+    temporal_model = GaussianTemporalModel(t_ref=t_ref.mjd * u.d, sigma="2.0 day")
+    times = temporal_model.sample_time(2)
+
+    assert times.unit == u.d
+    assert_allclose(times.value, [55555.25146, 55554.73579], rtol=1e-8)
 
 
 @requires_data()


### PR DESCRIPTION
The `sample_time` function is generally needed for event sampling of variable sources. This PR aims at introducing such a function into the `~gammapy.model.temporal.ExpDecayTemporalModel` and `~gammapy.model.temporal.GaussianTemporalModel`, where it is currently missing.
The new function is based on `numpy.random.Generator.exponential` and `numpy.random.Generator.normal`, which allow to generate random numbers following an exponential or a normal distribution .

