### PR TITLE
Fix broken links and add subpackages in documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -341,7 +341,7 @@ accordingly to an ``EBLAbsorptionNormSpectralModel``. A new
 have been introduced.
 
 Gammapy v0.18 comes now with support for custom energy dependent spatial models.
-An example for this can be found in the models tutorial.
+An example for this can be found in the `models tutorial <https://docs.gammapy.org/0.18/tutorials/models.html>`__.
 The ``SkyDiffuseCube`` has been removed, the same functionality can now be
 achieved with the ``TemplateSpatialModel``. Following the proposal in
 `PIG 21`_, short YAML tags were introduced for all models. An overview of the
@@ -364,7 +364,8 @@ The ``Map`` class now supports boolean and comparator operations, such as
 
 A ``Fit.stat_surface()`` method was introduced which allows to compute a
 fit statistic surface. In addition an option to store the trace of the fit was
-added. Both are demonstrated in dedicated sections in the modeling and fitting tutorial.
+added. Both are demonstrated in dedicated sections in the
+`modeling and fitting tutorial<https://docs.gammapy.org/0.18/tutorials/modeling.html>`__.
 
 Following the proposal in `PIG 19`_, the ``gammapy.time`` sub-package was removed.
 All functionality related to light curves can be found in ``gammapy.estimators``.
@@ -505,11 +506,11 @@ API for Gammapy v1.0.
 The main feature introduces in Gammapy v0.17 is event sampling. Based
 on the newly introduced ``MapDatasetEventSampler`` class, event lists can be
 sampled from a ``MapDataset`` object. The use of this class is shown in a dedicated
-event sampling tutorial. Gammapy v0.17 now
+`event sampling tutorial<https://docs.gammapy.org/0.17/notebooks/event_sampling.html>`__. Gammapy v0.17 now
 supports simulation and fitting of temporal models. Both are demonstrated in the
-lightcurve simulation tutorial.
+`lightcurve simulation tutorial<https://docs.gammapy.org/0.17/notebooks/light_curve_simulation.html>`__.
 A more general introduction to modeling and fitting in Gammapy is now available
-as a modeling and fitting tutorial.
+as a `modeling and fitting tutorial<https://docs.gammapy.org/0.17/notebooks/modeling.html>`__.
 
 Following the proposal in `PIG 19`_ the sub-package structure of Gammapy was
 unified. Instead of grouping the main functionality by use-case it is now
@@ -660,10 +661,10 @@ different methods of adapting the norm and tilt of a field of view background
 model to the data.
 
 To provide a visual overview of the available models in Gammapy a
-model gallery was added. A general introduction
-on how to work with the different models is now available in a dedicated models tutorial.
+`model gallery<https://docs.gammapy.org/0.16/modeling/gallery/index.html>`__ was added. A general introduction
+on how to work with the different models is now available in a dedicated `models tutorial<https://docs.gammapy.org/0.16/notebooks/models.html>`__.
 The spectral analysis of an extended source is demonstrated in the newly
-added extended source spectral analysis tutorial.
+added `extended source spectral analysis tutorial<https://docs.gammapy.org/0.16/notebooks/extended_source_spectral_analysis.html>`__.
 
 To further improve API consistency the ``EnergyDispersion`` class
 was renamed to ``EDispKernel`` and the ``SkyModels`` class was
@@ -782,11 +783,11 @@ which executes the data reduction part of an analysis, based on a given config
 file.
 
 Following the proposal in `PIG 18`_ the structure of the documentation was
-improved. The new overview page gives an introduction and
+improved. The new `overview page<https://docs.gammapy.org/0.15/overview.html>`__ gives an introduction and
 overview of the Gammapy analysis workflow and package structure. The structure
-and content of the tutorials page was simplified and
-cleaned up and a how to page was introduced. A tutorial notebook
-showing how to do a joint multi-instrument analysis
+and content of the `tutorials<https://docs.gammapy.org/0.15/tutorials/index.html>`__ page was simplified and
+cleaned up and a `how to page<https://docs.gammapy.org/0.15/howto.html>`__ was introduced. A tutorial notebook
+showing how to do a joint `multi-instrument analysis<https://docs.gammapy.org/0.15/notebooks/analysis_mwl.html>`__
 of the Crab Nebula using H.E.S.S. and Fermi-LAT data and HAWC flux points was added.
 
 Another focus of the work for Gammapy v0.15 was the clean-up and unification of
@@ -796,7 +797,8 @@ and ``SpectrumDatasetMaker`` which directly produce a ``MapDataset`` or
 were adapted by introducing a ``ReflectedRegionsBackgroundMaker``,
 ``RingBackgroundMaker`` and ``AdaptiveRingbackgroundMaker``. Those makers can
 also be chained to create custom data reduction workflows. The new data reduction
-API is shown in the second analysis with Gammapy notebook and corresponding docs page.
+API is shown in the `second analysis with Gammapy notebook<https://docs.gammapy.org/0.15/notebooks/analysis_mwl.html>`__
+and corresponding `docs page<https://docs.gammapy.org/0.15/cube/index.html>`__.
 
 A ``MapDatasetOnOff`` class was introduced to handle on-off observation based analyses
 and as a container for image based ring-background estimation. All datasets now
@@ -805,16 +807,19 @@ geometry or energy specification. Gammapy now supports spatially varying PSF and
 energy dispersion in the data reduction as well as during fitting. By introducing
 an in memory ``Observation`` class Gammapy now features unified support for
 binned simulations of spectrum and map datasets. This is shown in the
-1d simulation and 3d simulation <tutorials/simulate_3d.html tutorial notebooks.
+`1d simulation<https://docs.gammapy.org/0.15/notebooks/spectrum_simulation.html>`__ and
+`3d simulation<https://docs.gammapy.org/0.15/notebooks/simulate_3d.html>`__ tutorial notebooks.
 
 The ``LightCurveEstimator`` was improved to use the GTIs defined on datasets
 and allow for grouping of datasets according to provided time intervals. Details
-are explained on the time docs page and the newly added flare light curve notebook.
+are explained on the `time docs page<https://docs.gammapy.org/0.15/time/index.html>`__
+and the newly added `flare light curve notebook<https://docs.gammapy.org/0.15/notebooks/light_curve_flare.html>`__.
 
 The support for 2FHL and 4FGL was improved by adding attributes returning
 spatial and spectral models as well as lightcurves to the corresponding objects.
 The support for the Fermi-LAT 1FHL catalog was dropped. An overview can be found
