### PR TITLE
Change tutorials to use Models.to_parameters_table() method.

### DIFF
--- a/docs/tutorials/analysis/1D/extended_source_spectral_analysis.ipynb
+++ b/docs/tutorials/analysis/1D/extended_source_spectral_analysis.ipynb
@@ -49,14 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:16.338629Z",
-     "iopub.status.busy": "2021-02-12T11:31:16.336652Z",
-     "iopub.status.idle": "2021-02-12T11:31:16.656635Z",
-     "shell.execute_reply": "2021-02-12T11:31:16.657024Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -66,14 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:16.661192Z",
-     "iopub.status.busy": "2021-02-12T11:31:16.660603Z",
-     "iopub.status.idle": "2021-02-12T11:31:17.538307Z",
-     "shell.execute_reply": "2021-02-12T11:31:17.537799Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import astropy.units as u\n",
@@ -103,14 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:17.542382Z",
-     "iopub.status.busy": "2021-02-12T11:31:17.541915Z",
-     "iopub.status.idle": "2021-02-12T11:31:17.589327Z",
-     "shell.execute_reply": "2021-02-12T11:31:17.588933Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "datastore = DataStore.from_dir(\"$GAMMAPY_DATA/hess-dl3-dr1/\")\n",
@@ -140,14 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:17.593515Z",
-     "iopub.status.busy": "2021-02-12T11:31:17.593081Z",
-     "iopub.status.idle": "2021-02-12T11:31:17.595242Z",
-     "shell.execute_reply": "2021-02-12T11:31:17.594811Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "target_position = SkyCoord(347.3, -0.5, unit=\"deg\", frame=\"galactic\")\n",
@@ -169,14 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:17.600915Z",
-     "iopub.status.busy": "2021-02-12T11:31:17.600483Z",
-     "iopub.status.idle": "2021-02-12T11:31:17.602456Z",
-     "shell.execute_reply": "2021-02-12T11:31:17.602014Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The binning of the final spectrum is defined here.\n",
@@ -202,14 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:17.612183Z",
-     "iopub.status.busy": "2021-02-12T11:31:17.611760Z",
-     "iopub.status.idle": "2021-02-12T11:31:17.613913Z",
-     "shell.execute_reply": "2021-02-12T11:31:17.613481Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dataset_empty = SpectrumDataset.create(\n",
@@ -230,14 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:17.616853Z",
-     "iopub.status.busy": "2021-02-12T11:31:17.616439Z",
-     "iopub.status.idle": "2021-02-12T11:31:17.618468Z",
-     "shell.execute_reply": "2021-02-12T11:31:17.618038Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "maker = SpectrumDatasetMaker(\n",
@@ -255,14 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:17.621752Z",
-     "iopub.status.busy": "2021-02-12T11:31:17.621333Z",
-     "iopub.status.idle": "2021-02-12T11:31:17.623379Z",
-     "shell.execute_reply": "2021-02-12T11:31:17.622952Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "bkg_maker = ReflectedRegionsBackgroundMaker()\n",
@@ -287,14 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:17.629511Z",
-     "iopub.status.busy": "2021-02-12T11:31:17.629063Z",
-     "iopub.status.idle": "2021-02-12T11:31:21.302179Z",
-     "shell.execute_reply": "2021-02-12T11:31:21.301734Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -314,14 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:21.309669Z",
-     "iopub.status.busy": "2021-02-12T11:31:21.309219Z",
-     "iopub.status.idle": "2021-02-12T11:31:21.311209Z",
-     "shell.execute_reply": "2021-02-12T11:31:21.311661Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "datasets.meta_table"
@@ -338,15 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:21.357547Z",
-     "iopub.status.busy": "2021-02-12T11:31:21.352863Z",
-     "iopub.status.idle": "2021-02-12T11:31:22.805800Z",
-     "shell.execute_reply": "2021-02-12T11:31:22.805324Z"
-    },
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "datasets[0].peek()\n",
@@ -365,14 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:23.036360Z",
-     "iopub.status.busy": "2021-02-12T11:31:22.926618Z",
-     "iopub.status.idle": "2021-02-12T11:31:23.037741Z",
-     "shell.execute_reply": "2021-02-12T11:31:23.038118Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "info_table = datasets.info_table(cumulative=True)"
@@ -381,14 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:23.043714Z",
-     "iopub.status.busy": "2021-02-12T11:31:23.043191Z",
-     "iopub.status.idle": "2021-02-12T11:31:23.045663Z",
-     "shell.execute_reply": "2021-02-12T11:31:23.045258Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "info_table"
@@ -397,14 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:23.074344Z",
-     "iopub.status.busy": "2021-02-12T11:31:23.061486Z",
-     "iopub.status.idle": "2021-02-12T11:31:23.231668Z",
-     "shell.execute_reply": "2021-02-12T11:31:23.231239Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(10, 6))\n",
@@ -445,14 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:23.240123Z",
-     "iopub.status.busy": "2021-02-12T11:31:23.239660Z",
-     "iopub.status.idle": "2021-02-12T11:31:23.241056Z",
-     "shell.execute_reply": "2021-02-12T11:31:23.241412Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "spectral_model = PowerLawSpectralModel(\n",
@@ -473,14 +367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:23.245362Z",
-     "iopub.status.busy": "2021-02-12T11:31:23.244913Z",
-     "iopub.status.idle": "2021-02-12T11:31:24.054862Z",
-     "shell.execute_reply": "2021-02-12T11:31:24.054277Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fit_joint = Fit()\n",
@@ -500,17 +387,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-02-12T11:31:24.060449Z",
-     "iopub.status.busy": "2021-02-12T11:31:24.060021Z",
-     "iopub.status.idle": "2021-02-12T11:31:24.062780Z",
-     "shell.execute_reply": "2021-02-12T11:31:24.062334Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "result_joint[\"optimize_result\"].parameters.to_table()"
+    "datasets.models.to_parameters_table()"
    ]
   },
   {
@@ -539,6 +419,13 @@
     "ax_spectrum, ax_residuals = reduced.plot_fit()\n",
     "reduced.plot_masks(ax=ax_spectrum);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -557,7 +444,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,
@@ -565,9 +452,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1.0,
+   "current_citInitial": 1,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1.0,
+   "eqNumInitial": 1,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"

--- a/docs/tutorials/analysis/1D/sed_fitting.ipynb
+++ b/docs/tutorials/analysis/1D/sed_fitting.ipynb
@@ -287,7 +287,7 @@
    "source": [
     "datasets.models = model\n",
     "result_ecpl = fitter.run(datasets=datasets)\n",
-    "print(model)"
+    "print(model.to_dict())"
    ]
   },
   {

--- a/docs/tutorials/analysis/1D/spectral_analysis.ipynb
+++ b/docs/tutorials/analysis/1D/spectral_analysis.ipynb
@@ -452,7 +452,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result_joint[\"optimize_result\"].parameters.to_table()"
+    "datasets.models.to_parameters_table()"
    ]
   },
   {
@@ -731,9 +731,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1.0,
+   "current_citInitial": 1,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1.0,
+   "eqNumInitial": 1,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"

--- a/docs/tutorials/analysis/2D/modeling_2D.ipynb
+++ b/docs/tutorials/analysis/2D/modeling_2D.ipynb
@@ -316,7 +316,7 @@
    "outputs": [],
    "source": [
     "# To see the best fit values along with the errors\n",
-    "analysis.fit_result.parameters.to_table()"
+    "analysis.models.to_parameters_table()"
    ]
   },
   {
@@ -347,5 +347,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/tutorials/analysis/3D/analysis_3d.ipynb
+++ b/docs/tutorials/analysis/3D/analysis_3d.ipynb
@@ -357,7 +357,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result[\"optimize_result\"].parameters.to_table()"
+    "models_stacked.to_parameters_table()"
    ]
   },
   {
@@ -752,7 +752,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/docs/tutorials/starting/analysis_2.ipynb
+++ b/docs/tutorials/starting/analysis_2.ipynb
@@ -404,7 +404,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `FitResult` contains information on the fitted parameters."
+    "The `FitResult` contains information about the optimization and parameter error calculation."
    ]
   },
   {
@@ -413,7 +413,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result[\"optimize_result\"].parameters.to_table()"
+    "print(result[\"optimize_result\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The fitted parameters are visible from the `~astropy.modeling.models.Models` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stacked.models.to_parameters_table()"
    ]
   },
   {
@@ -595,7 +611,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies tutorials to make the use `Models.to_parameters_table()` rather than `fit_result.parameters.to_table()`.

This method is barely used in our documentation but it has the advantage of connecting parameters to their parent models which many users require when fitting multi-component models. 

It goes also in the direction of having users interact mostly with `Datasets` and `Models`.  

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
