### PR TITLE
Static method with 'self' as first argument

### DIFF
--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -151,7 +151,7 @@ class InterpolationScale:
         return self._scale(values)
 
     def inverse(self, values):
-        values = self._inverse(self, values)
+        values = self._inverse(values)
         if hasattr(self, "_unit"):
             return u.Quantity(values, self._unit, copy=False)
         else:
@@ -167,7 +167,6 @@ class LogScale(InterpolationScale):
         values = np.clip(values, self.tiny, np.inf)
         return np.log(values)
 
-    @staticmethod
     def _inverse(self, values):
         output = np.exp(values)
         return np.where(abs(output) - self.tiny <= self.tiny, 0, output)
@@ -181,7 +180,6 @@ class SqrtScale(InterpolationScale):
         sign = np.sign(values)
         return sign * np.sqrt(sign * values)
 
-    @staticmethod
     def _inverse(self, values):
         return np.power(values, 2)
 
@@ -197,7 +195,6 @@ class StatProfileScale(InterpolationScale):
         sign = np.sign(values)
         return sign * np.sqrt(sign * values)
 
-    @staticmethod
     def _inverse(self, values):
         return np.power(values, 2)
 
@@ -209,7 +206,6 @@ class LinearScale(InterpolationScale):
     def _scale(values):
         return values
 
-    @staticmethod
     def _inverse(self, values):
         return values
 


### PR DESCRIPTION
**Description**

Fixes DeepSource.io alerts:
> It is customary for instance or class methods to take `self` or `cls`, respectively, as their first arguments, a method that uses either of these names but is found to be a static method may have been defined incorrectly. Choose names other than `self` or `cls` for arguments to avoid confusing other programmers looking at your code. 

There were actual errors here, some functions couldn't possibly have worked.

I would suggest taking this further one step further and removing `@staticmethod` everywhere in the InterpolationScale class hierarchy:
```
InterpolationScale
├── LogScale
├── SqrtScale
├── StatProfileScale
└── LinearScale
```