### PR TITLE
Avoid assert outside of tests

### DIFF
--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -884,8 +884,8 @@ class Map(abc.ABC):
         map_copy = self.copy()
 
         if preserve_counts:
-            if geom.ndim > 2:
-                assert self.geom.axes[0] == geom.axes[0]  # Energy axis has to match
+            if geom.ndim > 2 and geom.axes[0] != self.geom.axes[0]:
+                raise ValueError("Energy axis has to match")
             map_copy.data /= map_copy.geom.solid_angle().to_value("deg2")
 
         if map_copy.is_mask:

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -885,7 +885,7 @@ class Map(abc.ABC):
 
         if preserve_counts:
             if geom.ndim > 2 and geom.axes[0] != self.geom.axes[0]:
-                raise ValueError("Energy axis has to match")
+                raise ValueError(f"Energy axis do not match: expected {self.geom.axes[0]}, but got {geom.axes[0]}.")
             map_copy.data /= map_copy.geom.solid_angle().to_value("deg2")
 
         if map_copy.is_mask:


### PR DESCRIPTION
**Description**

Fixes a DeepSource.io alert:

> Usage of `assert` statement in application logic is discouraged. `assert` is removed with compiling to optimized byte code. Consider raising an exception instead. Ideally, `assert` statement should be used only in tests.
> 
> Python has an option to compile the optimized bytecode and create the respective `.pyo` files by using the options `-O` and `-OO`. When used, these basic optimizations are done:
> * All the `assert` statements are removed
> * All docstrings are removed (when `-OO` is selected)
> * Value of the `__debug__` built-in variable is set to `False`
> 
> It is recommended not to use `assert` in non-test files. A better way for internal self-checks is to check explicitly and raise respective error using an if statement.