### PR TITLE
Add peek method to IRFMaps and unify peek methods

### DIFF
--- a/docs/tutorials/analysis/3D/analysis_3d.ipynb
+++ b/docs/tutorials/analysis/3D/analysis_3d.ipynb
@@ -259,6 +259,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# We can quickly check the PSF\n",
+    "dataset_stacked.psf.peek()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# And the energy dispersion in the center of the map\n",
+    "dataset_stacked.edisp.peek()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# You can also get an excess image with a few lines of code:\n",
     "excess = dataset_stacked.excess.sum_over_axes()\n",
     "excess.smooth(\"0.06 deg\").plot(stretch=\"sqrt\", add_cbar=True);"
@@ -803,7 +823,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -825,9 +845,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1.0,
+   "current_citInitial": 1,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1.0,
+   "eqNumInitial": 1,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"
@@ -1049,7 +1069,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0.0,
+       "index": 0,
        "layout": "IPY_MODEL_630e7d062f92495f80cc891b5f41e459",
        "orientation": "horizontal",
        "readout": true,
@@ -1085,7 +1105,7 @@
        "description": "Select energy:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 0.0,
+       "index": 0,
        "layout": "IPY_MODEL_2a623c0d2f104f7085d8dbe4ba7b1288",
        "orientation": "horizontal",
        "readout": true,
@@ -1113,7 +1133,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 1.0,
+       "index": 1,
        "layout": "IPY_MODEL_0aeefaeaa8cb4eaab1d9b3e2f598f1c8",
        "style": "IPY_MODEL_b276e62a203044e5aa6a19271c359963"
       }
@@ -1495,7 +1515,7 @@
        "description": "Select stretch:",
        "description_tooltip": null,
        "disabled": false,
-       "index": 1.0,
+       "index": 1,
        "layout": "IPY_MODEL_8b34344bdfd04c8ba35f109aa2968082",
        "style": "IPY_MODEL_9dac402f20464c7fb2bd21fe32d1f3ec"
       }
@@ -1525,8 +1545,8 @@
       }
      }
     },
-    "version_major": 2.0,
-    "version_minor": 0.0
+    "version_major": 2,
+    "version_minor": 0
    }
   }
  },

--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -166,7 +166,7 @@ class MapEvaluator:
         if edisp:
             energy_axis = geom.axes["energy"]
             self.edisp = edisp.get_edisp_kernel(
-                self.model.position, energy_axis=energy_axis
+                position=self.model.position, energy_axis=energy_axis
             )
 
         # lookup psf

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1879,13 +1879,9 @@ class MapDataset(Dataset):
 
         Parameters
         ----------
-        fig : `~matplotlib.figure.Figure`
-            Figure to add AxesSubplot on.
+        figsize : tuple
+            Size of the figure.
 
-        Returns
-        -------
-        ax1, ax2, ax3 : `~matplotlib.axes.AxesSubplot`
-            Counts, excess and exposure.
         """
 
         def plot_mask(ax, mask, **kwargs):

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -227,6 +227,8 @@ class PlotMixin:
             Size of the figure.
 
         """
+        import matplotlib.pyplot as plt
+
         fig, ax1, ax2, ax3 = plt.subplots(1, 3, figsize=figsize)
 
         ax1.set_title("Counts")

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 from gammapy.utils.scripts import make_path
 from .map import MapDataset, MapDatasetOnOff
-from .utils import get_axes, get_figure
+from .utils import get_axes
 
 __all__ = ["SpectrumDatasetOnOff", "SpectrumDataset"]
 
@@ -229,7 +229,7 @@ class PlotMixin:
         """
         import matplotlib.pyplot as plt
 
-        fig, ax1, ax2, ax3 = plt.subplots(1, 3, figsize=figsize)
+        fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=figsize)
 
         ax1.set_title("Counts")
         self.plot_counts(ax1)

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -218,21 +218,16 @@ class PlotMixin:
         ax.legend(numpoints=1)
         return ax
 
-    def peek(self, fig=None):
+    def peek(self, figsize=(16,4)):
         """Quick-look summary plots.
 
         Parameters
         ----------
-        fig : `~matplotlib.figure.Figure`
-            Figure to add AxesSubplot on.
+        figsize : tuple
+            Size of the figure.
 
