### PR TITLE
Fix doc strings for makers and datasets

### DIFF
--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -17,13 +17,8 @@ log = logging.getLogger(__name__)
 class MapEvaluator:
     """Sky model evaluation on maps.
 
-    This evaluates a sky model on a 3D map and convolves with the IRFs,
-    and returns a map of the predicted counts.
-    Note that background counts are not added.
-
-    For now, we only make it work for 3D WCS maps with an energy axis.
-    No HPX, no other axes, those can be added later here or via new
-    separate model evaluator classes.
+    Evaluates a sky model on a 3D map and returns a map of the predicted counts.
+    Convolution with IRFs will be performed as defined in the sky_model
 
     Parameters
     ----------

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -15,7 +15,7 @@ __all__ = ["FluxPointsDataset"]
 
 class FluxPointsDataset(Dataset):
     """
-    Bundle a set of flux points with a parametric model, to compute a likelihood. Uses chi2 statistics.
+    Bundle a set of flux points with a parametric model, to compute fit statistic function using chi2 statistics.
 
     Parameters
     ----------

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -15,7 +15,7 @@ __all__ = ["FluxPointsDataset"]
 
 class FluxPointsDataset(Dataset):
     """
-    Bundle a set of flux points with a parametric model, to perform a fit. Uses chi2 statistics.
+    Bundle a set of flux points with a parametric model, to compute a likelihood. Uses chi2 statistics.
 
     Parameters
     ----------
@@ -207,14 +207,13 @@ class FluxPointsDataset(Dataset):
 
         str_ += "\t{:32}: {} \n".format("Number of models", n_models)
 
-        str_ += "\t{:32}: {}\n".format(
-            "Number of parameters", len(self.models.parameters)
-        )
-        str_ += "\t{:32}: {}\n\n".format(
-            "Number of free parameters", len(self.models.parameters.free_parameters)
-        )
-
         if self.models is not None:
+            str_ += "\t{:32}: {}\n".format(
+                "Number of parameters", len(self.models.parameters)
+            )
+            str_ += "\t{:32}: {}\n\n".format(
+                "Number of free parameters", len(self.models.parameters.free_parameters)
+            )
             str_ += "\t" + "\n\t".join(str(self.models).split("\n")[2:])
 
         return str_.expandtabs(tabsize=2)
@@ -241,7 +240,7 @@ class FluxPointsDataset(Dataset):
         return ((data - model) / sigma.quantity[:, 0, 0]).to_value("") ** 2
 
     def residuals(self, method="diff"):
-        """Compute the flux point residuals ().
+        """Compute flux point residuals
 
         Parameters
         ----------
@@ -290,6 +289,22 @@ class FluxPointsDataset(Dataset):
         -------
         ax_spectrum, ax_residuals : `~matplotlib.axes.Axes`
             Flux points, best fit model and residuals plots.
+
+        Examples
+        --------
+        >>> from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
+        >>> from gammapy.estimators import FluxPoints
+        >>> from gammapy.datasets import FluxPointsDataset
+
+        >>> #load precomputed flux points
+        >>> filename = "$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits"
+        >>> flux_points = FluxPoints.read(filename)
+        >>> model = SkyModel(spectral_model=PowerLawSpectralModel())
+        >>> dataset = FluxPointsDataset(model, flux_points)
+        >>> #configuring optional parameters
+        >>> kwargs_spectrum = {"kwargs_model": {"color":"red", "ls":"--"}, "kwargs_fp":{"color":"green", "marker":"o"}}
+        >>> kwargs_residuals = {"color": "blue", "markersize":4, "marker":'s', }
+        >>> dataset.plot_fit(kwargs_residuals=kwargs_residuals, kwargs_spectrum=kwargs_spectrum) # doctest: +SKIP
         """
         import matplotlib.pyplot as plt
         from matplotlib.gridspec import GridSpec
@@ -338,6 +353,7 @@ class FluxPointsDataset(Dataset):
         -------
         ax : `~matplotlib.axes.Axes`
             Axes object.
