### PR TITLE
Add new RegionsFinder that uses a fixed number of regions symmetrically distributed on the circle

### DIFF
--- a/gammapy/makers/__init__.py
+++ b/gammapy/makers/__init__.py
@@ -2,12 +2,14 @@ from gammapy.utils.registry import Registry
 
 from .core import Maker
 from .background import (
-    ReflectedRegionsFinder,
-    ReflectedRegionsBackgroundMaker,
     AdaptiveRingBackgroundMaker,
     FoVBackgroundMaker,
     PhaseBackgroundMaker,
+    ReflectedRegionsBackgroundMaker,
+    ReflectedRegionsFinder,
+    RegionsFinder,
     RingBackgroundMaker,
+    WobbleRegionsFinder,
 )
 
 from .map import MapDatasetMaker
@@ -40,7 +42,9 @@ __all__ = [
     "PhaseBackgroundMaker",
     "ReflectedRegionsBackgroundMaker",
     "ReflectedRegionsFinder",
+    "RegionsFinder",
     "RingBackgroundMaker",
     "SafeMaskMaker",
     "SpectrumDatasetMaker",
+    "WobbleRegionsFinder",
 ]

--- a/gammapy/makers/background/__init__.py
+++ b/gammapy/makers/background/__init__.py
@@ -1,6 +1,11 @@
 from .fov import FoVBackgroundMaker
 from .phase import PhaseBackgroundMaker
-from .reflected import ReflectedRegionsFinder, ReflectedRegionsBackgroundMaker
+from .reflected import (
+    ReflectedRegionsBackgroundMaker,
+    ReflectedRegionsFinder,
+    RegionsFinder,
+    WobbleRegionsFinder,
+)
 from .ring import RingBackgroundMaker, AdaptiveRingBackgroundMaker
 
 
@@ -10,5 +15,7 @@ __all__ = [
     "PhaseBackgroundMaker",
     "ReflectedRegionsBackgroundMaker",
     "ReflectedRegionsFinder",
+    "RegionsFinder",
     "RingBackgroundMaker",
+    "WobbleRegionsFinder",
 ]


### PR DESCRIPTION
Added another finder to the background makers returning symmetric OFF positions.
Added a minimal test.

Co-authored-by: Maximilian Nöthe <maximilian.noethe@tu-dortmund.de>

Fixes: #3718 