### PR TITLE
Use .is_norm property in FluxEstimator

### DIFF
--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -113,10 +113,12 @@ class FluxEstimator(ParameterEstimator):
         ref_model = models[self.source].spectral_model
         scale_model = ScaleSpectralModel(ref_model)
 
-        if "amplitude" in ref_model.parameters.names:
-            scaled_parameter = ref_model.parameters["amplitude"]
+        for scaled_parameter in ref_model.parameters:
+            if scaled_parameter.is_norm:
+                break
         else:
-            scaled_parameter = ref_model.parameters["norm"]
+            raise ValueError(f"{self.tag} requires a 'norm' or 'amplitude' parameter"
+                             " in the model to run")
 
         scale_model.norm = self._set_norm_parameter(scale_model.norm, scaled_parameter)
         return scale_model


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes #3694 and supersedes #3845. It replaces the check for the parameter name `norm/amplitude` by the check of the met property `.is_norm`. Which users have to define for custom models now. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
