### PR TITLE
Started to implement the energy-dependent 1D spectrum extraction

### DIFF
--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -298,7 +298,7 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
 
     @classmethod
     def from_dict(cls, data, **kwargs):
-        """Create flux point dataset from dict.
+        """Create spectrum dataset from dict.
 
         Parameters
         ----------
@@ -309,7 +309,6 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
         -------
         dataset : `SpectrumDatasetOnOff`
             Spectrum dataset on off.
-
         """
 
         filename = make_path(data["filename"])
@@ -343,7 +342,6 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
         -------
         dataset : `SpectrumDatasetOnOff`
             Spectrum dataset on off.
-
         """
         return cls.from_map_dataset(**kwargs)
 

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -298,7 +298,8 @@ class ReflectedRegionsBackgroundMaker(Maker):
         ):
             counts_off, acceptance_off = make_counts_off_rad_max(
                 geom=dataset.counts.geom,
-                observation=observation,
+                rad_max=observation.rad_max,
+                events=observation.events,
                 binsz=self.binsz,
                 exclusion_mask=self.exclusion_mask,
                 min_distance=self.min_distance,

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -83,7 +83,7 @@ class MapDatasetMaker(Maker):
             Counts map.
         """
         if geom.is_region and isinstance(geom.region, PointSkyRegion):
-            counts = make_counts_rad_max(geom, observation)
+            counts = make_counts_rad_max(geom, observation.rad_max, observation.events)
         else:
             counts = Map.from_geom(geom)
             counts.fill_events(observation.events)

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -14,7 +14,7 @@ from .utils import (
     make_map_background_irf,
     make_map_exposure_true_energy,
     make_psf_map,
-    make_counts_rad_max
+    make_counts_rad_max,
 )
 
 __all__ = ["MapDatasetMaker"]
@@ -53,7 +53,7 @@ class MapDatasetMaker(Maker):
             selection = self.available_selection
 
         selection = set(selection)
-        
+
         if not selection.issubset(self.available_selection):
             difference = selection.difference(self.available_selection)
             raise ValueError(f"{difference} is not a valid method.")
@@ -64,7 +64,7 @@ class MapDatasetMaker(Maker):
     def make_counts(geom, observation):
         """Make counts map.
 
-        **NOTE for 1D analysis:** if the `~gammapy.maps.Geom` is built from a 
+        **NOTE for 1D analysis:** if the `~gammapy.maps.Geom` is built from a
         `~regions.CircleSkyRegion`, the latter will be directly used to extract
         the counts. If instead the `~gammapy.maps.Geom` is built from a
         `~regions.PointSkyRegion`, the size of the ON region is taken from
@@ -82,9 +82,9 @@ class MapDatasetMaker(Maker):
         counts : `~gammapy.maps.Map`
             Counts map.
         """
-        if isinstance(geom.region, PointSkyRegion):
+        if geom.is_region and isinstance(geom.region, PointSkyRegion):
             counts = make_counts_rad_max(geom, observation)
-        elif isinstance(geom.region, CircleSkyRegion):
+        else:
             counts = Map.from_geom(geom)
             counts.fill_events(observation.events)
         return counts

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -64,10 +64,9 @@ class MapDatasetMaker(Maker):
     def make_counts(geom, observation):
         """Make counts map.
 
-        **NOTE:** for 1D analyses, if the `~gammapy.maps.Geom` is built from a
+        **NOTE for 1D analysis:** if the `~gammapy.maps.Geom` is built from a 
         `~regions.CircleSkyRegion`, the latter will be directly used to extract
-        the counts.
-        If instead the `~gammapy.maps.Geom` is built from a
+        the counts. If instead the `~gammapy.maps.Geom` is built from a
         `~regions.PointSkyRegion`, the size of the ON region is taken from
         the `RAD_MAX_2D` table containing energy-dependent theta2 cuts.
 

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -29,7 +29,7 @@ class SpectrumDatasetMaker(MapDatasetMaker):
     """
 
     tag = "SpectrumDatasetMaker"
-    available_selection = ["counts", "background", "exposure", "edisp"]
+    available_selection = ["counts", "background", "exposure", "edisp", "rad_max"]
 
     def __init__(
         self,

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -29,7 +29,7 @@ class SpectrumDatasetMaker(MapDatasetMaker):
     """
 
     tag = "SpectrumDatasetMaker"
-    available_selection = ["counts", "background", "exposure", "edisp", "rad_max"]
+    available_selection = ["counts", "background", "exposure", "edisp"]
 
     def __init__(
         self,

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -35,8 +35,10 @@ def observations_hess():
 
 @pytest.fixture(scope="session")
 def observations_magic():
-    files = make_path("$GAMMAPY_DATA/magic/rad_max/data").glob("*.fits")
-    observations = [Observation.read(_file) for _file in files]
+    observations = [
+        Observation.read("$GAMMAPY_DATA/magic/rad_max/data/magic_dl3_run_05029747.fits"),
+        Observation.read("$GAMMAPY_DATA/magic/rad_max/data/magic_dl3_run_05029748.fits"),
+    ]
     return observations
 
 
@@ -254,7 +256,7 @@ def test_datasetsmaker_spectrum(observations_hess, makers_spectrum):
 def test_dataset_maker_spectrum_rad_max(observations_magic):
     """test the energy-dependent spectrum extraction"""
 
-    observation = observations_magic[1]
+    observation = observations_magic[0]
 
     maker = SpectrumDatasetMaker(
         containment_correction=False, selection=["counts", "exposure", "edisp"]

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -36,8 +36,12 @@ def observations_hess():
 @pytest.fixture(scope="session")
 def observations_magic():
     observations = [
-        Observation.read("$GAMMAPY_DATA/magic/rad_max/data/magic_dl3_run_05029747.fits"),
-        Observation.read("$GAMMAPY_DATA/magic/rad_max/data/magic_dl3_run_05029748.fits"),
+        Observation.read(
+            "$GAMMAPY_DATA/magic/rad_max/data/magic_dl3_run_05029747.fits"
+        ),
+        Observation.read(
+            "$GAMMAPY_DATA/magic/rad_max/data/magic_dl3_run_05029748.fits"
+        ),
     ]
     return observations
 
@@ -253,6 +257,7 @@ def test_datasetsmaker_spectrum(observations_hess, makers_spectrum):
     assert_allclose(exposure.data.mean(), 3.94257338e08, rtol=3e-3)
 
 
+@requires_data()
 def test_dataset_maker_spectrum_rad_max(observations_magic):
     """test the energy-dependent spectrum extraction"""
 

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -1,10 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from gammapy.makers.tests.test_spectrum import observations_magic_dl3
 import pytest
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
-from regions import CircleSkyRegion
-from gammapy.data import DataStore
+from regions import CircleSkyRegion, PointSkyRegion
+from gammapy.data import DataStore, Observation
 from gammapy.datasets import MapDataset, SpectrumDataset
 from gammapy.makers import (
     DatasetsMaker,
@@ -16,6 +17,7 @@ from gammapy.makers import (
 )
 from gammapy.maps import MapAxis, RegionGeom, WcsGeom
 from gammapy.utils.testing import requires_data
+from gammapy.utils.scripts import make_path
 
 
 @pytest.fixture(scope="session")
@@ -29,6 +31,13 @@ def observations_hess():
     datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
     obs_ids = [23523, 23526, 23559, 23592]
     return datastore.get_observations(obs_ids)
+
+
+@pytest.fixture(scope="session")
+def observations_magic():
+    files = make_path("$GAMMAPY_DATA/magic/rad_max/data").glob("*.fits")
+    observations = [Observation.read(_file) for _file in files]
+    return observations
 
 
 def get_mapdataset(name):
@@ -55,6 +64,25 @@ def get_spectrumdataset(name):
     )
 
     geom = RegionGeom.create(region=on_region, axes=[energy_axis])
+    return SpectrumDataset.create(
+        geom=geom, energy_axis_true=energy_axis_true, name=name
+    )
+
+
+def get_spectrumdataset_rad_max(name):
+    """get the spectrum dataset maker for the energy-dependent spectrum extraction"""
+    target_position = SkyCoord(ra=83.63, dec=22.01, unit="deg", frame="icrs")
+    on_center = PointSkyRegion(target_position)
+
+    energy_axis = MapAxis.from_energy_bounds(
+        0.005, 50, nbin=28, per_decade=False, unit="TeV", name="energy"
+    )
+    energy_axis_true = MapAxis.from_energy_bounds(
+        0.005, 50, nbin=20, per_decade=False, unit="TeV", name="energy_true"
+    )
+
+    geom = RegionGeom.create(region=on_center, axes=[energy_axis])
+
     return SpectrumDataset.create(
         geom=geom, energy_axis_true=energy_axis_true, name=name
     )
@@ -221,3 +249,28 @@ def test_datasetsmaker_spectrum(observations_hess, makers_spectrum):
     exposure = datasets[0].exposure
     assert exposure.unit == "m2 s"
     assert_allclose(exposure.data.mean(), 3.94257338e08, rtol=3e-3)
+
+
+def test_dataset_maker_spectrum_rad_max(observations_magic):
+    """test the energy-dependent spectrum extraction"""
+
+    observation = observations_magic[1]
+
+    maker = SpectrumDatasetMaker(
+        containment_correction=False, selection=["counts", "exposure", "edisp"]
+    )
+    dataset = maker.run(get_spectrumdataset_rad_max("spec"), observation)
+
+    bkg_maker = ReflectedRegionsBackgroundMaker()
+    dataset_on_off = bkg_maker.run(dataset, observation)
+
+    counts = dataset_on_off.counts
+    counts_off = dataset_on_off.counts_off
+    assert counts.unit == ""
+    assert counts_off.unit == ""
+    assert_allclose(counts.data.sum(), 1138, rtol=1e-5)
+    assert_allclose(counts_off.data.sum(), 2128, rtol=1e-5)
+
+    exposure = dataset_on_off.exposure
+    assert exposure.unit == "m2 s"
+    assert_allclose(exposure.data.mean(), 68714990.52908568, rtol=1e-5)


### PR DESCRIPTION
**Description**

**What is the motivation for this pull request?**
This PR starts the implementation of the energy-dependent spectrum extraction.

**Briefly: what changes are done here?**
* For the moment I have modified the `SpectrumDatasetMaker` - actually the `MapDatasetMaker` from which it inherits - to use the information in `~gammapy.irf.RadMax2D` to create a different ON region for each energy bin and fill the array with the ON counts accordingly.

* The next step would be to modify the `ReflectedRegionsBackgroundMaker` to extract the OFF counts using the same strategy.

**If this is to address a Github issue, mention its number to create a link**
Related to Issue #3296.

**Status**
This is a draft, meant for discussion. No docs and no tests have been added yet.
But find here a snippet of how the energy-dependent spectrum extraction will look with these modifications (I stop at the `SpectrumDatasetMaker.run`).
```python
from astropy.coordinates import SkyCoord
from regions import PointSkyRegion
from gammapy.data import Observation
from gammapy.maps import MapAxis, RegionGeom
from gammapy.makers import SpectrumDatasetMaker
from gammapy.datasets import SpectrumDataset
import matplotlib.pyplot as plt

# load the observation
observation = Observation.read("$GAMMAPY_DATA/magic/rad_max/data/magic_dl3_run_05029747.fits")
# observation = Observation.read("$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020323.fits.gz")

# energy axes
energy_axis = MapAxis.from_energy_bounds(
    0.005, 50, nbin=28, per_decade=False, unit="TeV", name="energy"
)
energy_true_axis = MapAxis.from_energy_bounds(
    0.005, 50, nbin=20, per_decade=False, unit="TeV", name="energy_true"
)

# create a point-like geometry for the centre of the ON region
target_position = SkyCoord(ra=83.63, dec=22.01, unit="deg", frame="icrs")
on_center = PointSkyRegion(target_position)
geom = RegionGeom.create(region=on_center, axes=[energy_axis])

# spectrum dataset and its maker
dataset_empty = SpectrumDataset.create(
    geom=geom, energy_axis_true=energy_true_axis
)

dataset_maker = SpectrumDatasetMaker(
    containment_correction=False, selection=["counts", "exposure", "edisp", "rad_max"]
)

# try to run it and plot the counts
dataset = dataset_maker.run(
    dataset_empty.copy(name="trial"), observation
)
dataset.counts.plot(drawstyle="steps-mid", ls="-")
plt.grid(ls=":")
plt.show()
```

![Figure_1](https://user-images.githubusercontent.com/26409711/145576981-292a7ee3-63ff-42ad-be23-367bb6cf5475.png)

It looks in agreement with what I was obtaining with MARS and with my custom scripts
![run_5029747_counts_comparison](https://user-images.githubusercontent.com/26409711/145577401-e68a2b75-b557-4ec9-8876-78c902aeb013.png)

Thanks!

P.S.
It would help other testing if you merge https://github.com/gammapy/gammapy-data/pull/18.
