### PR TITLE
Avoid copy in background model evaluation

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -414,7 +414,7 @@ class MapDataset(Dataset):
             if self._background_cached is None:
                 self._background_cached = background * values
             else:
-                self._background_cached.data = background.data * values.data
+                self._background_cached.data = background.data * values.value
                 self._background_cached.unit = background.unit
             return self._background_cached
         else:

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -179,6 +179,7 @@ class MapDataset(Dataset):
         self.counts = counts
         self.exposure = exposure
         self.background = background
+        self._background_cached = None
         self.mask_fit = mask_fit
 
         if psf and not isinstance(psf, (PSFMap, HDULocation)):
@@ -408,10 +409,16 @@ class MapDataset(Dataset):
             Predicted counts from the background.
         """
         background = self.background
-
         if self.background_model and background:
             values = self.background_model.evaluate_geom(geom=self.background.geom)
-            background = background * values
+            if self._background_cached is None:
+                self._background_cached = background * values
+            else:
+                self._background_cached.data = background.data * values.data
+                self._background_cached.unit = background.unit
+            return self._background_cached
+        else:
+            return background
 
         return background
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -180,6 +180,8 @@ class MapDataset(Dataset):
         self.exposure = exposure
         self.background = background
         self._background_cached = None
+        self._background_parameters_cached = None
+
         self.mask_fit = mask_fit
 
         if psf and not isinstance(psf, (PSFMap, HDULocation)):
@@ -410,17 +412,26 @@ class MapDataset(Dataset):
         """
         background = self.background
         if self.background_model and background:
-            values = self.background_model.evaluate_geom(geom=self.background.geom)
-            if self._background_cached is None:
-                self._background_cached = background * values
-            else:
-                self._background_cached.data = background.data * values.value
-                self._background_cached.unit = background.unit
+            if self._background_parameters_changed:
+                values = self.background_model.evaluate_geom(geom=self.background.geom)
+                if self._background_cached is None:
+                    self._background_cached = background * values
+                else:
+                    self._background_cached.data = background.data * values.value
+                    self._background_cached.unit = background.unit
             return self._background_cached
         else:
             return background
 
         return background
+
+    def _background_parameters_changed(self):
+        values = self.background_model.parameters.value
+        # TODO: possibly allow for a tolerance here?
+        changed = ~np.all(self._background_parameters_cached == values)
+        if changed:
+            self._background_parameters_cached = values
+        return changed
 
     def npred_signal(self, model_name=None):
         """ "Model predicted signal counts.

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -895,7 +895,7 @@ def test_stack(sky_model):
 
 
 @requires_data()
-def test_npred_sig(sky_model, geom, geom_etrue):
+def test_npred(sky_model, geom, geom_etrue):
     dataset = get_map_dataset(geom, geom_etrue)
 
     pwl = PowerLawSpectralModel()
@@ -910,14 +910,24 @@ def test_npred_sig(sky_model, geom, geom_etrue):
     assert_allclose(
         dataset.npred_signal(model_name=model1.name).data.sum(), 150.7487, rtol=1e-3
     )
+    assert dataset._background_cached is None
+    assert_allclose(dataset.npred_background().data.sum(), 4000., rtol=1e-3)
+    assert_allclose(dataset._background_cached.data.sum(), 4000., rtol=1e-3)
+
     assert_allclose(dataset.npred().data.sum(), 9676.047906, rtol=1e-3)
     assert_allclose(dataset.npred_signal().data.sum(), 5676.04790, rtol=1e-3)
+
+    bkg.spectral_model.norm.value = 1.1
+    assert_allclose(dataset.npred_background().data.sum(), 4400., rtol=1e-3)
+    assert_allclose(dataset._background_cached.data.sum(), 4400., rtol=1e-3)
+
 
     with pytest.raises(
         KeyError,
         match="m2",
     ):
         dataset.npred_signal(model_name="m2")
+
 
 
 def test_stack_npred():


### PR DESCRIPTION
Avoid copy in background model evaluation in order to slightly improve performance.