### PR TITLE
Introduce Parameter.is_norm property

### DIFF
--- a/docs/tutorials/api/models.ipynb
+++ b/docs/tutorials/api/models.ipynb
@@ -1235,7 +1235,7 @@
     "    \"\"\"\n",
     "\n",
     "    tag = \"MyCustomSpectralModel\"\n",
-    "    amplitude = Parameter(\"amplitude\", \"1e-12 cm-2 s-1 TeV-1\", min=0)\n",
+    "    amplitude = Parameter(\"amplitude\", \"1e-12 cm-2 s-1 TeV-1\", min=0, is_norm=True)\n",
     "    index = Parameter(\"index\", 2, min=0)\n",
     "    reference = Parameter(\"reference\", \"1 TeV\", frozen=True)\n",
     "    mean = Parameter(\"mean\", \"1 TeV\", min=0)\n",

--- a/examples/models/spectral/plot_compound.py
+++ b/examples/models/spectral/plot_compound.py
@@ -30,6 +30,9 @@ pwl = PowerLawSpectralModel(
 lp = LogParabolaSpectralModel(
     amplitude="1e-12 cm-2 s-1 TeV-1", reference="10 TeV", alpha=2.0, beta=1.0
 )
+
+# freeze the amplitude to avoid degeneracy when fitting
+lp.amplitude.frozen = True
 model = CompoundSpectralModel(pwl, lp, operator.add)
 model.plot(energy_bounds)
 plt.grid(which="both")

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -66,11 +66,11 @@ class FluxPointsDataset(Dataset):
     	message    : Hesse terminated successfully.
 
     >>> print(result.parameters.to_table())
-      type      name     value         unit        error   min max frozen is_norm link
-    -------- --------- ---------- -------------- --------- --- --- ------ ------- ----
-    spectral     index 2.2159e+00                1.043e-02 nan nan  False   False
-    spectral amplitude 2.1619e-13 cm-2 s-1 TeV-1 1.901e-14 nan nan  False    True
-    spectral reference 1.0000e+00            TeV 0.000e+00 nan nan   True   False
+      type      name     value         unit      ... max frozen is_norm link
+    -------- --------- ---------- -------------- ... --- ------ ------- ----
+    spectral     index 2.2159e+00                ... nan  False   False
+    spectral amplitude 2.1619e-13 cm-2 s-1 TeV-1 ... nan  False    True
+    spectral reference 1.0000e+00            TeV ... nan   True   False
 
     Note: In order to reproduce the example you need the tests datasets folder.
     You may download it with the command

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -45,7 +45,7 @@ class FluxPointsDataset(Dataset):
     >>> dataset.models = model
 
     Make the fit
-    
+
     >>> fit = Fit()
     >>> result = fit.run([dataset])
     >>> print(result)
@@ -66,11 +66,11 @@ class FluxPointsDataset(Dataset):
     	message    : Hesse terminated successfully.
 
     >>> print(result.parameters.to_table())
-          type      name     value         unit        error   min max frozen link
-    -------- --------- ---------- -------------- --------- --- --- ------ ----
-    spectral     index 2.2159e+00                1.043e-02 nan nan  False
-    spectral amplitude 2.1619e-13 cm-2 s-1 TeV-1 1.901e-14 nan nan  False
-    spectral reference 1.0000e+00            TeV 0.000e+00 nan nan   True
+      type      name     value         unit        error   min max frozen is_norm link
+    -------- --------- ---------- -------------- --------- --- --- ------ ------- ----
+    spectral     index 2.2159e+00                1.043e-02 nan nan  False   False
+    spectral amplitude 2.1619e-13 cm-2 s-1 TeV-1 1.901e-14 nan nan  False    True
+    spectral reference 1.0000e+00            TeV 0.000e+00 nan nan   True   False
 
     Note: In order to reproduce the example you need the tests datasets folder.
     You may download it with the command

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -170,13 +170,16 @@ def test_flux_estimator_norm_range_template():
     assert_allclose(scale_model.norm.max, 10)
     assert scale_model.norm.interp == "log"
 
+
 def test_flux_estimator_compound_model():
     pl = PowerLawSpectralModel()
     pl.amplitude.min = 1e-15
     pl.amplitude.max = 1e-10
+
     pln = PowerLawNormSpectralModel()
     pln.norm.value = 0.1
-    spectral_model = pl*pln
+    pln.norm.frozen = True
+    spectral_model = pl * pln
     model = SkyModel(spectral_model=spectral_model, name="test")
 
     estimator = FluxEstimator(source="test", selection_optional=[], reoptimize=True)
@@ -185,6 +188,7 @@ def test_flux_estimator_compound_model():
 
     assert_allclose(scale_model.norm.min, 1e-3)
     assert_allclose(scale_model.norm.max, 1e2)
+
 
 @requires_dependency("naima")
 def test_flux_estimator_naima_model():

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -788,7 +788,7 @@ class DatasetModels(collections.abc.Sequence):
         return restore_models_status(self, restore_values)
 
     def set_parameters_bounds(
-        self, tag, model_type, parameter_type=None, parameters_names=None, min=None, max=None, value=None
+        self, tag, model_type, parameters_names=None, min=None, max=None, value=None
     ):
         """Set bounds for the selected models types and parameters names
 
@@ -798,8 +798,6 @@ class DatasetModels(collections.abc.Sequence):
             Tag of the models
         model_type :  {"spatial", "spectral", "temporal"}
             Type of model
-        parameter_type: {"norm", "spatial", "spectral", "temporal"}
-            Type of parameter
         parameters_names : str or list
             parameters names
         min : float
@@ -810,7 +808,7 @@ class DatasetModels(collections.abc.Sequence):
             init value
         """
         models = self.select(tag=tag, model_type=model_type)
-        parameters = models.parameters.select(name=parameters_names, type=parameter_type)
+        parameters = models.parameters.select(name=parameters_names, type=model_type)
         n = len(parameters)
 
         if min is not None:

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -71,6 +71,7 @@ class ModelBase:
                 par = value
 
             setattr(self, par.name, par)
+
         self._covariance = Covariance(self.parameters)
 
     def __getattribute__(self, name):
@@ -146,7 +147,8 @@ class ModelBase:
         return copy.deepcopy(self)
 
     def to_dict(self, full_output=False):
-        """Create dict for YAML serialisation"""
+        """Create dict for YAML serialisation
+        """
         tag = self.tag[0] if isinstance(self.tag, list) else self.tag
         params = self.parameters.to_dict()
 
@@ -164,11 +166,13 @@ class ModelBase:
 
                 if init["unit"] == "":
                     del par["unit"]
+
         data = {"type": tag, "parameters": params}
-        if self._type is None:
+
+        if self.type is None:
             return data
         else:
-            return {self._type: data}
+            return {self.type: data}
 
     @classmethod
     def from_dict(cls, data):
@@ -176,11 +180,13 @@ class ModelBase:
 
         par_data = []
         key0 = next(iter(data))
+
         if key0 in ["spatial", "temporal", "spectral"]:
             data = data[key0]
+
         if data["type"] not in cls.tag:
             raise ValueError(
-                f"Invalid model type {data['type']} for Class {cls.__name__}"
+                f"Invalid model type {data['type']} for class {cls.__name__}"
             )
 
         input_names = [_["name"] for _ in data["parameters"]]
@@ -192,7 +198,7 @@ class ModelBase:
                 par_dict.update(data["parameters"][index])
             except ValueError:
                 log.warning(
-                    f"Parameter {par_dict['name']} not defined. Using default value: {par_dict['value']} {par_dict['unit']}"
+                    f"Parameter '{par_dict['name']}' not defined in YAML file. Using default value: {par_dict['value']} {par_dict['unit']}"
                 )
             par_data.append(par_dict)
 
@@ -560,7 +566,7 @@ class DatasetModels(collections.abc.Sequence):
         table.write(make_path(filename), **kwargs)
 
     def __str__(self):
-        
+
         self.update_link_label()
 
         str_ = f"{self.__class__.__name__}\n\n"
@@ -782,16 +788,18 @@ class DatasetModels(collections.abc.Sequence):
         return restore_models_status(self, restore_values)
 
     def set_parameters_bounds(
-        self, tag, model_type, parameters_names, min=None, max=None, value=None
+        self, tag, model_type, parameter_type=None, parameters_names=None, min=None, max=None, value=None
     ):
         """Set bounds for the selected models types and parameters names
 
         Parameters
         ----------
         tag : str or list
-            tag of the models
-        model_type : {"spatial", "spectral"}
-            type of models
+            Tag of the models
+        model_type :  {"spatial", "spectral", "temporal"}
+            Type of model
+        parameter_type: {"norm", "spatial", "spectral", "temporal"}
+            Type of parameter
         parameters_names : str or list
             parameters names
         min : float
@@ -801,9 +809,8 @@ class DatasetModels(collections.abc.Sequence):
         value : float
             init value
         """
-
         models = self.select(tag=tag, model_type=model_type)
-        parameters = models.parameters.select(name=parameters_names, type=model_type)
+        parameters = models.parameters.select(name=parameters_names, type=parameter_type)
         n = len(parameters)
 
         if min is not None:

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -73,7 +73,6 @@ class SkyModel(ModelBase):
         is_norm = np.array([par.is_norm for par in spectral_model.parameters])
 
         if not np.any(is_norm):
-            print(spectral_model)
             raise ValueError("Spectral model used with SkyModel requires a norm type parameter.")
 
         is_free_norm = np.array([par.is_norm for par in spectral_model.parameters.free_parameters])

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -69,6 +69,18 @@ class SkyModel(ModelBase):
         self.apply_irf = apply_irf
         self.datasets_names = datasets_names
         self._check_unit()
+
+        is_norm = np.array([par.is_norm for par in spectral_model.parameters])
+
+        if not np.any(is_norm):
+            print(spectral_model)
+            raise ValueError("Spectral model used with SkyModel requires a norm type parameter.")
+
+        is_free_norm = np.array([par.is_norm for par in spectral_model.parameters.free_parameters])
+
+        if np.sum(is_free_norm) > 1:
+            raise ValueError("Spectral model used with SkyModel can only have a single free norm type parameter.")
+
         super().__init__()
 
     @property
@@ -805,6 +817,7 @@ class TemplateNPredModel(ModelBase):
         from gammapy.modeling.models import SPECTRAL_MODEL_REGISTRY
 
         spectral_data = data.get("spectral")
+
         if spectral_data is not None:
             model_class = SPECTRAL_MODEL_REGISTRY.get_cls(spectral_data["type"])
             spectral_model = model_class.from_dict(spectral_data)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -601,7 +601,7 @@ class ConstantSpectralModel(SpectralModel):
     """
 
     tag = ["ConstantSpectralModel", "const"]
-    const = Parameter("const", "1e-12 cm-2 s-1 TeV-1")
+    const = Parameter("const", "1e-12 cm-2 s-1 TeV-1", type="norm")
 
     @staticmethod
     def evaluate(energy, const):
@@ -687,7 +687,11 @@ class PowerLawSpectralModel(SpectralModel):
     tag = ["PowerLawSpectralModel", "pl"]
     index = Parameter("index", 2.0)
     amplitude = Parameter(
-        "amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log"
+        "amplitude",
+        "1e-12 cm-2 s-1 TeV-1",
+        scale_method="scale10",
+        interp="log",
+        type="norm",
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
 
@@ -804,7 +808,7 @@ class PowerLawNormSpectralModel(SpectralModel):
     """
 
     tag = ["PowerLawNormSpectralModel", "pl-norm"]
-    norm = Parameter("norm", 1, unit="", interp="log")
+    norm = Parameter("norm", 1, unit="", interp="log", type="norm")
     tilt = Parameter("tilt", 0, frozen=True)
     reference = Parameter("reference", "1 TeV", frozen=True)
 
@@ -902,7 +906,11 @@ class PowerLaw2SpectralModel(SpectralModel):
     tag = ["PowerLaw2SpectralModel", "pl-2"]
 
     amplitude = Parameter(
-        "amplitude", "1e-12 cm-2 s-1", scale_method="scale10", interp="log"
+        name="amplitude",
+        value="1e-12 cm-2 s-1",
+        scale_method="scale10",
+        interp="log",
+        type="norm",
     )
     index = Parameter("index", 2)
     emin = Parameter("emin", "0.1 TeV", frozen=True)
@@ -986,7 +994,11 @@ class BrokenPowerLawSpectralModel(SpectralModel):
     index1 = Parameter("index1", 2.0)
     index2 = Parameter("index2", 2.0)
     amplitude = Parameter(
-        "amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log"
+        name="amplitude",
+        value="1e-12 cm-2 s-1 TeV-1",
+        scale_method="scale10",
+        interp="log",
+        type="norm",
     )
     ebreak = Parameter("ebreak", "1 TeV")
 
@@ -1030,7 +1042,11 @@ class SmoothBrokenPowerLawSpectralModel(SpectralModel):
     index1 = Parameter("index1", 2.0)
     index2 = Parameter("index2", 2.0)
     amplitude = Parameter(
-        "amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log"
+        name="amplitude",
+        value="1e-12 cm-2 s-1 TeV-1",
+        scale_method="scale10",
+        interp="log",
+        type="norm",
     )
     ebreak = Parameter("ebreak", "1 TeV")
     reference = Parameter("reference", "1 TeV", frozen=True)
@@ -1062,7 +1078,6 @@ class PiecewiseNormSpectralModel(SpectralModel):
     interp : str
         Interpolation scaling in {"log", "lin"}. Default is "log"
     """
-
     tag = ["PiecewiseNormSpectralModel", "piecewise-norm"]
 
     def __init__(self, energy, norms=None, interp="log"):
@@ -1155,7 +1170,11 @@ class ExpCutoffPowerLawSpectralModel(SpectralModel):
 
     index = Parameter("index", 1.5)
     amplitude = Parameter(
-        "amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log"
+        name="amplitude",
+        value="1e-12 cm-2 s-1 TeV-1",
+        scale_method="scale10",
+        interp="log",
+        type="norm",
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
@@ -1212,7 +1231,7 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
     tag = ["ExpCutoffPowerLawNormSpectralModel", "ecpl-norm"]
 
     index = Parameter("index", 1.5)
-    norm = Parameter("norm", 1, unit="", interp="log")
+    norm = Parameter("norm", 1, unit="", interp="log", type="norm")
     reference = Parameter("reference", "1 TeV", frozen=True)
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
     alpha = Parameter("alpha", "1.0", frozen=True)
@@ -1246,7 +1265,11 @@ class ExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
     tag = ["ExpCutoffPowerLaw3FGLSpectralModel", "ecpl-3fgl"]
     index = Parameter("index", 1.5)
     amplitude = Parameter(
-        "amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log"
+        "amplitude",
+        "1e-12 cm-2 s-1 TeV-1",
+        scale_method="scale10",
+        interp="log",
+        type="norm",
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     ecut = Parameter("ecut", "10 TeV")
@@ -1286,7 +1309,11 @@ class SuperExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
 
     tag = ["SuperExpCutoffPowerLaw3FGLSpectralModel", "secpl-3fgl"]
     amplitude = Parameter(
-        "amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log"
+        "amplitude",
+        "1e-12 cm-2 s-1 TeV-1",
+        scale_method="scale10",
+        interp="log",
+        type="norm",
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     ecut = Parameter("ecut", "10 TeV")
@@ -1323,7 +1350,11 @@ class SuperExpCutoffPowerLaw4FGLSpectralModel(SpectralModel):
 
     tag = ["SuperExpCutoffPowerLaw4FGLSpectralModel", "secpl-4fgl"]
     amplitude = Parameter(
-        "amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log"
+        "amplitude",
+        "1e-12 cm-2 s-1 TeV-1",
+        scale_method="scale10",
+        interp="log",
+        type="norm",
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     expfactor = Parameter("expfactor", "1e-2")
@@ -1410,7 +1441,11 @@ class LogParabolaSpectralModel(SpectralModel):
     """
     tag = ["LogParabolaSpectralModel", "lp"]
     amplitude = Parameter(
-        "amplitude", "1e-12 cm-2 s-1 TeV-1", scale_method="scale10", interp="log"
+        "amplitude",
+        "1e-12 cm-2 s-1 TeV-1",
+        scale_method="scale10",
+        interp="log",
+        type="norm",
     )
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 2)
@@ -1463,7 +1498,7 @@ class LogParabolaNormSpectralModel(SpectralModel):
     LogParabolaSpectralModel
     """
     tag = ["LogParabolaNormSpectralModel", "lp-norm"]
-    norm = Parameter("norm", 1, unit="", interp="log")
+    norm = Parameter("norm", 1, unit="", interp="log", type="norm")
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 2)
     beta = Parameter("beta", 1)
@@ -1502,7 +1537,7 @@ class TemplateSpectralModel(SpectralModel):
     meta : dict, optional
         Meta information, meta['filename'] will be used for serialization
     """
