### PR TITLE
Merge obs_info from obs index with EVENTS Header, fixes #3724

### DIFF
--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -362,7 +362,7 @@
    "outputs": [],
    "source": [
     "primary_hdu = fits.PrimaryHDU()\n",
-    "hdu_evt = fits.BinTableHDU(events.table)\n",
+    "hdu_evt = events.to_table_hdu()\n",
     "hdu_gti = fits.BinTableHDU(dataset.gti.table, name=\"GTI\")\n",
     "hdu_all = fits.HDUList([primary_hdu, hdu_evt, hdu_gti])\n",
     "hdu_all.writeto(\"./event_sampling/events_0001.fits\", overwrite=True)"
@@ -700,7 +700,7 @@
     "\n",
     "    sampler = MapDatasetEventSampler(random_state=idx)\n",
     "    events = sampler.run(dataset, observation)\n",
-    "    events.table.write(\n",
+    "    events.to_table_hdu().writeto(\n",
     "        f\"./event_sampling/events_{idx:04d}.fits\", overwrite=True\n",
     "    )"
    ]
@@ -753,7 +753,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -767,7 +767,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.12"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -9,6 +9,7 @@ from astropy.table import Table
 from astropy.table import vstack as vstack_tables
 from astropy.visualization import quantity_support
 from astropy.io import fits
+from astropy.time import Time
 from gammapy.maps import MapAxis, MapCoord, RegionGeom, WcsNDMap
 from gammapy.utils.fits import earth_location_from_dict
 from gammapy.utils.scripts import make_path
@@ -798,6 +799,15 @@ class EventList:
                 table.meta[key] = table.meta[key].to_value(spec.unit)
 
         table.meta.update(MANDATORY_HEADERS)
+
+        if 'CREATOR' not in table.meta:
+            from gammapy import __version__
+            table.meta['CREATOR'] = 'gammapy ' + __version__
+
+        if 'DATE' not in table.meta:
+            table.meta['DATE'] = Time.now().iso
+        elif isinstance(table.meta, Time):
+            table.meta['DATE'] = table.meta['DATE'].iso
 
         return fits.BinTableHDU(table, name='EVENTS')
 

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -8,7 +8,7 @@ from astropy.time import Time
 from astropy.units import Quantity
 from gammapy.utils.fits import LazyFitsData, earth_location_from_dict
 from gammapy.utils.testing import Checker
-from .event_list import EventList, EventListChecker
+from .event_list import EventList, EventListChecker, GADF_HEADERS
 from .filters import ObservationFilter
 from .gti import GTI
 from .pointing import FixedPointingInfo
@@ -119,7 +119,9 @@ class Observation:
 
         obs_info = {} if self._obs_info is None else self._obs_info.copy()
         if self.events is not None:
-            obs_info.update(self.events.table.meta)
+            for key in GADF_HEADERS:
+                if key in self.events.table.meta and key not in obs_info:
+                    obs_info[key] = self.events.table.meta[key]
 
         return obs_info
 

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -68,7 +68,7 @@ class Observation:
         obs_filter=None,
     ):
         self.obs_id = obs_id
-        self.obs_info = obs_info
+        self._obs_info = obs_info
         self.aeff = aeff
         self.edisp = edisp
         self.psf = psf
@@ -110,6 +110,18 @@ class Observation:
             "DEC_PNT": pointing.icrs.dec.deg,
             "DEADC": 1 - deadtime_fraction,
         }
