### PR TITLE
Make obs_table optional on DataStore

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -96,7 +96,7 @@ class DataStore:
 
         hdu_table = HDUIndexTable.read(filename, hdu=hdu_hdu, format="fits")
 
-        obs_table=None
+        obs_table = None
         if hdu_obs:
             obs_table = ObservationTable.read(filename, hdu=hdu_obs, format="fits")
 
@@ -155,7 +155,7 @@ class DataStore:
         hdu_table.meta["BASE_DIR"] = str(base_dir)
 
         if not obs_table_filename.exists():
-            log.warning("Cannot find default obs-index table.")
+            log.info("Cannot find default obs-index table.")
             obs_table = None
         else:
             log.debug(f"Reading {obs_table_filename}")

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -92,6 +92,7 @@ class DataStore:
 
         hdu_table = HDUIndexTable.read(filename, hdu=hdu_hdu, format="fits")
 
+        obs_table=None
         if hdu_obs:
             obs_table = ObservationTable.read(filename, hdu=hdu_obs, format="fits")
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -152,6 +152,7 @@ class DataStore:
             log.warning(f"Cannot find observation index file : {obs_table_filename}.")
             obs_table = None
         else:
+            log.debug(f"Reading {obs_table_filename}")
             obs_table = ObservationTable.read(obs_table_filename, format="fits")
 
         return cls(hdu_table=hdu_table, obs_table=obs_table)
@@ -242,16 +243,6 @@ class DataStore:
             raise ValueError(f"OBS_ID = {obs_id} not in HDU index table.")
 
         kwargs = {"obs_id": int(obs_id)}
-
-        if self.obs_table and obs_id in self.obs_table["OBS_ID"]:
-            row = self.obs_table.select_obs_id(obs_id=obs_id)[0]
-
-            # add info from table meta, e.g. the time references
-            kwargs["obs_info"] = {
-                k: v for k, v in self.obs_table.meta.items()
-                if not k.startswith('HDU')  # Ignore GADF structure of index table
-            }
-            kwargs["obs_info"].update(table_row_to_dict(row))
 
         hdu_list = ["events", "gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -349,7 +349,8 @@ class DataStore:
             subhdutable.add_index("HDU_CLASS")
             with subhdutable.index_mode("discard_on_copy"):
                 subhdutable = subhdutable.loc[hdu_class]
-        subobstable = self.obs_table.select_obs_id(obs_id)
+        if self.obs_table:
+            subobstable = self.obs_table.select_obs_id(obs_id)
 
         for idx in range(len(subhdutable)):
             # Changes to the file structure could be made here
@@ -367,8 +368,9 @@ class DataStore:
         filename = outdir / self.DEFAULT_HDU_TABLE
         subhdutable.write(filename, format="fits", overwrite=overwrite)
 
-        filename = outdir / self.DEFAULT_OBS_TABLE
-        subobstable.write(str(filename), format="fits", overwrite=overwrite)
+        if self.obs_table:
+            filename = outdir / self.DEFAULT_OBS_TABLE
+            subobstable.write(str(filename), format="fits", overwrite=overwrite)
 
     def check(self, checks="all"):
         """Check index tables and data files.

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -7,7 +7,6 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from gammapy.utils.scripts import make_path
-from gammapy.utils.table import table_row_to_dict
 from gammapy.utils.testing import Checker
 from .hdu_index_table import HDUIndexTable
 from .obs_table import ObservationTable, ObservationTableChecker
@@ -144,8 +143,8 @@ class DataStore:
             obs_table_filename = make_path(obs_table_filename)
             if (base_dir / obs_table_filename).exists():
                 obs_table_filename = base_dir / obs_table_filename
-            else:
-                raise IOError(f"File not found : {base_dir / obs_table_filename}")
+            elif not obs_table_filename.exists():
+                raise IOError(f"File not found : {obs_table_filename}")
         else:
             obs_table_filename = base_dir / cls.DEFAULT_OBS_TABLE
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -68,6 +68,11 @@ class DataStore:
     def __str__(self):
         return self.info(show=False)
 
+    @property
+    def obs_ids(self):
+        """Return list of obs_ids contained in the datastore."""
+        return np.unique(self.hdu_table["OBS_ID"].data)
+
     @classmethod
     def from_file(cls, filename, hdu_hdu="HDU_INDEX", hdu_obs="OBS_INDEX"):
         """Create a Datastore from a FITS file.
@@ -139,6 +144,8 @@ class DataStore:
             obs_table_filename = make_path(obs_table_filename)
             if (base_dir / obs_table_filename).exists():
                 obs_table_filename = base_dir / obs_table_filename
+            else:
+                raise IOError(f"File not found : {base_dir / obs_table_filename}")
         else:
             obs_table_filename = base_dir / cls.DEFAULT_OBS_TABLE
 
@@ -149,7 +156,7 @@ class DataStore:
         hdu_table.meta["BASE_DIR"] = str(base_dir)
 
         if not obs_table_filename.exists():
-            log.warning(f"Cannot find observation index file : {obs_table_filename}.")
+            log.warning("Cannot find default obs-index table.")
             obs_table = None
         else:
             log.debug(f"Reading {obs_table_filename}")
@@ -289,7 +296,7 @@ class DataStore:
             )
 
         if obs_id is None:
-            obs_id = np.unique(self.hdu_table["OBS_ID"].data)
+            obs_id = self.obs_ids
 
         obs_list = []
 

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -262,18 +262,15 @@ class Observation:
     @lazyproperty
     def obs_info(self):
         """Observation info dictionary."""
