### PR TITLE
Add PYTHONNOUSERSITE=1 to conda env

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,6 +11,9 @@ channels:
   - conda-forge
   - sherpa
 
+variables:
+  PYTHONNOUSERSITE: "1"
+
 dependencies:
   # core dependencies
   - python=3.7
@@ -69,4 +72,3 @@ dependencies:
   - ruamel.yaml
   - pip:
       - pytest-sphinx
-


### PR DESCRIPTION
This prevents the user site packages (where `pip install --user` installs to) to take precedence over the packages in the environment.

This is a long standing issue with conda, that this is not done by default (unlike e.g. python virtualenvs, which do this by default).