### PR TITLE
Allow tolerance in fft binary operations

### DIFF
--- a/gammapy/maps/wcs/tests/test_ndmap.py
+++ b/gammapy/maps/wcs/tests/test_ndmap.py
@@ -837,7 +837,8 @@ def test_binary_erode():
     assert_allclose(mask.data.sum(), 4832)
 
     mask = mask.binary_erode(width=0.2 * u.deg, kernel="box", use_fft=True)
-    assert_allclose(mask.data.sum(), 3372)
+    # Due to fft noise the result is not exact here. See https://github.com/gammapy/gammapy/issues/3662
+    assert_allclose(mask.data.sum(), 3372, atol=20)
 
 
 def test_binary_dilate():
@@ -848,7 +849,8 @@ def test_binary_dilate():
     assert_allclose(mask.data.sum(), 8048)
 
     mask = mask.binary_dilate(width=(10, 10), kernel="box")
-    assert_allclose(mask.data.sum(), 9203, rtol=3e-3)
+    # Due to fft noise the result is not exact here. See https://github.com/gammapy/gammapy/issues/3662
+    assert_allclose(mask.data.sum(), 9203, atol=20)
 
 
 def test_binary_dilate_erode_3d():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request solves #3662, by increasing the test tolerance for now.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
