### PR TITLE
Fix print of catalogs

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -99,6 +99,11 @@ class SourceCatalog(abc.ABC):
         """Catalog description (str)."""
         pass
 
+    @property
+    @abc.abstractmethod
+    def tag(self):
+        pass
+
     source_object_class = SourceCatalogObject
     """Source class (`SourceCatalogObject`)."""
 
@@ -110,7 +115,7 @@ class SourceCatalog(abc.ABC):
     def __str__(self):
         return (
             f"{self.__class__.__name__}:\n"
-            f"    name: {self.name}\n"
+            f"    name: {self.tag}\n"
             f"    description: {self.description}\n"
             f"    sources: {len(self.table)}\n"
         )

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.table import Column, Table
 from astropy.units import Quantity
-from gammapy.catalog import SourceCatalog, CATALOG_REGISTRY
+from gammapy.catalog import SourceCatalog
 from gammapy.utils.testing import assert_quantity_allclose
 
 
@@ -12,6 +12,7 @@ class SomeSourceCatalog(SourceCatalog):
     """Minimal test source catalog class for unit tests."""
 
     name = "test123"
+    tag = "test123"
     description = "Test source catalog"
 
 
@@ -29,6 +30,7 @@ class TestSourceCatalog:
 
     def test_str(self):
         assert "description" in str(self.cat)
+        assert "name" in str(self.cat)
 
     def test_table(self):
         assert_allclose(self.cat.table["RA"][1], 43.3)

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.table import Column, Table
 from astropy.units import Quantity
-from gammapy.catalog import SourceCatalog
+from gammapy.catalog import SourceCatalog, CATALOG_REGISTRY
 from gammapy.utils.testing import assert_quantity_allclose
 
 

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -34,6 +34,10 @@ class TestSourceCatalogHGPS:
         assert len(cat.table) == 78
 
     @staticmethod
+    def test_str(cat):
+        assert "name: hgps" in str(cat.__str__())
+
+    @staticmethod
     def test_positions(cat):
         assert len(cat.positions) == 78
 


### PR DESCRIPTION
Fixes #3749 by replacing `catalog.name` by `catalog.tag`
I do not know how best to add a test for a print statement