### PR TITLE
Event wise rad max

### DIFF
--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -414,7 +414,10 @@ class ReflectedRegionsBackgroundMaker(Maker):
             Counts vs estimated energy extracted from the OFF regions.
         """
         on_geom = dataset.counts.geom
-        if on_geom.is_region and isinstance(on_geom.region, PointSkyRegion):
+        if observation.rad_max is not None:
+            if not isinstance(on_geom.region, PointSkyRegion):
+                raise ValueError('Must use PointSkyRegion on region in point-like analysis')
+
             counts_off, acceptance_off = make_counts_off_rad_max(
                 on_geom=on_geom,
                 rad_max=observation.rad_max,

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -169,7 +169,17 @@ class WobbleRegionsFinder(RegionsFinder):
             angle = i * increment
             region_test = region_pix.rotate(center_pixel, angle)
 
-            if exclusion_mask is None or not np.any(region_test.contains(excluded_pixels)):
+            # for PointSkyRegion, we test if the point is inside the exclusion mask
+            # otherwise we test if there is overlap
+
+            excluded = False
+            if exclusion_mask is not None:
+                if isinstance(region, PointSkyRegion):
+                    excluded = (excluded_pixels.separation(region_test.center) < 1).any()
+                else:
+                    excluded = region_test.contains(excluded_pixels).any()
+
+            if not excluded:
                 regions.append(region_test)
 
 

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -320,6 +320,12 @@ class ReflectedRegionsFinder(RegionsFinder):
         wcs: `~astropy.wcs.WCS`
             WCS for the determined regions
         """
