### PR TITLE
Allows DataStoreMaker  to be used with IRFs not following CALDB structure

### DIFF
--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -748,6 +748,7 @@
     "%%time\n",
     "n_obs = len(tstarts)\n",
     "irf_paths = [Path(irf_filename)] * n_obs\n",
+    "events_paths = []\n",
     "for idx, tstart in enumerate(tstarts):\n",
     "    irf_path = load_cta_irfs(irf_paths[idx])\n",
     "    observation = Observation.create(\n",
@@ -761,12 +762,12 @@
     "\n",
     "    dataset = maker.run(empty, observation)\n",
     "    dataset.models = models\n",
-    "\n",
     "    sampler = MapDatasetEventSampler(random_state=idx)\n",
     "    events = sampler.run(dataset, observation)\n",
-    "    events.table.write(\n",
-    "        f\"./event_sampling/events_{idx:04d}.fits\", overwrite=True\n",
-    "    )"
+    "    \n",
+    "    path = Path(f\"./event_sampling/events_{idx:04d}.fits\")\n",
+    "    events_paths.append(path)\n",
+    "    events.table.write(path, overwrite=True)"
    ]
   },
   {

--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -787,7 +787,7 @@
    "source": [
     "path = Path(\"./event_sampling/\")\n",
     "events_paths = list(path.rglob(\"events*.fits\"))\n",
-    "data_store = DataStore.from_events_files(events_paths, irfs_paths)\n",
+    "data_store = DataStore.from_events_files(events_paths, irf_paths)\n",
     "data_store.obs_table"
    ]
   },

--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -750,7 +750,7 @@
     "irf_paths = [Path(irf_filename)] * n_obs\n",
     "events_paths = []\n",
     "for idx, tstart in enumerate(tstarts):\n",
-    "    irf_path = load_cta_irfs(irf_paths[idx])\n",
+    "    irfs = load_cta_irfs(irf_paths[idx])\n",
     "    observation = Observation.create(\n",
     "        obs_id=idx,\n",
     "        pointing=pointing,\n",

--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -144,7 +144,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = \"$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz\"\n",
+    "irf_filename = \"$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz\"\n",
     "\n",
     "pointing = SkyCoord(0.0, 0.0, frame=\"galactic\", unit=\"deg\")\n",
     "livetime = 1 * u.hr"
@@ -165,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "irfs = load_cta_irfs(filename)\n",
+    "irfs = load_cta_irfs(irf_filename)\n",
     "location = observatory_locations['cta_south']\n",
     "\n",
     "observation = Observation.create(\n",
@@ -375,12 +375,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "events.table.meta[\"OBJECT\"] = dataset.models[0].name"
+    "events.table.meta[\"OBJECT\"] = dataset.models[0].name\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "874b911e",
+   "metadata": {},
+   "source": [
+    "We have to add the path to the IRF file in the metadata (this will be used later to create the index files linking events and irfs)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events.table.meta[\"IRF_FILE\"] = irf_filename\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Let's write the event list and its GTI extension to a FITS file. We make use of `fits` library in `astropy`:"
@@ -763,6 +778,7 @@
     "\n",
     "    sampler = MapDatasetEventSampler(random_state=idx)\n",
     "    events = sampler.run(dataset, observation)\n",
+    "    events.table.meta[\"IRF_FILE\"] = irf_filename\n",
     "    events.table.write(\n",
     "        f\"./event_sampling/events_{idx:04d}.fits\", overwrite=True\n",
     "    )"
@@ -794,7 +810,17 @@
    "id": "bbf88446",
    "metadata": {},
    "source": [
-    "For completeness, `data_store` is a `~gammapy.data.Datastore` object. You can find more information about it [here](https://docs.gammapy.org/dev/tutorials/data/cta.html#Datastore)."
+    "Then you can create the obervations from the Datastore:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "observations = data_store.get_observations()\n",
+    "observations[0].peek()"
    ]
   },
   {
@@ -812,6 +838,8 @@
    "id": "38a38c6a",
    "metadata": {},
    "source": [
+    "For completeness, `data_store` is a `~gammapy.data.Datastore` object. You can find more information about it [here](https://docs.gammapy.org/dev/tutorials/data/cta.html#Datastore).\n",
+    "\n",
     "## Exercises\n",
     "- Try to sample events for an extended source (e.g. a radial gaussian morphology);\n",
     "- Change the spatial model and the spectrum of the simulated Sky model;\n",

--- a/docs/tutorials/analysis/3D/event_sampling.ipynb
+++ b/docs/tutorials/analysis/3D/event_sampling.ipynb
@@ -382,22 +382,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have to add the path to the IRF file in the metadata (this will be used later to create the index files linking events and irfs)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "events.table.meta[\"IRF_FILE\"] = irf_filename\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Let's write the event list and its GTI extension to a FITS file. We make use of `fits` library in `astropy`:"
    ]
   },
