### PR TITLE
Make alt/az pointing optional in DataStore.from_event_files

### DIFF
--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -158,7 +158,7 @@ class TestDataStoreMaker:
         table = self.data_store.obs_table
         assert table.__class__.__name__ == "ObservationTable"
         assert len(table) == 4
-        assert len(table.colnames) == 24
+        assert len(table.colnames) == 21
 
         # TODO: implement https://github.com/gammapy/gammapy/issues/1218 and add tests here
         # assert table.time_start[0].iso == "spam"


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request make the alt /az information optional in `DataStore.from_event_files`. This solves #3119.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
