### PR TITLE
Minor fix to evaluation_bin_size_min for Shell2SpatialModel

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -887,7 +887,7 @@ class Shell2SpatialModel(SpatialModel):
 
         The bin min size is defined as r_0*eta.
         """
-        return self.eta.value * self.r_0
+        return self.eta.value * self.r_0.quantity
 
     @property
     def evaluation_radius(self):


### PR DESCRIPTION
Fixed this broken line: https://github.com/gammapy/gammapy/blob/dd35f7a27c2f939fa6af3080d9c0ec0d1029260e/gammapy/modeling/models/spatial.py#L890

`self.r_0` -> `self.r_0.quantity`