### PR TITLE
Introduce global FitResult object

### DIFF
--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -299,7 +299,7 @@ def test_analysis_1d_stacked_no_fit_range():
 
     assert len(analysis.datasets) == 1
     assert_allclose(analysis.datasets["stacked"].counts.data.sum(), 184)
-    pars = analysis.fit_result.parameters
+    pars = analysis.models.parameters
     assert_allclose(analysis.datasets[0].mask_fit.data, True)
 
     assert_allclose(pars["index"].value, 2.76913, rtol=1e-2)
@@ -375,8 +375,8 @@ def test_analysis_3d():
     analysis.get_flux_points()
 
     assert len(analysis.datasets) == 1
-    assert len(analysis.fit_result.parameters) == 8
-    res = analysis.fit_result.parameters
+    assert len(analysis.models.parameters) == 8
+    res = analysis.models.parameters
     assert res["amplitude"].unit == "cm-2 s-1 TeV-1"
 
     table = analysis.flux_points.data.to_table(sed_type="dnde")

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -82,26 +82,26 @@ class TestFluxPointFit:
     def test_fit_pwl_minuit(self, dataset):
         fit = Fit()
         result = fit.run(dataset)
-        self.assert_result(result)
+        self.assert_result(result, dataset.models)
 
     @requires_dependency("sherpa")
     def test_fit_pwl_sherpa(self, dataset):
         fit = Fit(backend="sherpa", optimize_opts={"method": "simplex"})
         result = fit.optimize(datasets=[dataset])
-        self.assert_result(result)
+        self.assert_result(result, dataset.models)
 
     @staticmethod
-    def assert_result(result):
+    def assert_result(result, models):
         assert result.success
         assert_allclose(result.total_stat, 25.2059, rtol=1e-3)
 
-        index = result.parameters["index"]
+        index = models.parameters["index"]
         assert_allclose(index.value, 2.216, rtol=1e-3)
 
-        amplitude = result.parameters["amplitude"]
+        amplitude = models.parameters["amplitude"]
         assert_allclose(amplitude.value, 2.1616e-13, rtol=1e-3)
 
-        reference = result.parameters["reference"]
+        reference = models.parameters["reference"]
         assert_allclose(reference.value, 1, rtol=1e-8)
 
     @staticmethod
@@ -129,8 +129,8 @@ class TestFluxPointFit:
         )
         assert_allclose(ts_diff, [110.244116, 0.0, 110.292074], rtol=1e-2, atol=1e-7)
 
-        value = result.parameters["amplitude"].value
-        err = result.parameters["amplitude"].error
+        value = model.parameters["amplitude"].value
+        err = model.parameters["amplitude"].error
 
         model.amplitude.scan_values = np.array([value - err, value, value + err])
         profile = fit.stat_profile(

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -650,7 +650,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
     assert_allclose(npred, 7525.790688, rtol=1e-3)
     assert_allclose(result.total_stat, 21625.845714, rtol=1e-3)
 
-    pars = result.parameters
+    pars = models.parameters
     assert_allclose(pars["lon_0"].value, 0.2, rtol=1e-2)
     assert_allclose(pars["lon_0"].error, 0.002244, rtol=1e-2)
 
@@ -720,7 +720,7 @@ def test_map_fit_one_energy_bin(sky_model, geom_image):
     assert_allclose(npred, 16538.124036, rtol=1e-3)
     assert_allclose(result.total_stat, -34844.125047, rtol=1e-3)
 
-    pars = result.parameters
+    pars = sky_model.parameters
 
     assert_allclose(pars["lon_0"].value, 0.2, rtol=1e-2)
     assert_allclose(pars["lon_0"].error, 0.001689, rtol=1e-2)

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -164,7 +164,7 @@ def test_fit(spectrum_dataset):
     assert_allclose(npred, 907012.186399, rtol=1e-3)
     assert_allclose(result.total_stat, -18087404.624, rtol=1e-3)
 
-    pars = result.parameters
+    pars = spectrum_dataset.models.parameters
     assert_allclose(pars["index"].value, 2.1, rtol=1e-2)
     assert_allclose(pars["index"].error, 0.001276, rtol=1e-2)
 
@@ -732,7 +732,7 @@ class TestSpectralFit:
     def test_basic_errors(self):
         self.set_model(self.pwl)
         result = self.fit.run([self.datasets[0]])
-        pars = result.parameters
+        pars = self.pwl.parameters
 
         assert_allclose(pars["index"].error, 0.149633, rtol=1e-3)
         assert_allclose(pars["amplitude"].error, 6.423139e-12, rtol=1e-3)
@@ -786,7 +786,7 @@ class TestSpectralFit:
 
         fit = Fit()
         result = fit.run(datasets=[dataset])
-        assert_allclose(result.parameters["index"].value, 2.7961, atol=0.02)
+        assert_allclose(self.pwl.spectral_model.index.value, 2.7961, atol=0.02)
 
     def test_stacked_fit(self):
         dataset = self.datasets[0].copy()
@@ -795,7 +795,7 @@ class TestSpectralFit:
 
         fit = Fit()
         result = fit.run(datasets=[dataset])
-        pars = result.parameters
+        pars = dataset.models.parameters
 
         assert_allclose(pars["index"].value, 2.7767, rtol=1e-3)
         assert u.Unit(pars["amplitude"].unit) == "cm-2 s-1 TeV-1"
@@ -1104,7 +1104,7 @@ class TestFit:
         result = fit.run(datasets=[dataset])
 
         # These values are check with sherpa fits, do not change
-        pars = result.parameters
+        pars = self.source_model.parameters
         assert_allclose(pars["index"].value, 1.995525, rtol=1e-3)
         assert_allclose(pars["amplitude"].value, 100245.9, rtol=1e-3)
 
@@ -1161,7 +1161,7 @@ class TestFit:
         )
         fit = Fit()
         result = fit.run(datasets=[dataset])
