### PR TITLE
Add default zero counts in MapDatasetMaker.run

### DIFF
--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -306,7 +306,9 @@ class MapDatasetMaker(Maker):
 
         if "counts" in self.selection:
             counts = self.make_counts(dataset.counts.geom, observation)
-            kwargs["counts"] = counts
+        else:
+            counts = Map.from_geom(dataset.counts.geom, data=0)
+        kwargs["counts"] = counts
 
         if "exposure" in self.selection:
             exposure = self.make_exposure(dataset.exposure.geom, observation)

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -230,7 +230,7 @@ def test_make_meta_table(observations):
     assert_allclose(map_dataset_meta_table["OBS_ID"], 110380)
 
 @requires_data()
-def test_make_map_no(observations):
+def test_make_map_no_count(observations):
     dataset = MapDataset.create(geom((0.1, 1, 10)))
     maker_obs = MapDatasetMaker(selection=["exposure"])
     map_dataset = maker_obs.run(dataset, observation=observations[0])

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -229,6 +229,15 @@ def test_make_meta_table(observations):
     assert_allclose(map_dataset_meta_table["DEC_PNT"], -29.6075)
     assert_allclose(map_dataset_meta_table["OBS_ID"], 110380)
 
+@requires_data()
+def test_make_map_no(observations):
+    dataset = MapDataset.create(geom((0.1, 1, 10)))
+    maker_obs = MapDatasetMaker(selection=["exposure"])
+    map_dataset = maker_obs.run(dataset, observation=observations[0])
+
+    assert map_dataset.counts is not None
+    assert_allclose(map_dataset.counts.data, 0)
+    assert map_dataset.counts.geom == dataset.counts.geom
 
 @requires_data()
 @requires_dependency("healpy")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request provides a solution to #3555 . 
In general having no counts entry in a `MapDataset` or `SpectrumDataset` is bad. With ONOff statistic it will lead to errors as in the above issue. 

This situation usually happens when `MapDatasetMaker` is run without the `"counts"` selection applied (usually to make simulations). Here we change the behavior by adding an empty `counts` to the `MapDataset` if `"counts"` is not selected. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
