### PR TITLE
Improve serialisation in analysis

### DIFF
--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -230,7 +230,8 @@ class GeneralConfig(GammapyBaseConfig):
     log: LogConfig = LogConfig()
     outdir: str = "."
     n_jobs: int = 1
-
+    datasets_file: Path = None
+    models_file: Path = None
 
 class AnalysisConfig(GammapyBaseConfig):
     """Gammapy analysis configuration."""

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -248,7 +248,7 @@ class Analysis:
 
 
     def write_datasets(self, filename=None, filename_models=None):
-        """Write datasets from YAML file.
+        """Write datasets to YAML file.
         
         Parameters
         ----------

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -53,10 +53,17 @@ class Analysis:
         self.datastore = None
         self.observations = None
         self.datasets = None
-        self.models = None
         self.fit = Fit()
         self.fit_result = None
         self.flux_points = None
+
+    @property
+    def models(self):
+        return self.datasets.models
+    
+    @models.setter
+    def models(self, models):
+        self.set_models(models, extend=False)
 
     @property
     def config(self):
@@ -174,25 +181,23 @@ class Analysis:
 
         log.info("Reading model.")
         if isinstance(models, str):
-            self.models = Models.from_yaml(models)
-        elif isinstance(models, Models):
-            self.models = models
+            models = Models.from_yaml(models)
         else:
             raise TypeError(f"Invalid type: {models!r}")
 
         if extend:
-            self.models.extend(self.datasets.models)
+            models.extend(self.datasets.models)
 
         if self.config.datasets.type == "3d":
             for dataset in self.datasets:
                 if dataset.background_model is None:
                     bkg_model = FoVBackgroundModel(dataset_name=dataset.name)
 
-                self.models.append(bkg_model)
+                models.append(bkg_model)
 
-        self.datasets.models = self.models
+        self.datasets.models = models
 
-        log.info(self.models)
+        log.info(models)
 
     def read_models(self, filename=None, extend=True):
         """Read models from YAML file.
@@ -263,7 +268,7 @@ class Analysis:
         config = self.config
         if filename is None:
             filename = self.config.general.datasets_file
-        else: 
+        else:
             config.general.datasets_file = filename
             self.update_config(config)
         if filename_models is None:

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -206,83 +206,67 @@ class Analysis:
 
         log.info(models)
 
-    def read_models(self, filename=None, extend=True):
-        """Read models from YAML file.
-       
-        Parameters
-        ----------
-        filename : str
-            path to  the model file
-        extend : bool
-            Extent the exiting models on the datasets or replace them.
-        By default the filename is taken from the configuration file.
-        If provided here the configuration will be uptdated.
-        """        
-        _, filename = self._update_datasets_files(filename_models=filename)
-        if filename is not None :
-            models = Models.read(filename)
-            self.set_models(models, extend)
-            log.info(f"Models loaded from {filename}.")
-
-
-    def read_datasets(self, filename=None, filename_models=None):
-        """Read datasets from YAML file.
-        
-        Parameters
-        ----------
-        filename : str
-            path to  the datasets file
-        filename_models : str
-            path to  the model file
-        By default these filenames are taken from the configuration file.
-        If provided here the configuration will be uptdated.
+    def write_models(self, overwrite=True, write_covariance=True):
+        """Write models to YAML file.
+           Filename is taken from the configuration file.
         """
 
-        filename, filename_models = self._update_datasets_files(filename, filename_models)
+        filename_models = self.config.general.models_file
+        if filename_models is not None:
+            self.models.write(filename_models,
+                              overwrite=overwrite,
+                              write_covariance=write_covariance)
+            log.info(f"Datasets stored to {filename_models}.")
+        else:
+            raise RuntimeError("Missing models_file in config.general")
+   
+
+    def read_datasets(self):
+        """Read datasets from YAML file.
+        Filenames are taken from the configuration file.
+
+        Parameters
+        ----------
+        overwrite : bool
+            overwrite datasets FITS files
+        write_covariance : bool
+            save covariance or not
+        """
+
+        filename = self.config.general.datasets_file
+        filename_models = self.config.general.models_file
         if filename is not None:
-            self.datasets = Datasets.read(filename, filename_models)
+            self.datasets = Datasets.read(filename)
+            self.set_models(filename_models)
             log.info(f"Datasets loaded from {filename}.")
             log.info(f"Models loaded from {filename_models}.")
         else:
-            self.datasets = None
+            raise RuntimeError("Missing datasets_file in config.general")
 
 
-    def write_datasets(self, filename=None, filename_models=None):
+    def write_datasets(self, overwrite=True, write_covariance=True):
         """Write datasets to YAML file.
-        
+        Filenames are taken from the configuration file.
+
         Parameters
         ----------
-        filename : str
-            path to  the datasets file
-        filename_models : str
-            path to  the model file
-        By default these filenames are taken from the configuration file.
-        If provided here the configuration will be uptdated.
+        overwrite : bool
+            overwrite datasets FITS files
+        write_covariance : bool
+            save covariance or not
         """
 
-        filename, filename_models = self._update_datasets_files(filename, filename_models)
+        filename = self.config.general.datasets_file
+        filename_models = self.config.general.models_file
         if filename is not None:
             self.datasets.write(filename,
                                  filename_models,
-                                 overwrite=True,
-                                 write_covariance=True)
+                                 overwrite=overwrite,
+                                 write_covariance=write_covariance)
             log.info(f"Datasets stored to {filename}.")
             log.info(f"Datasets stored to {filename_models}.")