-        Returns
-        -------
-        ax1, ax2, ax3 : `~matplotlib.axes.AxesSubplot`
-            Counts, effective area and energy dispersion subplots.
         """
-        fig = get_figure(fig, 16, 4)
-        ax1, ax2, ax3 = fig.subplots(1, 3)
+        fig, ax1, ax2, ax3 = plt.subplots(1, 3, figsize=figsize)
 
         ax1.set_title("Counts")
         self.plot_counts(ax1)
@@ -247,8 +242,6 @@ class PlotMixin:
         if self.edisp is not None:
             kernel = self.edisp.get_edisp_kernel()
             kernel.plot_matrix(ax=ax3, add_cbar=True)
-
-        return ax1, ax2, ax3
 
 
 class SpectrumDataset(PlotMixin, MapDataset):

--- a/gammapy/estimators/profile.py
+++ b/gammapy/estimators/profile.py
@@ -365,6 +365,8 @@ class ImageProfile:
 
         Parameters
         ----------
+        figsize : tuple
+            Size of the figure.
         **kwargs : dict
             Keyword arguments passed to `ImageProfile.plot_profile()`
 

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -137,6 +137,14 @@ class Background3D(BackgroundIRF):
         )
 
     def peek(self, figsize=(10, 8)):
+        """Quick-look summary plots.
+
+        Parameters
+        ----------
+        figsize : tuple
+            Size of the figure.
+
+        """
         return self.to_2d().peek(figsize)
 
     def plot_at_energy(

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -578,7 +578,14 @@ class EDispKernel(IRF):
         return ax
 
     def peek(self, figsize=(15, 5)):
-        """Quick-look summary plot."""
+        """Quick-look summary plots.
+
+        Parameters
+        ----------
+        figsize : tuple
+            Size of the figure.
+
+        """
         import matplotlib.pyplot as plt
 
         fig, axes = plt.subplots(nrows=1, ncols=2, figsize=figsize)

--- a/gammapy/irf/edisp/map.py
+++ b/gammapy/irf/edisp/map.py
@@ -264,8 +264,8 @@ class EDispMap(IRFMap):
             Size of figure.
 
         """
-        e_reco = self.edisp_map.geom.axes[1].copy()
-        e_reco.name = 'energy'
+        e_true = self.edisp_map.geom.axes[1]
+        e_reco = MapAxis.from_energy_bounds(e_true.edges.min(), e_true.edges.max(), nbin = len(e_true.center), name='energy')
 
         self.get_edisp_kernel(energy_axis=e_reco).peek(figsize)
 

--- a/gammapy/irf/edisp/map.py
+++ b/gammapy/irf/edisp/map.py
@@ -254,6 +254,20 @@ class EDispMap(IRFMap):
 
         return cls.from_geom(geom)
 
+    def peek(self, figsize=(15,5)):
+        """Quick-look summary plots.
+        Plots corresponding to the center of the map.
+
+        Parameters
+        ----------
+        figsize : tuple
+            Size of figure.
+
+        """
+        e_reco = self.edisp_map.geom.axes[1].copy()
+        e_reco.name = 'energy'
+
+        self.get_edisp_kernel(energy_axis=e_reco).peek(figsize)
 
 class EDispKernelMap(IRFMap):
     """Energy dispersion kernel map.
@@ -484,6 +498,8 @@ class EDispKernelMap(IRFMap):
 
     def peek(self, figsize=(15, 5)):
         """Quick-look summary plots.
+        Plots corresponding to the center of the map.
+
 
         Parameters
         ----------

--- a/gammapy/irf/edisp/map.py
+++ b/gammapy/irf/edisp/map.py
@@ -93,15 +93,16 @@ class EDispMap(IRFMap):
         """Normalize PSF map"""
         self.edisp_map.normalize(axis_name="migra")
 
