### PR TITLE
Add sum_over_energy_groups option to FluxPointsEstimator

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2573,4 +2573,5 @@ class MapDatasetOnOff(MapDataset):
             acceptance=acceptance,
             acceptance_off=acceptance_off,
             counts_off=counts_off,
+            name=name
         )

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -63,12 +63,16 @@ class FluxPointsEstimator(FluxEstimator):
         Fit instance specifying the backend and fit options.
     reoptimize : bool
         Re-optimize other free model parameters. Default is True.
+    sum_over_energy_groups : bool
+        Whether to sum over the energy groups or fit the norm on the full energy
+        grid.
     """
 
     tag = "FluxPointsEstimator"
 
-    def __init__(self, energy_edges=[1, 10] * u.TeV, **kwargs):
+    def __init__(self, energy_edges=[1, 10] * u.TeV, sum_over_energy_groups=False, **kwargs):
         self.energy_edges = energy_edges
+        self.sum_over_energy_groups = sum_over_energy_groups
 
         fit = Fit(confidence_opts={"backend": "scipy"})
         kwargs.setdefault("fit", fit)
@@ -133,6 +137,8 @@ class FluxPointsEstimator(FluxEstimator):
         datasets_sliced = datasets.slice_by_energy(
             energy_min=energy_min, energy_max=energy_max
         )
+        if self.sum_over_energy_groups:
+            datasets_sliced = Datasets([_.to_image(name=_.name) for _ in datasets_sliced])
 
         if len(datasets_sliced) > 0:
             datasets_sliced.models = datasets.models.copy()

--- a/gammapy/estimators/points/tests/test_profile.py
+++ b/gammapy/estimators/points/tests/test_profile.py
@@ -127,9 +127,10 @@ def test_radial_profile_one_interval():
         regions,
         selection_optional="all",
         energy_edges=[0.1, 10] * u.TeV,
-        n_sigma_ul=3
+        n_sigma_ul=3,
+        sum_over_energy_groups=True
     )
-    result = prof_maker.run(dataset.to_image())
+    result = prof_maker.run(dataset)
 
     imp_prof = result.to_table(sed_type="flux", format="profile")
 
@@ -137,6 +138,9 @@ def test_radial_profile_one_interval():
     assert_allclose(imp_prof[7]["npred_excess"], [[1568.0]], rtol=1e-3)
     assert_allclose(imp_prof[7]["sqrt_ts"], [33.780533], rtol=1e-3)
     assert_allclose(imp_prof[0]["flux"], [16e-06], atol=1e-3)
+
+    axis = result.counts.geom.axes["dataset"]
+    assert axis.center == ["test-on-off"]
 
     errn = result.npred_excess_errn.data[7].squeeze()
     assert_allclose(errn, [48.278367], rtol=2e-3)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a `sum_over_energy_groups` option to the `FluxPointsEstimator`. This option will exactly do what it says. While it's not a standard option to choose it can be useful to compare results against excess based methods and it also is uniform with the `TSMapEstimator`. I adapted one of the current flux profile tests.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
