### PR TITLE
Add authors.py helper script and adapt CITATION.cff

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,5 @@
+Adam Ginsburg <keflavich@gmail.com> Adam Ginsburg (keflavich) <keflavich@gmail.com>
+
 Alexis de Almeida Coutinho <alexis.almeida98@usp.br> Alexis de Almeida Coutinho <alexis.almeida98@yahoo.com.br>
 
 Anne Lemière <alemiere@MacBook-Pro-de-Anne.local> Anne Lemière <alemiere@apcdhcp62.in2p3.fr>
@@ -35,7 +37,6 @@ Cosimo Nigro <cosimonigro2@gmail.com> cnigro <cosimo.nigro@ifae.es>
 
 Jose Enrique Ruiz <jer@iaa.es> Bultako <jer@iaa.es>
 
-
 David Fidalgo <dfidalgo@gae.ucm.es> David Fidalgo <davidc.fidalgo@gmail.com>
 David Fidalgo <dfidalgo@gae.ucm.es> dcfidalgo <dfidalgo@gae.ucm.es>
 
@@ -56,12 +57,14 @@ Fabio Pintore <fabio.pintore@inaf.it> Mac_di_Fabio <fabio@wlan-3-144.mpi-hd.mpg.
 Fabio Acero <fabio.f.acero@gmail.co> facero <fabio.f.acero@gmail.com>
 Fabio Acero <fabio.f.acero@gmail.co> facero <fabacero@gmail.com>
 
+Hugo van Kemenade <hugovk@users.noreply.github.com> Hugo <hugovk@users.noreply.github.com>
+
 Jalel Eddine Hajlaoui <hajlaouijalel.ig@gmail.com> Jaleleddine <hajlaouijalel.ig@gmail.com>
 
 Jason Watson <jason.jw@live.co.uk> watsonjj <jason.jw@live.co.uk>
 
-Jean-Phillipe Lenain <jeanphilippe.lenain@free.fr> jlenain <jeanphilippe.lenain@free.fr>
-Jean-Phillipe Lenain <jeanphilippe.lenain@free.fr> Jean-Philippe Lenain <jlenain@users.noreply.github.com>
+Jean-Philippe Lenain <jeanphilippe.lenain@free.fr> jlenain <jeanphilippe.lenain@free.fr>
+Jean-Philippe Lenain <jeanphilippe.lenain@free.fr> Jean-Philippe Lenain <jlenain@users.noreply.github.com>
 
 Johannes King <johannes.king@mpi-hd.mpg.de> Johannes King <johannes.king@sqlnet.ai>
 Johannes King <johannes.king@mpi-hd.mpg.de> kingj90 <johannes.king@mpi-hd.mpg.de>
@@ -132,3 +135,5 @@ Ellis Owen <ellis.owen@mpi-hd.mpg.de> ellisowen <ellis.owen@mpi-hd.mpg.de>
 
 Roberta Zanin <Roberta.Zanin@mpi-hd.mpg.de> robertazanin <Roberta.Zanin@mpi-hd.mpg.de>
 Roberta Zanin <Roberta.Zanin@mpi-hd.mpg.de> robertazanin <robertazanin@gmail.com>
+
+Zé Vinicius <jvmirca@gmail.com> Ze Vinicius <jvmirca@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -57,6 +57,9 @@ Fabio Pintore <fabio.pintore@inaf.it> Mac_di_Fabio <fabio@wlan-3-144.mpi-hd.mpg.
 Fabio Acero <fabio.f.acero@gmail.co> facero <fabio.f.acero@gmail.com>
 Fabio Acero <fabio.f.acero@gmail.co> facero <fabacero@gmail.com>
 
+Gabriel Emery <gabriel.emery@lpnhe.in2p3.fr> Emery Gabriel <gabriel.emery@lpnhe.in2p3.fr>
+Gabriel Emery <gabriel.emery@lpnhe.in2p3.fr> Gabriel Emery <35919817+gabemery@users.noreply.github.com>
+
 Hugo van Kemenade <hugovk@users.noreply.github.com> Hugo <hugovk@users.noreply.github.com>
 
 Jalel Eddine Hajlaoui <hajlaouijalel.ig@gmail.com> Jaleleddine <hajlaouijalel.ig@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -54,8 +54,9 @@ Eric O. Lebigot <eric.lebigot@normalesup.org> Eric O. LEBIGOT (EOL) <eric.lebigo
 Fabio Pintore <fabio.pintore@inaf.it> fabiopintore <39336833+fabiopintore@users.noreply.github.com>
 Fabio Pintore <fabio.pintore@inaf.it> Mac_di_Fabio <fabio@wlan-3-144.mpi-hd.mpg.de>
 
