### PR TITLE
Codespell infrastructure: erratum

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -106,6 +106,6 @@ use_parentheses=True
 line_length=88
 
 [codespell]
-skip = ~/.git
+skip = ./.git
 ignore-words = dev/codespell/ignore-words.txt
 exclude-file = dev/codespell/exclude-file.txt


### PR DESCRIPTION
**Description**

Do tell `codespell` to skip the `.git/` directory!

**Dear reviewer**

Fixes an error in #3559. Sorry about that!