+
         """
         import matplotlib.pyplot as plt
 
@@ -397,6 +413,22 @@ class FluxPointsDataset(Dataset):
         -------
         ax : `~matplotlib.axes.Axes`
             Axes object.
+
+        Examples
+        --------
+        >>> from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
+        >>> from gammapy.estimators import FluxPoints
+        >>> from gammapy.datasets import FluxPointsDataset
+
+        >>> #load precomputed flux points
+        >>> filename = "$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits"
+        >>> flux_points = FluxPoints.read(filename)
+        >>> model = SkyModel(spectral_model=PowerLawSpectralModel())
+        >>> dataset = FluxPointsDataset(model, flux_points)
+        >>> #configuring optional parameters
+        >>> kwargs_model = {"color":"red", "ls":"--"}
+        >>> kwargs_fp = {"color":"green", "marker":"o"}
+        >>> dataset.plot_spectrum(kwargs_fp=kwargs_fp, kwargs_model=kwargs_model) # doctest: +SKIP
         """
         kwargs_fp = (kwargs_fp or {}).copy()
         kwargs_model = (kwargs_model or {}).copy()

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -15,14 +15,14 @@ __all__ = ["FluxPointsDataset"]
 
 class FluxPointsDataset(Dataset):
     """
-    Fit a set of flux points with a parametric model.
+    Bundle a set of flux points with a parametric model, to perform a fit. Uses chi2 statistics.
 
     Parameters
     ----------
     models : `~gammapy.modeling.models.Models`
         Models (only spectral part needs to be set)
     data : `~gammapy.estimators.FluxPoints`
-        Flux points.
+        Flux points. Must be sorted along the energy axis
     mask_fit : `numpy.ndarray`
         Mask to apply for fitting
     mask_safe : `numpy.ndarray`
@@ -35,21 +35,44 @@ class FluxPointsDataset(Dataset):
     --------
     Load flux points from file and fit with a power-law model::
 
-        from gammapy.modeling import Fit
-        from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
-        from gammapy.estimators import FluxPoints
-        from gammapy.datasets import FluxPointsDataset
+    >>> from gammapy.modeling import Fit
+    >>> from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
+    >>> from gammapy.estimators import FluxPoints
+    >>> from gammapy.datasets import FluxPointsDataset
 
-        filename = "$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits"
-        flux_points = FluxPoints.read(filename)
+    >>> #load precomputed flux points
+    >>> filename = "$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits"
+    >>> flux_points = FluxPoints.read(filename)
 
-        model = SkyModel(spectral_model=PowerLawSpectralModel())
+    >>> model = SkyModel(spectral_model=PowerLawSpectralModel())
 
-        dataset = FluxPointsDataset(model, flux_points)
-        fit = Fit()
-        result = fit.run([dataset])
-        print(result)
-        print(result.parameters.to_table())
+    >>> #create dataset and fit
+    >>> dataset = FluxPointsDataset(model, flux_points)
+    >>> fit = Fit()
+    >>> result = fit.run([dataset])
+    >>> print(result)
+    OptimizeResult
+    <BLANKLINE>
+    	backend    : minuit
+    	method     : migrad
+    	success    : True
+    	message    : Optimization terminated successfully.
+    	nfev       : 135
+    	total stat : 25.21
+    <BLANKLINE>
+    CovarianceResult
+    <BLANKLINE>
+    	backend    : minuit
+    	method     : hesse
+    	success    : True
+    	message    : Hesse terminated successfully.
+
+    >>> print(result.parameters.to_table())
+          type      name     value         unit        error   min max frozen link
+    -------- --------- ---------- -------------- --------- --- --- ------ ----
+    spectral     index 2.2159e+00                1.043e-02 nan nan  False
+    spectral amplitude 2.1619e-13 cm-2 s-1 TeV-1 1.901e-14 nan nan  False
+    spectral reference 1.0000e+00            TeV 0.000e+00 nan nan   True
 
     Note: In order to reproduce the example you need the tests datasets folder.
     You may download it with the command

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -871,7 +871,7 @@ class MapDataset(Dataset):
         -------
         >>> from gammapy.datasets import MapDataset
         >>> dataset = MapDataset.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
-        >>> kwargs = {"cmap": "gnuplot2", "add_cbar": True}
+        >>> kwargs = {"cmap": "RdBu_r", "vmin":-5, "vmax":5, "add_cbar": True}
         >>> dataset.plot_residuals_spatial(method="diff/sqrt(model)", **kwargs) # doctest: +SKIP
         """
         counts, npred = self.counts.copy(), self.npred()
@@ -1022,7 +1022,7 @@ class MapDataset(Dataset):
         >>> from gammapy.datasets import MapDataset
         >>> dataset = MapDataset.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
         >>> reg = CircleSkyRegion(SkyCoord(0,0, unit="deg", frame="galactic"), radius=1.0*u.deg)
-        >>> kwargs_spatial = {"cmap": "gnuplot2", "add_cbar": True}
+        >>> kwargs_spatial = {"cmap": "RdBu_r", "vmin":-5, "vmax":5, "add_cbar": True}
         >>> kwargs_spectral = {"region":reg, "markerfacecolor": "blue", "markersize":8, "marker":'s'}
         >>> dataset.plot_residuals(kwargs_spatial=kwargs_spatial, kwargs_spectral=kwargs_spectral) # doctest: +SKIP
         """

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -468,7 +468,7 @@ class MapDataset(Dataset):
     def npred_signal(self, model_name=None):
         """Model predicted signal counts.
 