-Fabio Acero <fabio.f.acero@gmail.co> facero <fabio.f.acero@gmail.com>
-Fabio Acero <fabio.f.acero@gmail.co> facero <fabacero@gmail.com>
+Fabio Acero <fabio.f.acero@gmail.com> facero <fabio.f.acero@gmail.com>
+Fabio Acero <fabio.f.acero@gmail.com> facero <fabacero@gmail.com>
+Fabio Acero <fabio.f.acero@gmail.com> facero <fabio.acero@cea.fr>
 
 Gabriel Emery <gabriel.emery@lpnhe.in2p3.fr> Emery Gabriel <gabriel.emery@lpnhe.in2p3.fr>
 Gabriel Emery <gabriel.emery@lpnhe.in2p3.fr> Gabriel Emery <35919817+gabemery@users.noreply.github.com>

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,6 +29,8 @@ authors:
   affiliation: Pamyra
 - given-names: Quentin
   family-names: Remy
+  affiliation: MPIK
+  orcid: https://orcid.org/0000-0002-8815-6530
 - given-names: Atreyee
   family-names: Sinha
   affiliation: EMFTEL, UCM

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -173,6 +173,24 @@ authors:
   family-names: Lebigot
 - given-names: Stefan
   family-names: Klepser
+- given-names: Anne
+  family-names: Lemière
+- given-names: Dimitri
+  family-names: Papadopoulos
+- given-names: Gabriel
+  family-names: Emery
+- given-names: Laura
+  family-names: Vega Garcia
+- given-names: Marion
+  family-names: Spir-Jacob
+- given-names: Roberta
+  family-names: Zanin
+- given-names: Matthias
+  family-names: Wegenmat
+- given-names: Silvia
+  family-names: Manconi
+- given-names: Sebastian
+  family-names: Panny
 version: 0.18.2
 date-released: 2020-11-19
 repository-code: https://github.com/gammapy/gammapy

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,36 +1,40 @@
 # YAML 1.2
 # Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
 cff-version: 1.0.3
-message: This research made use of Gammapy, a community-developed core Python package for gamma-ray astronomy. https://ui.adsabs.harvard.edu/abs/2017ICRC...35..766D/abstract
+message: This research made use of Gammapy, a community-developed core Python package
+  for gamma-ray astronomy. https://ui.adsabs.harvard.edu/abs/2017ICRC...35..766D/abstract
 title: 'Gammapy: Python toolbox for gamma-ray astronomy'
-abstract: 'Gammapy analyzes gamma-ray data and creates sky images, spectra and lightcurves, from event lists and instrument response information; it can also determine the position, morphology and spectra of gamma-ray sources. It is used to analyze data from H.E.S.S., Fermi-LAT, and the Cherenkov Telescope Array (CTA).'
+abstract: 'Gammapy analyzes gamma-ray data and creates sky images, spectra and lightcurves,
+  from event lists and instrument response information; it can also determine the
+  position, morphology and spectra of gamma-ray sources. It is used to analyze data
+  from H.E.S.S., Fermi-LAT, and the Cherenkov Telescope Array (CTA).'
 doi: 10.5281/zenodo.4701500
 authors:
-- given-names: Christoph
-  family-names: Deil
-  affiliation: HeidelbergCement
 - given-names: Axel
   family-names: Donath
   affiliation: "Center for Astrophysics | Harvard & Smithonian"
   orcid: https://orcid.org/0000-0003-4568-7005
   email: "axel.donath@cfa.havard.edu"
+- given-names: Christoph
+  family-names: Deil
+  affiliation: HeidelbergCement
 - given-names: Régis
   family-names: Terrier
   affiliation: Astroparticle and Cosmology, CNRS, Université de Paris
   orcid: https://orcid.org/0000-0002-8219-4667
-- given-names: Léa
-  family-names: Jouvin
+- given-names: Johannes
+  family-names: King
+  affiliation: Pamyra
 - given-names: Jose Enrique
   family-names: Ruiz
   affiliation: Instituto de Astrofísica de Andalucía - CSIC
   orcid: https://orcid.org/0000-0003-3274-4445
