### PR TITLE
Unexpected keyword argument 'psf_map' in constructor call

### DIFF
--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -627,7 +627,7 @@ class IRFMap:
             exposure_map = Map.from_geom(
                 geom=geom_exposure, data=table["Exposure"].data, unit="cm2 s"
             )
-            return cls(psf_map=psf_map, exposure_map=exposure_map)
+            return cls(irf_map=psf_map, exposure_map=exposure_map)
         else:
             raise ValueError(f"Format {format} not supported")
 


### PR DESCRIPTION
**Description**

Fixes a DeepSource.io alert:
> The function call has passed a keyword argument that doesn't correspond to one of the function's parameter names. This is an error.