### PR TITLE
Adapt TemplateSpectralModel to support single bin input

### DIFF
--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -99,11 +99,11 @@ def test_lightcurve_properties_flux(lc):
 # is no header info in CSV to store the time scale!
 
 
-@pytest.mark.parametrize("format", ["fits"])
-def test_lightcurve_read_write(tmp_path, lc, format):
-    table = lc.to_table(format="lightcurve", sed_type="flux")
-    table.write(tmp_path / "tmp", format=format)
-    lc = FluxPoints.read(tmp_path / "tmp", format="lightcurve")
+@pytest.mark.parametrize("sed_type", ["dnde", "flux", "likelihood"])
+def test_lightcurve_read_write(tmp_path, lc, sed_type):
+    lc.write(tmp_path / "tmp.fits", format="lightcurve", sed_type=sed_type)
+
+    lc = FluxPoints.read(tmp_path / "tmp.fits", format="lightcurve")
 
     # Check if time-related info round-trips
     axis = lc.geom.axes["time"]

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1519,6 +1519,9 @@ class TemplateSpectralModel(SpectralModel):
         interp_kwargs.setdefault("values_scale", "log")
         interp_kwargs.setdefault("points_scale", ("log",))
 
+        if len(energy)==1:
+            interp_kwargs["method"] = "nearest"
+
         self._evaluate = ScaledRegularGridInterpolator(
             points=(energy,), values=values, **interp_kwargs
         )

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -631,6 +631,18 @@ def test_TemplateSpectralModel_evaluate_tiny():
     assert np.all(result[mask] == 0.0)
 
 
+def test_TemplateSpectralModel_single_value():
+    energy = [1]*u.TeV
+    values = [1e-12]* u.Unit("TeV-1 s-1 cm-2")
+
+    model = TemplateSpectralModel(
+        energy=energy, values=values
+    )
+    result = model.evaluate([0.5, 2]*u.TeV)
+
+    assert_allclose(result.data, 1e-12)
+
+
 def test_TemplateSpectralModel_compound():
     energy = [1.00e06, 1.25e06, 1.58e06, 1.99e06] * u.MeV
     values = [4.39e-7, 1.96e-7, 8.80e-7, 3.94e-7] * u.Unit("MeV-1 s-1 sr-1")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request solves issue #3881 .  If a single value is passed to the `TemplateSpectralModel` init, the `nearest` interpolation method will be applied.

This allows read/write of `FluxPoints` with single energy bin in `likelihood` sed format. A test is added to test read/write of the various formats.


**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
