### PR TITLE
Separate handling of safe mask default thresholds

### DIFF
--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -117,12 +117,19 @@ class SafeMaskMaker(Maker):
         if observation is None:
             raise ValueError("Method 'offset-max' requires an observation object.")
 
-        try:
-            energy_max = observation.aeff.meta["HI_THRES"] * u.TeV
-            energy_min = observation.aeff.meta["LO_THRES"] * u.TeV
-        except KeyError:
-            log.warning(f"No default thresholds defined for obs {observation.obs_id}")
-            energy_min, energy_max = None, None
+        energy_max = observation.aeff.meta.get("HI_THRES", None)
+
+        if energy_max:
+            energy_max = energy_max * u.TeV
+        else:
+            log.warning(f"No default upper safe energy threshold defined for obs {observation.obs_id}")
+
+        energy_min = observation.aeff.meta.get("LO_THRES", None)
+
+        if energy_min:
+            energy_min = energy_min * u.TeV
+        else:
+            log.warning(f"No default lower safe energy threshold defined for obs {observation.obs_id}")
 
         return dataset._geom.energy_mask(energy_min=energy_min, energy_max=energy_max)
 

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -25,59 +25,142 @@ def observations_hess_dl3():
     return datastore.get_observations(obs_ids)
 
 
-@requires_data()
-def test_safe_mask_maker(observations, caplog):
-    obs = observations[0]
+@pytest.fixture(scope="session")
+def observation_cta_1dc():
+    data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps/")
+    return data_store.obs(110380)
 
+
+@pytest.fixture(scope="session")
+def dataset(observation_cta_1dc):
     axis = MapAxis.from_bounds(
         0.1, 10, nbin=16, unit="TeV", name="energy", interp="log"
     )
     axis_true = MapAxis.from_bounds(
         0.1, 50, nbin=30, unit="TeV", name="energy_true", interp="log"
     )
-    geom = WcsGeom.create(npix=(11, 11), axes=[axis], skydir=obs.pointing_radec)
+    geom = WcsGeom.create(
+        npix=(11, 11), axes=[axis], skydir=observation_cta_1dc.pointing_radec
+    )
 
     empty_dataset = MapDataset.create(geom=geom, energy_axis_true=axis_true)
     dataset_maker = MapDatasetMaker()
+    return dataset_maker.run(
+        dataset=empty_dataset, observation=observation_cta_1dc
+    )
+
+
+@requires_data()
+def test_safe_mask_maker_offset_max(dataset, observation_cta_1dc):
     safe_mask_maker = SafeMaskMaker(
-        offset_max="3 deg", bias_percent=0.02, position=obs.pointing_radec
+        offset_max="3 deg",
+        position=observation_cta_1dc.pointing_radec
     )
 
-    fixed_offset = 1.5 * u.deg
-    safe_mask_maker_offset = SafeMaskMaker(
-        offset_max="3 deg", bias_percent=0.02, fixed_offset=fixed_offset
+    mask_offset = safe_mask_maker.make_mask_offset_max(
+        dataset=dataset, observation=observation_cta_1dc
     )
-
-    dataset = dataset_maker.run(empty_dataset, obs)
-
-    mask_offset = safe_mask_maker.make_mask_offset_max(dataset=dataset, observation=obs)
     assert_allclose(mask_offset.sum(), 109)
 
+
+@requires_data()
+def test_safe_mask_maker_aeff_default(dataset, observation_cta_1dc, caplog):
+    safe_mask_maker = SafeMaskMaker(
+        position=observation_cta_1dc.pointing_radec
+    )
+
     mask_energy_aeff_default = safe_mask_maker.make_mask_energy_aeff_default(
-        dataset=dataset, observation=obs
+        dataset=dataset, observation=observation_cta_1dc
     )
     assert_allclose(mask_energy_aeff_default.data.sum(), 1936)
 
-    mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset)
-    mask_aeff_max_offset = safe_mask_maker_offset.make_mask_energy_aeff_max(
-        dataset, obs
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    messages = [_.message for _ in caplog.records]
+
+    message = "No default upper safe energy threshold defined for obs 110380"
+    assert message == messages[0]
+
+    message = "No default lower safe energy threshold defined for obs 110380"
+    assert message == messages[1]
+
+
+@requires_data()
+def test_safe_mask_maker_aeff_max(dataset, observation_cta_1dc):
+    safe_mask_maker = SafeMaskMaker(
+        position=observation_cta_1dc.pointing_radec
     )
+
+    mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset)
+
     assert_allclose(mask_aeff_max.data.sum(), 1210)
