### PR TITLE
Convolve exposure in ExcessMapEstimator

### DIFF
--- a/docs/estimators/index.rst
+++ b/docs/estimators/index.rst
@@ -152,7 +152,7 @@ This how to compute flux maps with the `ExcessMapEstimator`:
         shape : (320, 240, 2)
         ndim  : 3
         unit  : 1 / (cm2 s)
-        dtype : float64
+        dtype : >f4
     <BLANKLINE>
 
 Flux points

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -232,7 +232,7 @@ class ExcessMapEstimator(Estimator):
             with np.errstate(invalid="ignore", divide="ignore"):
                 reco_exposure = reco_exposure.convolve(kernel.array) / mask.convolve(kernel.array)
                 flux = excess / reco_exposure
-            flux.quantity = flux.quantity.to("1 / (cm2 s)")
+                flux.quantity = flux.quantity.to("1 / (cm2 s)").astype(dataset.exposure.data.dtype)
         else:
             flux = Map.from_geom(
                 geom=dataset.counts.geom, data=np.nan * np.ones(dataset.data_shape)

--- a/gammapy/estimators/excess_map.py
+++ b/gammapy/estimators/excess_map.py
@@ -230,6 +230,7 @@ class ExcessMapEstimator(Estimator):
         if dataset.exposure:
             reco_exposure = estimate_exposure_reco_energy(dataset, self.spectral_model)
             with np.errstate(invalid="ignore", divide="ignore"):
+                reco_exposure = reco_exposure.convolve(kernel.array) / mask.convolve(kernel.array)
                 flux = excess / reco_exposure
             flux.quantity = flux.quantity.to("1 / (cm2 s)")
         else:

--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -225,7 +225,7 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
     assert_allclose(result_image["background"].data[0, 9, 9], 152)
 
     assert result_image["flux"].unit == u.Unit("cm-2s-1")
-    assert_allclose(result_image["flux"].data[0, 9, 9], 1.52e-8, rtol=1e-3)
+    assert_allclose(result_image["flux"].data[0, 9, 9], 1.190928e-08, rtol=1e-3)
 
     simple_dataset_on_off.psf = None
 
@@ -254,7 +254,7 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
 
     assert result_mod["flux"].unit == "cm-2s-1"
     assert_allclose(result_mod["flux"].data[0, 10, 10], 1.906806e-08, rtol=1e-3)
-    assert_allclose(result_mod["flux"].data.sum(), 5.920642e-06 , rtol=1e-3)
+    assert_allclose(result_mod["flux"].data.sum(), 5.920642e-06, rtol=1e-3)
 
     spectral_model=PowerLawSpectralModel(index=15)
     estimator_mod = ExcessMapEstimator(
@@ -266,10 +266,11 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
     result_mod = estimator_mod.run(simple_dataset_on_off)
 
     assert result_mod["flux"].unit == "cm-2s-1"
-    assert_allclose(result_mod["flux"].data.sum(),5.920642e-06, rtol=1e-3)
+    assert_allclose(result_mod["flux"].data.sum(), 5.920642e-06, rtol=1e-3)
 
     reco_exposure=estimate_exposure_reco_energy(simple_dataset_on_off, spectral_model=spectral_model)
     assert_allclose(reco_exposure.data.sum(), 7.977796e+12, rtol=0.001)
+
 
 def test_incorrect_selection():
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the flux computation in the `ExcessMapEstimator` to use the mean exposure in the region defined by the correlation kernel. The tests were already sensitive to this change so I just adapted the test values.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
