### PR TITLE
Remove apply_mask_fit option from ExcessMapEstimator

### DIFF
--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -96,9 +96,6 @@ class ExcessMapEstimator(Estimator):
         Default is None so the optional steps are not executed.
     energy_edges : `~astropy.units.Quantity`
         Energy edges of the target excess maps bins.
-    apply_mask_fit : bool
-        Apply a mask for the computation.
-        A `~gammapy.datasets.MapDataset.mask_fit` must be present on the input dataset
     correlate_off : bool
         Correlate OFF events in the case of a `MapDatasetOnOff`. Default is True.
     spectral_model : `~gammapy.modeling.models.SpectralModel`
@@ -116,14 +113,12 @@ class ExcessMapEstimator(Estimator):
         n_sigma_ul=2,
         selection_optional=None,
         energy_edges=None,
-        apply_mask_fit=False,
         correlate_off=True,
         spectral_model=None,
     ):
         self.correlation_radius = correlation_radius
         self.n_sigma = n_sigma
         self.n_sigma_ul = n_sigma_ul
-        self.apply_mask_fit = apply_mask_fit
         self.selection_optional = selection_optional
         self.energy_edges = energy_edges
         self.correlate_off = correlate_off
@@ -192,7 +187,7 @@ class ExcessMapEstimator(Estimator):
 
         geom = dataset.counts.geom
 
-        if self.apply_mask_fit:
+        if  dataset.mask_fit:
             mask = dataset.mask
         elif dataset.mask_safe:
             mask = dataset.mask_safe

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -208,7 +208,7 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
     simple_dataset_on_off.mask_fit = mask_fit
 
     estimator_image = ExcessMapEstimator(
-        0.11 * u.deg, apply_mask_fit=True, correlate_off=True
+        0.11 * u.deg, correlate_off=True
     )
 
     result_image = estimator_image.run(simple_dataset_on_off)
@@ -237,9 +237,12 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
 
     simple_dataset_on_off.models = [model]
 
+    
     estimator_mod = ExcessMapEstimator(
-        0.11 * u.deg, apply_mask_fit=False, correlate_off=True
+        0.11 * u.deg, correlate_off=True
     )
+
+    simple_dataset_on_off.mask_fit = None
     result_mod = estimator_mod.run(simple_dataset_on_off)
     assert result_mod["npred"].data.shape == (1, 20, 20)
 
@@ -255,7 +258,6 @@ def test_significance_map_estimator_map_dataset_on_off_with_correlation(
     spectral_model = PowerLawSpectralModel(index=15)
     estimator_mod = ExcessMapEstimator(
         0.11 * u.deg,
-        apply_mask_fit=False,
         correlate_off=True,
         spectral_model=spectral_model,
     )


### PR DESCRIPTION
Remove apply_mask_fit option from ExcessMapEstimator and use mask_fit by default. If one want to ignore the mask_fit it can be set to None on the dataset as suggested in : https://github.com/gammapy/gammapy/issues/3031#issuecomment-973321493