-on the catalog docs page and the catalog tutorial notebook.
+on the `catalog docs page<https://docs.gammapy.org/0.15/catalog/index.html>`__ and the
+`catalog tutorial notebook<https://docs.gammapy.org/0.15/notebooks/catalog.html>`__.
 
 Error propagation is now fully supported for the ``AbsorbedSpectralModel`` and
 ``NaimaModel``.
@@ -952,7 +957,7 @@ Gammapy v0.14 features a new high level analysis interface. Starting from
 a YAML configuration file, it supports the standard use-cases of joint
 or stacked 3D as well as 1D reflected region analyses. It also supports
 computation of flux points for all cases. The usage of this new ``Analysis``
-class is demonstrated in the hess tutorial.
+class is demonstrated in the `hess tutorial<https://docs.gammapy.org/0.14/notebooks/hess.html>`__.
 
 Following the proposal in :ref:`pig-016` the subpackages ``gammapy.background``
 and ``gammapy.image`` were removed. Existing functionality was moved to the
@@ -1193,8 +1198,8 @@ gamma-ray data. To improve the fit convergence of the ``SkyDisk`` and ``SkyEllip
 models we introduced a new parameter defining the slope of the edge of these models.
 
 If you would like to know how to adapt your old spectral analysis scripts to Gammapy
-v0.12, please checkout the updated tutorial notebooks and get in contact with us
-anytime if you need help.
+v0.12, please checkout the updated `tutorial notebooks<https://docs.gammapy.org/0.12/tutorials.html>`__
+and `get in contact with us <https://gammapy.org/contact.html>`__ anytime if you need help.
 
 **Contributors:**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -341,7 +341,7 @@ accordingly to an ``EBLAbsorptionNormSpectralModel``. A new
 have been introduced.
 
 Gammapy v0.18 comes now with support for custom energy dependent spatial models.
-An example for this can be found in the `models tutorial <tutorials/models.html>`__.
+An example for this can be found in the models tutorial.
 The ``SkyDiffuseCube`` has been removed, the same functionality can now be
 achieved with the ``TemplateSpatialModel``. Following the proposal in
 `PIG 21`_, short YAML tags were introduced for all models. An overview of the
@@ -364,7 +364,7 @@ The ``Map`` class now supports boolean and comparator operations, such as
 
 A ``Fit.stat_surface()`` method was introduced which allows to compute a
 fit statistic surface. In addition an option to store the trace of the fit was
-added. Both are demonstrated in dedicated sections in the `modeling and fitting tutorial <tutorials/modeling.html>`__
+added. Both are demonstrated in dedicated sections in the modeling and fitting tutorial.
 
 Following the proposal in `PIG 19`_, the ``gammapy.time`` sub-package was removed.
 All functionality related to light curves can be found in ``gammapy.estimators``.
@@ -505,11 +505,11 @@ API for Gammapy v1.0.
 The main feature introduces in Gammapy v0.17 is event sampling. Based
 on the newly introduced ``MapDatasetEventSampler`` class, event lists can be
 sampled from a ``MapDataset`` object. The use of this class is shown in a dedicated
-`event sampling tutorial <tutorials/event_sampling.html>`__. Gammapy v0.17 now
+event sampling tutorial. Gammapy v0.17 now
 supports simulation and fitting of temporal models. Both are demonstrated in the
-`lightcurve simulation tutorial <tutorials/light_curve_simulation.html>`__.
+lightcurve simulation tutorial.
 A more general introduction to modeling and fitting in Gammapy is now available
-as a `modeling and fitting tutorial <tutorials/modeling.html>`__
+as a modeling and fitting tutorial.
 
 Following the proposal in `PIG 19`_ the sub-package structure of Gammapy was
 unified. Instead of grouping the main functionality by use-case it is now
@@ -660,10 +660,10 @@ different methods of adapting the norm and tilt of a field of view background
 model to the data.
 
 To provide a visual overview of the available models in Gammapy a
-`model gallery <modeling/gallery/index.rst>`__ was added. A general introduction
-on how to work with the different models is now available in a dedicated `models tutorial <tutorials/models.html>`__.
+model gallery was added. A general introduction
+on how to work with the different models is now available in a dedicated models tutorial.
 The spectral analysis of an extended source is demonstrated in the newly
-added `extended source spectral analysis tutorial <tutorials/extended_source_spectral_analysis.ipynb>`__.
+added extended source spectral analysis tutorial.
 
 To further improve API consistency the ``EnergyDispersion`` class
 was renamed to ``EDispKernel`` and the ``SkyModels`` class was
@@ -776,17 +776,17 @@ For Gammapy v0.15 the high level ``Analysis`` class was moved to the newly
 introduced ``gammapy.analysis`` sub-package. The syntax of the YAML config
 file was simplified and validation of config parameters is now available
 for interactive use of the ``Analysis`` class as well. Both is demonstrated in the
-`first analysis with Gammapy notebook <tutorials/analysis_1.html>`__.
+`first analysis with Gammapy notebook <tutorials/starting/analysis_1.html>`__.
 In addition a new ``gammapy analysis`` command line tool was introduced,
 which executes the data reduction part of an analysis, based on a given config
 file.
 
 Following the proposal in `PIG 18`_ the structure of the documentation was
-improved. The new `overview page <overview.rst>`__ gives an introduction and
+improved. The new overview page gives an introduction and
 overview of the Gammapy analysis workflow and package structure. The structure
-and content of the `tutorials page <tutorials/index.rst>`__ was simplified and
-cleaned up and a `how to <howto.rst>`__ page was introduced. A tutorial notebook
-showing how to do a joint `multi-instrument analysis <tutorials/analysis_mwl.html>`__
+and content of the tutorials page was simplified and
+cleaned up and a how to page was introduced. A tutorial notebook
+showing how to do a joint multi-instrument analysis
 of the Crab Nebula using H.E.S.S. and Fermi-LAT data and HAWC flux points was added.
 
 Another focus of the work for Gammapy v0.15 was the clean-up and unification of
