### PR TITLE
Allow MapAxis with single bin and node type center

### DIFF
--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -571,7 +571,7 @@ class FluxMaps:
     def flux_ref(self):
         """Reference integral flux"""
         if not self.is_convertible_to_flux_sed_type:
-            raise ValueError("Missing energy range definition, cannot convert to flux sed type.")
+            raise ValueError("Missing energy range definition, cannot convert to sed type 'flux'.")
 
         energy_min = self.energy_axis.edges[:-1]
         energy_max = self.energy_axis.edges[1:]
@@ -582,7 +582,7 @@ class FluxMaps:
     def eflux_ref(self):
         """Reference energy flux"""
         if not self.is_convertible_to_flux_sed_type:
-            raise ValueError("Missing energy range definition, cannot convert to flux sed type.")
+            raise ValueError("Missing energy range definition, cannot convert to sed type 'eflux'.")
 
         energy_min = self.energy_axis.edges[:-1]
         energy_max = self.energy_axis.edges[1:]

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -134,7 +134,7 @@ class TSMapEstimator(Estimator):
       n_sigma                : 1
       n_sigma_ul             : 2
       sqrt_ts_threshold_ul   : 2
-      sed type init          : None
+      sed type init          : likelihood
 
 
     References

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -333,6 +333,14 @@ class FluxPoints(FluxMaps):
 
             idx = (Ellipsis, 0, 0)
             table = self.energy_axis.to_table(format="gadf-sed")
+
+            if self.energy_axis.nbin == 1 and self.energy_axis.node_type == "center":
+                if sed_type in ["flux", "eflux", "likelihood"]:
+                    raise ValueError("Cannot convert single energy bin with node"
+                                     f" type center to integral sed type '{sed_type}'")
+                else:
+                    table.remove_columns(["e_min", "e_max"])
+
             table.meta["SED_TYPE"] = sed_type
 
             if self.n_sigma_ul:

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -314,6 +314,7 @@ def test_is_ul(tmp_path):
     table = fp.to_table()
     assert_allclose(table["is_ul"].data.data, is_ul)
 
+
 @requires_dependency("matplotlib")
 def test_flux_points_plot_no_error_bar():
     table = Table()
@@ -326,4 +327,4 @@ def test_flux_points_plot_no_error_bar():
 
     flux_points = FluxPoints.from_table(table)
     with mpl_plot_check():
-       flux_points.plot(sed_type="flux")
+       _ = flux_points.plot(sed_type="dnde")

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -241,6 +241,9 @@ def test_flux_points_single_bin_dnde():
     table_single_bin = table[1:2]
     fp = FluxPoints.from_table(table_single_bin, sed_type="dnde")
 
+    with pytest.raises(ValueError):
+        _ = fp.flux_ref
+
     with mpl_plot_check():
         fp.plot(sed_type="e2dnde")
 

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -234,6 +234,27 @@ class TestFluxPoints:
 
 
 @requires_data()
