### PR TITLE
Iterate over the dictionary instead of its keys

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1879,7 +1879,7 @@ class MapAxes(Sequence):
 
                 axes.append(axis)
         elif format == "gadf-dl3":
-            for column_prefix in IRF_DL3_AXES_SPECIFICATION.keys():
+            for column_prefix in IRF_DL3_AXES_SPECIFICATION:
                 try:
                     axis = MapAxis.from_table(
                         table, format=format, column_prefix=column_prefix


### PR DESCRIPTION
**Description**

This fixes a DeepSource.io alert:

> Consider iterating the dictionary directly instead of calling `.keys()`. Using `for key in dictionary` would always iterate the dictionary keys.