@@ -762,8 +746,10 @@
    "outputs": [],
    "source": [
     "%%time\n",
+    "n_obs = len(tstarts)\n",
+    "irf_paths = [Path(irf_filename)] * n_obs\n",
     "for idx, tstart in enumerate(tstarts):\n",
-    "\n",
+    "    irf_path = load_cta_irfs(irf_paths[idx])\n",
     "    observation = Observation.create(\n",
     "        obs_id=idx,\n",
     "        pointing=pointing,\n",
@@ -778,7 +764,6 @@
     "\n",
     "    sampler = MapDatasetEventSampler(random_state=idx)\n",
     "    events = sampler.run(dataset, observation)\n",
-    "    events.table.meta[\"IRF_FILE\"] = irf_filename\n",
     "    events.table.write(\n",
     "        f\"./event_sampling/events_{idx:04d}.fits\", overwrite=True\n",
     "    )"
@@ -789,7 +774,7 @@
    "id": "626a8673",
    "metadata": {},
    "source": [
-    "You can now load the event list with `Datastore.from_events_files()` and make your own analysis following the instructions in the [`analysis_2`](analysis_2.ipynb) tutorial."
+    "You can now load the event list and the corresponding IRFs with `Datastore.from_events_files()` : "
    ]
   },
   {
@@ -800,8 +785,8 @@
    "outputs": [],
    "source": [
     "path = Path(\"./event_sampling/\")\n",
-    "paths = list(path.rglob(\"events*.fits\"))\n",
-    "data_store = DataStore.from_events_files(paths)\n",
+    "events_paths = list(path.rglob(\"events*.fits\"))\n",
+    "data_store = DataStore.from_events_files(events_paths, irfs_paths)\n",
     "data_store.obs_table"
    ]
   },
