### PR TITLE
Fix compound_region_center for scipy 1.8, pin pytest to 6 for now

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -29,7 +29,7 @@ dependencies:
   - scipy
   # test dependencies
   - codecov
-  - pytest
+  - pytest=6
   - pytest-astropy
   - pytest-cov
   - pytest-xdist

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -51,6 +51,9 @@ def compound_region_center(compound_region):
         Geometric median of the positions of the individual regions
     """
     regions = compound_region_to_regions(compound_region)
+    if len(regions) == 1:
+        return regions[0].center
+
     positions = SkyCoord([region.center for region in regions])
 
     def f(x, coords):
@@ -61,11 +64,18 @@ def compound_region_center(compound_region):
 
     ra, dec = positions.icrs.ra.wrap_at("180d").deg, positions.icrs.dec.deg
 
+
+
+    bounds = [
+        (np.min(ra), np.max(ra)),
+        (np.min(dec), np.max(dec)),
+    ]
+
     result = minimize(
         f,
         x0=[np.mean(ra), np.mean(dec)],
         args=(positions,),
-        bounds=[(np.min(ra), np.max(ra)), (np.min(dec), np.max(dec))],
+        bounds=bounds,
         method="L-BFGS-B",
     )
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
Fixes the current CI failures by fixing the single region case of `compound_region_center` for scipy 1.8 and pinning pytest to version 6 for now