### PR TITLE
Include CovarianceResults into OptimizeResults

### DIFF
--- a/docs/tutorials/analysis/1D/cta_sensitivity.ipynb
+++ b/docs/tutorials/analysis/1D/cta_sensitivity.ipynb
@@ -27,14 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:48.748175Z",
-     "iopub.status.busy": "2021-10-15T09:51:48.747275Z",
-     "iopub.status.idle": "2021-10-15T09:51:49.129127Z",
-     "shell.execute_reply": "2021-10-15T09:51:49.129646Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -45,14 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:49.133860Z",
-     "iopub.status.busy": "2021-10-15T09:51:49.133323Z",
-     "iopub.status.idle": "2021-10-15T09:51:50.485344Z",
-     "shell.execute_reply": "2021-10-15T09:51:50.484815Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import astropy.units as u\n",
@@ -78,14 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:50.499488Z",
-     "iopub.status.busy": "2021-10-15T09:51:50.495995Z",
-     "iopub.status.idle": "2021-10-15T09:51:50.518588Z",
-     "shell.execute_reply": "2021-10-15T09:51:50.518071Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "energy_axis = MapAxis.from_energy_bounds(\"0.03 TeV\", \"30 TeV\", nbin=20)\n",
@@ -112,14 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:50.522550Z",
-     "iopub.status.busy": "2021-10-15T09:51:50.522030Z",
-     "iopub.status.idle": "2021-10-15T09:51:50.638868Z",
-     "shell.execute_reply": "2021-10-15T09:51:50.638336Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "irfs = load_cta_irfs(\n",
@@ -133,14 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:50.662012Z",
-     "iopub.status.busy": "2021-10-15T09:51:50.650888Z",
-     "iopub.status.idle": "2021-10-15T09:51:50.911666Z",
-     "shell.execute_reply": "2021-10-15T09:51:50.911136Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "spectrum_maker = SpectrumDatasetMaker(\n",
@@ -159,14 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:50.917209Z",
-     "iopub.status.busy": "2021-10-15T09:51:50.916681Z",
-     "iopub.status.idle": "2021-10-15T09:51:50.931719Z",
-     "shell.execute_reply": "2021-10-15T09:51:50.931186Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "containment = 0.68\n",
@@ -192,14 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:50.936767Z",
-     "iopub.status.busy": "2021-10-15T09:51:50.936166Z",
-     "iopub.status.idle": "2021-10-15T09:51:50.938521Z",
-     "shell.execute_reply": "2021-10-15T09:51:50.938013Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dataset_on_off = SpectrumDatasetOnOff.from_spectrum_dataset(\n",
@@ -220,14 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:50.985462Z",
-     "iopub.status.busy": "2021-10-15T09:51:50.982528Z",
-     "iopub.status.idle": "2021-10-15T09:51:51.006191Z",
-     "shell.execute_reply": "2021-10-15T09:51:51.005659Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sensitivity_estimator = SensitivityEstimator(\n",
@@ -249,14 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:51.013089Z",
-     "iopub.status.busy": "2021-10-15T09:51:51.012534Z",
-     "iopub.status.idle": "2021-10-15T09:51:51.015425Z",
-     "shell.execute_reply": "2021-10-15T09:51:51.015947Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Show the results table\n",
@@ -266,14 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:51.019237Z",
-     "iopub.status.busy": "2021-10-15T09:51:51.018751Z",
-     "iopub.status.idle": "2021-10-15T09:51:51.021256Z",
-     "shell.execute_reply": "2021-10-15T09:51:51.020746Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Save it to file (could use e.g. format of CSV or ECSV or FITS)\n",
@@ -284,12 +214,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:51.050678Z",
-     "iopub.status.busy": "2021-10-15T09:51:51.026765Z",
-     "iopub.status.idle": "2021-10-15T09:51:51.768665Z",
-     "shell.execute_reply": "2021-10-15T09:51:51.769174Z"
-    },
     "nbsphinx-thumbnail": {
      "tooltip": "Estimate the CTA sensitivity for a point-like IRF at a fixed zenith angle and fixed offset."
     }
@@ -337,14 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-10-15T09:51:51.808610Z",
-     "iopub.status.busy": "2021-10-15T09:51:51.792240Z",
-     "iopub.status.idle": "2021-10-15T09:51:52.651741Z",
-     "shell.execute_reply": "2021-10-15T09:51:52.652305Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Plot expected number of counts for signal and background\n",

--- a/docs/tutorials/analysis/1D/cta_sensitivity.ipynb
+++ b/docs/tutorials/analysis/1D/cta_sensitivity.ipynb
@@ -27,7 +27,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:48.748175Z",
+     "iopub.status.busy": "2021-10-15T09:51:48.747275Z",
+     "iopub.status.idle": "2021-10-15T09:51:49.129127Z",
+     "shell.execute_reply": "2021-10-15T09:51:49.129646Z"
+    }
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -38,7 +45,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:49.133860Z",
+     "iopub.status.busy": "2021-10-15T09:51:49.133323Z",
+     "iopub.status.idle": "2021-10-15T09:51:50.485344Z",
+     "shell.execute_reply": "2021-10-15T09:51:50.484815Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import astropy.units as u\n",
@@ -64,7 +78,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:50.499488Z",
+     "iopub.status.busy": "2021-10-15T09:51:50.495995Z",
+     "iopub.status.idle": "2021-10-15T09:51:50.518588Z",
+     "shell.execute_reply": "2021-10-15T09:51:50.518071Z"
+    }
+   },
    "outputs": [],
    "source": [
     "energy_axis = MapAxis.from_energy_bounds(\"0.03 TeV\", \"30 TeV\", nbin=20)\n",
@@ -91,7 +112,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:50.522550Z",
+     "iopub.status.busy": "2021-10-15T09:51:50.522030Z",
+     "iopub.status.idle": "2021-10-15T09:51:50.638868Z",
+     "shell.execute_reply": "2021-10-15T09:51:50.638336Z"
+    }
+   },
    "outputs": [],
    "source": [
     "irfs = load_cta_irfs(\n",
@@ -105,7 +133,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:50.662012Z",
+     "iopub.status.busy": "2021-10-15T09:51:50.650888Z",
+     "iopub.status.idle": "2021-10-15T09:51:50.911666Z",
+     "shell.execute_reply": "2021-10-15T09:51:50.911136Z"
+    }
+   },
    "outputs": [],
    "source": [
     "spectrum_maker = SpectrumDatasetMaker(\n",
@@ -124,7 +159,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:50.917209Z",
+     "iopub.status.busy": "2021-10-15T09:51:50.916681Z",
+     "iopub.status.idle": "2021-10-15T09:51:50.931719Z",
+     "shell.execute_reply": "2021-10-15T09:51:50.931186Z"
+    }
+   },
    "outputs": [],
    "source": [
     "containment = 0.68\n",
@@ -150,7 +192,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:50.936767Z",
+     "iopub.status.busy": "2021-10-15T09:51:50.936166Z",
+     "iopub.status.idle": "2021-10-15T09:51:50.938521Z",
+     "shell.execute_reply": "2021-10-15T09:51:50.938013Z"
+    }
+   },
    "outputs": [],
    "source": [
     "dataset_on_off = SpectrumDatasetOnOff.from_spectrum_dataset(\n",
@@ -171,7 +220,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:50.985462Z",
+     "iopub.status.busy": "2021-10-15T09:51:50.982528Z",
+     "iopub.status.idle": "2021-10-15T09:51:51.006191Z",
+     "shell.execute_reply": "2021-10-15T09:51:51.005659Z"
+    }
+   },
    "outputs": [],
    "source": [
     "sensitivity_estimator = SensitivityEstimator(\n",
@@ -193,7 +249,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:51.013089Z",
+     "iopub.status.busy": "2021-10-15T09:51:51.012534Z",
+     "iopub.status.idle": "2021-10-15T09:51:51.015425Z",
+     "shell.execute_reply": "2021-10-15T09:51:51.015947Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Show the results table\n",
@@ -203,7 +266,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:51.019237Z",
+     "iopub.status.busy": "2021-10-15T09:51:51.018751Z",
+     "iopub.status.idle": "2021-10-15T09:51:51.021256Z",
+     "shell.execute_reply": "2021-10-15T09:51:51.020746Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Save it to file (could use e.g. format of CSV or ECSV or FITS)\n",
@@ -214,6 +284,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:51.050678Z",
+     "iopub.status.busy": "2021-10-15T09:51:51.026765Z",
+     "iopub.status.idle": "2021-10-15T09:51:51.768665Z",
+     "shell.execute_reply": "2021-10-15T09:51:51.769174Z"
+    },
     "nbsphinx-thumbnail": {
      "tooltip": "Estimate the CTA sensitivity for a point-like IRF at a fixed zenith angle and fixed offset."
     }
