### PR TITLE
Change flux map attribute axis type 

### DIFF
--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -446,9 +446,11 @@ class FluxMaps:
 
     @staticmethod
     def _change_energy_axis_node_type(input_map, node_type='center'):
-        """This change the node_type of the input map."""
-        input_map.geom.axes["energy"]._node_type = node_type
-        return input_map
+        """Change the node_type of the input map."""
+        energy_axis = input_map.geom.axes["energy"]
+        new_axis = energy_axis.to_node_type(node_type)
+        geom = input_map.geom.replace_axis(axis=new_axis)
+        return Map.from_geom(geom, data=input_map.data, unit=input_map.unit, meta=input_map.meta)
 
     @property
     def npred_excess_ref(self):

--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -444,6 +444,12 @@ class FluxMaps:
             data = np.expand_dims(data, axis=idx)
         return data
 
+    @staticmethod
+    def _change_energy_axis_node_type(input_map, node_type='center'):
+        """This change the node_type of the input map."""
+        input_map.geom.axes["energy"]._node_type = node_type
+        return input_map
+
     @property
     def npred_excess_ref(self):
         """Predicted excess reference counts"""
@@ -592,52 +598,52 @@ class FluxMaps:
     @property
     def dnde(self):
         """Return differential flux (dnde) SED values."""
-        return self.norm * self.dnde_ref
+        return self._change_energy_axis_node_type(self.norm * self.dnde_ref)
 
     @property
     def dnde_err(self):
         """Return differential flux (dnde) SED errors."""
-        return self.norm_err * self.dnde_ref
+        return self._change_energy_axis_node_type(self.norm_err * self.dnde_ref)
 
     @property
     def dnde_errn(self):
         """Return differential flux (dnde) SED negative errors."""
-        return self.norm_errn * self.dnde_ref
+        return self._change_energy_axis_node_type(self.norm_errn * self.dnde_ref)
 
     @property
     def dnde_errp(self):
         """Return differential flux (dnde) SED positive errors."""
-        return self.norm_errp * self.dnde_ref
+        return self._change_energy_axis_node_type(self.norm_errp * self.dnde_ref)
 
     @property
     def dnde_ul(self):
         """Return differential flux (dnde) SED upper limit."""
-        return self.norm_ul * self.dnde_ref
+        return self._change_energy_axis_node_type(self.norm_ul * self.dnde_ref)
 
     @property
     def e2dnde(self):
         """Return differential energy flux (e2dnde) SED values."""
-        return self.norm * self.e2dnde_ref
+        return self._change_energy_axis_node_type(self.norm * self.e2dnde_ref)
 
     @property
     def e2dnde_err(self):
         """Return differential energy flux (e2dnde) SED errors."""
-        return self.norm_err * self.e2dnde_ref
+        return self._change_energy_axis_node_type(self.norm_err * self.e2dnde_ref)
 
     @property
     def e2dnde_errn(self):
         """Return differential energy flux (e2dnde) SED negative errors."""
-        return self.norm_errn * self.e2dnde_ref
+        return self._change_energy_axis_node_type(self.norm_errn * self.e2dnde_ref)
 
     @property
     def e2dnde_errp(self):
         """Return differential energy flux (e2dnde) SED positive errors."""
-        return self.norm_errp * self.e2dnde_ref
+        return self._change_energy_axis_node_type(self.norm_errp * self.e2dnde_ref)
 
     @property
     def e2dnde_ul(self):
         """Return differential energy flux (e2dnde) SED upper limit."""
-        return self.norm_ul * self.e2dnde_ref
+        return self._change_energy_axis_node_type(self.norm_ul * self.e2dnde_ref)
 
     @property
     def flux(self):

--- a/gammapy/estimators/map/tests/test_core.py
+++ b/gammapy/estimators/map/tests/test_core.py
@@ -426,10 +426,17 @@ def test_flux_map_from_dict_inconsistent_units(wcs_flux_map, reference_model):
     assert_allclose(flux_map.norm_err.data[:, 0, 0], 0.1)
     assert flux_map.norm_err.unit == ""
 
-def test_flux_map_check_node_types(wcs_flux_map, reference_model):
+def test_flux_map_check_node_types(wcs_flux_map, region_map_flux_estimate, reference_model):
     ref_map = FluxMaps(wcs_flux_map, reference_model)