@@ -810,7 +795,7 @@
    "id": "bbf88446",
    "metadata": {},
    "source": [
-    "Then you can create the obervations from the Datastore:"
+    "Then you can create the obervations from the Datastore and make your own analysis following the instructions in the [`analysis_2`](analysis_2.ipynb) tutorial."
    ]
   },
   {

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -173,12 +173,12 @@ class DataStore:
 
         Parameters
         -------
-        events_paths : list of  str or Path
+        events_paths : list of str or Path
             List of paths to the events files
             
-        irfs_paths : list of  str or Path
-            List of paths to the IRFs files, if provided must be the same length than `events_paths`.
-            If None the events file header have to contain CALDB and IRF keywords to locate the IRF file,
+        irfs_paths : str, Path, or list of str or Path
+            Path to the IRFs file. If a list is provided it must be the same length than `events_paths`.
+            If None the events files have to contain CALDB and IRF header keywords to locate the IRF files,
             otherwise the IRFs are assumed to be contained in the events files.
         
         Returns
@@ -465,10 +465,10 @@ class DataStoreMaker:
             raise TypeError("Need list of paths, not a single string or Path object.")
 
         self.events_paths = [make_path(path) for path in events_paths]
-        if irfs_paths:
-             self.irfs_paths = [make_path(path) for path in irfs_paths]
+        if irfs_paths is None or isinstance(irfs_paths, (str, Path)):
+            self.irfs_paths = [make_path(irfs_paths)] * len(events_paths)
         else:
-            self.irfs_paths = [None]*len(events_paths)
+            self.irfs_paths = [make_path(path) for path in irfs_paths]
 
         # Cache for EVENTS file header information, to avoid multiple reads
         self._events_info = {}
@@ -650,5 +650,5 @@ class CalDBIRF:
 
     @property
     def file_name(self):
-        path = Path(os.path.expandvars(self.file_dir))
+        path = make_path(self.file_dir)
         return list(path.glob("*"))[0].name

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -176,12 +176,15 @@ class DataStore:
         events_paths : list of  str or Path
             List of paths to the events files
             
-        Returns
-        -------
         irfs_paths : list of  str or Path
             List of paths to the IRFs files, if provided must be the same length than `events_paths`.
             If None the events file header have to contain CALDB and IRF keywords to locate the IRF file,
             otherwise the IRFs are assumed to be contained in the events files.
+        
+        Returns
+        -------
+        data_store : `DataStore`
+            Data store
             
         Examples
         --------

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -190,6 +190,8 @@ class DataStore:
         This is how you can access a single event list::
 
         >>> from gammapy.data import DataStore
+        >>> import os
+        >>> os.environ["CALDB"] = os.environ["GAMMAPY_DATA"] + "/cta-1dc/caldb"
         >>> path = "$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_110380.fits"
         >>> data_store = DataStore.from_events_files([path])
         >>> observations = data_store.get_observations()

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import os
 import logging
 import subprocess
 from pathlib import Path

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
 import logging
 import subprocess
 from pathlib import Path
@@ -650,4 +651,7 @@ class CalDBIRF:
     @property
     def file_name(self):
         path = make_path(self.file_dir)
+        path_str = str(path)
+        if "$CALDB" in path_str:
+            path = Path(path_str.replace("$CALDB", os.environ["CALDB"]))
         return list(path.iterdir())[0].name

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -539,7 +539,7 @@ class DataStoreMaker:
         info["IRF"] = header.get("IRF", na_str)
         if irf_path is not None:
             info["IRF_FILENAME"] = str(irf_path)
-        elif info["CALDB"] != na_str and info["CALDB"] != na_str:
+        elif info["CALDB"] != na_str and info["IRF"] != na_str:
             caldb_irf = CalDBIRF.from_meta(info)
             info["IRF_FILENAME"] = str(caldb_irf.file_path)
         else:

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
 import logging
 import subprocess
 from pathlib import Path
@@ -631,8 +632,9 @@ class CalDBIRF:
 
     @property
     def file_path(self):
-        return Path(self.file_dir).glob("*")[0]
+        return Path(f"{self.file_dir}/{self.file_name}")
 
     @property
     def file_name(self):
-        return self.file_path.name
+        path = Path(os.path.expandvars(self.file_dir))
+        return list(path.glob("*"))[0].name

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -651,7 +651,4 @@ class CalDBIRF:
     @property
     def file_name(self):
         path = make_path(self.file_dir)
-        path_str = str(path)
-        if "$CALDB" in path_str:
-            path = Path(path_str.replace("$CALDB", os.environ["CALDB"]))
         return list(path.iterdir())[0].name

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -650,4 +650,4 @@ class CalDBIRF:
     @property
     def file_name(self):
         path = make_path(self.file_dir)
-        return list(path.glob("*"))[0].name
+        return list(path.iterdir())[0].name

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -146,9 +146,6 @@ class TestDataStoreChecker:
 @requires_data("gammapy-data")
 class TestDataStoreMaker:
 
-    # Note: IRF access requires the CALDB env var
-    caldb_path = Path(os.environ["GAMMAPY_DATA"]) / Path("cta-1dc/caldb")
-
     def setup(self):
         paths = [
             f"$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_{obs_id:06d}.fits"
@@ -161,7 +158,9 @@ class TestDataStoreMaker:
         # self.data_store.obs_table.write("obs-index.fits.gz", overwrite=True)
 
     def test_obs_table(self, monkeypatch):
-        monkeypatch.setenv("CALDB", str(self.caldb_path))
+        # Note: IRF access requires the CALDB env var
+        caldb_path = Path(os.environ["GAMMAPY_DATA"]) / Path("cta-1dc/caldb")
+        monkeypatch.setenv("CALDB", str(caldb_path))
 
         table = self.data_store.obs_table
         assert table.__class__.__name__ == "ObservationTable"
@@ -176,7 +175,9 @@ class TestDataStoreMaker:
         # assert table.time_start[-1].iso == "spam"
 
     def test_hdu_table(self, monkeypatch):
-        monkeypatch.setenv("CALDB", str(self.caldb_path))
+        # Note: IRF access requires the CALDB env var
+        caldb_path = Path(os.environ["GAMMAPY_DATA"]) / Path("cta-1dc/caldb")
+        monkeypatch.setenv("CALDB", str(caldb_path))
 
         table = self.data_store.hdu_table
         assert table.__class__.__name__ == "HDUIndexTable"
@@ -188,7 +189,9 @@ class TestDataStoreMaker:
 
     def test_observation(self, monkeypatch):
         """Check that one observation can be accessed OK"""
-        monkeypatch.setenv("CALDB", str(self.caldb_path))
+        # Note: IRF access requires the CALDB env var
+        caldb_path = Path(os.environ["GAMMAPY_DATA"]) / Path("cta-1dc/caldb")
+        monkeypatch.setenv("CALDB", str(caldb_path))
 
         obs = self.data_store.obs(110380)
         assert obs.obs_id == 110380

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -9,7 +9,6 @@ from gammapy.data import DataStore
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import requires_data
 
-
 @pytest.fixture()
 def data_store():
     return DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
@@ -63,36 +62,6 @@ def test_datastore_from_file(tmpdir):
 
     assert data_store.obs_table["OBS_ID"][0] == 20136
 
-
-@requires_data()
-def test_datastore_from_events(monkeypatch):
-    # Test that `DataStore.from_events_files` works.
-    # The real tests for `DataStoreMaker` are below.
-    caldb_path = Path(os.environ["GAMMAPY_DATA"]) / Path("cta-1dc/caldb")
-    monkeypatch.setenv("CALDB", str(caldb_path))
-
-    path = "$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_110380.fits"
-    data_store = DataStore.from_events_files([path])
-    assert len(data_store.obs_table) == 1
-    assert len(data_store.hdu_table) == 6
-
-    @requires_data()
-    def test_datastore_get_observations(data_store, caplog):
-        """Test loading data and IRF files via the DataStore"""
-        observations = data_store.get_observations([23523, 23592])
-        assert observations[0].obs_id == 23523
-        observations = data_store.get_observations()
-        assert len(observations) == 105
-
-        with pytest.raises(ValueError):
-            data_store.get_observations([11111, 23592])
-
-        observations = data_store.get_observations([11111, 23523], skip_missing=True)
-        assert observations[0].obs_id == 23523
-        assert "WARNING" in [_.levelname for _ in caplog.records]
-        assert "Skipping missing obs_id: 11111" in [_.message for _ in caplog.records]
-
-
 @requires_data()
 def test_broken_links_datastore(data_store):
     # Test that datastore without complete IRFs are properly loaded
@@ -143,66 +112,81 @@ class TestDataStoreChecker:
         assert len(records) == 32
 
 
-@requires_data("gammapy-data")
-class TestDataStoreMaker:
 
-    def setup(self):
-        paths = [
-            f"$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_{obs_id:06d}.fits"
-            for obs_id in [110380, 111140, 111630, 111159]
-        ]
-        self.data_store = DataStore.from_events_files(paths)
+@requires_data()
+def test_datastore_get_observations(data_store, caplog):
+    """Test loading data and IRF files via the DataStore"""
+    observations = data_store.get_observations([23523, 23592])
+    assert observations[0].obs_id == 23523
+    observations = data_store.get_observations()
+    assert len(observations) == 105
 
-        # Useful for debugging:
-        # self.data_store.hdu_table.write("hdu-index.fits.gz", overwrite=True)
-        # self.data_store.obs_table.write("obs-index.fits.gz", overwrite=True)
+    with pytest.raises(ValueError):
+        data_store.get_observations([11111, 23592])
 
-    def test_obs_table(self, monkeypatch):
-        # Note: IRF access requires the CALDB env var
-        caldb_path = Path(os.environ["GAMMAPY_DATA"]) / Path("cta-1dc/caldb")
-        monkeypatch.setenv("CALDB", str(caldb_path))
+    observations = data_store.get_observations([11111, 23523], skip_missing=True)
+    assert observations[0].obs_id == 23523
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert "Skipping missing obs_id: 11111" in [_.message for _ in caplog.records]
 
-        table = self.data_store.obs_table
-        assert table.__class__.__name__ == "ObservationTable"
-        assert len(table) == 4
-        assert len(table.colnames) == 22
-        assert table["CALDB"][0] == "1dc"
-        assert table["IRF"][0] == "South_z20_50h"
-        assert table["IRF_FILENAME"][0] == "$CALDB/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 
-        # TODO: implement https://github.com/gammapy/gammapy/issues/1218 and add tests here
-        # assert table.time_start[0].iso == "spam"
-        # assert table.time_start[-1].iso == "spam"
+@pytest.fixture()
+def data_store_dc1(monkeypatch):
+    paths = [
+        f"$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_{obs_id:06d}.fits"
+        for obs_id in [110380, 111140, 111630, 111159]
+    ]
+    caldb_path = Path(os.environ["GAMMAPY_DATA"]) / Path("cta-1dc/caldb")
+    monkeypatch.setenv("CALDB", str(caldb_path))
+    return DataStore.from_events_files(paths)
 
-    def test_hdu_table(self, monkeypatch):
-        # Note: IRF access requires the CALDB env var
-        caldb_path = Path(os.environ["GAMMAPY_DATA"]) / Path("cta-1dc/caldb")
-        monkeypatch.setenv("CALDB", str(caldb_path))
+@requires_data()
+def test_datastore_from_events(data_store_dc1):
+    # Test that `DataStore.from_events_files` works.
+    # The real tests for `DataStoreMaker` are below.
 
-        table = self.data_store.hdu_table
-        assert table.__class__.__name__ == "HDUIndexTable"
-        assert len(table) == 24
-        hdu_class = ["events", "gti", "aeff_2d", "edisp_2d", "psf_3gauss", "bkg_3d"]
-        assert list(self.data_store.hdu_table["HDU_CLASS"]) == 4 * hdu_class
+    path = "$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_110380.fits"
+    data_store = DataStore.from_events_files([path])
+    assert len(data_store.obs_table) == 1
+    assert len(data_store.hdu_table) == 6
 
-        assert table["FILE_DIR"][2] == "$CALDB/data/cta/1dc/bcf/South_z20_50h"
+@requires_data()
+def test_datastoremaker_obs_table(data_store_dc1):
+    table = data_store_dc1.obs_table
+    assert table.__class__.__name__ == "ObservationTable"
+    assert len(table) == 4
+    assert len(table.colnames) == 22
+    assert table["CALDB"][0] == "1dc"
+    assert table["IRF"][0] == "South_z20_50h"
+    assert table["IRF_FILENAME"][0] == "$CALDB/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 
-    def test_observation(self, monkeypatch):
-        """Check that one observation can be accessed OK"""
-        # Note: IRF access requires the CALDB env var
-        caldb_path = Path(os.environ["GAMMAPY_DATA"]) / Path("cta-1dc/caldb")
-        monkeypatch.setenv("CALDB", str(caldb_path))
+    # TODO: implement https://github.com/gammapy/gammapy/issues/1218 and add tests here
+    # assert table.time_start[0].iso == "spam"
+    # assert table.time_start[-1].iso == "spam"
 
-        obs = self.data_store.obs(110380)
-        assert obs.obs_id == 110380
+@requires_data()
+def test_datastoremaker_hdu_table(data_store_dc1):
+    table = data_store_dc1.hdu_table
+    assert table.__class__.__name__ == "HDUIndexTable"
+    assert len(table) == 24
+    hdu_class = ["events", "gti", "aeff_2d", "edisp_2d", "psf_3gauss", "bkg_3d"]
+    assert list(data_store_dc1.hdu_table["HDU_CLASS"]) == 4 * hdu_class
+    assert table["FILE_DIR"][2] == "$CALDB/data/cta/1dc/bcf/South_z20_50h"
 
-        assert obs.events.time[0].iso == "2021-01-21 12:00:03.045"
-        assert obs.gti.time_start[0].iso == "2021-01-21 12:00:00.000"
+@requires_data()
+def test_datastoremaker_observation(data_store_dc1):
+    """Check that one observation can be accessed OK"""
 
-        assert obs.aeff.__class__.__name__ == "EffectiveAreaTable2D"
-        assert obs.bkg.__class__.__name__ == "Background3D"
-        assert obs.edisp.__class__.__name__ == "EnergyDispersion2D"
-        assert obs.psf.__class__.__name__ == "EnergyDependentMultiGaussPSF"
+    obs = data_store_dc1.obs(110380)
+    assert obs.obs_id == 110380
+
+    assert obs.events.time[0].iso == "2021-01-21 12:00:03.045"
+    assert obs.gti.time_start[0].iso == "2021-01-21 12:00:00.000"
+
+    assert obs.aeff.__class__.__name__ == "EffectiveAreaTable2D"
+    assert obs.bkg.__class__.__name__ == "Background3D"
+    assert obs.edisp.__class__.__name__ == "EnergyDispersion2D"
+    assert obs.psf.__class__.__name__ == "EnergyDependentMultiGaussPSF"
 
 
 @requires_data('gammapy-data')

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -157,7 +157,10 @@ class TestDataStoreMaker:
         table = self.data_store.obs_table
         assert table.__class__.__name__ == "ObservationTable"
         assert len(table) == 4
-        assert len(table.colnames) == 21
+        assert len(table.colnames) == 22
+        assert table["CALDB"][0] == "1dc"
+        assert table["IRF"][0] == "South_z20_50h"
+        assert table["IRF_FILE"][0] == "$CALDB/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 
         # TODO: implement https://github.com/gammapy/gammapy/issues/1218 and add tests here
         # assert table.time_start[0].iso == "spam"

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -160,7 +160,7 @@ class TestDataStoreMaker:
         assert len(table.colnames) == 22
         assert table["CALDB"][0] == "1dc"
         assert table["IRF"][0] == "South_z20_50h"
-        assert table["IRF_FILE"][0] == "$CALDB/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+        assert table["IRF_FILENAME"][0] == "$CALDB/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 
         # TODO: implement https://github.com/gammapy/gammapy/issues/1218 and add tests here
         # assert table.time_start[0].iso == "spam"

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -110,7 +110,10 @@ def make_path(path):
     # TODO: raise error or warning if environment variables that don't resolve are used
     # e.g. "spam/$DAMN/ham" where `$DAMN` is not defined
     # Otherwise this can result in cryptic errors later on
-    return Path(os.path.expandvars(path))
+    if path is None :
+        return None
+    else:
+        return Path(os.path.expandvars(path))
 
 
 def recursive_merge_dicts(a, b):


### PR DESCRIPTION
DataStore.from_events_files is used to create HDU and observation index tables from the EVENTS header. But this works only for IRFs following the CALDB structure, and the events file header have to contains the TELESCOP, CALDB, and IRF keywords (not part of GADF).

 This PR improve the generation of the irf filename from the CALDB infos, and alternatively allow to read it directly from an extra keyword IRF_FILE in the events metadata.
Now, the events_sampling notebook show how to add this keyword, so the index files generated are not broken.