### PR TITLE
Use `... != ...` instead of `not ... == ...`

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -837,7 +837,7 @@ class MapAxis:
             Map axis group table.
         """
         # TODO: try to simplify this code
-        if not self.node_type == "edges":
+        if self.node_type != "edges":
             raise ValueError("Only edge based map axis can be grouped")
 
         edges_pix = self.coord_to_pix(edges)


### PR DESCRIPTION
**Description**

Simplifies codes and fixes DeepSource.io alert:
> The boolean expression contains an unneeded negation and can be re-written without using the `not` statement.