+        if isinstance(region, PointSkyRegion):
+            raise NotImplementedError(
+                '`ReflectedRegionsFinder` does not work for `PointSkyRegion`'
+                ', use `WobbleRegionsFinder` instead'
+            )
+
         regions = []
 
         reference_geom = self._create_reference_geometry(region, center)

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -331,7 +331,7 @@ class ReflectedRegionsFinder(RegionsFinder):
             WCS for the determined regions
         """
         if isinstance(region, PointSkyRegion):
-            raise NotImplementedError(
+            raise TypeError(
                 '`ReflectedRegionsFinder` does not work for `PointSkyRegion`'
                 ', use `WobbleRegionsFinder` instead'
             )

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -263,6 +263,11 @@ def test_dataset_maker_spectrum_rad_max(observations_magic):
 
     observation = observations_magic[0]
 
+    # test file is broken, always overlapping regions in low energy
+    # max_theta = np.sin(np.pi / (n_off + 1)) * offset
+    invalid = observation.rad_max.quantity > (0.28 * u.deg)
+    observation.rad_max.quantity[invalid] = 0.28 * u.deg
+
     maker = SpectrumDatasetMaker(
         containment_correction=False, selection=["counts", "exposure", "edisp"]
     )
@@ -276,8 +281,8 @@ def test_dataset_maker_spectrum_rad_max(observations_magic):
     counts_off = dataset_on_off.counts_off
     assert counts.unit == ""
     assert counts_off.unit == ""
-    assert_allclose(counts.data.sum(), 1135, rtol=1e-5)
-    assert_allclose(counts_off.data.sum(), 2186, rtol=1e-5)
+    assert_allclose(counts.data.sum(), 1078, rtol=1e-5)
+    assert_allclose(counts_off.data.sum(), 2046, rtol=1e-5)
 
     exposure = dataset_on_off.exposure
     assert exposure.unit == "m2 s"

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -281,8 +281,8 @@ def test_dataset_maker_spectrum_rad_max(observations_magic_rad_max):
     counts_off = dataset_on_off.counts_off
     assert counts.unit == ""
     assert counts_off.unit == ""
-    assert_allclose(counts.data.sum(), 1078, rtol=1e-5)
-    assert_allclose(counts_off.data.sum(), 2046, rtol=1e-5)
+    assert_allclose(counts.data.sum(), 1088, rtol=1e-5)
+    assert_allclose(counts_off.data.sum(), 2053, rtol=1e-5)
 
     exposure = dataset_on_off.exposure
     assert exposure.unit == "m2 s"

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -37,10 +37,10 @@ def observations_hess():
 def observations_magic_rad_max():
     observations = [
         Observation.read(
-            "$GAMMAPY_DATA/magic/rad_max/data/magic_dl3_run_05029747.fits"
+            "$GAMMAPY_DATA/magic/rad_max/data/20131004_05029747_DL3_CrabNebula-W0.40+035.fits"
         ),
         Observation.read(
-            "$GAMMAPY_DATA/magic/rad_max/data/magic_dl3_run_05029748.fits"
+            "$GAMMAPY_DATA/magic/rad_max/data/20131004_05029748_DL3_CrabNebula-W0.40+215.fits"
         ),
     ]
     return observations
@@ -263,30 +263,26 @@ def test_dataset_maker_spectrum_rad_max(observations_magic_rad_max):
 
     observation = observations_magic_rad_max[0]
 
-    # test file is broken, always overlapping regions in low energy
-    # max_theta = np.sin(np.pi / (n_off + 1)) * offset
-    invalid = observation.rad_max.quantity > (0.28 * u.deg)
-    observation.rad_max.quantity[invalid] = 0.28 * u.deg
-
     maker = SpectrumDatasetMaker(
         containment_correction=False, selection=["counts", "exposure", "edisp"]
     )
     dataset = maker.run(get_spectrumdataset_rad_max("spec"), observation)
 
-    finder = WobbleRegionsFinder(n_off_regions=3)
+    finder = WobbleRegionsFinder(n_off_regions=1)
     bkg_maker = ReflectedRegionsBackgroundMaker(region_finder=finder)
     dataset_on_off = bkg_maker.run(dataset, observation)
 
     counts = dataset_on_off.counts
     counts_off = dataset_on_off.counts_off
     assert counts.unit == ""
+    assert counts_off is not None, "Extracting off counts failed"
     assert counts_off.unit == ""
-    assert_allclose(counts.data.sum(), 1088, rtol=1e-5)
-    assert_allclose(counts_off.data.sum(), 2053, rtol=1e-5)
+    assert_allclose(counts.data.sum(), 949, rtol=1e-5)
+    assert_allclose(counts_off.data.sum(), 517, rtol=1e-5)
 
     exposure = dataset_on_off.exposure
     assert exposure.unit == "m2 s"
-    assert_allclose(exposure.data.mean(), 68714990.52908568, rtol=1e-5)
+    assert_allclose(exposure.data.mean(), 67838458.245686, rtol=1e-5)
 
 
 @requires_data()
@@ -308,8 +304,6 @@ def test_dataset_maker_spectrum_global_rad_max():
     counts_off = dataset_on_off.counts_off
     assert counts.unit == ""
     assert counts_off.unit == ""
-    print(counts.data)
-    print(counts_off.data)
     assert_allclose(counts.data.sum(), 437, rtol=1e-5)
     assert_allclose(counts_off.data.sum(), 273, rtol=1e-5)
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -487,7 +487,13 @@ def apply_rad_max(events, rad_max, position):
     '''Apply the RAD_MAX cut to the event list for given region'''
     offset = position.separation(events.pointing_radec)
     separation = position.separation(events.radec)
-    selected = separation <= rad_max.evaluate(energy=events.energy, offset=offset)
+
+    if rad_max.data.shape == (1, 1):
+        rad_max_for_events = rad_max.quantity[0, 0]
+    else:
+        rad_max_for_events = rad_max.evaluate(energy=events.energy, offset=offset)
+
+    selected = separation <= rad_max_for_events
     return events.select_row_subset(selected)
 
 
@@ -502,7 +508,12 @@ def are_regions_overlapping_rad_max(regions, rad_max, offset):
     ])
 
 
-    rad_max_at_offset = rad_max.evaluate(offset=offset)
+    # evaluate fails with a single bin somewhere trying to interpolate
+    if rad_max.data.shape == (1, 1):
+        rad_max_at_offset = rad_max.quantity[0, 0]
+    else:
+        rad_max_at_offset = rad_max.evaluate(offset=offset)
+
     return np.any(separations[np.newaxis, :] < (2 * rad_max_at_offset))
 
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -556,6 +556,7 @@ def make_counts_off_rad_max(
     )
 
     if len(off_regions) == 0:
+        log.warn("RegionsFinder returned no regions")
         # counts_off=None, acceptance_off=0
         return None, RegionNDMap.from_geom(on_geom, data=0)
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -491,7 +491,9 @@ def apply_rad_max(events, rad_max, position):
     if rad_max.data.shape == (1, 1):
         rad_max_for_events = rad_max.quantity[0, 0]
     else:
-        rad_max_for_events = rad_max.evaluate(energy=events.energy, offset=offset)
+        rad_max_for_events = rad_max.evaluate(
+            method="nearest", energy=events.energy, offset=offset
+        )
 
     selected = separation <= rad_max_for_events
     return events.select_row_subset(selected)

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import numpy as np
+from itertools import combinations
 from astropy.coordinates import Angle, SkyOffsetFrame
 from astropy.table import Table
-from regions import CircleSkyRegion
+import astropy.units as u
 from gammapy.data import FixedPointingInfo
 from gammapy.irf import EDispMap, PSFMap
 from gammapy.maps import Map, RegionGeom, RegionNDMap
@@ -13,6 +14,7 @@ from gammapy.utils.coordinates import sky_to_fov
 
 
 __all__ = [
+    "make_counts_rad_max",
     "make_edisp_kernel_map",
     "make_edisp_map",
     "make_map_background_irf",
@@ -472,26 +474,39 @@ def make_counts_rad_max(geom, rad_max, events):
     counts : `~gammapy.maps.RegionNDMap`
         Counts vs estimated energy extracted from the ON region.
     """