@@ -261,7 +337,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-10-15T09:51:51.808610Z",
+     "iopub.status.busy": "2021-10-15T09:51:51.792240Z",
+     "iopub.status.idle": "2021-10-15T09:51:52.651741Z",
+     "shell.execute_reply": "2021-10-15T09:51:52.652305Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Plot expected number of counts for signal and background\n",

--- a/docs/tutorials/analysis/1D/sed_fitting.ipynb
+++ b/docs/tutorials/analysis/1D/sed_fitting.ipynb
@@ -206,7 +206,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(result_pwl[\"optimize_result\"])"
+    "print(result_pwl)"
    ]
   },
   {

--- a/docs/tutorials/analysis/1D/spectral_analysis.ipynb
+++ b/docs/tutorials/analysis/1D/spectral_analysis.ipynb
@@ -217,7 +217,7 @@
    "outputs": [],
    "source": [
     "energy_axis = MapAxis.from_energy_bounds(\n",
-    "    0.1, 40, nbin=15, per_decade=True, unit=\"TeV\", name=\"energy\"\n",
+    "    0.1, 40, nbin=10, per_decade=True, unit=\"TeV\", name=\"energy\"\n",
     ")\n",
     "energy_axis_true = MapAxis.from_energy_bounds(\n",
     "    0.05, 100, nbin=20, per_decade=True, unit=\"TeV\", name=\"energy_true\"\n",
@@ -731,9 +731,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1,
+   "current_citInitial": 1.0,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1,
+   "eqNumInitial": 1.0,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"

--- a/docs/tutorials/analysis/3D/analysis_3d.ipynb
+++ b/docs/tutorials/analysis/3D/analysis_3d.ipynb
@@ -760,9 +760,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1,
+   "current_citInitial": 1.0,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1,
+   "eqNumInitial": 1.0,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"
@@ -984,7 +984,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0,
+       "index": 0.0,
        "layout": "IPY_MODEL_630e7d062f92495f80cc891b5f41e459",
        "orientation": "horizontal",
        "readout": true,
@@ -1020,7 +1020,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0,
+       "index": 0.0,
        "layout": "IPY_MODEL_2a623c0d2f104f7085d8dbe4ba7b1288",
        "orientation": "horizontal",
        "readout": true,
@@ -1048,7 +1048,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 1,
+       "index": 1.0,
        "layout": "IPY_MODEL_0aeefaeaa8cb4eaab1d9b3e2f598f1c8",
        "style": "IPY_MODEL_b276e62a203044e5aa6a19271c359963"
       }
@@ -1430,7 +1430,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 1,
+       "index": 1.0,
        "layout": "IPY_MODEL_8b34344bdfd04c8ba35f109aa2968082",
        "style": "IPY_MODEL_9dac402f20464c7fb2bd21fe32d1f3ec"
       }
