### PR TITLE
Show linked parameters when printing model

### DIFF
--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -464,9 +464,8 @@ class DatasetModels(collections.abc.Sequence):
             data, sort_keys=False, indent=4, width=80, default_flow_style=False
         )
 
-    def to_dict(self, full_output=False, overwrite_templates=False):
-        """Convert to dict."""
-        # update linked parameters labels
+    def update_link_label(self):
+        """update linked parameters labels used for serialization and print"""
         params_list = []
         params_shared = []
         for param in self.parameters:
@@ -477,6 +476,12 @@ class DatasetModels(collections.abc.Sequence):
                 params_shared.append(param)
         for param in params_shared:
             param._link_label_io = param.name + "@" + make_name()
+
+
+    def to_dict(self, full_output=False, overwrite_templates=False):
+        """Convert to dict."""
+
+        self.update_link_label()
 
         models_data = []
         for model in self._models:
@@ -554,6 +559,9 @@ class DatasetModels(collections.abc.Sequence):
         table.write(make_path(filename), **kwargs)
 
     def __str__(self):
+        
+        self.update_link_label()
+
         str_ = f"{self.__class__.__name__}\n\n"
 
         for idx, model in enumerate(self):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -23,7 +23,12 @@ def _get_parameters_str(parameters):
         else:
             value_format, error_format = "{:10.3f}", "{:7.2f}"
 
-        line = "\t{:12} {:11}: " + value_format + "\t {} {:<12s}\n"
+        line = "\t{:21} {:8}: " + value_format + "\t {} {:<12s}\n"
+
+        if par._link_label_io is not None:
+            name = par._link_label_io
+        else:
+            name = par.name
 
         if par.frozen:
             frozen, error = "(frozen)", "\t\t"
@@ -33,8 +38,7 @@ def _get_parameters_str(parameters):
                 error = "+/- " + error_format.format(par.error)
             except AttributeError:
                 error = ""
-
-        str_ += line.format(par.name, frozen, par.value, error, par.unit)
+        str_ += line.format(name, frozen, par.value, error, par.unit)
     return str_.expandtabs(tabsize=2)
 
 


### PR DESCRIPTION
Solves #3692.
-Move the code that update linked parameters labels into a function and run it  not only in .to_dict() but also in .__str__().
-display link label in .__str__()