-    rad_max = get_rad_max_vs_energy(rad_max, events.pointing_radec, geom)
+    selected_events = apply_rad_max(events, rad_max, geom.region.center)
 
-    counts_list = []
-
-    # create and fill a map per each energy bin, fetch the counts
-    for i, rad in enumerate(rad_max):
-        on_region = CircleSkyRegion(center=geom.center_skydir, radius=rad)
-        energy_range = geom.axes["energy"].slice(i)
-        on_region_geom = RegionGeom(on_region, axes=[energy_range])
-        counts = Map.from_geom(on_region_geom)
-        counts.fill_events(events)
-        counts_list.append(counts.data[0])
-
-    counts = RegionNDMap.from_geom(geom, data=np.asarray(counts_list))
+    counts_geom = RegionGeom(geom.region, axes=[geom.axes['energy']])
+    counts = Map.from_geom(counts_geom)
+    counts.fill_events(selected_events)
 
     return counts
 
 
+def apply_rad_max(events, rad_max, position):
+    '''Apply the RAD_MAX cut to the event list for given region'''
+    offset = position.separation(events.pointing_radec)
+    separation = position.separation(events.radec)
+    selected = separation <= rad_max.evaluate(energy=events.energy, offset=offset)
+    return events.select_row_subset(selected)
+
+
+def are_regions_overlapping(regions, rad_max, offset):
+    """
+    Calculate pair-wise separations between all regions and compare with rad_max
+    to find overlaps.
+    """
+    separations = u.Quantity([
+        a.center.separation(b.center)
+        for a, b in combinations(regions, 2)
+    ])
+
+    rad_max_at_offset = rad_max.evaluate(offset=offset)
+    return np.any(separations[np.newaxis, :] < rad_max_at_offset)
+
+
 def make_counts_off_rad_max(
-    geom,
+    on_geom,
     rad_max,
     events,
     region_finder,
@@ -505,7 +520,7 @@ def make_counts_off_rad_max(
     Parameters
     ----------
     geom: `~gammapy.maps.RegionGeom`
-        reference map geom
+        reference map geom for the on region
     rad_max: `~gammapy.irf.RadMax2D`
         the RAD_MAX_2D table IRF
     events: `~gammapy.data.EventList`
@@ -519,44 +534,41 @@ def make_counts_off_rad_max(
     acceptance_off : `~gammapy.maps.RegionNDMap`
         ratio of the acceptances of the OFF to ON regions.
     """
-    rad_max = get_rad_max_vs_energy(rad_max, events.pointing_radec, geom)
 
-    counts_off_list = []
-    acceptance_off_list = []
-
-    # we have to define an ON region and a region finder for each energy bin
-    for i, rad in enumerate(rad_max):
-
-        on_region = CircleSkyRegion(center=geom.center_skydir, radius=rad)
-        energy_range = geom.axes["energy"].slice(i)
-
-        regions, wcs = region_finder.run(
-            center=events.pointing_radec,
-            region=on_region,
-            exclusion_mask=exclusion_mask,
-        )
-
-        if len(regions) > 0:
-            off_region_geom = RegionGeom.from_regions(
-                regions=regions,
-                axes=[energy_range],
-                wcs=wcs,
-            )
-            counts_off = RegionNDMap.from_geom(geom=off_region_geom)
-            counts_off.fill_events(events)
-            counts_off_list.append(counts_off.data[0])
-        else:
-            log.warning(
-                f"ReflectedRegionsBackgroundMaker failed in estimated energy bin {i}."
-            )
-            counts_off_list.append([[0]])
-
-        acceptance_off_list.append(len(regions))
-
-    # create the final arrays with the OFF counts and the acceptance
-    counts_off = RegionNDMap.from_geom(geom=geom, data=np.asarray(counts_off_list))
-    acceptance_off = RegionNDMap.from_geom(
-        geom=geom, data=np.asarray(acceptance_off_list)
+    off_regions, wcs = region_finder.run(
+        center=events.pointing_radec,
+        region=on_geom.region,
+        exclusion_mask=exclusion_mask,
     )
+
+    if len(off_regions) == 0:
+        # counts_off=None, acceptance_off=0
+        return None, RegionNDMap.from_geom(on_geom, data=0)
+
+
+    offset = on_geom.region.center.separation(events.pointing_radec)
+    if are_regions_overlapping([on_geom.region] + off_regions, rad_max, offset):
+        log.warning("Found overlapping on/off regions, choose less off regions")
+        # counts_off=None, acceptance_off=0
+        return None, RegionNDMap.from_geom(on_geom, data=0)
+
+    # check for overlap
+    energy_axis = on_geom.axes["energy"]
+
+    off_region_geom = RegionGeom.from_regions(
+        regions=off_regions,
+        axes=[energy_axis],
+        wcs=wcs,
+    )
+
+    counts_off = RegionNDMap.from_geom(geom=off_region_geom)
+    acceptance_off = RegionNDMap.from_geom(
+        geom=off_region_geom,
+        data=np.full(energy_axis.nbin, len(off_regions))
+    )
+
+    for off_region in off_regions:
+        selected_events = apply_rad_max(events, rad_max, off_region.center)
+        counts_off.fill_events(selected_events)
 
     return counts_off, acceptance_off

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -491,7 +491,7 @@ def apply_rad_max(events, rad_max, position):
     return events.select_row_subset(selected)
 
 
-def are_regions_overlapping(regions, rad_max, offset):
+def are_regions_overlapping_rad_max(regions, rad_max, offset):
     """
     Calculate pair-wise separations between all regions and compare with rad_max
     to find overlaps.
@@ -501,8 +501,9 @@ def are_regions_overlapping(regions, rad_max, offset):
         for a, b in combinations(regions, 2)
     ])
 
+
     rad_max_at_offset = rad_max.evaluate(offset=offset)
-    return np.any(separations[np.newaxis, :] < rad_max_at_offset)
+    return np.any(separations[np.newaxis, :] < (2 * rad_max_at_offset))
 
 
 def make_counts_off_rad_max(
@@ -547,7 +548,7 @@ def make_counts_off_rad_max(
 
 
     offset = on_geom.region.center.separation(events.pointing_radec)
-    if are_regions_overlapping([on_geom.region] + off_regions, rad_max, offset):
+    if are_regions_overlapping_rad_max([on_geom.region] + off_regions, rad_max, offset):
         log.warning("Found overlapping on/off regions, choose less off regions")
         # counts_off=None, acceptance_off=0
         return None, RegionNDMap.from_geom(on_geom, data=0)


### PR DESCRIPTION
**Description**

    
Instead of evaluating rad_max at the bin center of the given counts
energy axis, we now use the individual event energy.

By making the WobbleRegionsFinder work properly with PointSkyRegion and
adding a check for overlapping regions in the rad_max case, we can now
perform the classical data reduction for point sky analyses.

The ReflectedRegionsFinder does not work and probably cannot be made to
work with PointSkyRegion, since it uses the extent of the previous
region to place the next. This is obviously not possible for
PointSkyRegion.

This simplified the code in `make_counts_rad_max` and `make_counts_off_rad_max` quite significantly, there is now only a loop over the off regions and not over the reco energy bins anymore.