### PR TITLE
Cleanup HDUs required in Datastore.get_observations()

### DIFF
--- a/docs/tutorials/analysis/1D/spectral_analysis_rad_max.ipynb
+++ b/docs/tutorials/analysis/1D/spectral_analysis_rad_max.ipynb
@@ -158,7 +158,7 @@
    "outputs": [],
    "source": [
     "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/magic/rad_max/data\")\n",
-    "observations = data_store.get_observations(required_irf=[\"aeff\", \"edisp\"])"
+    "observations = data_store.get_observations(required_irf=[\"aeff\", \"edisp\", \"rad_max\"])"
    ]
   },
   {

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -218,7 +218,7 @@ class ObservationsConfig(GammapyBaseConfig):
     obs_file: Path = None
     obs_cone: SpatialCircleConfig = SpatialCircleConfig()
     obs_time: TimeRangeConfig = TimeRangeConfig()
-    required_hdu: List[RequiredHDUEnum] = ["events", "gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
+    required_hdu: List[RequiredHDUEnum] = []
 
 
 class LogConfig(GammapyBaseConfig):

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -218,7 +218,7 @@ class ObservationsConfig(GammapyBaseConfig):
     obs_file: Path = None
     obs_cone: SpatialCircleConfig = SpatialCircleConfig()
     obs_time: TimeRangeConfig = TimeRangeConfig()
-    required_hdu: List[RequiredHDUEnum] = []
+    required_hdu: List[RequiredHDUEnum] = ["events", "gti", "aeff", "edisp", "psf", "bkg"]
 
 
 class LogConfig(GammapyBaseConfig):

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -218,7 +218,7 @@ class ObservationsConfig(GammapyBaseConfig):
     obs_file: Path = None
     obs_cone: SpatialCircleConfig = SpatialCircleConfig()
     obs_time: TimeRangeConfig = TimeRangeConfig()
-    required_hdu: List[RequiredHDUEnum] = ["events", "gti", "aeff", "edisp", "psf", "bkg"]
+    required_irf: List[RequiredHDUEnum] = ["aeff", "edisp", "psf", "bkg"]
 
 
 class LogConfig(GammapyBaseConfig):

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -215,7 +215,7 @@ class ObservationsConfig(GammapyBaseConfig):
     obs_file: Path = None
     obs_cone: SpatialCircleConfig = SpatialCircleConfig()
     obs_time: TimeRangeConfig = TimeRangeConfig()
-    required_irf: List[RequiredIRFEnum] = ["aeff", "edisp", "psf", "bkg"]
+    required_hdu: List[RequiredIRFEnum] = ["full-containment"]
 
 
 class LogConfig(GammapyBaseConfig):

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -65,11 +65,14 @@ class FrameEnum(str, Enum):
     galactic = "galactic"
 
 
-class RequiredIRFEnum(str, Enum):
+class RequiredHDUEnum(str, Enum):
+    events = "events"
+    gti = "gti"
     aeff = "aeff"
     bkg = "bkg"
     edisp = "edisp"
     psf = "psf"
+    rad_max = "rad_max"
 
 
 class BackgroundMethodEnum(str, Enum):
@@ -215,7 +218,7 @@ class ObservationsConfig(GammapyBaseConfig):
     obs_file: Path = None
     obs_cone: SpatialCircleConfig = SpatialCircleConfig()
     obs_time: TimeRangeConfig = TimeRangeConfig()
-    required_hdu: List[RequiredIRFEnum] = ["full-containment"]
+    required_hdu: List[RequiredHDUEnum] = ["events", "gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
 
 
 class LogConfig(GammapyBaseConfig):

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -135,9 +135,9 @@ class Analysis:
 
         log.info("Fetching observations.")
         ids = self._make_obs_table_selection()
-        required_hdu = [_.value for _ in observations_settings.required_hdu]
+        required_irf = [_.value for _ in observations_settings.required_irf]
         self.observations = self.datastore.get_observations(
-            ids, skip_missing=True, required_hdu=required_hdu
+            ids, skip_missing=True, required_irf=required_irf
         )
 
         if observations_settings.obs_time.start is not None:

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -135,9 +135,9 @@ class Analysis:
 
         log.info("Fetching observations.")
         ids = self._make_obs_table_selection()
-
+        required_hdu = [_.value for _ in observations_settings.required_hdu]
         self.observations = self.datastore.get_observations(
-            ids, skip_missing=True, required_hdu=observations_settings.required_hdu
+            ids, skip_missing=True, required_hdu=required_hdu
         )
 
         if observations_settings.obs_time.start is not None:

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -137,7 +137,7 @@ class Analysis:
         ids = self._make_obs_table_selection()
 
         self.observations = self.datastore.get_observations(
-            ids, skip_missing=True, required_irf=observations_settings.required_irf
+            ids, skip_missing=True, required_hdu=observations_settings.required_hdu
         )
 
         if observations_settings.obs_time.start is not None:

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -127,7 +127,7 @@ def test_get_observations_missing_irf():
     analysis.config.observations.obs_ids = ["05029748"]
     analysis.config.observations.required_hdu = ["events", "gti", "aeff", "edisp"]
     analysis.get_observations()
-    assert len(analysis.observations) == 1
+    assert len(analysis.observations) == 0
 
 
 @requires_data()

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -128,7 +128,7 @@ def test_get_observations_missing_irf():
     analysis.config.observations.obs_ids = ["05029748"]
     analysis.config.observations.required_irf = ["aeff", "edisp"]
     analysis.get_observations()
-    assert len(analysis.observations) == 0
+    assert len(analysis.observations) == 1
 
 
 @requires_data()

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -125,7 +125,7 @@ def test_get_observations_missing_irf():
     analysis = Analysis(config)
     analysis.config.observations.datastore = "$GAMMAPY_DATA/joint-crab/dl3/magic/"
     analysis.config.observations.obs_ids = ["05029748"]
-    analysis.config.observations.required_irf = ["aeff", "edisp"]
+    analysis.config.observations.required_hdu = ["events", "gti", "aeff", "edisp"]
     analysis.get_observations()
     assert len(analysis.observations) == 1
 

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -126,7 +126,7 @@ def test_get_observations_missing_irf():
     analysis = Analysis(config)
     analysis.config.observations.datastore = "$GAMMAPY_DATA/joint-crab/dl3/magic/"
     analysis.config.observations.obs_ids = ["05029748"]
-    analysis.config.observations.required_hdu = ["events", "gti", "aeff", "edisp"]
+    analysis.config.observations.required_irf = ["aeff", "edisp"]
     analysis.get_observations()
     assert len(analysis.observations) == 0
 

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -11,6 +11,7 @@ from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
 from gammapy.maps import WcsGeom, WcsNDMap
 from gammapy.modeling.models import DatasetModels
 from gammapy.utils.testing import requires_data, requires_dependency
+import logging
 
 CONFIG_PATH = Path(__file__).resolve().parent / ".." / "config"
 MODEL_FILE = CONFIG_PATH / "model.yaml"
@@ -346,13 +347,13 @@ def test_analysis_ring_3d():
 def test_analysis_no_bkg_1d(caplog):
     config = get_example_config("1d")
     analysis = Analysis(config)
-    analysis.get_observations()
-    analysis.get_datasets()
-    assert not isinstance(analysis.datasets[0], SpectrumDatasetOnOff)
-    assert "WARNING" in [_.levelname for _ in caplog.records]
-    assert "No background maker set. Check configuration." in [
-        _.message for _ in caplog.records
-    ]
+    with caplog.at_level(logging.WARNING):
+        analysis.get_observations()
+        analysis.get_datasets()
+        assert not isinstance(analysis.datasets[0], SpectrumDatasetOnOff)
+        assert "No background maker set. Check configuration." in [
+            _.message for _ in caplog.records
+        ]
 
 
 @requires_data()
@@ -360,13 +361,13 @@ def test_analysis_no_bkg_3d(caplog):
     config = get_example_config("3d")
     config.datasets.background.method = None
     analysis = Analysis(config)
-    analysis.get_observations()
-    analysis.get_datasets()
-    assert isinstance(analysis.datasets[0], MapDataset)
-    assert "WARNING" in [_.levelname for _ in caplog.records]
-    assert "No background maker set. Check configuration." in [
-        _.message for _ in caplog.records
-    ]
+    with caplog.at_level(logging.WARNING):
+        analysis.get_observations()
+        analysis.get_datasets()
+        assert isinstance(analysis.datasets[0], MapDataset)
+        assert "No background maker set. Check configuration." in [
+            _.message for _ in caplog.records
+        ]
 
 
 @requires_dependency("iminuit")

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -14,6 +14,12 @@ from .observations import Observation, ObservationChecker, Observations
 
 __all__ = ["DataStore"]
 
+REQUIRED_IRFS = {
+    "full-enclosure": ["aeff", "edisp", "psf", "bkg"],
+    "point-like": ["aeff", "edisp"],
+    "all-optional":  ["aeff", "edisp", "psf", "bkg", "rad_max"],
+}
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
@@ -317,15 +323,11 @@ class DataStore:
             Container holding a list of `~gammapy.data.Observation`
         """
 
-        all_hdu = ["aeff", "edisp", "psf", "bkg", "rad_max"]
+        all_hdu = REQUIRED_IRFS["all-optional"]
         is_all_optinal = required_irf == "all-optional"
-        
-        if required_irf == "full-enclosure":
-            required_irf = ["aeff", "edisp", "psf", "bkg"]
-        elif required_irf == "point-like":
-            required_irf = ["aeff", "edisp"]
-        elif required_irf == "all-optional":
-            required_irf = all_hdu
+
+        if isinstance(required_irf, str) and required_irf in REQUIRED_IRFS.keys():
+            required_irf = REQUIRED_IRFS[required_irf]
 
         if not set(required_irf).issubset(all_hdu):
             difference = set(required_irf).difference(all_hdu)

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -15,6 +15,7 @@ from .observations import Observation, ObservationChecker, Observations
 __all__ = ["DataStore"]
 
 log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
 
 
 class DataStore:
@@ -346,7 +347,7 @@ class DataStore:
                 obs_list.append(obs)
             else:
                 log.warning(f"Skipping run with missing HDUs; obs_id: {_!r}")
-
+        log.info(f"Observations selected: {len(obs_list)} out of {len(obs_id)}.")
         return Observations(obs_list)
 
     def copy_obs(self, obs_id, outdir, hdu_class=None, verbose=False, overwrite=False):

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -296,7 +296,7 @@ class DataStore:
             * `psf` : Point Spread Function
             * `rad_max` : Maximal radius
             * `full-containment` :["events", "gti", "aeff", "edisp", "psf", "bkg"]
-            * `point-source` : ["events", "gti", "aeff", "edisp", "rad_max"]
+            * `point-like` : ["events", "gti", "aeff", "edisp"]
             By default, no HDUs are required, only warnings will be emitted
             for missing HDUs among all possibilities.
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -337,7 +337,7 @@ class DataStore:
                 else:
                     raise err
 
-            if set(required_hdu).issubset(obs.available_irfs):
+            if set(required_hdu).issubset(obs.available_hdus):
                 obs_list.append(obs)
             else:
                 log.warning(f"Skipping run with missing HDUs; obs_id: {_!r}")

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -305,12 +305,12 @@ class DataStore:
         observations : `~gammapy.data.Observations`
             Container holding a list of `~gammapy.data.Observation`
         """
-        full_containment = ["events", "gti", "aeff", "edisp", "psf", "bkg"]
+        full_enclosure = ["events", "gti", "aeff", "edisp", "psf", "bkg"]
         point_like = ["events", "gti", "aeff", "edisp"]
         available_hdu = ["events", "gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
         
         if required_hdu == "full-enclosure":
-            required_hdu = full_containment
+            required_hdu = full_enclosure
         if required_hdu == "point-like":
             required_hdu = point_like
         elif required_hdu is None:

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -295,8 +295,8 @@ class DataStore:
             * `edisp`: Energy dispersion
             * `psf` : Point Spread Function
             * `rad_max` : Maximal radius
-            * `full_containment` :["events", "gti", "aeff", "edisp", "psf", "bkg"]
-            * `point_like` : ["events", "gti", "aeff", "edisp"]
+            * `full-enclosure` :["events", "gti", "aeff", "edisp", "psf", "bkg"]
+            * `point-like` : ["events", "gti", "aeff", "edisp"]
             By default, no HDUs are required, only warnings will be emitted
             for missing HDUs among all possibilities.
 
@@ -309,9 +309,9 @@ class DataStore:
         point_like = ["events", "gti", "aeff", "edisp"]
         available_hdu = ["events", "gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
         
-        if required_hdu == "full_containment":
+        if required_hdu == "full-enclosure":
             required_hdu = full_containment
-        if required_hdu == "point_like":
+        if required_hdu == "point-like":
             required_hdu = point_like
         elif required_hdu is None:
             required_hdu = []

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -258,8 +258,8 @@ class DataStore:
         ----------
         obs_id : int
             Observation ID.
-        required_irf : list of str
-            The list can inlcude the following options:
+        required_irf : list of str or str
+            The list can include the following options:
             * `events` : Events
             * `gti` :  Good time intervals
             * `aeff` : Effective area
@@ -267,6 +267,9 @@ class DataStore:
             * `edisp`: Energy dispersion
             * `psf` : Point Spread Function
             * `rad_max` : Maximal radius
+            Alternatively single string can be used as shortcut:
+            * `full-enclosure` : ["events", "gti", "aeff", "edisp", "psf", "bkg"]
+            * `point-like` : ["events", "gti", "aeff", "edisp"]
 
         Returns
         -------
@@ -303,7 +306,7 @@ class DataStore:
         required_irf : list of str or str
             Runs will be added to the list of observations only if the
             required HDUs are present. Otherwise, the given run will be skipped
-            The list can inlcude the following options:
+            The list can include the following options:
             * `events` : Events
             * `gti` :  Good time intervals
             * `aeff` : Effective area
@@ -324,7 +327,7 @@ class DataStore:
         """
 
         all_hdu = REQUIRED_IRFS["all-optional"]
-        is_all_optinal = required_irf == "all-optional"
+        is_all_optional = required_irf == "all-optional"
 
         if isinstance(required_irf, str) and required_irf in REQUIRED_IRFS.keys():
             required_irf = REQUIRED_IRFS[required_irf]
@@ -350,7 +353,7 @@ class DataStore:
                 else:
                     raise err
 
-            if is_all_optinal or set(required_irf).issubset(obs.available_hdus):
+            if is_all_optional or set(required_irf).issubset(obs.available_hdus):
                 obs_list.append(obs)
             else:
                 log.warning(f"Skipping run with missing HDUs; obs_id: {_!r}")

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -295,8 +295,8 @@ class DataStore:
             * `edisp`: Energy dispersion
             * `psf` : Point Spread Function
             * `rad_max` : Maximal radius
-            * `full-containment` :["events", "gti", "aeff", "edisp", "psf", "bkg"]
-            * `point-like` : ["events", "gti", "aeff", "edisp"]
+            * `full_containment` :["events", "gti", "aeff", "edisp", "psf", "bkg"]
+            * `point_like` : ["events", "gti", "aeff", "edisp"]
             By default, no HDUs are required, only warnings will be emitted
             for missing HDUs among all possibilities.
 
@@ -306,13 +306,13 @@ class DataStore:
             Container holding a list of `~gammapy.data.Observation`
         """
         full_containment = ["events", "gti", "aeff", "edisp", "psf", "bkg"]
-        point_source = ["events", "gti", "aeff", "edisp", "bkg", "rad_max"]
+        point_like = ["events", "gti", "aeff", "edisp"]
         available_hdu = ["events", "gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
         
         if required_hdu == "full_containment":
             required_hdu = full_containment
-        if required_hdu == "point_source":
-            required_hdu = point_source
+        if required_hdu == "point_like":
+            required_hdu = point_like
         elif required_hdu is None:
             required_hdu = []
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -245,7 +245,7 @@ class DataStore:
         else:
             return s
 
-    def obs(self, obs_id, required_hdu):
+    def obs(self, obs_id, required_hdu="full-enclosure"):
         """Access a given `~gammapy.data.Observation`.
 
         Parameters
@@ -273,13 +273,15 @@ class DataStore:
 
         kwargs = {"obs_id": int(obs_id)}
 
+        if required_hdu == "full-enclosure":
+            required_hdu = ["events", "gti", "aeff", "edisp", "psf", "bkg"]
         for hdu in required_hdu:
             kwargs[hdu] = self.hdu_table.hdu_location(obs_id=obs_id, hdu_type=hdu)
 
         return Observation(**kwargs)
 
 
-    def get_observations(self, obs_id=None, skip_missing=False, required_hdu="all-optional"):
+    def get_observations(self, obs_id=None, skip_missing=False, required_hdu="full-enclosure"):
         """Generate a `~gammapy.data.Observations`.
 
         Parameters
@@ -303,7 +305,7 @@ class DataStore:
             * `full-enclosure` : ["events", "gti", "aeff", "edisp", "psf", "bkg"]
             * `point-like` : ["events", "gti", "aeff", "edisp"]
             * `all-optional` : no HDUs are required, only warnings will be emitted
-                               for missing HDUs among all possibilities (Default).
+                               for missing HDUs among all possibilities.
 
         Returns
         -------

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -119,6 +119,11 @@ class Observation:
         return available_hdus
 
     @property
+    def available_irfs(self):
+        """Which IRFs are available"""
+        return [ _ for _ in self.available_hdus if _ not in ["events", "gti"]]
+
+    @property
     def events(self):
         events = self.obs_filter.filter_events(self._events)
         return events

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -106,18 +106,17 @@ class Observation:
         return self._rad_max
 
     @property
-    def available_irfs(self):
-        """Which irfs are available"""
-        available_irf = []
-
-        for irf in ["aeff", "edisp", "psf", "bkg", "rad_max"]:
-            available = self.__dict__.get(irf, False)
-            available_hdu = self.__dict__.get(f"_{irf}_hdu", False)
-
+    def available_hdus(self):
+        """Which HDUs are available"""
+        available_hdus = []
+        keys = ["_events", "_gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
+        hdus = ["events", "gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
+        for key, hdu in zip(keys, hdus):
+            available = self.__dict__.get(key, False)
+            available_hdu = self.__dict__.get(f"_{key}_hdu", False)
             if available or available_hdu:
-                available_irf.append(irf)
-
-        return available_irf
+                available_hdus.append(hdu)
+        return available_hdus
 
     @property
     def events(self):
@@ -343,7 +342,7 @@ class Observation:
         """
         import matplotlib.pyplot as plt
 
-        n_irfs = len(self.available_irfs)
+        n_irfs = len(self.available_hdus)
 
         fig, axes = plt.subplots(
             nrows=n_irfs // 2,
@@ -352,13 +351,13 @@ class Observation:
             gridspec_kw={"wspace": 0.25, "hspace": 0.25},
         )
 
-        axes_dict = dict(zip(self.available_irfs, axes.flatten()))
+        axes_dict = dict(zip(self.available_hdus, axes.flatten()))
 
-        if "aeff" in self.available_irfs:
+        if "aeff" in self.available_hdus:
             self.aeff.plot(ax=axes_dict["aeff"])
             axes_dict["aeff"].set_title("Effective area")
 
-        if "bkg" in self.available_irfs:
+        if "bkg" in self.available_hdus:
             bkg = self.bkg
 
             if not bkg.has_offset_axis:
@@ -369,13 +368,13 @@ class Observation:
         else:
             logging.warning(f"No background model found for obs {self.obs_id}.")
 
-        if "psf" in self.available_irfs:
+        if "psf" in self.available_hdus:
             self.psf.plot_containment_radius_vs_energy(ax=axes_dict["psf"])
             axes_dict["psf"].set_title("Point spread function")
         else:
             logging.warning(f"No PSF found for obs {self.obs_id}.")
 
-        if "edisp" in self.available_irfs:
+        if "edisp" in self.available_hdus:
             self.edisp.plot_bias(ax=axes_dict["edisp"], add_cbar=True)
             axes_dict["edisp"].set_title("Energy dispersion")
         else:

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -109,12 +109,13 @@ class Observation:
     def available_hdus(self):
         """Which HDUs are available"""
         available_hdus = []
-        keys = ["_events", "_gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
+        keys = ["_events", "_gti", "aeff", "edisp", "psf", "bkg", "_rad_max"]
         hdus = ["events", "gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
         for key, hdu in zip(keys, hdus):
             available = self.__dict__.get(key, False)
-            available_hdu = self.__dict__.get(f"_{key}_hdu", False)
-            if available or available_hdu:
+            available_hdu = self.__dict__.get(f"_{hdu}_hdu", False)
+            available_hdu_ = self.__dict__.get(f"_{key}_hdu", False)
+            if available or available_hdu or available_hdu_:
                 available_hdus.append(hdu)
         return available_hdus
 

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -141,24 +141,6 @@ class TestDataStoreChecker:
         assert len(records) == 32
 
 
-
-@requires_data()
-def test_datastore_get_observations(data_store, caplog):
-    """Test loading data and IRF files via the DataStore"""
-    observations = data_store.get_observations([23523, 23592])
-    assert observations[0].obs_id == 23523
-    observations = data_store.get_observations()
-    assert len(observations) == 105
-
-    with pytest.raises(ValueError):
-        data_store.get_observations([11111, 23592])
-
-    observations = data_store.get_observations([11111, 23523], skip_missing=True)
-    assert observations[0].obs_id == 23523
-    assert "WARNING" in [_.levelname for _ in caplog.records]
-    assert "Skipping missing obs_id: 11111" in [_.message for _ in caplog.records]
-
-
 @pytest.fixture()
 def data_store_dc1(monkeypatch):
     paths = [
@@ -169,15 +151,6 @@ def data_store_dc1(monkeypatch):
     monkeypatch.setenv("CALDB", str(caldb_path))
     return DataStore.from_events_files(paths)
 
-@requires_data()
-def test_datastore_from_events(data_store_dc1):
-    # Test that `DataStore.from_events_files` works.
-    # The real tests for `DataStoreMaker` are below.
-
-    path = "$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_110380.fits"
-    data_store = DataStore.from_events_files([path])
-    assert len(data_store.obs_table) == 1
-    assert len(data_store.hdu_table) == 6
 
 @requires_data()
 def test_datastoremaker_obs_table(data_store_dc1):

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -70,12 +70,12 @@ def test_broken_links_datastore(data_store):
     hdu_table.remove_row(index)
     hdu_table._hdu_type_stripped = np.array([_.strip() for _ in hdu_table["HDU_TYPE"]])
     observations = data_store.get_observations(
-        [23523, 23526], required_irf=["aeff", "bkg"]
+        [23523, 23526], required_hdu=["events", "gti", "aeff", "edisp"]
     )
     assert len(observations) == 1
 
     with pytest.raises(ValueError):
-        _ = data_store.get_observations([23523], required_irf=["xyz"])
+        _ = data_store.get_observations([23523], required_hdu=["xyz"])
 
 
 @requires_data()

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -63,14 +63,6 @@ def test_datastore_from_file(tmpdir):
 
     assert data_store.obs_table["OBS_ID"][0] == 20136
 
-@requires_data()
-def test_datastore_from_events():
-    # Test that `DataStore.from_events_files` works.
-    # The real tests for `DataStoreMaker` are below.
-    path = "$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_110380.fits"
-    data_store = DataStore.from_events_files([path])
-    assert len(data_store.obs_table) == 1
-    assert len(data_store.hdu_table) == 6
 
 @requires_data()
 def test_datastore_get_observations(data_store, caplog):
@@ -150,6 +142,16 @@ def data_store_dc1(monkeypatch):
     caldb_path = Path(os.environ["GAMMAPY_DATA"]) / Path("cta-1dc/caldb")
     monkeypatch.setenv("CALDB", str(caldb_path))
     return DataStore.from_events_files(paths)
+
+@requires_data()
+def test_datastore_from_events(data_store_dc1):
+    # data_store_dc1 fixture is needed to set CALDB
+    # Test that `DataStore.from_events_files` works.
+    # The real tests for `DataStoreMaker` are below.
+    path = "$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_110380.fits"
+    data_store = DataStore.from_events_files([path])
+    assert len(data_store.obs_table) == 1
+    assert len(data_store.hdu_table) == 6
 
 
 @requires_data()

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -99,12 +99,12 @@ def test_broken_links_datastore(data_store):
     hdu_table.remove_row(index)
     hdu_table._hdu_type_stripped = np.array([_.strip() for _ in hdu_table["HDU_TYPE"]])
     observations = data_store.get_observations(
-        [23523, 23526], required_hdu=["events", "gti", "aeff", "edisp"]
+        [23523, 23526], required_irf=["aeff", "edisp"]
     )
     assert len(observations) == 1
 
     with pytest.raises(ValueError):
-        _ = data_store.get_observations([23523], required_hdu=["xyz"])
+        _ = data_store.get_observations([23523], required_irf=["xyz"])
 
 
 @requires_data()

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -266,7 +266,7 @@ def test_observation_read():
 
     assert obs.obs_id == 20136
     assert len(obs.events.energy) == 11243
-    assert obs.available_irfs == ["aeff", "edisp", "psf", "bkg"]
+    assert obs.available_hdus == ["events","gti", "aeff", "edisp", "psf", "bkg"]
     assert_allclose(val.value, 278000.54120855, rtol=1e-5)
     assert val.unit == "m2"
 
@@ -284,7 +284,7 @@ def test_observation_read_single_file():
 
     assert obs.obs_id == 20136
     assert len(obs.events.energy) == 11243
-    assert obs.available_irfs == ["aeff", "edisp", "psf", "bkg"]
+    assert obs.available_hdus == ["events","gti", "aeff", "edisp", "psf", "bkg"]
     assert_allclose(val.value, 273372.44851054, rtol=1e-5)
     assert val.unit == "m2"
 

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import logging
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -43,29 +44,29 @@ def test_observation(data_store):
 @requires_dependency("matplotlib")
 @requires_data()
 def test_observation_peek(data_store, caplog):
-    obs = Observation.read(
-        "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
-    )
+    with caplog.at_level(logging.WARNING):
+        obs = Observation.read(
+            "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
+        )
+    
+        with mpl_plot_check():
+            obs.peek()
+    
+        obs.bkg = None
+    
+        with mpl_plot_check():
+            obs.peek()
+    
+        message = "No background model found for obs 23523."
+        assert message in [record.message for record in caplog.records]
 
-    with mpl_plot_check():
-        obs.peek()
-
-    obs.bkg = None
-
-    with mpl_plot_check():
-        obs.peek()
-
-    assert "WARNING" in [record.levelname for record in caplog.records]
-    message = "No background model found for obs 23523."
-    assert message in [record.message for record in caplog.records]
-
-    obs.psf = None
-    with mpl_plot_check():
-        obs.peek()
-
-    assert "WARNING" in [record.levelname for record in caplog.records]
-    message = "No PSF found for obs 23523."
-    assert message in [record.message for record in caplog.records]
+        obs.psf = None
+        with mpl_plot_check():
+            obs.peek()
+    
+        assert "WARNING" in [record.levelname for record in caplog.records]
+        message = "No PSF found for obs 23523."
+        assert message in [record.message for record in caplog.records]
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -29,7 +29,7 @@ def observations_magic_dl3():
     """MAGIC DL3 observation list."""
     datastore = DataStore.from_dir("$GAMMAPY_DATA/joint-crab/dl3/magic/")
     obs_ids = [5029748]
-    return datastore.get_observations(obs_ids, required_hdu=["events", "gti", "aeff", "edisp"])
+    return datastore.get_observations(obs_ids, required_irf=["aeff", "edisp"])
 
 
 @pytest.fixture
@@ -84,8 +84,7 @@ def reflected_regions_bkg_maker():
     exclusion_mask = ~geom.region_mask([exclusion_region])
 
     return ReflectedRegionsBackgroundMaker(
-        exclusion_mask=exclusion_mask,
-        min_distance_input="0.2 deg"
+        exclusion_mask=exclusion_mask, min_distance_input="0.2 deg"
     )
 
 

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -29,7 +29,7 @@ def observations_magic_dl3():
     """MAGIC DL3 observation list."""
     datastore = DataStore.from_dir("$GAMMAPY_DATA/joint-crab/dl3/magic/")
     obs_ids = [5029748]
-    return datastore.get_observations(obs_ids, required_irf=["aeff", "edisp"])
+    return datastore.get_observations(obs_ids, required_hdu=["events", "gti", "aeff", "edisp"])
 
 
 @pytest.fixture


### PR DESCRIPTION
Resolve issues #3666 and #3677
- replace `required_irf` argument by `required_hdu` in Datastore.get_observations()
- set default requirement to None (all hdu will be loaded if possible and a warning is emitted otherwise)
- remove `all` option and add two options `full-enclosure` and `point-like` as suggested in https://github.com/gammapy/gammapy/issues/3666#issuecomment-980095022