-        If a model name is passed, predicted counts from that component is returned.
+        If a model name is passed, predicted counts from that component are returned.
         Else, the total signal counts are returned.
 
         Parameters
@@ -2032,7 +2032,7 @@ class MapDatasetOnOff(MapDataset):
         return alpha
 
     def npred_background(self):
-        """Prediced background counts (mu_bkg) estimated from the marginalized likelihood estimate.
+        """Predicted background counts (mu_bkg) estimated from the marginalized likelihood estimate.
 
         See :ref:`wstat`
 

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -22,7 +22,7 @@ class PlotMixin:
     ):
         """Plot spectrum and residuals in two panels.
 
-        Calls `~SpectrumDataset.plot_excess` and `~SpectrumDataset.plot_residuals`.
+        Calls `~SpectrumDataset.plot_excess` and `~SpectrumDataset.plot_residuals_spectral`.
 
         Parameters
         ----------
@@ -33,12 +33,23 @@ class PlotMixin:
         kwargs_spectrum : dict
             Keyword arguments passed to `~SpectrumDataset.plot_excess`.
         kwargs_residuals : dict
-            Keyword arguments passed to `~SpectrumDataset.plot_residuals`.
+            Keyword arguments passed to `~SpectrumDataset.plot_residuals_spectral`.
 
         Returns
         -------
         ax_spectrum, ax_residuals : `~matplotlib.axes.Axes`
             Spectrum and residuals plots.
+
+        Examples
+        --------
+        >>> #Creating a spectral dataset
+        >>> from gammapy.datasets import SpectrumDatasetOnOff
+        >>> from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
+        >>> dataset = SpectrumDatasetOnOff.read(f"$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs23523.fits")
+        >>> p = PowerLawSpectralModel()
+        >>> dataset.models = SkyModel(spectral_model=p)
+        >>> kwargs_residuals = {"color": "black", "markersize":4, "marker":'s', } #optional configuration
+        >>> dataset.plot_fit(kwargs_residuals=kwargs_residuals)  # doctest: +SKIP
         """
         from matplotlib.gridspec import GridSpec
 
@@ -119,6 +130,19 @@ class PlotMixin:
         -------
         ax : `~matplotlib.axes.Axes`
             Axes object.
+
+        Examples
+        --------
+        >>> #Reading a spectral dataset
+        >>> from gammapy.datasets import SpectrumDatasetOnOff
+        >>> dataset = SpectrumDatasetOnOff.read(f"$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs23523.fits")
+        >>> dataset.mask_fit = dataset.mask_safe.copy()
+        >>> dataset.mask_fit.data[40:46]=False #setting dummy mask_fit for illustration
+        >>> #Plot the masks on top of the counts histogram
+        >>> kwargs_safe = {"color":"green", "alpha":0.2} #optinonal arguments to configure
+        >>> kwargs_fit = {"color":"pink", "alpha":0.2}
+        >>> ax=dataset.plot_counts()
+        >>> dataset.plot_masks(ax=ax, kwargs_fit=kwargs_fit, kwargs_safe=kwargs_safe)  # doctest: +SKIP
         """
 
         kwargs_fit = kwargs_fit or {}
@@ -135,6 +159,7 @@ class PlotMixin:
         if self.mask_safe:
             self.mask_safe.plot_mask(ax=ax, **kwargs_safe)
 
+        ax.legend()
         return ax
 
     def plot_excess(
@@ -159,6 +184,19 @@ class PlotMixin:
         -------
         ax : `~matplotlib.axes.Axes`
             Axes object.
+
+        Examples
+        --------
+        >>> #Creating a spectral dataset
+        >>> from gammapy.datasets import SpectrumDatasetOnOff
+        >>> from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
+        >>> dataset = SpectrumDatasetOnOff.read(f"$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs23523.fits")
+        >>> p = PowerLawSpectralModel()
+        >>> dataset.models = SkyModel(spectral_model=p)
+        >>> #Plot the excess in blue and the npred in black dotted lines
+        >>> kwargs_excess = {"color": "blue", "markersize":8, "marker":'s', }
+        >>> kwargs_npred_signal = {"color": "black", "ls":"--"}
+        >>> dataset.plot_excess(kwargs_excess=kwargs_excess, kwargs_npred_signal=kwargs_npred_signal)  # doctest: +SKIP
         """
         kwargs_excess = kwargs_excess or {}
         kwargs_npred_signal = kwargs_npred_signal or {}
