### PR TITLE
generate RadMax2D from the RAD_MAX keyword of a point-like IRF

### DIFF
--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -282,6 +282,19 @@ def test_observation_read_single_file():
 
 
 @requires_data()
+def test_observation_read_single_file_fixed_rad_max():
+    """check that for a point-like observation without the RAD_MAX_2D table
+    a RadMax2D object is generated from the RAD_MAX keyword"""
+    obs = Observation.read(
+        "$GAMMAPY_DATA/joint-crab/dl3/magic/run_05029748_DL3.fits"
+    )
+
+    assert obs.rad_max is not None
+    assert obs.rad_max.quantity.shape == (1, 1)
+    assert u.allclose(obs.rad_max.quantity, 0.1414213 * u.deg)
+
+
+@requires_data()
 class TestObservationChecker:
     def setup(self):
         self.data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps")

--- a/gammapy/irf/rad_max.py
+++ b/gammapy/irf/rad_max.py
@@ -1,3 +1,5 @@
+import astropy.units as u
+
 from .core import IRF
 
 __all__ = [
@@ -28,3 +30,48 @@ class RadMax2D(IRF):
 
     tag = "rad_max_2d"
     required_axes = ["energy", "offset"]
+
+
+    @classmethod
+    def from_irf(cls, irf):
+        '''
+        Create a RadMax2D instance from another IRF component.
+
+        This reads the RAD_MAX metadata keyword from the irf and creates
+        a RadMax2D with a single bin in energy and offset using the
+        ranges from the input irf.
+
+        Parameters
+        ----------
+        irf: `~gammapy.irf.EffectiveAreaTable2D` or `~gammapy.irf.EnergyDispersion2D`
+            IRF instance from which to read the RAD_MAX and limit information
+
+        Returns
+        -------
+        rad_max: `RadMax2D`
+            `RadMax2D` object with a single bin corresponding to the fixed
+            RAD_MAX cut.
+
+        Notes
+        -----
+        This assumes the true energy axis limits are also valid for the
+        reco energy limits.
+        '''
+        if not irf.is_pointlike:
+            raise ValueError('RadMax2D.from_irf is only valid for point-like irfs')
+
+        if 'RAD_MAX' not in irf.meta:
+            raise ValueError('irf does not contain RAD_MAX keyword')
+
+        rad_max_value = irf.meta["RAD_MAX"]
+        if not isinstance(rad_max_value, float):
+            raise ValueError('RAD_MAX must be a float')
+
+        energy_axis = irf.axes["energy_true"].squash()
+        energy_axis.name = 'energy'
+        offset_axis = irf.axes["offset"].squash()
+
+        return cls(
+            data=u.Quantity([[rad_max_value]], u.deg),
+            axes=[energy_axis, offset_axis],
+        )

--- a/gammapy/irf/tests/test_rad_max.py
+++ b/gammapy/irf/tests/test_rad_max.py
@@ -1,6 +1,7 @@
 import numpy as np
 import astropy.units as u
 from gammapy.maps import MapAxis
+import pytest
 
 
 def test_rad_max_roundtrip(tmp_path):
@@ -31,3 +32,45 @@ def test_rad_max_roundtrip(tmp_path):
 
     assert np.all(rad_max_read.data.data == rad_max)
     assert np.all(rad_max_read.data.data == rad_max_read.data.data)
+
+
+def test_rad_max_from_irf():
+    from gammapy.irf import RadMax2D, EffectiveAreaTable2D
+
+    e_bins = 3
+    o_bins = 2
+    energy_axis = MapAxis.from_energy_bounds(1 * u.TeV, 10 * u.TeV, nbin=e_bins, name='energy_true')
+    offset_axis = MapAxis.from_bounds(0 * u.deg, 3 * u.deg, nbin=o_bins, name='offset')
+    aeff = EffectiveAreaTable2D(
+        data=u.Quantity(np.ones((e_bins, o_bins)), u.m**2, copy=False),
+        axes=[energy_axis, offset_axis],
+    )
+
+    with pytest.raises(ValueError):
+        # not a point-like IRF
+        RadMax2D.from_irf(aeff)
+
+
+    aeff.meta['is_pointlike'] = True
+
+    with pytest.raises(ValueError):
+        # missing rad_max
+        RadMax2D.from_irf(aeff)
+
+
+    aeff.meta['RAD_MAX'] = '0.2 deg'
+    with pytest.raises(ValueError):
+        # invalid format
+        RadMax2D.from_irf(aeff)
+
+    aeff.meta['RAD_MAX'] = 0.2
+    rad_max = RadMax2D.from_irf(aeff)
+
+    assert rad_max.axes['energy'].nbin == 1
+    assert rad_max.axes['offset'].nbin ==  1
+    assert rad_max.axes['energy'].edges[0] == aeff.axes['energy_true'].edges[0]
+    assert rad_max.axes['energy'].edges[1] == aeff.axes['energy_true'].edges[-1]
+    assert rad_max.axes['offset'].edges[0] == aeff.axes['offset'].edges[0]
+    assert rad_max.axes['offset'].edges[1] == aeff.axes['offset'].edges[-1]
+    assert rad_max.quantity.shape == (1, 1)
+    assert rad_max.quantity[0, 0] == 0.2 * u.deg


### PR DESCRIPTION
in case of a point-like IRF without the RAD_MAX_2D HDU, a RadMax2D object with
a single bin in energy and offset is generated from the RAD_MAX header keyword

Co-authored-by: Maximilian Nöthe <maximilian.noethe@tu-dortmund.de>

Fixes #3717