-- given-names: Johannes
-  family-names: King
-  affiliation: Pamyra
 - given-names: Quentin
   family-names: Remy
   affiliation: MPIK
   orcid: https://orcid.org/0000-0002-8815-6530
+- given-names: Léa
+  family-names: Jouvin
 - given-names: Atreyee
   family-names: Sinha
   affiliation: EMFTEL, UCM
@@ -47,6 +51,9 @@ authors:
 - given-names: Luca
   family-names: Giunti
   affiliation: APC
+- given-names: Bruno
+  family-names: Khelifi
+  affiliation: CNRS
 - given-names: Ellis
   family-names: Owen
 - given-names: Brigitta
@@ -54,29 +61,36 @@ authors:
   affiliation: DIRAC Institute, UW
 - given-names: Olga
   family-names: Vorokh
+- given-names: Julien
+  family-names: Lefaucheur
 - given-names: Fabio
   family-names: Acero
   affiliation: "DAp/AIM, CEA-Saclay/CNRS"
-  orcid: https://orcid.org/0000-0002-6606-2816  
-- given-names: David
-  family-names: Fidalgo
+  orcid: https://orcid.org/0000-0002-6606-2816
 - given-names: Thomas
   family-names: Robitaille
+- given-names: David
+  family-names: Fidalgo
 - given-names: Jonathan
   name-particle: D.
   family-names: Harris
 - given-names: Lars
   family-names: Mohrmann
   affiliation: MPIK, Heidelberg
-- given-names: Bruno
-  family-names: Khelifi
-  affiliation: CNRS
-- given-names: Jalel
-  name-particle: Eddine
-  family-names: Hajlaoui
 - given-names: Cosimo
   family-names: Nigro
   affiliation: IFAE
+- given-names: Dirk
+  family-names: Lennarz
+- given-names: Jalel
+  name-particle: Eddine
+  family-names: Hajlaoui
+- given-names: Alexis
+  family-names: de Almeida Coutinho
+- given-names: Matthias
+  family-names: Wegenmat
+- given-names: Maximilian
+  family-names: Nöthe
 - given-names: Nachiketa
   family-names: Chakraborty
 - given-names: Michael
@@ -84,8 +98,6 @@ authors:
   affiliation: Mozilla
 - given-names: Helen
   family-names: Poon
-- given-names: Alexis
-  family-names: de Almeida Coutinho
 - given-names: Jason
   family-names: Watson
   affiliation: DESY
@@ -94,124 +106,116 @@ authors:
 - given-names: Erik
   family-names: Tollerud
   affiliation: Space Telescope Science Institute
+- given-names: Vikas
+  family-names: Joshi
+- given-names: Dimitri
+  family-names: Papadopoulos
 - given-names: Thomas
   family-names: Armstrong
-- given-names: Domenico
-  family-names: Tiziani
 - given-names: Erik
   name-particle: M.
   family-names: Bray
-- given-names: Maximilian
-  family-names: Nöthe
-- given-names: Kai
-  family-names: Brügge
-- given-names: Ignacio
-  family-names: Minaya
-- given-names: Arpit
-  family-names: Gogia
-- given-names: Yves
-  family-names: Gallant
+- given-names: Domenico
+  family-names: Tiziani
+- given-names: Gabriel
+  family-names: Emery
 - given-names: Hubert
   family-names: Siejkowski
-- given-names: Vikas
-  family-names: Joshi
+- given-names: Kai
+  family-names: Brügge
 - given-names: Luigi
   family-names: Tibaldo
+- given-names: Arpit
+  family-names: Gogia
+- given-names: Ignacio
+  family-names: Minaya
+- given-names: Marion
+  family-names: Spir-Jacob
+- given-names: Yves
+  family-names: Gallant
 - given-names: Andrew
   name-particle: W.
   family-names: Chen
-- given-names: Lab
-  family-names: Saha
-- given-names: Kaori
-  family-names: Nakashima
-- given-names: Julien
-  family-names: Lefaucheur
+- given-names: Roberta
+  family-names: Zanin
+- given-names: Jean-Philippe
+  family-names: Lenain
 - given-names: Larry
   family-names: Bradley
-- given-names: Matthew
-  family-names: Craig
+- given-names: Kaori
+  family-names: Nakashima
+- given-names: Anne
+  family-names: Lemière
 - given-names: Mathieu
   family-names: de Bony
