### PR TITLE
Refactor pointing information handling and `Observation.create`

### DIFF
--- a/docs/datasets/plot_stack.py
+++ b/docs/datasets/plot_stack.py
@@ -3,7 +3,7 @@
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 import matplotlib.pyplot as plt
-from gammapy.data import Observation
+from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import SpectrumDataset
 from gammapy.datasets.map import MIGRA_AXIS_DEFAULT
 from gammapy.irf import EffectiveAreaTable2D, EnergyDispersion2D
@@ -35,6 +35,7 @@ observation = Observation.create(
     irfs={"aeff": aeff, "edisp": edisp},
     tstart=0 * u.h,
     tstop=0.5 * u.h,
+    location=observatory_locations["hess"],
 )
 
 geom = RegionGeom.create("icrs;circle(0, 0, 0.1)", axes=[energy_reco])

--- a/docs/tutorials/analysis/1D/cta_sensitivity.ipynb
+++ b/docs/tutorials/analysis/1D/cta_sensitivity.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "from gammapy.irf import load_cta_irfs\n",
     "from gammapy.makers import SpectrumDatasetMaker\n",
-    "from gammapy.data import Observation\n",
+    "from gammapy.data import Observation, observatory_locations\n",
     "from gammapy.estimators import SensitivityEstimator\n",
     "from gammapy.datasets import SpectrumDataset, SpectrumDatasetOnOff\n",
     "from gammapy.maps import MapAxis, RegionGeom"
@@ -105,9 +105,9 @@
     "irfs = load_cta_irfs(\n",
     "    \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
     ")\n",
-    "\n",
+    "location = observatory_locations[\"cta_south\"]\n",
     "pointing = SkyCoord(\"0 deg\", \"0 deg\")\n",
-    "obs = Observation.create(pointing=pointing, irfs=irfs, livetime=\"5 h\")"
+    "obs = Observation.create(pointing=pointing, irfs=irfs, livetime=\"5 h\", location=location)"
    ]
   },
   {
@@ -333,7 +333,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -347,7 +347,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/analysis/1D/spectrum_simulation.ipynb
+++ b/docs/tutorials/analysis/1D/spectrum_simulation.ipynb
@@ -69,7 +69,7 @@
     "    SkyModel,\n",
     ")\n",
     "from gammapy.irf import load_cta_irfs\n",
-    "from gammapy.data import Observation\n",
+    "from gammapy.data import Observation, observatory_locations\n",
     "from gammapy.maps import MapAxis, RegionGeom"
    ]
   },
@@ -151,7 +151,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obs = Observation.create(pointing=pointing, livetime=livetime, irfs=irfs)\n",
+    "location = observatory_locations['cta_south']\n",
+    "obs = Observation.create(\n",
+    "    pointing=pointing, livetime=livetime, irfs=irfs,\n",
+    "    location=location,\n",
+    ")\n",
     "print(obs)"
    ]
   },
@@ -361,7 +365,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -375,7 +379,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -102,7 +102,7 @@
     "from astropy.time import Time\n",
     "from astropy.coordinates import SkyCoord, Angle\n",
     "from regions import CircleSkyRegion\n",
-    "from gammapy.data import DataStore, Observation\n",
+    "from gammapy.data import DataStore, Observation, observatory_locations\n",
     "from gammapy.datasets import MapDataset, MapDatasetEventSampler\n",
     "from gammapy.estimators import LightCurveEstimator\n",
     "from gammapy.maps import MapAxis, WcsGeom, Map\n",
@@ -166,8 +166,11 @@
    "outputs": [],
    "source": [
     "irfs = load_cta_irfs(filename)\n",
+    "location = observatory_locations['cta_south']\n",
+    "\n",
     "observation = Observation.create(\n",
-    "    obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs\n",
+    "    obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs,\n",
+    "    location=location,\n",
     ")"
    ]
   },
@@ -732,7 +735,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tstarts = [1, 5, 7] * u.hr\n",
+    "tstarts = Time(\"2020-01-01 00:00:00\") + [1, 5, 7] * u.hr\n",
     "livetimes = [1, 1, 1] * u.hr"
    ]
   },
@@ -752,6 +755,7 @@
     "        tstart=tstart,\n",
     "        livetime=livetimes[idx],\n",
     "        irfs=irfs,\n",
+    "        location=location,\n",
     "    )\n",
     "\n",
     "    dataset = maker.run(empty, observation)\n",
@@ -817,7 +821,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -831,7 +835,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.12"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/docs/tutorials/analysis/3D/simulate_3d.ipynb
+++ b/docs/tutorials/analysis/3D/simulate_3d.ipynb
@@ -69,7 +69,7 @@
     ")\n",
     "from gammapy.makers import MapDatasetMaker, SafeMaskMaker\n",
     "from gammapy.modeling import Fit\n",
