### PR TITLE
Fix FluxPointsEstimators to support TemplateNPredModel

### DIFF
--- a/gammapy/estimators/map/asmooth.py
+++ b/gammapy/estimators/map/asmooth.py
@@ -183,7 +183,12 @@ class ASmoothMapEstimator(Estimator):
             dataset_sliced = dataset.slice_by_energy(
                 energy_min=energy_min, energy_max=energy_max, name=dataset.name
             )
-            dataset_sliced.models = dataset.models
+            if dataset.models is not None:
+                models_sliced = dataset.models.slice_by_energy(
+                    energy_min=energy_min,
+                    energy_max=energy_max,
+                )
+                dataset_sliced.models = models_sliced
             result = self.estimate_maps(dataset_sliced)
             results.append(result)
 

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -493,15 +493,21 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         for energy_min, energy_max in progress_bar(
             energy_axis.iter_by_edges, desc="Energy bins"
         ):
-            sliced_dataset = dataset.slice_by_energy(
+            dataset_sliced = dataset.slice_by_energy(
                 energy_min=energy_min, energy_max=energy_max, name=dataset.name
             )
 
             if self.sum_over_energy_groups:
-                sliced_dataset = sliced_dataset.to_image(name=dataset.name)
+                dataset_sliced = dataset_sliced.to_image(name=dataset.name)
 
-            sliced_dataset.models = dataset_models
-            result = self.estimate_flux_map(sliced_dataset)
+            if dataset_models is not None:
+                models_sliced = dataset_models.slice_by_energy(
+                    energy_min=energy_min,
+                    energy_max=energy_max,
+                    sum_over_energy_groups=self.sum_over_energy_groups,
+                )
+                dataset_sliced.models = models_sliced
+            result = self.estimate_flux_map(dataset_sliced)
             results.append(result)
 
         maps = Maps()

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -200,14 +200,14 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
             )
 
         if len(datasets_sliced) > 0:
-            models_copy = Models(datasets.models.copy())
-            for k, m in enumerate(models_copy):
-                if m.tag == "TemplateNPredModel":
-                    m_sliced = m.slice_by_energy(energy_min, energy_max)
-                    if self.sum_over_energy_groups:
-                        m_sliced.map = m_sliced.map.sum_over_axes(keepdims=True)
-                    models_copy[k] = m_sliced
-            datasets_sliced.models = models_copy
+            if datasets.models is not None:
+                models_sliced = datasets.models.slice_by_energy(
+                    energy_min=energy_min,
+                    energy_max=energy_max,
+                    sum_over_energy_groups=self.sum_over_energy_groups,
+                )
+                datasets_sliced.models = models_sliced
+
             return super().run(datasets=datasets_sliced)
         else:
             log.warning(f"No dataset contribute in range {energy_min}-{energy_max}")

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -11,9 +11,6 @@ from gammapy.datasets.flux_points import _get_reference_model
 from gammapy.maps import MapAxis
 from gammapy.modeling import Fit
 from gammapy.utils.deprecation import deprecated_attribute
-from gammapy.modeling.models import Models
-from gammapy.utils.pbar import progress_bar
-from gammapy.utils.table import table_from_row_data
 from ..flux import FluxEstimator
 from .core import FluxPoints
 

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -11,6 +11,9 @@ from gammapy.datasets.flux_points import _get_reference_model
 from gammapy.maps import MapAxis
 from gammapy.modeling import Fit
 from gammapy.utils.deprecation import deprecated_attribute
+from gammapy.modeling.models import Models
+from gammapy.utils.pbar import progress_bar
+from gammapy.utils.table import table_from_row_data
 from ..flux import FluxEstimator
 from .core import FluxPoints
 
@@ -197,7 +200,11 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
             )
 
         if len(datasets_sliced) > 0:
-            datasets_sliced.models = datasets.models.copy()
+            models_copy = Models(datasets.models.copy())
+            for k, m in enumerate(models_copy):
+                if m.tag == "TemplateNPredModel":
+                    models_copy[k] = m.slice_by_energy(energy_min, energy_max)
+            datasets_sliced.models = models_copy
             return super().run(datasets=datasets_sliced)
         else:
             log.warning(f"No dataset contribute in range {energy_min}-{energy_max}")

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -203,7 +203,10 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
             models_copy = Models(datasets.models.copy())
             for k, m in enumerate(models_copy):
                 if m.tag == "TemplateNPredModel":
