### PR TITLE
Fix bug on MC_ID when sampling IRF background events

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -7,7 +7,7 @@ from astropy.table import Table
 import gammapy
 from gammapy.data import EventList, observatory_locations
 from gammapy.maps import MapCoord
-from gammapy.modeling.models import ConstantTemporalModel
+from gammapy.modeling.models import ConstantTemporalModel, Models
 from gammapy.utils.random import get_random_state
 
 __all__ = ["MapDatasetEventSampler"]
@@ -295,8 +295,8 @@ class MapDatasetEventSampler:
         meta["CONV_DEC"] = 0
 
         for idx, model in enumerate(dataset.models):
-            meta["MID{:05d}".format(idx + 1)] = idx + 1
-            meta["MMN{:05d}".format(idx + 1)] = model.name
+            meta["MID{:05d}".format(idx)] = idx
+            meta["MMN{:05d}".format(idx)] = model.name
         meta["NMCIDS"] = len(dataset.models)
 
         # Necessary for DataStore, but they should be ALT and AZ instead!
@@ -351,6 +351,16 @@ class MapDatasetEventSampler:
             Event list.
         """
         if len(dataset.models) > 1:
+            for i, mod in enumerate(dataset.models):
+                if mod.tag[0] == "FoVBackgroundModel":
+                    break
+
+            sky_model = np.delete(dataset.models, i, 0)
+            fov_bkg = dataset.models[i]
+            model_new = Models([fov_bkg])
+            model_new.extend(sky_model)
+            dataset.models = model_new
+
             events_src = self.sample_sources(dataset)
 
             if len(events_src.table) > 0:

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -88,6 +88,8 @@ class MapDatasetEventSampler:
             table = self._sample_coord_time(npred, temporal_model, dataset.gti)
             if len(table) > 0:
                 table["MC_ID"] = idx + 1
+                table.meta["MID{:05d}".format(idx + 1)] = idx + 1
+                table.meta["MMN{:05d}".format(idx + 1)] = dataset.models[idx].name
             else:
                 mcid = table.Column(name="MC_ID", length=0, dtype=int)
                 table.add_column(mcid)
@@ -118,6 +120,12 @@ class MapDatasetEventSampler:
         table["ENERGY"] = table["ENERGY_TRUE"]
         table["RA"] = table["RA_TRUE"]
         table["DEC"] = table["DEC_TRUE"]
+
+        for i, mod in enumerate(dataset.models):
+            if mod.tag[0] == "FoVBackgroundModel":
+                break
+        table.meta["MID{:05d}".format(0)] = 0
+        table.meta["MMN{:05d}".format(0)] = dataset.models[i].name
 
         return EventList(table)
 
@@ -294,9 +302,6 @@ class MapDatasetEventSampler:
         meta["CONV_RA"] = 0
         meta["CONV_DEC"] = 0
 
-        for idx, model in enumerate(dataset.models):
-            meta["MID{:05d}".format(idx)] = idx
-            meta["MMN{:05d}".format(idx)] = model.name
         meta["NMCIDS"] = len(dataset.models)
 
         # Necessary for DataStore, but they should be ALT and AZ instead!
@@ -351,16 +356,6 @@ class MapDatasetEventSampler:
             Event list.
         """
         if len(dataset.models) > 1:
-            for i, mod in enumerate(dataset.models):
-                if mod.tag[0] == "FoVBackgroundModel":
-                    break
-
-            sky_model = np.delete(dataset.models, i, 0)
-            fov_bkg = dataset.models[i]
-            model_new = Models([fov_bkg])
-            model_new.extend(sky_model)
-            dataset.models = model_new
-
             events_src = self.sample_sources(dataset)
 
             if len(events_src.table) > 0:
@@ -387,7 +382,7 @@ class MapDatasetEventSampler:
 
         events = self.event_det_coords(observation, events)
         events.table["EVENT_ID"] = np.arange(len(events.table))
-        events.table.meta = self.event_list_meta(dataset, observation)
+        events.table.meta.update(self.event_list_meta(dataset, observation))
 
         geom = dataset._geom
         selection = geom.contains(events.map_coord(geom))

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -89,7 +89,7 @@ class MapDatasetEventSampler:
             if len(table) > 0:
                 table["MC_ID"] = idx + 1
                 table.meta["MID{:05d}".format(idx + 1)] = idx + 1
-                table.meta["MMN{:05d}".format(idx + 1)] = dataset.models[idx].name
+                table.meta["MMN{:05d}".format(idx + 1)] = evaluator.model.name
             else:
                 mcid = table.Column(name="MC_ID", length=0, dtype=int)
                 table.add_column(mcid)
@@ -121,11 +121,8 @@ class MapDatasetEventSampler:
         table["RA"] = table["RA_TRUE"]
         table["DEC"] = table["DEC_TRUE"]
 
-        for i, mod in enumerate(dataset.models):
-            if mod.tag[0] == "FoVBackgroundModel":
-                break
         table.meta["MID{:05d}".format(0)] = 0
-        table.meta["MMN{:05d}".format(0)] = dataset.models[i].name
+        table.meta["MMN{:05d}".format(0)] = dataset.background_model.name
 
         return EventList(table)
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -7,7 +7,7 @@ from astropy.table import Table
 import gammapy
 from gammapy.data import EventList, observatory_locations
 from gammapy.maps import MapCoord
-from gammapy.modeling.models import ConstantTemporalModel, Models
+from gammapy.modeling.models import ConstantTemporalModel
 from gammapy.utils.random import get_random_state
 
 __all__ = ["MapDatasetEventSampler"]


### PR DESCRIPTION
This PR fixes the bug reported in #3866 and replaces the previous PR #3867 .
When sampling events from the an IRF background model, MapDatasetEventSampler is set like that the MC_ID of these events is always zero. However, this is true only in the table of sample event list, but not in the metadata where it can assume every kind of value. 

A solution is to apply an internal re-order of the model so to have always the bkg model as first model.