@@ -796,8 +796,7 @@ and ``SpectrumDatasetMaker`` which directly produce a ``MapDataset`` or
 were adapted by introducing a ``ReflectedRegionsBackgroundMaker``,
 ``RingBackgroundMaker`` and ``AdaptiveRingbackgroundMaker``. Those makers can
 also be chained to create custom data reduction workflows. The new data reduction
-API is shown in the `second analysis with Gammapy notebook <tutorials/analysis_2.html>`__
-and corresponding `docs page <cube/index.rst>`__.
+API is shown in the second analysis with Gammapy notebook and corresponding docs page.
 
 A ``MapDatasetOnOff`` class was introduced to handle on-off observation based analyses
 and as a container for image based ring-background estimation. All datasets now
@@ -806,19 +805,16 @@ geometry or energy specification. Gammapy now supports spatially varying PSF and
 energy dispersion in the data reduction as well as during fitting. By introducing
 an in memory ``Observation`` class Gammapy now features unified support for
 binned simulations of spectrum and map datasets. This is shown in the
-`1d simulation <tutorials/spectrum_simulation.html>`__ and
-`3d simulation <tutorials/simulate_3d.html>`__ tutorial notebooks.
+1d simulation and 3d simulation <tutorials/simulate_3d.html tutorial notebooks.
 
 The ``LightCurveEstimator`` was improved to use the GTIs defined on datasets
 and allow for grouping of datasets according to provided time intervals. Details
-are explained on the `time docs page <time/index.rst>`__ and the newly added
-`flare light curve notebook <tutorials/light_curve_flare.html>`__.
+are explained on the time docs page and the newly added flare light curve notebook.
 
 The support for 2FHL and 4FGL was improved by adding attributes returning
 spatial and spectral models as well as lightcurves to the corresponding objects.
 The support for the Fermi-LAT 1FHL catalog was dropped. An overview can be found
-on the `catalog docs page <catalog/index.rst>`__ and the `catalog tutorial notebook
-<tutorials/catalog.html>`__.
+on the catalog docs page and the catalog tutorial notebook.
 
 Error propagation is now fully supported for the ``AbsorbedSpectralModel`` and
 ``NaimaModel``.
@@ -956,7 +952,7 @@ Gammapy v0.14 features a new high level analysis interface. Starting from
 a YAML configuration file, it supports the standard use-cases of joint
 or stacked 3D as well as 1D reflected region analyses. It also supports
 computation of flux points for all cases. The usage of this new ``Analysis``
-class is demonstrated in the `hess.html <./tutorials/hess.html>`__ tutorial.
+class is demonstrated in the hess tutorial.
 
 Following the proposal in :ref:`pig-016` the subpackages ``gammapy.background``
 and ``gammapy.image`` were removed. Existing functionality was moved to the
@@ -1197,8 +1193,8 @@ gamma-ray data. To improve the fit convergence of the ``SkyDisk`` and ``SkyEllip
 models we introduced a new parameter defining the slope of the edge of these models.
 
 If you would like to know how to adapt your old spectral analysis scripts to Gammapy
-v0.12, please checkout the updated tutorial notebooks (https://docs.gammapy.org/0.12/tutorials.html)
-and `get in contact with us <https://gammapy.org/contact.html>`__ anytime if you need help.
+v0.12, please checkout the updated tutorial notebooks and get in contact with us
+anytime if you need help.
 
 **Contributors:**
 
@@ -1811,8 +1807,7 @@ Documentation:
   notebooks easier to navigate and search, a rendered static version of the notebooks was integrated
   in the Sphinx-based documentation (the one you are looking at) at :ref:`tutorials`.
 - Most of the Gammapy tutorials can be executed directly in the browser via the https://mybinder.org/
-  service. There is a "launch in binder" link at the top of each tutorial in the docs,
-  see e.g. here: `CTA data analysis with Gammapy <tutorials/cta_data_analysis.html>`__
+  service. There is a "launch in binder" link at the top of each tutorial in the docs.
 - A page was created to collect the information for CTA members how to get started with Gammapy
   and with contact / support channels: https://gammapy.org/cta.html
 
@@ -2153,7 +2148,7 @@ Summary
 
 - Tutorial-style getting started documentation as Jupyter notebooks
 - Removed ``gammapy.regions`` and have switched to the move complete
-  and powerful `regions <http://astropy-regions.readthedocs.io/>`__ package
+  and powerful `regions <https://astropy-regions.readthedocs.io/en/stable/>`__ package
   (planned to be added to the Astropy core within the next year).
 - ``gammapy.spectrum`` - Many 1-dimensional spectrum analysis improvements (e.g. spectral point computation)
 - ``gammapy.image`` - Many ``SkyImage`` improvements, adaptive ring background estimation, asmooth algorithm

--- a/docs/datasets/index.rst
+++ b/docs/datasets/index.rst
@@ -72,10 +72,9 @@ analyse the following datasets:
 
 
 In general, `OnOff` datasets should be used when the
-background is estimated from real off counts
-(eg: `RingBackground` or `ReflectedBackground`),
+background is estimated from real off counts,
 rather than from a background model.
-The `FluxPointDataset` is used to fit pre-computed flux points
+The `~gammapy.datasets.FluxPointsDataset` is used to fit pre-computed flux points
 when no convolution with IRFs are needed.
 
 
@@ -88,8 +87,7 @@ objects) with an energy axis. There are no spatial axes or information, the 1D
 spectra are obtained for a given on region.
 
 Note that in Gammapy, 2D image analyses are done with 3D cubes with a single
-energy bin, e.g. for modeling and fitting,
-see the `2D map analysis tutorial <./tutorials/image_analysis.html>`__.
+energy bin, e.g. for modeling and fitting.
 
 To analyse multiple runs, you can either stack the datasets together, or perform
 a joint fit across multiple datasets.

--- a/docs/development/dev_howto.rst
+++ b/docs/development/dev_howto.rst
@@ -412,7 +412,7 @@ See the `~gammapy.data.EventListDatasetChecker` as an example.
 Command line tools using click
 ------------------------------
 
-Command line tools that use the `click <http://click.pocoo.org/>`__ module should disable
+Command line tools that use the `click <https://click.palletsprojects.com/en/8.0.x/>`__ module should disable
 the unicode literals warnings to clean up the output of the tool:
 
 .. testcode::
@@ -420,7 +420,7 @@ the unicode literals warnings to clean up the output of the tool:
     import click
     click.disable_unicode_literals_warning = True
 
