### PR TITLE
Remove uneeded pins to old versions of h5py and nbformat

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -64,7 +64,7 @@ dependencies:
   - twine
   - yamllint
   - nbformat
-  - h5py=3
+  - h5py
   - ruamel.yaml
   - pip:
       - pytest-sphinx

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -63,8 +63,8 @@ dependencies:
   - pydata-sphinx-theme
   - twine
   - yamllint
-  - nbformat==5.0.8
-  - h5py==2.10.0
+  - nbformat
+  - h5py=3
   - ruamel.yaml
   - pip:
       - pytest-sphinx


### PR DESCRIPTION
* Remove pin to h5py < 3, I guess this was due to https://github.com/astropy/astropy/pull/11359, but this got fixed in the astropy versions we are using

* What was the reason for pinning nbformat?