-    "from gammapy.data import Observation\n",
+    "from gammapy.data import Observation, observatory_locations\n",
     "from gammapy.datasets import MapDataset"
    ]
   },
@@ -195,7 +195,8 @@
    "outputs": [],
    "source": [
     "# Create an in-memory observation\n",
-    "obs = Observation.create(pointing=pointing, livetime=livetime, irfs=irfs)\n",
+    "location = observatory_locations['cta_south']\n",
+    "obs = Observation.create(pointing=pointing, livetime=livetime, irfs=irfs, location=location)\n",
     "print(obs)"
    ]
   },
@@ -361,19 +362,11 @@
    "source": [
     "result.parameters.to_table()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "35d0d7d0",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -387,7 +380,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.12"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,
@@ -395,9 +388,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1.0,
+   "current_citInitial": 1,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1.0,
+   "eqNumInitial": 1,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"
@@ -453,7 +446,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0.0,
+       "index": 0,
        "layout": "IPY_MODEL_af4d5cf4a93b4c2aa9fd249e0ebea901",
        "orientation": "horizontal",
        "readout": true,
@@ -731,7 +724,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0.0,
+       "index": 0,
        "layout": "IPY_MODEL_ad8503b6c8494978874f7c11be4e77f8",
        "style": "IPY_MODEL_3cf9799567f44cc2a06127e22b70907d"
       }
@@ -752,8 +745,8 @@
       }
      }
     },
-    "version_major": 2.0,
-    "version_minor": 0.0
+    "version_major": 2,
+    "version_minor": 0
    }
   }
  },

--- a/docs/tutorials/analysis/time/light_curve_simulation.ipynb
+++ b/docs/tutorials/analysis/time/light_curve_simulation.ipynb
@@ -89,7 +89,8 @@
     "from gammapy.maps import MapAxis, RegionGeom\n",
     "from gammapy.estimators import LightCurveEstimator\n",
     "from gammapy.makers import SpectrumDatasetMaker\n",
-    "from gammapy.modeling import Fit"
+    "from gammapy.modeling import Fit\n",
+    "from gammapy.data import observatory_locations"
    ]
   },
   {
@@ -201,7 +202,8 @@
    "outputs": [],
    "source": [
     "n_obs = 10\n",
-    "tstart = [1, 2, 3, 5, 8, 10, 20, 22, 23, 24] * u.h\n",
+    "\n",
+    "tstart = gti_t0 + [1, 2, 3, 5, 8, 10, 20, 22, 23, 24] * u.h\n",
     "lvtm = [55, 25, 26, 40, 40, 50, 40, 52, 43, 47] * u.min"
    ]
   },
@@ -228,6 +230,7 @@
     "\n",
     "maker = SpectrumDatasetMaker(selection=[\"exposure\", \"background\", \"edisp\"])\n",
     "\n",
+    "\n",
     "for idx in range(n_obs):\n",
     "    obs = Observation.create(\n",
     "        pointing=pointing,\n",
@@ -236,6 +239,7 @@
     "        irfs=irfs,\n",
     "        reference_time=gti_t0,\n",
     "        obs_id=idx,\n",
+    "        location=observatory_locations['cta_south'],\n",
     "    )\n",
     "    empty_i = empty.copy(name=f\"dataset-{idx}\")\n",
     "    dataset = maker.run(empty_i, obs)\n",
@@ -429,19 +433,11 @@
     "2. Model the flare of PKS 2155-304 which you obtained using the [light curve flare tutorial](light_curve_flare.ipynb). Use a combination of a Gaussian and Exponential flare profiles, and fit using `scipy.optimize.curve_fit`\n",
     "3. Do a joint fitting of the datasets."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "03a57536",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -455,7 +451,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.12"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,
@@ -463,9 +459,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1.0,
+   "current_citInitial": 1,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1.0,
+   "eqNumInitial": 1,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -408,13 +408,16 @@ def test_analysis_3d_joint_datasets():
     assert_allclose(
         analysis.datasets[0].background_model.spectral_model.norm.value,
         1.031743694988066,
+        rtol=1e-6,
     )
     assert_allclose(
-        analysis.datasets[0].background_model.spectral_model.tilt.value, 0.0
+        analysis.datasets[0].background_model.spectral_model.tilt.value, 0.0,
+        rtol=1e-6,
     )
     assert_allclose(
         analysis.datasets[1].background_model.spectral_model.norm.value,
         0.9776349021876344,
+        rtol=1e-6,
     )
 
 

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -6,6 +6,7 @@ from astropy.io import fits
 from astropy.table import Table, vstack
 from astropy.time import Time
 from astropy.units import Quantity
