### PR TITLE
MapAxes.__getitem__ returns MapAxes type

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1609,13 +1609,16 @@ class MapAxes(Sequence):
         return self.__class__(axes=axes)
 
     def __getitem__(self, idx):
-        if isinstance(idx, (int, slice)):
+        if isinstance(idx, int):
             return self._axes[idx]
         elif isinstance(idx, str):
             for ax in self._axes:
                 if ax.name == idx:
                     return ax
             raise KeyError(f"No axes: {idx!r}")
+        elif isinstance(idx, slice):
+            axes = self._axes[idx]
+            return self.__class__(axes=axes)
         elif isinstance(idx, list):
             axes = []
             for name in idx:

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -601,6 +601,20 @@ def test_axes_basics():
 
     assert axes.primary_axis.name == "time"
 
+def test_axes_getitem():
+    axis1 = MapAxis.from_bounds(1, 4, 3, name="a1")
+    axis2 = axis1.copy(name="a2")
+    axis3 = axis1.copy(name="a3")
+    axes = MapAxes([axis1, axis2, axis3])
+
+    assert isinstance(axes[0], MapAxis)
+    assert axes[-1].name == "a3"
+    assert isinstance(axes[1:], MapAxes)
+    assert len(axes[1:]) == 2
+    assert isinstance(axes[0:1], MapAxes)
+    assert len(axes[0:1]) == 1
+    assert isinstance(axes[["a3", "a1"]], MapAxes)
+    assert axes[["a3", "a1"]][0].name == "a3"
 
 def test_label_map_axis_basics():
     axis = LabelMapAxis(labels=["label-1", "label-2"], name="label-axis")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request solves #3771 . When passed a `slice`, `MapAxes.__getitem__` now returns a `MapAxes`. A test is added.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
