### PR TITLE
Fix untar downloaded tutorials and change test

### DIFF
--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -39,11 +39,19 @@ def progress_download(source, destination):
                     progress_bar.update(len(chunk))
     progress_bar.close()
 
+
+def members(tf):
+    list_members = tf.getmembers()
+    root_folder = list_members[0].name
+    for member in list_members:
+        if member.path.startswith(root_folder):
+            member.path = member.path[len(root_folder) + 1 :]
+            yield member
+
+
 def extract_bundle(bundle, destination):
-    my_tar = tarfile.open(bundle)
-    my_tar.extractall(destination)
-    my_tar.close()
-    Path(bundle).unlink()
+    with tarfile.open(bundle) as tar:
+        tar.extractall(path=destination, members=members(tar))
 
 
 def show_info_notebooks(outfolder, release):
@@ -86,7 +94,10 @@ def cli_download_notebooks(release, out):
     url_tar_notebooks = f"{NBTAR_BASE_URL}/{release}/_downloads/notebooks-{release}.tar"
     tar_destination_file = localfolder / f"notebooks_{release}.tar"
     progress_download(url_tar_notebooks, tar_destination_file)
-    extract_bundle(tar_destination_file, localfolder)
+    my_tar = tarfile.open(tar_destination_file)
+    my_tar.extractall(localfolder)
+    my_tar.close()
+    Path(tar_destination_file).unlink()
     show_info_notebooks(localfolder, release)
 
 
@@ -105,4 +116,5 @@ def cli_download_datasets(out):
     progress_download(TAR_DATASETS, tar_destination_file)
     log.info(f"Extracting {tar_destination_file}")
     extract_bundle(tar_destination_file, localfolder)
+    Path(tar_destination_file).unlink()
     show_info_datasets(localfolder)

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -87,6 +87,9 @@ def cli_download_notebooks(release, out):
     """Download notebooks"""
     localfolder = Path(out) / release
     url_file_env = f"{ENVS_BASE_URL}/gammapy-{release}-environment.yml"
+    if release == "dev":
+        url_file_env = f"https://raw.githubusercontent.com/gammapy/gammapy/master/environment-dev.yml"
+
     yaml_destination_file = localfolder / f"gammapy-{release}-environment.yml"
     progress_download(url_file_env, yaml_destination_file)
     url_tar_notebooks = f"{NBTAR_BASE_URL}/{release}/_downloads/notebooks-{release}.tar"

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -39,19 +39,10 @@ def progress_download(source, destination):
                     progress_bar.update(len(chunk))
     progress_bar.close()
 
-
-def members(tf):
-    list_members = tf.getmembers()
-    root_folder = list_members[0].name
-    for member in list_members:
-        if member.path.startswith(root_folder):
-            member.path = member.path[len(root_folder) + 1 :]
-            yield member
-
-
 def extract_bundle(bundle, destination):
-    with tarfile.open(bundle) as tar:
-        tar.extractall(path=destination, members=members(tar))
+    my_tar = tarfile.open(bundle)
+    my_tar.extractall(destination)
+    my_tar.close()
     Path(bundle).unlink()
 
 

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -8,8 +8,8 @@ from gammapy.utils.testing import run_cli
 def config():
     return {
         "release": "dev",
-        "notebook": "astro_dark_matter",
-        "envfilename": "gammapy-0.18-environment.yml",
+        "notebook": "overview",
+        "envfilename": "gammapy-dev-environment.yml",
     }
 
 
@@ -28,7 +28,7 @@ def test_cli_download_notebooks(tmp_path, config):
     ]
     run_cli(cli, args)
     assert (tmp_path / config["release"] / config["envfilename"]).exists()
-    assert (tmp_path / config["release"] / f"{config['notebook']}.ipynb").exists()
+    assert (tmp_path / config["release"] / "tutorials" / "starting" / f"{config['notebook']}.ipynb").exists()
 
 
 @pytest.mark.remote_data

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -7,7 +7,7 @@ from gammapy.utils.testing import run_cli
 @pytest.fixture(scope="session")
 def config():
     return {
-        "release": "0.18",
+        "release": "dev",
         "notebook": "astro_dark_matter",
         "envfilename": "gammapy-0.18-environment.yml",
     }


### PR DESCRIPTION
This PR is a continuation of #3653.

It fixes the way how downloaded tar bundled tutorials are extracted and modifies the notebooks download test to check if the dev version of produced tar bundlle is properly produced, downloaded and uncompressed.