### PR TITLE
Fix EnergyDispersion2D.from_gauss if sigma is an array

### DIFF
--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -98,7 +98,7 @@ class EnergyDispersion2D(IRF):
         pdf = pdf / (migra_max - migra_min)
 
         # no offset dependence
-        data = pdf * np.ones(axes.shape)
+        data = pdf.T * np.ones(axes.shape)
         data[data < pdf_threshold] = 0
 
         return cls(

--- a/gammapy/irf/edisp/tests/test_core.py
+++ b/gammapy/irf/edisp/tests/test_core.py
@@ -26,7 +26,7 @@ class TestEnergyDispersion2D:
         )
         offset_axis = MapAxis.from_bounds(0, 2.5, nbin=5, unit="deg", name="offset")
 
-        energy_true = energy_axis_true.edges[:-1].reshape((-1, 1, 1))
+        energy_true = energy_axis_true.edges[:-1]
         sigma = 0.15 / (energy_true / (1 * u.TeV)).value ** 0.3
         bias = 1e-3 * (energy_true - 1 * u.TeV).value
 


### PR DESCRIPTION
Fix EnergyDispersion2D.from_gauss if sigma is an array. For now this works only if   sigma is given with a shape (N,1,1) which is not obvious to guess, otherwise there is an error about invalid broadcast shapes. So I adapted the test to not assume a (N,1,1)  shape and applied a transposition within .from_gauss(). 