### PR TITLE
Update event sampling tutorial for IRF alpha-configuration

### DIFF
--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -136,8 +136,8 @@
    "outputs": [],
    "source": [
     "filename = (\n",
-    "    \"$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz\"\n",
-    ")\n",
+    "            \"$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz\"\n",
+    "            )\n",
     "\n",
     "pointing = SkyCoord(0.0, 0.0, frame=\"galactic\", unit=\"deg\")\n",
     "livetime = 1 * u.hr"

--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -136,7 +136,7 @@
    "outputs": [],
    "source": [
     "filename = (\n",
-    "    \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    "    \"$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz\"\n",
     ")\n",
     "\n",
     "pointing = SkyCoord(0.0, 0.0, frame=\"galactic\", unit=\"deg\")\n",
@@ -160,6 +160,25 @@
     "observation = Observation.create(\n",
     "    obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*It may happen that, when using the CTA IRFs for the alpha-configuration, some mandatory keywords requested by the `MapDatasetEventSampler` are not present in the header of the IRF files (see [here](https://gamma-astro-data-formats.readthedocs.io/en/latest/events/index.html)). We suggest the user to update the metadata info with the following lines of code (change values according to the set of IRF you are using):*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "observation.aeff.meta.update({\"CBD50001\":\"ZENITH(20.000)deg\"})\n",
+    "observation.aeff.meta.update({\"CBD60001\":\"AZIMUTH(0.000)deg\"})\n",
+    "observation.aeff.meta.update({\"CBD20001\":\"NAME(South_z20_50h\"})\n",
+    "observation.aeff.meta.update({\"CBD10001\":\"VERSION(alpha_config)\"})"
    ]
   },
   {
@@ -432,15 +451,6 @@
     "fit = Fit()\n",
     "result = fit.run(dataset)\n",
     "print(result)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result.parameters.to_table()"
    ]
   },
   {
@@ -786,9 +796,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1.0,
+   "current_citInitial": 1,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1.0,
+   "eqNumInitial": 1,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"

--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -166,25 +166,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*It may happen that, when using the CTA IRFs for the alpha-configuration, some mandatory keywords requested by the `MapDatasetEventSampler` are not present in the header of the IRF files (see [here](https://gamma-astro-data-formats.readthedocs.io/en/latest/events/index.html)). We suggest the user to update the metadata info with the following lines of code (change values according to the set of IRF you are using):*"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "observation.aeff.meta.update({\"CBD50001\":\"ZENITH(20.000)deg\"})\n",
-    "observation.aeff.meta.update({\"CBD60001\":\"AZIMUTH(0.000)deg\"})\n",
-    "observation.aeff.meta.update({\"CBD20001\":\"NAME(South_z20_50h\"})\n",
-    "observation.aeff.meta.update({\"CBD10001\":\"VERSION(alpha_config)\"})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Define the MapDataset\n",
     "\n",
     "Let's generate the `~gammapy.datasets.Dataset` object (for more info on `~gammapy.datasets.Dataset` objects, please visit the [link](../../starting/analysis_2.ipynb#Preparing-reduced-datasets-geometry)): we define the energy axes (true and reconstruncted), the migration axis and the geometry of the observation. \n",


### PR DESCRIPTION
The event sampler tutorial is currently adapted to work with the CTA IRFs of DC1. This PR updates the tutorial to work with the new IRFs for the alpha-configuration.