-
-
-    def _update_datasets_files(self, filename=None, filename_models=None):
-        config = self.config
-        if filename is None:
-            filename = self.config.general.datasets_file
         else:
-            config.general.datasets_file = filename
-            self.update_config(config)
-        if filename_models is None:
-            filename_models = self.config.general.models_file
-        else: 
-            config.general.models_file = filename_models
-            self.update_config(config)
-        return filename, filename_models 
+            raise RuntimeError("Missing datasets_file in config.general")
 
 
     def run_fit(self):

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -223,8 +223,7 @@ class Analysis:
             models = Models.read(filename)
             self.set_models(models, extend)
             log.info(f"Models loaded from {filename}.")
-        else:
-            self.models = None
+
 
     def read_datasets(self, filename=None, filename_models=None):
         """Read datasets from YAML file.

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -206,9 +206,27 @@ class Analysis:
 
         log.info(models)
 
+
+    def read_models(self, path, extend=True):
+        """Read models from YAML file.
+
+        Parameters
+        ----------
+        path : str
+            path to the model file
+        extend : bool
+            Extent the exiting models on the datasets or replace them.
+        """
+
+        path = make_path(path)
+        models = Models.read(path)
+        self.set_models(models, extend=extend)
+        log.info(f"Models loaded from {path}.")
+
+
     def write_models(self, overwrite=True, write_covariance=True):
         """Write models to YAML file.
-           Filename is taken from the configuration file.
+           File name is taken from the configuration file.
         """
 
         filename_models = self.config.general.models_file
@@ -216,37 +234,31 @@ class Analysis:
             self.models.write(filename_models,
                               overwrite=overwrite,
                               write_covariance=write_covariance)
-            log.info(f"Datasets stored to {filename_models}.")
+            log.info(f"Models loaded from {filename_models}.")
         else:
             raise RuntimeError("Missing models_file in config.general")
    
 
     def read_datasets(self):
         """Read datasets from YAML file.
-        Filenames are taken from the configuration file.
+        File names are taken from the configuration file.
 
-        Parameters
-        ----------
-        overwrite : bool
-            overwrite datasets FITS files
-        write_covariance : bool
-            save covariance or not
         """
 
         filename = self.config.general.datasets_file
         filename_models = self.config.general.models_file
         if filename is not None:
             self.datasets = Datasets.read(filename)
-            self.set_models(filename_models)
             log.info(f"Datasets loaded from {filename}.")
-            log.info(f"Models loaded from {filename_models}.")
+            if filename_models is not  None:
+                self.read_models(filename_models, extend=False)
         else:
             raise RuntimeError("Missing datasets_file in config.general")
 
 
     def write_datasets(self, overwrite=True, write_covariance=True):
         """Write datasets to YAML file.
-        Filenames are taken from the configuration file.
+        File names are taken from the configuration file.
 
         Parameters
         ----------

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Session class driving the high level interface API"""
-import os
 import logging
 from astropy.coordinates import SkyCoord
 from astropy.table import Table

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -9,7 +9,7 @@ from pydantic.error_wrappers import ValidationError
 from gammapy.analysis import Analysis, AnalysisConfig
 from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
 from gammapy.maps import WcsGeom, WcsNDMap
-from gammapy.modeling.models import Models
+from gammapy.modeling.models import DatasetModels
 from gammapy.utils.testing import requires_data, requires_dependency
 
 CONFIG_PATH = Path(__file__).resolve().parent / ".." / "config"
@@ -138,14 +138,14 @@ def test_set_models():
     analysis.get_datasets()
     models_str = Path(MODEL_FILE).read_text()
     analysis.set_models(models=models_str)
-    assert isinstance(analysis.models, Models)
+    assert isinstance(analysis.models, DatasetModels)
     assert len(analysis.models) == 2
     assert  analysis.models.names == ['source', 'stacked-bkg']
     with pytest.raises(TypeError):
         analysis.set_models(0)
     
     new_source = analysis.models["source"].copy(name="source2")
-    analysis.set_models(models=new_source, extend=False)
+    analysis.set_models(models=[new_source], extend=False)
     assert len(analysis.models) == 2
     assert  analysis.models.names == ['source2', 'stacked-bkg']
 

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -438,10 +438,14 @@ def test_usage_errors():
 def test_datasets_io(tmpdir):
     config = get_example_config("3d")
     analysis = Analysis(config)
+    
+    analysis.read_datasets()
+    assert analysis.datasets == None
+    
     analysis.get_observations()
     analysis.get_datasets()
     models_str = Path(MODEL_FILE).read_text()
-    analysis.set_models(models=models_str)
+    analysis.models = models_str
 
     filename = tmpdir / "datasets.yaml"
     filename_models = tmpdir / "models.yaml"


### PR DESCRIPTION
This PR implements a part of the features proposed in #3788 related to datasets serialisation  :
- add datasets_file and models_file to general config
- add read_datasets write_datasets methods on analysis
- add extend option to set_models so extending the exiting models is not hard-coded
- change analysis.models to a property returning datasets.models so they are always the same and add a models setter on analysis that call set_models(models, extend=False)