### PR TITLE
Correct warning raised by SpectrumDatasetMaker 

### DIFF
--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -64,7 +64,7 @@ class SpectrumDatasetMaker(MapDatasetMaker):
         )
 
         is_pointlike = exposure.meta.get("is_pointlike", False)
-        if is_pointlike:
+        if is_pointlike and self.use_region_center is False:
             log.warning(
                 "MapMaker: use_region_center=False should not be used with point-like IRF. "
                 "Results are likely inaccurate."


### PR DESCRIPTION

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request resolves #3691 . `SpectrumDatasetMaker.run()` should not raise a warning if `use_center is True` and IRFs are point like. The test is modified to correctly detect this and the condition is modified accordingly. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