@@ -299,6 +337,7 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
     @classmethod
     def from_dict(cls, data, **kwargs):
         """Create spectrum dataset from dict.
+        Reads file from the disk as specified in the dict
 
         Parameters
         ----------

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -48,8 +48,12 @@ class PlotMixin:
         >>> dataset = SpectrumDatasetOnOff.read(f"$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs23523.fits")
         >>> p = PowerLawSpectralModel()
         >>> dataset.models = SkyModel(spectral_model=p)
+        >>> #optional configurations
+        >>> kwargs_excess = {"color": "blue", "markersize":8, "marker":'s', }
+        >>> kwargs_npred_signal = {"color": "black", "ls":"--"}
+        >>> kwargs_spectrum = {"kwargs_excess":kwargs_excess, "kwargs_npred_signal":kwargs_npred_signal}
         >>> kwargs_residuals = {"color": "black", "markersize":4, "marker":'s', } #optional configuration
-        >>> dataset.plot_fit(kwargs_residuals=kwargs_residuals)  # doctest: +SKIP
+        >>> dataset.plot_fit(kwargs_residuals=kwargs_residuals, kwargs_spectrum=kwargs_spectrum)  # doctest: +SKIP
         """
         from matplotlib.gridspec import GridSpec
 
@@ -141,7 +145,7 @@ class PlotMixin:
         >>> #Plot the masks on top of the counts histogram
         >>> kwargs_safe = {"color":"green", "alpha":0.2} #optinonal arguments to configure
         >>> kwargs_fit = {"color":"pink", "alpha":0.2}