-
+    norm = Parameter("norm", 1, unit="", interp="log", type="norm", frozen=True)
     tag = ["TemplateSpectralModel", "template"]
 
     def __init__(
@@ -1578,9 +1613,9 @@ class TemplateSpectralModel(SpectralModel):
         kwargs.setdefault("interp_kwargs", {"values_scale": "lin"})
         return cls(energy=energy, values=values, **kwargs)
 
-    def evaluate(self, energy):
+    def evaluate(self, energy, norm):
         """Evaluate the model (static function)."""
-        return self._evaluate((energy,), clip=True)
+        return norm * self._evaluate((energy,), clip=True)
 
     def to_dict(self, full_output=False):
         return {
@@ -1657,7 +1692,7 @@ class TemplateNDSpectralModel(SpectralModel):
                 points_scale.append(axis.interp)
                 parameters.append(parameter)
             else:
-                has_energy|=True
+                has_energy |= True
         if not has_energy:
             raise ValueError("Invalid map, no energy axis found")
 
@@ -1678,11 +1713,12 @@ class TemplateNDSpectralModel(SpectralModel):
         coord = {"energy_true": energy}
         coord.update(kwargs)
 
-        pixels = [0,0] + [self.map.geom.axes[key].coord_to_pix(value) for key, value in coord.items()]
+        pixels = [0, 0] + [
+            self.map.geom.axes[key].coord_to_pix(value) for key, value in coord.items()
+        ]
 
         val = self.map.interp_by_pix(pixels, **self._interp_kwargs)
         return u.Quantity(val, self.map.unit, copy=False)
-
 
     def write(self, overwrite=False):
         if self.filename is None:
@@ -1721,7 +1757,7 @@ class ScaleSpectralModel(SpectralModel):
     """
 
     tag = ["ScaleSpectralModel", "scale"]
-    norm = Parameter("norm", 1, unit="", interp="log")
+    norm = Parameter("norm", 1, unit="", interp="log", type="norm")
 
     def __init__(self, model, norm=norm.quantity):
         self.model = model
@@ -2078,7 +2114,7 @@ class GaussianSpectralModel(SpectralModel):
 
     Parameters
     ----------
-    norm : `~astropy.units.Quantity`
+    amplitude : `~astropy.units.Quantity`
         :math:`N_0`
     mean : `~astropy.units.Quantity`
         :math:`\bar{E}`
@@ -2087,14 +2123,16 @@ class GaussianSpectralModel(SpectralModel):
     """
 
     tag = ["GaussianSpectralModel", "gauss"]
-    norm = Parameter("norm", 1e-12 * u.Unit("cm-2 s-1"), interp="log")
+    amplitude = Parameter(
+        "amplitude", 1e-12 * u.Unit("cm-2 s-1"), interp="log", type="norm"
+    )
     mean = Parameter("mean", 1 * u.TeV)
     sigma = Parameter("sigma", 2 * u.TeV)
 
     @staticmethod
-    def evaluate(energy, norm, mean, sigma):
+    def evaluate(energy, amplitude, mean, sigma):
         return (
-            norm
+            amplitude
             / (sigma * np.sqrt(2 * np.pi))
             * np.exp(-((energy - mean) ** 2) / (2 * sigma ** 2))
         )
@@ -2120,7 +2158,7 @@ class GaussianSpectralModel(SpectralModel):
         ).to_value("")
 
         return (
-            self.norm.quantity
+            self.amplitude.quantity
             / 2
             * (scipy.special.erf(u_max) - scipy.special.erf(u_min))
         )
@@ -2145,8 +2183,8 @@ class GaussianSpectralModel(SpectralModel):
         u_max = (
             (energy_max - self.mean.quantity) / (np.sqrt(2) * self.sigma.quantity)
         ).to_value("")
-        a = self.norm.quantity * self.sigma.quantity / np.sqrt(2 * np.pi)
-        b = self.norm.quantity * self.mean.quantity / 2
+        a = self.amplitude.quantity * self.sigma.quantity / np.sqrt(2 * np.pi)
+        b = self.amplitude.quantity * self.mean.quantity / 2
         return a * (np.exp(-(u_min ** 2)) - np.exp(-(u_max ** 2))) + b * (
             scipy.special.erf(u_max) - scipy.special.erf(u_min)
         )

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -601,7 +601,7 @@ class ConstantSpectralModel(SpectralModel):
     """
 
     tag = ["ConstantSpectralModel", "const"]
-    const = Parameter("const", "1e-12 cm-2 s-1 TeV-1", type="norm")
+    const = Parameter("const", "1e-12 cm-2 s-1 TeV-1", is_norm=True)
 
     @staticmethod
     def evaluate(energy, const):
@@ -691,7 +691,7 @@ class PowerLawSpectralModel(SpectralModel):
         "1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        type="norm",
+        is_norm=True,
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
 
@@ -808,7 +808,7 @@ class PowerLawNormSpectralModel(SpectralModel):
     """
 
     tag = ["PowerLawNormSpectralModel", "pl-norm"]
-    norm = Parameter("norm", 1, unit="", interp="log", type="norm")
+    norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
     tilt = Parameter("tilt", 0, frozen=True)
     reference = Parameter("reference", "1 TeV", frozen=True)
 
@@ -910,7 +910,7 @@ class PowerLaw2SpectralModel(SpectralModel):
         value="1e-12 cm-2 s-1",
         scale_method="scale10",
         interp="log",
-        type="norm",
+        is_norm=True,
     )
     index = Parameter("index", 2)
     emin = Parameter("emin", "0.1 TeV", frozen=True)
