### PR TITLE
Avoid calling subprocess functions with shell=True

### DIFF
--- a/dev/authors.py
+++ b/dev/authors.py
@@ -22,7 +22,7 @@ def cli():
 def get_git_shortlog_authors():
     """Get list of authors from git shortlog"""
     authors = []
-    command = "git shortlog --summary --numbered"
+    command = ("git", "shortlog", "--summary", "--numbered")
     result = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True).decode()
     data = result.split("\n")
     for row in data:


### PR DESCRIPTION
**Description**

From the documentation of [`subprocess`](https://docs.python.org/3/library/subprocess.html#frequently-used-arguments):
> If _shell_ is `True`, the specified command will be executed through the shell. This can be useful if you are using Python primarily for the enhanced control flow it offers over most system shells and still want convenient access to other shell features such as shell pipes, filename wildcards, environment variable expansion, and expansion of `~` to a user’s home directory.
> [...]
> **Note:** Read the [Security Considerations](https://docs.python.org/3/library/subprocess.html#security-considerations) section before using `shell=True`.

In this specific case, there are no security issues. On the other hand, there is no need to call a shell either.