### PR TITLE
Restore "scale10" method as default parameter scaling

### DIFF
--- a/gammapy/estimators/points/tests/test_profile.py
+++ b/gammapy/estimators/points/tests/test_profile.py
@@ -76,7 +76,7 @@ def test_profile_content():
     assert_allclose(errn, [10.75, 10.75], atol=1e-2)
 
     ul = result.npred_excess_ul.data[7].squeeze()
-    assert_allclose(ul, [111.31, 111.31], atol=1e-2)
+    assert_allclose(ul, [111.32, 111.32], atol=1e-2)
 
 
 @requires_dependency("iminuit")

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -133,7 +133,7 @@ class Model:
         if not full_output:
             for par, par_default in zip(params, self.default_parameters):
                 init = par_default.to_dict()
-                for item in ["min", "max", "error"]:
+                for item in ["min", "max", "error", "interp", "scale_method"]:
                     default = init[item]
 
                     if par[item] == default or np.isnan(default):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -402,10 +402,9 @@ class Parameter:
             "min": self.min,
             "max": self.max,
             "frozen": self.frozen,
-            "interp": self.interp
+            "interp": self.interp,
+            "scale_method": self.scale_method
         }
-        if self.scale_method is not None:
-            output["scale_method"] = self.scale_method
 
         if self._link_label_io is not None:
             output["link"] = self._link_label_io

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -105,7 +105,7 @@ class Parameter:
         scan_n_values=11,
         scan_n_sigma=2,
         scan_values=None,
-        scale_method=None,
+        scale_method="scale10",
         interp="lin",
     ):
         if not isinstance(name, str):

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -264,11 +264,11 @@ def test_stat_contour():
     x = result["y"]
     assert_allclose(len(x), 10)
     assert_allclose(x[0], 299, rtol=1e-5)
-    assert_allclose(x[-1], 299.292893, rtol=1e-5)
+    assert_allclose(x[-1], 299.133975, rtol=1e-5)
     y = result["z"]
     assert_allclose(len(y), 10)
     assert_allclose(y[0], 0.04, rtol=1e-5)
-    assert_allclose(y[-1], 0.747107, rtol=1e-5)
+    assert_allclose(y[-1], 0.54, rtol=1e-5)
 
     # Check that original value state wasn't changed
     assert_allclose(dataset.models.parameters["y"].value, 300)

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -186,7 +186,7 @@ def test_parameters_s():
     assert_allclose(pars[0].scale, 10)
 
     assert pars_dict[0]["scale_method"] == "scale10"
-    assert "scale_method" not in pars_dict[1]
+    assert pars_dict[1]["scale_method"] is None
     pars = Parameters.from_dict(pars_dict)
     pars.autoscale()
     assert_allclose(pars[0].factor, 2)


### PR DESCRIPTION
This PR changes the default parameter scaling to "scale10" (as previously) instead of `None`. This fix a drop of performance by about 40 % in the `profile_analysis_3d_joint` benchmark. Without scaling  for lon/lat parameters the number of evaluator `.update()` calls required increase by a factor of 6.