+
+
+@requires_data()
+def test_safe_mask_maker_offset_max_fixed_offset(dataset, observation_cta_1dc):
+    safe_mask_maker_offset = SafeMaskMaker(
+        offset_max="3 deg", fixed_offset=1.5 * u.deg
+    )
+
+    mask_aeff_max_offset = safe_mask_maker_offset.make_mask_energy_aeff_max(
+        dataset=dataset, observation=observation_cta_1dc
+    )
     assert_allclose(mask_aeff_max_offset.data.sum(), 1210)
 
-    mask_edisp_bias = safe_mask_maker.make_mask_energy_edisp_bias(dataset)
-    mask_edisp_bias_offset = safe_mask_maker_offset.make_mask_energy_edisp_bias(
-        dataset, obs
+
+@requires_data()
+def test_safe_mask_maker_edisp_bias(dataset, observation_cta_1dc):
+    safe_mask_maker = SafeMaskMaker(
+        bias_percent=0.02,
+        position=observation_cta_1dc.pointing_radec
     )
+
+    mask_edisp_bias = safe_mask_maker.make_mask_energy_edisp_bias(dataset=dataset)
     assert_allclose(mask_edisp_bias.data.sum(), 1815)
+
+
+@requires_data()
+def test_safe_mask_maker_edisp_bias_fixed_offset(dataset, observation_cta_1dc):
+    safe_mask_maker_offset = SafeMaskMaker(
+        offset_max="3 deg", bias_percent=0.02, fixed_offset=1.5 * u.deg
+    )
+
+    mask_edisp_bias_offset = safe_mask_maker_offset.make_mask_energy_edisp_bias(
+        dataset=dataset, observation=observation_cta_1dc
+    )
     assert_allclose(mask_edisp_bias_offset.data.sum(), 1694)
+
+
+@requires_data()
+def test_safe_mask_maker_bkg_peak(dataset, observation_cta_1dc):
+    safe_mask_maker = SafeMaskMaker(
+        position=observation_cta_1dc.pointing_radec
+    )
 
     mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
     assert_allclose(mask_bkg_peak.data.sum(), 1936)
-    assert "WARNING" in [_.levelname for _ in caplog.records]
-    message1 = "No default thresholds defined for obs 110380"
-    assert message1 in [_.message for _ in caplog.records]
 
+
+@requires_data()
+def test_safe_mask_maker_bkg_peak_first_bin(dataset, observation_cta_1dc):
+    safe_mask_maker = SafeMaskMaker(
+        position=observation_cta_1dc.pointing_radec
+    )
+
+    dataset_maker = MapDatasetMaker()
+
+    axis = MapAxis.from_bounds(1.0, 10, nbin=6, unit="TeV", name="energy", interp="log")
+
+    geom = WcsGeom.create(
+        npix=(5, 5), axes=[axis], skydir=observation_cta_1dc.pointing_radec
+    )
+    empty_dataset = MapDataset.create(geom=geom)
+    dataset = dataset_maker.run(empty_dataset, observation_cta_1dc)
+    mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
+    assert np.all(mask_bkg_peak)
+
+
+@requires_data()
+def test_safe_mask_maker_no_root(dataset, observation_cta_1dc):
     safe_mask_maker_noroot = SafeMaskMaker(
         offset_max="3 deg", aeff_percent=-10, bias_percent=-10
     )
@@ -85,14 +168,6 @@ def test_safe_mask_maker(observations, caplog):
     mask_edisp_bias_noroot = safe_mask_maker_noroot.make_mask_energy_edisp_bias(dataset)
     assert_allclose(mask_aeff_max_noroot.data.sum(), 1815)
     assert_allclose(mask_edisp_bias_noroot.data.sum(), 1936)
-
-    ## test if the peak is in the first bin
-    axis = MapAxis.from_bounds(1.0, 10, nbin=6, unit="TeV", name="energy", interp="log")
-    geom = WcsGeom.create(npix=(5, 5), axes=[axis], skydir=obs.pointing_radec)
-    empty_dataset = MapDataset.create(geom=geom, energy_axis_true=axis_true)
-    dataset = dataset_maker.run(empty_dataset, obs)
-    mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
-    assert np.all(mask_bkg_peak)
 
 
 @requires_data()


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

When looking at the rad max tutorial I noticed that the default low energy thresholds are not taken into account. This is because the IRFs only define the `LO_THRESH` keyword. However Gammapy tries to access lower and upper threshold in the same try/except block. So if the upper threshold is missing, the lower threshold will not be applied either. This PR fixes the behavior to handle both thresholds independently. 


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
