### PR TITLE
Revert change in HDUIndexTable.read to fill only problematic column

### DIFF
--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -47,8 +47,11 @@ class HDUIndexTable(Table):
         table = super().read(filename, **kwargs)
         table.meta["BASE_DIR"] = filename.parent.as_posix()
 
-        # TODO: simply return the table when empty string column is not masked by default
-        return table.filled(fill_value='')
+        # TODO: this is a workaround for the joint-crab validation with astropy>4.0.
+        # TODO: Remove when handling of empty columns is clarified
+        table["FILE_DIR"].fill_value=''
+
+        return table.filled()
 
     @property
     def base_dir(self):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

See title. This is working with joint-crab validation and with existing hess fit productions.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