@@ -1460,8 +1460,8 @@
       }
      }
     },
-    "version_major": 2,
-    "version_minor": 0
+    "version_major": 2.0,
+    "version_minor": 0.0
    }
   }
  },

--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -440,7 +440,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result[\"optimize_result\"].parameters.to_table()"
+    "result.parameters.to_table()"
    ]
   },
   {
@@ -786,9 +786,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1,
+   "current_citInitial": 1.0,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1,
+   "eqNumInitial": 1.0,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"

--- a/docs/tutorials/analysis/3D/simulate_3d.ipynb
+++ b/docs/tutorials/analysis/3D/simulate_3d.ipynb
@@ -330,7 +330,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result[\"optimize_result\"].parameters.to_table()"
+    "result.parameters.to_table()"
    ]
   },
   {
@@ -365,9 +365,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1,
+   "current_citInitial": 1.0,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1,
+   "eqNumInitial": 1.0,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"
@@ -423,7 +423,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0,
+       "index": 0.0,
        "layout": "IPY_MODEL_af4d5cf4a93b4c2aa9fd249e0ebea901",
        "orientation": "horizontal",
        "readout": true,
@@ -701,7 +701,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0,
+       "index": 0.0,
        "layout": "IPY_MODEL_ad8503b6c8494978874f7c11be4e77f8",
        "style": "IPY_MODEL_3cf9799567f44cc2a06127e22b70907d"
       }