-See `here <http://click.pocoo.org/5/python3/#unicode-literals>`__ for further
+See `here <https://click.palletsprojects.com/en/5.x/python3/#unicode-literals>`__ for further
 information.
 
 
@@ -762,7 +762,7 @@ Notes:
   a well-defined alignment, like we have for the "FOV frames" above,
   doesn't occur and thus doesn't need to be defined yet (but it would be natural
   to use the same naming convention as for FOV if it eventually does occur).
-* These definitions are mostly in agreement with the `format spec <gadf>`_.
+* These definitions are mostly in agreement with the `Gamma Astro Data Formats`_ specifications.
   We do not achieve 100% consistency everywhere in the spec and Gammapy code.
   Achieving this seems unrealistic, because legacy formats have to be supported,
   we are not starting from scratch and have time to make all formats consistent.

--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -365,7 +365,6 @@ To check for broken external links from the Sphinx documentation:
 
 .. code-block:: bash
 
-   $ python setup.py install
    $ cd docs; make linkcheck
 
 You may also use `brök <https://github.com/smallhadroncollider/brok>`__ software, which will also check

--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -17,7 +17,7 @@ which is what most scientific Python packages use.
 
 .. _restructured text (RST): http://sphinx-doc.org/rest.html
 .. _Sphinx: http://sphinx-doc.org/
-.. _Numpy docstring standard: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+.. _Numpy docstring standard: https://github.com/numpy/numpy/blob/main/doc/HOWTO_DOCUMENT.rst.txt
 
 There's a few details that are not easy to figure out by browsing the Numpy or Astropy
 documentation guidelines, or that we actually do differently in Gammapy.
@@ -93,7 +93,7 @@ Class attributes
 Class attributes (data members) and properties are currently a bit of a mess.
 Attributes are listed in an *Attributes* section because I've listed them in a class-level
 docstring attributes section as recommended
-`here <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#class-docstring>`__.
+`here <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`__.
 Properties are listed in separate *Attributes summary* and *Attributes Documentation*
 sections, which is confusing to users ("what's the difference between attributes and properties?").
 

--- a/docs/development/intro.rst
+++ b/docs/development/intro.rst
@@ -118,7 +118,7 @@ Get set up
     The rest of this page isn't written yet. It's almost identical to
     https://cta-observatory.github.io/ctapipe/getting_started/index.html so for
     now, see there. Also, we shouldn't duplicate content from
-    http://astropy.readthedocs.io/en/latest/#developer-documentation but link
+    https://docs.astropy.org/en/latest/#developer-documentation but link
     there instead.
 
 The first steps are basically identical to

--- a/docs/development/pigs/pig-018.rst
+++ b/docs/development/pigs/pig-018.rst
@@ -319,4 +319,4 @@ weeks, but also in 2020 and after.
 .. _Glossary: https://docs.gammapy.org/0.14/references.html#glossary
 .. _Jupytext: https://jupytext.readthedocs.io
 .. _Documentation Github project: https://github.com/gammapy/gammapy/projects/1
-.. _HowTo documentation page: https://docs.gammapy.org/dev/howto.html
+.. _HowTo documentation page: https://docs.gammapy.org/dev/development/dev_howto.html

--- a/docs/estimators/index.rst
+++ b/docs/estimators/index.rst
@@ -214,5 +214,9 @@ Reference/API
     :no-inheritance-diagram:
     :include-all-objects:
 
+.. automodapi:: gammapy.estimators.utils
+    :no-inheritance-diagram:
+    :include-all-objects:
+
 
 .. _`likelihood SED type page`: https://gamma-astro-data-formats.readthedocs.io/en/latest/spectra/binned_likelihoods/index.html

--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -8,7 +8,7 @@ Installation
 Using Anaconda
 --------------
 The easiest way to install Gammapy is to install the Anaconda distribution.
-The installation is explained in the :ref:`quickstart` section.
+The installation is explained in the :ref:`getting-started` section.
 
 .. _virtual-envs:
 
@@ -18,7 +18,7 @@ Using virtual environments
 We recommend to create an isolated virtual environment for each version of Gammapy, so that you have full
 control over additional packages that you may use in your analysis. We provide, for each stable release of Gammapy,
 a YAML file that allows you to easily create a specific conda execution environment. This could also help you on
-improving reproducibility within the users community. See installation instructions on :ref:`quickstart` section.
+improving reproducibility within the users community. See installation instructions on :ref:`getting-started` section.
 
 You may prefer to create your virtual environments with Python `venv` command instead of using Anaconda.
 To create a virtual environment with `venv` (Python 3.5+ required) run the command:

--- a/docs/irf/bkg.rst
+++ b/docs/irf/bkg.rst
@@ -25,4 +25,4 @@ Its format specifications are available in :ref:`gadf:bkg_2d`.
 
 You can produce a radially-symmetric background from a list of DL3 observations 
 devoid of gamma-ray signal using the tutorial in 
-`background_model.html <../tutorials/background_model.html>`__ 
+`background_model.html <https://gammapy.github.io/gammapy-recipes/_build/html/notebooks/background-model/background_model.html>`__

--- a/docs/irf/index.rst
+++ b/docs/irf/index.rst
@@ -72,7 +72,3 @@ Reference/API
 .. automodapi:: gammapy.irf
     :no-inheritance-diagram:
     :include-all-objects:
-
-.. automodapi:: gammapy.irf.edisp
-    :no-inheritance-diagram:
-    :include-all-objects:

--- a/docs/irf/index.rst
+++ b/docs/irf/index.rst
@@ -49,7 +49,7 @@ Variable          Definition
 Getting started
 ===============
 
-See `cta.html <../tutorials/cta.html>`__ for an example how to access IACT IRFs.
+See `cta.html <../tutorials/data/cta.html>`__ for an example how to access IACT IRFs.
 
 Using `gammapy.irf`
 ===================
@@ -70,5 +70,9 @@ Reference/API
 =============
 
 .. automodapi:: gammapy.irf
+    :no-inheritance-diagram:
+    :include-all-objects:
+
+.. automodapi:: gammapy.irf.edisp
     :no-inheritance-diagram:
     :include-all-objects:

--- a/docs/makers/fov.rst
+++ b/docs/makers/fov.rst
@@ -14,13 +14,13 @@ Overview
 Background models stored in IRF might not predict accurately the actual number of background counts.
 To correct the predicted counts, one can use the data themselves in regions deprived of gamma-ray signal.
 The field-of-view background technique is used to adjust the predicted counts on the measured ones outside