-    def get_edisp_kernel(self, position=None, energy_axis=None):
+    def get_edisp_kernel(self, energy_axis, position=None):
         """Get energy dispersion at a given position.
 
         Parameters
         ----------
-        position : `~astropy.coordinates.SkyCoord`
-            the target position. Should be a single coordinates
         energy_axis : `MapAxis`
             Reconstructed energy axis
+        position : `~astropy.coordinates.SkyCoord`
+            the target position. Should be a single coordinates
+
 
         Returns
         -------

--- a/gammapy/irf/edisp/map.py
+++ b/gammapy/irf/edisp/map.py
@@ -481,3 +481,14 @@ class EDispKernelMap(IRFMap):
         return self.__class__(
             edisp_kernel_map=new_edisp_map, exposure_map=self.exposure_map
         )
+
+    def peek(self, figsize=(15, 5)):
+        """Quick-look summary plots.
+
+        Parameters
+        ----------
+        figsize : tuple
+            Size of figure.
+
+        """
+        self.get_edisp_kernel().peek(figsize)

--- a/gammapy/irf/edisp/tests/test_map.py
+++ b/gammapy/irf/edisp/tests/test_map.py
@@ -321,3 +321,7 @@ def test_peek():
     edisp = EDispKernelMap.from_diagonal_response(e_reco, e_true)
     with mpl_plot_check():
         edisp.peek()
+    edisp = EDispMap.from_diagonal_response(e_true)
+    with mpl_plot_check():
+        edisp.peek()
+

--- a/gammapy/irf/edisp/tests/test_map.py
+++ b/gammapy/irf/edisp/tests/test_map.py
@@ -313,6 +313,11 @@ def test_edisp_kernel_map_resample_axis():
     assert_allclose(res, 1.0, rtol=1e-5)
 
 @requires_dependency("matplotlib")
-def test_peek(self):
+def test_peek():
+    e_reco = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=3)
+    e_true = MapAxis.from_energy_bounds(
+        "0.08 TeV", "20 TeV", nbin=5, name="energy_true"
+    )
+    edisp = EDispKernelMap.from_diagonal_response(e_reco, e_true)
     with mpl_plot_check():
-        self.peek()
+        edisp.peek()

--- a/gammapy/irf/edisp/tests/test_map.py
+++ b/gammapy/irf/edisp/tests/test_map.py
@@ -107,7 +107,7 @@ def test_edisp_map_to_energydispersion():
     position = SkyCoord(0, 0, unit="deg")
     energy_axis = MapAxis.from_edges(np.logspace(-0.3, 0.2, 200) * u.TeV, name="energy")
 
-    edisp = edmap.get_edisp_kernel(position, energy_axis=energy_axis)
+    edisp = edmap.get_edisp_kernel(position=position, energy_axis=energy_axis)
     # Note that the bias and resolution are rather poorly evaluated on an EnergyDispersion object
     assert_allclose(edisp.get_bias(energy_true=1.0 * u.TeV), 0.0, atol=3e-2)
     assert_allclose(edisp.get_resolution(energy_true=1.0 * u.TeV), 0.2, atol=3e-2)
@@ -162,7 +162,7 @@ def test_edisp_from_diagonal_response(position):
     )
 
     edisp_map = EDispMap.from_diagonal_response(energy_axis_true)
-    edisp_kernel = edisp_map.get_edisp_kernel(position, energy_axis=energy_axis)
+    edisp_kernel = edisp_map.get_edisp_kernel(position=position, energy_axis=energy_axis)
 
     sum_kernel = np.sum(edisp_kernel.data, axis=1)
 
@@ -183,7 +183,7 @@ def test_edisp_map_to_edisp_kernel_map():
 
     edisp_kernel_map = edisp_map.to_edisp_kernel_map(energy_axis)
     position = SkyCoord(0, 0, unit="deg")
-    kernel = edisp_kernel_map.get_edisp_kernel(position)
+    kernel = edisp_kernel_map.get_edisp_kernel(position=position)
 
     assert edisp_kernel_map.exposure_map.geom.axes[0].name == "energy"
     actual = kernel.pdf_matrix.sum(axis=0)
@@ -212,7 +212,7 @@ def test_edisp_kernel_map_stack():
     edisp_1.stack(edisp_2, weights=weights)
 
     position = SkyCoord(0, 0, unit="deg")
-    kernel = edisp_1.get_edisp_kernel(position)
+    kernel = edisp_1.get_edisp_kernel(position=position)
 
     actual = kernel.pdf_matrix.sum(axis=0)
     exposure = edisp_1.exposure_map.data[:, 0, 0, 0]

--- a/gammapy/irf/edisp/tests/test_map.py
+++ b/gammapy/irf/edisp/tests/test_map.py
@@ -14,7 +14,7 @@ from gammapy.irf import (
 )
 from gammapy.makers.utils import make_edisp_map, make_map_exposure_true_energy
 from gammapy.maps import MapAxis, MapCoord, RegionGeom, WcsGeom
-
+from gammapy.utils.testing import mpl_plot_check, requires_dependency
 
 def fake_aeff2d(area=1e6 * u.m ** 2):
     offsets = np.array((0.0, 1.0, 2.0, 3.0)) * u.deg
@@ -311,3 +311,8 @@ def test_edisp_kernel_map_resample_axis():
 
     assert im.edisp_map.data.shape == (10, 2, 1, 2)
     assert_allclose(res, 1.0, rtol=1e-5)
+
+@requires_dependency("matplotlib")
+def test_peek(self):
+    with mpl_plot_check():
+        self.peek()

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -179,7 +179,14 @@ class EffectiveAreaTable2D(IRF):
         return ax
 
     def peek(self, figsize=(15, 5)):
-        """Quick-look summary plots."""
+        """Quick-look summary plots.
+
+        Parameters
+        ----------
+        figsize : tuple
+            Size of the figure.
+
+        """
         import matplotlib.pyplot as plt
 
         fig, axes = plt.subplots(nrows=1, ncols=3, figsize=figsize)

--- a/gammapy/irf/psf/core.py
+++ b/gammapy/irf/psf/core.py
@@ -255,7 +255,14 @@ class PSF(IRF):
         return ax
 
     def peek(self, figsize=(15, 5)):
-        """Quick-look summary plots."""
+        """Quick-look summary plots.
+
+        Parameters
+        ----------
+        figsize : tuple
+            Size of the figure.
+
+        """
         import matplotlib.pyplot as plt
 
         fig, axes = plt.subplots(nrows=1, ncols=3, figsize=figsize)

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -6,7 +6,6 @@ from gammapy.maps import Map, MapAxis, MapCoord, WcsGeom
 from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.utils.gauss import Gauss2DPDF
 from gammapy.utils.random import InverseCDFSampler, get_random_state
-from matplotlib.ticker import FormatStrFormatter
 from ..core import IRFMap
 from .core import PSF
 from .kernel import PSFKernel
@@ -425,6 +424,7 @@ class PSFMap(IRFMap):
 
         """
         import matplotlib.pyplot as plt
