### PR TITLE
Static method with `self` as first argument

### DIFF
--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -151,7 +151,7 @@ class InterpolationScale:
         return self._scale(values)
 
     def inverse(self, values):
-        values = self._inverse(self, values)
+        values = self._inverse(values)
         if hasattr(self, "_unit"):
             return u.Quantity(values, self._unit, copy=False)
         else:
@@ -167,10 +167,10 @@ class LogScale(InterpolationScale):
         values = np.clip(values, self.tiny, np.inf)
         return np.log(values)
 
-    @staticmethod
-    def _inverse(self, values):
+    @classmethod
+    def _inverse(cls, values):
         output = np.exp(values)
-        return np.where(abs(output) - self.tiny <= self.tiny, 0, output)
+        return np.where(abs(output) - cls.tiny <= cls.tiny, 0, output)
 
 
 class SqrtScale(InterpolationScale):
@@ -181,8 +181,8 @@ class SqrtScale(InterpolationScale):
         sign = np.sign(values)
         return sign * np.sqrt(sign * values)
 
-    @staticmethod
-    def _inverse(self, values):
+    @classmethod
+    def _inverse(cls, values):
         return np.power(values, 2)
 
 
@@ -197,8 +197,8 @@ class StatProfileScale(InterpolationScale):
         sign = np.sign(values)
         return sign * np.sqrt(sign * values)
 
-    @staticmethod
-    def _inverse(self, values):
+    @classmethod
+    def _inverse(cls, values):
         return np.power(values, 2)
 
 
@@ -209,8 +209,8 @@ class LinearScale(InterpolationScale):
     def _scale(values):
         return values
 
-    @staticmethod
-    def _inverse(self, values):
+    @classmethod
+    def _inverse(cls, values):
         return values
 
 


### PR DESCRIPTION
**Description**

Fixes DeepSource.io alerts:
> It is customary for instance or class methods to take `self` or `cls`, respectively, as their first arguments, a method that uses either of these names but is found to be a static method may have been defined incorrectly. Choose names other than `self` or `cls` for arguments to avoid confusing other programmers looking at your code. 