### PR TITLE
Minor update in dev HowTo

### DIFF
--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -221,6 +221,12 @@ following command.
 
     pytest --doctest-modules --ignore-glob=*/tests gammapy
 
+If you get a zsh error try using putting the ignore block inside quotes 
+
+.. code-block:: bash
+
+    pytest --doctest-modules "--ignore-glob=*/tests" gammapy
+
 Sphinx gallery extension
 ------------------------
 


### PR DESCRIPTION
I was getting an error `zsh: no matches found: -glob=*/tests` while testing doc strings. This was the solution I found after some searching, so adding it. I don't understand the issue though...

