### PR TITLE
Allow for regular reflected region analysis with fixed rad_max IRFs

### DIFF
--- a/gammapy/irf/rad_max.py
+++ b/gammapy/irf/rad_max.py
@@ -146,8 +146,6 @@ class RadMax2D(IRF):
                 valid = np.allclose(geom.region.radius.to_value('deg'),
                                     self.quantity.to_value('deg'),
                                     rtol)
-            else:
-                raise TypeError("CircleSkyRegion can only be used with fixed RADMAX point-like IRFs.")
         elif geom.is_all_point_sky_regions:
             valid = True
         return valid

--- a/gammapy/irf/rad_max.py
+++ b/gammapy/irf/rad_max.py
@@ -1,4 +1,7 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import astropy.units as u
+import numpy as np
+from regions import CircleSkyRegion
 from astropy.visualization import quantity_support
 from .core import IRF
 
@@ -114,3 +117,39 @@ class RadMax2D(IRF):
         ax.set_ylabel(f"Rad max. ({ax.yaxis.units})")
         ax.yaxis.set_major_formatter("{x:.1f}")
         return ax
+
+    @property
+    def is_fixed_radmax(self):
+        """Returns True if rad_max axes are flat."""
+        return self.axes.is_flat
+
+    def check_geom(self, geom, rtol = 0.01):
+        """Check if input RegionGeom is compatible with rad_max for point-like analysis.
+
+        Parameters
+        ----------
+        geom : `~gammapy.maps.RegionGeom`
+            input RegionGeom.
+        rtol : float
+            relative tolerance
+
+        Returns
+        -------
+        valid : bool
+            True if rad_max is fixed and region is a CircleSkyRegion with compatible radius
+            True if region is a PointSkyRegion
+            False otherwise.
+        """
+        valid = False
+        if isinstance(geom.region, CircleSkyRegion):
+            if self.is_fixed_radmax:
+                valid = np.allclose(geom.region.radius.to_value('deg'),
+                                    self.quantity.to_value('deg'),
+                                    rtol)
+            else:
+                raise TypeError("CircleSkyRegion can only be used with fixed RADMAX point-like IRFs.")
+        elif geom.is_all_point_sky_regions:
+            valid = True
+        return valid
+
+

--- a/gammapy/irf/tests/test_rad_max.py
+++ b/gammapy/irf/tests/test_rad_max.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from gammapy.maps import MapAxis
+from gammapy.maps import MapAxis, RegionGeom
 from gammapy.irf import RadMax2D, EffectiveAreaTable2D
 from gammapy.utils.testing import mpl_plot_check, requires_dependency
 
@@ -98,4 +98,8 @@ def test_rad_max_single_bin():
     value = rad_max.evaluate(energy=[1, 2, 3] * u.TeV, offset=[[1]] * u.deg)
     assert value.shape == (1, 3)
     assert_allclose(value, 0.1 * u.deg)
+
+    geom = RegionGeom.create("fk5;circle(0,0,0.1)")
+    assert rad_max.is_fixed_radmax
+    assert rad_max.check_geom(geom)
 

--- a/gammapy/irf/tests/test_rad_max.py
+++ b/gammapy/irf/tests/test_rad_max.py
@@ -103,3 +103,6 @@ def test_rad_max_single_bin():
     assert rad_max.is_fixed_radmax
     assert rad_max.check_geom(geom)
 
+    geom = RegionGeom.create("fk5;box(0,0,0.1,0.1)")
+    assert rad_max.check_geom(geom) is False
+

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
-from numpy.testing import assert_allclose
 import numpy as np
 from itertools import combinations
 from abc import ABCMeta, abstractmethod
@@ -482,8 +481,8 @@ class ReflectedRegionsBackgroundMaker(Maker):
                             f"Expected {rad_max} got {radius}."
                         )
                 else:
