### PR TITLE
Fix coordinate handling for PSFMap.containment()

### DIFF
--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -118,7 +118,7 @@ class PSFMap(IRFMap):
         coords = MapCoord.create(kwargs)
 
         geom = self.psf_map.geom.to_image()
-        lon_pix, lat_pix = geom.coord_to_pix((coords.lon, coords.lat))
+        lon_pix, lat_pix = geom.coord_to_pix(coords.skycoord)
 
         coords_irf = {
             "lon_idx": lon_pix,

--- a/gammapy/irf/psf/tests/test_map.py
+++ b/gammapy/irf/psf/tests/test_map.py
@@ -480,6 +480,7 @@ def test_psf_map_plot_psf_vs_rad():
         psf.plot_psf_vs_rad()
 
 
+@requires_data()
 def test_psf_containment_coords():
     # regression test to check the cooordinate conversion for PSFMap.containment
     psf = PSFMap.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz", hdu="PSF")
@@ -491,4 +492,3 @@ def test_psf_containment_coords():
     )
 
     assert_allclose(radius, 0.10575 * u.deg, rtol=1e-5)
-

--- a/gammapy/irf/psf/tests/test_map.py
+++ b/gammapy/irf/psf/tests/test_map.py
@@ -478,3 +478,17 @@ def test_psf_map_plot_psf_vs_rad():
 
     with mpl_plot_check():
         psf.plot_psf_vs_rad()
+
+
+def test_psf_containment_coords():
+    # regression test to check the cooordinate conversion for PSFMap.containment
+    psf = PSFMap.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz", hdu="PSF")
+
+    position = SkyCoord("266.415d", "-29.006d", frame="icrs")
+
+    radius = psf.containment_radius(
+        energy_true=1 * u.TeV, fraction=0.99, position=position
+    )
+
+    assert_allclose(radius, 0.10575 * u.deg, rtol=1e-5)
+


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes a bug in the coordinate handling of `PSFMap.containment()` and `PSFMap.containment_radius()`. The handling missed the coordinate transformation, when the  position was passed in a different coordinate system than the one the `PSFMap` is defined in.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
