### PR TITLE
Add headers from obs_table to obs_info for individual observation

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -239,7 +239,13 @@ class DataStore:
 
         row = self.obs_table.select_obs_id(obs_id=obs_id)[0]
         kwargs = {"obs_id": int(obs_id)}
-        kwargs["obs_info"] = table_row_to_dict(row)
+
+        # add info from table meta, e.g. the time references
+        kwargs["obs_info"] = {
+            k: v for k, v in self.obs_table.meta.items()
+            if not k.startswith('HDU')  # Ignore GADF structure of index table
+        }
+        kwargs["obs_info"].update(table_row_to_dict(row))
 
         hdu_list = ["events", "gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
 

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -214,3 +214,16 @@ def test_datastore_fixed_rad_max():
     obs.aeff = None
     obs.edisp = None
     assert obs.rad_max is None
+
+
+@requires_data()
+def test_datastore_header_info_in_obs_info(data_store):
+    '''Test information from the obs index header is propagated into obs_info'''
+    obs = data_store.obs(obs_id=23523)
+
+    assert "MJDREFI" in obs.obs_info
+    assert "MJDREFF" in obs.obs_info
+    assert "GEOLON" in obs.obs_info
+    assert "GEOLAT" in obs.obs_info
+    # make sure we don't add the OBS_INDEX HDUCLAS
+    assert "HDUCLAS1" not in obs.obs_info


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a breakout from #3797 that should be easy to review and merge. It ensures that we have the information from the header of the `OBS_INDEX` table available in the `obs_info` of the individual observations.

This is required since otherwise the `TSTART` / `TSTOP` columns cannot be interpreted due to missing reference headers.