@@ -998,7 +998,7 @@ class BrokenPowerLawSpectralModel(SpectralModel):
         value="1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        type="norm",
+        is_norm=True,
     )
     ebreak = Parameter("ebreak", "1 TeV")
 
@@ -1046,7 +1046,7 @@ class SmoothBrokenPowerLawSpectralModel(SpectralModel):
         value="1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        type="norm",
+        is_norm=True,
     )
     ebreak = Parameter("ebreak", "1 TeV")
     reference = Parameter("reference", "1 TeV", frozen=True)
@@ -1174,7 +1174,7 @@ class ExpCutoffPowerLawSpectralModel(SpectralModel):
         value="1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        type="norm",
+        is_norm=True,
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
@@ -1231,7 +1231,7 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
     tag = ["ExpCutoffPowerLawNormSpectralModel", "ecpl-norm"]
 
     index = Parameter("index", 1.5)
-    norm = Parameter("norm", 1, unit="", interp="log", type="norm")
+    norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
     reference = Parameter("reference", "1 TeV", frozen=True)
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
     alpha = Parameter("alpha", "1.0", frozen=True)
@@ -1269,7 +1269,7 @@ class ExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
         "1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        type="norm",
+        is_norm=True,
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     ecut = Parameter("ecut", "10 TeV")
@@ -1313,7 +1313,7 @@ class SuperExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
         "1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        type="norm",
