### PR TITLE
Do not use `len()` to determine if a sequence is empty

### DIFF
--- a/gammapy/extern/xmltodict.py
+++ b/gammapy/extern/xmltodict.py
@@ -113,7 +113,7 @@ class _DictSAXHandler(object):
             should_continue = self.item_callback(self.path, item)
             if not should_continue:
                 raise ParsingInterrupted()
-        if len(self.stack):
+        if self.stack:
             item, data = self.item, self.data
             self.item, self.data = self.stack.pop()
             if self.strip_whitespace and data is not None:


### PR DESCRIPTION
**Description**

Fixes a DeepSource.io alert:

> Using the `len` function to check if a sequence is empty is not idiomatic and can be less performant than checking the truthiness of the object.
> 
> `len` doesn't know the context in which it is called, so if computing the length means traversing the entire sequence, it must; it doesn't know that the result is just being compared to 0. Computing the boolean value can stop after it sees the first element, regardless of how long the sequence actually is.

Not an actual issue here - just trying to avoid alerts from automated reviewing tools.