### PR TITLE
Add unit equivalency check to MapAxis.from_energy methods

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -419,9 +419,8 @@ class MapAxis:
         """
         energy_edges = u.Quantity(energy_edges, unit)
 
-        if unit is None:
-            unit = energy_edges.unit
-            energy_edges = energy_edges.to(unit)
+        if not energy_edges.unit.is_equivalent("TeV"):
+            raise ValueError(f"Please provide a valid energy unit, got {energy_edges.unit} instead.")
 
         if name is None:
             name = "energy"
@@ -471,6 +470,9 @@ class MapAxis:
         if unit is None:
             unit = energy_max.unit
             energy_min = energy_min.to(unit)
+
+        if not energy_max.unit.is_equivalent("TeV"):
+            raise ValueError(f"Please provide a valid energy unit, got {energy_max.unit} instead.")
 
         if per_decade:
             nbin = np.ceil(np.log10(energy_max / energy_min).value * nbin)

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -309,6 +309,14 @@ def test_mapaxis_from_bounds(nodes, interp):
         MapAxis.from_bounds(1, 1, 1)
 
 
+def test_map_axis_from_energy_units():
+    with pytest.raises(ValueError):
+        axis = MapAxis.from_energy_bounds(0.1, 10, 2, unit="deg")
+
+    with pytest.raises(ValueError):
+        axis = MapAxis.from_energy_edges([0.1, 1, 10] * u.deg)
+
+
 @pytest.mark.parametrize(("nodes", "interp", "node_type"), MAP_AXIS_NODE_TYPES)
 def test_mapaxis_pix_to_coord(nodes, interp, node_type):
     axis = MapAxis(nodes, interp=interp, node_type=node_type)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes #3575 by adding an `unit.is_equivalent` check to `MapAxis.from_energy_bounds` and `MapAxis.from_energy_edges`.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
