### PR TITLE
Fix Fit.covariance shape in case of linked parameters

### DIFF
--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -726,14 +726,6 @@ def test_map_fit_linked(sky_model, geom, geom_etrue):
     assert len(datasets.models.parameters.unique_parameters) == 20 
     assert datasets.models.covariance.shape == (22,22) 
 
-    models.to_dict()
-    pars = sky_model.parameters
-    pars2 = sky_model2.parameters
-    assert pars["index"]._link_label_io is not None 
-    assert pars2["reference"]._link_label_io is not None 
-    assert pars["index"]._link_label_io == pars2["index"]._link_label_io
-    assert pars["reference"]._link_label_io == pars2["reference"]._link_label_io
-
 
 @requires_dependency("iminuit")
 @requires_data()

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -723,8 +723,6 @@ def test_map_fit_linked(sky_model, geom, geom_etrue):
     assert sky_model2.parameters["index"] is sky_model.parameters["index"]
     assert sky_model2.parameters["reference"] is sky_model.parameters["reference"]
 
-    print(models.parameters.to_table())
-
     assert len(datasets.models.parameters.unique_parameters) == 20 
     assert datasets.models.covariance.shape == (22,22) 
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -241,7 +241,7 @@ class Fit:
         result : `CovarianceResult`
             Results
         """
-        datasets, _ = self._parse_datasets(datasets=datasets)
+        datasets, unique_pars = self._parse_datasets(datasets=datasets)
         parameters = datasets.models.parameters
 
         kwargs = self.covariance_opts.copy()
@@ -249,14 +249,14 @@ class Fit:
         backend = kwargs.pop("backend", self.backend)
         compute = registry.get("covariance", backend)
 
-        with parameters.restore_status():
+        with unique_pars.restore_status():
             if self.backend == "minuit":
                 method = "hesse"
             else:
                 method = ""
 
             factor_matrix, info = compute(
-                parameters=parameters, function=datasets.stat_sum, **kwargs
+                parameters=unique_pars, function=datasets.stat_sum, **kwargs
             )
 
             datasets.models.covariance = Covariance.from_factor_matrix(

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -241,7 +241,8 @@ class Fit:
         result : `CovarianceResult`
             Results
         """
-        datasets, parameters = self._parse_datasets(datasets=datasets)
+        datasets, _ = self._parse_datasets(datasets=datasets)
+        parameters = datasets.models.parameters
 
         kwargs = self.covariance_opts.copy()
         kwargs["minuit"] = self.minuit

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -130,7 +130,11 @@ def test_run_linked(backend):
 
     assert len(dataset.models.parameters.unique_parameters) == 3 
     assert dataset.models.covariance.shape == (6,6) 
-
+    expected = [[1.00000000e+00, 1.69728073e-30, 4.76456033e-16],
+                [1.69728073e-30, 1.00000000e+00, 3.56230294e-15],
+                [4.76456033e-16, 3.56230294e-15, 1.00000000e+00]]
+    assert_allclose(dataset.models[0].covariance.data, expected)
+    assert_allclose(dataset.models[1].covariance.data, expected)
 
 @requires_dependency("sherpa")
 @pytest.mark.parametrize("backend", ["minuit", "sherpa", "scipy"])


### PR DESCRIPTION
Fix the shape of the covariance matrix in `Fit.covariance` in case of linked parameters using the full list of parameters instead of the list of unique parameters.