### PR TITLE
Print minuit fit detailed infos in Fit API tutorial

### DIFF
--- a/docs/tutorials/api/fitting.ipynb
+++ b/docs/tutorials/api/fitting.ipynb
@@ -251,7 +251,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25cbc728",
+   "metadata": {},
+   "source": [
+    "If the fit is performed with minuit you can print detailed informations to check the convergence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(fit.minuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Check the trace of the fit e.g. in case the fit did not converge properly"


### PR DESCRIPTION
As discussed in the help channel printing the FitResults no longer shows the detailed convergence infos from minuit, but it can be displayed printing directly the minuit object attached to the fit. This PR shows this in the Fit API notebook.