+        meta = self._obs_info.copy() if self._obs_info is not None else {}
         if self.events is not None:
-            return {k: v for k, v in self.events.table.meta.items() if not k.startswith('HDU')}
-        else:
-            return self._obs_info
+            meta.update({k: v for k, v in self.events.table.meta.items() if not k.startswith('HDU')})
+        return meta
 
     @lazyproperty
     def fixed_pointing_info(self):
         """Fixed pointing info for this observation (`FixedPointingInfo`)."""
-        meta = self.obs_info.copy() if self.obs_info is not None else {}
-        if self.events is not None:
-            meta.update(self.events.table.meta)
-        return FixedPointingInfo(meta)
+        return FixedPointingInfo(self.obs_info)
 
     @property
     def pointing_radec(self):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -71,7 +71,7 @@ class Observation:
         obs_filter=None,
     ):
         self.obs_id = obs_id
-        self.obs_info = obs_info
+        self._obs_info = obs_info
         self.aeff = aeff
         self.edisp = edisp
         self.psf = psf
@@ -258,6 +258,14 @@ class Observation:
         which in turn is used in the exposure and flux computation.
         """
         return 1 - self.obs_info["DEADC"]
+
+    @lazyproperty
+    def obs_info(self):
+        """Observation info dictionary."""
+        if self.events is not None:
+            return {k: v for k, v in self.events.table.meta.items() if not k.startswith('HDU')}
+        else:
+            return self._obs_info
 
     @lazyproperty
     def fixed_pointing_info(self):

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -236,7 +236,7 @@ def test_datastore_from_dir_no_obs_index(caplog):
     )
 
     obs = data_store.obs(23523)
-    observations = data_store.get_observations([23523, 23592])
+    observations = data_store.get_observations()
 
     assert data_store.obs_table is None
     assert "WARNING" in [record.levelname for record in caplog.records]
@@ -245,4 +245,4 @@ def test_datastore_from_dir_no_obs_index(caplog):
     assert "No observation index table." in data_store.info(show=False)
 
     assert obs.obs_info is None
-    assert len(observations) == 2
+    assert len(observations) == 105

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -236,9 +236,13 @@ def test_datastore_from_dir_no_obs_index(caplog):
     )
 
     obs = data_store.obs(23523)
+    observations = data_store.get_observations([23523, 23592])
 
     assert data_store.obs_table is None
     assert "WARNING" in [record.levelname for record in caplog.records]
     message = "Cannot find observation index file : bad_name."
     assert message in [record.message for record in caplog.records]
     assert "No observation index table." in data_store.info(show=False)
+
+    assert obs.obs_info is None
+    assert len(observations) == 2

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -227,3 +227,18 @@ def test_datastore_header_info_in_obs_info(data_store):
     assert "GEOLAT" in obs.obs_info
     # make sure we don't add the OBS_INDEX HDUCLAS
     assert "HDUCLAS1" not in obs.obs_info
+
+@requires_data()
+def test_datastore_from_dir_no_obs_index(caplog):
+    """Test the `from_dir` method."""
+    data_store = DataStore.from_dir(
+        "$GAMMAPY_DATA/hess-dl3-dr1/", "hdu-index.fits.gz", "bad_name"
+    )
+
+    obs = data_store.obs(23523)
+
+    assert data_store.obs_table is None
+    assert "WARNING" in [record.levelname for record in caplog.records]
+    message = "Cannot find observation index file : bad_name."
+    assert message in [record.message for record in caplog.records]
+    assert "No observation index table." in data_store.info(show=False)

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -255,3 +255,8 @@ def test_datastore_from_dir_no_obs_index(caplog, tmpdir):
 
     assert obs.obs_info["ONTIME"] == 1687.0
     assert len(observations) == 2
+
+    data_store.copy_obs([23523], tmpdir, overwrite=True)
+    data_store_copy = DataStore.from_dir(tmpdir)
+    assert len(data_store_copy.obs_ids) == 1
+    assert data_store_copy.obs_table == None

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -256,7 +256,9 @@ def test_datastore_from_dir_no_obs_index(caplog, tmpdir):
     assert obs.obs_info["ONTIME"] == 1687.0
     assert len(observations) == 2
 
-    data_store.copy_obs([23523], tmpdir, overwrite=True)
-    data_store_copy = DataStore.from_dir(tmpdir)
+    test_dir = tmpdir / "test"
+    os.mkdir(test_dir)
+    data_store.copy_obs([23523], test_dir)
+    data_store_copy = DataStore.from_dir(test_dir)
     assert len(data_store_copy.obs_ids) == 1
     assert data_store_copy.obs_table == None

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -248,9 +248,6 @@ def test_datastore_from_dir_no_obs_index(caplog, tmpdir):
     observations = data_store.get_observations()
 
     assert data_store.obs_table is None
-    assert "WARNING" in [record.levelname for record in caplog.records]
-    message = "Cannot find default obs-index table."
-    assert message in [record.message for record in caplog.records]
     assert "No observation index table." in data_store.info(show=False)
 
     assert obs.obs_info["ONTIME"] == 1687.0

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -244,5 +244,5 @@ def test_datastore_from_dir_no_obs_index(caplog):
     assert message in [record.message for record in caplog.records]
     assert "No observation index table." in data_store.info(show=False)
 
-    assert obs.obs_info is None
+    assert obs.obs_info["ONTIME"] == 1687.0
     assert len(observations) == 105


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request makes the `ObservationTable` an optional argument in `DataStore`. This solves #3790 .

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
