### PR TITLE
Decorate methods with `@staticmethod`

### DIFF
--- a/gammapy/data/obs_table.py
+++ b/gammapy/data/obs_table.py
@@ -377,7 +377,8 @@ class ObservationTableChecker(Checker):
     def __init__(self, obs_table):
         self.obs_table = obs_table
 
-    def _record(self, level="info", msg=None):
+    @staticmethod
+    def _record(level="info", msg=None):
         return {"level": level, "hdu": "obs-index", "msg": msg}
 
     def check_meta(self):

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -262,7 +262,8 @@ class TSMapEstimator(Estimator):
         flux = flux.convolve(kernel)
         return flux.sum_over_axes()
 
-    def estimate_mask_default(self, dataset):
+    @staticmethod
+    def estimate_mask_default(dataset):
         """Compute default mask where to estimate TS values.
 
         Parameters

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -233,7 +233,8 @@ class IRF(metaclass=abc.ABCMeta):
             data[~np.isfinite(data)] = self.interp_kwargs["fill_value"]
         return data
 
-    def _mask_out_bounds(self, invalid):
+    @staticmethod
+    def _mask_out_bounds(invalid):
         return np.any(invalid, axis=0)
 
     def integrate_log_log(self, axis_name, **kwargs):

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2308,7 +2308,8 @@ class TimeMapAxis:
         pix[~valid_pix] = INVALID_INDEX.float
         return pix - 0.5
 
-    def pix_to_idx(self, pix, clip=False):
+    @staticmethod
+    def pix_to_idx(pix, clip=False):
         return pix
 
     @property

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -438,7 +438,8 @@ class WcsNDMap(WcsMap):
 
         return ax
 
-    def _plot_format(self, ax):
+    @staticmethod
+    def _plot_format(ax):
         try:
             ax.coords["glon"].set_axislabel("Galactic Longitude")
             ax.coords["glat"].set_axislabel("Galactic Latitude")

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -738,7 +738,8 @@ class DiskSpatialModel(SpatialModel):
         edge_width_95 = 2.326174307353347
         return 0.5 * (1 - scipy.special.erf(value * edge_width_95))
 
-    def evaluate(self, lon, lat, lon_0, lat_0, r_0, e, phi, edge_width):
+    @staticmethod
+    def evaluate(lon, lat, lon_0, lat_0, r_0, e, phi, edge_width):
         """Evaluate model."""
         sep = angular_separation(lon, lat, lon_0, lat_0)
 


### PR DESCRIPTION
**Description**

Fixes these DeepSource.io alerts:

> The method doesn't use its bound instance. Decorate this method with `@staticmethod` decorator, so that Python does not have to instantiate a bound method for every instance of this class thereby saving memory and computation. Read more about staticmethods [here](https://docs.python.org/3/library/functions.html#staticmethod).

I have not fixed tests in this merge request.