### PR TITLE
Rename IRF.is_offset_dependent to IRF.has_offset_axis

### DIFF
--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -340,7 +340,7 @@ class Observation:
         if "bkg" in self.available_irfs:
             bkg = self.bkg
 
-            if not bkg.is_offset_dependent:
+            if not bkg.has_offset_axis:
                 bkg = bkg.to_2d()
 
             bkg.plot(ax=axes_dict["bkg"])

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -72,8 +72,8 @@ class IRF(metaclass=abc.ABCMeta):
         return self.meta.get("is_pointlike", False)
 
     @property
-    def is_offset_dependent(self):
-        """Whether the IRF depends on offset"""
+    def has_offset_axis(self):
+        """Whether the IRF explicitly depends on offset"""
         return "offset" in self.required_axes
 
     @property

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -163,7 +163,7 @@ def make_map_background_irf(
         sky_coord = map_coord.skycoord
         d_omega = image_geom.solid_angle()
 
-    if bkg.is_offset_dependent:
+    if bkg.has_offset_axis:
         coords["offset"] = sky_coord.separation(pointing)
     else:
         if isinstance(pointing, FixedPointingInfo):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**

As discussed with @adonath via slack, the `IRF.is_offset_dependent` property is badly named, since a `Background3D` for example is definitely offset dependent, albeit not explicitly via the `offset` axis.

Renamed to the more explicit `has_offset_axis`
 