-- given-names: Kyle
-  family-names: Barbary
+- given-names: Matthew
+  family-names: Craig
+- given-names: Lab
+  family-names: Saha
 - given-names: Zé
   family-names: Vinicius
+- given-names: Kyle
+  family-names: Barbary
 - given-names: Thomas
   family-names: Vuillaume
-- given-names: Dirk
-  family-names: Lennarz
-- given-names: Oscar
-  family-names: Blanch Bigas
-- given-names: Víctor
-  family-names: Zabalza
-- given-names: Wolfgang
-  family-names: Kerzendorf
 - given-names: Adam
   family-names: Ginsburg
 - given-names: Daniel
   family-names: Morcuende
 - given-names: José Luis
   family-names: Contreras
-- given-names: Jean-Philippe
-  family-names: Lenain
-- given-names: Hugo
-  family-names: van Kemenade
-- given-names: Rubén
-  family-names: López-Coto
+- given-names: Laura
+  family-names: Vega Garcia
+- given-names: Oscar
+  family-names: Blanch Bigas
+- given-names: Víctor
+  family-names: Zabalza
+- given-names: Wolfgang
+  family-names: Kerzendorf
+- given-names: Rolf
+  family-names: Buehler
+- given-names: Sebastian
+  family-names: Panny
+- given-names: Silvia
+  family-names: Manconi
+- given-names: Stefan
+  family-names: Klepser
 - given-names: Peter
   family-names: Deiml
 - given-names: Johannes
   family-names: Buchner
-- given-names: Sam
-  family-names: Carter
-- given-names: Rolf
-  family-names: Buehler
+- given-names: Hugo
+  family-names: van Kemenade
+- given-names: Eric
+  name-particle: O.
+  family-names: Lebigot
 - given-names: Benjamin Alan
   family-names: Weaver
 - given-names: Debanjan
   family-names: Bose
-- given-names: Eric
-  name-particle: O.
-  family-names: Lebigot
-- given-names: Stefan
-  family-names: Klepser
-- given-names: Anne
-  family-names: Lemière
-- given-names: Dimitri
-  family-names: Papadopoulos
-- given-names: Gabriel
-  family-names: Emery
-- given-names: Laura
-  family-names: Vega Garcia
-- given-names: Marion
-  family-names: Spir-Jacob
-- given-names: Roberta
-  family-names: Zanin
-- given-names: Matthias
-  family-names: Wegenmat
-- given-names: Silvia
-  family-names: Manconi
-- given-names: Sebastian
-  family-names: Panny
+- given-names: Rubén
+  family-names: López-Coto
+- given-names: Sam
+  family-names: Carter
 version: 0.18.2
 date-released: 2020-11-19
 repository-code: https://github.com/gammapy/gammapy
 license: BSD3
 keywords:
-  - Astronomy
-  - "Gamma-rays"
-  - "Data analysis"
+- Astronomy
+- "Gamma-rays"
+- "Data analysis"
 identifiers:
- - type: "doi"
-   value: 10.5281/zenodo.4701500
-   description: Zenodo DOI v0.18.2
- - type: "doi"
-   value: 10.5281/zenodo.4701492
-   description: Zenodo DOI v0.17
- - type: "doi"
-   value: 10.5281/zenodo.4701489
-   description: Zenodo DOI v0.16
- - type: "bibcode"
-   value: "2017ascl.soft11014D"
- - type: "ascl-id"
-   value: "1711.014"
+- type: "doi"
+  value: 10.5281/zenodo.4701500
+  description: Zenodo DOI v0.18.2
+- type: "doi"
+  value: 10.5281/zenodo.4701492
+  description: Zenodo DOI v0.17
+- type: "doi"
+  value: 10.5281/zenodo.4701489
+  description: Zenodo DOI v0.16
+- type: "bibcode"
+  value: "2017ascl.soft11014D"
+- type: "ascl-id"
+  value: "1711.014"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,7 +18,7 @@ authors:
   family-names: Terrier
   affiliation: Astroparticle and Cosmology, CNRS, Université de Paris
   orcid: https://orcid.org/0000-0002-8219-4667
-- given-names: Lea
+- given-names: Léa
   family-names: Jouvin
 - given-names: Jose Enrique
   family-names: Ruiz
@@ -37,8 +37,8 @@ authors:
 - given-names: Fabio
   family-names: Pintore
   affiliation: INAF/IASF Palermo