-an exclusion mask. This technique is recommended for 3D analysis, in particular when stacking `Datasets`.
+an exclusion mask. This technique is recommended for 3D analysis, in particular when stacking `~gammapy.datasets.Datasets`.
 
 Gammapy provides the `~gammapy.makers.FoVBackgroundMaker`. The latter creates a
 `~gammapy.modeling.models.FoVBackgroundModel` which combines the `background` predicted number of counts
 and a `~gammapy.modeling.models.NormSpectralModel` which allows to renormalize the background cube, and
 possibly to change its spectral distribution. By default, only the `norm` parameter of a
-`~gammapy.modeling.models.PowerLaWNormSpectralModel` is left free. If needed the spectral parameters
+`~gammapy.modeling.models.PowerLawNormSpectralModel` is left free. If needed the spectral parameters
 can be unfrozen.
 
 .. testcode::

--- a/docs/makers/index.rst
+++ b/docs/makers/index.rst
@@ -47,3 +47,11 @@ Reference/API
 .. automodapi:: gammapy.makers
     :no-inheritance-diagram:
     :include-all-objects:
+
+.. automodapi:: gammapy.makers.background
+    :no-inheritance-diagram:
+    :include-all-objects:
+
+.. automodapi:: gammapy.makers.utils
+    :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/makers/index.rst
+++ b/docs/makers/index.rst
@@ -48,10 +48,6 @@ Reference/API
     :no-inheritance-diagram:
     :include-all-objects:
 
-.. automodapi:: gammapy.makers.background
-    :no-inheritance-diagram:
-    :include-all-objects:
-
 .. automodapi:: gammapy.makers.utils
     :no-inheritance-diagram:
     :include-all-objects:

--- a/docs/makers/reflected.rst
+++ b/docs/makers/reflected.rst
@@ -12,7 +12,7 @@ Overview
 --------
 
 This method is used in classical Cherenkov astronomy to estimate background
-for spectral analysis. As illustrated in `Fig. 1 <figure_reflected_background>`_,
+for spectral analysis. As illustrated in Fig. 1,
 a region on the sky, the ON region, is chosen to select events
 around the studied source position. In the absence of a solid template of the
 residual hadronic background, a classical method to estimate it is the so-called
@@ -33,7 +33,7 @@ be found in [Berge2007]_.
 
 The extraction of the OFF events from the `~gammapy.data.EventList` of a
 set of observations is performed by the `ReflectedRegionsBackgroundMaker`.
-The latter uses the `~gammapy.makers.ReflectedRegionsFinder` to create reflected
+The latter uses the `~gammapy.makers.background.ReflectedRegionsFinder` to create reflected
 regions for a given circular on region and exclusion mask.
 
 .. code-block:: python
@@ -87,7 +87,7 @@ The reflected region finder
 
 The following example illustrates how to create reflected regions for a given
 circular on region and exclusion mask using the
-`~gammapy.makers.ReflectedRegionsFinder`. In particular, it shows how to
+`~gammapy.makers.background.ReflectedRegionsFinder`. In particular, it shows how to
 change the minimal distance between the ON region and the reflected regions.
 This is useful to limit contamination by events leaking out the ON region. It
 also shows how to change the minimum distance between adjacent regions as well
@@ -100,7 +100,7 @@ Using the reflected background estimator
 ----------------------------------------
 
 In practice, the user does not usually need to directly interact with the
-`~gammapy.makers.ReflectedRegionsFinder`. This actually is done via the
+`~gammapy.makers.background.ReflectedRegionsFinder`. This actually is done via the
 `~gammapy.makers.ReflectedRegionsBackgroundMaker`, which extracts the ON
 and OFF events for an `~gammapy.data.Observations` object. The last example
 shows how to run it on a few observations with a rectangular region.

--- a/docs/makers/ring.rst
+++ b/docs/makers/ring.rst
@@ -11,7 +11,7 @@ Ring background
 Overview
 --------
 This background estimation technique is used in classical Cherenkov astronomy
-for 2D image analysis. The working principle is illustrated in `Fig. 1 <figure_ring_background>`_.
+for 2D image analysis. The working principle is illustrated in Fig. 1.
 For any given pixel in a counts map the off counts are estimate from a ring
 centered on the test position with a given fixed radius and width. To improve
 the estimate, regions with known gamma-ray emission are excluded from measuring

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -44,8 +44,8 @@ a map without reference to the underlying data representation (e.g. whether a
 map uses WCS or HEALPix pixelization). For applications which do depend on the
 specific representation one can also work directly with the classes derived from
 `~Map`. In the following we review some of the basic methods for working with
-map objects, more details are given in the * `maps tutorial <../tutorials/maps.html>`__
-.
+map objects, more details are given in the `maps tutorial <../tutorials/api/maps.html>`__.
+
 
 .. _node_types:
 
@@ -54,7 +54,7 @@ Differential and integral maps
 
 `gammapy.maps` supports both differential and integral maps, representing
 differential values at specific coordinates, or integral values within bins.
-This is achieved by specifying the ``node_type`` of a ``MapAxis``. Quantities
+This is achieved by specifying the ``node_type`` of a `~gammapy.maps.MapAxis`. Quantities
 defined at bin centers should have a node_type of "center", and quantities
 integrated in bins should have node_type of ``edges``. Interpolation is defined
 only for differential quantities.

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -6,7 +6,7 @@
 .. _Practical Python for Astronomers Tutorial: http://python4astronomers.github.io/
 .. _GammaLib: http://gammalib.sourceforge.net
 .. _ctools: http://cta.irap.omp.eu/ctools
-.. _3ML: https://threeml.stanford.edu/
+.. _3ML: https://github.com/threeML/threeML
 .. _numpy: http://www.numpy.org/
 .. _affiliated package: http://www.astropy.org/affiliated/index.html
 .. _regions: https://astropy-regions.readthedocs.io
@@ -42,9 +42,7 @@
 .. _click: http://click.pocoo.org/
 .. _sphinx-click: https://github.com/click-contrib/sphinx-click
 .. _pycrflux: https://github.com/akira-okumura/pycrflux
-.. _act-analysis: https://bitbucket.org/kosack/act-analysis
 .. _VHEObserverTools: https://github.com/kialio/VHEObserverTools
