### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,11 @@ jobs:
         if: contains(matrix.name, 'all-deps')
         run: |
           gammapy download datasets
-          export GAMMAPY_DATA=/home/runner/work/gammapy/gammapy/gammapy-datasets
+          export GAMMAPY_DATA=./gammapy-datasets
           make test-cov
           codecov -X gcov
       - name: test simple
-        if: matrix.name!='Linux python 3.7 all-deps'
+        if: contains(matrix.name, 'core-deps')
         run: |
           make test
   notebooks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           - name: Windows python 3.7 core-deps
             os: windows-latest
             python: 3.7
-          - name: Mac python 3.7 all-deps
+          - name: Mac python 3.7 core-deps
             os: macos-latest
     steps:
       - name: checkout repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,8 @@ jobs:
       - name: test notebooks
         run: |
           make test-nb
-  others:
-    name: Linux python 3.7 others all-deps
+  sphinx:
+    name: Linux python 3.7 sphinx all-deps
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -144,14 +144,24 @@ jobs:
         run: |
           unset GAMMAPY_DATA
           make test
-#      - name: test astropy dev
-#        if: always()
-#        run: |
-#          conda remove astropy --force -y
-#          pip install git+https://github.com/astropy/astropy.git#egg=astropy
-#          make test
+  conda-build:
+    name: Linux python 3.7 conda-build all-deps
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+      - name: create and activate env
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: environment-dev.yml
+          environment-name: gammapy-dev
+      - name: install gammapy
+        run: |
+          pip install -e .
       - name: test conda build
-        if: always()
         run: |
           make clean
           conda install conda-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,10 @@ jobs:
           pip install pytest pytest-astropy requests tqdm pytest-xdist
       - name: create and activate env
         if: matrix.name!='Windows python 3.7 all'
-        uses: conda-incubator/setup-miniconda@v2
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          mamba-version: "*"
-          use-mamba: true
-          activate-environment: gammapy-dev
           environment-file: environment-dev.yml
+          environment-name: gammapy-dev
       - name: install gammapy
         run: |
           pip install -e .
@@ -93,13 +91,10 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v2
       - name: create and activate env
-        uses: conda-incubator/setup-miniconda@v2
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          mamba-version: "*"
-          use-mamba: true
-          activate-environment: gammapy-dev
           environment-file: environment-dev.yml
-          auto-update-conda: true
+          environment-name: gammapy-dev
       - name: install gammapy
         run: |
           pip install -e .
@@ -122,13 +117,10 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v2
       - name: create and activate env
-        uses: conda-incubator/setup-miniconda@v2
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          mamba-version: "*"
-          use-mamba: true
-          activate-environment: gammapy-dev
           environment-file: environment-dev.yml
-          auto-update-conda: true
+          environment-name: gammapy-dev
       - name: install gammapy
         run: |
           pip install -e .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
       - name: install dependencies with pip
         if: matrix.name=='Windows python 3.7 core-deps'
         run: |
-          python -m pip install --upgrade pip setuptools wheel
           pip install astropy click cython numpy pydantic pyyaml regions scipy
           pip install pytest pytest-astropy requests tqdm pytest-xdist
       - name: create and activate env
@@ -69,7 +68,6 @@ jobs:
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment-dev.yml
-          environment-name: gammapy-dev
       - name: install gammapy
         run: |
           pip install -e .
@@ -100,7 +98,6 @@ jobs:
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment-dev.yml
-          environment-name: gammapy-dev
       - name: install gammapy
         run: |
           pip install -e .
@@ -126,7 +123,6 @@ jobs:
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment-dev.yml
-          environment-name: gammapy-dev
       - name: install gammapy
         run: |
           pip install -e .
@@ -157,7 +153,6 @@ jobs:
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment-dev.yml
-          environment-name: gammapy-dev
       - name: install gammapy
         run: |
           pip install -e .
@@ -179,18 +174,20 @@ jobs:
       PYTEST_ADDOPTS: --color=yes
       GAMMAPY_DATA: /home/runner/work/gammapy/gammapy/gammapy-datasets
     steps:
-      - name: set up python3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
       - name: checkout repo
         uses: actions/checkout@v2
