### PR TITLE
Helper function to rebin map axis

### DIFF
--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -237,6 +237,51 @@ class SpectrumDataset(PlotMixin, MapDataset):
     def to_spectrum_dataset(self, *args, **kwargs):
         raise NotImplementedError("Already a Spectrum Dataset. Method not supported")
 
+    def get_resampled_energy_axis(self, name="energy", conditions_kw={}):
+        """Returns an energy axis whose binning satisfies given conditions on the per-bin statistics.
+
+        Parameters
+        ----------
+        name: str
+            Name of the axis to be resampled.
+        conditions_kw : dict
+            Keyword arguments containing the per-bin conditions used to resample the axis.
+            Available options are: "min_counts", "min_excess".
+
+        Returns
+        -------
+        energy_axis : `~gammapy.maps.MapAxis`
+            New energy axis.
+        """
+        available_options = ["min_counts", "min_excess"]
+
+        def _find_idx(key):
+            if key in available_options:
+                data = getattr(self, key.strip("min_")).data[::-1]
+                cumsum_idx = np.where(np.cumsum(data) >= conditions_kw[key])[0][0]
+                data_idx = np.where(data >= conditions_kw[key])[0][0]
+                return max(cumsum_idx, data_idx)
+            else:
+                raise ValueError(
+                    f"Unrecognized option {key}. The available methods are: {available_options}."
+                )
+
+        idx = 0
+        for key in conditions_kw.keys():
+            idx = max(idx, _find_idx(key))
+
+        energy_axis = self._geom.axes[name]
+        if (
+            energy_axis.node_type != "edges"
+        ):  # Here for consistency, since the map axis resampling requires "edges"
+            raise ValueError("Only edge based axes can be rebinned")
+        edges = energy_axis.edges
+        rebinned_energy_axis = energy_axis.copy(
+            nodes=np.delete(edges, range(len(edges) - 1 - idx, len(edges) - 1))
+        )
+
+        return rebinned_energy_axis
+
 
 class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
     stat_type = "wstat"

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -237,6 +237,7 @@ class SpectrumDataset(PlotMixin, MapDataset):
     def to_spectrum_dataset(self, *args, **kwargs):
         raise NotImplementedError("Already a Spectrum Dataset. Method not supported")
 
+
 class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
     stat_type = "wstat"
     tag = "SpectrumDatasetOnOff"
@@ -359,5 +360,3 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
             SpectrumDatset with cash statistics
         """
         return self.to_map_dataset(name=name).to_spectrum_dataset(on_region=None)
-
-

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -237,52 +237,6 @@ class SpectrumDataset(PlotMixin, MapDataset):
     def to_spectrum_dataset(self, *args, **kwargs):
         raise NotImplementedError("Already a Spectrum Dataset. Method not supported")
 
-    def get_resampled_energy_axis(self, name="energy", conditions={}):
-        """Returns an energy axis whose binning satisfies given conditions on the per-bin statistics.
-
-        Parameters
-        ----------
-        name: str
-            Name of the axis to be resampled.
-        conditions : dict
-            Keyword arguments containing the per-bin conditions used to resample the axis.
-            Available options are: "min_counts", "min_excess".
-
-        Returns
-        -------
-        energy_axis : `~gammapy.maps.MapAxis`
-            New energy axis.
-        """
-        available_conditions = ["min_counts", "min_excess"]
-
-        def _find_idx(key):
-            if key in available_conditions:
-                data = getattr(self, key.strip("min_")).data[::-1]
-                cumsum_idx = np.where(np.cumsum(data) >= conditions[key])[0][0]
-                data_idx = np.where(data >= conditions[key])[0][0]
-                return max(cumsum_idx, data_idx)
-            else:
-                raise ValueError(
-                    f"Unrecognized option {key}. The available methods are: {available_conditions}."
-                )
-
-        idx = 0
-        for key in conditions.keys():
-            idx = max(idx, _find_idx(key))
-
-        energy_axis = self._geom.axes[name]
-        if (
-            energy_axis.node_type != "edges"
-        ):  # This is here for consistency, since the map axis resampling requires "edges"
-            raise ValueError("Only edge based axes can be rebinned")
-        edges = energy_axis.edges
-        rebinned_energy_axis = energy_axis.copy(
-            nodes=np.delete(edges, range(len(edges) - 1 - idx, len(edges) - 1))
-        )
-
-        return rebinned_energy_axis
-
-
 class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
     stat_type = "wstat"
     tag = "SpectrumDatasetOnOff"
@@ -406,22 +360,4 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
         """
         return self.to_map_dataset(name=name).to_spectrum_dataset(on_region=None)
 
-    def get_resampled_energy_axis(self, name="energy", conditions={}):
-        """Returns an energy axis whose binning satisfies given conditions on the per-bin statistics.
 
-        Parameters
-        ----------
-        name: str
-            Name of the axis to be resampled.
-        conditions : dict
-            Keyword arguments containing the per-bin conditions used to resample the axis.
-            Available options are: "min_counts", "min_excess".
-
-        Returns
-        -------
-        energy_axis : `~gammapy.maps.MapAxis`
-            New energy axis.
-        """
-        return self.to_spectrum_dataset().get_resampled_energy_axis(
-            name=name, conditions=conditions
-        )

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -665,6 +665,26 @@ class TestSpectrumOnOff:
         assert_allclose(np.squeeze(grouped.acceptance), [2, 2])
         assert_allclose(np.squeeze(grouped.acceptance_off), [20, 20])
 
+    def test_get_resampled_energy_axis(self):
+        resampled_energy_axis = self.dataset.get_resampled_energy_axis(conditions={})
+        assert resampled_energy_axis == self.dataset._geom.axes["energy"]
+
+        with pytest.raises(IndexError):
+            self.dataset.get_resampled_energy_axis(
+                conditions={"min_counts": 10, "min_excess": 10}
+            )
+
+        dataset = self.dataset.copy()
+        dataset.counts += 1  # Necessary to test the "min_excess" option
+        grouped = dataset.resample_energy_axis(
+            energy_axis=dataset.get_resampled_energy_axis(
+                conditions={"min_counts": 1, "min_excess": 1}
+            )
+        )
+        assert grouped.counts.data.shape == (3, 1, 1)
+        assert_allclose(np.squeeze(grouped.counts), [2, 2, 3])
+        assert_allclose(np.squeeze(grouped.background), [1, 1, 2])
+
     def test_to_image(self):
         grouped = self.dataset.to_image()
 


### PR DESCRIPTION
**Description**
Thi PR addresses #3685 

**Dear reviewer**
A few points:
1. This implementation assumes that the low stat bins are always toward the high-energy end of a spectrum dataset
2. It fails with `IndexError` when the user-defined condition cannot be met (e.g. `min_counts=1e10`)
3. I think it is not too complex to add also significance-based options, using the Cash/WstatCountsStatistic. Possibly in a future PR
4. I raised an error if the input axis has `node_dtype="center"`, even if in principle this could work in that case as well. That's for consistency with the `Dataset.resample_energy_axis()` (to which the axis obtained with this new method is expected to be passed), which works only for `node_dtype="edges".`