-.. _photon_simulator: http://yt-project.org/doc/analyzing/analysis_modules/photon_simulator.html
 .. _PINT: https://github.com/nanograv/PINT
 .. _Gamera: https://github.com/JoachimHahn/GAMERA
 .. _gammatools: https://github.com/woodmd/gammatools
@@ -70,6 +68,7 @@
 .. _Fermi ScienceTools: https://fermi.gsfc.nasa.gov/ssc/data/analysis/software/
 .. _FermiPy: https://github.com/fermiPy/fermipy
 .. _gadf: https://gamma-astro-data-formats.readthedocs.io/
+.. _Gamma Astro Data Formats: https://gamma-astro-data-formats.readthedocs.io/
 
 .. _April 2016 IACT data meeting: https://github.com/open-gamma-ray-astro/2016-04_IACT_DL3_Meeting/
 

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -25,7 +25,7 @@ Notations
 ---------
 
 For statistical analysis we use the following variable names following mostly the
-notation in [LiMa1983]_. For the ``MapDataset`` attributes we chose more verbose
+notation in [LiMa1983]_. For the `~gammapy.datasets.MapDataset` attributes we chose more verbose
 equivalents:
 
 ================= ====================== ====================================================

--- a/docs/tutorials/data/cta.ipynb
+++ b/docs/tutorials/data/cta.ipynb
@@ -9,7 +9,7 @@
     "## Introduction\n",
     "\n",
     "The [Cherenkov Telescope Array (CTA)](https://www.cta-observatory.org/) is the next generation ground-based observatory for gamma-ray astronomy.\n",
-    "Gammapy is a prototype for the Cherenkov Telescope Array (CTA) science tools ([2017ICRC...35..766D](https://ui.adsabs.harvard.edu/abs/2017ICRC...35..766D)).\n",
+    "Gammapy is the core library for the Cherenkov Telescope Array (CTA) science tools ([2017ICRC...35..766D](https://ui.adsabs.harvard.edu/abs/2017ICRC...35..766D) and [CTAO Press Release](https://www.cta-observatory.org/ctao-adopts-the-gammapy-software-package-for-science-analysis/)).\n",
     "\n",
     "CTA will start taking data in the coming years. For now, to learn how to analyse CTA data and to use Gammapy, if you are a member of the CTA consortium, you can use the simulated dataset from the CTA first data challenge which ran in 2017 and 2018.\n",
     "\n",

--- a/docs/tutorials/starting/analysis_1.ipynb
+++ b/docs/tutorials/starting/analysis_1.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "# High level interface\n",
     "\n",
-    "## Prerequisites:\n",
+    "## Prerequisites\n",
     "\n",
     "- Understanding the gammapy data workflow, in particular what are DL3 events and instrument response functions (IRF).\n",
     "\n",
@@ -43,7 +43,7 @@
     "\n",
     "**Objective: Create a 3D dataset of the Crab using the H.E.S.S. DL3 data release 1 and perform a simple model fitting of the Crab nebula.**\n",
     "\n",
-    "## Proposed approach:\n",
+    "## Proposed approach\n",
     "\n",
     "This notebook uses the high level `Analysis` class to orchestrate data reduction. In its current state, `Analysis` supports the standard analysis cases of joint or stacked 3D and 1D analyses. It is instantiated with an `AnalysisConfig` object that gives access to analysis parameters either directly or via a YAML config file. \n",
     "\n",
