### PR TITLE
Add available formats to docstring of FluxPoints.write()

### DIFF
--- a/docs/estimators/index.rst
+++ b/docs/estimators/index.rst
@@ -86,7 +86,7 @@ e_max             Maximum energy
 dnde              Differential flux at ``e_ref``
 flux              Integrated flux between ``e_min`` and ``e_max``
 eflux             Integrated energy flux between ``e_min`` and ``e_max``
-e2dnde            Differential energy flux between ``e_ref``
+e2dnde            Differential energy flux at ``e_ref``
 ================= =================================================
 
 The same can be applied for the error and upper limit information.

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -152,8 +152,19 @@ class FluxPoints(FluxMaps):
             Filename
         sed_type : {"dnde", "flux", "eflux", "e2dnde", "likelihood"}
             Sed type
-        format : {"gadf-sed", "lightcurve"}
-            Format string.
+        format : {"gadf-sed", "lightcurve", "binned-time-series", "profile"}
+            Format specification. The following formats are supported:
+
+            * "gadf-sed": format for sed flux points see :ref:`gadf:flux-points`
+                for details
+            * "lightcurve": Gammapy internal format to store energy dependent
+                lightcurves. Basically a generalisation of the "gadf" format, but
+                currently there is no detailed documentation available.
+            * "binned-time-series": table format support by Astropy's
+                `~astropy.timeseries.BinnedTimeSeries`.
+            * "profile": Gammapy internal format to store energy dependent
+                flux profiles. Basically a generalisation of the "gadf" format, but
+                currently there is no detailed documentation available.
         **kwargs : dict
             Keyword arguments passed to `astropy.table.Table.write`.
         """


### PR DESCRIPTION
This pull request makes very small changes to the documentation. Just a couple of things I noticed recently and wanted to fix before forgetting.

* a typo in the .rst page of the estimators sub-package
* the docstring of the `FluxPoints.write()` method was missing two of the available formats. I also copied the definition of each format from the  `FluxPoints.to_table()` method, because from a user perspective it is better to have that info already in the write method documentation without needing to figure out what method is that one calling. 
