### PR TITLE
Allow nearest neighbor interpolation with scalar data

### DIFF
--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -769,6 +769,34 @@ class EventList:
         mask &= offset < offset_band[1]
         return self.select_row_subset(mask)
 
+    def select_rad_max(self, rad_max, position=None):
+        """Select energy dependent offset
+
+        Parameters
+        ----------
+        rad_max : `~gamapy.irf.RadMax2D`
+            Rad max definition
+        position : `~astropy.coordinates.SkyCoord`
+            Center position. By default the pointing position is used.
+
+        Returns
+        -------
+        event_list : `EventList`
+            Copy of event list with selection applied.
+        """
+        if position is None:
+            position = self.pointing_radec
+
+        offset = position.separation(self.pointing_radec)
+        separation = position.separation(self.radec)
+
+        rad_max_for_events = rad_max.evaluate(
+            method="nearest", energy=self.energy, offset=offset
+        )
+
+        selected = separation <= rad_max_for_events
+        return self.select_row_subset(selected)
+
     @property
     def is_pointed_observation(self):
         """Whether observation is pointed"""

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -258,6 +258,7 @@ class IRF(metaclass=abc.ABCMeta):
         """
         # TODO: change to coord dict?
         non_valid_axis = set(kwargs).difference(self.axes.names)
+
         if non_valid_axis:
             raise ValueError(
                 f"Not a valid coordinate axis {non_valid_axis}"
@@ -270,7 +271,8 @@ class IRF(metaclass=abc.ABCMeta):
             coord = kwargs.get(key, value)
             if coord is not None:
                 coords_default[key] = u.Quantity(coord, copy=False)
-        data = self._interpolate(coords_default.values(), method=method)
+
+        data = self._interpolate(tuple(coords_default.values()), method=method)
 
         if self.interp_kwargs["fill_value"] is not None:
             idxs = self.axes.coord_to_idx(coords_default, clip=False)

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -272,7 +272,7 @@ class IRF(metaclass=abc.ABCMeta):
             if coord is not None:
                 coords_default[key] = u.Quantity(coord, copy=False)
 
-        data = self._interpolate(tuple(coords_default.values()), method=method)
+        data = self._interpolate(coords_default.values(), method=method)
 
         if self.interp_kwargs["fill_value"] is not None:
             idxs = self.axes.coord_to_idx(coords_default, clip=False)

--- a/gammapy/irf/rad_max.py
+++ b/gammapy/irf/rad_max.py
@@ -32,11 +32,9 @@ class RadMax2D(IRF):
     required_axes = ["energy", "offset"]
     default_unit = u.deg
 
-
     @classmethod
     def from_irf(cls, irf):
-        '''
-        Create a RadMax2D instance from another IRF component.
+        """Create a RadMax2D instance from another IRF component.
 
         This reads the RAD_MAX metadata keyword from the irf and creates
         a RadMax2D with a single bin in energy and offset using the
@@ -57,21 +55,25 @@ class RadMax2D(IRF):
         -----
         This assumes the true energy axis limits are also valid for the
         reco energy limits.