-                    models_copy[k] = m.slice_by_energy(energy_min, energy_max)
+                    m_sliced = m.slice_by_energy(energy_min, energy_max)
+                    if self.sum_over_energy_groups:
+                        m_sliced.map = m_sliced.map.sum_over_axes(keepdims=True)
+                    models_copy[k] = m_sliced
             datasets_sliced.models = models_copy
             return super().run(datasets=datasets_sliced)
         else:

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -400,6 +400,7 @@ def test_run_template_npred(fpe_map_pwl, tmpdir):
     model = TemplateNPredModel(dataset.background, datasets_names=[dataset.name])
     models.append(model)
     dataset.models = models
+    dataset.background.data = 0
 
     fp = fpe.run(dataset)
 

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -22,8 +22,10 @@ from gammapy.modeling.models import (
     Models,
     PiecewiseNormSpectralModel,
     PowerLawSpectralModel,
+    TemplateNPredModel,
     SkyModel,
     TemplateSpatialModel,
+    Models,
 )
 from gammapy.utils import parallel
 from gammapy.utils.testing import requires_data, requires_dependency
@@ -389,6 +391,15 @@ def test_run_map_pwl_reoptimize(fpe_map_pwl_reoptimize):
     actual = table["stat_scan"][0] - table["stat"][0]
     assert_allclose(actual, [9.788123, 0.486066, 17.603708], rtol=1e-2)
 
+@requires_dependency("iminuit")
+def test_run_template_npred(fpe_map_pwl, tmpdir):
+    datasets, fpe = fpe_map_pwl
+    dataset = datasets[0]
+    models = Models(dataset.models)
+    model = TemplateNPredModel(dataset.background, datasets_names=[dataset.name])
+    models.append(model)
+    dataset.models = models
+    fpe.run(dataset)
 
 @requires_data()
 def test_reoptimize_no_free_parameters(fpe_pwl, caplog):

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -22,10 +22,9 @@ from gammapy.modeling.models import (
     Models,
     PiecewiseNormSpectralModel,
     PowerLawSpectralModel,
-    TemplateNPredModel,
     SkyModel,
+    TemplateNPredModel,
     TemplateSpatialModel,
-    Models,
 )
 from gammapy.utils import parallel
 from gammapy.utils.testing import requires_data, requires_dependency
@@ -391,6 +390,7 @@ def test_run_map_pwl_reoptimize(fpe_map_pwl_reoptimize):
     actual = table["stat_scan"][0] - table["stat"][0]
     assert_allclose(actual, [9.788123, 0.486066, 17.603708], rtol=1e-2)
 
+
 @requires_dependency("iminuit")
 @requires_data()
 def test_run_template_npred(fpe_map_pwl, tmpdir):
@@ -400,10 +400,11 @@ def test_run_template_npred(fpe_map_pwl, tmpdir):
     model = TemplateNPredModel(dataset.background, datasets_names=[dataset.name])
     models.append(model)
     dataset.models = models
-    
+
     fpe.run(dataset)
     fpe.sum_over_energy_groups = True
     fpe.run(dataset)
+
 
 @requires_data()
 def test_reoptimize_no_free_parameters(fpe_pwl, caplog):
@@ -693,7 +694,6 @@ def test_fpe_non_uniform_datasets():
 
 @requires_data()
 def test_flux_points_estimator_norm_spectral_model(fermi_datasets):
-
     energy_edges = [10, 30, 100, 300, 1000] * u.GeV
 
     model_ref = fermi_datasets.models["Crab Nebula"]

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -392,6 +392,7 @@ def test_run_map_pwl_reoptimize(fpe_map_pwl_reoptimize):
     assert_allclose(actual, [9.788123, 0.486066, 17.603708], rtol=1e-2)
 
 @requires_dependency("iminuit")
+@requires_data()
 def test_run_template_npred(fpe_map_pwl, tmpdir):
     datasets, fpe = fpe_map_pwl
     dataset = datasets[0]

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -399,6 +399,9 @@ def test_run_template_npred(fpe_map_pwl, tmpdir):
     model = TemplateNPredModel(dataset.background, datasets_names=[dataset.name])
     models.append(model)
     dataset.models = models
+    
+    fpe.run(dataset)
+    fpe.sum_over_energy_groups = True
     fpe.run(dataset)
 
 @requires_data()

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -401,9 +401,18 @@ def test_run_template_npred(fpe_map_pwl, tmpdir):
     models.append(model)
     dataset.models = models
 
-    fpe.run(dataset)
+    fp = fpe.run(dataset)
+
+    table = fp.to_table()
+    actual = table["norm"].data
+    assert_allclose(actual, [0.974726, 0.96342, 0.994251], rtol=1e-2)
+
     fpe.sum_over_energy_groups = True
-    fpe.run(dataset)
+    fp = fpe.run(dataset)
+
+    table = fp.to_table()
+    actual = table["norm"].data
+    assert_allclose(actual, [0.955512, 0.965328, 0.995237], rtol=1e-2)
 
 
 @requires_data()

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -689,7 +689,7 @@ class DatasetModels(collections.abc.Sequence):
         energy_min, energy_max : `~astropy.units.Quantity`
             Energy bounds of the slice
         sum_over_energy_groups : bool