-- given-names: Paz
-  family-names: Arribas
+- given-names: Manuel
+  family-names: Paz Arribas
 - given-names: Laura
   family-names: Olivera
   affiliation: MPIK
@@ -61,6 +61,7 @@ authors:
 - given-names: Thomas
   family-names: Robitaille
 - given-names: Jonathan
+  name-particle: D.
   family-names: Harris
 - given-names: Lars
   family-names: Mohrmann
@@ -68,8 +69,9 @@ authors:
 - given-names: Bruno
   family-names: Khelifi
   affiliation: CNRS
-- given-names: Jaleleddine
-  family-names: ''
+- given-names: Jalel
+  name-particle: Eddine
+  family-names: Hajlaoui
 - given-names: Cosimo
   family-names: Nigro
   affiliation: IFAE
@@ -81,7 +83,7 @@ authors:
 - given-names: Helen
   family-names: Poon
 - given-names: Alexis
-  family-names: Coutinho
+  family-names: de Almeida Coutinho
 - given-names: Jason
   family-names: Watson
   affiliation: DESY
@@ -94,7 +96,8 @@ authors:
   family-names: Armstrong
 - given-names: Domenico
   family-names: Tiziani
-- given-names: E. M.
+- given-names: Erik
+  name-particle: M.
   family-names: Bray
 - given-names: Maximilian
   family-names: Nöthe
@@ -103,9 +106,9 @@ authors:
 - given-names: Ignacio
   family-names: Minaya
 - given-names: Arpit
-  family-names: ''
-- given-names: gallanty
-  family-names: ''
+  family-names: Gogia
+- given-names: Yves
+  family-names: Gallant
 - given-names: Hubert
   family-names: Siejkowski
 - given-names: Vikas
@@ -113,16 +116,17 @@ authors:
 - given-names: Luigi
   family-names: Tibaldo
 - given-names: Andrew
+  name-particle: W.
   family-names: Chen
 - given-names: Lab
   family-names: Saha
-- given-names: kaoriinakashima
-  family-names: ''
+- given-names: Kaori
+  family-names: Nakashima
 - given-names: Julien
   family-names: Lefaucheur
 - given-names: Larry
   family-names: Bradley
-- given-names: Matt
+- given-names: Matthew
   family-names: Craig
 - given-names: Mathieu
   family-names: de Bony
@@ -131,12 +135,12 @@ authors:
 - given-names: Zé
   family-names: Vinicius
 - given-names: Thomas
-  family-names: Villaume
+  family-names: Vuillaume
 - given-names: Dirk
   family-names: Lennarz
 - given-names: Oscar
   family-names: Blanch Bigas
-- given-names: Victor
+- given-names: Víctor
   family-names: Zabalza
 - given-names: Wolfgang
   family-names: Kerzendorf
@@ -144,7 +148,7 @@ authors:
   family-names: Ginsburg
 - given-names: Daniel
   family-names: Morcuende
-- given-names: Jose Luis
+- given-names: José Luis
   family-names: Contreras
 - given-names: Jean-Philippe
   family-names: Lenain
@@ -152,22 +156,23 @@ authors:
   family-names: van Kemenade
 - given-names: Rubén
   family-names: López-Coto
-- given-names: pdeiml
-  family-names: ''
+- given-names: Peter
+  family-names: Deiml
 - given-names: Johannes
   family-names: Buchner
-- given-names: samcarter
-  family-names: ''
-- given-names: rbuehler
-  family-names: ''
+- given-names: Sam
+  family-names: Carter
+- given-names: Rolf
+  family-names: Buehler
 - given-names: Benjamin Alan
   family-names: Weaver
 - given-names: Debanjan
   family-names: Bose
-- given-names: Eric O.
+- given-names: Eric
+  name-particle: O.
   family-names: Lebigot
-- given-names: klepser
-  family-names: ''
+- given-names: Stefan
+  family-names: Klepser
 version: 0.18.2
 date-released: 2020-11-19
 repository-code: https://github.com/gammapy/gammapy

