### PR TITLE
Fix matplotlib 3.5+ incompatibility with WcsNDMap.plot()

### DIFF
--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -365,7 +365,7 @@ class WcsNDMap(WcsMap):
         mask = np.isfinite(data)
 
         if mask.any():
-            min_cut, max_cut = kwargs.pop("vmin", None), kwargs.pop("vmin", None)
+            min_cut, max_cut = kwargs.pop("vmin", None), kwargs.pop("vmax", None)
             norm = simple_norm(data[mask], stretch, min_cut=min_cut, max_cut=max_cut)
             kwargs.setdefault("norm", norm)
 


### PR DESCRIPTION
I believe the second pop should be 'vmax' rather than another 'vmin'. This fixes incompatibility between maps.wcs.ndmap.plot() and matplotlib 3.5+.

If I'm mistaken, then we still need to pop vmax as well in order to make this compatible with the latest matplotlib.

Tested and working with https://docs.gammapy.org/0.19/tutorials/analysis/3D/simulate_3d.html