@@ -722,8 +722,8 @@
       }
      }
     },
-    "version_major": 2,
-    "version_minor": 0
+    "version_major": 2.0,
+    "version_minor": 0.0
    }
   }
  },

--- a/docs/tutorials/analysis/time/light_curve_simulation.ipynb
+++ b/docs/tutorials/analysis/time/light_curve_simulation.ipynb
@@ -377,7 +377,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result[\"optimize_result\"].parameters.to_table()"
+    "result.parameters.to_table()"
    ]
   },
   {
@@ -430,9 +430,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1,
+   "current_citInitial": 1.0,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1,
+   "eqNumInitial": 1.0,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"

--- a/docs/tutorials/api/fitting.ipynb
+++ b/docs/tutorials/api/fitting.ipynb
@@ -244,7 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result_minuit[\"optimize_result\"].trace"
+    "result_minuit.trace"
    ]
   },
   {
@@ -260,7 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result_minuit[\"optimize_result\"].parameters.to_table()"
+    "result_minuit.parameters.to_table()"
    ]
   },
   {
@@ -276,7 +276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "total_stat = result_minuit[\"optimize_result\"].total_stat\n",
+    "total_stat = result_minuit.total_stat\n",
     "\n",
     "fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(14, 4))\n",
     "\n",
@@ -430,7 +430,7 @@
     "cts_sigma = make_contours(\n",
     "    fit=fit,\n",
     "    datasets=[dataset_hess],\n",
-    "    result=result_minuit[\"optimize_result\"],\n",
+    "    result=result_minuit,\n",
     "    npoints=10,\n",
     "    sigmas=sigmas,\n",
     ")"
@@ -563,7 +563,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = result_minuit[\"optimize_result\"]\n",
+    "result = result_minuit\n",
     "par_alpha = result.parameters[\"alpha\"]\n",
     "par_beta = result.parameters[\"beta\"]\n",
     "\n",

--- a/docs/tutorials/starting/analysis_2.ipynb
+++ b/docs/tutorials/starting/analysis_2.ipynb
@@ -413,7 +413,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(result[\"optimize_result\"])"
+    "print(result)"
    ]
   },
   {
@@ -619,9 +619,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1,
+   "current_citInitial": 1.0,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1,
+   "eqNumInitial": 1.0,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"
@@ -724,7 +724,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0,
+       "index": 0.0,
        "layout": "IPY_MODEL_095494c994ba43aa96803803704a7cdb",
        "orientation": "horizontal",
        "readout": true,
@@ -861,7 +861,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0,
+       "index": 0.0,
        "layout": "IPY_MODEL_cceb2b5d8e8241978dca97767054211d",
        "style": "IPY_MODEL_203fa8f78fd848f596a7e354c693d2f0"
       }
@@ -971,8 +971,8 @@
       }
      }
     },