@@ -128,7 +128,7 @@
    "source": [
     "We want to use Crab runs from the H.E.S.S. DL3-DR1. We define here the datastore and a cone search of observations pointing with 5 degrees of the Crab nebula. Parameters can be set directly or as a python dict.\n",
     "\n",
-    "PS: do not forget to setup your environment variable _$GAMMAPY\\_DATA_ to your local directory containing the H.E.S.S. DL3-DR1 as described in [quickstart](https://docs.gammapy.org/dev/getting-started/quickstart.html#download-tutorials)."
+    "PS: do not forget to setup your environment variable _$GAMMAPY\\_DATA_ to your local directory containing the H.E.S.S. DL3-DR1 as described in [getting started](https://docs.gammapy.org/dev/getting-started/index.html#download-tutorials)."
    ]
   },
   {

--- a/docs/tutorials/starting/overview.ipynb
+++ b/docs/tutorials/starting/overview.ipynb
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In case you encounter an error, you can un-comment and execute the following cell to continue. But we recommend to set up your environment correctly as described in [quickstart](https://docs.gammapy.org/dev/getting-started/quickstart.html#download-tutorials) after you are done with this notebook."
+    "In case you encounter an error, you can un-comment and execute the following cell to continue. But we recommend to set up your environment correctly as described in [getting started](https://docs.gammapy.org/dev/getting-started/index.html#download-tutorials) after you are done with this notebook."
    ]
   },
   {

--- a/docs/userguide/howto.rst
+++ b/docs/userguide/howto.rst
@@ -27,10 +27,10 @@ Please give feedback and suggest additions to this page!
 
     To access IACT data in the DL3 format, use the `~gammapy.data.DataStore`. It allows
     easy access to observations stored in the DL3 data library. You can create it directly
-    as in `this example <tutorials/data/hess.html#Datastore>`__.
+    as in `this example <../tutorials/data/hess.html#Datastore>`__.
     It is also internally used by the high level interface `~gammapy.analysis.Analysis`. You
     can see how to properly set it `here
-    <tutorials/starting/analysis_1.html#Setting-the-data-to-use>`__.
+    <../tutorials/starting/analysis_1.html#Setting-the-data-to-use>`__.
 
 .. dropdown:: Select observations
     :animate: fade-in-slide-down
@@ -38,7 +38,7 @@ Please give feedback and suggest additions to this page!
     The `~gammapy.data.DataStore` provides access to a summary table of all observations available.
     It can be used to select observations with various criterion.
     You can for instance apply a cone search as shown `here
-    <tutorials/starting/analysis_2.html#Defining-the-datastore-and-selecting-observations>`__.
+    <../tutorials/starting/analysis_2.html#Defining-the-datastore-and-selecting-observations>`__.
     You can also select observations based on other information available using the
     `~gammapy.data.ObservationTable.select_observations` method.
 
@@ -48,21 +48,21 @@ Please give feedback and suggest additions to this page!
     IACT detection efficiency varies in the FoV. To have an estimate
     of the effective exposure with respect to the on-axis one,
     it can be useful to build an `on-axis equivalent lifetime map
-    <tutorials/data/hess.html#On-axis-equivalent-livetime>`__.
+    <../tutorials/data/hess.html#On-axis-equivalent-livetime>`__.
 
 .. dropdown:: Check IRFs
     :animate: fade-in-slide-down
 
     Gammapy offers a number of methods to explore the content of the various IRFs
     contained in an observation. This is usually done thanks to their ``peek()``
-    methods. See example for CTA `here <tutorials/data/cta.html#IRFs>`__ and for H.E.S.S.
-    `here <tutorials/data/hess.html#DL3-DR1>`__.
+    methods. See example for CTA `here <../tutorials/data/cta.html#IRFs>`__ and for H.E.S.S.
+    `here <../tutorials/data/hess.html#DL3-DR1>`__.
 
 .. dropdown:: Model 2D images
     :animate: fade-in-slide-down
 
     Gammapy treats 2D maps as 3D cubes with one bin in energy. To see an example of the relevant data reduction, see
-    `2-dim sky image analysis <tutorials#core-tutorials>`
+    `2-dim sky image analysis <../tutorials/index.html#d-image>`__.
 
     Sometimes, you might want to use previously obtained images lacking an energy axis
     (eg: reduced using traditional IACT tools) for modeling and fitting inside gammapy.
@@ -74,22 +74,22 @@ Please give feedback and suggest additions to this page!
     The `~gammapy.analysis.Analysis` class can perform spectral extraction. The
     `~gammapy.analysis.AnalysisConfig` must be defined to produce '1d' datasets.
     Alternatively, you can follow the `spectrum extraction notebook
-    <tutorials/analysis/1D/spectral_analysis.html>`__.
+    <../tutorials/analysis/1D/spectral_analysis.html>`__.
 
 .. dropdown:: Extract a lightcurve
     :animate: fade-in-slide-down
 
-    The `Light curve estimation <tutorials/analysis/time/light_curve.html>`__ tutorial shows how
+    The `Light curve estimation <../tutorials/analysis/time/light_curve.html>`__ tutorial shows how
     to extract a run-wise lightcurve.
 
     To perform an analysis in a time range smaller than that of an observation, it
-    is necessary to filter the latter with its `select_time` method. This produces
+    is necessary to filter the latter with its `~gammapy.data.Observations.select_time` method. This produces
     an new observation containing events in the specified time range. With the new
     `~gammapy.data.Observations` it is then possible to perform the usual data
     reduction which will produce datasets in the correct time range. The light curve
     extraction can then be performed as usual with the
     `~gammapy.estimators.LightCurveEstimator`. This is demonstrated in the `Light curve -
-    Flare <tutorials/analysis/time/light_curve_flare.html>`__ tutorial.
+    Flare <../tutorials/analysis/time/light_curve_flare.html>`__ tutorial.
 
 .. dropdown:: Choose units for plotting
     :animate: fade-in-slide-down
@@ -129,8 +129,8 @@ Please give feedback and suggest additions to this page!
     source as a function of observing time. In Gammapy, you can produce it with 1D
     (spectral) analysis. Once datasets are produced for a given ON region, you can
     access the total statistics with the ``info_table(cumulative=True)`` method of
-    `~gammapy.modeling.Datasets`. See example `here
-    <tutorials/analysis/1D/spectral_analysis.html#Source-statistic>`__.
+    `~gammapy.datasets.Datasets`. See example `here
+    <../tutorials/analysis/1D/spectral_analysis.html#Source-statistic>`__.
 
 .. dropdown:: Detect sources in a map
     :animate: fade-in-slide-down
@@ -142,7 +142,7 @@ Please give feedback and suggest additions to this page!
     used. A simple correlated Li & Ma significance can be used, in particular for
     ON-OFF datasets. The second step consists in applying a peak finer algorithm,
     such as `~gammapy.estimators.utils.find_peaks`. This is demonstrated in the `Source
-    detection tutorial <tutorials/analysis/2D/detect.html>`__.
+    detection tutorial <../tutorials/analysis/2D/detect.html>`__.
 
 .. dropdown:: Astrophysical source modeling
     :animate: fade-in-slide-down
@@ -159,7 +159,7 @@ Please give feedback and suggest additions to this page!
 
     Gammapy allows the flexibility of using user-defined models for analysis.
     For an example, see `Implementing a Custom Model
-    <tutorials/api/models.html#Implementing-a-Custom-Model>`__.
+    <../tutorials/api/models.html#Implementing-a-Custom-Model>`__.
 
 .. dropdown:: Implement an energy dependent spatial models
     :animate: fade-in-slide-down
@@ -167,7 +167,7 @@ Please give feedback and suggest additions to this page!
     While Gammapy does not ship energy dependent spatial models, it is possible to define
     such models within the modeling framework.
     For an example, see `here
-    <tutorials/api/models.html#Models-with-Energy-dependent-morphologyl>`__.
+    <../tutorials/api/models.html#Models-with-Energy-dependent-morphologyl>`__.
 
 .. dropdown:: Reduce memory budget for large datasets
     :animate: fade-in-slide-down
@@ -197,8 +197,8 @@ Please give feedback and suggest additions to this page!
 .. dropdown:: Interpolate maps onto a different geometry
     :animate: fade-in-slide-down
 
-    To interpolate maps onto a different geometry, use `Map.interp_to_geom`,
-    see `here <tutorials/api/maps.html#Filling-maps-from-interpolation>`__.
+    To interpolate maps onto a different geometry, use `~gammapy.maps.Map.interp_to_geom`,
+    see `here <../tutorials/api/maps.html#Filling-maps-from-interpolation>`__.
 
 .. dropdown:: Suppress warnings
     :animate: fade-in-slide-down

--- a/docs/userguide/howto.rst
+++ b/docs/userguide/howto.rst
@@ -209,7 +209,7 @@ Please give feedback and suggest additions to this page!
     logging output. In this case it can be useful to locally suppress a specific
     warning like so:
 
-    .. code::
+    .. testcode::
 
         from astropy.io.fits.verify import VerifyWarning
         import warnings

--- a/docs/userguide/package.rst
+++ b/docs/userguide/package.rst
@@ -35,7 +35,7 @@ instrument response functions (IRFs). The instrument response includes effective
 area, point spread function (PSF), energy dispersion and residual hadronic background.
 In addition there is associated meta data including information on the observation such
 as pointing] direction, observation time and observation conditions. The main FITS format