+        is_norm=True,
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     ecut = Parameter("ecut", "10 TeV")
@@ -1354,7 +1354,7 @@ class SuperExpCutoffPowerLaw4FGLSpectralModel(SpectralModel):
         "1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        type="norm",
+        is_norm=True,
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     expfactor = Parameter("expfactor", "1e-2")
@@ -1445,7 +1445,7 @@ class LogParabolaSpectralModel(SpectralModel):
         "1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        type="norm",
+        is_norm=True,
     )
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 2)
@@ -1498,7 +1498,7 @@ class LogParabolaNormSpectralModel(SpectralModel):
     LogParabolaSpectralModel
     """
     tag = ["LogParabolaNormSpectralModel", "lp-norm"]
-    norm = Parameter("norm", 1, unit="", interp="log", type="norm")
+    norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 2)
     beta = Parameter("beta", 1)
@@ -1537,7 +1537,7 @@ class TemplateSpectralModel(SpectralModel):
     meta : dict, optional
         Meta information, meta['filename'] will be used for serialization
     """
-    norm = Parameter("norm", 1, unit="", interp="log", type="norm", frozen=True)
+    norm = Parameter("norm", 1, unit="", interp="log", is_norm=True, frozen=True)
     tag = ["TemplateSpectralModel", "template"]
 
     def __init__(
@@ -1757,7 +1757,7 @@ class ScaleSpectralModel(SpectralModel):
     """
 
     tag = ["ScaleSpectralModel", "scale"]
-    norm = Parameter("norm", 1, unit="", interp="log", type="norm")
+    norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
 
     def __init__(self, model, norm=norm.quantity):
         self.model = model
@@ -2124,7 +2124,7 @@ class GaussianSpectralModel(SpectralModel):
 
     tag = ["GaussianSpectralModel", "gauss"]
     amplitude = Parameter(
-        "amplitude", 1e-12 * u.Unit("cm-2 s-1"), interp="log", type="norm"
+        "amplitude", 1e-12 * u.Unit("cm-2 s-1"), interp="log", is_norm=True
     )
     mean = Parameter("mean", 1 * u.TeV)
     sigma = Parameter("sigma", 2 * u.TeV)

--- a/gammapy/modeling/models/spectral_crab.py
+++ b/gammapy/modeling/models/spectral_crab.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 from astropy import units as u
+from gammapy.modeling import Parameter
 from .spectral import (
     ExpCutoffPowerLawSpectralModel,
     LogParabolaSpectralModel,
@@ -19,16 +20,16 @@ class MeyerCrabSpectralModel(SpectralModel):
 
     Reference: https://ui.adsabs.harvard.edu/abs/2010A%26A...523A...2M, Appendix D
     """
-
+    norm = Parameter("norm", value=1, frozen=True, is_norm=True)
     coefficients = [-0.00449161, 0, 0.0473174, -0.179475, -0.53616, -10.2708]
 
     @staticmethod
-    def evaluate(energy):
+    def evaluate(energy, norm):
         polynomial = np.poly1d(MeyerCrabSpectralModel.coefficients)
         log_energy = np.log10(energy.to_value("TeV"))
         log_flux = polynomial(log_energy)
         flux = u.Quantity(np.power(10, log_flux), "erg / (cm2 s)", copy=False)
-        return flux / energy ** 2
+        return norm * flux / energy ** 2
 
 
 def create_crab_spectral_model(reference="meyer"):

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -235,3 +235,11 @@ def test_plot_models(caplog):
     assert "Skipping model m2 - no spatial component present" in [
         _.message for _ in caplog.records
     ]
+
+
+def test_parameter_name():
+    with pytest.raises(RuntimeError):
+        class MyTestModel:
+            par = Parameter("wrong-name", value=3)
+
+        _ = MyTestModel()

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -34,6 +34,7 @@ def models():
     models = Models.from_dict(models_data)
     return models
 
+
 @requires_data()
 def test_dict_to_skymodels(models):
 
@@ -332,9 +333,9 @@ def test_link_label(models):
 
     txt = skymodels.__str__()
     lines = txt.splitlines()
-    n_link = 0 
+    n_link = 0
     for line in lines:
         if "@" in line:
             assert "reference" in line
-            n_link +=1 
+            n_link +=1
     assert n_link == 2

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -259,7 +259,6 @@ def test_bounds(models):
     models.set_parameters_bounds(
         tag=["pl", "pl-norm"],
         model_type="spectral",
-        parameter_type="norm",
         min=0,
         max=None,
     )

--- a/gammapy/modeling/models/tests/test_management.py
+++ b/gammapy/modeling/models/tests/test_management.py
@@ -250,6 +250,7 @@ def test_bounds(models):
         max=5,
         value=2.4,
     )