+
+    @property
+    def obs_info(self):
+        # for backwards compatibility, previous behaviour
+        if self._obs_info is None and self.events is None:
+            return None
+
+        obs_info = {} if self._obs_info is None else self._obs_info.copy()
+        if self.events is not None:
+            obs_info.update(self.events.table.meta)
+
+        return obs_info
 
     @classmethod
     def create(
@@ -385,12 +397,10 @@ class Observation:
         irf_file = irf_file if irf_file is not None else event_file
         irf_dict = load_irf_dict_from_file(irf_file)
 
-        obs_info = events.table.meta
         return cls(
             events=events,
             gti=gti,
-            obs_info=obs_info,
-            obs_id=obs_info.get("OBS_ID"),
+            obs_id=events.table.meta.get("OBS_ID"),
             **irf_dict,
         )
 

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -303,3 +303,26 @@ class TestObservationChecker:
         assert records[5]["msg"] == "Loading aeff failed"
         assert records[7]["msg"] == "Loading edisp failed"
         assert records[9]["msg"] == "Loading psf failed"
+
+
+
+@requires_data()
+def test_obs_info_from_events_header(tmp_path):
+    '''Test that obs_info is also read from event table header'''
+    source_obs = Observation.read(
+        "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+    )
+
+    # no obs_info given
+    obs = Observation(
+        obs_id=source_obs.obs_id,
+        events=source_obs.events,
+        aeff=source_obs.aeff,
+        edisp=source_obs.edisp,
+    )
+
+    obs_info = obs.obs_info
+    assert 'TSTART' in obs_info
+    assert 'DEADC' in obs_info
+    assert 'LIVETIME' in obs_info
+

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -232,17 +232,17 @@ class MapDatasetEventSampler:
         meta["OBS_ID"] = observation.obs_id
 
         meta["TSTART"] = (
-            ((observation.tstart.mjd - dataset.gti.time_ref.mjd) * u.day).to(u.s).value
+            ((observation.tstart.mjd - dataset.gti.time_ref.mjd) * u.day).to(u.s)
         )
         meta["TSTOP"] = (
-            ((observation.tstop.mjd - dataset.gti.time_ref.mjd) * u.day).to(u.s).value
+            ((observation.tstop.mjd - dataset.gti.time_ref.mjd) * u.day).to(u.s)
         )
-        meta["ONTIME"] = observation.observation_time_duration.to("s").value
-        meta["LIVETIME"] = observation.observation_live_time_duration.to("s").value
+        meta["ONTIME"] = observation.observation_time_duration.to("s")
+        meta["LIVETIME"] = observation.observation_live_time_duration.to("s")
         meta["DEADC"] = 1 - observation.observation_dead_time_fraction
 
-        meta["RA_PNT"] = observation.pointing_radec.icrs.ra.deg
-        meta["DEC_PNT"] = observation.pointing_radec.icrs.dec.deg
+        meta["RA_PNT"] = observation.pointing_radec.icrs.ra.to(u.deg)
+        meta["DEC_PNT"] = observation.pointing_radec.icrs.dec.to(u.deg)
 
         meta["EQUINOX"] = "J2000"
         meta["RADECSYS"] = "icrs"
@@ -279,10 +279,10 @@ class MapDatasetEventSampler:
 
         if model:
             meta["OBJECT"] = model.name
-            meta["RA_OBJ"] = model.position.icrs.ra.deg
-            meta["DEC_OBJ"] = model.position.icrs.dec.deg
+            meta["RA_OBJ"] = model.position.icrs.ra.to(u.deg)
+            meta["DEC_OBJ"] = model.position.icrs.dec.to(u.deg)
 
-        meta["TELAPSE"] = dataset.gti.time_sum.to("s").value
+        meta["TELAPSE"] = dataset.gti.time_sum.to("s")
         meta["MJDREFI"] = int(dataset.gti.time_ref.mjd)
         meta["MJDREFF"] = dataset.gti.time_ref.mjd % 1
         meta["TIMEUNIT"] = "s"
@@ -317,8 +317,8 @@ class MapDatasetEventSampler:
         altaz_frame = AltAz(obstime=dataset.gti.time_start, location=loc)
         coord_altaz = observation.pointing_radec.transform_to(altaz_frame)
 
-        meta["ALT_PNT"] = str(coord_altaz.alt.deg[0])
-        meta["AZ_PNT"] = str(coord_altaz.az.deg[0])
+        meta["ALT_PNT"] = coord_altaz.alt[0].to(u.deg)
+        meta["AZ_PNT"] = coord_altaz.az[0].to(u.deg)
 
         # TO DO: these keywords should be taken from the IRF of the dataset
         meta["ORIGIN"] = "Gammapy"

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -249,13 +249,13 @@ def test_mde_run(dataset, models):
     assert meta["HDUVERS"] == "0.2"
     assert meta["HDUCLASS"] == "GADF"
     assert meta["OBS_ID"] == 1001
-    assert_allclose(meta["TSTART"], 0.0)
-    assert_allclose(meta["TSTOP"], 3600.0)
-    assert_allclose(meta["ONTIME"], 3600.0)
-    assert_allclose(meta["LIVETIME"], 3600.0)
-    assert_allclose(meta["DEADC"], 1.0)
-    assert_allclose(meta["RA_PNT"], 266.4049882865447)
-    assert_allclose(meta["DEC_PNT"], -28.936177761791473)
+    assert u.isclose(meta["TSTART"], 0.0 * u.s)
+    assert u.isclose(meta["TSTOP"], 3600.0 * u.s)
+    assert u.isclose(meta["ONTIME"], 3600.0 * u.s)
+    assert u.isclose(meta["LIVETIME"], 3600.0 * u.s)
+    assert u.isclose(meta["DEADC"], 1.0)
+    assert u.isclose(meta["RA_PNT"], 266.4049882865447 * u.deg)
+    assert u.isclose(meta["DEC_PNT"], -28.936177761791473 * u.deg)
     assert meta["EQUINOX"] == "J2000"
     assert meta["RADECSYS"] == "icrs"
     assert "Gammapy" in meta["CREATOR"]
@@ -273,11 +273,11 @@ def test_mde_run(dataset, models):
     assert "CIRCLE" in meta["DSVAL3"]
     assert meta["DSUNI3"] == "deg             "
     assert meta["NDSKEYS"] == " 3 "
-    assert_allclose(meta["RA_OBJ"], 266.4049882865447)
-    assert_allclose(meta["DEC_OBJ"], -28.936177761791473)
-    assert_allclose(meta["TELAPSE"], 1000.0)
-    assert_allclose(meta["MJDREFI"], 51544)
-    assert_allclose(meta["MJDREFF"], 0.0007428703684126958)
+    assert u.isclose(meta["RA_OBJ"], 266.4049882865447 * u.deg)
+    assert u.isclose(meta["DEC_OBJ"], -28.936177761791473 * u.deg)
+    assert u.isclose(meta["TELAPSE"], 1000.0 * u.s)
+    assert u.isclose(meta["MJDREFI"], 51544)
+    assert u.isclose(meta["MJDREFF"], 0.0007428703684126958)
     assert meta["TIMEUNIT"] == "s"
     assert meta["TIMESYS"] == "tt"
     assert meta["TIMEREF"] == "LOCAL"
@@ -289,8 +289,8 @@ def test_mde_run(dataset, models):
     assert meta["MID00001"] == 1
     assert meta["MID00002"] == 2
     assert meta["NMCIDS"] == 2
-    assert_allclose(float(meta["ALT_PNT"]), float("-13.5345076464"), rtol=1e-7)
-    assert_allclose(float(meta["AZ_PNT"]), float("228.82981620065763"), rtol=1e-7)
+    assert u.isclose(meta["ALT_PNT"], -13.5345076464 * u.deg, rtol=1e-7)
+    assert u.isclose(meta["AZ_PNT"], 228.82981620065763 * u.deg, rtol=1e-7)
     assert meta["ORIGIN"] == "Gammapy"
     assert meta["TELESCOP"] == "CTA"
     assert meta["INSTRUME"] == "1DC"
@@ -342,8 +342,8 @@ def test_mde_run_switchoff(dataset, models):
 
     meta = events.table.meta
 
-    assert meta["RA_PNT"] == 266.4049882865447
-    assert meta["ONTIME"] == 3600.0
+    assert u.isclose(meta["RA_PNT"], 266.4049882865447 * u.deg)
+    assert u.isclose(meta["ONTIME"], 3600.0 * u.s)
     assert meta["OBS_ID"] == 1001
     assert meta["RADECSYS"] == "icrs"
 
@@ -364,7 +364,7 @@ def test_events_datastore(tmp_path, dataset, models):
     events = sampler.run(dataset=dataset, observation=obs)
 
     primary_hdu = fits.PrimaryHDU()
-    hdu_evt = fits.BinTableHDU(events.table)
+    hdu_evt = events.to_table_hdu()
     hdu_gti = fits.BinTableHDU(dataset.gti.table, name="GTI")
     hdu_all = fits.HDUList([primary_hdu, hdu_evt, hdu_gti])
     hdu_all.writeto(str(tmp_path / "events.fits"))


### PR DESCRIPTION
* Turn Observation.obs_info into a property that merges the explicitly
  given obs_info, e.g. as filled by `DataStore` from the obs-index table
  with the meta information in `events.table.meta`, which contains
  the mandadatory information, at least for GADF.
