### PR TITLE
Remove is_pointlike keyword from irf.to_table method

### DIFF
--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -422,6 +422,8 @@ class IRF(metaclass=abc.ABCMeta):
             table.meta["HDUCLAS2"] = spec["hduclas2"]
             if self.is_pointlike:
                 table.meta["HDUCLAS3"] = "POINT-LIKE"
+            if "is_pointlike" in table.meta:
+                del table.meta["is_pointlike"]
             table[spec["column_name"]] = self.quantity.T[np.newaxis]
         else:
             raise ValueError(f"Not a valid supported format: '{format}'")

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -422,8 +422,7 @@ class IRF(metaclass=abc.ABCMeta):
             table.meta["HDUCLAS2"] = spec["hduclas2"]
             if self.is_pointlike:
                 table.meta["HDUCLAS3"] = "POINT-LIKE"
-            if "is_pointlike" in table.meta:
-                del table.meta["is_pointlike"]
+            table.meta.pop("is_pointlike", None)
             table[spec["column_name"]] = self.quantity.T[np.newaxis]
         else:
             raise ValueError(f"Not a valid supported format: '{format}'")

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -87,7 +87,7 @@ def test_to_table():
 @requires_data()
 def test_to_table_is_pointlike(aeff):
     hdu = aeff.to_table_hdu()
-    assert(bool(hdu.meta.pop("is_pointlike", None)) == False)
+    assert "is_pointlike" in hdu.header
 
 
 def test_wrong_axis_order():

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -84,6 +84,11 @@ def test_to_table():
     assert hdu.header["TUNIT1"] == aeff.axes["energy_true"].unit
 
 
+@requires_data()
+def test_to_table_is_pointlike(aeff):
+    hdu = aeff.to_table_hdu()
+    assert(bool(table.meta.pop("is_pointlike", None)) == False)
+
 def test_wrong_axis_order():
     energy_axis_true = MapAxis.from_energy_bounds(
         "1 TeV", "10 TeV", nbin=10, name="energy_true"
@@ -98,7 +103,6 @@ def test_wrong_axis_order():
         EffectiveAreaTable2D(
             axes=[energy_axis_true, offset_axis], data=data, unit="cm2"
         )
-
 
 @requires_data("gammapy-data")
 def test_aeff2d_pointlike():

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -87,7 +87,7 @@ def test_to_table():
 @requires_data()
 def test_to_table_is_pointlike(aeff):
     hdu = aeff.to_table_hdu()
-    assert "is_pointlike" in hdu.header
+    assert "is_pointlike" not in hdu.header
 
 
 def test_wrong_axis_order():

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -87,7 +87,8 @@ def test_to_table():
 @requires_data()
 def test_to_table_is_pointlike(aeff):
     hdu = aeff.to_table_hdu()
-    assert(bool(table.meta.pop("is_pointlike", None)) == False)
+    assert(bool(hdu.meta.pop("is_pointlike", None)) == False)
+
 
 def test_wrong_axis_order():
     energy_axis_true = MapAxis.from_energy_bounds(
@@ -103,6 +104,7 @@ def test_wrong_axis_order():
         EffectiveAreaTable2D(
             axes=[energy_axis_true, offset_axis], data=data, unit="cm2"
         )
+
 
 @requires_data("gammapy-data")
 def test_aeff2d_pointlike():

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -84,8 +84,14 @@ def test_to_table():
     assert hdu.header["TUNIT1"] == aeff.axes["energy_true"].unit
 
 
-@requires_data()
-def test_to_table_is_pointlike(aeff):
+def test_to_table_is_pointlike():
+    energy_axis = MapAxis.from_energy_bounds('1 TeV', '10 TeV',
+                                            nbin=3, name='energy_true')
+    offset_axis = MapAxis.from_bounds(0 * u.deg, 2 * u.deg,
+                                      nbin=2, name='offset')
+
+    aeff = EffectiveAreaTable2D(data=np.ones((3, 2)) * u.m**2,
+                                axes=[energy_axis, offset_axis])
     hdu = aeff.to_table_hdu()
     assert "is_pointlike" not in hdu.header
 


### PR DESCRIPTION
This PR solves the issue #3668. 
The keyword `is_pointlike` is an optional one that can be found in the IRFs. Currently, all the metadata information of the IRF are copied when the `~gammapy.irf.to_table_hdu` method is called, not being consistent with the GADF format. 
The PR adds a filter to remove such a keyword from the output HDU.