### PR TITLE
Validate EnergyDispersion2D units

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -112,7 +112,7 @@ class Background3D(BackgroundIRF):
 
     tag = "bkg_3d"
     required_axes = ["energy", "fov_lon", "fov_lat"]
-    unit = u.Unit("s-1 MeV-1 sr-1")
+    default_unit = u.s**-1 * u.MeV**-1 * u.sr**-1
 
     def to_2d(self):
         """Convert to `Background2D`.
@@ -214,7 +214,7 @@ class Background2D(BackgroundIRF):
 
     tag = "bkg_2d"
     required_axes = ["energy", "offset"]
-    unit = u.Unit("s-1 MeV-1 sr-1")
+    default_unit = u.s**-1 * u.MeV**-1 * u.sr**-1
     default_interp_kwargs = dict(bounds_error=False, fill_value=0.0)
     """Default Interpolation kwargs."""
 

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -112,6 +112,7 @@ class Background3D(BackgroundIRF):
 
     tag = "bkg_3d"
     required_axes = ["energy", "fov_lon", "fov_lat"]
+    unit = u.Unit("s-1 MeV-1 sr-1")
 
     def to_2d(self):
         """Convert to `Background2D`.
@@ -213,6 +214,7 @@ class Background2D(BackgroundIRF):
 
     tag = "bkg_2d"
     required_axes = ["energy", "offset"]
+    unit = u.Unit("s-1 MeV-1 sr-1")
     default_interp_kwargs = dict(bounds_error=False, fill_value=0.0)
     """Default Interpolation kwargs."""
 

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -44,7 +44,7 @@ class IRF(metaclass=abc.ABCMeta):
         self._axes = axes
         if isinstance(data, u.Quantity):
             self.data = data.value
-            if not self.unit.is_equivalent(data.unit):
+            if not self.default_unit.is_equivalent(data.unit):
                 raise ValueError(f"Error: {data.unit} is not an allowed unit. {self.tag} requires dimensionless data quantities!")
             else:
                 self.unit = data.unit

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -45,6 +45,9 @@ class IRF(metaclass=abc.ABCMeta):
         if isinstance(data, u.Quantity):
             self.data = data.value
             self.unit = data.unit
+            if self.axes.names == ["energy_true", "migra", "offset"] :
+                if self.unit != u.dimensionless_unscaled:
+                    raise ValueError(f"Error: {self.unit} is not an allowed unit. EDisp requires dimensionless data quantities!")
         else:
             self.data = data
             self.unit = unit

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -44,10 +44,10 @@ class IRF(metaclass=abc.ABCMeta):
         self._axes = axes
         if isinstance(data, u.Quantity):
             self.data = data.value
-            self.unit = data.unit
-            if self.axes.names == ["energy_true", "migra", "offset"] :
-                if self.unit != u.dimensionless_unscaled:
-                    raise ValueError(f"Error: {self.unit} is not an allowed unit. EDisp requires dimensionless data quantities!")
+            if not self.unit.is_equivalent(data.unit):
+                raise ValueError(f"Error: {data.unit} is not an allowed unit. {self.tag} requires dimensionless data quantities!")
+            else:
+                self.unit = data.unit
         else:
             self.data = data
             self.unit = unit

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -45,7 +45,7 @@ class IRF(metaclass=abc.ABCMeta):
         if isinstance(data, u.Quantity):
             self.data = data.value
             if not self.default_unit.is_equivalent(data.unit):
-                raise ValueError(f"Error: {data.unit} is not an allowed unit. {self.tag} requires dimensionless data quantities!")
+                raise ValueError(f"Error: {data.unit} is not an allowed unit. {self.tag} requires {self.default_unit} data quantities.")
             else:
                 self.unit = data.unit
         else:

--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -48,7 +48,7 @@ class EnergyDispersion2D(IRF):
 
     tag = "edisp_2d"
     required_axes = ["energy_true", "migra", "offset"]
