### PR TITLE
Remove unit setter on IRF and Map 

### DIFF
--- a/docs/tutorials/data/fermi_lat.ipynb
+++ b/docs/tutorials/data/fermi_lat.ipynb
@@ -31,7 +31,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0e7bb89e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Check that you have the prepared Fermi-LAT dataset\n",
@@ -43,7 +45,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6534398b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -54,7 +58,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d76221de",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from astropy import units as u\n",
@@ -89,7 +95,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cd82b69d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "events = EventList.read(\n",
@@ -110,7 +118,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f2449f3f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "events.table.colnames"
@@ -120,7 +130,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a3df26c9",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "events.table[:5][[\"ENERGY\", \"RA\", \"DEC\"]]"
@@ -130,7 +142,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "996505ba",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "print(events.time[0].iso)\n",
@@ -141,7 +155,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0f9bb332",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "energy = events.energy\n",
@@ -160,7 +176,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8e121afc",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "for e_min in [10, 100, 1000] * u.GeV:\n",
@@ -182,7 +200,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "88389c59",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "gc_pos = SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\")\n",
@@ -208,7 +228,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a634890c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "counts.geom.axes[0]"
@@ -218,7 +240,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8d94134c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "counts.sum_over_axes().smooth(2).plot(stretch=\"sqrt\", vmax=30);"
@@ -242,7 +266,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8d8de151",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "exposure_hpx = Map.read(\n",
@@ -256,7 +282,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "749cfb1f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "exposure_hpx.plot();"
@@ -266,7 +294,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "86aadcf8",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# For exposure, we choose a geometry with node_type='center',\n",
@@ -287,7 +317,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "062aa441",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "counts.geom.axes[0]"
@@ -297,7 +329,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "aa8b8846",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "print(exposure.geom)\n",
@@ -308,7 +342,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b95a6fe7",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Exposure is almost constant across the field of view\n",
@@ -319,7 +355,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b66474bf",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Exposure varies very little with energy at these high energies\n",
@@ -350,16 +388,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d319a48e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "diffuse_galactic_fermi = Map.read(\n",
     "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\"\n",
     ")\n",
     "\n",
-    "# Unit is not stored in the file, set it manually\n",
-    "diffuse_galactic_fermi.unit = \"cm-2 s-1 MeV-1 sr-1\"\n",
-    "print(diffuse_galactic_fermi.geom)\n",
+    "print(diffuse_galactic_fermi)\n",
     "\n",
     "print(diffuse_galactic_fermi.geom.axes[0])"
    ]
@@ -368,7 +406,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a1aa48eb",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "template_diffuse = TemplateSpatialModel(\n",
@@ -702,7 +742,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -724,9 +764,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1.0,
+   "current_citInitial": 1,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1.0,
+   "eqNumInitial": 1,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"
@@ -737,7 +777,7 @@
    "user_envs_cfg": false
   },
   "toc": {
-   "base_numbering": 1.0,
+   "base_numbering": 1,
    "nav_menu": {
     "height": "237px",
     "width": "253px"
@@ -754,9 +794,9 @@
   },
   "varInspector": {
    "cols": {
-    "lenName": 16.0,
-    "lenType": 16.0,
-    "lenVar": 40.0
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
    },
    "kernels_config": {
     "python": {

--- a/examples/models/spatial/plot_template.py
+++ b/examples/models/spatial/plot_template.py
@@ -23,7 +23,7 @@ from gammapy.modeling.models import (
 filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
 
 m = Map.read(filename)
-m.unit = "sr^-1"
+m = m.copy(unit="sr^-1")
 model = TemplateSpatialModel(m, filename=filename)
 
 model.plot(add_cbar=True)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -449,8 +449,7 @@ class MapDataset(Dataset):
                 if self._background_cached is None:
                     self._background_cached = background * values
                 else:
-                    self._background_cached.data = background.data * values.value
-                    self._background_cached.unit = background.unit
+                    self._background_cached.quantity = background.quantity * values.value
             return self._background_cached
         else:
             return background

--- a/gammapy/datasets/tests/test_evaluator.py
+++ b/gammapy/datasets/tests/test_evaluator.py
@@ -36,10 +36,8 @@ def test_compute_flux_spatial():
     model = Models(models)
 
     exposure_region = RegionNDMap.create(
-        region, axes=[energy_axis_true], binsz_wcs="0.01deg"
+        region, axes=[energy_axis_true], binsz_wcs="0.01deg", unit="m2 s", data=1.0
     )
-    exposure_region.data += 1.0
-    exposure_region.unit = "m2 s"
 
     geom = RegionGeom(region, axes=[energy_axis_true], binsz_wcs="0.01deg")
     psf = PSFKernel.from_gauss(geom.to_wcs_geom(), sigma="0.1 deg")
@@ -70,9 +68,7 @@ def test_compute_flux_spatial_no_psf():
     models = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)
     model = Models(models)
 
-    exposure_region = RegionNDMap.create(region, axes=[energy_axis_true])
-    exposure_region.data += 1.0
-    exposure_region.unit = "m2 s"
+    exposure_region = RegionNDMap.create(region, axes=[energy_axis_true], unit="m2 s", data=1.0)
 
     evaluator = MapEvaluator(model=model[0], exposure=exposure_region)
     flux = evaluator.compute_flux_spatial()

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -49,7 +49,7 @@ def input_dataset():
     counts2D = Map.read(filename, hdu="counts")
     counts = counts2D.to_cube([energy])
     exposure2D = Map.read(filename, hdu="exposure")
-    exposure2D.unit = "cm2s"
+    exposure2D = Map.from_geom(exposure2D.geom, data=exposure2D.data, unit="cm2s")
     exposure = exposure2D.to_cube([energy_true])
     background2D = Map.read(filename, hdu="background")
     background = background2D.to_cube([energy])

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -176,6 +176,22 @@ class IRF(metaclass=abc.ABCMeta):
         self.data = val.value
         self._unit = val.unit
 
+    def to_unit(self, unit):
+        """Convert irf to different unit
+
+        Parameters
+        ----------
+        unit : `~astropy.unit.Unit` or str
+            New unit
+
+        Returns
+        -------
+        irf : `IRF`
+            IRF with new unit and converted data
+        """
+        data = self.quantity.to_value(unit)
+        return self.__class__(self.axes, data = data, meta = self.meta, interp_kwargs = self.interp_kwargs)
+
     @property
     def axes(self):
         """`MapAxes`"""

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -47,10 +47,10 @@ class IRF(metaclass=abc.ABCMeta):
             if not self.default_unit.is_equivalent(data.unit):
                 raise ValueError(f"Error: {data.unit} is not an allowed unit. {self.tag} requires {self.default_unit} data quantities.")
             else:
-                self.unit = data.unit
+                self._unit = data.unit
         else:
             self.data = data
-            self.unit = unit
+            self._unit = unit
         self.meta = meta or {}
         if interp_kwargs is None:
             interp_kwargs = self.default_interp_kwargs.copy()
@@ -144,10 +144,6 @@ class IRF(metaclass=abc.ABCMeta):
         """Map unit (`~astropy.units.Unit`)"""
         return self._unit
 
-    @unit.setter
-    def unit(self, val):
-        self._unit = u.Unit(val)
-
     @lazyproperty
     def _interpolate(self):
         kwargs = self.interp_kwargs.copy()
@@ -178,7 +174,7 @@ class IRF(metaclass=abc.ABCMeta):
         """
         val = u.Quantity(val, copy=False)
         self.data = val.value
-        self.unit = val.unit
+        self._unit = val.unit
 
     @property
     def axes(self):

--- a/gammapy/irf/psf/parametric.py
+++ b/gammapy/irf/psf/parametric.py
@@ -60,10 +60,6 @@ class ParametricPSF(PSF):
         """Map unit (`~astropy.units.Unit`)"""
         return self._unit
 
-    @unit.setter
-    def unit(self, values):
-        self._unit = {key: u.Unit(val) for key, val in values.items()}
-
     @property
     def _interpolators(self):
         interps = {}
@@ -167,6 +163,7 @@ class ParametricPSF(PSF):
             data[name] = values.reshape(axes.shape)
             unit[name] = column.unit or ""
 
+        unit = {key: u.Unit(val) for key, val in unit.items()}
         return cls(axes=axes, data=data, meta=table.meta.copy(), unit=unit)
 
     def to_psf3d(self, rad=None):

--- a/gammapy/irf/psf/parametric.py
+++ b/gammapy/irf/psf/parametric.py
@@ -60,6 +60,10 @@ class ParametricPSF(PSF):
         """Map unit (`~astropy.units.Unit`)"""
         return self._unit
 
+    def to_unit(self, unit):
+        """Convert IRF to unit."""
+        raise NotImplementedError
+
     @property
     def _interpolators(self):
         interps = {}

--- a/gammapy/irf/psf/tests/test_parametric.py
+++ b/gammapy/irf/psf/tests/test_parametric.py
@@ -40,6 +40,10 @@ class TestEnergyDependentMultiGaussPSF:
 
         assert_allclose(desired, [0.14775, 0.18675, 0.25075] * u.deg, rtol=1e-3)
 
+    def test_to_unit(self, psf):
+        with pytest.raises(NotImplementedError):
+            psf.to_unit("deg-2")
+
     def test_to_psf3d(self, psf):
         rads = np.linspace(0.0, 1.0, 101) * u.deg
         psf_3d = psf.to_psf3d(rads)

--- a/gammapy/irf/psf/tests/test_table.py
+++ b/gammapy/irf/psf/tests/test_table.py
@@ -45,6 +45,9 @@ def test_psf_3d_basics(psf_3d):
     assert psf_3d.data.shape == (32, 6, 144)
     assert psf_3d.unit == "sr-1"
 
+    psf_3d_new_unit = psf_3d.to_unit("deg-2")
+    assert_allclose(psf_3d_new_unit.data, psf_3d.data/3282.8063, rtol=1e-6)
+
     assert_allclose(psf_3d.meta["LO_THRES"], 0.01)
 
     assert "PSF3D" in str(psf_3d)

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -78,6 +78,9 @@ def test_background_3d_basics(bkg_3d):
     bkg_2d = bkg_3d.to_2d()
     assert bkg_2d.data.data.shape == (2, 3)
 
+    bkg_3d_new_unit = bkg_3d.to_unit("s-1 MeV-1 sr-1")
+    assert_allclose(bkg_3d_new_unit.data[1, 1, 1], 0.1)
+
 
 def test_background_3d_read_write(tmp_path, bkg_3d):
     bkg_3d.to_table_hdu().writeto(tmp_path / "bkg3d.fits")

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -39,11 +39,11 @@ class Map(abc.ABC):
         self._geom = geom
 
         if isinstance(data, u.Quantity):
-            self.unit = unit
+            self._unit = u.Unit(unit)
             self.quantity = data
         else:
             self.data = data
-            self.unit = unit
+            self._unit = u.Unit(unit)
 
         if meta is None:
             self.meta = {}
@@ -102,10 +102,6 @@ class Map(abc.ABC):
         """Map unit (`~astropy.units.Unit`)"""
         return self._unit
 
-    @unit.setter
-    def unit(self, val):
-        self._unit = u.Unit(val)
-
     @property
     def meta(self):
         """Map meta (`dict`)"""
@@ -132,7 +128,7 @@ class Map(abc.ABC):
         val = u.Quantity(val, copy=False)
 
         self.data = val.value
-        self.unit = val.unit
+        self._unit = val.unit
 
     @staticmethod
     def create(**kwargs):

--- a/gammapy/maps/hpx/core.py
+++ b/gammapy/maps/hpx/core.py
@@ -3,6 +3,7 @@ import abc
 import json
 import numpy as np
 from astropy.io import fits
+import astropy.units as u
 from ..core import Map
 from ..io import find_bands_hdu, find_bintable_hdu
 from .geom import HpxGeom
@@ -156,7 +157,7 @@ class HpxMap(Map):
 
         # exposure maps have an additional GTI hdu
         if format == "fgst-bexpcube" and "GTI" in hdu_list:
-            hpx_map.unit = "cm2 s"
+            hpx_map._unit = u.Unit("cm2 s")
 
         return hpx_map
 

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -49,7 +49,7 @@ class RegionNDMap(Map):
         self._geom = geom
         self.data = data
         self.meta = meta
-        self.unit = u.Unit(unit)
+        self._unit = u.Unit(unit)
 
     def plot(self, ax=None, axis_name=None, **kwargs):
         """Plot the data contained in region map along the non-spatial axis.

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -233,8 +233,8 @@ def test_map_properties():
     m = Map.create(npix=(2, 1))
 
     assert isinstance(m.unit, u.CompositeUnit)
-    assert m.unit == ""
-    m.unit = "cm-2 s-1"
+    assert m._unit == u.one
+    m._unit = u.Unit("cm-2 s-1")
     assert m.unit.to_string() == "1 / (cm2 s)"
 
     assert isinstance(m.meta, dict)
@@ -322,7 +322,7 @@ def test_map_arithmetics(map_type):
         m5 += 1 * u.W
 
     m1.data *= 0.0
-    m1.unit = ""
+    m1._unit = u.one
     m1 += 4
     assert m1.unit == u.Unit("")
     assert_allclose(m1.data, 4)

--- a/gammapy/maps/wcs/core.py
+++ b/gammapy/maps/wcs/core.py
@@ -2,6 +2,7 @@
 import json
 import numpy as np
 from astropy.io import fits
+import astropy.units as u
 from ..core import Map
 from ..io import JsonQuantityEncoder, find_bands_hdu, find_hdu
 from .geom import WcsGeom
@@ -143,9 +144,9 @@ class WcsMap(Map):
         if wcs_map.unit.is_equivalent(""):
             if format == "fgst-template":
                 if "GTI" in hdu_list:  # exposure maps have an additional GTI hdu
-                    wcs_map.unit = "cm2 s"
+                    wcs_map._unit = u.Unit("cm2 s")
                 else:
-                    wcs_map.unit = "cm-2 s-1 MeV-1 sr-1"
+                    wcs_map._unit = u.Unit("cm-2 s-1 MeV-1 sr-1")
 
         return wcs_map
 

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -244,11 +244,11 @@ class SpatialModel(ModelBase):
             )
 
             # Finally stack result
-            result.unit = integrated.unit
+            result._unit = integrated.unit
             result.stack(integrated)
         else:
             values = self.evaluate_geom(wcs_geom)
-            result.unit = values.unit
+            result._unit = values.unit
             result += values
 
         result *= result.geom.solid_angle()

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -326,9 +326,8 @@ def test_sky_diffuse_map_3d():
 @requires_data()
 def test_sky_diffuse_map_normalize():
     # define model map with a constant value of 1
-    model_map = Map.create(map_type="wcs", width=(10, 5), binsz=0.5)
+    model_map = Map.create(map_type="wcs", width=(10, 5), binsz=0.5, unit="sr-1")
     model_map.data += 1.0
-    model_map.unit = "sr-1"
     model = TemplateSpatialModel(model_map)
 
     # define data map with a different spatial binning


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request solves #3784 and removes the unit setter on both `IRF` and  `Map`. 
A `to_unit` method is added on `IRF` to follow the implementation of `Map`. This is not implemented for parametric PSFs which have several parameters and several units. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
