### PR TITLE
Avoid mutable default values for keyword arguments

### DIFF
--- a/gammapy/irf/psf/core.py
+++ b/gammapy/irf/psf/core.py
@@ -71,8 +71,8 @@ class PSF(IRF):
 
     def info(
         self,
-        fraction=[0.68, 0.95],
-        energy_true=[[1.0], [10.0]] * u.TeV,
+        fraction=(0.68, 0.95),
+        energy_true=([1.0], [10.0]) * u.TeV,
         offset=0 * u.deg,
     ):
         """
@@ -118,7 +118,7 @@ class PSF(IRF):
         return info
 
     def plot_containment_radius_vs_energy(
-        self, ax=None, fraction=[0.68, 0.95], offset=[0, 1] * u.deg, **kwargs
+        self, ax=None, fraction=(0.68, 0.95), offset=(0, 1) * u.deg, **kwargs
     ):
         """Plot containment fraction as a function of energy.
 

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -402,7 +402,7 @@ class PSFMap(IRFMap):
         return self.__class__(psf_map=psf, exposure_map=exposure)
 
     def plot_containment_radius_vs_energy(
-        self, ax=None, fraction=[0.68, 0.95], **kwargs
+        self, ax=None, fraction=(0.68, 0.95), **kwargs
     ):
         """Plot containment fraction as a function of energy.
 

--- a/gammapy/visualization/heatmap.py
+++ b/gammapy/visualization/heatmap.py
@@ -74,7 +74,7 @@ def annotate_heatmap(
     im,
     data=None,
     valfmt="{x:.2f}",
-    textcolors=["black", "white"],
+    textcolors=("black", "white"),
     threshold=None,
     **textkw
 ):


### PR DESCRIPTION
**Description**

Address a DeepSource.io alert:
> Do not use a mutable like `list` or `dictionary` as a default value to an argument. Python’s default arguments are evaluated once when the function is defined. Using a mutable default argument and mutating it will mutate that object for all future calls to the function as well.

In these cases, mutables are not mutated, so it's not an actual issue. Still, avoid this anti-pattern - see [Python Mutable Defaults Are The Source of All Evil](https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/).