### PR TITLE
Fix build docs

### DIFF
--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -231,6 +231,8 @@ def cli_jupyter_tar(out):
     """Create a tar file with the notebooks in docs."""
 
     tar_name = Path(out)
+    tar_name.parent.mkdir(parents=True, exist_ok=True)
+
     with tarfile.open(tar_name, "w:") as tar:
         for name in get_notebooks_paths():
             path_tail = str(name).split(str(PATH_DOCS.resolve()))[1]


### PR DESCRIPTION
This PR fixes the build docs CI after #3778 
It creates target folder in `gammapy jupyter tar` when it does not exist.

https://github.com/gammapy/gammapy-docs/runs/5233129211?check_suite_focus=true#step:7:38

 