### PR TITLE
Unnecessary comprehension

### DIFF
--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -240,7 +240,7 @@ class FluxMaps:
     @property
     def has_any_ts(self):
         """Whether the flux estimate has either sqrt(ts) or ts defined"""
-        return any([_ in self._data for _ in ["ts", "sqrt_ts"]])
+        return any(_ in self._data for _ in ["ts", "sqrt_ts"])
 
     @property
     def has_stat_profiles(self):


### PR DESCRIPTION
**Description**

Fixes a DeepSource. io alert:

> The built-in function being used does not require comprehension and can work directly with a generator expression.
> 
> Using a generator expression within these functions is faster than using a comprehension:
> - `all`
> - `any`
> - `enumerate`
> - `iter`
> - `itertools.cycle`
> - `itertools.accumulate`
> 
> The inbuilt functions `all()` and `any()` in Python also support short-circuiting (evaluation stops as soon as the overall return value of the function is known), but this behavior is lost if you use a list comprehension. This affects performance.