+import astropy.units as u
 from gammapy.utils.scripts import make_path
 from gammapy.utils.time import (
     time_ref_from_dict,
@@ -70,16 +71,23 @@ class GTI:
 
         Parameters
         ----------
-        start : `~astropy.units.Quantity`
-            start times w.r.t. reference time
-        stop : `~astropy.units.Quantity`
-            stop times w.r.t. reference time
+        start : `~astropy.time.Time` or `~astropy.units.Quantity`
+            Start times, if a quantity then w.r.t. reference time
+        stop : `~astropy.time.Time` or `~astropy.units.Quantity`
+            Stop times, if a quantity then w.r.t. reference time
         reference_time : `~astropy.time.Time`
             the reference time to use in GTI definition
         """
+        reference_time = Time(reference_time)
+
+        if isinstance(start, Time):
+            start = (start - reference_time).to(u.s)
+
+        if isinstance(stop, Time):
+            stop = (stop - reference_time).to(u.s)
+
         start = Quantity(start, ndmin=1)
         stop = Quantity(stop, ndmin=1)
-        reference_time = Time(reference_time)
         meta = time_ref_to_dict(reference_time)
         table = Table({"START": start.to("s"), "STOP": stop.to("s")}, meta=meta)
         return cls(table)

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -191,21 +191,13 @@ class Observation:
         if tstop is None:
             tstop = tstart + Quantity(livetime)
 
-        if not isinstance(tstart, Time):
-            tstart = reference_time + tstart
-
-        if not isinstance(tstop, Time):
-            tstop = reference_time + tstop
-
-        tstart_rel = (tstart - reference_time).to(u.s)
-        tstop_rel = (tstop - reference_time).to(u.s)
-        gti = GTI.create([tstart_rel], [tstop_rel], reference_time=reference_time)
+        gti = GTI.create(tstart, tstop, reference_time=reference_time)
 
         obs_info = cls._get_obs_info(
             pointing=pointing,
             deadtime_fraction=deadtime_fraction,
-            time_start=tstart,
-            time_stop=tstop,
+            time_start=gti.time_start[0],
+            time_stop=gti.time_stop[0],
             reference_time=reference_time,
             location=location,
         )

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -136,3 +136,14 @@ def test_gti_write(tmp_path):
     assert_time_allclose(new_gti.time_start, gti.time_start)
     assert_time_allclose(new_gti.time_stop, gti.time_stop)
     assert new_gti.table.meta["MJDREFF"] == gti.table.meta["MJDREFF"]
+
+
+def test_gti_from_time():
+    '''Test astropy time is supported as input for GTI.create'''
+    start = Time("2020-01-01T20:00:00")
+    stop = Time("2020-01-01T20:15:00")
+    ref = Time("2020-01-01T00:00:00")
+    gti = GTI.create(start, stop, ref)
+
+    assert u.isclose(gti.table["START"], 20 * u.hour)
+    assert u.isclose(gti.table["STOP"], 20 * u.hour + 15 * u.min)

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import logging
+import numpy as np
 from numpy.testing import assert_allclose
 from astropy.time import Time
 from gammapy.data import FixedPointingInfo, PointingInfo
@@ -107,3 +109,22 @@ class TestPointingInfo:
         assert_allclose(pos.az.deg, 11.45751357)
         assert_allclose(pos.alt.deg, 41.34088901)
         assert pos.name == "altaz"
+
+
+
+def test_altaz_without_location(caplog):
+    meta = {'ALT_PNT': 20.0, 'AZ_PNT': 170.0}
+    pointing = FixedPointingInfo(meta)
+
+    with caplog.at_level(logging.WARNING):
+        altaz = pointing.altaz
+        assert altaz.alt.deg == 20.0
+        assert altaz.az.deg == 170.0
+
+
+    pointing = FixedPointingInfo({})
+
+    with caplog.at_level(logging.WARNING):
+        altaz = pointing.altaz
+        assert np.isnan(altaz.alt.value)
+        assert np.isnan(altaz.az.value)

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, EarthLocation
 from astropy.io import fits
 from astropy.table import Table
 from astropy.time import Time
@@ -20,6 +20,9 @@ from gammapy.modeling.models import (
     SkyModel,
 )
 from gammapy.utils.testing import requires_data
+
+
+LOCATION = EarthLocation(lon="-70d18m58.84s", lat="-24d41m0.34s", height="2000m")
 
 
 @pytest.fixture()
@@ -109,7 +112,8 @@ def test_mde_sample_weak_src(dataset, models):
     livetime = 10.0 * u.hr
     pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
     obs = Observation.create(
-        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
+        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs,
+        location=LOCATION,
     )
 
     models[0].parameters["amplitude"].value = 1e-25
@@ -192,7 +196,8 @@ def test_event_det_coords(dataset, models):
     livetime = 1.0 * u.hr
     pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
     obs = Observation.create(
-        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
+        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs,
+        location=LOCATION,
     )
 
     dataset.models = models
@@ -215,7 +220,8 @@ def test_mde_run(dataset, models):
     livetime = 1.0 * u.hr
     pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
     obs = Observation.create(
-        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
+        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs,
+        location=LOCATION,
     )
 
     dataset.models = models
@@ -306,7 +312,8 @@ def test_irf_alpha_config(dataset, models):
     livetime = 1.0 * u.hr
     pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
     obs = Observation.create(
-        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
+        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs,
+        location=LOCATION,
     )
 
     dataset.models = models
@@ -323,7 +330,8 @@ def test_mde_run_switchoff(dataset, models):
     livetime = 1.0 * u.hr
     pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
     obs = Observation.create(
-        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
+        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs,
+        location=LOCATION,
     )
 
     dataset.models = models
@@ -343,7 +351,7 @@ def test_mde_run_switchoff(dataset, models):
     meta = events.table.meta
 
     assert meta["RA_PNT"] == 266.4049882865447
-    assert meta["ONTIME"] == 3600.0
+    assert_allclose(meta["ONTIME"], 3600.0)
     assert meta["OBS_ID"] == 1001
     assert meta["RADECSYS"] == "icrs"
 
@@ -356,7 +364,8 @@ def test_events_datastore(tmp_path, dataset, models):
     livetime = 10.0 * u.hr
     pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
     obs = Observation.create(
-        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
+        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs,
+        location=LOCATION,
     )
 
     dataset.models = models

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, EarthLocation
 from gammapy.data import Observation
 from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
 from gammapy.estimators import FluxPoints, FluxPointsEstimator
@@ -112,7 +112,12 @@ def simulate_map_dataset(random_state=0, name=None):
     pwl = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     skymodel = SkyModel(spatial_model=gauss, spectral_model=pwl, name="source")
 
-    obs = Observation.create(pointing=skydir, livetime=1 * u.h, irfs=irfs)
+    obs = Observation.create(
+        pointing=skydir,
+        livetime=1 * u.h,
+        irfs=irfs,
+        location=EarthLocation(lon="-70d18m58.84s", lat="-24d41m0.34s", height="2000m"),
+    )
     empty = MapDataset.create(geom, name=name)
     maker = MapDatasetMaker(selection=["exposure", "background", "psf", "edisp"])
     dataset = maker.run(empty, obs)

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -329,7 +329,7 @@ def test_interpolate_map_dataset():
     # define observation
     obs = Observation(
         obs_id=0,
-        obs_info={},
+        obs_info={"RA_PNT": 0.0, "DEC_PNT": 0.0},
         gti=gti,
         aeff=aeff_map,
         edisp=edispmap,

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -97,7 +97,7 @@ def test_safe_mask_maker_bkg_invalid(observations_hess_dl3):
     axis_true = MapAxis.from_bounds(
         0.1, 50, nbin=30, unit="TeV", name="energy_true", interp="log"
     )
-    geom = WcsGeom.create(npix=(11, 11), axes=[axis], skydir=obs.pointing_radec)
+    geom = WcsGeom.create(npix=(9, 9), axes=[axis], skydir=obs.pointing_radec)
 
     empty_dataset = MapDataset.create(geom=geom, energy_axis_true=axis_true)
     dataset_maker = MapDatasetMaker()

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -4,6 +4,7 @@ import sys
 from astropy.coordinates import Angle, EarthLocation
 from astropy.io import fits
 from astropy.units import Quantity
+import astropy.units as u
 from .scripts import make_path
 
 log = logging.getLogger(__name__)
@@ -154,3 +155,12 @@ def earth_location_from_dict(meta):
         raise KeyError("The GEOALT or ALTITUDE header keyword must be set")
 
     return EarthLocation(lon=lon, lat=lat, height=height)
+
+
+def earth_location_to_dict(location):
+    """Create `~astropy.coordinates.EarthLocation` from FITS header dict."""
+    return {
+        "GEOLON": location.lon.deg,
+        "GEOLAT": location.lat.deg,
+        "ALTITUDE": location.height.to_value(u.m),
+    }


### PR DESCRIPTION
**Description**

As discussed here #3767, the `Observation` class duplicated in a less correct manner code that is implemented in `FixedPointingInfo`. 

Here I remove the code and change the properties to look up the corresponding properties in the `fixed_pointing_info`, making that a `lazyproperty`.

This also made it necessary, to require the `locatation` for all observations. This was not always given, mostly in simulation examples. However, I think requiring the observatory location makes sense in general so I added it where needed.