### PR TITLE
Add missing ABCMeta to IRF base class

### DIFF
--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -18,7 +18,7 @@ from .io import IRF_DL3_HDU_SPECIFICATION, IRF_MAP_HDU_SPECIFICATION
 log = logging.getLogger(__name__)
 
 
-class IRF:
+class IRF(metaclass=abc.ABCMeta):
     """IRF base class for DL3 instrument response functions
 
     Parameters

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -50,7 +50,7 @@ class EDispKernel(IRF):
     >>> edisp.peek()
 
     """
-
+    tag = "edisp_kernel"
     required_axes = ["energy_true", "energy"]
     default_interp_kwargs = dict(bounds_error=False, fill_value=0, method="nearest")
     """Default Interpolation kwargs for `~IRF`. Fill zeros and do not

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -15,6 +15,7 @@ __all__ = ["PSFMap"]
 
 class IRFLikePSF(PSF):
     required_axes = ["energy_true", "rad", "lat_idx", "lon_idx"]
+    tag = "irf_like_psf"
 
 
 class PSFMap(IRFMap):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This contains the fix for the missing `ABCMeta` of the `IRF` class that was part of the closed without merging #3537.

Before, the interface for subclasses of `IRF` was not enforced.