### PR TITLE
Add `FluxPointsDataset.read`

### DIFF
--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -163,8 +163,17 @@ class FluxPointsDataset(Dataset):
 
         filename = make_path(filename)
         table = Table.read(filename)
+        mask_fit = None
+        mask_safe = None
+        if "mask_safe" in table.colnames:
+            mask_safe = table["mask_safe"].data.astype("bool")
+        if "mask_fit" in table.colnames:
+            mask_fit = table["mask_fit"].data.astype("bool")
         return cls(
-            name=make_name(name), data=FluxPoints.from_table(table, format=format)
+            name=make_name(name),
+            data=FluxPoints.from_table(table, format=format),
+            mask_fit=mask_fit,
+            mask_safe=mask_safe
         )
 
     @classmethod

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -39,33 +39,28 @@ class FluxPointsDataset(Dataset):
     >>> from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
     >>> from gammapy.estimators import FluxPoints
     >>> from gammapy.datasets import FluxPointsDataset
-
-    >>> #load precomputed flux points
     >>> filename = "$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits"
-    >>> flux_points = FluxPoints.read(filename)
-
+    >>> dataset = FluxPointsDataset.read(filename)
     >>> model = SkyModel(spectral_model=PowerLawSpectralModel())
-
-    >>> #create dataset and fit
-    >>> dataset = FluxPointsDataset(model, flux_points)
+    >>> dataset.models = model
     >>> fit = Fit()
     >>> result = fit.run([dataset])
     >>> print(result)
     OptimizeResult
     <BLANKLINE>
-    	backend    : minuit
-    	method     : migrad
-    	success    : True
-    	message    : Optimization terminated successfully.
-    	nfev       : 135
-    	total stat : 25.21
+        backend    : minuit
+        method     : migrad
+        success    : True
+        message    : Optimization terminated successfully.
+        nfev       : 135
+        total stat : 25.21
     <BLANKLINE>
     CovarianceResult
     <BLANKLINE>
-    	backend    : minuit
-    	method     : hesse
-    	success    : True
-    	message    : Hesse terminated successfully.
+        backend    : minuit
+        method     : hesse
+        success    : True
+        message    : Hesse terminated successfully.
 
     >>> print(result.parameters.to_table())
           type      name     value         unit        error   min max frozen link
@@ -123,7 +118,7 @@ class FluxPointsDataset(Dataset):
             models = DatasetModels(models)
             self._models = models.select(datasets_names=self.name)
 
-    def write(self, filename, overwrite=True, **kwargs):
+    def write(self, filename, overwrite=False, **kwargs):
         """Write flux point dataset to file.
 
         Parameters
@@ -145,6 +140,32 @@ class FluxPointsDataset(Dataset):
         table["mask_fit"] = mask_fit
         table["mask_safe"] = self.mask_safe
         table.write(make_path(filename), overwrite=overwrite, **kwargs)
+
+    @classmethod
+    def read(cls, filename, name=None, format="gadf-sed"):
+        """Read pre-computed flux points and create a dataset
+
+        Parameters
+        ----------
+        filename : str
+            Filename to read from.
+        name : str
+            Name of the new dataset.
+        format : {"gadf-sed"}
+            Format of the dataset file.
+
+        Returns
+        -------
+        dataset : `FluxPointsDataset`
+            FluxPointsDataset
+        """
+        from gammapy.estimators import FluxPoints
+
+        filename = make_path(filename)
+        table = Table.read(filename)
+        return cls(
+            name=make_name(name), data=FluxPoints.from_table(table, format=format)
+        )
 
     @classmethod
     def from_dict(cls, data, **kwargs):

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -53,6 +53,11 @@ def test_flux_point_dataset_serialization(tmp_path):
     model = SkyModel(spectral_model=spectral_model, name="test_model")
     dataset = FluxPointsDataset(model, data, name="test_dataset")
 
+    dataset2 = FluxPointsDataset.read(path, name="test_dataset2")
+    assert_allclose(dataset.data.dnde.data, dataset2.data.dnde.data)
+    assert dataset.mask_safe.data == dataset2.mask_safe.data
+    assert dataset2.name == "test_dataset2"
+
     Datasets([dataset]).write(
         filename=tmp_path / "tmp_datasets.yaml",
         filename_models=tmp_path / "tmp_models.yaml",


### PR DESCRIPTION
Directly allows to create a `FluxPointsDataset` as proposed in #3747 
This makes the API homogeneous with `MapDataset`

Also, changing `FluxPointsDataset.write` default `overwrite` to `False` to be consistent with `MapDataset.write`