### PR TITLE
Correct FluxEstimator bug with compound model 

### DIFF
--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -113,10 +113,10 @@ class FluxEstimator(ParameterEstimator):
         ref_model = models[self.source].spectral_model
         scale_model = ScaleSpectralModel(ref_model)
 
-        if hasattr(ref_model, "amplitude"):
-            scaled_parameter = ref_model.amplitude
+        if "amplitude" in ref_model.parameters.names:
+            scaled_parameter = ref_model.parameters["amplitude"]
         else:
-            scaled_parameter = ref_model.norm
+            scaled_parameter = ref_model.parameters["norm"]
 
         scale_model.norm = self._set_norm_parameter(scale_model.norm, scaled_parameter)
         return scale_model

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -173,6 +173,7 @@ def test_flux_estimator_compound_model():
     pl.amplitude.min = 1e-15
     pl.amplitude.max = 1e-10
     pln = PowerLawNormSpectralModel()
+    pln.norm.value = 1
     spectral_model = pl*pln
     model = SkyModel(spectral_model=spectral_model, name="test")
 

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -167,3 +167,18 @@ def test_flux_estimator_norm_range_template():
     assert_allclose(scale_model.norm.min, 0)
     assert_allclose(scale_model.norm.max, 10)
     assert scale_model.norm.interp == "log"
+
+def test_flux_estimator_compound_model():
+    pl = PowerLawSpectralModel()
+    pl.amplitude.min = 1e-15
+    pl.amplitude.max = 1e-10
+    pln = PowerLawNormSpectralModel()
+    spectral_model = pl*pln
+    model = SkyModel(spectral_model=spectral_model, name="test")
+
+    estimator = FluxEstimator(source="test", selection_optional=[], reoptimize=True)
+
+    scale_model = estimator.get_scale_model(Models([model]))
+
+    assert_allclose(scale_model.norm.min, 1e-3)
+    assert_allclose(scale_model.norm.max, 1e2)

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from numpy.testing import assert_allclose
+import numpy as np
 import astropy.units as u
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
 from gammapy.estimators.flux import FluxEstimator
@@ -11,6 +12,7 @@ from gammapy.modeling.models import (
     PowerLawSpectralModel,
     SkyModel,
     TemplateSpatialModel,
+    NaimaSpectralModel
 )
 from gammapy.utils.testing import requires_data, requires_dependency
 
@@ -173,7 +175,7 @@ def test_flux_estimator_compound_model():
     pl.amplitude.min = 1e-15
     pl.amplitude.max = 1e-10
     pln = PowerLawNormSpectralModel()
-    pln.norm.value = 1
+    pln.norm.value = 0.1
     spectral_model = pl*pln
     model = SkyModel(spectral_model=spectral_model, name="test")
 
@@ -183,3 +185,19 @@ def test_flux_estimator_compound_model():
 
     assert_allclose(scale_model.norm.min, 1e-3)
     assert_allclose(scale_model.norm.max, 1e2)
+
+@requires_dependency("naima")
+def test_flux_estimator_naima_model():
+    import naima
+    ECPL = naima.models.ExponentialCutoffPowerLaw(1e36 * u.Unit("1/eV"), 1 * u.TeV, 2.1, 13 * u.TeV)
+    IC = naima.models.InverseCompton(ECPL, seed_photon_fields=["CMB"])
+    naima_model = NaimaSpectralModel(IC)
+
+    model = SkyModel(spectral_model=naima_model, name="test")
+
+    estimator = FluxEstimator(source="test", selection_optional=[], reoptimize=True)
+
+    scale_model = estimator.get_scale_model(Models([model]))
+
+    assert_allclose(scale_model.norm.min, np.nan)
+    assert_allclose(scale_model.norm.max, np.nan)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request resolves issues #3690 . The `amplitude` parameter is accessed with the `parameters` attribute
to avoid issues when it is not directly accessible on the model itself. 

Tests are added to make sure the scaling is possible with `CompoundSpectralModel` and with `NaimaSpectralModel`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
