### PR TITLE
Add error check for flux points dataset stat profile

### DIFF
--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -113,6 +113,8 @@ class TestFluxPointFit:
 
         model = dataset.models[0].spectral_model
 
+        assert_allclose(model.amplitude.error, 2.39e-14, rtol=1e-2)
+
         model.amplitude.scan_n_values = 3
         model.amplitude.scan_n_sigma = 1
         model.amplitude.interp = "lin"
@@ -124,7 +126,6 @@ class TestFluxPointFit:
 
         ts_diff = profile["stat_scan"] - result.total_stat
         assert_allclose(ts_diff, [174.358204, 0., 174.418515], rtol=1e-2, atol=1e-7)
-        assert_allclose(model.amplitude.error, 1e-12)
 
         value = result.parameters["amplitude"].value
         err = result.parameters["amplitude"].error
@@ -137,7 +138,6 @@ class TestFluxPointFit:
 
         ts_diff = profile["stat_scan"] - result.total_stat
         assert_allclose(ts_diff, [174.358204, 0., 174.418515], rtol=1e-2, atol=1e-7)
-        assert_allclose(model.amplitude.error, 1e-12)
 
     @staticmethod
     @requires_dependency("matplotlib")

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -125,6 +125,7 @@ class TestFluxPointFit:
         )
 
         ts_diff = profile["stat_scan"] - result.total_stat
+        assert_allclose(model.amplitude.scan_values, [1.92e-13, 2.16e-13, 2.40e-13], rtol=1e-2)
         assert_allclose(ts_diff, [174.358204, 0., 174.418515], rtol=1e-2, atol=1e-7)
 
         value = result.parameters["amplitude"].value
@@ -137,6 +138,7 @@ class TestFluxPointFit:
         )
 
         ts_diff = profile["stat_scan"] - result.total_stat
+        assert_allclose(model.amplitude.scan_values, [1.92e-13, 2.16e-13, 2.40e-13], rtol=1e-2)
         assert_allclose(ts_diff, [174.358204, 0., 174.418515], rtol=1e-2, atol=1e-7)
 
     @staticmethod

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -124,6 +124,7 @@ class TestFluxPointFit:
 
         ts_diff = profile["stat_scan"] - result.total_stat
         assert_allclose(ts_diff, [174.358204, 0., 174.418515], rtol=1e-2, atol=1e-7)
+        assert_allclose(model.amplitude.error, 1e-12)
 
         value = result.parameters["amplitude"].value
         err = result.parameters["amplitude"].error
@@ -136,6 +137,7 @@ class TestFluxPointFit:
 
         ts_diff = profile["stat_scan"] - result.total_stat
         assert_allclose(ts_diff, [174.358204, 0., 174.418515], rtol=1e-2, atol=1e-7)
+        assert_allclose(model.amplitude.error, 1e-12)
 
     @staticmethod
     @requires_dependency("matplotlib")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a check for the error in `TestFluxPointFit.test_stat_profile()` to understand the change noted in https://github.com/gammapy/gammapy/pull/3409#discussion_r738563963.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
