### PR TITLE
Return Maps object in ASmoothMapEstimator

### DIFF
--- a/gammapy/estimators/asmooth_map.py
+++ b/gammapy/estimators/asmooth_map.py
@@ -4,7 +4,7 @@ import numpy as np
 from astropy.convolution import Gaussian2DKernel, Tophat2DKernel
 from astropy.coordinates import Angle
 from gammapy.datasets import MapDatasetOnOff
-from gammapy.maps import Map, WcsNDMap, MapAxis
+from gammapy.maps import Map, WcsNDMap, Maps
 from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.stats import CashCountsStatistic
 from gammapy.utils.array import scale_cube
@@ -168,13 +168,14 @@ class ASmoothMapEstimator(Estimator):
             result = self.estimate_maps(dataset_sliced)
             results.append(result)
 
-        result_all = {}
+        maps = Maps()
 
         for name in results[0].keys():
-            map_all = Map.from_stack(maps=[_[name] for _ in results], axis_name="energy")
-            result_all[name] = map_all
+            maps[name] = Map.from_stack(
+                maps=[_[name] for _ in results], axis_name="energy"
+            )
 
-        return result_all
+        return maps
 
     def estimate_maps(self, dataset):
         """Run adaptive smoothing on input Maps.

--- a/gammapy/estimators/tests/test_asmooth_map.py
+++ b/gammapy/estimators/tests/test_asmooth_map.py
@@ -86,7 +86,6 @@ def test_asmooth_dataset(input_dataset):
         assert_allclose(actual, desired[name], rtol=1e-2)
 
 
-@pytest.mark.xfail
 def test_asmooth_map_dataset_on_off():
     kernel = Tophat2DKernel
     scales = ASmoothMapEstimator.get_scales(3, factor=2, kernel=kernel) * 0.1 * u.deg
@@ -116,6 +115,6 @@ def test_asmooth_map_dataset_on_off():
     )
 
     smoothed = asmooth.run(dataset)
-    assert_allclose(smoothed["counts"].data[25, 25], 2)
-    assert_allclose(smoothed["background"].data[25, 25], 1.25)
-    assert_allclose(smoothed["significance"].data[25, 25], 3.079799117645, rtol=1e-2)
+    assert_allclose(smoothed["counts"].data[0, 25, 25], 2)
+    assert_allclose(smoothed["background"].data[0, 25, 25], 1)
+    assert_allclose(smoothed["sqrt_ts"].data[0, 25, 25], 4.39, rtol=1e-2)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the `ASmoothMapEstimator` to return a `Maps` object.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
