### PR TITLE
Fix matplotlib deprecation and change WcsNDMap.plot ro return ax only.

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -36,7 +36,7 @@ dependencies:
   - ipython
   - jupyter
   - jupyterlab
-  - matplotlib>=3.4
+  - matplotlib>=3.4, <3.5
   - naima
   - pandas
   - reproject

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -36,7 +36,7 @@ dependencies:
   - ipython
   - jupyter
   - jupyterlab
-  - matplotlib>=3.4, <3.5
+  - matplotlib >=3.4,<3.5
   - naima
   - pandas
   - reproject

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -840,8 +840,7 @@ class MapDataset(Dataset):
         kwargs.setdefault("cmap", "coolwarm")
         kwargs.setdefault("vmin", -5)
         kwargs.setdefault("vmax", 5)
-        _, ax, _ = residuals.plot(ax, **kwargs)
-
+        ax = residuals.plot(ax, **kwargs)
         return ax
 
     def plot_residuals_spectral(self, ax=None, method="diff", region=None, **kwargs):

--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -889,13 +889,8 @@ class HpxNDMap(HpxMap):
 
         Returns
         -------
-        fig : `~matplotlib.figure.Figure`
-            Figure object.
         ax : `~astropy.visualization.wcsaxes.WCSAxes`
             WCS axis object
-        im : `~matplotlib.image.AxesImage` or `~matplotlib.collections.PatchCollection`
-            Image object.
-
         """
         if method == "raster":
             m = self.to_wcs(
@@ -991,7 +986,7 @@ class HpxNDMap(HpxMap):
         ax.autoscale_view()
         ax.coords.grid(color="w", linestyle=":", linewidth=0.5)
 
-        return fig, ax, p
+        return ax
 
     def plot_mask(self,
         method="raster",

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -362,7 +362,8 @@ class WcsNDMap(WcsMap):
         mask = np.isfinite(data)
 
         if mask.any():
-            norm = simple_norm(data[mask], stretch)
+            min_cut, max_cut = kwargs.pop("vmin", None), kwargs.pop("vmin", None)
+            norm = simple_norm(data[mask], stretch, min_cut=min_cut, max_cut=max_cut)
             kwargs.setdefault("norm", norm)
 
         im = ax.imshow(data, **kwargs)

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -331,12 +331,8 @@ class WcsNDMap(WcsMap):
 
         Returns
         -------
-        fig : `~matplotlib.figure.Figure`
-            Figure object.
         ax : `~astropy.visualization.wcsaxes.WCSAxes`
             WCS axis object
-        cbar : `~matplotlib.colorbar.Colorbar` or None
-            Colorbar object.
         """
         import matplotlib.pyplot as plt
         from astropy.visualization import simple_norm
@@ -368,7 +364,7 @@ class WcsNDMap(WcsMap):
 
         im = ax.imshow(data, **kwargs)
 
-        cbar = fig.colorbar(im, ax=ax, label=str(self.unit)) if add_cbar else None
+        fig.colorbar(im, ax=ax, label=str(self.unit)) if add_cbar else None
 
         if self.geom.is_allsky:
             ax = self._plot_format_allsky(ax)
@@ -377,7 +373,7 @@ class WcsNDMap(WcsMap):
 
         # without this the axis limits are changed when calling scatter
         ax.autoscale(enable=False)
-        return fig, ax, cbar
+        return ax
 
     def plot_mask(self, ax=None, **kwargs):
         """Plot the mask as a shaded area

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -913,7 +913,7 @@ class DatasetModels(collections.abc.Sequence):
         kwargs_point = kwargs_point or {}
 
         if ax is None or not isinstance(ax, WCSAxes):
-            fig, ax, _ = Map.from_geom(self.wcs_geom).plot()
+            ax = Map.from_geom(self.wcs_geom).plot()
 
         kwargs.setdefault("color", "tab:blue")
         kwargs.setdefault("fc", "None")
@@ -956,7 +956,7 @@ class DatasetModels(collections.abc.Sequence):
         import matplotlib.pyplot as plt
 
         if ax is None or not isinstance(ax, WCSAxes):
-            fig, ax, _ = Map.from_geom(self.wcs_geom).plot()
+            ax = Map.from_geom(self.wcs_geom).plot()
 
         kwargs.setdefault("marker", "*")
         kwargs.setdefault("color", "tab:blue")

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -286,8 +286,7 @@ class SpatialModel(Model):
             raise TypeError(
                 "Use .plot_interactive() or .plot_grid() for Map dimension > 2"
             )
-        _, ax, _ = m.plot(ax=ax, **kwargs)
-        return ax
+        return m.plot(ax=ax, **kwargs)
 
     def plot_interative(self, ax=None, geom=None, **kwargs):
         """Plot spatial model.

--- a/gammapy/visualization/panel.py
+++ b/gammapy/visualization/panel.py
@@ -88,7 +88,7 @@ class MapPanelPlotter:
         spec = self.grid_spec[panel]
         ax = self.figure.add_subplot(spec, projection=map.geom.wcs)
         try:
-            ax = map.plot(ax=ax, **kwargs)[1]
+            ax = map.plot(ax=ax, **kwargs)
         except AttributeError:
             ax = map.plot_rgb(ax=ax, **kwargs)
         ax = self._set_ax_fov(ax, panel_fov)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes the deprecation warnings about the `vmin/vmax` and adapts `WcsNDMap.plot()` to only return `ax`, just as any other plot method we have. It also limits the Matplotlib version to fix the most recent test fails seen in  https://github.com/gammapy/gammapy/runs/4253642210?check_suite_focus=true#step:10:3158

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
