### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false # true
       matrix:
         include:
-          - name: Linux python 3.6.2 core
-            os: ubuntu-latest
           - name: Linux python 3.7 all
             os: ubuntu-latest
           - name: Linux python 3.8 core
@@ -28,10 +26,6 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v2
-      - name: install python3.6
-        if: contains(matrix.name, '3.6')
-        run: |
-          sed -i 's/python==3.7/python==3.6.2/' environment-dev.yml
       - name: install python3.8
         if: contains(matrix.name, '3.8')
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Programming Language :: C
     Programming Language :: Cython
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
@@ -28,7 +27,7 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     numpy>=1.17
     astropy>=4.1


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

With the most recent CI build fails (e.g. https://github.com/gammapy/gammapy/runs/4263760636?check_suite_focus=true) and official support ending Dec 2021 (https://endoflife.date/python) we decided to drop support for Python 3.6.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