-    unit = u.Unit("")
+    default_unit = u.one
 
     def _mask_out_bounds(self, invalid):
         return (

--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -48,6 +48,7 @@ class EnergyDispersion2D(IRF):
 
     tag = "edisp_2d"
     required_axes = ["energy_true", "migra", "offset"]
+    unit = u.Unit("")
 
     def _mask_out_bounds(self, invalid):
         return (

--- a/gammapy/irf/edisp/tests/test_core.py
+++ b/gammapy/irf/edisp/tests/test_core.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
@@ -83,6 +84,12 @@ class TestEnergyDispersion2D:
         axes = MapAxes([energy_axis_true, migra_axis, offset_axis])
 
         data = np.ones(shape=axes.shape)
+        
+        with pytest.raises(ValueError) as error:
+            unit = u.m**2
+            edisp = EnergyDispersion2D(axes=axes, data=data * unit)
+            assert error.match(f"Error: {unit} is not an allowed unit. EDisp requires dimensionless data quantities!")
+
         edisp = EnergyDispersion2D(axes=axes, data=data)
 
         hdu = edisp.to_table_hdu()

--- a/gammapy/irf/edisp/tests/test_core.py
+++ b/gammapy/irf/edisp/tests/test_core.py
@@ -85,10 +85,11 @@ class TestEnergyDispersion2D:
 
         data = np.ones(shape=axes.shape)
         
+        edisp_test = EnergyDispersion2D(axes=axes)
         with pytest.raises(ValueError) as error:
             wrong_unit = u.m**2
-            edisp = EnergyDispersion2D(axes=axes, data=data * wrong_unit)
-            assert error.match(f"Error: {wrong_unit} is not an allowed unit. {edisp.tag} requires dimensionless data quantities!")
+            EnergyDispersion2D(axes=axes, data=data * wrong_unit)
+            assert error.match(f"Error: {wrong_unit} is not an allowed unit. {edisp_test.tag} requires {edisp_test.default_unit} data quantities.")
 
         edisp = EnergyDispersion2D(axes=axes, data=data)
 

--- a/gammapy/irf/edisp/tests/test_core.py
+++ b/gammapy/irf/edisp/tests/test_core.py
@@ -86,9 +86,9 @@ class TestEnergyDispersion2D:
         data = np.ones(shape=axes.shape)
         
         with pytest.raises(ValueError) as error:
-            unit = u.m**2
-            edisp = EnergyDispersion2D(axes=axes, data=data * unit)
-            assert error.match(f"Error: {unit} is not an allowed unit. EDisp requires dimensionless data quantities!")
+            wrong_unit = u.m**2
+            edisp = EnergyDispersion2D(axes=axes, data=data * wrong_unit)
+            assert error.match(f"Error: {wrong_unit} is not an allowed unit. {edisp.tag} requires dimensionless data quantities!")
 
         edisp = EnergyDispersion2D(axes=axes, data=data)
 

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -64,7 +64,7 @@ class EffectiveAreaTable2D(IRF):
 
     tag = "aeff_2d"
     required_axes = ["energy_true", "offset"]
-    unit = u.Unit("m**2")
+    default_unit = u.m**2
 
     def plot_energy_dependence(self, ax=None, offset=None, **kwargs):
         """Plot effective area versus energy for a given offset.

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -64,6 +64,7 @@ class EffectiveAreaTable2D(IRF):
 
     tag = "aeff_2d"
     required_axes = ["energy_true", "offset"]
+    unit = u.Unit("m**2")
 
     def plot_energy_dependence(self, ax=None, offset=None, **kwargs):
         """Plot effective area versus energy for a given offset.

--- a/gammapy/irf/psf/table.py
+++ b/gammapy/irf/psf/table.py
@@ -29,4 +29,4 @@ class PSF3D(PSF):
 
     tag = "psf_table"
     required_axes = ["energy_true", "offset", "rad"]
-    unit = u.Unit("sr**-1")
+    default_unit = u.sr**-1

--- a/gammapy/irf/psf/table.py
+++ b/gammapy/irf/psf/table.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
+import astropy.units as u
 from .core import PSF
 
 __all__ = ["PSF3D"]
@@ -28,3 +29,4 @@ class PSF3D(PSF):
 
     tag = "psf_table"
     required_axes = ["energy_true", "offset", "rad"]
+    unit = u.Unit("sr**-1")

--- a/gammapy/irf/psf/tests/test_table.py
+++ b/gammapy/irf/psf/tests/test_table.py
@@ -23,10 +23,11 @@ def test_psf_3d_wrong_units():
 
     wrong_unit = u.cm**2 * u.s
     data = np.ones((energy_axis.nbin, offset_axis.nbin, rad_axis.nbin)) * wrong_unit
+    psf3d_test = PSF3D(axes=[energy_axis, offset_axis, rad_axis])
     with pytest.raises(ValueError) as error:
-        psf3d = PSF3D(axes=[energy_axis, offset_axis, rad_axis],
+        PSF3D(axes=[energy_axis, offset_axis, rad_axis],
                  data=data)
-        assert error == (f"Error: {wrong_unit} is not an allowed unit. {psf3d.tag} requires dimensionless data quantities!")
+        assert error.match(f"Error: {wrong_unit} is not an allowed unit. {psf3d_test.tag} requires {psf3d_test.default_unit} data quantities.")
 
 
 @requires_data()

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -248,8 +248,6 @@ def test_bkg_2d_wrong_units():
 
     wrong_unit = u.cm**2 * u.s
     data = np.ones((energy_axis.nbin, offset_axis.nbin)) * wrong_unit
-    # Axis order is (energy, fov_lon, fov_lat)
-    # data.value[1, 0, 0] = 1
     with pytest.raises(ValueError) as error:
         bkg2d = Background2D(axes=[energy_axis, offset_axis],
                  data=data)

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -220,6 +220,42 @@ def test_background_3d_read_gadf():
     assert data.unit == "s-1 MeV-1 sr-1"
 
 
+def test_bkg_3d_wrong_units():
+    energy = [0.1, 10, 1000] * u.TeV
+    energy_axis = MapAxis.from_energy_edges(energy)
+
+    fov_lon = [0, 1, 2, 3] * u.deg
+    fov_lon_axis = MapAxis.from_edges(fov_lon, name="fov_lon")
+
+    fov_lat = [0, 1, 2, 3] * u.deg
+    fov_lat_axis = MapAxis.from_edges(fov_lat, name="fov_lat")
+
+    wrong_unit = u.cm**2 * u.s
+    data = np.ones((2, 3, 3)) * wrong_unit
+    # Axis order is (energy, fov_lon, fov_lat)
+    # data.value[1, 0, 0] = 1
+    with pytest.raises(ValueError) as error:
+        bkg3d = Background3D(axes=[energy_axis, fov_lon_axis, fov_lat_axis],
+                 data=data)
+        assert error == (f"Error: {wrong_unit} is not an allowed unit. {bkg3d.tag} requires dimensionless data quantities!")
+
+
+def test_bkg_2d_wrong_units():
+    energy = [0.1, 10, 1000] * u.TeV
+    energy_axis = MapAxis.from_energy_edges(energy)
+    
+    offset_axis = MapAxis.from_edges([0, 1, 2], unit="deg", name="offset")
+
+    wrong_unit = u.cm**2 * u.s
+    data = np.ones((energy_axis.nbin, offset_axis.nbin)) * wrong_unit
+    # Axis order is (energy, fov_lon, fov_lat)
+    # data.value[1, 0, 0] = 1
+    with pytest.raises(ValueError) as error:
+        bkg2d = Background2D(axes=[energy_axis, offset_axis],
+                 data=data)
+        assert error == (f"Error: {wrong_unit} is not an allowed unit. {bkg2d.tag} requires dimensionless data quantities!")
+
+
 def test_background_2d_read_missing_hducls():
     energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
     offset_axis = MapAxis.from_edges([0, 1, 2], unit="deg", name="offset")

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -235,7 +235,7 @@ def test_bkg_3d_wrong_units():
     with pytest.raises(ValueError) as error:
         Background3D(axes=[energy_axis, fov_lon_axis, fov_lat_axis],
                  data=data)
-    assert error.match(f"Error: (.*) is not an allowed unit. (.*) requires (.*) data quantities.")
+    assert error.match("Error: (.*) is not an allowed unit. (.*) requires (.*) data quantities.")
 
 
 def test_bkg_2d_wrong_units():

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -236,7 +236,7 @@ def test_bkg_3d_wrong_units():
     with pytest.raises(ValueError) as error:
         Background3D(axes=[energy_axis, fov_lon_axis, fov_lat_axis],
                  data=data)
-    assert error.match(f"Error: {wrong_unit} is not an allowed unit. {bkg3d_test.tag} requires {bkg3d_test.default_unit} data quantities.")
+    assert error.match(f"Error: (.*) is not an allowed unit. (.*) requires (.*) data quantities.")
 
 
 def test_bkg_2d_wrong_units():

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -232,7 +232,6 @@ def test_bkg_3d_wrong_units():
 
     wrong_unit = u.cm**2 * u.s
     data = np.ones((2, 3, 3)) * wrong_unit
-    bkg3d_test = Background3D(axes=[energy_axis, fov_lon_axis, fov_lat_axis])
     with pytest.raises(ValueError) as error:
         Background3D(axes=[energy_axis, fov_lon_axis, fov_lat_axis],
                  data=data)

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -232,12 +232,11 @@ def test_bkg_3d_wrong_units():
 
     wrong_unit = u.cm**2 * u.s
     data = np.ones((2, 3, 3)) * wrong_unit
-    # Axis order is (energy, fov_lon, fov_lat)
-    # data.value[1, 0, 0] = 1
+    bkg3d_test = Background3D(axes=[energy_axis, fov_lon_axis, fov_lat_axis])
     with pytest.raises(ValueError) as error:
-        bkg3d = Background3D(axes=[energy_axis, fov_lon_axis, fov_lat_axis],
+        Background3D(axes=[energy_axis, fov_lon_axis, fov_lat_axis],
                  data=data)
-        assert error == (f"Error: {wrong_unit} is not an allowed unit. {bkg3d.tag} requires dimensionless data quantities!")
+    assert error.match(f"Error: {wrong_unit} is not an allowed unit. {bkg3d_test.tag} requires {bkg3d_test.default_unit} data quantities.")
 
 
 def test_bkg_2d_wrong_units():
@@ -248,10 +247,11 @@ def test_bkg_2d_wrong_units():
 
     wrong_unit = u.cm**2 * u.s
     data = np.ones((energy_axis.nbin, offset_axis.nbin)) * wrong_unit
+    bkg2d_test = Background2D(axes=[energy_axis, offset_axis])
     with pytest.raises(ValueError) as error:
-        bkg2d = Background2D(axes=[energy_axis, offset_axis],
+        Background2D(axes=[energy_axis, offset_axis],
                  data=data)
-        assert error == (f"Error: {wrong_unit} is not an allowed unit. {bkg2d.tag} requires dimensionless data quantities!")
+        assert error.match(f"Error: {wrong_unit} is not an allowed unit. {bkg2d_test.tag} requires {bkg2d_test.default_unit} data quantities.")
 
 
 def test_background_2d_read_missing_hducls():

--- a/gammapy/irf/tests/test_core.py
+++ b/gammapy/irf/tests/test_core.py
@@ -9,7 +9,7 @@ def test_irf_init_quantity():
     class TestIRF(IRF):
         tag = "myirf"
         required_axes = ["energy", "offset"]
-        unit = u.Unit("deg")
+        default_unit = u.deg
 
     energy_axis = MapAxis.from_energy_bounds(10, 100, 10, unit="TeV", name="energy")
     offset_axis = MapAxis.from_bounds(0, 2.5, 5, unit="deg", name="offset")

--- a/gammapy/irf/tests/test_core.py
+++ b/gammapy/irf/tests/test_core.py
@@ -9,6 +9,7 @@ def test_irf_init_quantity():
     class TestIRF(IRF):
         tag = "myirf"
         required_axes = ["energy", "offset"]
+        unit = u.Unit("deg")
 
     energy_axis = MapAxis.from_energy_bounds(10, 100, 10, unit="TeV", name="energy")
     offset_axis = MapAxis.from_bounds(0, 2.5, 5, unit="deg", name="offset")

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -111,6 +111,19 @@ def test_wrong_axis_order():
             axes=[energy_axis_true, offset_axis], data=data, unit="cm2"
         )
 
+def test_wrong_units():
+    energy_axis_true = MapAxis.from_energy_bounds(
+        "1 TeV", "10 TeV", nbin=10, name="energy_true"
+    )
+
+    offset_axis = MapAxis.from_bounds(0 * u.deg, 2 * u.deg, nbin=2, name='offset')
+
+    wrong_unit = u.TeV
+    data = np.ones((energy_axis_true.nbin, offset_axis.nbin)) * wrong_unit
+
+    with pytest.raises(ValueError) as error:
+        area = EffectiveAreaTable2D(data=data, axes=[energy_axis_true, offset_axis])
+        assert error == (f"Error: {wrong_unit} is not an allowed unit. {area.tag} requires dimensionless data quantities!")
 
 @requires_data("gammapy-data")
 def test_aeff2d_pointlike():

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -120,10 +120,12 @@ def test_wrong_units():
 
     wrong_unit = u.TeV
     data = np.ones((energy_axis_true.nbin, offset_axis.nbin)) * wrong_unit
+    area_test = EffectiveAreaTable2D(axes=[energy_axis_true, offset_axis])
 
     with pytest.raises(ValueError) as error:
-        area = EffectiveAreaTable2D(data=data, axes=[energy_axis_true, offset_axis])
-        assert error == (f"Error: {wrong_unit} is not an allowed unit. {area.tag} requires dimensionless data quantities!")
+        EffectiveAreaTable2D(data=data, axes=[energy_axis_true, offset_axis])
+
+        assert error.match(f"Error: {wrong_unit} is not an allowed unit. {area_test.tag} requires {area_test.default_unit} data quantities.")
 
 @requires_data("gammapy-data")
 def test_aeff2d_pointlike():

--- a/gammapy/irf/tests/test_gadf.py
+++ b/gammapy/irf/tests/test_gadf.py
@@ -39,7 +39,7 @@ def test_energy_dispersion_2d_to_gadf():
     energy_axis = MapAxis.from_energy_bounds(1 * u.TeV, 10 * u.TeV, nbin=3, name='energy_true')
     offset_axis = MapAxis.from_bounds(0 * u.deg, 2 * u.deg, nbin=2, name='offset')
     migra_axis = MapAxis.from_bounds(0.2, 5, nbin=5, interp='log', name='migra')
-    data = np.zeros((energy_axis.nbin, migra_axis.nbin, offset_axis.nbin)) * u.m**2
+    data = np.zeros((energy_axis.nbin, migra_axis.nbin, offset_axis.nbin))
 
     edisp = EnergyDispersion2D(data=data, axes=[energy_axis, migra_axis, offset_axis])
     hdu = edisp.to_table_hdu(format='gadf-dl3')


### PR DESCRIPTION
The PR solves a bug on the units of the input data for `~gammapy.irf.EnergyDispersion2D`, as reported in the issue #3725 .
It is now added a check on the units, and the code raises an error if the units are wrong.
The bug fix applies on `~gammapy.irf.core.py` although it is probably not the most elegant way to do it...
