### PR TITLE
Fix the handling of units in PSF scale parameter

### DIFF
--- a/gammapy/irf/psf/parametric.py
+++ b/gammapy/irf/psf/parametric.py
@@ -263,7 +263,7 @@ def get_sigmas_and_norms(**kwargs):
     sigmas = u.Quantity([kwargs[f"sigma_{idx}"] for idx in [1, 2, 3]])
 
     scale = kwargs["scale"]
-    ones = np.ones_like(scale)
+    ones = np.ones_like(scale).value
     amplitudes = u.Quantity([ones, kwargs["ampl_2"], kwargs["ampl_3"]])
     norms = 2 * scale * amplitudes * sigmas ** 2
     return sigmas, norms

--- a/gammapy/irf/psf/parametric.py
+++ b/gammapy/irf/psf/parametric.py
@@ -263,7 +263,7 @@ def get_sigmas_and_norms(**kwargs):
     sigmas = u.Quantity([kwargs[f"sigma_{idx}"] for idx in [1, 2, 3]])
 
     scale = kwargs["scale"]
-    ones = np.ones_like(scale).value
+    ones = np.ones(scale.shape)
     amplitudes = u.Quantity([ones, kwargs["ampl_2"], kwargs["ampl_3"]])
     norms = 2 * scale * amplitudes * sigmas ** 2
     return sigmas, norms

--- a/gammapy/irf/psf/tests/test_parametric.py
+++ b/gammapy/irf/psf/tests/test_parametric.py
@@ -88,6 +88,17 @@ def test_psf_cta_1dc():
     assert_allclose(radius, 0.052841 * u.deg, atol=1e-4)
 
 
+@requires_data()
+def test_get_sigmas_and_norms():
+    filename = "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
+
+    psf_irf = EnergyDependentMultiGaussPSF.read(filename, hdu="POINT SPREAD FUNCTION")
+
+    value = psf_irf.evaluate(
+        energy_true=0.05 * u.TeV, rad=0.03 * u.deg, offset=4.5 * u.deg
+    )
+    assert_allclose(value, 0 * u.Unit("deg-2"))
+
 @pytest.fixture(scope="session")
 def psf_king():
     return PSFKing.read("$GAMMAPY_DATA/tests/hess_psf_king_023523.fits.gz")

--- a/gammapy/irf/psf/tests/test_parametric.py
+++ b/gammapy/irf/psf/tests/test_parametric.py
@@ -95,9 +95,9 @@ def test_get_sigmas_and_norms():
     psf_irf = EnergyDependentMultiGaussPSF.read(filename, hdu="POINT SPREAD FUNCTION")
 
     value = psf_irf.evaluate(
-        energy_true=0.05 * u.TeV, rad=0.03 * u.deg, offset=4.5 * u.deg
+        energy_true=1 * u.TeV, rad=0.03 * u.deg, offset=3.5 * u.deg
     )
-    assert_allclose(value, 0 * u.Unit("deg-2"))
+    assert_allclose(value, 78.25826069 * u.Unit("deg-2"))
 
 @pytest.fixture(scope="session")
 def psf_king():


### PR DESCRIPTION
When using the new CTA IRFs for the alpha configuration, the `scale` parameter of the PSF is given in units of `sr-1`. The current function `get_sigmas_and_norms` in `~gammapy.irf`, that reads the `scale` parameters, expects a dimensionless value. This PR fixes this by imposing a dimensionless quantity.