+
     pl_mask = models.selection_mask(tag="pl", model_type="spectral")
     assert np.all([m.spectral_model.index.value == 2.4 for m in models[pl_mask]])
     assert np.all([m.spectral_model.index.min == 0 for m in models[pl_mask]])
@@ -258,13 +259,14 @@ def test_bounds(models):
     models.set_parameters_bounds(
         tag=["pl", "pl-norm"],
         model_type="spectral",
-        parameters_names=["norm", "amplitude"],
+        parameter_type="norm",
         min=0,
         max=None,
     )
-    bkg_mask = models.selection_mask(tag="TemplateNPredModel")
     assert np.all([m.spectral_model.amplitude.min == 0 for m in models[pl_mask]])
-    assert np.all([m._spectral_model.norm.min == 0 for m in models[bkg_mask]])
+
+    bkg_mask = models.selection_mask(tag="TemplateNPredModel")
+    assert np.all([m.spectral_model.norm.min == 0 for m in models[bkg_mask]])
 
 
 def test_freeze(models):

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -634,13 +634,13 @@ def test_template_spectral_model_evaluate_tiny():
 
 
 def test_template_spectral_model_single_value():
-    energy = [1]*u.TeV
-    values = [1e-12]* u.Unit("TeV-1 s-1 cm-2")
+    energy = [1] * u.TeV
+    values = [1e-12] * u.Unit("TeV-1 s-1 cm-2")
 
     model = TemplateSpectralModel(
         energy=energy, values=values
     )