+    ref_region_map = FluxMaps(region_map_flux_estimate, reference_model)
 
     assert ref_map.dnde.geom.axes[0].node_type == 'center'
     assert ref_map.e2dnde.geom.axes[0].node_type == 'center'
     assert ref_map.flux.geom.axes[0].node_type == 'edges'
     assert ref_map.eflux.geom.axes[0].node_type == 'edges'
+
+    assert ref_region_map.dnde_err.geom.axes[0].node_type == 'center'
+    assert ref_region_map.e2dnde_ul.geom.axes[0].node_type == 'center'
+    assert ref_region_map.flux_err.geom.axes[0].node_type == 'edges'
+    assert ref_region_map.eflux_ul.geom.axes[0].node_type == 'edges'
+

--- a/gammapy/estimators/map/tests/test_core.py
+++ b/gammapy/estimators/map/tests/test_core.py
@@ -425,3 +425,11 @@ def test_flux_map_from_dict_inconsistent_units(wcs_flux_map, reference_model):
     assert flux_map.norm.unit == ""
     assert_allclose(flux_map.norm_err.data[:, 0, 0], 0.1)
     assert flux_map.norm_err.unit == ""
+
+def test_flux_map_check_node_types(wcs_flux_map, reference_model):
+    ref_map = FluxMaps(wcs_flux_map, reference_model)
+
+    assert ref_map.dnde.geom.axes[0].node_type == 'center'
+    assert ref_map.e2dnde.geom.axes[0].node_type == 'center'
+    assert ref_map.flux.geom.axes[0].node_type == 'edges'
+    assert ref_map.eflux.geom.axes[0].node_type == 'edges'

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -62,7 +62,7 @@ PLOT_AXIS_LABEL = {
     "time": "Time",
 }
 
-DEFAULT_LABEL_TEMPLATE = '{quantity} [{unit}]'
+DEFAULT_LABEL_TEMPLATE = "{quantity} [{unit}]"
 
 
 class MapAxis:
@@ -280,6 +280,34 @@ class MapAxis:
 
         return mpl_scale[self.interp]
 
+    def to_node_type(self, node_type):
+        """Return MapAxis copy chaning its node type to node_type.
+
+        Parameters
+        ----------
+        node_type : str 'edges' or 'center'
+            the target node type
+
+        Returns
+        -------
+        axis : `~gammapy.maps.MapAxis`
+            the new MapAxis
+        """
+        if node_type == self.node_type:
+            return self
+        else:
+            if node_type == "center":
+                nodes = self.center
+            else:
+                nodes = self.edges
+            return self.__class__(
+                nodes=nodes,
+                interp=self.interp,
+                name=self.name,
+                node_type=node_type,
+                unit=self.unit,
+            )
+
     def format_plot_xaxis(self, ax):
         """Format plot axis
 
@@ -296,8 +324,9 @@ class MapAxis:
         ax.set_xscale(self.as_plot_scale)
 
         xlabel = DEFAULT_LABEL_TEMPLATE.format(
-                                        quantity=PLOT_AXIS_LABEL.get(self.name, self.name.capitalize())
-                                        , unit=self.unit )
+            quantity=PLOT_AXIS_LABEL.get(self.name, self.name.capitalize()),
+            unit=self.unit,
+        )
         ax.set_xlabel(xlabel)
         xmin, xmax = self.bounds
         if not xmin == xmax:
@@ -2214,8 +2243,9 @@ class TimeMapAxis:
         from matplotlib.dates import DateFormatter
 
         xlabel = DEFAULT_LABEL_TEMPLATE.format(
-                                        quantity=PLOT_AXIS_LABEL.get(self.name, self.name.capitalize())
-                                        , unit=self.time_format )
+            quantity=PLOT_AXIS_LABEL.get(self.name, self.name.capitalize()),
+            unit=self.time_format,
+        )
         ax.set_xlabel(xlabel)
 
         if self.time_format == "iso":


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the axis type of the `FluxMaps.dnde` and `FluxMaps.e2dnde` attributes to `center`. This correctly represents differential quantities.

For now a static methods changes the `MapAxis._node_type` keyword. Possibly it could be better to add a setter on the `MapAxis.node_type` itself.

This solves #3766.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