-        true_idx = result.parameters["index"].value
+        true_idx = self.source_model.parameters["index"].value
 
         values = np.linspace(0.95 * true_idx, 1.05 * true_idx, 100)
         self.source_model.spectral_model.index.scan_values = values

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -86,7 +86,7 @@ class ParameterEstimator(Estimator):
         if np.any(datasets.contributes_to_stat):
             result = self.fit.run(datasets=datasets)
             value, error = parameter.value, parameter.error
-            total_stat = result.total_stat
+            total_stat = result.optimize_result.total_stat
             success = result.success
 
         return {

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -218,6 +218,7 @@ class Fit:
         parameters.set_parameter_factors(factors)
         parameters.check_limits()
         return OptimizeResult(
+            models=datasets.models.copy(),
             total_stat=datasets.stat_sum(),
             backend=backend,
             method=kwargs.get("method", backend),
@@ -528,12 +529,22 @@ class CovarianceResult(FitStepResult):
 
 class OptimizeResult(FitStepResult):
     """Optimize result object."""
-
-    def __init__(self, nfev, total_stat, trace, **kwargs):
+    def __init__(self, models, nfev, total_stat, trace, **kwargs):
+        self._models = models
         self._nfev = nfev
         self._total_stat = total_stat
         self._trace = trace
         super().__init__(**kwargs)
+
+    @property
+    def models(self):
+        """Best fit models"""
+        return self._models
+
+    @property
+    def parameters(self):
+        """Best fit parameters"""
+        return self.models.parameters
 
     @property
     def trace(self):
@@ -570,6 +581,12 @@ class FitResult:
     def __init__(self, optimize_result=None, covariance_result=None):
         self._optimize_result = optimize_result
         self._covariance_result = covariance_result
+
+    @property
+    def parameters(self):
+        """Best fit parameters from the optimization"""
+        # TODO: is the convenience access needed?
+        return self.optimize_result.models.parameters
 
     @property
     def total_stat(self):

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -147,7 +147,7 @@ class Fit:
 
         Returns
         -------
-        fit_result : `FitResult`
+        fit_result : `FitStepResult`
             Results
         """
         optimize_result = self.optimize(datasets=datasets)
@@ -477,7 +477,7 @@ class Fit:
         }
 
 
-class FitResult:
+class FitStepResult:
     """Fit result base class"""
 
     def __init__(self, parameters, backend, method, success, message):
@@ -522,13 +522,13 @@ class FitResult:
         )
 
 
-class CovarianceResult(FitResult):
+class CovarianceResult(FitStepResult):
     """Covariance result object."""
 
     pass
 
 
-class OptimizeResult(FitResult):
+class OptimizeResult(FitStepResult):
     """Optimize result object."""
 
     def __init__(self, nfev, total_stat, trace, covariance_result=None, **kwargs):

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -218,7 +218,7 @@ class Fit:
         parameters.set_parameter_factors(factors)
         parameters.check_limits()
         return OptimizeResult(
-            models=datasets.models.copy(),
+            parameters=parameters,
             total_stat=datasets.stat_sum(),
             backend=backend,
             method=kwargs.get("method", backend),
@@ -529,22 +529,17 @@ class CovarianceResult(FitStepResult):
 
 class OptimizeResult(FitStepResult):
     """Optimize result object."""
-    def __init__(self, models, nfev, total_stat, trace, **kwargs):
-        self._models = models
+    def __init__(self, parameters, nfev, total_stat, trace, **kwargs):
+        self._parameters = parameters
         self._nfev = nfev
         self._total_stat = total_stat
         self._trace = trace
         super().__init__(**kwargs)
 
     @property
-    def models(self):
-        """Best fit models"""
-        return self._models
-
-    @property
     def parameters(self):
         """Best fit parameters"""
-        return self.models.parameters
+        return self._parameters
 
     @property
     def trace(self):
@@ -586,7 +581,7 @@ class FitResult:
     @property
     def parameters(self):
         """Best fit parameters of the optimization step"""
-        return self.optimize_result.models.parameters
+        return self.optimize_result.parameters
 
     # TODO: is the convenience access needed?
     @property

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -145,10 +145,15 @@ class Fit:
     def run(self, datasets):
         """Run all fitting steps.
 
+        Parameters
+        ----------
+        datasets : `Datasets` or list of `Dataset`
+            Datasets to optimize.
+
         Returns
         -------
-        fit_result : `FitStepResult`
-            Results
+        fit_result : `FitResult`
+            Fit result
         """
         optimize_result = self.optimize(datasets=datasets)
 
@@ -158,9 +163,10 @@ class Fit:
 
         covariance_result = self.covariance(datasets=datasets)
 
-        optimize_result._covariance_result = covariance_result
-
-        return optimize_result
+        return FitResult(
+            optimize_result=optimize_result,
+            covariance_result=covariance_result,
+        )
 
     def optimize(self, datasets):
         """Run the optimization.
@@ -523,11 +529,10 @@ class CovarianceResult(FitStepResult):
 class OptimizeResult(FitStepResult):
     """Optimize result object."""
 
-    def __init__(self, nfev, total_stat, trace, covariance_result=None, **kwargs):
+    def __init__(self, nfev, total_stat, trace, **kwargs):
         self._nfev = nfev
         self._total_stat = total_stat
         self._trace = trace
-        self._covariance_result = covariance_result
         super().__init__(**kwargs)
 
     @property
@@ -545,17 +550,56 @@ class OptimizeResult(FitStepResult):
         """Value of the fit statistic at minimum."""
         return self._total_stat
 
-    @property
-    def covariance_result(self):
-        """Covariance results."""
-        return self._covariance_result
-
     def __repr__(self):
         str_ = super().__repr__()
         str_ += f"\tnfev       : {self.nfev}\n"
         str_ += f"\ttotal stat : {self.total_stat:.2f}\n\n"
+        return str_
 
-        if self.covariance_result is not None:
+
+class FitResult:
+    """Fit result class
+
+    Parameters
+    ----------
+    optimize_result : `OptimizeResult`
+        Result of the optimization step.
+    covariance_result : `CovarianceResult`
+        Result of the covariance step.
+    """
+    def __init__(self, optimize_result=None, covariance_result=None):
+        self._optimize_result = optimize_result
+        self._covariance_result = covariance_result
+
+    @property
+    def total_stat(self):
+        """Total stat from the optimization"""
+        # TODO: is the convenience access needed?
+        return self.optimize_result.total_stat
+
+    @property
+    def success(self):
+        """Total success flag"""
+        success = self.optimize_result.success and self.covariance_result.success
+        return success
+
+    @property
+    def optimize_result(self):
+        """Optimize result"""
+        return self._optimize_result
+
+    @property
+    def covariance_result(self):
+        """Optimize result"""
+        return self._optimize_result
+
+    def __repr__(self):
+        str_ = ""
+        if self.optimize_result:
+            str_ += str(self.optimize_result)
+
+        if self.covariance_result:
             str_ += str(self.covariance_result)
 
         return str_
+

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -212,7 +212,6 @@ class Fit:
         parameters.set_parameter_factors(factors)
         parameters.check_limits()
         return OptimizeResult(
-            parameters=parameters,
             total_stat=datasets.stat_sum(),
             backend=backend,
             method=kwargs.get("method", backend),
@@ -258,7 +257,6 @@ class Fit:
 
         # TODO: decide what to return, and fill the info correctly!
         return CovarianceResult(
-            parameters=parameters,
             backend=backend,
             method=method,
             success=info["success"],
@@ -480,17 +478,11 @@ class Fit:
 class FitStepResult:
     """Fit result base class"""
 
-    def __init__(self, parameters, backend, method, success, message):
-        self._parameters = parameters
+    def __init__(self, backend, method, success, message):
         self._success = success
         self._message = message
         self._backend = backend
         self._method = method
-
-    @property
-    def parameters(self):
-        """Optimizer backend used for the fit."""
-        return self._parameters
 
     @property
     def backend(self):

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -548,7 +548,7 @@ class OptimizeResult(FitStepResult):
 
     @property
     def trace(self):
-        """Optimizer backend used for the fit."""
+        """Parameter trace from the optimisation"""
         return self._trace
 
     @property
@@ -582,17 +582,47 @@ class FitResult:
         self._optimize_result = optimize_result
         self._covariance_result = covariance_result
 
+    # TODO: is the convenience access needed?
     @property
     def parameters(self):
-        """Best fit parameters from the optimization"""
-        # TODO: is the convenience access needed?
+        """Best fit parameters of the optimization step"""
         return self.optimize_result.models.parameters
 
+    # TODO: is the convenience access needed?
     @property
     def total_stat(self):
-        """Total stat from the optimization"""
-        # TODO: is the convenience access needed?
+        """Total stat of the optimization step"""
         return self.optimize_result.total_stat
+
+    # TODO: is the convenience access needed?
+    @property
+    def trace(self):
+        """Parameter trace of the optimisation step"""
+        return self.optimize_result.trace
+
+    # TODO: is the convenience access needed?
+    @property
+    def nfev(self):
+        """Number of function evaluations of the optimisation step"""
+        return self.optimize_result.nfev
+
+    # TODO: is the convenience access needed?
+    @property
+    def backend(self):
+        """Optimizer backend used for the fit."""
+        return self.optimize_result.backend
+
+    # TODO: is the convenience access needed?
+    @property
+    def method(self):
+        """Optimizer method used for the fit."""
+        return self.optimize_result.method
+
+    # TODO: is the convenience access needed?
+    @property
+    def message(self):
+        """Optimizer status message."""
+        return self.optimize_result.message
 
     @property
     def success(self):

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -94,7 +94,7 @@ def test_run(backend):
     pars = dataset.models.parameters
 
     assert result.success
-    assert result.method == "migrad"
+    assert result.optimize_result.method == "migrad"
 
     assert_allclose(pars["x"].value, 2, rtol=1e-3)
     assert_allclose(pars["y"].value, 3e2, rtol=1e-3)

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -69,7 +69,9 @@ def test_optimize_backend_and_covariance(backend):
     fit = Fit(optimize_opts=kwargs)
     result = fit.run([dataset])
 
-    pars = result.parameters
+    assert result is not None
+
+    pars = dataset.models.parameters
     assert_allclose(pars["x"].value, 2, rtol=1e-3)
     assert_allclose(pars["y"].value, 3e2, rtol=1e-3)
     assert_allclose(pars["z"].value, 4e-2, rtol=1e-2)
@@ -89,7 +91,7 @@ def test_run(backend):
     dataset = MyDataset()
     fit = Fit(backend=backend)
     result = fit.run([dataset])
-    pars = result.parameters
+    pars = dataset.models.parameters
 
     assert result.success
     assert result.method == "migrad"


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduce a global `FitResult` object, which just contains the individual results form the covariance and optimize steps. The motivation is a clearer API and future convenience, such as `FitResult.read()`, `FitResult.write()` or `FitResult.status` or `FitResult.check()`.

This is partly a backwards incompatible change, because we previously returned an `OptimizeResult` in `Fit.run()`, which probably was never a good idea. For now I repeated the most common quantities, such as `.total_stat` or `.parameters`. Other quantities such as `.trace` need to be accessed like `FitResult.optimize_result.trace`. Should we fully break the API or repeat all optimize quantities on the `FitResult` to stay backwards compatible?

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
