### PR TITLE
Improve FOVALIGN check for background

### DIFF
--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -3,7 +3,7 @@ import logging
 import astropy.units as u
 from astropy.table import Table
 from regions import PointSkyRegion
-from gammapy.irf import EDispKernelMap, PSFMap, FoVAlignment
+from gammapy.irf import EDispKernelMap, PSFMap
 from gammapy.maps import Map
 from .core import Maker
 from .utils import (

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -210,18 +210,13 @@ class MapDatasetMaker(Maker):
         if isinstance(bkg, Map):
             return bkg.interp_to_geom(geom=geom, preserve_counts=True)
 
-        if observation.bkg.fov_alignment == FoVAlignment.ALTAZ:
-            pointing = observation.fixed_pointing_info
-        else:
-            pointing = observation.pointing_radec
-
         use_region_center = getattr(self, "use_region_center", True)
 
         if self.background_interp_missing_data:
             bkg.interp_missing_data(axis_name="energy")
 
         return make_map_background_irf(
-            pointing=pointing,
+            pointing=observation.fixed_pointing_info,
             ontime=observation.observation_time_duration,
             bkg=bkg,
             geom=geom,

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -211,13 +211,13 @@ def geom(map_type, ebounds, skydir):
             "map_type": "wcs",
             "ebounds": [0.1, 1, 10],
             "shape": (2, 3, 4),
-            "sum": 1050.930197,
+            "sum": 1051.960299,
         },
         {
             "map_type": "wcs",
             "ebounds": [0.1, 10],
             "shape": (1, 3, 4),
-            "sum": 1050.9301972,
+            "sum": 1051.960299,
         },
         # TODO: make this work for HPX
         # 'HpxGeom' object has no attribute 'separation'


### PR DESCRIPTION
This makes the check more explicit and always passes the `fixed_pointing_info`.

The unit test before was wrong.
It passed a `FixedPointingInfo`, which was the convoluted signal for
"FOVALIGN" == "ALTAZ" for a Background3D with no FOVALIGN, which is not
allowed by the standard, but gammapy assumes to mean "RADEC".

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

