### PR TITLE
Add example of DataStore.from_events_files in CTA notebook

### DIFF
--- a/docs/tutorials/data/cta.ipynb
+++ b/docs/tutorials/data/cta.ipynb
@@ -139,7 +139,28 @@
    "outputs": [],
    "source": [
     "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/cta-1dc/index/gps\")\n",
-    "data_store"
+    "print(data_store)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you can't download the index files, or got errors related to the data acces using them, you can generate the `DataStore` directly from the event files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "path = Path(os.environ[\"GAMMAPY_DATA\"]) / \"cta-1dc/data\"\n",
+    "paths = list(path.rglob(\"*.fits\"))\n",
+    "data_store = DataStore.from_events_files(paths)\n",
+    "print(data_store)"
    ]
   },
   {

--- a/docs/tutorials/data/cta.ipynb
+++ b/docs/tutorials/data/cta.ipynb
@@ -50,6 +50,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
     "import numpy as np\n",
     "import astropy\n",
     "import gammapy\n",
@@ -127,6 +130,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The access to the IRFs files requires to define a `CALDB` environment variable. We are going to define it only for this notebook so it won't overwrite the one you may have already defined."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ[\"CALDB\"] = os.environ[\"GAMMAPY_DATA\"] + \"/cta-1dc/caldb\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Datastore\n",
     "\n",
     "You can use the `~gammapy.data.DataStore` to load via the index files"
@@ -146,7 +165,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you can't download the index files, or got errors related to the data acces using them, you can generate the `DataStore` directly from the event files"
+    "If you can't download the index files, or got errors related to the data acces using them, you can generate the `DataStore` directly from the event files."
    ]
   },
   {
@@ -155,12 +174,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#import os\n",
-    "#from pathlib import Path\n",
-    "#path = Path(os.environ[\"GAMMAPY_DATA\"]) / \"cta-1dc/data\"\n",
-    "#paths = list(path.rglob(\"*.fits\"))\n",
-    "#data_store = DataStore.from_events_files(paths)\n",
-    "#print(data_store)"
+    "path = Path(os.environ[\"GAMMAPY_DATA\"]) / \"cta-1dc/data\"\n",
+    "paths = list(path.rglob(\"*.fits\"))\n",
+    "data_store = DataStore.from_events_files(paths)\n",
+    "print(data_store)"
    ]
   },
   {

--- a/docs/tutorials/data/cta.ipynb
+++ b/docs/tutorials/data/cta.ipynb
@@ -155,12 +155,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "from pathlib import Path\n",
-    "path = Path(os.environ[\"GAMMAPY_DATA\"]) / \"cta-1dc/data\"\n",
-    "paths = list(path.rglob(\"*.fits\"))\n",
-    "data_store = DataStore.from_events_files(paths)\n",
-    "print(data_store)"
+    "#import os\n",
+    "#from pathlib import Path\n",
+    "#path = Path(os.environ[\"GAMMAPY_DATA\"]) / \"cta-1dc/data\"\n",
+    "#paths = list(path.rglob(\"*.fits\"))\n",
+    "#data_store = DataStore.from_events_files(paths)\n",
+    "#print(data_store)"
    ]
   },
   {


### PR DESCRIPTION
This PR copy the usage example of  `DataStore.from_events_files()`
from its docstring  to the CTA notebook. This illustrates an alternative solution if ones can't get the index files  (received report about download link broken and bad file received from someone else...).