-                    raise TypeError(f"Only circular regions can be used with fixed rad_max IRF and "
-                                    f"ReflectedRegionsFinder.")
+                    raise TypeError("Only circular regions can be used with fixed rad_max IRF and "
+                                    "ReflectedRegionsFinder.")
             elif not geom.is_all_point_sky_regions:
                 raise ValueError(
                     "Must use PointSkyRegion on region in point-like analysis,"

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -471,15 +471,19 @@ class ReflectedRegionsBackgroundMaker(Maker):
         is_point_like = False
 
         if observation.rad_max is not None:
-            if isinstance(geom.region, CircleSkyRegion):
-                if not observation.rad_max.check_geom(geom):
-                    rad_max = observation.rad_max.quantity
-                    radius = geom.region.radius
-                    raise ValueError(
-                        f"CircleSkyRegion radius must be equal to RADMAX "
-                        f"for point-like IRFs with fixed RADMAX. "
-                        f"Expected {rad_max} got {radius}."
-                    )
+            if isinstance(self.region_finder, ReflectedRegionsFinder):
+                if isinstance(geom.region, CircleSkyRegion):
+                    if not observation.rad_max.check_geom(geom):
+                        rad_max = observation.rad_max.quantity
+                        radius = geom.region.radius
+                        raise ValueError(
+                            f"CircleSkyRegion radius must be equal to RADMAX "
+                            f"for point-like IRFs with fixed RADMAX. "
+                            f"Expected {rad_max} got {radius}."
+                        )
+                else:
+                    raise TypeError(f"Only circular regions can be used with fixed rad_max IRF and "
+                                    f"ReflectedRegionsFinder.")
             elif not geom.is_all_point_sky_regions:
                 raise ValueError(
                     "Must use PointSkyRegion on region in point-like analysis,"

--- a/gammapy/makers/background/tests/test_reflected.py
+++ b/gammapy/makers/background/tests/test_reflected.py
@@ -406,14 +406,14 @@ def test_reflected_bkg_maker_fixed_rad_max_bad(reflected_bkg_maker, observations
 
     dataset = maker.run(dataset_empty, obs)
     with pytest.raises(ValueError):
-        dataset_on_off = reflected_bkg_maker.run(dataset, obs)
+        reflected_bkg_maker.run(dataset, obs)
 
     region_bad_shape = RectangleSkyRegion(pos, 0.2*u.deg, 0.2*u.deg)
     geom_bad_shape = RegionGeom(region_bad_shape, axes=[e_reco])
     dataset_empty = SpectrumDataset.create(geom=geom_bad_shape)
 
     dataset = maker.run(dataset_empty, obs)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         reflected_bkg_maker.run(dataset, obs)
 
     region_point_shape = PointSkyRegion(pos)

--- a/gammapy/makers/background/tests/test_reflected.py
+++ b/gammapy/makers/background/tests/test_reflected.py
@@ -391,6 +391,34 @@ def test_reflected_bkg_maker_fixed_rad_max(reflected_bkg_maker, observations_fix
     assert_allclose(len(regions_0), 6)
 
 @requires_data()
+def test_reflected_bkg_maker_fixed_rad_max_wobble(exclusion_mask, observations_fixed_rad_max):
+    reflected_bkg_maker = ReflectedRegionsBackgroundMaker(
+        region_finder=WobbleRegionsFinder(n_off_regions=3),
+        exclusion_mask=exclusion_mask,
+    )
+    e_reco = MapAxis.from_energy_bounds(0.1, 10, 5, unit="TeV")
+    e_true = MapAxis.from_energy_bounds(0.1, 10, 5, unit="TeV", name="energy_true")
+
+    pos = SkyCoord(83.63, 22.01, unit="deg", frame="icrs")
+    radius = Angle(0.1414, "deg")
+    region = CircleSkyRegion(pos, radius)
+
+    geom = RegionGeom(region=region, axes=[e_reco])
+    dataset_empty = SpectrumDataset.create(geom=geom, energy_axis_true=e_true)
+
+    maker = SpectrumDatasetMaker(selection=["counts"])
+
+    obs = observations_fixed_rad_max[0]
+    dataset = maker.run(dataset_empty, obs)
+    dataset_on_off = reflected_bkg_maker.run(dataset, obs)
+
+    assert_allclose(dataset_on_off.counts_off.data.sum(), 102)
+
+    regions_0 = compound_region_to_regions(dataset_on_off.counts_off.geom.region)
+    assert_allclose(len(regions_0), 3)
+
+
+@requires_data()
 def test_reflected_bkg_maker_fixed_rad_max_bad(reflected_bkg_maker, observations_fixed_rad_max):
     e_reco = MapAxis.from_energy_bounds(0.1, 10, 5, unit="TeV")
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request solves #3889 by introducing a `RadMax2D.check_geom` that validates the region shape and size w.r.t. to the rad_max. For now, it only allows circular region with identical radius if rad_max is constant and point sky region otherwise. 
A test is then performed in `ReflectedRegionsMaker.run` to check whether the input is valid and raise exception otherwise. The check is basically:
- if no rad_max, OK
- if rad_max and if reflected regions, OK only if rad_max and region agree
- if rad_max and not reflected region, valid only if point sky region

With this the joint crab validation runs.
**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
