### PR TITLE
Fix call to Datasets.write()

### DIFF
--- a/gammapy/modeling/models/tests/data/make.py
+++ b/gammapy/modeling/models/tests/data/make.py
@@ -99,8 +99,8 @@ def make_datasets_example():
         datasets.append(stacked)
 
     datasets.write(
-        "$GAMMAPY_DATA/tests/models",
-        prefix="gc_example",
+        filename="$GAMMAPY_DATA/tests/models/gc_example_datasets.yaml",
+        filename_models="$GAMMAPY_DATA/tests/models/gc_example_models.yaml",
         overwrite=True,
         write_covariance=False,
     )


### PR DESCRIPTION
**Description**

The Datasets.write() signature had been modified by a03d1a7 (#3089), but this script had not been modified accordingly.

Partially fixes #3638.

**Dear reviewer**

Fixing the script here, but the script should eventually be moved to https://github.com/gammapy/gammapy-data/tree/master/tests/models as suggested in https://github.com/gammapy/gammapy/issues/3638#issuecomment-982980095.