-    result = model.evaluate([0.5, 2]*u.TeV)
+    result = model(energy=[0.5, 2] * u.TeV)
 
     assert_allclose(result.data, 1e-12)
 

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -346,10 +346,7 @@ def test_models(spectrum):
     model = spectrum["model"]
 
     for p in model.parameters:
-        if p.is_norm:
-            assert p.type == "norm"
-        else:
-            assert p.type == "spectral"
+        assert p.type == "spectral"
 
     energy = 2 * u.TeV
     value = model(energy)

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -2,12 +2,10 @@
 """Model parameter classes."""
 import collections.abc
 import copy
-from enum import Enum
 import itertools
 import logging
 import numpy as np
 from astropy import units as u
-from astropy.utils import classproperty
 from gammapy.utils.interpolation import interpolation_scale
 from gammapy.utils.table import table_from_row_data
 

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -127,6 +127,7 @@ class Parameter:
         self.frozen = frozen
         self._error = error
         self._is_norm = is_norm
+        self._type = None
 
         # TODO: move this to a setter method that can be called from `__set__` also!
         # Having it here is bad: behaviour not clear if Quantity and `unit` is passed.
@@ -418,7 +419,7 @@ class Parameter:
             "frozen": self.frozen,
             "interp": self.interp,
             "scale_method": self.scale_method,
-            "type": self.type,
+            "is_norm": self.is_norm,
         }
 
         if self._link_label_io is not None:

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -160,6 +160,10 @@ class Parameter:
             par = instance.__dict__[self.name]
             raise TypeError(f"Cannot assign {value!r} to parameter {par!r}")
 
+    def __set_name__(self, owner, name):
+        if not self._name == name:
+            raise ValueError(f"Expected parameter name '{name}', got {self._name}")
+
     @property
     def is_norm(self):
         """Whether the parameter represents the norm of the model"""

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -161,7 +161,7 @@ def test_parameters_to_table(pars):
 
     table = pars.to_table()
     assert len(table) == 2
-    assert len(table.columns) == 9
+    assert len(table.columns) == 10
     assert table["link"][0] == "test"
     assert table["link"][1] == ""
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a `"norm"` parameter type, to distinguish the norm type parameters such as `"norm"` and  `"amplitude"`. The PR also addressed implicitly #3845.

The behavior is now, that on init of `SkyModel` the existence of a norm type parameter will be checked and additionally checked that there is only one(!) such a parameter free for fitting. This prevents failing fits because of correlated amplitude values.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