-        '''
+        """
         if not irf.is_pointlike:
-            raise ValueError('RadMax2D.from_irf is only valid for point-like irfs')
+            raise ValueError("RadMax2D.from_irf requires a point-like irf")
 
-        if 'RAD_MAX' not in irf.meta:
-            raise ValueError('irf does not contain RAD_MAX keyword')
+        if "RAD_MAX" not in irf.meta:
+            raise ValueError("Irf does not contain RAD_MAX keyword")
 
         rad_max_value = irf.meta["RAD_MAX"]
         if not isinstance(rad_max_value, float):
-            raise ValueError('RAD_MAX must be a float')
+            raise ValueError(
+                f"RAD_MAX must be a float, got '{type(rad_max_value)}' instead"
+            )
 
         energy_axis = irf.axes["energy_true"].copy(name="energy").squash()
         offset_axis = irf.axes["offset"].squash()
 
         return cls(
-            data=u.Quantity([[rad_max_value]], u.deg),
+            data=rad_max_value,
             axes=[energy_axis, offset_axis],
+            unit="deg",
+            interp_kwargs={"method": "nearest", "fill_value": None},
         )

--- a/gammapy/irf/tests/test_rad_max.py
+++ b/gammapy/irf/tests/test_rad_max.py
@@ -75,7 +75,12 @@ def test_rad_max_from_irf():
 def test_rad_max_single_bin():
     energy_axis = MapAxis.from_energy_bounds(0.01, 100, 1, unit="TeV")
     offset_axis = MapAxis.from_bounds(0., 5, 1, unit="deg", name="offset", )
-    rad_max = RadMax2D(data=[[0.1]] * u.deg, axes=[energy_axis, offset_axis])
+
+    rad_max = RadMax2D(
+        data=[[0.1]] * u.deg,
+        axes=[energy_axis, offset_axis],
+        interp_kwargs={"method": "nearest", "fill_value": None}
+    )
 
     value = rad_max.evaluate(energy=1 * u.TeV, offset=1 * u.deg)
     assert_allclose(value, 0.1 * u.deg)

--- a/gammapy/irf/tests/test_rad_max.py
+++ b/gammapy/irf/tests/test_rad_max.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.maps import MapAxis
 from gammapy.irf import RadMax2D, EffectiveAreaTable2D
@@ -30,8 +31,8 @@ def test_rad_max_roundtrip(tmp_path):
     rad_max_2d.write(tmp_path / "rad_max.fits")
     rad_max_read = RadMax2D.read(tmp_path / "rad_max.fits")
 
-    assert np.all(rad_max_read.data.data == rad_max)
-    assert np.all(rad_max_read.data.data == rad_max_read.data.data)
+    assert np.all(rad_max_read.data == rad_max)
+    assert np.all(rad_max_read.data == rad_max_read.data)
 
 
 def test_rad_max_from_irf():
@@ -76,5 +77,10 @@ def test_rad_max_single_bin():
     offset_axis = MapAxis.from_bounds(0., 5, 1, unit="deg", name="offset", )
     rad_max = RadMax2D(data=[[0.1]] * u.deg, axes=[energy_axis, offset_axis])
 
-    value = rad_max.evaluate(1 * u.TeV)
+    value = rad_max.evaluate(energy=1 * u.TeV, offset=1 * u.deg)
     assert_allclose(value, 0.1 * u.deg)
+
+    value = rad_max.evaluate(energy=[1, 2, 3] * u.TeV, offset=[[1]] * u.deg)
+    assert value.shape == (1, 3)
+    assert_allclose(value, 0.1 * u.deg)
+

--- a/gammapy/irf/tests/test_rad_max.py
+++ b/gammapy/irf/tests/test_rad_max.py
@@ -1,12 +1,12 @@
 import numpy as np
 import astropy.units as u
 from gammapy.maps import MapAxis
+from gammapy.irf import RadMax2D, EffectiveAreaTable2D
+
 import pytest
 
 
 def test_rad_max_roundtrip(tmp_path):
-    from gammapy.irf import RadMax2D
-
     n_energy = 10
     energy_axis = MapAxis.from_energy_bounds(
         50 * u.GeV, 100 * u.TeV, n_energy, name="energy"
@@ -35,8 +35,6 @@ def test_rad_max_roundtrip(tmp_path):
 
 
 def test_rad_max_from_irf():
-    from gammapy.irf import RadMax2D, EffectiveAreaTable2D
-
     e_bins = 3
     o_bins = 2
     energy_axis = MapAxis.from_energy_bounds(1 * u.TeV, 10 * u.TeV, nbin=e_bins, name='energy_true')
@@ -71,3 +69,12 @@ def test_rad_max_from_irf():
     assert rad_max.axes['offset'].edges[1] == aeff.axes['offset'].edges[-1]
     assert rad_max.quantity.shape == (1, 1)
     assert rad_max.quantity[0, 0] == 0.2 * u.deg
+
+
+def test_rad_max_single_bin():
+    energy_axis = MapAxis.from_energy_bounds(0.01, 100, 1, unit="TeV")
+    offset_axis = MapAxis.from_bounds(0., 5, 1, unit="deg", name="offset", )
+    rad_max = RadMax2D(data=[[0.1]] * u.deg, axes=[energy_axis, offset_axis])
+
+    value = rad_max.evaluate(1 * u.TeV)
+    assert_allclose(value, 0.1 * u.deg)

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -465,19 +465,15 @@ def are_regions_overlapping_rad_max(regions, rad_max, offset, e_min, e_max):
         for a, b in combinations(regions, 2)
     ])
 
-    # evaluate fails with a single bin somewhere trying to interpolate
-    if rad_max.data.shape == (1, 1):
-        rad_max_at_offset = rad_max.quantity[0, 0]
-    else:
-        rad_max_at_offset = rad_max.evaluate(offset=offset)
-        # do not check bins outside of energy range
-        edges_min = rad_max.axes['energy'].edges_min
-        edges_max = rad_max.axes['energy'].edges_max
-        # to be sure all possible values are included, we check
-        # for the *upper* energy bin to be larger than e_min and the *lower* edge
-        # to be larger than e_max
-        mask = (edges_max >= e_min) & (edges_min <= e_max)
-        rad_max_at_offset = rad_max_at_offset[mask]
+    rad_max_at_offset = rad_max.evaluate(offset=offset)
+    # do not check bins outside of energy range
+    edges_min = rad_max.axes['energy'].edges_min
+    edges_max = rad_max.axes['energy'].edges_max
+    # to be sure all possible values are included, we check
+    # for the *upper* energy bin to be larger than e_min and the *lower* edge
+    # to be larger than e_max
+    mask = (edges_max >= e_min) & (edges_min <= e_max)
+    rad_max_at_offset = rad_max_at_offset[mask]
 
     return np.any(separations[np.newaxis, :] < (2 * rad_max_at_offset))
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -484,16 +484,13 @@ def make_counts_rad_max(geom, rad_max, events):
 
 
 def apply_rad_max(events, rad_max, position):
-    '''Apply the RAD_MAX cut to the event list for given region'''
+    """Apply the RAD_MAX cut to the event list for given region"""
     offset = position.separation(events.pointing_radec)
     separation = position.separation(events.radec)
 
-    if rad_max.data.shape == (1, 1):
-        rad_max_for_events = rad_max.quantity[0, 0]
-    else:
-        rad_max_for_events = rad_max.evaluate(
-            method="nearest", energy=events.energy, offset=offset
-        )
+    rad_max_for_events = rad_max.evaluate(
+        method="nearest", energy=events.energy, offset=offset
+    )
 
     selected = separation <= rad_max_for_events
     return events.select_row_subset(selected)

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -476,10 +476,8 @@ def make_counts_rad_max(geom, rad_max, events):
     """
     selected_events = apply_rad_max(events, rad_max, geom.region.center)
 
-    counts_geom = RegionGeom(geom.region, axes=[geom.axes['energy']])
-    counts = Map.from_geom(counts_geom)
+    counts = Map.from_geom(geom=geom)
     counts.fill_events(selected_events)
-
     return counts
 
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -428,34 +428,6 @@ def make_theta_squared_table(
     return table
 
 
-def get_rad_max_vs_energy(rad_max, pointing, geom):
-    """Obtain the values of `RAD_MAX` at a given offset and for an array of
-    estimated energy values (in the geom energy axis).
-
-    Parameters
-    ----------
-    rad_max : `~gammapy.irf.RadMax2D`
-        the RAD_MAX_2D table IRF
-    geom : `~gammapy.maps.Geom`
-        the map geom to be used
-    pointing : `~astropy.coordinates.SkyCoord`
-        pointing direction
-
-    Returns
-    -------
-    array : `~astropy.units.Quantity`
-        Values of the `RAD_MAX` corresponding to each estimated energy bin center.
-    """
-    on_center = geom.center_skydir
-    offset = on_center.separation(pointing)
-
-    rad_max_vals = rad_max.evaluate(
-        offset=offset, energy=geom.axes["energy"].center
-    )
-
-    return rad_max_vals
-
-
 def make_counts_rad_max(geom, rad_max, events):
     """Extract the counts using for the ON region size the values in the
     `RAD_MAX_2D` table.

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -3,6 +3,7 @@
 import numpy as np
 import scipy.interpolate
 from astropy import units as u
+from itertools import compress
 
 __all__ = [
     "interpolate_profile",
@@ -67,6 +68,8 @@ class ScaledRegularGridInterpolator:
 
         if not np.any(self._include_dimensions):
             kwargs["method"] = "nearest"
+        else:
+            values_scaled = np.squeeze(values_scaled)
 
         if axis is None:
             self._interpolate = scipy.interpolate.RegularGridInterpolator(
@@ -78,10 +81,10 @@ class ScaledRegularGridInterpolator:
             )
 
     def _scale_points(self, points):
-        points_scaled = np.array([scale(p) for p, scale in zip(points, self.scale_points)])
+        points_scaled = [scale(p) for p, scale in zip(points, self.scale_points)]
 
         if np.any(self._include_dimensions):
-            points_scaled = points_scaled[self._include_dimensions]
+            points_scaled = compress(points_scaled, self._include_dimensions)
 
         return tuple(points_scaled)
 

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -66,9 +66,16 @@ class ScaledRegularGridInterpolator:
             kwargs.setdefault("bounds_error", False)
             kwargs.setdefault("fill_value", None)
 
+        method = kwargs.get("method", None)
+
         if not np.any(self._include_dimensions):
-            kwargs["method"] = "nearest"
-        else:
+            if method != "nearest":
+                raise ValueError(
+                    "Interpolating scalar values requires using "
+                    "method='nearest' explicitely."
+                )
+
+        if np.any(self._include_dimensions):
             values_scaled = np.squeeze(values_scaled)
 
         if axis is None:


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes #3835, by allowing nearest neighbor interpolation with scalar data in the `ScaledRegularGridInterpolator`.

**Dear reviewer**
- Should we raise an error when scalar data is interpolated with `method="linear"` or just silently use `"nearest"`?

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
