### PR TITLE
Add back FluxMaps.npred_background

### DIFF
--- a/docs/estimators/index.rst
+++ b/docs/estimators/index.rst
@@ -38,9 +38,9 @@ In general the flux can be estimated using two methods:
    not re-optimising other parameters, one can estimate the significance based on the
    analytical solution by [LiMa1983]. In this case the "best fit" flux and significance
    are given by the excess over the null hypothesis. This method is also named
-   **backward folding**.
+   **backward folding**. This method is currently only exposed in the `ExcessMapEstimator`
 
-
+In case the data is fitted to a single data bin only, e.g. one energy bin
 Uniformly for both methods most estimators compute the same basic quantities:
 
 ================= =================================================
@@ -52,10 +52,10 @@ stat              Fit statistics value of the best fit hypothesis
 stat_null         Fit statistics value of the null hypothesis
 ts                Difference in fit statistics (`stat - stat_null` )
 sqrt_ts           Square root of ts time sign(norm), in case of one degree of freedom, corresponds to significance (Wilk's theorem)
-npred             Predicted counts of the best fit hypothesis, equivalent to correlated counts for backward folding
-npred_excess      Predicted excess counts of the best fit hypothesis equivalent to correlated excess for backward folding
+npred             Predicted counts of the best fit hypothesis. Equivalent to correlated counts for backward folding
+npred_excess      Predicted excess counts of the best fit hypothesis. Equivalent to correlated excess for backward folding
+npred_background  Predicted background counts of the best fit hypothesis. Equivalent to correlated excess for backward folding
 ================= =================================================
-
 
 In addition the following optional quantities can be computed:
 

--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -384,18 +384,25 @@ class FluxMaps:
 
     @property
     def npred(self):
-        """Predicted counts"""
+        """Predicted counts from best fit hypothesis"""
         self._check_quantity("npred")
         return self._data["npred"]
 
     @property
+    def npred_background(self):
+        """Predicted background counts from best fit hypothesis"""
+        self._check_quantity("npred")
+        self._check_quantity("npred_excess")
+        return self.npred - self.npred_excess
+
+    @property
     def npred_excess(self):
-        """Predicted excess counts"""
+        """Predicted excess count  rom best fit hypothesis"""
         self._check_quantity("npred_excess")
         return self._data["npred_excess"]
 
     def _expand_dims(self, data):
-        # instead make map support broadcasting
+        # TODO: instead make map support broadcasting
         axes = self.npred.geom.axes
         # here we need to rely on broadcasting
         if "dataset" in axes.names:

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -72,6 +72,9 @@ def test_compute_lima_image():
 
     assert_allclose(result_lima["sqrt_ts"].data[:, 100, 100], 30.814916, atol=1e-3)
     assert_allclose(result_lima["sqrt_ts"].data[:, 1, 1], 0.164, atol=1e-3)
+    assert_allclose(result_lima["npred_background"].data[:, 1, 1], 37, atol=1e-3)
+    assert_allclose(result_lima["npred"].data[:, 1, 1], 38, atol=1e-3)
+    assert_allclose(result_lima["npred_excess"].data[:, 1, 1], 1, atol=1e-3)
 
 
 @requires_data()
@@ -112,7 +115,16 @@ def test_compute_lima_on_off_image():
     # Set boundary to NaN in reference image
     # The absolute tolerance is low because the method used here is slightly different from the one used in HGPS
     # n_off is convolved as well to ensure the method applies to true ON-OFF datasets
-    assert_allclose(actual, desired, atol=0.2)
+    assert_allclose(actual, desired, atol=0.2, rtol=1e-5)
+
+    actual = np.nan_to_num(results["npred_background"].crop((11, 11)).data)
+    background_corr = image_to_cube(Map.read(filename, hdu="BACKGROUNDCORRELATED"), "1 TeV", "100 TeV")
+    desired = background_corr.crop((11, 11)).data
+
+    # Set boundary to NaN in reference image
+    # The absolute tolerance is low because the method used here is slightly different from the one used in HGPS
+    # n_off is convolved as well to ensure the method applies to true ON-OFF datasets
+    assert_allclose(actual, desired, atol=0.2, rtol=1e-5)
 
 
 def test_significance_map_estimator_map_dataset(simple_dataset):
@@ -122,6 +134,7 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
 
     assert_allclose(result["npred"].data[0, 10, 10], 162)
     assert_allclose(result["npred_excess"].data[0, 10, 10], 81)
+    assert_allclose(result["npred_background"].data[0, 10, 10], 81)
     assert_allclose(result["sqrt_ts"].data[0, 10, 10], 7.910732, atol=1e-5)
 
     assert_allclose(result["npred_excess_err"].data[0, 10, 10], 12.727922, atol=1e-3)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds back the derived quantity `FluxMaps.npred_background`, defined as `npred - npred_excess`. It also adds corresponding tests.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
