### PR TITLE
Enable serialisation of spectrum datasets

### DIFF
--- a/gammapy/datasets/__init__.py
+++ b/gammapy/datasets/__init__.py
@@ -4,6 +4,7 @@ from .flux_points import FluxPointsDataset
 from .map import MapDataset, MapDatasetOnOff, create_map_dataset_geoms
 from .simulate import MapDatasetEventSampler
 from .spectrum import SpectrumDataset, SpectrumDatasetOnOff
+from .io import OGIPDatasetWriter, OGIPDatasetReader
 
 DATASET_REGISTRY = Registry([MapDataset, SpectrumDatasetOnOff, FluxPointsDataset])
 """Registry of dataset classes in Gammapy."""
@@ -17,6 +18,8 @@ __all__ = [
     "MapDataset",
     "MapDatasetEventSampler",
     "MapDatasetOnOff",
+    "OGIPDatasetWriter",
+    "OGIPDatasetReader",
     "SpectrumDataset",
     "SpectrumDatasetOnOff",
 ]

--- a/gammapy/datasets/__init__.py
+++ b/gammapy/datasets/__init__.py
@@ -6,7 +6,15 @@ from .simulate import MapDatasetEventSampler
 from .spectrum import SpectrumDataset, SpectrumDatasetOnOff
 from .io import OGIPDatasetWriter, OGIPDatasetReader
 
-DATASET_REGISTRY = Registry([MapDataset, SpectrumDatasetOnOff, FluxPointsDataset])
+DATASET_REGISTRY = Registry(
+    [
+        MapDataset,
+        MapDatasetOnOff,
+        SpectrumDataset,
+        SpectrumDatasetOnOff,
+        FluxPointsDataset,
+    ]
+)
 """Registry of dataset classes in Gammapy."""
 
 __all__ = [

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1202,7 +1202,10 @@ class MapDataset(Dataset):
         return cls(**kwargs)
 
     def write(self, filename, overwrite=False):
-        """Write map dataset to file.
+        """Write Dataset to file.
+
+        A MapDataset is serialised using the GADF format with a WCS geometry.
+        A SpectrumDataset uses the same format, with a RegionGeom.
 
         Parameters
         ----------
@@ -1254,7 +1257,7 @@ class MapDataset(Dataset):
 
     @classmethod
     def read(cls, filename, name=None, lazy=False, cache=True, format="gadf"):
-        """Read map dataset from file.
+        """Read a dataset from file.
 
         Parameters
         ----------

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -297,9 +297,6 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
         from .io import OGIPDatasetReader
 
         if format == "gadf":
-            kwargs.setdefault("name", None)
-            kwargs.setdefault("lazy", False)
-            kwargs.setdefault("cache", True)
             return super().read(filename, format="gadf", **kwargs)
 
         reader = OGIPDatasetReader(filename=filename)

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -255,21 +255,6 @@ class SpectrumDataset(PlotMixin, MapDataset):
     stat_type = "cash"
     tag = "SpectrumDataset"
 
-    def write(self, *args, **kwargs):
-        raise NotImplementedError("Method not supported on a spectrum dataset")
-
-    def read(self, *args, **kwargs):
-        raise NotImplementedError("Method not supported on a spectrum dataset")
-
-    def to_hdulist(self, *args, **kwargs):
-        raise NotImplementedError("Method not supported on a spectrum dataset")
-
-    def from_hdulist(self, *args, **kwargs):
-        raise NotImplementedError("Method not supported on a spectrum dataset")
-
-    def from_dict(self, *args, **kwargs):
-        raise NotImplementedError("Method not supported on a spectrum dataset")
-
     def cutout(self, *args, **kwargs):
         raise NotImplementedError("Method not supported on a spectrum dataset")
 
@@ -290,27 +275,32 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
     def plot_residuals_spatial(self, *args, **kwargs):
         raise NotImplementedError("Method not supported on a spectrum dataset")
 
-    def to_hdulist(self, *args, **kwargs):
-        raise NotImplementedError("Method not supported on a spectrum dataset")
-
-    def from_hdulist(self, *args, **kwargs):
-        raise NotImplementedError("Method not supported on a spectrum dataset")
-
     @classmethod
-    def read(cls, filename):
+    def read(cls, filename, format="ogip", **kwargs):
         """Read from file
 
-        For now, filename is assumed to the name of a PHA file where BKG file, ARF, and RMF names
+        For OGIP formats, filename is assumed to the name of a PHA file where
+        BKG file, ARF, and RMF names
         must be set in the PHA header and be present in the same folder.
+        For details, see `OGIPDatasetReader.read`
 
-        For formats specs see `OGIPDatasetReader.read`
+        For the GADF format, a MapDataset serialisation is used
 
         Parameters
         ----------
         filename : `~pathlib.Path` or str
             OGIP PHA file to read
+        format : {"ogip", "ogip-sherpa", "gadf"}
+            Format to use.
+        kwargs : arguments passed to `MapDataset.read`
         """
         from .io import OGIPDatasetReader
+
+        if format == "gadf":
+            kwargs.setdefault("name", None)
+            kwargs.setdefault("lazy", False)
+            kwargs.setdefault("cache", True)
+            return super().read(filename, format="gadf", **kwargs)
 
         reader = OGIPDatasetReader(filename=filename)
         return reader.read()
@@ -318,9 +308,9 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
     def write(self, filename, overwrite=False, format="ogip"):
         """Write spectrum dataset on off to file.
 
-        Currently only the OGIP format is supported
-
-        For formats specs see `OGIPDatasetWriter`
+        Can be serialised either as a `MapDataset` with a `RegionGeom`
+        following the GADF specifications, or as per the OGIP format.
+        For OGIP formats specs see `OGIPDatasetWriter`
 
         Parameters
         ----------
@@ -328,15 +318,20 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
             Filename to write to.
         overwrite : bool
             Overwrite existing file.
-        format : {"ogip", "ogip-sherpa"}
+        format : {"ogip", "ogip-sherpa", "gadf"}
             Format to use.
         """
         from .io import OGIPDatasetWriter
 
-        writer = OGIPDatasetWriter(
-            filename=filename, format=format, overwrite=overwrite
-        )
-        writer.write(self)
+        if format == "gadf":
+            super().write(filename=filename, overwrite=overwrite)
+        elif format in ["ogip", "ogip-sherpa"]:
+            writer = OGIPDatasetWriter(
+                filename=filename, format=format, overwrite=overwrite
+            )
+            writer.write(self)
+        else:
+            raise ValueError(f"{format} is not a valid serialisation format")
 
     @classmethod
     def from_dict(cls, data, **kwargs):

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -102,7 +102,7 @@ def test_spectrum_dataset_fits_io(spectrum_dataset, tmp_path):
     )
     assert dataset_new.edisp is None
     assert dataset_new.edisp is None
-    assert dataset_new.name is "test"
+    assert dataset_new.name == "test"
 
     assert_allclose(spectrum_dataset.exposure.data, dataset_new.exposure.data)
     assert spectrum_dataset.counts.geom == dataset_new.counts.geom


### PR DESCRIPTION
This introduces a `format=gadf` option for the serialisation of `SpectrumDataset`. The serialisation was forbidden before, but it works directly as expected for `MapDataset` with a `RegionGeom`. I added the clarification in the doc strings, don't know if it needs to be explicitly mentioned somewhere in the docs as well. Ideally this should go in the  GADF I imagine, but since https://github.com/open-gamma-ray-astro/gamma-astro-data-formats/pull/170 is still in progress, we may add a serialisation subsection in the Package guide DL4 page...