### PR TITLE
Allow for flux points plotting without error measurements

### DIFF
--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -495,13 +495,12 @@ class FluxPoints(FluxMaps):
             kwargs.setdefault("uplims", is_ul)
 
         # set flux points plotting defaults
-        if y_errp:
+        if y_errp and y_errn:
             y_errp = scale_plot_flux(y_errp, energy_power=energy_power).quantity
-
-        if y_errn:
             y_errn = scale_plot_flux(y_errn, energy_power=energy_power).quantity
-
-        kwargs.setdefault("yerr", (y_errn, y_errp))
+            kwargs.setdefault("yerr", (y_errn, y_errp))
+        else:
+            kwargs.setdefault("yerr", None)
 
         flux = scale_plot_flux(flux=flux.to_unit(flux_unit), energy_power=energy_power)
         ax = flux.plot(ax=ax, **kwargs)

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -6,7 +6,7 @@ import astropy.units as u
 from astropy.table import Table
 from gammapy.catalog.fermi import SourceCatalog3FGL, SourceCatalog4FGL
 from gammapy.estimators import FluxPoints
-from gammapy.modeling.models import SpectralModel
+from gammapy.modeling.models import SpectralModel, PowerLawSpectralModel
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import (
     assert_quantity_allclose,
@@ -289,3 +289,16 @@ def test_is_ul(tmp_path):
     assert_allclose(fp.is_ul.data.squeeze(), is_ul)
     table = fp.to_table()
     assert_allclose(table["is_ul"].data.data, is_ul)
+
+def test_flux_points_plot_no_error_bar():
+    table = Table()
+    pwl = PowerLawSpectralModel()
+    e_ref = np.geomspace(1, 100, 7) * u.TeV
+
+    table["e_ref"] = e_ref
+    table["dnde"] = pwl(e_ref)
+    table.meta["SED_TYPE"] = "dnde"
+
+    flux_points = FluxPoints.from_table(table)
+    with mpl_plot_check():
+       flux_points.plot(sed_type="flux")

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -290,6 +290,7 @@ def test_is_ul(tmp_path):
     table = fp.to_table()
     assert_allclose(table["is_ul"].data.data, is_ul)
 
+@requires_dependency("matplotlib")
 def test_flux_points_plot_no_error_bar():
     table = Table()
     pwl = PowerLawSpectralModel()


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request solves issue #3811. If no error column is present `FluxPoints` will be plotted without flux errors. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