-    "version_major": 2,
-    "version_minor": 0
+    "version_major": 2.0,
+    "version_minor": 0.0
    }
   }
  },

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -203,7 +203,7 @@ class Analysis:
 
         log.info("Fitting datasets.") 
         result = self.fit.run(datasets=self.datasets)
-        self.fit_result = result["optimize_result"]
+        self.fit_result = result
         log.info(self.fit_result)
 
     def get_flux_points(self):

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -49,8 +49,8 @@ class FluxPointsDataset(Dataset):
         dataset = FluxPointsDataset(model, flux_points)
         fit = Fit()
         result = fit.run([dataset])
-        print(result["optimize_result"])
-        print(result["optimize_result"].parameters.to_table())
+        print(result)
+        print(result.parameters.to_table())
 
     Note: In order to reproduce the example you need the tests datasets folder.
     You may download it with the command

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -82,7 +82,7 @@ class TestFluxPointFit:
     def test_fit_pwl_minuit(self, dataset):
         fit = Fit()
         result = fit.run(dataset)
-        self.assert_result(result["optimize_result"])
+        self.assert_result(result)
 
     @requires_dependency("sherpa")
     def test_fit_pwl_sherpa(self, dataset):
@@ -109,7 +109,6 @@ class TestFluxPointFit:
     def test_stat_profile(dataset):
         fit = Fit()
         result = fit.run(datasets=dataset)
-        result = result["optimize_result"]
 
         model = dataset.models[0].spectral_model
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -644,7 +644,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
 
     fit = Fit()
     result = fit.run(datasets=datasets)
-    result = result["optimize_result"]
+
     assert result.success
     assert "minuit" in repr(result)
 
@@ -715,7 +715,7 @@ def test_map_fit_one_energy_bin(sky_model, geom_image):
 
     fit = Fit()
     result = fit.run(datasets=[dataset])
-    result = result["optimize_result"]
+
     assert result.success
 
     npred = dataset.npred().data.sum()

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -151,7 +151,6 @@ def test_fit(spectrum_dataset):
     """Simple CASH fit to the on vector"""
     fit = Fit()
     result = fit.run(datasets=[spectrum_dataset])
-    result = result["optimize_result"]
     # assert result.success
     assert "minuit" in repr(result)
 
@@ -711,7 +710,6 @@ class TestSpectralFit:
     def test_basic_results(self):
         self.set_model(self.pwl)
         result = self.fit.run([self.datasets[0]])
-        result = result["optimize_result"]
         pars = self.datasets.parameters
 
         assert self.pwl is self.datasets[0].models[0]
@@ -726,7 +724,6 @@ class TestSpectralFit:
     def test_basic_errors(self):
         self.set_model(self.pwl)
         result = self.fit.run([self.datasets[0]])
-        result = result["optimize_result"]
         pars = result.parameters
 
         assert_allclose(pars["index"].error, 0.149633, rtol=1e-3)
@@ -759,7 +756,6 @@ class TestSpectralFit:
 
         fit = Fit()
         result = fit.run(datasets=[dataset])
-        result = result["optimize_result"]
         stats = dataset.stat_array()
         actual = np.sum(stats[dataset.mask_safe])
 
@@ -782,7 +778,6 @@ class TestSpectralFit:
 
         fit = Fit()
         result = fit.run(datasets=[dataset])
-        result = result["optimize_result"]
         assert_allclose(result.parameters["index"].value, 2.7961, atol=0.02)
 
     def test_stacked_fit(self):
@@ -792,7 +787,6 @@ class TestSpectralFit:
 
         fit = Fit()
         result = fit.run(datasets=[dataset])
-        result = result["optimize_result"]
         pars = result.parameters
 
         assert_allclose(pars["index"].value, 2.7767, rtol=1e-3)
@@ -1098,7 +1092,6 @@ class TestFit:
 
         fit = Fit()
         result = fit.run(datasets=[dataset])
-        result = result["optimize_result"]
 
         # These values are check with sherpa fits, do not change
         pars = result.parameters
