### PR TITLE
Correct confidence level used for contours

### DIFF
--- a/gammapy/modeling/iminuit.py
+++ b/gammapy/modeling/iminuit.py
@@ -173,7 +173,7 @@ def contour_iminuit(parameters, function, x, y, numpoints, sigma, **kwargs):
     idx_y = parameters.free_parameters.index(par_y)
     y = _make_parname(idx_y, par_y)
 
-    cl = chi2(2).cdf(sigma)
+    cl = chi2(2).cdf(sigma**2)
     contour = minuit.mncontour(x=x, y=y, size=numpoints, cl=cl)
     # TODO: add try and except to get the success
     return {


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects the confidence level calculation for contours. 

There is general question one can ask now that `mncontours` takes a confidence level expressed as probability rather than number of sigma. Should we stick with `sigma` as the argument for this method compared to `cl` as done in iminuit?
Opinions @adonath @QRemy @bkhelifi ?

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
