### PR TITLE
Use literal syntax to create dict

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -118,7 +118,7 @@ class SourceCatalog(abc.ABC):
     @lazyproperty
     def _name_to_index_cache(self):
         # Make a dict for quick lookup: source name -> row index
-        names = dict()
+        names = {}
         for idx, row in enumerate(self.table):
             name = row[self._source_name_key]
             names[name.strip()] = idx

--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -837,7 +837,7 @@ class FluxMaps:
         # TODO: handle reshaping in MapAxis
         factor = fluxes[f"ref_{sed_type}"].to(map_ref.unit)[cls._expand_slice]
 
-        data = dict()
+        data = {}
         data["norm"] = map_ref / factor
 
         for key in OPTIONAL_QUANTITIES[sed_type]:

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1056,7 +1056,7 @@ class TemplateSpatialModel(SpatialModel):
 
         self._map = map.copy()
 
-        self.meta = dict() if meta is None else meta
+        self.meta = {} if meta is None else meta
         interp_kwargs = {} if interp_kwargs is None else interp_kwargs
         interp_kwargs.setdefault("method", "linear")
         interp_kwargs.setdefault("fill_value", 0)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1438,7 +1438,7 @@ class TemplateSpectralModel(SpectralModel):
     ):
         self.energy = energy
         self.values = u.Quantity(values, copy=False)
-        self.meta = dict() if meta is None else meta
+        self.meta = {} if meta is None else meta
         interp_kwargs = interp_kwargs or {}
         interp_kwargs.setdefault("values_scale", "log")
         interp_kwargs.setdefault("points_scale", ("log",))
@@ -1721,7 +1721,7 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
             `Link <https://ui.adsabs.harvard.edu/abs/2010ApJ...712..238F>`__
 
         """
-        models = dict()
+        models = {}
         models["franceschini"] = "$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz"
         models["dominguez"] = "$GAMMAPY_DATA/ebl/ebl_dominguez11.fits.gz"
         models["finke"] = "$GAMMAPY_DATA/ebl/frd_abs.fits.gz"

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -18,7 +18,7 @@ __all__ = [
 ]
 
 # Cache for `requires_dependency`
-_requires_dependency_cache = dict()
+_requires_dependency_cache = {}
 
 
 def requires_dependency(name):


### PR DESCRIPTION
**Description**

Fixes DeepSource.io alerts:
> Using the literal syntax can give minor performance bumps compared to using function calls to create `dict`, `list` and `tuple`.
> [...]
> This is because here, the name `dict` must be looked up in the global scope in case it has been rebound. Same goes for the other two types `list()` and `tuple()`.

This is debatable: one of the advantages of Python is readability, and using `dict()` instead of `{}` might be more readable, especially for empty dictionaries.