### PR TITLE
Add convenience method to write EventLists to file

### DIFF
--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -142,7 +142,8 @@ Writing event lists and GTIs to file
 ====================================
 To write the events or GTIs separately, one can just save the underlying
 `astropy.table.Table`. However, it is usually best to save the events and
-their associated GTIs together in the same FITS file.
+their associated GTIs together in the same FITS file. This can be done using
+the `~gammapy.data.EventList.write` method:
 
 .. testcode::
 
@@ -154,17 +155,11 @@ their associated GTIs together in the same FITS file.
     gti = GTI.read(filename)
 
     # Save separately
-    events.table.meta = {"extname": "EVENTS"}
-    events.table.write("test_events.fits.gz")
+    events.write("test_events.fits.gz", gti=None)
     gti.write("test_gti.fits.gz")
 
     # Save together
-    from astropy.io import fits
-    primary_hdu = fits.PrimaryHDU()
-    events_hdu = fits.BinTableHDU(data=events.table, name="events")
-    gti_hdu = fits.BinTableHDU(gti.table, name="gti")
-    hdulist = fits.HDUList([primary_hdu, events_hdu, gti_hdu])
-    hdulist.writeto("test_together.fits.gz")
+    events.write("test_events_with_GTI.fits.gz", gti=gti)
 
 
 

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -76,11 +76,24 @@ class EventList:
         table = Table.read(filename, **kwargs)
         return cls(table=table)
 
-    def write(self, filename, gti=None, overwrite=False):
+    def write(self, filename, gti=None, overwrite=False, format='gadf'):
         """Write the event list to a FITS file.
 
         If a GTI object is provided, it is saved into
         a second extension in the file.
+
+        Parameters
+        ----------
+        filename : `pathlib.Path`, str
+            Filename
+        gti : `~gammapy.data.GTI`
+            Good Time Intervals object to save to the same file.
+            Default is None.
+        overwrite : bool
+            Overwrite existing file?
+        format : str, optional
+            FITS format convention.  By default files will be written
+            to the gamma-astro-data-formats (GADF) format.
         """
 
         filename = make_path(filename)

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -99,6 +99,19 @@ class EventList:
         if format != "gadf":
             raise ValueError(f"{format} is not a valid EventList format.")
 
