### PR TITLE
Allow MapDatasetOff in Datasets serialization and avoid read_lazy

### DIFF
--- a/gammapy/datasets/__init__.py
+++ b/gammapy/datasets/__init__.py
@@ -5,7 +5,7 @@ from .map import MapDataset, MapDatasetOnOff, create_map_dataset_geoms
 from .simulate import MapDatasetEventSampler
 from .spectrum import SpectrumDataset, SpectrumDatasetOnOff
 
-DATASET_REGISTRY = Registry([MapDataset, SpectrumDatasetOnOff, FluxPointsDataset])
+DATASET_REGISTRY = Registry([MapDataset, MapDatasetOnOff, SpectrumDatasetOnOff, FluxPointsDataset])
 """Registry of dataset classes in Gammapy."""
 
 __all__ = [

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2371,8 +2371,9 @@ class MapDatasetOnOff(MapDataset):
 
     @classmethod
     def _read_lazy(cls, filename, name=None, cache=True, format="gadf"):
-        #TODO: implement _read_lazy, for now only avoid it to prevent fail
-        return cls.read(filename, name=name, lazy=False, cache=cache, format=format)
+        raise NotImplementedError(
+                f"Lazy loading is not implemented for {cls}, please use option lazy=False."
+                )
 
     @classmethod
     def from_hdulist(cls, hdulist, name=None, format="gadf"):

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2368,6 +2368,12 @@ class MapDatasetOnOff(MapDataset):
 
         return hdulist
 
+
+    @classmethod
+    def _read_lazy(cls, filename, name=None, cache=True, format="gadf"):
+        #TODO: implement _read_lazy, for now only avoid it to prevent fail
+        return cls.read(filename, name=name, lazy=False, cache=cache, format=format)
+
     @classmethod
     def from_hdulist(cls, hdulist, name=None, format="gadf"):
         """Create map dataset from list of HDUs.

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1143,37 +1143,44 @@ def test_map_dataset_on_off_fits_io(images, lazy, tmp_path):
 
     dataset.write(tmp_path / "test.fits")
 
-    dataset_new = MapDatasetOnOff.read(tmp_path / "test.fits", lazy=lazy)
-    assert dataset_new.mask.data.dtype == bool
-    assert dataset_new.meta_table["livetime"] == 1.0*u.h
-    assert dataset_new.meta_table["obs_id"] == 111
-
-    assert_allclose(dataset.counts.data, dataset_new.counts.data)
-    assert_allclose(dataset.counts_off.data, dataset_new.counts_off.data)
-    assert_allclose(dataset.acceptance.data, dataset_new.acceptance.data)
-    assert_allclose(dataset.acceptance_off.data, dataset_new.acceptance_off.data)
-    assert_allclose(dataset.exposure.data, dataset_new.exposure.data)
-    assert_allclose(dataset.mask_safe, dataset_new.mask_safe)
-
-    assert np.all(dataset.mask_safe.data == dataset_new.mask_safe.data)
-    assert dataset.mask_safe.geom == dataset_new.mask_safe.geom
-    assert dataset.counts.geom == dataset_new.counts.geom
-    assert dataset.exposure.geom == dataset_new.exposure.geom
-
-    assert_allclose(
-        dataset.gti.time_sum.to_value("s"), dataset_new.gti.time_sum.to_value("s")
-    )
-
-    assert dataset.psf.psf_map == dataset_new.psf.psf_map
-    assert dataset.psf.exposure_map == dataset_new.psf.exposure_map
-    assert dataset.edisp.edisp_map == dataset_new.edisp.edisp_map
-    assert dataset.edisp.exposure_map == dataset_new.edisp.exposure_map
+    if lazy:
+        with pytest.raises(NotImplementedError):
+            dataset_new = MapDatasetOnOff.read(tmp_path / "test.fits", lazy=lazy)
+    else:
+        dataset_new = MapDatasetOnOff.read(tmp_path / "test.fits", lazy=lazy)
+        assert dataset_new.mask.data.dtype == bool
+        assert dataset_new.meta_table["livetime"] == 1.0*u.h
+        assert dataset_new.meta_table["obs_id"] == 111
+    
+        assert_allclose(dataset.counts.data, dataset_new.counts.data)
+        assert_allclose(dataset.counts_off.data, dataset_new.counts_off.data)
+        assert_allclose(dataset.acceptance.data, dataset_new.acceptance.data)
+        assert_allclose(dataset.acceptance_off.data, dataset_new.acceptance_off.data)
+        assert_allclose(dataset.exposure.data, dataset_new.exposure.data)
+        assert_allclose(dataset.mask_safe, dataset_new.mask_safe)
+    
+        assert np.all(dataset.mask_safe.data == dataset_new.mask_safe.data)
+        assert dataset.mask_safe.geom == dataset_new.mask_safe.geom
+        assert dataset.counts.geom == dataset_new.counts.geom
+        assert dataset.exposure.geom == dataset_new.exposure.geom
+    
+        assert_allclose(
+            dataset.gti.time_sum.to_value("s"), dataset_new.gti.time_sum.to_value("s")
+        )
+    
+        assert dataset.psf.psf_map == dataset_new.psf.psf_map
+        assert dataset.psf.exposure_map == dataset_new.psf.exposure_map
+        assert dataset.edisp.edisp_map == dataset_new.edisp.edisp_map
+        assert dataset.edisp.exposure_map == dataset_new.edisp.exposure_map
 
 @requires_data()
 def test_map_datasets_on_off_fits_io(images, tmp_path):
     dataset = get_map_dataset_onoff(images)
     Datasets([dataset]).write(tmp_path / "test.yaml")
-    datasets = Datasets.read(tmp_path / "test.yaml")
+    datasets = Datasets.read(tmp_path / "test.yaml", lazy=False)
+    with pytest.raises(NotImplementedError):
+        datasets = Datasets.read(tmp_path / "test.yaml", lazy=True)
+
     dataset_new = datasets[0]
 
     assert dataset.name == dataset_new.name

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1102,9 +1102,9 @@ def get_map_dataset_onoff(images, **kwargs):
         **kwargs,
     )
 
-
 @requires_data()
-def test_map_dataset_on_off_fits_io(images, tmp_path):
+@pytest.mark.parametrize("lazy", [False, True])
+def test_map_dataset_on_off_fits_io(images, lazy, tmp_path):
     dataset = get_map_dataset_onoff(images)
     dataset.meta_table = Table(data=[[1.0*u.h], [111]], names=["livetime", "obs_id"])
     gti = GTI.create([0 * u.s], [1 * u.h], reference_time="2010-01-01T00:00:00")
@@ -1143,7 +1143,7 @@ def test_map_dataset_on_off_fits_io(images, tmp_path):
 
     dataset.write(tmp_path / "test.fits")
 
-    dataset_new = MapDatasetOnOff.read(tmp_path / "test.fits")
+    dataset_new = MapDatasetOnOff.read(tmp_path / "test.fits", lazy=lazy)
     assert dataset_new.mask.data.dtype == bool
     assert dataset_new.meta_table["livetime"] == 1.0*u.h
     assert dataset_new.meta_table["obs_id"] == 111
@@ -1169,6 +1169,20 @@ def test_map_dataset_on_off_fits_io(images, tmp_path):
     assert dataset.edisp.edisp_map == dataset_new.edisp.edisp_map
     assert dataset.edisp.exposure_map == dataset_new.edisp.exposure_map
 
+@requires_data()
+def test_map_datasets_on_off_fits_io(images, tmp_path):
+    dataset = get_map_dataset_onoff(images)
+    Datasets([dataset]).write(tmp_path / "test.yaml")
+    datasets = Datasets.read(tmp_path / "test.yaml")
+    dataset_new = datasets[0]
+
+    assert dataset.name == dataset_new.name
+    assert_allclose(dataset.counts.data, dataset_new.counts.data)
+    assert_allclose(dataset.counts_off.data, dataset_new.counts_off.data)
+    assert_allclose(dataset.acceptance.data, dataset_new.acceptance.data)
+    assert_allclose(dataset.acceptance_off.data, dataset_new.acceptance_off.data)
+    assert_allclose(dataset.exposure.data, dataset_new.exposure.data)
+    assert_allclose(dataset.mask_safe, dataset_new.mask_safe)
 
 def test_create_onoff(geom):
     # tests empty datasets created


### PR DESCRIPTION
Allow `MapDatasetsOff` in Datasets serialization. 
Note that `lazy=True` is only supported for `MapDataset` so in order  to prevent a fail I added a `MapDatasetsOff._read_lazy()` that avoid the problem but I did not actually implemented the lazy loading (could be done in a separate PR).