### PR TITLE
Modified mask_fit handling in FoVBackgroundMaker

### DIFF
--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -18,7 +18,8 @@ class FoVBackgroundMaker(Maker):
     The dataset background model can be simply scaled (method="scale") or fitted (method="fit")
     on the dataset counts.
 
-    The normalization is performed outside the exclusion mask that is passed on init.
+    The normalization is performed outside the exclusion mask that is passed on init. This also internally 
+    takes into account the dataset fit mask.
 
     If a SkyModel is set on the input dataset its parameters
     are frozen during the fov re-normalization.
@@ -183,8 +184,6 @@ class FoVBackgroundMaker(Maker):
 
     def run(self, dataset, observation=None):
         """Run FoV background maker.
-
-        This internally takes into account both the exclusion mask and the dataset fit mask.
         
         Parameters
         ----------

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -184,8 +184,8 @@ class FoVBackgroundMaker(Maker):
     def run(self, dataset, observation=None):
         """Run FoV background maker.
 
-        Fit the background model norm
-
+        This internally takes into account both the exclusion mask and the dataset fit mask.
+        
         Parameters
         ----------
         dataset : `~gammapy.datasets.MapDataset`

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -193,8 +193,10 @@ class FoVBackgroundMaker(Maker):
 
         """
         mask_fit = dataset.mask_fit
-
-        dataset.mask_fit = self.make_exclusion_mask(dataset)
+        if mask_fit:
+            dataset.mask_fit *= self.make_exclusion_mask(dataset)
+        else:
+            dataset.mask_fit = self.make_exclusion_mask(dataset)
 
         if dataset.background_model is None:
             dataset = self.make_default_fov_background_model(dataset)

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import Angle, SkyCoord
 from regions import CircleSkyRegion
@@ -99,6 +100,7 @@ def test_fov_bkg_maker_scale_nocounts(obs_dataset, exclusion_mask, caplog):
     assert "WARNING" in [_.levelname for _ in caplog.records]
     message1 = "FoVBackgroundMaker failed. Only 0 counts outside exclusion mask for test-fov. Setting mask to False."
     assert message1 in [_.message for _ in caplog.records]
+
 
 @requires_data()
 @requires_dependency("iminuit")
@@ -227,18 +229,22 @@ def test_fov_bkg_maker_with_source_model(obs_dataset, exclusion_mask, caplog):
     assert not dataset.models.parameters["index"].frozen
     assert not dataset.models.parameters["lon_0"].frozen
 
-    #test  
+    # test
     model.spectral_model.amplitude.value *= 1e5
     fov_bkg_maker = FoVBackgroundMaker(method="scale")
     dataset = fov_bkg_maker.run(test_dataset)
     assert "WARNING" in [_.levelname for _ in caplog.records]
-    message1 = 'FoVBackgroundMaker failed. Negative residuals counts for test-fov. Setting mask to False.'
+    message1 = "FoVBackgroundMaker failed. Negative residuals counts for test-fov. Setting mask to False."
     assert message1 in [_.message for _ in caplog.records]
+
 
 @requires_data()
 @requires_dependency("iminuit")
 def test_fov_bkg_maker_fit_with_tilt(obs_dataset, exclusion_mask):
-    fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask,)
+    fov_bkg_maker = FoVBackgroundMaker(
+        method="fit",
+        exclusion_mask=exclusion_mask,
+    )
 
     test_dataset = obs_dataset.copy(name="test-fov")
 
@@ -285,17 +291,19 @@ def test_fov_bkg_maker_scale_fail(obs_dataset, exclusion_mask, caplog):
     message1 = "FoVBackgroundMaker failed. Only -1940 background counts outside exclusion mask for test-fov. Setting mask to False."
     assert message1 in [_.message for _ in caplog.records]
 
+
 @requires_data()
 def test_fov_bkg_maker_mask_fit_handling(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="scale", exclusion_mask=exclusion_mask)
     test_dataset = obs_dataset.copy(name="test-fov")
     region = CircleSkyRegion(obs_dataset._geom.center_skydir, Angle(0.4, "deg"))
-    test_dataset.mask_fit = obs_dataset._geom.region_mask(regions=[region])
+    mask_fit = obs_dataset._geom.region_mask(regions=[region])
+    test_dataset.mask_fit = mask_fit
 
     dataset = fov_bkg_maker.run(test_dataset)
+    assert np.all((test_dataset.mask_fit == mask_fit).data) == True
 
     model = dataset.models[f"{dataset.name}-bkg"].spectral_model
-
     assert_allclose(model.norm.value, 0.9975, rtol=1e-3)
     assert_allclose(model.norm.error, 0.1115, rtol=1e-3)
     assert_allclose(model.tilt.value, 0.0, rtol=1e-2)

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -301,7 +301,7 @@ def test_fov_bkg_maker_mask_fit_handling(obs_dataset, exclusion_mask):
     test_dataset.mask_fit = mask_fit
 
     dataset = fov_bkg_maker.run(test_dataset)
-    assert np.all((test_dataset.mask_fit == mask_fit).data) == True
+    assert np.all(test_dataset.mask_fit == mask_fit) == True
 
     model = dataset.models[f"{dataset.name}-bkg"].spectral_model
     assert_allclose(model.norm.value, 0.9975, rtol=1e-3)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
This pull request addresses #2921: the `mask_fit` was silently overridden by the `FoVBackgroundMaker`. Now it is taken into account.