### PR TITLE
Make `make docs-show` work not only on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,8 @@ docs-all:
 	python -m gammapy.utils.notebooks_links --src="$(src)"
 
 docs-show:
-	open docs/_build/html/index.html
+	python docs/serve.py
+
 
 trailing-spaces:
 	find $(PROJECT) examples docs -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;

--- a/docs/serve.py
+++ b/docs/serve.py
@@ -1,0 +1,34 @@
+'''
+Serve the docs page and open in default browser.
+
+Combination of these two SO (license CC-BY-SA 4.0) answers:
+https://stackoverflow.com/a/51295415/3838691
+https://stackoverflow.com/a/52531444/3838691
+'''
+import time
+from threading import Thread
+import webbrowser
+from functools import partial
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+ip = "localhost"
+port = 8000
+directory = "docs/_build/html"
+server_address = (ip, port)
+url = f"http://{ip}:{port}"
+
+
+def open_docs():
+    # give http server a little time to startup
+    time.sleep(0.1)
+    webbrowser.open(url)
+
+
+if __name__ == '__main__':
+    Thread(target=open_docs).start()
+    Handler = partial(SimpleHTTPRequestHandler, directory=directory)
+    httpd = HTTPServer(server_address, Handler)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
The `make docs-show` command used `open docs/_build/html/index.html` which is bad for two reasons:

* It only workes on macOS as other systems don't usually have the `open` command available in `sh` which is used by Make
* It opens the index file in the browser, instead of really serving the directory. Which can create problems with loading the custom css or js.

This adds a little python script using the python simple http server to serve the docs directory and open the served page in the default browser, which should work cross platform and handle the real webpage better.