### PR TITLE
Add FluxProfileEstimator tutorial

### DIFF
--- a/docs/tutorials/analysis/3D/flux_profiles.ipynb
+++ b/docs/tutorials/analysis/3D/flux_profiles.ipynb
@@ -1,0 +1,485 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Flux Profile Estimation\n",
+    "\n",
+    "\n",
+    "This tutorial shows how to estimate flux profiles.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "Knowledge of 3D data reduction and datasets used in Gammapy, see for instance the first analysis tutorial.\n",
+    "\n",
+    "\n",
+    "## Context\n",
+    "A useful tool to study and compare the saptial distribution of flux in images and data cubes is the measurement of flxu profiles. Flux profiles can show spatial correlations of gamma-ray data with e.g. gas maps or other type of gamma-ray data. Most commonly flux profiles are measured along some preferred coordinate axis, either radially distance from a source of interest, along longitude and latitude coordinate axes or along the path defined by two spatial coordinates. \n",
+    "\n",
+    "## Proposed Approach\n",
+    "Flux profile estimation essentially works by estimating flux points for a set of predefined spatially connected regions. For radial flux profiles the shape of the regions are annuli with a common center, for linear profiles it's typically a rectangular shape.\n",
+    "\n",
+    "We will work on a pre-computed `MapDataset` of Fermi-LAT data, use `Region` to define the structure of the bins of the flux profile and run the actualy profile extraction using the `FluxProfileEstimator` \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup and Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "from astropy import units as u\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.datasets import MapDataset\n",
+    "from gammapy.estimators import FluxProfileEstimator, FluxPoints\n",
+    "from gammapy.maps import RegionGeom\n",
+    "from gammapy.utils.regions import make_concentric_annulus_sky_regions, make_orthogonal_rectangle_sky_regions\n",
+    "from gammapy.modeling.models import PowerLawSpectralModel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read and Introduce Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = MapDataset.read(\"$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc.fits.gz\", name=\"fermi-dataset\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is what the counts image we will work with looks like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "counts_image = dataset.counts.sum_over_axes()\n",
+    "counts_image.smooth(\"0.1 deg\").plot(stretch=\"sqrt\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are 400x200 pixels in the dataset and 11 energy bins between 10 GeV and 2 TeV:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(dataset.counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Profile Estimation\n",
+    "\n",
+    "### Configuration\n",
+    "\n",
+    "We start by defining a list of spatially connected regions along the galactic longitude axis. For this there is a helper fucntion `make_orthogonal_rectangle_sky_regions`. The individual region bins for the profile have a height of 3 deg and in total there are 31 bins. The starts from  lon = 10 deg tand goes to lon = 350 deg. In additon we have to specify the `wcs` to take into account possible projections effects on the region definition:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "regions = make_orthogonal_rectangle_sky_regions(\n",
+    "    start_pos=SkyCoord(\"10d\", \"0d\", frame=\"galactic\"),\n",
+    "    end_pos=SkyCoord(\"350d\", \"0d\", frame=\"galactic\"),\n",
+    "    wcs=counts_image.geom.wcs,\n",
+    "    height=\"3 deg\",\n",
+    "    nbin=51\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the `RegionGeom` object to illustrate the regions on top of the counts image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx-thumbnail": {
+     "tooltip": "Learn how to estimate flux profiles on a Fermi-LAT dataset"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "geom = RegionGeom.create(region=regions)\n",
+    "ax = counts_image.smooth(\"0.1 deg\").plot(stretch=\"sqrt\")\n",
+    "geom.plot_region(ax=ax, color=\"w\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we create the `FluxProfileEstimator`. For the estimation of the flux profile we assume a spectral model with a power-law shape and an index of 2.3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux_profile_estimator = FluxProfileEstimator(\n",
+    "    regions=regions,\n",
+    "    spectrum=PowerLawSpectralModel(index=2.3),\n",
+    "    energy_edges=[10, 2000] * u.GeV,\n",
+    "    selection_optional=[\"ul\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see the full configuration by printing the estimator object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(flux_profile_estimator)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run Estimation\n",
+    "Now we can run the profile estimation and explore the results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "profile = flux_profile_estimator.run(datasets=dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(profile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see the flux profile is represented by a `FluxPoints` object with a `projected-distance` axis, which defines the main axis the flux profile is measured along. The `lon` and `lat` axes can be ignored. \n",
+    "\n",
+    "### Plotting Results\n",
+    "\n",
+    "Let us directly plot the result using `FluxPoints.plot()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = profile.plot(sed_type=\"dnde\")\n",
+    "ax.set_yscale(\"linear\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Based on the spectral model we specified above we can also plot in any other sed type, e.g. energy flux and define a different threshold when to plot upper limits:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "profile.sqrt_ts_threshold_ul = 2\n",
+    "\n",
+    "ax = profile.plot(sed_type=\"eflux\")\n",
+    "ax.set_yscale(\"linear\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also plot any other quantity of interest, that is defined on the `FluxPoints` result object. E.g. the predicted total counts, background counts and excess counts: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quantities = [\"npred\", \"npred_excess\", \"npred_background\"]\n",
+    "\n",
+    "for quantity in quantities:\n",
+    "    profile[quantity].plot(label=quantity.title())\n",
+    "    \n",
+    "plt.ylabel(\"Counts \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Serialisation and I/O\n",
+    "\n",
+    "The profile can be serialised using `FluxPoints.write()`, given a specific format:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "profile.write(filename=\"flux_profile_fermi.fits\", format=\"profile\", overwrite=True, sed_type=\"dnde\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "profile_new = FluxPoints.read(filename=\"flux_profile_fermi.fits\", format=\"profile\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = profile_new.plot()\n",
+    "ax.set_yscale(\"linear\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The profile can be serialised to a `~astropy.table.Table` object using:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = profile.to_table(format=\"profile\", formatted=True)\n",
+    "table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "No we can also estimate a radial profile starting from the Galactic center:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "regions = make_concentric_annulus_sky_regions(\n",
+    "    center=SkyCoord(\"0d\", \"0d\", frame=\"galactic\"),\n",
+    "    radius_max=\"1.5 deg\",\n",
+    "    nbin=11\n",
+    "    \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again we first illustrate the regions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geom = RegionGeom.create(region=regions)\n",
+    "gc_image = counts_image.cutout(position=SkyCoord(\"0d\", \"0d\", frame=\"galactic\"), width=3 * u.deg)\n",
+    "ax = gc_image.smooth(\"0.1 deg\").plot(stretch=\"sqrt\")\n",
+    "geom.plot_region(ax=ax, color=\"w\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This time we define two energy bins and include the fit statitic profile in the computation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux_profile_estimator = FluxProfileEstimator(\n",
+    "    regions=regions,\n",
+    "    spectrum=PowerLawSpectralModel(index=2.3),\n",
+    "    energy_edges=[10, 100, 2000] * u.GeV,\n",
+    "    selection_optional=[\"ul\", \"scan\"],\n",
+    "    norm_values=np.linspace(-1, 5, 11),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "profile = flux_profile_estimator.run(datasets=dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can directly plot the result:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = profile.plot(axis_name=\"projected-distance\", sed_type=\"flux\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However because of the powerlaw spectrum the flux at high energies is much lower. To extract the profile at high energies only we can use:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "profile_high = profile.slice_by_idx({\"energy\": slice(1,2)})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now plot the points together with the likelihood profiles:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = profile_high.plot(sed_type=\"eflux\", color=\"tab:orange\")\n",
+    "profile_high.plot_ts_profiles(ax=ax, sed_type=\"eflux\")\n",
+    "ax.set_yscale(\"linear\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -89,6 +89,7 @@ time-dependent analysis with light-curves.
    analysis/3D/simulate_3d.ipynb
    analysis/3D/analysis_mwl.ipynb
    analysis/3D/event_sampling.ipynb
+   analysis/3D/flux_profiles.ipynb
 
 Time
 ~~~~

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -192,7 +192,7 @@ class FluxPoints(FluxMaps):
             Table
         sed_type : {"dnde", "flux", "eflux", "e2dnde", "likelihood"}
             Sed type
-        format : {"gadf-sed", "lightcurve"}
+        format : {"gadf-sed", "lightcurve", "profile"}
             Table format.
         reference_model : `SpectralModel`
             Reference spectral model

--- a/gammapy/estimators/points/profile.py
+++ b/gammapy/estimators/points/profile.py
@@ -137,3 +137,11 @@ class FluxProfileEstimator(FluxPointsEstimator):
             maps=maps,
             axis=self.projected_distance_axis,
         )
+
+    @property
+    def config_parameters(self):
+        """Config parameters"""
+        pars = self.__dict__.copy()
+        pars = {key.strip("_"): value for key, value in pars.items()}
+        pars.pop("regions")
+        return pars

--- a/gammapy/estimators/points/tests/test_profile.py
+++ b/gammapy/estimators/points/tests/test_profile.py
@@ -153,6 +153,7 @@ def test_radial_profile_one_interval():
     assert_allclose(ul, [130.394824], rtol=1e-3)
 
 
+@requires_dependency("iminuit")
 def test_serialisation(tmpdir):
     dataset = get_simple_dataset_on_off()
     geom = dataset.counts.geom
@@ -177,8 +178,6 @@ def test_serialisation(tmpdir):
     assert_allclose(result.npred, profile.npred)
     assert_allclose(result.ts, profile.ts)
 
-    print(result.is_ul)
-    print(profile.is_ul)
     assert np.all(result.is_ul == profile.is_ul)
 
 

--- a/gammapy/estimators/points/tests/test_profile.py
+++ b/gammapy/estimators/points/tests/test_profile.py
@@ -1,13 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
 from gammapy.data import GTI
 from gammapy.datasets import MapDatasetOnOff
-from gammapy.estimators import FluxProfileEstimator
+from gammapy.estimators import FluxProfileEstimator, FluxPoints
 from gammapy.maps import MapAxis, WcsGeom
+from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.utils.regions import (
     make_concentric_annulus_sky_regions,
     make_orthogonal_rectangle_sky_regions,
@@ -149,6 +151,35 @@ def test_radial_profile_one_interval():
 
     ul = result.npred_excess_ul.data[0].squeeze()
     assert_allclose(ul, [130.394824], rtol=1e-3)
+
+
+def test_serialisation(tmpdir):
+    dataset = get_simple_dataset_on_off()
+    geom = dataset.counts.geom
+    regions = make_concentric_annulus_sky_regions(
+        center=geom.center_skydir,
+        radius_max=0.2 * u.deg,
+    )
+
+    est = FluxProfileEstimator(regions, energy_edges=[0.1, 10] * u.TeV)
+    result = est.run(dataset)
+
+    result.write(tmpdir / "profile.fits", format="profile")
+
+    profile = FluxPoints.read(
+        tmpdir / "profile.fits",
+        format="profile",
+        reference_model=PowerLawSpectralModel()
+    )
+
+    assert_allclose(result.norm, profile.norm, rtol=1e-4)
+    assert_allclose(result.norm_err, profile.norm_err, rtol=1e-4)
+    assert_allclose(result.npred, profile.npred)
+    assert_allclose(result.ts, profile.ts)
+
+    print(result.is_ul)
+    print(profile.is_ul)
+    assert np.all(result.is_ul == profile.is_ul)
 
 
 def test_regions_init():

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1242,10 +1242,8 @@ class MapAxis:
                 labels = np.unique(table["datasets"])
                 axis = LabelMapAxis(labels=labels, name="dataset")
             else:
-                x_min = table["x_min"].quantity
-                x_max = table["x_max"].quantity
-                edges = edges_from_lo_hi(x_min, x_max)
-                axis = MapAxis.from_edges(edges, name="projected-distance")
+                x_ref = table["x_ref"].quantity
+                axis = MapAxis.from_nodes(x_ref, name="projected-distance")
         else:
             raise ValueError(f"Format '{format}' not supported")
 

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1237,6 +1237,15 @@ class MapAxis:
                 shape = table["counts"].shape
                 edges = np.arange(shape[-1] + 1) - 0.5
                 axis = MapAxis.from_edges(edges, name="dataset")
+        elif format == "profile":
+            if "datasets" in table.colnames:
+                labels = np.unique(table["datasets"])
+                axis = LabelMapAxis(labels=labels, name="dataset")
+            else:
+                x_min = table["x_min"].quantity
+                x_max = table["x_max"].quantity
+                edges = edges_from_lo_hi(x_min, x_max)
+                axis = MapAxis.from_edges(edges, name="projected-distance")
         else:
             raise ValueError(f"Format '{format}' not supported")
 
@@ -1834,7 +1843,7 @@ class MapAxes(Sequence):
 
     @classmethod
     def from_table(cls, table, format="gadf"):
-        """Create MapAxes from BinTableHDU
+        """Create MapAxes from table
 
         Parameters
         ----------
@@ -1898,6 +1907,9 @@ class MapAxes(Sequence):
         elif format == "lightcurve":
             axes.extend(cls.from_table(table=table, format="gadf-sed"))
             axes.append(TimeMapAxis.from_table(table, format="lightcurve"))
+        elif format == "profile":
+            axes.extend(cls.from_table(table=table, format="gadf-sed"))
+            axes.append(MapAxis.from_table(table, format="profile"))
         else:
             raise ValueError(f"Unsupported format: '{format}'")
 

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -500,7 +500,7 @@ class RegionNDMap(Map):
         ----------
         table : `~astropy.table.Table`
             Table with input data
-        format : {"gadf-sed", "lightcurve"}
+        format : {"gadf-sed", "lightcurve", "profile"}
             Format to use
         colname : str
             Column name to take the data from.
@@ -537,6 +537,20 @@ class RegionNDMap(Map):
                 names = ["dataset", "energy", "time"]
             else:
                 names = ["energy", "time"]
+
+            axes = axes[names]
+            data = table[colname].data
+            unit = table[colname].unit or ""
+        elif format == "profile":
+            axes = MapAxes.from_table(table=table, format=format)
+
+            if colname == "stat_scan":
+                names = ["norm", "energy", "projected-distance"]
+            # TODO: this is not officially supported by GADF...
+            elif colname in ["counts", "npred", "npred_excess"]:
+                names = ["dataset", "energy", "projected-distance"]
+            else:
+                names = ["energy", "projected-distance"]
 
             axes = axes[names]
             data = table[colname].data


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a tutorial for the `FluxProfileEstimator` and extends the serialization of `FluxPoints` to make sure a profile can be serialized as well.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