+        from matplotlib.ticker import FormatStrFormatter
 
         ax = plt.gca() if ax is None else ax
 
@@ -467,6 +467,7 @@ class PSFMap(IRFMap):
 
         """
         import matplotlib.pyplot as plt
+        from matplotlib.ticker import FormatStrFormatter
 
         ax = plt.gca() if ax is None else ax
 

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -493,3 +493,47 @@ class PSFMap(IRFMap):
 
     def __str__(self):
         return str(self.psf_map)
+
+
+    def peek(self, figsize=(12, 10)):
+        """Quick-look summary plots.
+
+        Parameters
+        ----------
+        fig : `~matplotlib.figure.Figure`
+            Figure to add AxesSubplot on.
+
+        Returns
+        -------
+        ax1, ax2, ax3, ax4 : `~matplotlib.axes.AxesSubplot`
+            Containment radius at the center, PSF profile at the center,
+            exposure map and containment radius map at 1 TeV.
+        """
+
+        import matplotlib.pyplot as plt
+
+        fig, axes = plt.subplots(
+            ncols=2,
+            nrows=2,
+            subplot_kw={"projection": self.psf_map.geom.wcs},
+            figsize=figsize,
+            gridspec_kw={"hspace": 0.3, "wspace": 0.3},
+        )
+
+        axes = axes.flat
+        axes[0].remove()
+        ax0 = fig.add_subplot(2, 2, 1)
+        ax0.set_title("Containment radius at center of map")
+        self.plot_containment_radius_vs_energy(ax = ax0)
+
+        axes[1].remove()
+        ax1 = fig.add_subplot(2, 2, 2)
+        ax1.set_ylim(1e-4, 1e4)
+        ax1.set_title("PSF at center of map")
+        self.plot_psf_vs_rad(ax = ax1)
+
+        axes[2].set_title("Exposure")
+        self.exposure_map.reduce_over_axes().plot(ax = axes[2], add_cbar=True)
+
+        axes[3].set_title("Containment radius at 1 TeV")
+        self.containment_radius_map(energy_true=2*u.TeV).plot(ax = axes[3], add_cbar=True)

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -6,6 +6,7 @@ from gammapy.maps import Map, MapAxis, MapCoord, WcsGeom
 from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.utils.gauss import Gauss2DPDF
 from gammapy.utils.random import InverseCDFSampler, get_random_state
+from matplotlib.ticker import FormatStrFormatter
 from ..core import IRFMap
 from .core import PSF
 from .kernel import PSFKernel
@@ -440,6 +441,7 @@ class PSFMap(IRFMap):
 
         ax.semilogx()
         ax.legend(loc="best")
+        ax.yaxis.set_major_formatter(FormatStrFormatter('%.2f'))
         ax.set_xlabel(f"Energy ({ax.xaxis.units})")
         ax.set_ylabel(f"Containment radius ({ax.yaxis.units})")
         return ax
@@ -485,6 +487,7 @@ class PSFMap(IRFMap):
         ax.set_yscale("log")
         ax.set_xlabel(f"Rad ({ax.xaxis.units})")
         ax.set_ylabel(f"PSF ({ax.yaxis.units})")
+        ax.xaxis.set_major_formatter(FormatStrFormatter('%.2f'))
         plt.legend()
         return ax
 

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -500,14 +500,8 @@ class PSFMap(IRFMap):
 
         Parameters
         ----------
-        fig : `~matplotlib.figure.Figure`
-            Figure to add AxesSubplot on.
-
-        Returns
-        -------
-        ax1, ax2, ax3, ax4 : `~matplotlib.axes.AxesSubplot`
-            Containment radius at the center, PSF profile at the center,
-            exposure map and containment radius map at 1 TeV.
+        figsize : tuple
+            Size of figure.
         """
 
         import matplotlib.pyplot as plt

