### PR TITLE
Fix excess map mask handling

### DIFF
--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -38,7 +38,7 @@ def convolved_map_dataset_counts_statistics(dataset, kernel, mask, correlate_off
 
         npred_sig_convolve = npred_sig.convolve(kernel.array)
         if correlate_off:
-            background = dataset.background * dataset.mask
+            background = dataset.background * mask
             background.data[dataset.acceptance_off == 0] = 0.
             background_conv = background.convolve(kernel.array)
 

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -245,14 +245,14 @@ def test_excess_map_estimator_map_dataset_on_off_with_correlation_model(
     result_mod = estimator_mod.run(simple_dataset_on_off)
     assert result_mod["npred"].data.shape == (1, 20, 20)
 
-    assert_allclose(result_mod["sqrt_ts"].data[0, 10, 10], 8.899278, atol=1e-3)
+    assert_allclose(result_mod["sqrt_ts"].data[0, 10, 10], 6.240846, atol=1e-3)
 
     assert_allclose(result_mod["npred"].data[0, 10, 10], 388)
-    assert_allclose(result_mod["npred_excess"].data[0, 10, 10], 190.68057)
+    assert_allclose(result_mod["npred_excess"].data[0, 10, 10], 148.68057)
 
     assert result_mod["flux"].unit == "cm-2s-1"
-    assert_allclose(result_mod["flux"].data[0, 10, 10], 1.906806e-08, rtol=1e-3)
-    assert_allclose(result_mod["flux"].data.sum(), 5.920642e-06, rtol=1e-3)
+    assert_allclose(result_mod["flux"].data[0, 10, 10], 1.486806e-08, rtol=1e-3)
+    assert_allclose(result_mod["flux"].data.sum(), 5.254442e-06, rtol=1e-3)
 
 
 def test_excess_map_estimator_map_dataset_on_off_reco_exposure(
@@ -280,7 +280,7 @@ def test_excess_map_estimator_map_dataset_on_off_reco_exposure(
     result_mod = estimator_mod.run(simple_dataset_on_off)
 
     assert result_mod["flux"].unit == "cm-2s-1"
-    assert_allclose(result_mod["flux"].data.sum(), 5.920642e-06, rtol=1e-3)
+    assert_allclose(result_mod["flux"].data.sum(), 5.254442e-06, rtol=1e-3)
 
     reco_exposure = estimate_exposure_reco_energy(
         simple_dataset_on_off, spectral_model=spectral_model


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes a bug I noticed when looking at #3618. I was wondering about the test fails and realized that in `convolved_map_dataset_counts_statistics`, there is an additional access to `dataset.mask` instead of the mask passed in. This leads to the behavior that the `mask_fit` is taken into account for the correlated off counts even when `apply_mask_fit=False`. The PR fixes the behavior and adapts the values.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
