### PR TITLE
Bug fix in ParametricPSF

### DIFF
--- a/gammapy/irf/psf/parametric.py
+++ b/gammapy/irf/psf/parametric.py
@@ -191,7 +191,7 @@ class ParametricPSF(PSF):
         energy_axis_true = self.axes["energy_true"]
 
         if rad is None:
-            rad_axis = RAD_AXIS_DEFAULT.center
+            rad_axis = RAD_AXIS_DEFAULT
         else:
             rad_axis = MapAxis.from_edges(rad, name="rad")
 

--- a/gammapy/irf/psf/tests/test_parametric.py
+++ b/gammapy/irf/psf/tests/test_parametric.py
@@ -60,6 +60,10 @@ class TestEnergyDependentMultiGaussPSF:
         )
         assert_allclose(np.squeeze(desired), actual, atol=0.005)
 
+        # test default case
+        psf_3d_def = psf.to_psf3d()
+        assert psf_3d_def.axes["rad"].nbin == 66
+
     @requires_dependency("matplotlib")
     def test_peek(self, psf):
         with mpl_plot_check():


### PR DESCRIPTION
Minor bug: `to_psf3d` was failing for the default rad axis. Fixing in this PR