-supported by Gammapy is documented on the `Gamma astro data formats page <gadf>`_.
+supported by Gammapy is documented on the `Gamma Astro Data Formats`_ page.
 
 The access to the data and instrument response is implemented in
 :ref:`gammapy.data <data>` and :ref:`gammapy.irf <irf>`.

--- a/docs/userguide/references.rst
+++ b/docs/userguide/references.rst
@@ -189,9 +189,7 @@ Here are some other software packages for gamma-ray astronomy:
 * `Gamera`_ --- a C++ gamma-ray source modeling package (SED, SNR model, Galactic population model) with a Python wrapper called Gappa by Joachim Hahn
 * `FLaapLUC`_ --- Fermi/LAT automatic aperture photometry light-curve pipeline by Jean-Philippe Lenain
 * http://voparis-cta-client.obspm.fr/ --- prototype web app for CTA data access / analysis, not open source.
-* `act-analysis`_ --- Python scripts and Makefiles for some common gamma-ray data analysis tasks by Karl Kosack
 * `VHEObserverTools`_ --- tools to predict detectability at VHE by Jeremy Perkins
-* `photon_simulator`_ --- Python code to simulate X-ray observations
 * `pycrflux`_ --- Python module to plot cosmic-ray flux
 * Andy strong has C++ codes (GALPROP and Galplot) for Galactic cosmic rays and emission
   and source population synthesis at http://www.mpe.mpg.de/~aws/propagate.html .

--- a/docs/userguide/references.rst
+++ b/docs/userguide/references.rst
@@ -161,9 +161,6 @@ Software references:
 .. [Robitaille2013] `Robitaille et al. (2013) <https://ui.adsabs.harvard.edu/abs/2013A%26A...558A..33A>`_
    "Astropy: A community Python package for astronomy"
 
-.. [Knoedlseder2016] `Knödlseder et at. (2016) <https://ui.adsabs.harvard.edu/abs/2016A%26A...593A...1K>`_
-   "GammaLib and ctools. A software framework for the analysis of astronomical gamma-ray data"
-
 .. [FSSC2013] `Fermi LAT Collaboration (2013) <https://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/overview.html>`_
    "Science Tools: LAT Data Analysis Tools"
 

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -82,7 +82,7 @@ is done automatically by `astropy.coordinates.AltAz` when the
 `astropy.coordinates.AltAz.obstime` is set with a `~astropy.time.Time` object in
 any scale, no need for explicit time scale transformations in Gammapy (although
 if you do want to explicitly compute it, it's easy, see `here
-<http://docs.astropy.org/en/latest/time/index.html#sidereal-time>`__).
+<https://docs.astropy.org/en/latest/api/astropy.time.Time.html#astropy.time.Time.sidereal_time>`__).
 
 The `Fermi-LAT time systems in a nutshell`_ page gives a good, brief explanation
 of the differences between the relevant time scales ``UT1``, ``UTC`` and ``TT``.

--- a/gammapy/astro/source/pulsar.py
+++ b/gammapy/astro/source/pulsar.py
@@ -18,8 +18,6 @@ B_CONST = Quantity(3.2e19, "gauss s^(-1/2)")
 class SimplePulsar:
     """Magnetic dipole spin-down model for a pulsar.
 
-    Reference: http://www.cv.nrao.edu/course/astr534/Pulsars.html
-
     Parameters
     ----------
     P : `~astropy.units.Quantity`
@@ -65,8 +63,6 @@ class SimplePulsar:
 
 class Pulsar:
     """Magnetic dipole spin-down pulsar model.
-
-    Reference: http://www.cv.nrao.edu/course/astr534/Pulsars.html
 
     Parameters
     ----------

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -23,7 +23,7 @@ class DataStore:
     The data selection and access happens using an observation
     and an HDU index file as described at :ref:`gadf:iact-storage`.
 
-    For a usage example see `cta.html <../tutorials/cta.html>`__
+    For a usage example see `cta.html <../tutorials/data/cta.html>`__
 
     Parameters
     ----------

--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -31,7 +31,7 @@ class SensitivityEstimator(Estimator):
 
     Examples
     --------
-    For a usage example see `cta_sensitivity.html <../tutorials/cta_sensitivity.html>`__
+    For a usage example see `cta_sensitivity.html <../tutorials/analysis/1D/cta_sensitivity.html>`__
 
     """
 

--- a/gammapy/irf/__init__.py
+++ b/gammapy/irf/__init__.py
@@ -26,5 +26,5 @@ IRF_REGISTRY = Registry(
     ]
 )
 
-__all__ = ["IRF_REGISTRY"]
+__all__ = ["IRF_REGISTRY", "EDispKernel", "PSFKernel"]
 __all__.extend(cls.__name__ for cls in IRF_REGISTRY)

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class ReflectedRegionsFinder:
     """Find reflected regions.
 
-    This class is responsible for placing :ref:`region_reflected` for a given
+    This class is responsible for placing a reflected region for a given
     input region and pointing position. It converts to pixel coordinates
     internally assuming a tangent projection at center position.
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -76,7 +76,7 @@ class Fit:
         Global backend used for fitting, default : minuit
     optimize_opts : dict
         Keyword arguments passed to the optimizer. For the `"minuit"` backend
-        see https://iminuit.readthedocs.io/en/latest/api.html#iminuit.Minuit
+        see https://iminuit.readthedocs.io/en/stable/reference.html#iminuit.Minuit
         for a detailed description of the available options. If there is an entry
         'migrad_opts', those options will be passed to `iminuit.Minuit.migrad()`.
 


### PR DESCRIPTION
This PR fixes all broken links found with [make linkcheck](https://docs.gammapy.org/dev/development/doc_howto.html#check-broken-links) in RST files, notebooks and docstrings within scripts, as well as those listed in https://github.com/gammapy/gammapy/issues/3143#issuecomment-1005927960 fixing also others issues from that list. It also adds some subpackages missing in the docs as reported in https://github.com/gammapy/gammapy/issues/3679 and  https://github.com/gammapy/gammapy/issues/3143#issuecomment-1007430661