### PR TITLE
Add fov_alignment and is_pointlike attributes to IRF

### DIFF
--- a/gammapy/irf/__init__.py
+++ b/gammapy/irf/__init__.py
@@ -21,6 +21,7 @@ from .psf import (
     PSF3D,
 )
 from .rad_max import RadMax2D
+from .core import FoVAlignment
 
 
 __all__ = [
@@ -32,6 +33,7 @@ __all__ = [
     "EffectiveAreaTable2D",
     "EnergyDependentMultiGaussPSF",
     "EnergyDispersion2D",
+    "FoVAlignment",
     "IRF_REGISTRY",
     "load_cta_irfs",
     "load_irf_dict_from_file",

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -5,6 +5,7 @@ import astropy.units as u
 from astropy.visualization import quantity_support
 from gammapy.maps import MapAxes, MapAxis
 from .core import IRF
+from .io import gadf_is_pointlike
 
 __all__ = ["Background3D", "Background2D"]
 
@@ -71,7 +72,11 @@ class BackgroundIRF(IRF):
             log.debug("Transposing background table on read")
             data = data.transpose()
 
-        return cls(axes=axes, data=data.value, meta=table.meta, unit=data.unit)
+        return cls(
+            axes=axes, data=data.value, meta=table.meta, unit=data.unit,
+            is_pointlike=gadf_is_pointlike(table.meta),
+            fov_alignment=table.meta.get("FOVALIGN", "RADEC"),
+        )
 
 
 class Background3D(BackgroundIRF):

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -68,7 +68,7 @@ class IRF(metaclass=abc.ABCMeta):
         axes = MapAxes(axes)
         axes.assert_names(self.required_axes)
         self._axes = axes
-        self.fov_alignment = FoVAlignment(fov_alignment)
+        self._fov_alignment = FoVAlignment(fov_alignment)
         self._is_pointlike = is_pointlike
 
         if isinstance(data, u.Quantity):
@@ -104,6 +104,11 @@ class IRF(metaclass=abc.ABCMeta):
     def has_offset_axis(self):
         """Whether the IRF explicitly depends on offset"""
         return "offset" in self.required_axes
+
+    @property
+    def fov_alignment(self):
+        """Alignment of the field of view coordinate axes, see `FoVAlignment`"""
+        return self._fov_alignment
 
     @property
     def data(self):

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -10,6 +10,7 @@ __all__ = ["load_cta_irfs", "load_irf_dict_from_file"]
 log = logging.getLogger(__name__)
 
 
+
 IRF_DL3_AXES_SPECIFICATION = {
     "THETA": {"name": "offset", "interp": "lin"},
     "ENERG": {"name": "energy_true", "interp": "log"},
@@ -134,6 +135,11 @@ IRF_MAP_HDU_SPECIFICATION = {
     "edisp_map": "edisp",
     "psf_map": "psf",
 }
+
+
+def gadf_is_pointlike(header):
+    '''Check if a GADF IRF is pointlike based on the header'''
+    return header.get('HDUCLAS3') == "POINT-LIKE"
 
 
 def load_cta_irfs(filename):

--- a/gammapy/irf/tests/test_core.py
+++ b/gammapy/irf/tests/test_core.py
@@ -1,16 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 import numpy as np
 import astropy.units as u
-from gammapy.irf.core import IRF
+from gammapy.irf.core import IRF, FoVAlignment
 from gammapy.maps import MapAxis
 
 
-def test_irf_init_quantity():
-    class TestIRF(IRF):
-        tag = "myirf"
-        required_axes = ["energy", "offset"]
-        default_unit = u.deg
+class TestIRF(IRF):
+    tag = "myirf"
+    required_axes = ["energy", "offset"]
+    default_unit = u.deg
 
+
+def test_irf_init_quantity():
     energy_axis = MapAxis.from_energy_bounds(10, 100, 10, unit="TeV", name="energy")
     offset_axis = MapAxis.from_bounds(0, 2.5, 5, unit="deg", name="offset")
     data = np.full((10, 5), 1)
@@ -19,3 +21,22 @@ def test_irf_init_quantity():
     irf2 = TestIRF(axes=[energy_axis, offset_axis], data=data * u.deg)
 
     assert np.all(irf.quantity == irf2.quantity)
+
+
+
+def test_immutable():
+    energy_axis = MapAxis.from_energy_bounds(10, 100, 10, unit="TeV", name="energy")
+    offset_axis = MapAxis.from_bounds(0, 2.5, 5, unit="deg", name="offset")
+    data = np.full((10, 5), 1) * u.deg
+    test_irf = TestIRF(
+        axes=[energy_axis, offset_axis],
+        data=data,
+        is_pointlike=False,
+        fov_alignment=FoVAlignment.RADEC,
+    )
+
+    with pytest.raises(AttributeError):
+        test_irf.is_pointlike = True
+
+    with pytest.raises(AttributeError):
+        test_irf.fov_alignment = FoVAlignment.ALTAZ

--- a/gammapy/irf/tests/test_rad_max.py
+++ b/gammapy/irf/tests/test_rad_max.py
@@ -44,19 +44,16 @@ def test_rad_max_from_irf():
     aeff = EffectiveAreaTable2D(
         data=u.Quantity(np.ones((e_bins, o_bins)), u.m**2, copy=False),
         axes=[energy_axis, offset_axis],
+        is_pointlike=True,
     )
 
     with pytest.raises(ValueError):
         # not a point-like IRF
         RadMax2D.from_irf(aeff)
 
-
-    aeff.meta['is_pointlike'] = True
-
     with pytest.raises(ValueError):
         # missing rad_max
         RadMax2D.from_irf(aeff)
-
 
     aeff.meta['RAD_MAX'] = '0.2 deg'
     with pytest.raises(ValueError):

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -3,7 +3,7 @@ import logging
 import astropy.units as u
 from astropy.table import Table
 from regions import PointSkyRegion
-from gammapy.irf import EDispKernelMap, PSFMap
+from gammapy.irf import EDispKernelMap, PSFMap, FoVAlignment
 from gammapy.maps import Map
 from .core import Maker
 from .utils import (
@@ -210,16 +210,11 @@ class MapDatasetMaker(Maker):
         if isinstance(bkg, Map):
             return bkg.interp_to_geom(geom=geom, preserve_counts=True)
 
-        bkg_coordsys = observation.bkg.meta.get("FOVALIGN", "RADEC")
-        if bkg_coordsys == "ALTAZ":
+        if observation.bkg.fov_alignment == FoVAlignment.ALTAZ:
             pointing = observation.fixed_pointing_info
-        elif bkg_coordsys == "RADEC":
-            pointing = observation.pointing_radec
         else:
-            raise ValueError(
-                f"Invalid background coordinate system: {bkg_coordsys!r}\n"
-                "Options: ALTAZ, RADEC"
-            )
+            pointing = observation.pointing_radec
+
         use_region_center = getattr(self, "use_region_center", True)
 
         if self.background_interp_missing_data:


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request continues with the low hanging fruits of #3767, adding the `fov_alignment` and `is_pointlike` attributes to the `IRF` class, parsing/passing the information from the meta in `{to,from}_table`.


