### PR TITLE
Change API of ReflectedRegionsFinder, fixes #3734

### DIFF
--- a/docs/makers/make_reflected_regions.py
+++ b/docs/makers/make_reflected_regions.py
@@ -18,12 +18,13 @@ center = SkyCoord(83.633, 24, unit="deg")
 
 # One can impose a minimal distance between ON region and first reflected regions
 finder = ReflectedRegionsFinder(
+    min_distance_input="0.2 rad",
+)
+regions, _ = finder.run(
     region=on_region,
     center=center,
     exclusion_mask=exclusion_mask,
-    min_distance_input="0.2 rad",
 )
-regions = finder.run()
 
 fig, axes = plt.subplots(
     ncols=3,
@@ -47,12 +48,13 @@ plot_regions(ax=ax, regions=regions, on_region=on_region, exclusion_mask=exclusi
 
 # One can impose a minimal distance between two adjacent regions
 finder = ReflectedRegionsFinder(
+    min_distance="0.1 rad",
+)
+regions, _ = finder.run(
     region=on_region,
     center=center,
     exclusion_mask=exclusion_mask,
-    min_distance="0.1 rad",
 )
-regions = finder.run()
 
 ax = axes[1]
 ax.set_title("Min. distance all regions")
@@ -61,13 +63,14 @@ plot_regions(ax=ax, regions=regions, on_region=on_region, exclusion_mask=exclusi
 
 # One can impose a maximal number of regions to be extracted
 finder = ReflectedRegionsFinder(
-    region=on_region,
-    center=center,
-    exclusion_mask=exclusion_mask,
     max_region_number=5,
     min_distance="0.1 rad",
 )
-regions = finder.run()
+regions, _ = finder.run(
+    region=on_region,
+    center=center,
+    exclusion_mask=exclusion_mask,
+)
 
 ax = axes[2]
 ax.set_title("Max. number of regions")

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -1,10 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import numpy as np
+from abc import ABCMeta, abstractmethod
+
 from astropy import units as u
 from astropy.coordinates import Angle
-from astropy.utils import lazyproperty
-from regions import PixCoord, PointSkyRegion, CircleSkyRegion
+from regions import PixCoord, PointSkyRegion
 from gammapy.datasets import SpectrumDatasetOnOff
 from gammapy.maps import RegionGeom, RegionNDMap, WcsGeom, WcsNDMap
 from ..core import Maker
@@ -14,8 +15,33 @@ __all__ = ["ReflectedRegionsFinder", "ReflectedRegionsBackgroundMaker"]
 
 log = logging.getLogger(__name__)
 
+FULL_CIRCLE = Angle(2 * np.pi, "rad")
 
-class ReflectedRegionsFinder:
+
+class RegionsFinder(metaclass=ABCMeta):
+    '''Baseclass for regions finders'''
+
+    @abstractmethod
+    def run(self, region, center):
+        """Find regions to calculate background counts.
+
+        Parameters
+        ----------
+        region : `~regions.SkyRegion`
+            Region to rotate
+        center : `~astropy.coordinates.SkyCoord`
+            Rotation point
+
+        Returns
+        -------
+        regions : list of `SkyRegion`
+            Reflected regions
+        wcs: `~astropy.wcs.WCS`
+            WCS for the determined regions
+        """
+
+
+class ReflectedRegionsFinder(RegionsFinder):
     """Find reflected regions.
 
     This class is responsible for placing :ref:`region_reflected` for a given
@@ -31,10 +57,6 @@ class ReflectedRegionsFinder:
 
     Parameters
     ----------
-    region : `~regions.SkyRegion`
-        Region to rotate
-    center : `~astropy.coordinates.SkyCoord`
-        Rotation point
     angle_increment : `~astropy.coordinates.Angle`, optional
         Rotation angle applied when a region falls in an excluded region.
     min_distance : `~astropy.coordinates.Angle`, optional
@@ -57,8 +79,8 @@ class ReflectedRegionsFinder:
     >>> target_position = SkyCoord(80.2, 23.5, unit='deg', frame='icrs')
     >>> theta = Angle(0.4, 'deg')
     >>> on_region = CircleSkyRegion(target_position, theta)
-    >>> finder = ReflectedRegionsFinder(min_distance_input='1 rad', region=on_region, center=pointing)
-    >>> regions = finder.run()
+    >>> finder = ReflectedRegionsFinder(min_distance_input='1 rad')
+    >>> regions, wcs = finder.run(region=on_region, center=pointing)
     >>> print(regions[0])
     Region: CircleSkyRegion
     center: <SkyCoord (ICRS): (ra, dec) in deg
@@ -68,8 +90,6 @@ class ReflectedRegionsFinder:
 
     def __init__(
         self,
-        region,
-        center,
         angle_increment="0.1 rad",
         min_distance="0 rad",
         min_distance_input="0.1 rad",
@@ -77,8 +97,6 @@ class ReflectedRegionsFinder:
         exclusion_mask=None,
         binsz="0.01 deg",
     ):
-        self.region = region
-        self.center = center
 
         self.angle_increment = Angle(angle_increment)
 
@@ -95,8 +113,7 @@ class ReflectedRegionsFinder:
         self.max_region_number = max_region_number
         self.binsz = Angle(binsz)
 
-    @lazyproperty
-    def geom_ref(self):
+    def _create_reference_geometry(self, region, center):
         """Reference geometry
 
         The size of the map is chosen such that all reflected regions are
@@ -110,27 +127,27 @@ class ReflectedRegionsFinder:
         The WCS of the map is the TAN projection at the `center` in the coordinate
         system used by the `region` center.
         """
-        frame = self.region.center.frame.name
+        frame = region.center.frame.name
 
         # width is the full width of an image (not the radius)
-        width = 4 * self.region.center.separation(self.center) + Angle("0.3 deg")
+        width = 4 * region.center.separation(center) + Angle("0.3 deg")
 
         return WcsGeom.create(
-            skydir=self.center, binsz=self.binsz, width=width, frame=frame, proj="TAN"
+            skydir=center, binsz=self.binsz, width=width, frame=frame, proj="TAN"
         )
 
-    @lazyproperty
-    def center_pix(self):
+    @staticmethod
+    def _get_center_pixel(center, reference_geom):
         """Center pix coordinate"""
-        return PixCoord.from_sky(self.center, self.geom_ref.wcs)
+        return PixCoord.from_sky(center, reference_geom.wcs)
 
-    @lazyproperty
-    def region_pix(self):
+    @staticmethod
+    def _get_region_pixels(region, reference_geom):
         """Pixel region"""
-        return self.region.to_pixel(self.geom_ref.wcs)
+        return region.to_pixel(reference_geom.wcs)
 
-    @lazyproperty
-    def region_angular_size(self):
+    @staticmethod
+    def _region_angular_size(region, reference_geom, center_pix):
         """Compute maximum angular size of a group of pixels as seen from center.
 
         This assumes that the center lies outside the group of pixel
@@ -140,84 +157,91 @@ class ReflectedRegionsFinder:
         angular_size : `~astropy.coordinates.Angle`
             the maximum angular size
         """
-        mask = self.geom_ref.region_mask([self.region]).data
-        pix_y, pix_x = np.where(mask)
+        mask = reference_geom.region_mask([region]).data
+        pix_y, pix_x = np.nonzero(mask)
 
         pixels = PixCoord(pix_x, pix_y)
 
-        dx, dy = self.center_pix.x - pixels.x, self.center_pix.y - pixels.y
+        dx, dy = center_pix.x - pixels.x, center_pix.y - pixels.y
         angles = Angle(np.arctan2(dx, dy), "rad")
         angular_size = np.max(angles) - np.min(angles)
 
         if angular_size.value > np.pi:
-            angular_size = np.max(angles.wrap_at(0 * u.rad)) - np.min(
-                angles.wrap_at(0 * u.rad)
-            )
+            angle_wrapped = angles.wrap_at(0 * u.rad)
+            angular_size = np.max(angle_wrapped) - np.min(angle_wrapped)
 
         return angular_size
 
-    @lazyproperty
-    def exclusion_mask_ref(self):
+    def _exclusion_mask_ref(self, reference_geom):
         """Exclusion mask reprojected"""
         if self.exclusion_mask:
-            mask = self.exclusion_mask.interp_to_geom(self.geom_ref, fill_value=True)
+            mask = self.exclusion_mask.interp_to_geom(reference_geom, fill_value=True)
         else:
-            mask = WcsNDMap.from_geom(geom=self.geom_ref, data=True)
+            mask = WcsNDMap.from_geom(geom=reference_geom, data=True)
         return mask
 
-    @lazyproperty
-    def excluded_pix_coords(self):
+    def _get_excluded_pixels(self, reference_geom):
         """Excluded pix coords"""
         # find excluded PixCoords
-        pix_y, pix_x = np.where(~self.exclusion_mask_ref.data)
+        exclusion_mask = self._exclusion_mask_ref(reference_geom)
+        pix_y, pix_x = np.nonzero(~exclusion_mask.data)
         return PixCoord(pix_x, pix_y)
 
-    @lazyproperty
-    def angle_min(self):
-        """Minimum angle"""
+    def _get_angle_range(self, region, reference_geom, center_pix):
+        """Minimum and maximum angle"""
+        region_angular_size = self._region_angular_size(
+            region=region, reference_geom=reference_geom, center_pix=center_pix
+        )
         # Minimum angle a region has to be moved to not overlap with previous one
         # Add required minimal distance between two off regions
-        return self.region_angular_size + self.min_distance
+        angle_min = region_angular_size + self.min_distance
+        angle_max =  FULL_CIRCLE - angle_min - self.min_distance_input
+        return angle_min, angle_max
 
-    @lazyproperty
-    def angle_max(self):
-        """Maximum angle"""
-        return Angle("360deg") - self.angle_min - self.min_distance_input
-
-    def reset_cache(self):
-        """Reset cached properties"""
-        for name, value in self.__class__.__dict__.items():
-            if isinstance(value, lazyproperty):
-                self.__dict__.pop(name, None)
-
-    def run(self):
+    def run(self, region, center):
         """Find reflected regions.
+
+        Parameters
+        ----------
+        region : `~regions.SkyRegion`
+            Region to rotate
+        center : `~astropy.coordinates.SkyCoord`
+            Rotation point
 
         Returns
         -------
         regions : list of `SkyRegion`
             Reflected regions
+        wcs: `~astropy.wcs.WCS`
+            WCS for the determined regions
         """
-        self.reset_cache()
         regions = []
 
-        angle = self.angle_min + self.min_distance_input
+        reference_geom = self._create_reference_geometry(region, center)
+        center_pixel = self._get_center_pixel(center, reference_geom)
+        angle_min, angle_max = self._get_angle_range(
+            region=region, reference_geom=reference_geom, center_pix=center_pixel,
+        )
 
-        while angle < self.angle_max:
-            region_test = self.region_pix.rotate(self.center_pix, angle)
+        region_pix = self._get_region_pixels(region, reference_geom)
+        excluded_pixels = self._get_excluded_pixels(reference_geom)
 
-            if not np.any(region_test.contains(self.excluded_pix_coords)):
-                region = region_test.to_sky(self.geom_ref.wcs)
+        angle = angle_min + self.min_distance_input
+        while angle < angle_max:
+            region_test = region_pix.rotate(center_pixel, angle)
+
+            if not np.any(region_test.contains(excluded_pixels)):
+                region = region_test.to_sky(reference_geom.wcs)
                 regions.append(region)
 
                 if len(regions) >= self.max_region_number:
                     break
 
-                angle += self.angle_min
+                angle += angle_min
             else:
                 angle += self.angle_increment
 
-        return regions
+        return regions, reference_geom.wcs
 
 
 class ReflectedRegionsBackgroundMaker(Maker):
@@ -225,49 +249,20 @@ class ReflectedRegionsBackgroundMaker(Maker):
 
     Parameters
     ----------
-    angle_increment : `~astropy.coordinates.Angle`, optional
-        Rotation angle applied when a region falls in an excluded region.
-    min_distance : `~astropy.coordinates.Angle`, optional
-        Minimal distance between two consecutive reflected regions
-    min_distance_input : `~astropy.coordinates.Angle`, optional
-        Minimal distance from input region
-    max_region_number : int, optional
-        Maximum number of regions to use
-    exclusion_mask : `~gammapy.maps.WcsNDMap`, optional
-        Exclusion mask
-    binsz : `~astropy.coordinates.Angle`
-        Bin size of the reference map used for region finding.
+    regions_finder: RegionsFinder
     """
 
     tag = "ReflectedRegionsBackgroundMaker"
 
     def __init__(
         self,
-        angle_increment="0.1 rad",
-        min_distance="0 rad",
-        min_distance_input="0.1 rad",
-        max_region_number=10000,
-        exclusion_mask=None,
-        binsz="0.01 deg",
+        region_finder=None,
+        **kwargs,
     ):
-        self.binsz = binsz
-        self.exclusion_mask = exclusion_mask
-        self.angle_increment = Angle(angle_increment)
-        self.min_distance = Angle(min_distance)
-        self.min_distance_input = Angle(min_distance_input)
-        self.max_region_number = max_region_number
-
-    def _get_finder(self, dataset, observation):
-        return ReflectedRegionsFinder(
-            binsz=self.binsz,
-            exclusion_mask=self.exclusion_mask,
-            center=observation.pointing_radec,
-            region=dataset.counts.geom.region,
-            min_distance=self.min_distance,
-            min_distance_input=self.min_distance_input,
-            max_region_number=self.max_region_number,
-            angle_increment=self.angle_increment,
-        )
+        if region_finder is None:
+            self.region_finder = ReflectedRegionsFinder(**kwargs)
+        else:
+            self.region_finder = region_finder
 
     def make_counts_off(self, dataset, observation):
         """Make off counts.
@@ -300,23 +295,22 @@ class ReflectedRegionsBackgroundMaker(Maker):
                 geom=dataset.counts.geom,
                 rad_max=observation.rad_max,
                 events=observation.events,
-                binsz=self.binsz,
-                exclusion_mask=self.exclusion_mask,
-                min_distance=self.min_distance,
-                min_distance_input=self.min_distance_input,
-                max_region_number=self.max_region_number,
-                angle_increment=self.angle_increment,
+                region_finder=self.region_finder,
             )
 
         else:
-            finder = self._get_finder(dataset, observation)
-            regions = finder.run()
+            regions, wcs = self.region_finder.run(
+                center=observation.pointing_radec,
+                region=dataset.counts.geom.region,
+            )
 
             energy_axis = dataset.counts.geom.axes["energy"]
 
             if len(regions) > 0:
                 geom = RegionGeom.from_regions(
-                    regions=regions, axes=[energy_axis], wcs=finder.geom_ref.wcs
+                    regions=regions,
+                    axes=[energy_axis],
+                    wcs=wcs,
                 )
 
                 counts_off = RegionNDMap.from_geom(geom=geom)

--- a/gammapy/makers/background/tests/test_reflected.py
+++ b/gammapy/makers/background/tests/test_reflected.py
@@ -54,7 +54,8 @@ def observations():
 
 @pytest.fixture()
 def reflected_bkg_maker(exclusion_mask):
-    return ReflectedRegionsBackgroundMaker(exclusion_mask=exclusion_mask)
+    finder = ReflectedRegionsFinder(exclusion_mask=exclusion_mask)
+    return ReflectedRegionsBackgroundMaker(region_finder=finder)
 
 
 region_finder_param = [
@@ -73,29 +74,27 @@ def test_find_reflected_regions(
 ):
     pointing = pointing_pos
     finder = ReflectedRegionsFinder(
-        center=pointing,
-        region=on_region,
         exclusion_mask=exclusion_mask,
         min_distance_input="0 deg",
     )
-    regions = finder.run()
+    regions, _ = finder.run(center=pointing, region=on_region)
     assert len(regions) == nreg1
     assert_quantity_allclose(regions[3].center.icrs.ra, reg3_ra, rtol=1e-2)
 
     # Test without exclusion
     finder.exclusion_mask = None
-    regions = finder.run()
+    regions, _ = finder.run(center=pointing, region=on_region)
     assert len(regions) == nreg2
 
     # Test with too small exclusion
     small_mask = exclusion_mask.cutout(pointing, Angle("0.1 deg"))
     finder.exclusion_mask = small_mask
-    regions = finder.run()
+    regions, _ = finder.run(center=pointing, region=on_region)
     assert len(regions) == nreg3
 
     # Test with maximum number of regions
     finder.max_region_number = 5
-    regions = finder.run()
+    regions, _ = finder.run(center=pointing, region=on_region)
     assert len(regions) == 5
 
     # Test with an other type of region
@@ -107,9 +106,10 @@ def test_find_reflected_regions(
         outer_height=0.6 * u.deg,
         angle=130 * u.deg,
     )
-    finder.region = on_ellipse_annulus
-    finder.reference_map = None
-    regions = finder.run()
+    regions, _ = finder.run(
+        region=on_ellipse_annulus,
+        center=pointing,
+    )
     assert len(regions) == 5
 
 
@@ -129,9 +129,9 @@ def test_non_circular_regions(region, nreg):
     pointing = SkyCoord(0.0, 0.0, unit="deg")
 
     finder = ReflectedRegionsFinder(
-        center=pointing, region=region, min_distance_input="0 deg"
+        min_distance_input="0 deg"
     )
-    regions = finder.run()
+    regions, _ = finder.run(center=pointing, region=region)
     assert len(regions) == nreg
 
 
@@ -139,12 +139,13 @@ def test_non_circular_regions(region, nreg):
 def test_bad_on_region(exclusion_mask, on_region):
     pointing = SkyCoord(83.63, 22.01, unit="deg", frame="icrs")
     finder = ReflectedRegionsFinder(
-        center=pointing,
-        region=on_region,
         exclusion_mask=exclusion_mask,
         min_distance_input="0 deg",
     )
-    regions = finder.run()
+    regions, _ = finder.run(
+        center=pointing,
+        region=on_region,
+    )
     assert len(regions) == 0
 
 

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -84,7 +84,8 @@ def reflected_regions_bkg_maker():
     exclusion_mask = ~geom.region_mask([exclusion_region])
 
     return ReflectedRegionsBackgroundMaker(
-        exclusion_mask=exclusion_mask, min_distance_input="0.2 deg"
+        exclusion_mask=exclusion_mask,
+        min_distance_input="0.2 deg"
     )
 
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -495,6 +495,7 @@ def make_counts_off_rad_max(
     rad_max,
     events,
     region_finder,
+    exclusion_mask=None,
 ):
     """Extract the OFF counts and the ON / OFF acceptance considering for the
     sizes of the ON and OFF regions the values in the `RAD_MAX_2D` table.
@@ -532,6 +533,7 @@ def make_counts_off_rad_max(
         regions, wcs = region_finder.run(
             center=events.pointing_radec,
             region=on_region,
+            exclusion_mask=exclusion_mask,
         )
 
         if len(regions) > 0:


### PR DESCRIPTION
The ReflectedRegionsFinder now takes configuration options
as `__init__` arguments but the `region` and `center` are
now parameters to the `run` method.

This enables creating a `ReflectedRegionsFinder` and calling it
for each region / center in the `ReflectedRegionsBackgroundMaker`
instead of creating new finders over and over.

The run method returns the found regions and their wcs object.

The reliance on caching was removed and the code simplified by that.

Co-authored-by: Axel Donath <axel.donath@mpi-hd.mpg.de>

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request ...

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