-            Whether to sum over the energy groups or not.
+            Whether to sum over the energy groups or not. Default is False.
 
         Returns
         -------

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -682,7 +682,7 @@ class DatasetModels(collections.abc.Sequence):
         )
 
     def slice_by_energy(self, energy_min, energy_max, sum_over_energy_groups=False):
-        """Copy models and slice TemplateNPredModel in energy range
+        """Copy models and slice TemplateNPredModel in energy range.
 
         Parameters
         ----------
@@ -694,7 +694,7 @@ class DatasetModels(collections.abc.Sequence):
         Returns
         -------
         models : `Models`
-            Sliced models
+            Sliced models.
         """
         models_sliced = Models(self.copy())
         for k, m in enumerate(models_sliced):

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -683,14 +683,14 @@ class DatasetModels(collections.abc.Sequence):
 
     def slice_by_energy(self, energy_min, energy_max, sum_over_energy_groups=False):
         """Copy models and slice TemplateNPredModel in energy range
-        
+
         Parameters
         ----------
         energy_min, energy_max : `~astropy.units.Quantity`
             Energy bounds of the slice
         sum_over_energy_groups : bool
             Whether to sum over the energy groups or not.
-        
+
         Returns
         -------
         models : `Models`
@@ -1162,7 +1162,11 @@ class Models(DatasetModels, collections.abc.MutableSequence):
         del self._models[self.index(key)]
 
     def __setitem__(self, key, model):
-        from gammapy.modeling.models import FoVBackgroundModel, SkyModel, TemplateNPredModel
+        from gammapy.modeling.models import (
+            FoVBackgroundModel,
+            SkyModel,
+            TemplateNPredModel,
+        )
 
         if isinstance(model, (SkyModel, FoVBackgroundModel, TemplateNPredModel)):
             self._models[self.index(key)] = model

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -681,6 +681,30 @@ class DatasetModels(collections.abc.Sequence):
             models=models, covariance_data=self.covariance.data.copy()
         )
 
