### PR TITLE
Implement PSFKernelMap

### DIFF
--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -10,7 +10,7 @@ from ..core import IRFMap
 from .core import PSF
 from .kernel import PSFKernel
 
-__all__ = ["PSFMap"]
+__all__ = ["PSFMap", "PSFKernelMap"]
 
 
 class IRFLikePSF(PSF):
@@ -490,3 +490,11 @@ class PSFMap(IRFMap):
 
     def __str__(self):
         return str(self.psf_map)
+
+
+class PSFKernelMap(IRFMap):
+    tag = "psf_kernel_map"
+    required_axes = ["psf_lon","psf_true", "energy_true"]
+
+    def __init__(self, psf_kernel_map, exposure_map=None):
+        super().__init__(irf_map=psf_kernel_map, exposure_map=exposure_map)

--- a/gammapy/utils/gauss.py
+++ b/gammapy/utils/gauss.py
@@ -369,7 +369,7 @@ class AsymmetricGauss2DPDF:
         x2 = x * x
         y2 = y * y
         amplitude = 1 / (2 * np.pi * self.sigma_x * self.sigma_y)
-        exponent_x = -0.5 * x2 / self.sigma_x
-        exponent_y = -0.5 * y2 / self.sigma_y
+        exponent_x = -0.5 * x2 / self.sigma_x**2
+        exponent_y = -0.5 * y2 / self.sigma_y**2
 
         return amplitude * np.exp(exponent_x) * np.exp(exponent_y)

--- a/gammapy/utils/gauss.py
+++ b/gammapy/utils/gauss.py
@@ -368,8 +368,8 @@ class AsymmetricGauss2DPDF:
         """
         x2 = x * x
         y2 = y * y
-        amplitude = 1 / (2 * np.pi * self._sigma_x * self._sigma_y)
-        exponent_x = -0.5 * x2 / self._sigma_x
-        exponent_y = -0.5 * y2 / self._sigma_y
+        amplitude = 1 / (2 * np.pi * self.sigma_x * self.sigma_y)
+        exponent_x = -0.5 * x2 / self.sigma_x
+        exponent_y = -0.5 * y2 / self.sigma_y
 
         return amplitude * np.exp(exponent_x) * np.exp(exponent_y)

--- a/gammapy/utils/gauss.py
+++ b/gammapy/utils/gauss.py
@@ -327,3 +327,49 @@ class MultiGauss2D:
             norms.append(self.norms[ii] * norm)
 
         return MultiGauss2D(sigmas, norms)
+
+class AsymmetricGauss2DPDF:
+    """2D asymmetric Gaussian PDF.
+
+    Reference: http://en.wikipedia.org/wiki/Multivariate_normal_distribution#Bivariate_case
+
+    Parameters
+    ----------
+    sigma_x : float
+        Gaussian width in the x direction.
+    sigma_y : float
+        Gaussian width in the y direction.
+    """
+
+    def __init__(self, sigma_x=1, sigma_y=1):
+        self.sigma_x = sigma_x
+        self.sigma_y = sigma_y
+
+
+    @property
+    def amplitude(self):
+        """PDF amplitude at the center (float)"""
+        return self.__call(0, 0)
+
+    def __call__(self, x, y=0):
+        """dp / (dx dy) at position (x, y)
+
+        Parameters
+        ----------
+        x : `~numpy.ndarray`
+            x coordinate
+        y : `~numpy.ndarray`, optional
+            y coordinate
+
+        Returns
+        -------
+        dpdxdy : `~numpy.ndarray`
+            dp / (dx dy)
+        """
+        x2 = x * x
+        y2 = y * y
+        amplitude = 1 / (2 * np.pi * self._sigma_x * self._sigma_y)
+        exponent_x = -0.5 * x2 / self._sigma_x
+        exponent_y = -0.5 * y2 / self._sigma_y
+
+        return amplitude * np.exp(exponent_x) * np.exp(exponent_y)


### PR DESCRIPTION
This pull request addresses issue #3681 to implement a `PSFKernelMap`. 

So far, I have created the object and implemented a `from_gauss()` method to easily create Gaussian kernel maps. Since one of the uses of this implementation are asymmetric PSF kernels, I added an `AsymmetricGauss2DPDF` to `gammapy.utils.gauss` to easily create asymmetric Gaussian kernels.

I marked the PR as draft because I still have a bunch to do. An incomplete list below:

- [ ] Implement `from_geom` method
- [ ] Implement `get_psf_kernel()` ?
- [ ] Containment radius methods ?
- [ ] tests for everything
- [ ] Orientation of the asymmetric Gaussian ?
