### PR TITLE
Include ASTRI mini-array in the list of observatory locations

### DIFF
--- a/gammapy/data/observers.py
+++ b/gammapy/data/observers.py
@@ -96,6 +96,6 @@ observatory_locations["whipple"] = EarthLocation(
 
 # communication with ASTRI Project Manager
 observatory_locations["astri"] = EarthLocation(
-    lon="28d17m60.0s", lat="16d30m20.99s", height="2370m"
+    lon="-16d30m20.99s", lat="28d17m60.0s", height="2370m"
 )
 

--- a/gammapy/data/observers.py
+++ b/gammapy/data/observers.py
@@ -93,3 +93,9 @@ observatory_locations["veritas"] = EarthLocation(
 observatory_locations["whipple"] = EarthLocation(
     lon="-110d52m42s", lat="31d40m52s", height="2606m"
 )
+
+# communication with ASTRI Project Manager
+observatory_locations["astri"] = EarthLocation(
+    lon="28d17m60.0s", lat="16d30m20.99s", height="2370m"
+)
+


### PR DESCRIPTION
`~gammapy.data.observers` lists the Earth location of the main gamma-ray observatories. This PR includes the location of the future ASTRI mini-array.