### PR TITLE
Common format axis labels

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -45,6 +45,18 @@ def pix_to_coord(edges, pix, interp="lin"):
     return scale.inverse(interp_fn(pix))
 
 
+PLOT_AXIS_LABEL = {
+    "energy": "Energy",
+    "energy_true": "E$_{\rm true}$",
+    "offset": "Offset",
+    "rad": "$\delta p$",
+    "migra": "$\mu$",
+    "fov_lon": "FOV Lon.",
+    "fov_lat": "FOV Lat.",
+    "time": "Time",
+}
+
+
 class MapAxis:
     """Class representing an axis of a map.
 
@@ -278,7 +290,7 @@ class MapAxis:
         """
         ax.set_xscale(self.as_plot_scale)
 
-        xlabel = self.name.capitalize() + f" [{ax.xaxis.units}]"
+        xlabel = PLOT_AXIS_LABEL[self.name] + f" [{ax.xaxis.units}]"
         ax.set_xlabel(xlabel)
         ax.set_xlim(self.bounds)
         return ax
@@ -2187,7 +2199,7 @@ class TimeMapAxis:
         import matplotlib.pyplot as plt
         from matplotlib.dates import DateFormatter
 
-        xlabel = self.name.capitalize() + f" [{self.time_format}]"
+        xlabel = PLOT_AXIS_LABEL[self.name] + f" [{self.time_format}]"
 
         ax.set_xlabel(xlabel)
 

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -47,10 +47,10 @@ def pix_to_coord(edges, pix, interp="lin"):
 
 PLOT_AXIS_LABEL = {
     "energy": "Energy",
-    "energy_true": "E$_{\rm true}$",
+    "energy_true": r"E$_{\rm true}$",
     "offset": "Offset",
-    "rad": "$\delta p$",
-    "migra": "$\mu$",
+    "rad": r"$\delta p$",
+    "migra": r"$\mu$",
     "fov_lon": "FOV Lon.",
     "fov_lat": "FOV Lat.",
     "time": "Time",

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -47,14 +47,16 @@ def pix_to_coord(edges, pix, interp="lin"):
 
 PLOT_AXIS_LABEL = {
     "energy": "Energy",
-    "energy_true": r"E$_{\rm true}$",
+    "energy_true": "True Energy",
     "offset": "Offset",
-    "rad": r"$\delta p$",
-    "migra": r"$\mu$",
+    "rad": "Rad",
+    "migra": "Energy / True Energy",
     "fov_lon": "FOV Lon.",
     "fov_lat": "FOV Lat.",
     "time": "Time",
 }
+
+DEFAULT_LABEL_TEMPLATE = '{quantity} [{unit}]'
 
 
 class MapAxis:
@@ -290,7 +292,9 @@ class MapAxis:
         """
         ax.set_xscale(self.as_plot_scale)
 
-        xlabel = PLOT_AXIS_LABEL[self.name] + f" [{ax.xaxis.units}]"
+        xlabel = DEFAULT_LABEL_TEMPLATE.format(
+                                        quantity=PLOT_AXIS_LABEL.get(self.name, self.name.capitalize())
+                                        , unit=self.unit )
         ax.set_xlabel(xlabel)
         ax.set_xlim(self.bounds)
         return ax
@@ -2199,8 +2203,9 @@ class TimeMapAxis:
         import matplotlib.pyplot as plt
         from matplotlib.dates import DateFormatter
 
-        xlabel = PLOT_AXIS_LABEL[self.name] + f" [{self.time_format}]"
-
+        xlabel = DEFAULT_LABEL_TEMPLATE.format(
+                                        quantity=PLOT_AXIS_LABEL.get(self.name, self.name.capitalize())
+                                        , unit=self.time_format )
         ax.set_xlabel(xlabel)
 
         if self.time_format == "iso":

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -48,11 +48,11 @@ def pix_to_coord(edges, pix, interp="lin"):
 PLOT_AXIS_LABEL = {
     "energy": "Energy",
     "energy_true": "True Energy",
-    "offset": "Offset",
-    "rad": "Rad",
+    "offset": "FoV Offset",
+    "rad": "Source Offset",
     "migra": "Energy / True Energy",
-    "fov_lon": "FOV Lon.",
-    "fov_lat": "FOV Lat.",
+    "fov_lon": "FoV Lon.",
+    "fov_lat": "FoV Lat.",
     "time": "Time",
 }
 

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
+import matplotlib.pyplot as plt
 from astropy.table import Table
 from astropy.time import Time
 from astropy.visualization import quantity_support
@@ -682,8 +683,6 @@ def test_mixed_axes():
 
 @requires_dependency("matplotlib")
 def test_MapAxis_format_plot_xaxis():
-    import matplotlib.pyplot as plt
-    
     axis = MapAxis.from_energy_bounds(
             "0.03 TeV", "300 TeV", nbin=20,
             per_decade=True, name="energy_true")
@@ -697,9 +696,8 @@ def test_MapAxis_format_plot_xaxis():
     assert ax1.xaxis.label.properties()["text"] == "E$_{\\rm true}$ [TeV]"
 
 
+@requires_dependency("matplotlib")
 def test_TimeMapAxis_format_plot_xaxis(time_intervals):
-    import matplotlib.pyplot as plt
-    
     axis = TimeMapAxis(
         time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"], name="time"
     )

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -694,7 +694,7 @@ def test_MapAxis_format_plot_xaxis():
             ax.plot(axis.center, np.ones_like(axis.center))
 
     ax1 = axis.format_plot_xaxis(ax=ax)
-    assert ax1.xaxis.label.properties()["text"] == "E$_{\rm true}$ [TeV]"
+    assert ax1.xaxis.label.properties()["text"] == "E$_{\\rm true}$ [TeV]"
 
 
 def test_TimeMapAxis_format_plot_xaxis(time_intervals):

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -5,10 +5,11 @@ from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
 from astropy.table import Table
 from astropy.time import Time
+from astropy.visualization import quantity_support
 from gammapy.data import GTI
 from gammapy.maps import LabelMapAxis, MapAxes, MapAxis, RegionNDMap, TimeMapAxis
 from gammapy.utils.scripts import make_path
-from gammapy.utils.testing import assert_time_allclose, requires_data
+from gammapy.utils.testing import assert_time_allclose, requires_data, requires_dependency, mpl_plot_check
 from gammapy.utils.time import time_ref_to_dict
 
 MAP_AXIS_INTERP = [
@@ -677,3 +678,36 @@ def test_mixed_axes():
 
     assert table["LABEL"].dtype == np.dtype("<U7")
     assert len(table) == 24
+
+
+@requires_dependency("matplotlib")
+def test_MapAxis_format_plot_xaxis():
+    import matplotlib.pyplot as plt
+    
+    axis = MapAxis.from_energy_bounds(
+            "0.03 TeV", "300 TeV", nbin=20,
+            per_decade=True, name="energy_true")
+    
+    with mpl_plot_check():
+        ax = plt.gca()
+        with quantity_support():
+            ax.plot(axis.center, np.ones_like(axis.center))
+
+    ax1 = axis.format_plot_xaxis(ax=ax)
+    assert ax1.xaxis.label.properties()["text"] == "E$_{\rm true}$ [TeV]"
+
+
+def test_TimeMapAxis_format_plot_xaxis(time_intervals):
+    import matplotlib.pyplot as plt
+    
+    axis = TimeMapAxis(
+        time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"], name="time"
+    )
+
+    with mpl_plot_check():
+        ax = plt.gca()
+        with quantity_support():
+            ax.plot(axis.center, np.ones_like(axis.center))
+
+    ax1 = axis.format_plot_xaxis(ax=ax)
+    assert ax1.xaxis.label.properties()["text"] == "Time [iso]"

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -686,14 +686,14 @@ def test_MapAxis_format_plot_xaxis():
     axis = MapAxis.from_energy_bounds(
             "0.03 TeV", "300 TeV", nbin=20,
             per_decade=True, name="energy_true")
-    
+
     with mpl_plot_check():
         ax = plt.gca()
         with quantity_support():
             ax.plot(axis.center, np.ones_like(axis.center))
 
     ax1 = axis.format_plot_xaxis(ax=ax)
-    assert ax1.xaxis.label.properties()["text"] == "E$_{\\rm true}$ [TeV]"
+    assert ax1.xaxis.label.properties()["text"] == "True Energy [TeV]"
 
 
 @requires_dependency("matplotlib")

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -3,7 +3,6 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
-import matplotlib.pyplot as plt
 from astropy.table import Table
 from astropy.time import Time
 from astropy.visualization import quantity_support
@@ -683,6 +682,7 @@ def test_mixed_axes():
 
 @requires_dependency("matplotlib")
 def test_MapAxis_format_plot_xaxis():
+    import matplotlib.pyplot as plt
     axis = MapAxis.from_energy_bounds(
             "0.03 TeV", "300 TeV", nbin=20,
             per_decade=True, name="energy_true")
@@ -698,6 +698,7 @@ def test_MapAxis_format_plot_xaxis():
 
 @requires_dependency("matplotlib")
 def test_TimeMapAxis_format_plot_xaxis(time_intervals):
+    import matplotlib.pyplot as plt
     axis = TimeMapAxis(
         time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"], name="time"
     )


### PR DESCRIPTION
This PR fixes the issue #3675. 
A registry of labels is added to `~gammapy.maps.axes` and called by the `format_plot_xaxis` functions of `MapAxis` and `TimeMapAxis`. Two tests were added.
However, it's not clear to me how the `LabelMapAxis` should be treated in this case.