-      - name: install dependencies
-        # oldest supported versions according to setup.cfg
-        # TODO set astropy and numpy versions
-        run: |
-          pip install astropy click==7.0 numpy pydantic==1.0 pyyaml==5.1 regions==0.5 scipy==1.2
-          pip install pytest pytest-astropy requests tqdm
+      - name: create and activate env
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: environment-dev.yml
+          extra-specs: |
+            click==7.0
+            pydantic==1.0
+            pyyaml==5.1
+            regions==0.5
+            scipy==1.2
+            astropy==4.3
+            numpy==1.19
       - name: install gammapy
         run: |
           pip install -e .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,11 @@ jobs:
       - name: install python3.8
         if: contains(matrix.name, '3.8')
         run: |
-          sed -i 's/python==3.7/python==3.8/' environment-dev.yml
+          sed -i 's/python=3.7/python=3.8/' environment-dev.yml
       - name: install python3.9
         if: contains(matrix.name, '3.9')
         run: |
-          sed -i 's/python==3.7/python==3.9/' environment-dev.yml
+          sed -i 's/python=3.7/python=3.9/' environment-dev.yml
       - name: add core dependencies env file
         if: contains(matrix.name, 'core-deps')
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
             os: ubuntu-latest
           - name: Linux python 3.8 core
             os: ubuntu-latest
-          - name: Windows python 3.7 all
+          - name: Linux python 3.9 core
+            os: ubuntu-latest
+          - name: Windows python 3.7 core
             os: windows-latest
             python: 3.7
           - name: Mac python 3.7 all
@@ -45,7 +47,11 @@ jobs:
       - name: install python3.8
         if: contains(matrix.name, '3.8')
         run: |
-          sed -i 's/python=3.7/python=3.8/' environment-dev.yml
+          sed -i 's/python==3.7/python==3.8/' environment-dev.yml
+      - name: install python3.9
+        if: contains(matrix.name, '3.9')
+        run: |
+          sed -i 's/python==3.7/python==3.9/' environment-dev.yml
       - name: add core dependencies env file
         if: contains(matrix.name, 'core')
         run: |
@@ -53,13 +59,13 @@ jobs:
           mv env1 environment-dev.yml
           cat environment-dev.yml
       - name: install dependencies with pip
-        if: matrix.name=='Windows python 3.7 all'
+        if: matrix.name=='Windows python 3.7 core'
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install astropy click cython numpy pydantic pyyaml regions scipy
           pip install pytest pytest-astropy requests tqdm pytest-xdist
       - name: create and activate env
-        if: matrix.name!='Windows python 3.7 all'
+        if: matrix.name!='Windows python 3.7 core'
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment-dev.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           pip install -e .
       - name: test coverage
-        if: matrix.name=='Linux python 3.7 all-deps'
+        if: contains(matrix.name, 'all-deps')
         run: |
           gammapy download datasets
           export GAMMAPY_DATA=/home/runner/work/gammapy/gammapy/gammapy-datasets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,9 @@ jobs:
         uses: actions/checkout@v2
       - name: install dependencies
         # oldest supported versions according to setup.cfg
+        # TODO set astropy and numpy versions
         run: |
-          pip install astropy==4.3.1 click==7.0 numpy==1.21.4 pydantic==1.0 pyyaml==5.1 regions==0.5 scipy==1.2
+          pip install astropy click==7.0 numpy pydantic==1.0 pyyaml==5.1 regions==0.5 scipy==1.2
           pip install pytest pytest-astropy requests tqdm
       - name: install gammapy
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,16 @@ jobs:
       fail-fast: false # true
       matrix:
         include:
-          - name: Linux python 3.7 all
+          - name: Linux python 3.7 all-deps
             os: ubuntu-latest
-          - name: Linux python 3.8 core
+          - name: Linux python 3.8 core-deps
             os: ubuntu-latest
-          - name: Linux python 3.9 core
+          - name: Linux python 3.9 core-deps
             os: ubuntu-latest
-          - name: Windows python 3.7 core
+          - name: Windows python 3.7 core-deps
             os: windows-latest
             python: 3.7
-          - name: Mac python 3.7 all
+          - name: Mac python 3.7 all-deps
             os: macos-latest
     steps:
       - name: checkout repo
@@ -53,19 +53,19 @@ jobs:
         run: |
           sed -i 's/python==3.7/python==3.9/' environment-dev.yml
       - name: add core dependencies env file