+def test_flux_points_single_bin_dnde():
+    path = make_path("$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits")
+    table = Table.read(path)
+
+    table_single_bin = table[1:2]
+    fp = FluxPoints.from_table(table_single_bin, sed_type="dnde")
+
+    with mpl_plot_check():
+        fp.plot(sed_type="e2dnde")
+
+    with pytest.raises(ValueError):
+        fp.to_table(sed_type="flux")
+
+    table = fp.to_table(sed_type="dnde")
+
+    assert_allclose(table["e_ref"], 153.992 * u.MeV, rtol=0.001)
+    assert "e_min" not in table.colnames
+    assert "e_max" not in table.colnames
+
+
+@requires_data()
 def test_compute_flux_points_dnde_fermi():
     """
     Test compute_flux_points_dnde on fermi source.

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -301,7 +301,9 @@ class MapAxis:
                                         quantity=PLOT_AXIS_LABEL.get(self.name, self.name.capitalize())
                                         , unit=self.unit )
         ax.set_xlabel(xlabel)
-        ax.set_xlim(self.bounds)
+        xmin, xmax = self.bounds
+        if not xmin == xmax:
+            ax.set_xlim(self.bounds)
         return ax
 
     def format_plot_yaxis(self, ax):

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1330,13 +1330,15 @@ class MapAxes(Sequence):
     @property
     def is_flat(self):
         """Whether axes is flat"""
-        return np.all(self.shape == 1)
+        shape = np.array(self.shape)
+        return np.all(shape == 1)
 
     @property
     def is_unidimensional(self):
         """Whether axes is unidimensional"""
-        value = (np.array(self.shape) > 1).sum()
-        return value == 1
+        shape = np.array(self.shape)
+        non_zero = np.count_nonzero(shape > 1)
+        return self.is_flat or non_zero == 1
 
     @property
     def reverse(self):

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -26,11 +26,17 @@ def flat_if_equal(array):
 def coord_to_pix(edges, coord, interp="lin"):
     """Convert axis to pixel coordinates for given interpolation scheme."""
     scale = interpolation_scale(interp)
+    kwargs = {
+        "fill_value": "extrapolate",
+        "x": scale(edges),
+        "y": np.arange(len(edges), dtype=float),
+    }
 
-    interp_fn = scipy.interpolate.interp1d(
-        scale(edges), np.arange(len(edges), dtype=float), fill_value="extrapolate"
-    )
+    # change to nearest neighbour interpolation for single bins
+    if len(edges) == 1:
+        kwargs["kind"] = 0
 
+    interp_fn = scipy.interpolate.interp1d(**kwargs)
     return interp_fn(scale(coord))
 
 
@@ -38,10 +44,17 @@ def pix_to_coord(edges, pix, interp="lin"):
     """Convert pixel to grid coordinates for given interpolation scheme."""
     scale = interpolation_scale(interp)
 
-    interp_fn = scipy.interpolate.interp1d(
-        np.arange(len(edges), dtype=float), scale(edges), fill_value="extrapolate"
-    )
+    kwargs = {
+        "fill_value": "extrapolate",
+        "x": np.arange(len(edges), dtype=float),
+        "y": scale(edges),
+    }
 
+    # change to nearest neighbour interpolation for single bins
+    if len(edges) == 1:
+        kwargs["kind"] = 0
+
+    interp_fn = scipy.interpolate.interp1d(**kwargs)
     return scale.inverse(interp_fn(pix))
 
 

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -102,9 +102,6 @@ class MapAxis:
         if ~(np.all(nodes == np.sort(nodes)) or np.all(nodes[::-1] == np.sort(nodes))):
             raise ValueError("MapAxis: node values must be sorted")
 
-        if len(nodes) == 1 and node_type == "center":
-            raise ValueError("Single bins can only be used with node-type 'edges'")
-
         if isinstance(nodes, u.Quantity):
             unit = nodes.unit if nodes.unit is not None else ""
             nodes = nodes.value

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -74,9 +74,7 @@ class RegionNDMap(Map):
         ax = ax or plt.gca()
 
         if axis_name is None:
-            if len(self.geom.axes) == 1:
-                axis_name = self.geom.axes[0].name
-            elif self.geom.axes.is_unidimensional:
+            if self.geom.axes.is_unidimensional:
                 axis_name = self.geom.axes.primary_axis.name
             else:
                 raise ValueError(

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -74,7 +74,9 @@ class RegionNDMap(Map):
         ax = ax or plt.gca()
 
         if axis_name is None:
-            if self.geom.axes.is_unidimensional:
+            if len(self.geom.axes) == 1:
+                axis_name = self.geom.axes[0].name
+            elif self.geom.axes.is_unidimensional:
                 axis_name = self.geom.axes.primary_axis.name
             else:
                 raise ValueError(

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -175,6 +175,14 @@ def test_up_downsample_consistency(factor):
     assert_allclose(axis.edges, axis_new.edges)
 
 
+def test_one_bin_nodes():
+    axis = MapAxis.from_nodes([1], name="test", unit="deg")
+    assert_allclose(axis.center, 1 * u.deg)
+
+    assert_allclose(axis.coord_to_idx(2 * u.deg), 0)
+    assert_allclose(axis.idx_to_coord(1), 1 * u.deg)
+
+
 def test_group_table_basic(energy_axis_ref):
     energy_edges = [1, 2, 10] * u.TeV
 
@@ -695,7 +703,7 @@ def test_mixed_axes():
 
 
 @requires_dependency("matplotlib")
-def test_MapAxis_format_plot_xaxis():
+def test_map_axis_format_plot_xaxis():
     import matplotlib.pyplot as plt
     axis = MapAxis.from_energy_bounds(
             "0.03 TeV", "300 TeV", nbin=20,
@@ -711,7 +719,7 @@ def test_MapAxis_format_plot_xaxis():
 
 
 @requires_dependency("matplotlib")
-def test_TimeMapAxis_format_plot_xaxis(time_intervals):
+def test_time_map_axis_format_plot_xaxis(time_intervals):
     import matplotlib.pyplot as plt
     axis = TimeMapAxis(
         time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"], name="time"

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -177,10 +177,11 @@ def test_up_downsample_consistency(factor):
 
 def test_one_bin_nodes():
     axis = MapAxis.from_nodes([1], name="test", unit="deg")
-    assert_allclose(axis.center, 1 * u.deg)
 
-    assert_allclose(axis.coord_to_idx(2 * u.deg), 0)
-    assert_allclose(axis.idx_to_coord(1), 1 * u.deg)
+    assert_allclose(axis.center, 1 * u.deg)
+    assert_allclose(axis.coord_to_pix(1 * u.deg), 0)
+    assert_allclose(axis.coord_to_pix(2 * u.deg), 0)
+    assert_allclose(axis.pix_to_coord(0), 1 * u.deg)
 
 
 def test_group_table_basic(energy_axis_ref):
@@ -248,11 +249,6 @@ def test_group_table_outside_range(energy_axis_ref):
 
     with pytest.raises(ValueError):
         energy_axis_ref.group_table(energy_edges)
-
-
-def test_map_axis_single_bin():
-    with pytest.raises(ValueError):
-        _ = MapAxis.from_nodes([1])
 
 
 def test_map_axis_aligned():


### PR DESCRIPTION
This pull request addresses #1952 by changing to nearest neighbor interpolation for the case of a single axis bin. It adds a unit test for `MapAxis` and unit test for `FluxPoints` serialization and plotting, where the issue came up first. 