@@ -1125,7 +1118,6 @@ class TestFit:
 
         fit = Fit()
         result = fit.run(datasets=[dataset])
-        result = result["optimize_result"]
         pars = self.source_model.parameters
 
         assert_allclose(pars["index"].value, 1.997342, rtol=1e-3)
@@ -1159,7 +1151,6 @@ class TestFit:
         )
         fit = Fit()
         result = fit.run(datasets=[dataset])
-        result = result["optimize_result"]
         true_idx = result.parameters["index"].value
 
         values = np.linspace(0.95 * true_idx, 1.05 * true_idx, 100)

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -86,8 +86,8 @@ class ParameterEstimator(Estimator):
         if np.any(datasets.contributes_to_stat):
             result = self.fit.run(datasets=datasets)
             value, error = parameter.value, parameter.error
-            total_stat = result["optimize_result"].total_stat
-            success = result["optimize_result"].success
+            total_stat = result.total_stat
+            success = result.success
 
         return {
             f"{parameter.name}": value,

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -181,7 +181,7 @@ class FoVBackgroundMaker(Maker):
             models.select(tag="sky-model").freeze()
 
             fit_result = self.fit.run(datasets=[dataset])
-            if not fit_result["optimize_result"].success:
+            if not fit_result.success:
                 log.warning(
                     f"FoVBackgroundMaker failed. Fit did not converge for {dataset.name}. "
                     f"Setting mask to False."

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -152,7 +152,7 @@ class Fit:
 
         covariance_result = self.covariance(datasets=datasets)
 
-        optimize_result.covariance_results = covariance_result
+        optimize_result._covariance_result = covariance_result
 
         return optimize_result
 
@@ -518,11 +518,11 @@ class CovarianceResult(FitResult):
 class OptimizeResult(FitResult):
     """Optimize result object."""
 
-    def __init__(self, nfev, total_stat, trace, covariance_results=None, **kwargs):
+    def __init__(self, nfev, total_stat, trace, covariance_result=None, **kwargs):
         self._nfev = nfev
         self._total_stat = total_stat
         self._trace = trace
-        self.covariance_results = covariance_results
+        self._covariance_result = covariance_result
         super().__init__(**kwargs)
 
     @property
@@ -541,19 +541,14 @@ class OptimizeResult(FitResult):
         return self._total_stat
 
     @property
-    def covariance_results(self):
+    def covariance_result(self):
         """Covariance results."""
-        return self._covariance_results
-
-    @covariance_results.setter
-    def covariance_results(self, covariance_results):
-        """Set Covariance results."""
-        self._covariance_results = covariance_results
+        return self._covariance_result
 
     def __repr__(self):
         str_ = super().__repr__()
         str_ += f"\tnfev       : {self.nfev}\n"
         str_ += f"\ttotal stat : {self.total_stat:.2f}\n"
-        if self.covariance_results is not None:
-            str_ += self.covariance_results.__repr__()
+        if self.covariance_result is not None:
+            str_ += self.covariance_result.__repr__()
         return str_

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -68,7 +68,6 @@ def test_optimize_backend_and_covariance(backend):
 
     fit = Fit(optimize_opts=kwargs)
     result = fit.run([dataset])
-    result = result["optimize_result"]
 
     pars = result.parameters
     assert_allclose(pars["x"].value, 2, rtol=1e-3)
@@ -90,7 +89,6 @@ def test_run(backend):
     dataset = MyDataset()
     fit = Fit(backend=backend)
     result = fit.run([dataset])
-    result = result["optimize_result"]
     pars = result.parameters
 
     assert result.success is True


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request proposes a solution to #3542 . The current `Fit.run()` returns a dictionary of `FitResult` for optimize and covariance which is a bit cumbersome and counter-intuitive.

This PR simply makes `CovarianceResults` an optional member of `OptimizeResults`. I thinks this makes more sense as normally a covariance estimate is always made at the minimum. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
I still need to update the notebooks.