### PR TITLE
Fix gaussians with missing size in SourceCatalogHGPS.to_models

### DIFF
--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -565,7 +565,8 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         """
 
         spatial_type = self.data["Spatial_Model"]
-        if spatial_type in {"2-Gaussian", "3-Gaussian"}:
+        missing_size = spatial_type=="Gaussian" and self.spatial_model().sigma.value==0
+        if spatial_type in {"2-Gaussian", "3-Gaussian"} or missing_size:
             models = []
             spectral_model = self.spectral_model(which=which)
             for component in self.components:

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -73,6 +73,9 @@ class TestSourceCatalogHGPS:
         models = cat.to_models(components_status="merged")
         assert len(models) == 78
 
+        gaussians = models.select(tag="gauss", model_type="spatial")
+        assert np.all([m.spatial_model.sigma.value > 0. for m in gaussians])
+
 
 @requires_data()
 class TestSourceCatalogObjectHGPS:


### PR DESCRIPTION
Fix SourceCatalogHGPS.to_models for single gaussian sources with missing size in the main table using informations from the components table.