+    def slice_by_energy(self, energy_min, energy_max, sum_over_energy_groups=False):
+        """Copy models and slice TemplateNPredModel in energy range
+        
+        Parameters
+        ----------
+        energy_min, energy_max : `~astropy.units.Quantity`
+            Energy bounds of the slice
+        sum_over_energy_groups : bool
+            Whether to sum over the energy groups or not.
+        
+        Returns
+        -------
+        models : `Models`
+            Sliced models
+        """
+        models_sliced = Models(self.copy())
+        for k, m in enumerate(models_sliced):
+            if m.tag == "TemplateNPredModel":
+                m_sliced = m.slice_by_energy(energy_min, energy_max)
+                if sum_over_energy_groups:
+                    m_sliced.map = m_sliced.map.sum_over_axes(keepdims=True)
+                models_sliced[k] = m_sliced
+        return models_sliced
+
     def select(
         self,
         name_substring=None,

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -1138,9 +1138,9 @@ class Models(DatasetModels, collections.abc.MutableSequence):
         del self._models[self.index(key)]
 
     def __setitem__(self, key, model):
-        from gammapy.modeling.models import FoVBackgroundModel, SkyModel
+        from gammapy.modeling.models import FoVBackgroundModel, SkyModel, TemplateNPredModel
 
-        if isinstance(model, (SkyModel, FoVBackgroundModel)):
+        if isinstance(model, (SkyModel, FoVBackgroundModel, TemplateNPredModel)):
             self._models[self.index(key)] = model
         else:
             raise TypeError(f"Invalid type: {model!r}")

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -1132,11 +1132,11 @@ class TemplateNPredModel(ModelBase):
         slices = {
             "energy": slice(int(group["idx_min"][0]), int(group["idx_max"][0]) + 1)
         }
-        
+
         model = self.copy(name=name)
         model.map = model.map.slice_by_idx(slices=slices)
         return model
-    
+
     def __str__(self):
         str_ = self.__class__.__name__ + "\n\n"
         str_ += "\t{:26}: {}\n".format("Name", self.name)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -1099,9 +1099,9 @@ class TemplateNPredModel(ModelBase):
         Parameters
         ----------
         energy_min, energy_max : `~astropy.units.Quantity`
-            Energy bounds of the slice.  Default is None.
+            Energy bounds of the slice. Default is None.
         name : str
-            Name of the sliced model.  Default is None.
+            Name of the sliced model. Default is None.
 
         Returns
         -------

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -1094,12 +1094,12 @@ class TemplateNPredModel(ModelBase):
         self.spectral_model.tilt.value = 0
 
     def slice_by_energy(self, energy_min=None, energy_max=None, name=None):
-        """Select and slice datasets in energy range
+        """Select and slice model template in energy range
 
         Parameters
         ----------
         energy_min, energy_max : `~astropy.units.Quantity`
-            Energy bounds to compute the flux point for.
+            Energy bounds of the slice.
         name : str
             Name of the sliced model.
 

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -1093,6 +1093,50 @@ class TemplateNPredModel(ModelBase):
         self.spectral_model.norm.value = 1
         self.spectral_model.tilt.value = 0
 
+    def slice_by_energy(self, energy_min=None, energy_max=None, name=None):
+        """Select and slice datasets in energy range
+
+        Parameters
+        ----------
+        energy_min, energy_max : `~astropy.units.Quantity`
+            Energy bounds to compute the flux point for.
+        name : str
+            Name of the sliced model.
+
+        Returns
+        -------
+        model : `TemplateNpredModel`
+            Sliced Model
+
+        """
+        name = make_name(name)
+
+        energy_axis = self.map._geom.axes["energy"]
+
+        if energy_min is None:
+            energy_min = energy_axis.bounds[0]
+
+        if energy_max is None:
+            energy_max = energy_axis.bounds[1]
+
+        if name is None:
+            name = self.name
+
+        energy_min, energy_max = u.Quantity(energy_min), u.Quantity(energy_max)
+
+        group = energy_axis.group_table(edges=[energy_min, energy_max])
+
+        is_normal = group["bin_type"] == "normal   "
+        group = group[is_normal]
+
+        slices = {
+            "energy": slice(int(group["idx_min"][0]), int(group["idx_max"][0]) + 1)
+        }
+        
+        model = self.copy(name=name)
+        model.map = model.map.slice_by_idx(slices=slices)
+        return model
+    
     def __str__(self):
         str_ = self.__class__.__name__ + "\n\n"
         str_ += "\t{:26}: {}\n".format("Name", self.name)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -1099,14 +1099,14 @@ class TemplateNPredModel(ModelBase):
         Parameters
         ----------
         energy_min, energy_max : `~astropy.units.Quantity`
-            Energy bounds of the slice.
+            Energy bounds of the slice.  Default is None.
         name : str
-            Name of the sliced model.
+            Name of the sliced model.  Default is None.
 
         Returns
         -------
         model : `TemplateNpredModel`
-            Sliced Model
+            Sliced Model.
 
         """
         name = make_name(name)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -245,6 +245,14 @@ def test_background_model(background):
     assert_allclose(npred2.data[0][0][0], 2.254e-07, rtol=1e-3)
     assert_allclose(npred2.data.sum(), 7.352e-06, rtol=1e-3)
 
+def test_background_slice(background):
+    bkg1 = TemplateNPredModel(background)
+    e_edges = background.geom.axes[0].edges
+    bkg1_slice = bkg1.slice_by_energy(e_edges[0], e_edges[1]) #1 bin slice
+    assert bkg1_slice.name == bkg1_slice.name
+    assert bkg1_slice.map.data.shape == bkg1.map.sum_over_axes().data.shape
+    assert_allclose(bkg1_slice.map.data[0,:,:], bkg1.map.data[0,:,:], rtol=1e-5)
+
 
 def test_background_model_io(tmpdir, background):
     filename = str(tmpdir / "test-bkg-file.fits")

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -245,13 +245,14 @@ def test_background_model(background):
     assert_allclose(npred2.data[0][0][0], 2.254e-07, rtol=1e-3)
     assert_allclose(npred2.data.sum(), 7.352e-06, rtol=1e-3)
 
+
 def test_background_slice(background):
     bkg1 = TemplateNPredModel(background)
     e_edges = background.geom.axes[0].edges
-    bkg1_slice = bkg1.slice_by_energy(e_edges[0], e_edges[1]) #1 bin slice
+    bkg1_slice = bkg1.slice_by_energy(e_edges[0], e_edges[1])  # 1 bin slice
     assert bkg1_slice.name == bkg1_slice.name
     assert bkg1_slice.map.data.shape == bkg1.map.sum_over_axes().data.shape
-    assert_allclose(bkg1_slice.map.data[0,:,:], bkg1.map.data[0,:,:], rtol=1e-5)
+    assert_allclose(bkg1_slice.map.data[0, :, :], bkg1.map.data[0, :, :], rtol=1e-5)
 
 
 def test_background_model_io(tmpdir, background):


### PR DESCRIPTION
For each energy band the FluxPointsEstimators creates a dataset sliced in energy and copies the models but if TemplateNPredModel are present they are not sliced which cause an error in npred computation (invalid dimension to stack the maps). This PR fix the issue.
