### PR TITLE
Add serialisation test for temporal models

### DIFF
--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -10,10 +10,17 @@ from gammapy.modeling.models import (
     MODEL_REGISTRY,
     TemplateNPredModel,
     EBLAbsorptionNormSpectralModel,
+    SkyModel,
     Model,
     Models,
     PiecewiseNormSpectralModel,
     PowerLawSpectralModel,
+    ConstantTemporalModel,
+    LinearTemporalModel,
+    ExpDecayTemporalModel,
+    GaussianTemporalModel,
+    PowerLawTemporalModel,
+    SineTemporalModel,
     )
 from gammapy.utils.scripts import read_yaml, write_yaml
 from gammapy.utils.testing import requires_data
@@ -278,4 +285,22 @@ def test_simplified_output():
 
 def test_registries_print():
     assert "Registry" in str(MODEL_REGISTRY)
+
+
+def test_io_temporal():
+    classes = [
+        ConstantTemporalModel,
+        LinearTemporalModel,
+        ExpDecayTemporalModel,
+        GaussianTemporalModel,
+        PowerLawTemporalModel,
+        SineTemporalModel,
+    ]
+    for c in classes:
+        sky_model = SkyModel(spectral_model=PowerLawSpectralModel(), temporal_model=c())
+        model_dict = sky_model.to_dict()
+        read_model = SkyModel.from_dict(model_dict)
+        for p in sky_model.temporal_model.parameters:
+            assert_allclose(read_model.temporal_model.parameters[p.name].value, p.value)
+            assert read_model.temporal_model.parameters[p.name].unit == p.unit
 

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -7,6 +7,7 @@ from astropy.table import Table
 from astropy.time import Time
 from gammapy.data.gti import GTI
 from gammapy.modeling.models import (
+    TemporalModel,
     ConstantTemporalModel,
     LinearTemporalModel,
     ExpDecayTemporalModel,
@@ -288,3 +289,23 @@ def test_plot_constant_model():
     constant_model = ConstantTemporalModel(const=1)
     with mpl_plot_check():
         constant_model.plot(time_range)
+
+
+def test_io():
+    classes = [
+                ConstantTemporalModel,
+                LinearTemporalModel,
+                ExpDecayTemporalModel,
+                GaussianTemporalModel,
+                PowerLawTemporalModel,
+                SineTemporalModel,
+                ]
+    for c in classes:
+        sky_model = SkyModel(
+            spectral_model=PowerLawSpectralModel(), temporal_model=c()
+        )
+        model_dict = sky_model.to_dict()
+        read_model =  SkyModel.from_dict(model_dict)
+        for p in sky_model.temporal_model.parameters:
+            assert_allclose(read_model.temporal_model.parameters[p.name].value, p.value)
+            assert read_model.temporal_model.parameters[p.name].unit == p.unit

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -108,11 +108,15 @@ def test_time_sampling(tmp_path):
     assert_allclose(sampler_costant.value, [4330.10377559, 3334.04566256], rtol=1e-5)
 
     temporal_model = ExpDecayTemporalModel(t_ref=Time(t_ref).mjd * u.d)
-    sampler_expo = temporal_model.sample_time(n_events=2, t_min=t_min, t_max=t_max, random_state=0)
+    sampler_expo = temporal_model.sample_time(
+        n_events=2, t_min=t_min, t_max=t_max, random_state=0
+    )
     sampler_expo = u.Quantity((sampler_expo.mjd - Time(t_ref).mjd), "d")
 
     assert sampler_expo.unit == u.d
-    assert_allclose(sampler_expo.to("s").value, [11824.1055276 ,  7273.04658336], rtol=1e-8)
+    assert_allclose(
+        sampler_expo.to("s").value, [11824.1055276, 7273.04658336], rtol=1e-8
+    )
 
 
 def test_lightcurve_temporal_model_integral():
@@ -152,14 +156,16 @@ def test_constant_temporal_model_integral():
 def test_linear_temporal_model_evaluate():
     t = Time(46301, format="mjd")
     t_ref = 46300 * u.d
-    temporal_model = LinearTemporalModel(alpha=1., beta=0.1/u.day, t_ref=t_ref)
+    temporal_model = LinearTemporalModel(alpha=1.0, beta=0.1 / u.day, t_ref=t_ref)
     val = temporal_model(t)
     assert_allclose(val, 1.1, rtol=1e-5)
 
 
 def test_linear_temporal_model_integral():
     t_ref = Time(55555, format="mjd")
-    temporal_model = LinearTemporalModel(alpha=1., beta=0.1/u.day, t_ref=t_ref.mjd * u.d)
+    temporal_model = LinearTemporalModel(
+        alpha=1.0, beta=0.1 / u.day, t_ref=t_ref.mjd * u.d
+    )
     start = [1, 3, 5] * u.day
     stop = [2, 3.5, 6] * u.day
     gti = GTI.create(start, stop, reference_time=t_ref)
@@ -212,7 +218,7 @@ def test_gaussian_temporal_model_integral():
 def test_powerlaw_temporal_model_evaluate():
     t = Time(46302, format="mjd")
     t_ref = 46300 * u.d
-    alpha = -2.
+    alpha = -2.0
     temporal_model = PowerLawTemporalModel(t_ref=t_ref, alpha=alpha)
     val = temporal_model(t)
     assert_allclose(val, 0.25, rtol=1e-5)
@@ -220,7 +226,7 @@ def test_powerlaw_temporal_model_evaluate():
 
 def test_powerlaw_temporal_model_integral():
     t_ref = Time(55555, format="mjd")
-    temporal_model = PowerLawTemporalModel(alpha=-2., t_ref=t_ref.mjd * u.d)
+    temporal_model = PowerLawTemporalModel(alpha=-2.0, t_ref=t_ref.mjd * u.d)
     start = 1 * u.day
     stop = 4 * u.day
     gti = GTI.create(start, stop, reference_time=t_ref)
@@ -241,7 +247,7 @@ def test_powerlaw_temporal_model_integral():
 def test_sine_temporal_model_evaluate():
     t = Time(46302, format="mjd")
     t_ref = 46300 * u.d
-    omega = np.pi/4. * u.rad/u.day
+    omega = np.pi / 4.0 * u.rad / u.day
     temporal_model = SineTemporalModel(amp=0.5, omega=omega, t_ref=t_ref)
     val = temporal_model(t)
     assert_allclose(val, 1.5, rtol=1e-5)
@@ -249,7 +255,7 @@ def test_sine_temporal_model_evaluate():
 
 def test_sine_temporal_model_integral():
     t_ref = Time(55555, format="mjd")
-    omega = np.pi/4. * u.rad/u.day
+    omega = np.pi / 4.0 * u.rad / u.day
     temporal_model = SineTemporalModel(amp=0.5, omega=omega, t_ref=t_ref.mjd * u.d)
     start = [1, 3, 5] * u.day
     stop = [2, 3.5, 6] * u.day
@@ -293,19 +299,17 @@ def test_plot_constant_model():
 
 def test_io():
     classes = [
-                ConstantTemporalModel,
-                LinearTemporalModel,
-                ExpDecayTemporalModel,
-                GaussianTemporalModel,
-                PowerLawTemporalModel,
-                SineTemporalModel,
-                ]
+        ConstantTemporalModel,
+        LinearTemporalModel,
+        ExpDecayTemporalModel,
+        GaussianTemporalModel,
+        PowerLawTemporalModel,
+        SineTemporalModel,
+    ]
     for c in classes:
-        sky_model = SkyModel(
-            spectral_model=PowerLawSpectralModel(), temporal_model=c()
-        )
+        sky_model = SkyModel(spectral_model=PowerLawSpectralModel(), temporal_model=c())
         model_dict = sky_model.to_dict()
-        read_model =  SkyModel.from_dict(model_dict)
+        read_model = SkyModel.from_dict(model_dict)
         for p in sky_model.temporal_model.parameters:
             assert_allclose(read_model.temporal_model.parameters[p.name].value, p.value)
             assert read_model.temporal_model.parameters[p.name].unit == p.unit

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -7,7 +7,6 @@ from astropy.table import Table
 from astropy.time import Time
 from gammapy.data.gti import GTI
 from gammapy.modeling.models import (
-    TemporalModel,
     ConstantTemporalModel,
     LinearTemporalModel,
     ExpDecayTemporalModel,
@@ -296,20 +295,3 @@ def test_plot_constant_model():
     with mpl_plot_check():
         constant_model.plot(time_range)
 
-
-def test_io():
-    classes = [
-        ConstantTemporalModel,
-        LinearTemporalModel,
-        ExpDecayTemporalModel,
-        GaussianTemporalModel,
-        PowerLawTemporalModel,
-        SineTemporalModel,
-    ]
-    for c in classes:
-        sky_model = SkyModel(spectral_model=PowerLawSpectralModel(), temporal_model=c())
-        model_dict = sky_model.to_dict()
-        read_model = SkyModel.from_dict(model_dict)
-        for p in sky_model.temporal_model.parameters:
-            assert_allclose(read_model.temporal_model.parameters[p.name].value, p.value)
-            assert read_model.temporal_model.parameters[p.name].unit == p.unit


### PR DESCRIPTION
Follow up of PR #3574
Add serialisation tests for temporal models.

@bkhelifi, note that Model.from_dict() works only for  specific classes.
So if one call model_dict = PowerLawTemporalModel.to_dict()
 then PowerLawTemporalModel.from_dict(model_dict) works but TemporalModel.from_dict(model_dict) create a TemporalModel and not a PowerLawTemporalModel. To prevent this I could raise an error in from_dict if `data['type'] not in cls.tag` (in a separate PR). 