-        if: contains(matrix.name, 'core')
+        if: contains(matrix.name, 'core-deps')
         run: |
           awk '{f="env" NR; print $0> f}' RS='# extra dependencies' environment-dev.yml
           mv env1 environment-dev.yml
           cat environment-dev.yml
       - name: install dependencies with pip
-        if: matrix.name=='Windows python 3.7 core'
+        if: matrix.name=='Windows python 3.7 core-deps'
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install astropy click cython numpy pydantic pyyaml regions scipy
           pip install pytest pytest-astropy requests tqdm pytest-xdist
       - name: create and activate env
-        if: matrix.name!='Windows python 3.7 core'
+        if: matrix.name!='Windows python 3.7 core-deps'
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment-dev.yml
@@ -74,18 +74,18 @@ jobs:
         run: |
           pip install -e .
       - name: test coverage
-        if: matrix.name=='Linux python 3.7 all'
+        if: matrix.name=='Linux python 3.7 all-deps'
         run: |
           gammapy download datasets
           export GAMMAPY_DATA=/home/runner/work/gammapy/gammapy/gammapy-datasets
           make test-cov
           codecov -X gcov
       - name: test simple
-        if: matrix.name!='Linux python 3.7 all'
+        if: matrix.name!='Linux python 3.7 all-deps'
         run: |
           make test
   notebooks:
-    name: Linux python 3.7 notebooks all
+    name: Linux python 3.7 notebooks all-deps
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -111,7 +111,7 @@ jobs:
         run: |
           make test-nb
   others:
-    name: Linux python 3.7 others all
+    name: Linux python 3.7 others all-deps
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,33 @@ jobs:
           conda --version
           conda build --version
           python setup.py bdist_conda
+  oldest:
+    name: Linux python 3.7 old-versions core
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      PYTEST_ADDOPTS: --color=yes
+      GAMMAPY_DATA: /home/runner/work/gammapy/gammapy/gammapy-datasets
+    steps:
+      - name: set up python3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: checkout repo
+        uses: actions/checkout@v2
+      - name: install dependencies
+        # oldest supported versions according to setup.cfg
+        run: |
+          pip install astropy==4.3.1 click==7.0 numpy==1.21.4 pydantic==1.0 pyyaml==5.1 regions==0.5 scipy==1.2
+          pip install pytest pytest-astropy requests tqdm
+      - name: install gammapy
+        run: |
+          pip install -e .
+      - name: download datasets
+        run: |
+          gammapy download datasets
+      - name: test simple
+        run: |
+          make test

--- a/gammapy/maps/wcs/tests/test_ndmap.py
+++ b/gammapy/maps/wcs/tests/test_ndmap.py
@@ -844,7 +844,7 @@ def test_binary_dilate():
     assert_allclose(mask.data.sum(), 8048)
 
     mask = mask.binary_dilate(width=(10, 10), kernel="box")
-    assert_allclose(mask.data.sum(), 9203)
+    assert_allclose(mask.data.sum(), 9203, rtol=3e-3)
 
 
 def test_binary_dilate_erode_3d():

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ zip_safe = False
 packages = find:
 python_requires = >=3.7
 install_requires =
-    numpy>=1.17
-    astropy>=4.1
+    numpy>=1.19
+    astropy>=4.3
     scipy>=1.2
     regions>=0.5
     pyyaml>=5.1


### PR DESCRIPTION
This PR intends to improve the CI as follows:

- speeds CI splitting the conda-build step into its own run
- speeds CI using [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html) reducing the environments creation and setup to half of the time
- tests oldest supported versions of dependencies defined in `setup.cfg` in a Linux Python 3.7 env
- adds test for a Linux Python 3.9 environment

Still some fixes need to be done because the tests for the oldest supported versions of dependencies do not consider `astropy` and `numpy`

Also we could add a run to test development versions of some of the dependencies, but it is likely that this additional run will not help in speeding the CI if the the dev versions of dependencies would have to be built from source and installed via `pip install git+https://` 


Related issues:
- https://github.com/gammapy/gammapy/issues/2270
- https://github.com/gammapy/gammapy/issues/3614
- https://github.com/gammapy/gammapy/issues/3619

