### PR TITLE
Re-computation of upper limits on flux points

### DIFF
--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -632,7 +632,7 @@ class FluxPoints(FluxMaps):
             A new FluxPoints object with modified upper limits
         """
 
-        if self.has_stat_profiles is False:
+        if not self.has_stat_profiles:
             raise ValueError(
                 "Stat profiles not present. Upper limit computation is not possible"
             )

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -635,23 +635,11 @@ class FluxPoints(FluxMaps):
         delta_ts = n_sigma_ul ** 2
 
         value_scan = self.stat_scan.geom.axes["norm"].center
-        idx = (Ellipsis, 0, 0)
-        stat_scan_full = self.stat_scan.data[idx]
-        stat_min = self.stat.data
-        # TODO: can probably be simplified
-        if len(stat_scan_full.shape) == 2:
-            stat_scan_full = stat_scan_full.reshape((1,) + stat_scan_full.shape)
-            stat_min = stat_min.reshape((1,) + stat_min.shape)
-
-        ncols1 = stat_scan_full.shape[0]
-        ncols2 = stat_scan_full.shape[1]
-
-        norm_ul = np.empty(shape=(ncols1, ncols2))
-        for i in range(ncols1):
-            for j in range(ncols2):
-                stat_scan = np.ravel(stat_scan_full[i][j] - stat_min[i][j])
-                norm_ul[i][j] = stat_profile_ul_scipy(
-                    value_scan, stat_scan, delta_ts=delta_ts, **kwargs
-                )
-
-        self.norm_ul.data = norm_ul.reshape(self.norm.data.shape)
+        shape_axes = self.stat_scan.geom._shape[slice(3, None)]
+        for idx in np.ndindex(shape_axes):
+            stat_scan = (
+                self.stat_scan.data[idx].squeeze() - self.stat.data[idx].squeeze()
+            )
+            self.norm_ul.data[idx] = stat_profile_ul_scipy(
+                value_scan, stat_scan, delta_ts=delta_ts, **kwargs
+            )

--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -645,12 +645,14 @@ def test_recompute_ul():
         energy_edges=[1, 3, 30] * u.TeV, selection_optional=selection, n_sigma_ul=2
     )
     lightcurve = estimator.run(datasets)
-    table = lightcurve.to_table(format="lightcurve", sed_type="dnde")
-    assert_allclose(table["dnde_ul"][0], [3.26070325e-13, 1.15935401e-14], rtol=1e-3)
+    assert_allclose(
+        lightcurve.dnde_ul.data[0], [[[3.260703e-13]], [[1.159354e-14]]], rtol=1e-3
+    )
 
     new_lightcurve = lightcurve.recompute_ul(n_sigma_ul=4)
-    new_table = new_lightcurve.to_table(format="lightcurve", sed_type="dnde")
-    assert_allclose(new_table["dnde_ul"][0], [3.77456115e-13, 1.37442101e-14], rtol=1e-3)
+    assert_allclose(
+        new_lightcurve.dnde_ul.data[0], [[[3.774561e-13]], [[1.374421e-14]]], rtol=1e-3
+    )
     assert new_lightcurve.meta["n_sigma_ul"] == 4
 
     # test if scan is not present

--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -648,9 +648,10 @@ def test_recompute_ul():
     table = lightcurve.to_table(format="lightcurve", sed_type="dnde")
     assert_allclose(table["dnde_ul"][0], [3.26070325e-13, 1.15935401e-14], rtol=1e-3)
 
-    lightcurve.recompute_ul(n_sigma_ul=4)
-    table = lightcurve.to_table(format="lightcurve", sed_type="dnde")
-    assert_allclose(table["dnde_ul"][0], [3.77456115e-13, 1.37442101e-14], rtol=1e-3)
+    new_lightcurve = lightcurve.recompute_ul(n_sigma_ul=4)
+    new_table = new_lightcurve.to_table(format="lightcurve", sed_type="dnde")
+    assert_allclose(new_table["dnde_ul"][0], [3.77456115e-13, 1.37442101e-14], rtol=1e-3)
+    assert new_lightcurve.meta["n_sigma_ul"] == 4
 
     # test if scan is not present
     selection = []

--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -634,3 +634,29 @@ def test_lightcurve_estimator_map_datasets():
     assert_allclose(table["norm_err"][0], [0.031508], rtol=1e-2)
     assert_allclose(table["counts"][0], [[2205, 2220]])
     assert_allclose(table["ts"][0], [2557.346464], rtol=1e-2)
+
+
+@requires_data()
+@requires_dependency("iminuit")
+def test_recompute_ul():
+    datasets = get_spectrum_datasets()
+    selection = ["all"]
+    estimator = LightCurveEstimator(
+        energy_edges=[1, 3, 30] * u.TeV, selection_optional=selection, n_sigma_ul=2
+    )
+    lightcurve = estimator.run(datasets)
+    table = lightcurve.to_table(format="lightcurve", sed_type="dnde")
+    assert_allclose(table["dnde_ul"][0], [3.26070325e-13, 1.15935401e-14], rtol=1e-3)
+
+    lightcurve.recompute_ul(n_sigma_ul=4)
+    table = lightcurve.to_table(format="lightcurve", sed_type="dnde")
+    assert_allclose(table["dnde_ul"][0], [3.77456115e-13, 1.37442101e-14], rtol=1e-3)
+
+    # test if scan is not present
+    selection = []
+    estimator = LightCurveEstimator(
+        energy_edges=[1, 30] * u.TeV, selection_optional=selection
+    )
+    lightcurve = estimator.run(datasets)
+    with pytest.raises(ValueError):
+        lightcurve.recompute_ul(n_sigma_ul=4)

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -520,4 +520,4 @@ def test_flux_points_recompute_ul(fpe_pwl):
 
     # check that it returns a sensible value
     fp2 = fp.recompute_ul(n_sigma_ul=2)
-    assert_allclose(fp2.flux_ul.data, fp.flux_ul.data, rtol=1e-3)
+    assert_allclose(fp2.flux_ul.data, fp.flux_ul.data, rtol=1e-2)

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -498,3 +498,18 @@ def test_flux_points_estimator_small_edges():
     assert_allclose(fp.ts.data[0, 0, 0], 2156.96959291)
     assert np.isnan(fp.ts.data[1, 0, 0])
     assert np.isnan(fp.npred.data[1, 0, 0])
+
+
+@requires_dependency("iminuit")
+def test_flux_points_recompute_ul(fpe_pwl):
+    datasets, fpe = fpe_pwl
+    fp = fpe.run(datasets)
+    table = fp.to_table("flux")
+    assert_allclose(
+        table["flux_ul"], [2.629819e-12, 9.319243e-13, 9.004449e-14], rtol=1e-3
+    )
+    fp.recompute_ul(n_sigma_ul=4)
+    table = fp.to_table("flux")
+    assert_allclose(
+        table["flux_ul"], [2.93166296e-12, 1.05421128e-12, 1.22660055e-13], rtol=1e-3
+    )

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -517,3 +517,7 @@ def test_flux_points_recompute_ul(fpe_pwl):
         rtol=1e-3,
     )
     assert fp1.meta["n_sigma_ul"] == 4
+
+    # check that it returns a sensible value
+    fp2 = fp.recompute_ul(n_sigma_ul=2)
+    assert_allclose(fp2.flux_ul.data, fp.flux_ul.data, rtol=1e-3)

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -509,8 +509,9 @@ def test_flux_points_recompute_ul(fpe_pwl):
     assert_allclose(
         table["flux_ul"], [2.629819e-12, 9.319243e-13, 9.004449e-14], rtol=1e-3
     )
-    fp.recompute_ul(n_sigma_ul=4)
-    table = fp.to_table("flux")
+    fp1 = fp.recompute_ul(n_sigma_ul=4)
+    table = fp1.to_table("flux")
     assert_allclose(
         table["flux_ul"], [2.93166296e-12, 1.05421128e-12, 1.22660055e-13], rtol=1e-3
     )
+    assert fp1.meta["n_sigma_ul"] == 4

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -505,13 +505,15 @@ def test_flux_points_recompute_ul(fpe_pwl):
     datasets, fpe = fpe_pwl
     fpe.selection_optional = ["all"]
     fp = fpe.run(datasets)
-    table = fp.to_table("flux")
     assert_allclose(
-        table["flux_ul"], [2.629819e-12, 9.319243e-13, 9.004449e-14], rtol=1e-3
+        fp.flux_ul.data,
+        [[[2.629819e-12]], [[9.319243e-13]], [[9.004449e-14]]],
+        rtol=1e-3,
     )
     fp1 = fp.recompute_ul(n_sigma_ul=4)
-    table = fp1.to_table("flux")
     assert_allclose(
-        table["flux_ul"], [2.93166296e-12, 1.05421128e-12, 1.22660055e-13], rtol=1e-3
+        fp1.flux_ul.data,
+        [[[2.93166296e-12]], [[1.05421128e-12]], [[1.22660055e-13]]],
+        rtol=1e-3,
     )
     assert fp1.meta["n_sigma_ul"] == 4

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -503,6 +503,7 @@ def test_flux_points_estimator_small_edges():
 @requires_dependency("iminuit")
 def test_flux_points_recompute_ul(fpe_pwl):
     datasets, fpe = fpe_pwl
+    fpe.selection_optional = ["all"]
     fp = fpe.run(datasets)
     table = fp.to_table("flux")
     assert_allclose(


### PR DESCRIPTION
This PR adds an `FluxPoints.recompute_ul`. If the `stat_scan` is present, upper limits can be re-computed from the same. 
It might be useful to add the same for asymmetric error computation in future.