### PR TITLE
Add notes about order of observations to docstrings

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -76,7 +76,7 @@ class DataStore:
 
     @property
     def obs_ids(self):
-        """Return list of obs_ids contained in the datastore."""
+        """Return the sorted obs_ids contained in the datastore."""
         return np.unique(self.hdu_table["OBS_ID"].data)
 
     @classmethod
@@ -301,6 +301,8 @@ class DataStore:
         ----------
         obs_id : list
             Observation IDs (default of ``None`` means "all")
+            If not given, all observations ordered by OBS_ID are returned.
+            This is not necessarily the order in the ``obs_table``.
         skip_missing : bool, optional
             Skip missing observations, default: False
         required_irf : list of str or str


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

The issue described in #3890 was coming from the *wrong* assumption that `DataStore.get_observations` returns the observations in the same order as they are in `DataStore.obs_table`. 

By using `np.unique` which returns unique values in *sorted* order, `DataStore.get_observations` now returns observations ordered by obs_id, not in the order in the obs table.

I think this behavior is ok, but should be documented.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
