### PR TITLE
Fix zero clipping in npred calculation

### DIFF
--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -333,7 +333,6 @@ class MapEvaluator:
     def apply_psf(self, npred):
         """Convolve npred cube with PSF"""
         tmp = npred.convolve(self.psf)
-        tmp.data[tmp.data < 0.0] = 0
         return tmp
 
     def apply_edisp(self, npred):

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -393,7 +393,7 @@ class MapDataset(Dataset):
 
         if self.background:
             npred_total += self.npred_background()
-
+        npred_total.data[npred_total.data < 0.0] = 0
         return npred_total
 
     def npred_background(self):

--- a/gammapy/datasets/tests/test_evaluator.py
+++ b/gammapy/datasets/tests/test_evaluator.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 import astropy.units as u
+import numpy as np
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
 from gammapy.datasets.evaluator import MapEvaluator
@@ -12,6 +13,7 @@ from gammapy.modeling.models import (
     Models,
     PointSpatialModel,
     SkyModel,
+    PowerLawSpectralModel
 )
 from gammapy.utils.gauss import Gauss2DPDF
 
@@ -114,3 +116,34 @@ def test_large_oversampling():
     assert_allclose(flux_2.data.sum(), nbin, rtol=1e-4)
     assert_allclose(flux_3.data.sum(), nbin, rtol=1e-4)
     assert_allclose(flux_4.data.sum(), nbin, rtol=1e-4)
+
+def test_compute_npred_sign():
+    center = SkyCoord("0 deg", "0 deg", frame="galactic")
+    energy_axis_true = MapAxis.from_energy_bounds(
+        ".1 TeV", "10 TeV", nbin=2, name="energy_true"
+    )
+    geom = WcsGeom.create(skydir=center, width=1*u.deg, axes = [energy_axis_true], frame='galactic', binsz=0.2*u.deg)
+
+    spectral_model_pos = PowerLawSpectralModel(index = 2, amplitude="1e-11 TeV-1 s-1 m-2")
+    spectral_model_neg = PowerLawSpectralModel(index = 2, amplitude="-1e-11 TeV-1 s-1 m-2")
+
+    spatial_model = PointSpatialModel(
+        lon_0=0 * u.deg, lat_0=0 * u.deg, frame="galactic"
+    )
+    model_pos = SkyModel(spectral_model=spectral_model_pos, spatial_model=spatial_model)
+    model_neg = SkyModel(spectral_model=spectral_model_neg, spatial_model=spatial_model)
+
+    exposure = Map.from_geom(geom, unit="m2 s")
+    exposure.data += 1.0
+
+    psf = PSFKernel.from_gauss(geom, sigma="0.1 deg")
+
+    evaluator_pos = MapEvaluator(model=model_pos, exposure=exposure, psf=psf)
+    evaluator_neg = MapEvaluator(model=model_neg, exposure=exposure, psf=psf)
+
+    npred_pos = evaluator_pos.compute_npred()
+    npred_neg = evaluator_neg.compute_npred()
+
+    assert (npred_pos.data == -npred_neg.data).all()
+    assert np.all(npred_pos.data >= 0)
+    assert np.all(npred_neg.data <= 0)


### PR DESCRIPTION
This pull request addresses #3700 by moving the zero clipping applied to the predicted counts outside of the PSF convolution and into `dataset.npred`.

No tests are necessary because they were already added by #2342, which implemented the clipping in the first place:
https://github.com/gammapy/gammapy/blob/d342c5ac70cb321345f3c5e2c70f88ea8a116809/gammapy/datasets/tests/test_map.py#L250

With this fix, the snippet in #3700 results in

![image](https://user-images.githubusercontent.com/22521727/150136618-05474131-1f43-4d2c-8dfb-712c75b92a61.png)

which is clipped where the negative values are. However, if the model amplitude is such that the negative model counts expected are less than the background counts (i.e. compatible with background fluctuations), then the result is this
![image](https://user-images.githubusercontent.com/22521727/150138358-2b7167a8-854e-42f1-ac30-e56dd4f29ce5.png)

which is not clipped to zero as it used to.
