### PR TITLE
Apply min counts consistently to scale and fit in FoVBackgroundMaker

### DIFF
--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -132,6 +132,29 @@ class FoVBackgroundMaker(Maker):
             mask = Map.from_geom(geom=geom, data=1, dtype=bool)
         return mask
 
+    def _verify_requirements(self, dataset):
+        """"Verify that the requirements of min_counts
+        and min_npred_background are satisfied"""
+
+        mask = dataset.mask
+        count_tot = dataset.counts.data[mask].sum()
+        bkg_tot = dataset.npred_background().data[mask].sum()
+
+        if count_tot <= self.min_counts:
+            log.warning(
+                f"FoVBackgroundMaker failed. Only {int(count_tot)} counts outside exclusion mask for {dataset.name}. "
+                f"Setting mask to False."
+            )
+            return False
+        elif bkg_tot <= self.min_npred_background:
+            log.warning(
+                f"FoVBackgroundMaker failed. Only {int(bkg_tot)} background counts outside exclusion mask for {dataset.name}. "
+                f"Setting mask to False."
+            )
+            return False
+        else:
+            return True
+
     def run(self, dataset, observation=None):
         """Run FoV background maker.
 
@@ -150,11 +173,14 @@ class FoVBackgroundMaker(Maker):
         if dataset.background_model is None:
             dataset = self.make_default_fov_background_model(dataset)
 
-        if self.method == "fit":
-            dataset = self.make_background_fit(dataset)
+        if self._verify_requirements(dataset) is True:
+            if self.method == "fit":
+                dataset = self.make_background_fit(dataset)
+            else:
+                # always scale the background first
+                dataset = self.make_background_scale(dataset)
         else:
-            # always scale the background first
-            dataset = self.make_background_scale(dataset)
+            dataset.mask_safe.data[...] = False
 
         dataset.mask_fit = mask_fit
         return dataset
@@ -207,22 +233,8 @@ class FoVBackgroundMaker(Maker):
         count_tot = dataset.counts.data[mask].sum()
         bkg_tot = dataset.npred_background().data[mask].sum()
 
-        if count_tot <= self.min_counts:
-            log.warning(
-                f"FoVBackgroundMaker failed. Only {int(count_tot)} counts outside exclusion mask for {dataset.name}. "
-                f"Setting mask to False."
-            )
-            dataset.mask_safe.data[...] = False
-        elif bkg_tot <= self.min_npred_background:
-            log.warning(
-                f"FoVBackgroundMaker failed. Only {int(bkg_tot)} background counts outside exclusion mask for {dataset.name}. "
-                f"Setting mask to False."
-            )
-            dataset.mask_safe.data[...] = False
-        else:
-            value = count_tot / bkg_tot
-            err = np.sqrt(count_tot) / bkg_tot
-            dataset.models[f"{dataset.name}-bkg"].spectral_model.norm.value = value
-            dataset.models[f"{dataset.name}-bkg"].spectral_model.norm.error = err
-
+        value = count_tot / bkg_tot
+        err = np.sqrt(count_tot) / bkg_tot
+        dataset.models[f"{dataset.name}-bkg"].spectral_model.norm.value = value
+        dataset.models[f"{dataset.name}-bkg"].spectral_model.norm.error = err
         return dataset

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -193,10 +193,7 @@ def test_fov_bkg_maker_fit_with_source_model(obs_dataset, exclusion_mask):
 @requires_data()
 @requires_dependency("iminuit")
 def test_fov_bkg_maker_fit_with_tilt(obs_dataset, exclusion_mask):
-    fov_bkg_maker = FoVBackgroundMaker(
-        method="fit",
-        exclusion_mask=exclusion_mask,
-    )
+    fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask,)
 
     test_dataset = obs_dataset.copy(name="test-fov")
 
@@ -224,7 +221,7 @@ def test_fov_bkg_maker_fit_fail(obs_dataset, exclusion_mask, caplog):
     model = dataset.models[f"{dataset.name}-bkg"].spectral_model
     assert_allclose(model.norm.value, 1, rtol=1e-4)
     assert "WARNING" in [_.levelname for _ in caplog.records]
-    message1 = f"FoVBackgroundMaker failed. Fit did not converge for {dataset.name}. Setting mask to False."
+    message1 = f"FoVBackgroundMaker failed. Only 0 background counts outside exclusion mask for test-fov. Setting mask to False."
     assert message1 in [_.message for _ in caplog.records]
 
 


### PR DESCRIPTION
This PR address #3680 

I am not sure if applying a total min_counts requirement is the best option for fit (probably some requirement on each bin will be more reasonable), hence this was not applied to the `fit` option earlier.
However, this is confusing, and the present PR makes the behaviour consistent.