+        meta_dict = self.table.meta
+
+        if "HDUCLAS1" in meta_dict.keys() and meta_dict["HDUCLAS1"].lower() != "events":
+            raise ValueError("The HDUCLAS1 keyword should be EVENTS for an EventList")
+        else:
+            meta_dict["HDUCLAS1"] = "EVENTS"
+
+
+        if "HDUCLASS" in meta_dict.keys() and meta_dict["HDUCLASS"].lower() != format:
+            raise ValueError("The HDUCLASS keyword should match the format")
+        else:
+            meta_dict["HDUCLASS"] = format.upper()
+
         filename = make_path(filename)
 
         primary_hdu = fits.PrimaryHDU()

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -96,6 +96,9 @@ class EventList:
             to the gamma-astro-data-formats (GADF) format.
         """
 
+        if format != "gadf":
+            raise ValueError(f"{format} is not a valid EventList format.")
+
         filename = make_path(filename)
 
         primary_hdu = fits.PrimaryHDU()

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -85,18 +85,17 @@ class EventList:
 
         filename = make_path(filename)
 
-        if gti is None: # save just the events
-            if "extname" not in map(str.lower, self.table.meta.keys()):
-                self.table.meta = {"EXTNAME": "EVENTS"}
-            self.table.write(filename, overwrite=overwrite)
+        primary_hdu = fits.PrimaryHDU()
+        hdu_evt = fits.BinTableHDU(self.table, name='EVENTS')
+        hdu_all = fits.HDUList([primary_hdu, hdu_evt])
 
-        else:
-            assert isinstance(gti, GTI)
-            primary_hdu = fits.PrimaryHDU()
-            hdu_evt = fits.BinTableHDU(self.table, name='EVENTS')
+        if gti is not None:
+            if not isinstance(gti, GTI):
+                raise TypeError('gti must be an instance of GTI')
             hdu_gti = fits.BinTableHDU(gti.table, name="GTI")
-            hdu_all = fits.HDUList([primary_hdu, hdu_evt, hdu_gti])
-            hdu_all.writeto(filename, overwrite=True)
+            hdu_all.append(hdu_gti)
+
+        hdu_all.writeto(filename, overwrite=overwrite)
 
 
 

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -14,7 +14,7 @@ from gammapy.utils.fits import earth_location_from_dict
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import Checker
 from gammapy.utils.time import time_ref_from_dict
-from gammapy.data import GTI
+from .gti import GTI
 
 __all__ = ["EventList"]
 
@@ -86,16 +86,17 @@ class EventList:
         filename = make_path(filename)
 
         if gti is None: # save just the events
-            self.table.meta = {"extname": "events"}
+            if "extname" not in map(str.lower, self.table.meta.keys()):
+                self.table.meta = {"EXTNAME": "EVENTS"}
             self.table.write(filename, overwrite=overwrite)
 
         else:
             assert isinstance(gti, GTI)
             primary_hdu = fits.PrimaryHDU()
-            hdu_evt = fits.BinTableHDU(self.table, name='events')
-            hdu_gti = fits.BinTableHDU(gti.table, name="gti")
+            hdu_evt = fits.BinTableHDU(self.table, name='EVENTS')
+            hdu_gti = fits.BinTableHDU(gti.table, name="GTI")
             hdu_all = fits.HDUList([primary_hdu, hdu_evt, hdu_gti])
-            hdu_all.writeto("filename.fits", overwrite=True)
+            hdu_all.writeto(filename, overwrite=True)
 
 
 

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -4,7 +4,7 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from regions import CircleSkyRegion, RectangleSkyRegion
-from gammapy.data import EventList
+from gammapy.data import EventList, GTI
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
@@ -20,6 +20,31 @@ class TestEventListBase:
         events = self.events.select_parameter("ENERGY", (0.8 * u.TeV, 5.0 * u.TeV))
         assert len(events.table) == 2716
 
+    def test_write(self):
+        # Without GTI
+        self.events.write("test.fits", overwrite=True)
+        read_again = EventList.read("test.fits")
+
+        # the meta dictionaries match because the input one
+        # already has the EXTNAME keyword
+        assert self.events.table.meta == read_again.table.meta
+        assert (self.events.table == read_again.table).all()
+
+        dummy_events = EventList(Table())
+        dummy_events.write("test.fits", overwrite=True)
+        read_again = EventList.read("test.fits")
+        assert dummy_events.table.meta['EXTNAME'] == "EVENTS"
+
+        # With GTI
+        gti = GTI.read("$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz")
+        self.events.write("test.fits", overwrite=True, gti=gti)
+        read_again_ev = EventList.read("test.fits")
+        read_again_gti = GTI.read("test.fits")
+
+        assert self.events.table.meta == read_again_ev.table.meta
+        assert (self.events.table == read_again_ev.table).all()
+        assert gti.table.meta == read_again_gti.table.meta
+        assert (gti.table == read_again_gti.table).all()
 
 @requires_data()
 class TestEventListHESS:

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -7,6 +7,7 @@ from regions import CircleSkyRegion, RectangleSkyRegion
 from gammapy.data import EventList, GTI
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
+import pytest
 
 
 @requires_data()
@@ -45,6 +46,11 @@ class TestEventListBase:
         assert (self.events.table == read_again_ev.table).all()
         assert gti.table.meta == read_again_gti.table.meta
         assert (gti.table == read_again_gti.table).all()
+
+        # test that it won't work if gti is not a GTI
+        with pytest.raises(TypeError):
+            self.events.write("test.fits", overwrite=True, gti=gti.table)
+
 
 @requires_data()
 class TestEventListHESS:

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -35,6 +35,8 @@ class TestEventListBase:
         dummy_events.write("test.fits", overwrite=True)
         read_again = EventList.read("test.fits")
         assert read_again.table.meta['EXTNAME'] == "EVENTS"
+        assert read_again.table.meta['HDUCLASS'] == "GADF"
+        assert read_again.table.meta['HDUCLAS1'] == "EVENTS"
 
         # With GTI
         gti = GTI.read("$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz")
@@ -50,8 +52,24 @@ class TestEventListBase:
         # test that it won't work if gti is not a GTI
         with pytest.raises(TypeError):
             self.events.write("test.fits", overwrite=True, gti=gti.table)
+        # test that it won't work if format is not "gadf"
         with pytest.raises(ValueError):
             self.events.write("test.fits", overwrite=True, format='something')
+        # test that it won't work if the basic headers are wrong
+        with pytest.raises(ValueError):
+            dummy_events = EventList(Table())
+            dummy_events.table.meta['HDUCLAS1'] = 'response'
+            dummy_events.write("test.fits", overwrite=True)
+        with pytest.raises(ValueError):
+            dummy_events = EventList(Table())
+            dummy_events.table.meta['HDUCLASS'] = "ogip"
+            dummy_events.write("test.fits", overwrite=True)
+
+        # test that it works when the srings are right but lowercase
+        dummy_events = EventList(Table())
+        dummy_events.table.meta['HDUCLASS'] = "gadf"
+        dummy_events.table.meta['HDUCLAS1'] = "events"
+        dummy_events.write("test.fits", overwrite=True)
 
 
 @requires_data()

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -33,7 +33,7 @@ class TestEventListBase:
         dummy_events = EventList(Table())
         dummy_events.write("test.fits", overwrite=True)
         read_again = EventList.read("test.fits")
-        assert dummy_events.table.meta['EXTNAME'] == "EVENTS"
+        assert read_again.table.meta['EXTNAME'] == "EVENTS"
 
         # With GTI
         gti = GTI.read("$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz")

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -50,6 +50,8 @@ class TestEventListBase:
         # test that it won't work if gti is not a GTI
         with pytest.raises(TypeError):
             self.events.write("test.fits", overwrite=True, gti=gti.table)
+        with pytest.raises(ValueError):
+            self.events.write("test.fits", overwrite=True, format='something')
 
 
 @requires_data()


### PR DESCRIPTION

This pull request implements a `EventList.write` method to conveniently write event lists to disk. It has the option to pass a `GTI` object as input, which is saved together with the events in that case.

I've also updated the snippet in the documentation on how to save `EventList` objects to file.