### PR TITLE
Add test for event sampler using CTA IRF alpha configuration

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -290,9 +290,6 @@ class MapDatasetEventSampler:
         meta["TIMEREF"] = "LOCAL"
         meta["DATE-OBS"] = dataset.gti.time_start.isot[0][0:10]
         meta["DATE-END"] = dataset.gti.time_stop.isot[0][0:10]
-        meta["TIME-OBS"] = dataset.gti.time_start.isot[0][11:23]
-        meta["TIME-END"] = dataset.gti.time_stop.isot[0][11:23]
-        meta["TIMEDEL"] = 1e-9
         meta["CONV_DEP"] = 0
         meta["CONV_RA"] = 0
         meta["CONV_DEC"] = 0
@@ -303,7 +300,6 @@ class MapDatasetEventSampler:
         meta["NMCIDS"] = len(dataset.models)
 
         # Necessary for DataStore, but they should be ALT and AZ instead!
-        meta["ALTITUDE"] = observation.aeff.meta["CBD50001"][7:-4]
         meta["ALT_PNT"] = observation.aeff.meta["CBD50001"][7:-4]
         meta["AZ_PNT"] = observation.aeff.meta["CBD60001"][8:-4]
 
@@ -315,12 +311,10 @@ class MapDatasetEventSampler:
         meta["INSTRUME"] = observation.aeff.meta["INSTRUME"]
         meta["N_TELS"] = ""
         meta["TELLIST"] = ""
-        meta["GEOLON"] = ""
-        meta["GEOLAT"] = ""
-        # TO BE ADDED
-        #        meta["CREATED"] = ""
-        #        meta["OBS_MODE"] = ""
-        #        meta["EV_CLASS"] = ""
+
+        meta["CREATED"] = ""
+        meta["OBS_MODE"] = ""
+        meta["EV_CLASS"] = ""
 
         return meta
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -323,8 +323,6 @@ class MapDatasetEventSampler:
 
         # TO DO: these keywords should be taken from the IRF of the dataset
         meta["ORIGIN"] = "Gammapy"
-        meta["CALDB"] = observation.aeff.meta["CBD20001"][8:-1]
-        meta["IRF"] = observation.aeff.meta["CBD10001"][5:-2]
         meta["TELESCOP"] = observation.aeff.meta["TELESCOP"]
         meta["INSTRUME"] = observation.aeff.meta["INSTRUME"]
         meta["N_TELS"] = ""

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -311,7 +311,6 @@ class MapDatasetEventSampler:
                 loc = observatory_locations["cta_south"]
 
         else:
-            print("here")
             loc = observatory_locations[telescope.lower()]
 
         # this is not really correct but maybe OK for now

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -305,6 +305,22 @@ def test_mde_run(dataset, models):
 
 
 @requires_data()
+def test_irf_alpha_config(dataset, models):
+    irfs = load_cta_irfs(
+        "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
+    )
+    livetime = 1.0 * u.hr
+    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    obs = Observation.create(
+        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
+    )
+
+    dataset.models = models
+    sampler = MapDatasetEventSampler(random_state=0)
+    events = sampler.run(dataset=dataset, observation=obs)
+
+
+@requires_data()
 def test_mde_run_switchoff(dataset, models):
     irfs = load_cta_irfs(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -281,18 +281,14 @@ def test_mde_run(dataset, models):
     assert meta["TIMEREF"] == "LOCAL"
     assert meta["DATE-OBS"] == "2000-01-01"
     assert meta["DATE-END"] == "2000-01-01"
-    assert meta["TIME-OBS"] == "00:01:04.184"
-    assert meta["TIME-END"] == "00:17:44.184"
-    assert_allclose(meta["TIMEDEL"], 1e-09)
     assert meta["CONV_DEP"] == 0
     assert meta["CONV_RA"] == 0
     assert meta["CONV_DEC"] == 0
     assert meta["MID00001"] == 1
     assert meta["MID00002"] == 2
     assert meta["NMCIDS"] == 2
-    assert meta["ALTITUDE"] == "20.000"
-    assert meta["ALT_PNT"] == "20.000"
-    assert meta["AZ_PNT"] == "0.000"
+    assert meta["ALT_PNT"] == "-13.534507646452631"
+    assert meta["AZ_PNT"] == "228.82981620065763"
     assert meta["ORIGIN"] == "Gammapy"
     assert meta["CALDB"] == "1dc"
     assert meta["IRF"] == "South_z20_50"
@@ -300,8 +296,6 @@ def test_mde_run(dataset, models):
     assert meta["INSTRUME"] == "1DC"
     assert meta["N_TELS"] == ""
     assert meta["TELLIST"] == ""
-    assert meta["GEOLON"] == ""
-    assert meta["GEOLAT"] == ""
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -290,8 +290,6 @@ def test_mde_run(dataset, models):
     assert_allclose(float(meta["ALT_PNT"]), float("-13.5345076464"), rtol=1e-7)
     assert_allclose(float(meta["AZ_PNT"]), float("228.82981620065763"), rtol=1e-7)
     assert meta["ORIGIN"] == "Gammapy"
-    assert meta["CALDB"] == "1dc"
-    assert meta["IRF"] == "South_z20_50"
     assert meta["TELESCOP"] == "CTA"
     assert meta["INSTRUME"] == "1DC"
     assert meta["N_TELS"] == ""

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -287,8 +287,8 @@ def test_mde_run(dataset, models):
     assert meta["MID00001"] == 1
     assert meta["MID00002"] == 2
     assert meta["NMCIDS"] == 2
-    assert meta["ALT_PNT"] == "-13.534507646452631"
-    assert meta["AZ_PNT"] == "228.82981620065763"
+    assert_allclose(float(meta["ALT_PNT"]), float("-13.5345076464"), rtol=1e-7)
+    assert_allclose(float(meta["AZ_PNT"]), float("228.82981620065763"), rtol=1e-7)
     assert meta["ORIGIN"] == "Gammapy"
     assert meta["CALDB"] == "1dc"
     assert meta["IRF"] == "South_z20_50"


### PR DESCRIPTION
`MapDatasetEventSampler` searches for specific keywords from the IRF when sampling events. The new CTA IRFs for the alpha configuration misses some of these keywords. The PR adds a unit test to check if the `MapDatasetEventSampler` does not fail with these IRFs.
This PR is related to the issue #3556.