--- a/gammapy/irf/psf/tests/test_map.py
+++ b/gammapy/irf/psf/tests/test_map.py
@@ -496,3 +496,12 @@ def test_psf_containment_coords():
     )
 
     assert_allclose(radius, 0.10575 * u.deg, rtol=1e-5)
+
+
+@requires_dependency("matplotlib")
+@requires_data()
+def test_peek():
+    psf_map = PSFMap.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz", hdu="PSF")
+
+    with mpl_plot_check():
+        psf_map.peek()

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -212,16 +212,16 @@ class SafeMaskMaker(Maker):
 
         if isinstance(edisp, EDispKernelMap):
             if position:
-                edisp = edisp.get_edisp_kernel(position)
+                edisp = edisp.get_edisp_kernel(position=position)
             else:
-                edisp = edisp.get_edisp_kernel(self.position)
+                edisp = edisp.get_edisp_kernel(position=self.position)
         else:
             if position:
                 e_reco = dataset._geom.axes["energy"].edges
-                edisp = edisp.get_edisp_kernel(position, e_reco)
+                edisp = edisp.get_edisp_kernel(position=position, energy_axis=e_reco)
             else:
                 e_reco = dataset._geom.axes["energy"].edges
-                edisp = edisp.get_edisp_kernel(self.position, e_reco)
+                edisp = edisp.get_edisp_kernel(position=self.position, energy_axis=e_reco)
 
         energy_min = edisp.get_bias_energy(self.bias_percent / 100)
         return geom.energy_mask(energy_min=energy_min[0])

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -375,10 +375,10 @@ def test_interpolate_map_dataset():
 
     # test edispmap
     pdfmatrix_preinterp = edispmap.get_edisp_kernel(
-        SkyCoord("0 deg", "0 deg")
+        position=SkyCoord("0 deg", "0 deg")
     ).pdf_matrix
     pdfmatrix_postinterp = dataset.edisp.get_edisp_kernel(
-        SkyCoord("0 deg", "0 deg")
+        position=SkyCoord("0 deg", "0 deg")
     ).pdf_matrix
     assert_allclose(pdfmatrix_preinterp, pdfmatrix_postinterp, atol=1e-7)
 

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -301,7 +301,7 @@ def test_make_edisp_kernel_map():
     pointing = SkyCoord(0, 0, frame="icrs", unit="deg")
     edispmap = make_edisp_kernel_map(edisp, pointing, geom)
 
-    kernel = edispmap.get_edisp_kernel(pointing)
+    kernel = edispmap.get_edisp_kernel(position=pointing)
     assert_allclose(kernel.pdf_matrix[:, 0], (1.0, 1.0, 0.0, 0.0, 0.0, 0.0), atol=1e-14)
     assert_allclose(kernel.pdf_matrix[:, 1], (0.0, 0.0, 1.0, 1.0, 0.0, 0.0), atol=1e-14)
     assert_allclose(kernel.pdf_matrix[:, 2], (0.0, 0.0, 0.0, 0.0, 1.0, 1.0), atol=1e-14)


### PR DESCRIPTION
This pull request:

1.  addresses #3683 and adds a peek method for the IRFMaps, namely psf and edisp. Also adds an example of this to the 3D analysis tutorial.
2. Fixes a bug causing the axis tick labels of quantities with degree units to show 0º if the value was below 1
3. Unifies the docstring and argument of most peek method (except events.peek)
4. Fixes a bug in `EDispMap.get_edisp_kernel()` which had `energy_axis` as optional input but not giving it lead to an error.

The new peek methods look like:
![image](https://user-images.githubusercontent.com/22521727/165124435-9653c4fc-95d8-4b88-b6f9-780920664295.png)

and for the edisp
![image](https://user-images.githubusercontent.com/22521727/165124477-a93bae22-54d2-49de-a98a-036fa39ba410.png)