-        >>> ax=dataset.plot_counts()
+        >>> ax=dataset.plot_counts() # doctest: +SKIP
         >>> dataset.plot_masks(ax=ax, kwargs_fit=kwargs_fit, kwargs_safe=kwargs_safe)  # doctest: +SKIP
         """
 

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -74,6 +74,9 @@ def test_flux_point_dataset_serialization(tmp_path):
 @requires_data()
 def test_flux_point_dataset_str(dataset):
     assert "FluxPointsDataset" in str(dataset)
+    # check print if no models present
+    dataset.models = None
+    assert "FluxPointsDataset" in str(dataset)
 
 
 @requires_data()

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -81,11 +81,11 @@ class ReflectedRegionsFinder(RegionsFinder):
     >>> on_region = CircleSkyRegion(target_position, theta)
     >>> finder = ReflectedRegionsFinder(min_distance_input='1 rad')
     >>> regions, wcs = finder.run(region=on_region, center=pointing)
-    >>> print(regions[0])
+    >>> print(regions[0]) # doctest: +SKIP
     Region: CircleSkyRegion
     center: <SkyCoord (ICRS): (ra, dec) in deg
         (83.19879005, 25.57300957)>
-    radius: 1438.3203418953724 arcsec
+    radius: 1438.320341895 arcsec
     """
 
     def __init__(

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -85,7 +85,7 @@ class ReflectedRegionsFinder(RegionsFinder):
     Region: CircleSkyRegion
     center: <SkyCoord (ICRS): (ra, dec) in deg
         (83.19879005, 25.57300957)>
-    radius: 1438.3203419072468 arcsec
+    radius: 1438.3203418953724 arcsec
     """
 
     def __init__(

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -81,11 +81,11 @@ class ReflectedRegionsFinder(RegionsFinder):
     >>> on_region = CircleSkyRegion(target_position, theta)
     >>> finder = ReflectedRegionsFinder(min_distance_input='1 rad')
     >>> regions, wcs = finder.run(region=on_region, center=pointing)
-    >>> print(regions[0]) # doctest: +SKIP
+    >>> print(regions[0]) # doctest: +ELLIPSIS
     Region: CircleSkyRegion
     center: <SkyCoord (ICRS): (ra, dec) in deg
         (83.19879005, 25.57300957)>
-    radius: 1438.320341895 arcsec
+    radius: 1438.3... arcsec
     """
 
     def __init__(

--- a/gammapy/makers/background/ring.py
+++ b/gammapy/makers/background/ring.py
@@ -223,10 +223,8 @@ class AdaptiveRingBackgroundMaker(Maker):
 
 
 class RingBackgroundMaker(Maker):
-    """Ring background method for cartesian coordinates.
-
-    - Step 1: apply exclusion mask
-    - Step 2: ring-correlate
+    """Perform a local renormalisation of the existing background template, using a
+    ring kernel. Expected signal regions should be removed by passing an exclusion mask
 
     Parameters
     ----------
@@ -236,6 +234,11 @@ class RingBackgroundMaker(Maker):
         Ring width
     exclusion_mask : `~gammapy.maps.WcsNDMap`
         Exclusion mask
+
+
+    Example
+    -------
+    See: For a usage example, see `ring_background.html <../../../docs/tutorials/analysis/2D/ring_background.ipynb>`__
 
     See Also
     --------

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 
 class MapDatasetMaker(Maker):
-    """Make maps for a single IACT observation.
+    """Make binned maps for a single IACT observation.
 
     Parameters
     ----------
@@ -34,6 +34,56 @@ class MapDatasetMaker(Maker):
     background_interp_missing_data: bool
         Interpolate missing values in background 3d map.
         Default is True, have to be set to True for CTA IRF.
+
+    Examples
+    --------
+    This example shows how to run the MapMaker for a single observation
+
+    >>> from gammapy.data import DataStore
+    >>> from gammapy.datasets import MapDataset
+    >>> from gammapy.maps import WcsGeom, MapAxis
+    >>> from gammapy.makers import MapDatasetMaker
+
+    >>>  #load an observation
+    >>> data_store = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
+    >>> obs = data_store.obs(23523)
+
+    >>> #prepare the geom
+    >>> energy_axis = MapAxis.from_energy_bounds(1.0, 10.0, 4, unit="TeV")
+    >>> energy_axis_true = MapAxis.from_energy_bounds( 0.5, 20, 10, unit="TeV", name="energy_true")
+    >>> geom = WcsGeom.create(skydir=(83.633, 22.014), binsz=0.02, width=(2, 2), frame="icrs", proj="CAR", axes=[energy_axis])
+
+    >>> #Run the maker
+    >>> empty = MapDataset.create(geom=geom, energy_axis_true=energy_axis_true, name="empty")
+    >>> maker = MapDatasetMaker()
+    >>> dataset = maker.run(empty, obs)
+    >>> print(dataset)
+    MapDataset
+    ----------
+    <BLANKLINE>
+      Name                            : empty
+    <BLANKLINE>
+      Total counts                    : 787
+      Total background counts         : 684.52
+      Total excess counts             : 102.48
+    <BLANKLINE>
+      Predicted counts                : 684.52
+      Predicted background counts     : 684.52
+      Predicted excess counts         : nan
+    <BLANKLINE>
+      Exposure min                    : 7.01e+07 m2 s
+      Exposure max                    : 1.10e+09 m2 s
+    <BLANKLINE>
+      Number of total bins            : 40000
+      Number of fit bins              : 40000
+    <BLANKLINE>
+      Fit statistic type              : cash
+      Fit statistic value (-2 log(L)) : nan
+    <BLANKLINE>
+      Number of models                : 0
+      Number of parameters            : 0
+      Number of free parameters       : 0
+
     """
 
     tag = "MapDatasetMaker"

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -32,11 +32,12 @@ class SafeMaskMaker(Maker):
         Percentage of the energy bias to be used as lower
         energy threshold for method "edisp-bias"
     position : `~astropy.coordinates.SkyCoord`
-        Position at which the `aeff_percent` or `bias_percent` are computed. By default,
-        it uses the position of the center of the map.
+        Position at which the `aeff_percent` or `bias_percent` are computed.
     fixed_offset : `~astropy.coordinates.Angle`
         offset, calculated from the pointing position, at which
         the `aeff_percent` or `bias_percent` are computed.
+        If neither the position nor fixed_offset is specified,
+        it uses the position of the center of the map by default.
     offset_max : str or `~astropy.units.Quantity`
         Maximum offset cut.
     """

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -12,7 +12,7 @@ class SpectrumDatasetMaker(MapDatasetMaker):
     """Make spectrum for a single IACT observation.
 
     The irfs and background are computed at a single fixed offset,
-    which is recommend only for point-sources.
+    which is recommended only for point-sources.
 
     Parameters
     ----------
@@ -25,7 +25,9 @@ class SpectrumDatasetMaker(MapDatasetMaker):
     background_oversampling : int
         Background evaluation oversampling factor in energy.
     use_region_center : bool
-        Approximate the IRFs by the value at the center of the region
+        If True, approximate the IRFs by the value at the center of the region
+        If False, the IRFs are averaged over the entire region
+
     """
 
     tag = "SpectrumDatasetMaker"


### PR DESCRIPTION
This PR fixes the doc string in 2 sub packages.
Probably good to merge this before I start other packages to avoid changing too many files and creating merge conflicts.

I wanted to add an example for all classes, but it started to become like full tutorials, so avoided in some cases.