### PR TITLE
Modify SafeMaskMaker to ignore data only below the background peak 

### DIFF
--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -241,7 +241,7 @@ class SafeMaskMaker(Maker):
         background_spectrum = dataset.npred_background().get_spectrum()
         idx = np.argmax(background_spectrum.data, axis=0)
         energy_axis = geom.axes["energy"]
-        energy_min = energy_axis.pix_to_coord(idx)
+        energy_min = energy_axis.edges[idx]
         return geom.energy_mask(energy_min=energy_min)
 
     @staticmethod

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -223,9 +223,11 @@ class SafeMaskMaker(Maker):
     def make_mask_energy_bkg_peak(dataset):
         """Make safe energy mask based on the binned background.
 
-        The energy threshold is defined as the upper edge of the energy
-        bin with the highest predicted background rate. This method is motivated
-        by its use in the HESS DL3 validation paper: https://arxiv.org/pdf/1910.08088.pdf
+        The energy threshold is defined as the lower edge of the energy
+        bin with the highest predicted background rate. This is to ensure analysis in
+        a region where a  Powerlaw approximation to the background spectrum is valid.
+        The is motivated by its use in the HESS DL3
+        validation paper: https://arxiv.org/pdf/1910.08088.pdf
 
         Parameters
         ----------

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -73,7 +73,7 @@ def test_safe_mask_maker(observations, caplog):
     assert_allclose(mask_edisp_bias_offset.data.sum(), 1694)
 
     mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
-    assert_allclose(mask_bkg_peak.data.sum(), 1815)
+    assert_allclose(mask_bkg_peak.data.sum(), 1936)
     assert "WARNING" in [_.levelname for _ in caplog.records]
     message1 = "No default thresholds defined for obs 110380"
     assert message1 in [_.message for _ in caplog.records]
@@ -85,6 +85,14 @@ def test_safe_mask_maker(observations, caplog):
     mask_edisp_bias_noroot = safe_mask_maker_noroot.make_mask_energy_edisp_bias(dataset)
     assert_allclose(mask_aeff_max_noroot.data.sum(), 1815)
     assert_allclose(mask_edisp_bias_noroot.data.sum(), 1936)
+
+    ## test if the peak is in the first bin
+    axis = MapAxis.from_bounds(1.0, 10, nbin=6, unit="TeV", name="energy", interp="log")
+    geom = WcsGeom.create(npix=(5, 5), axes=[axis], skydir=obs.pointing_radec)
+    empty_dataset = MapDataset.create(geom=geom, energy_axis_true=axis_true)
+    dataset = dataset_maker.run(empty_dataset, obs)
+    mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
+    assert_allclose(np.all(mask_bkg_peak), True)
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -92,7 +92,7 @@ def test_safe_mask_maker(observations, caplog):
     empty_dataset = MapDataset.create(geom=geom, energy_axis_true=axis_true)
     dataset = dataset_maker.run(empty_dataset, obs)
     mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
-    assert_allclose(np.all(mask_bkg_peak), True)
+    assert np.all(mask_bkg_peak)
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -84,8 +84,7 @@ def reflected_regions_bkg_maker():
     exclusion_mask = ~geom.region_mask([exclusion_region])
 
     return ReflectedRegionsBackgroundMaker(
-        exclusion_mask=exclusion_mask,
-        min_distance_input="0.2 deg"
+        exclusion_mask=exclusion_mask, min_distance_input="0.2 deg"
     )
 
 
@@ -207,7 +206,7 @@ def test_safe_mask_maker_dl3(spectrum_dataset_crab, observations_hess_dl3):
     assert mask_safe.data.sum() == 3
 
     mask_safe = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
-    assert mask_safe.data.sum() == 3
+    assert mask_safe.data.sum() == 4
 
 
 @requires_data()
@@ -245,7 +244,6 @@ def test_region_center_spectrum_dataset_maker_magic_dl3(
     maker_correction = SpectrumDatasetMaker(
         containment_correction=True, selection=["exposure"]
     )
-
 
     # containment correction should fail
     with pytest.raises(ValueError):


### PR DESCRIPTION
This PR addresses #3851
The energy bin containing the peak of the background is now kept.
Surprisingly, this did not affect any of the fitting test results... 