--- a/dev/authors.py
+++ b/dev/authors.py
@@ -1,0 +1,112 @@
+"""Utility script to work with the CITATION.cff file"""
+import logging
+import subprocess
+import click
+from ruamel.yaml import YAML
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+EXCLUDE_AUTHORS = [
+    "azure-pipelines[bot]"
+]
+
+PATH = Path(__file__).parent.parent
+
+
+@click.group()
+def cli():
+    pass
+
+
+def get_git_shortlog_authors():
+    """Get list of authors from git shortlog"""
+    authors = []
+    command = "git shortlog --summary --numbered"
+    result = subprocess.check_output(command, stderr = subprocess.STDOUT, shell=True).decode()
+    data = result.split("\n")
+    for row in data:
+        parts = row.split("\t")
+
+        if len(parts) == 2:
+            n_commits, author = parts
+            if author not in EXCLUDE_AUTHORS:
+                authors.append(author)
+
+    return authors
+
+
+def get_full_name(author_data):
+    """Get full name from CITATION.cff parts"""
+    parts = []
+    parts.append(author_data["given-names"])
+
+    name_particle = author_data.get("name-particle", None)
+
+    if name_particle:
+        parts.append(name_particle)
+
+    parts.append(author_data["family-names"])
+    return " ".join(parts)
+
+
+def get_citation_cff_authors():
+    """Get list of authors from CITATION.cff"""
+    authors = []
+    citation_file = PATH / "CITATION.cff"
+
+    yaml = YAML()
+
+    with citation_file.open("r") as stream:
+        data = yaml.load(stream)
+
+    for author_data in data["authors"]:
+        full_name = get_full_name(author_data)
+        authors.append(full_name)
+
+    return authors
+
+
+@cli.command("sort", help="Sort authors by commits")
+def sort_citation_cff():
+    """Sort CITATION.cff according to the git shortlog"""
+    authors = get_git_shortlog_authors()
+    citation_file = PATH / "CITATION.cff"
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+
+    with citation_file.open("r") as stream:
+        data = yaml.load(stream)
+
+    authors_cff = get_citation_cff_authors()
+
+    sorted_authors = []
+
+    for author in authors:
+        idx = authors_cff.index(author)
+        sorted_authors.append(data["authors"][idx])
+
+    data["authors"] = sorted_authors
+
+    with citation_file.open("w") as stream:
+        yaml.dump(data, stream=stream)
+
+
+@cli.command("check", help="Check git shortlog vs CITATION.cff authors")
+def check_author_lists():
+    """Check CITATION.cff with git shortlog"""
+    authors = set(get_git_shortlog_authors())
+    authors_cff = set(get_citation_cff_authors())
+
+    message = "****Authors not in CITATION.cff****\n\n  "
+    diff = authors.difference(authors_cff)
+    print(message + "\n  ".join(sorted(diff)) + "\n")
+
+    message = "****Authors not in shortlog****\n\n"
+    diff = authors_cff.difference(authors)
+    print(message + "\n  ".join(sorted(diff)) + "\n")
+
+
+if __name__ == "__main__":
+    cli()

--- a/dev/authors.py
+++ b/dev/authors.py
@@ -23,7 +23,7 @@ def get_git_shortlog_authors():
     """Get list of authors from git shortlog"""
     authors = []
     command = "git shortlog --summary --numbered"
-    result = subprocess.check_output(command, stderr = subprocess.STDOUT, shell=True).decode()
+    result = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True).decode()
     data = result.split("\n")
     for row in data:
         parts = row.split("\t")

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -52,6 +52,9 @@ Steps to prepare for the release (e.g. a week before) to check that things are i
    Links are at https://github.com/gammapy/gammapy#status-shields
 #. Check that the changelog is complete, by going through the list of Github issues for the
    release milestone.
+#. Check the author list in CITATION.cff by running the ``def/authors.py`` script. Manually
+   fi any mismatches and finally sort by commits.
+
 
 Make release
 ------------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -63,6 +63,7 @@ dependencies:
   - nbformat==5.0.8
   - docutils==0.16
   - h5py==2.10.0
+  - ruamel.yaml
   - pip:
       - pytest-sphinx
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a follow up to #3344. It does the following changes:
- Add `authors.py` helper script. The script checks (1) for mismatches between the `CITATION.cff` and `git shortlog --summary --numbered` and (2) sorts the authors according to the output off the git short log. This is not necessarily the best way to sort the authors nor is it necessarily the fairest way, but it's an automatic and transparent way of doing it.
- After running the script I manually synchronized the `.mailmap` and `CITATION.cff`
- I finally sorted the `CITATION.cff`

The logic right now is to manually run the script before a release and update missing authors in `CITATION.cff` from the `git shortlog`. Then sort the `CITATION.cff`. I added an entry to the developer docs.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
