### PR TITLE
Fix evaluate_containment calculation in class PSFKing(ParametricPSF)

### DIFF
--- a/gammapy/irf/psf/parametric.py
+++ b/gammapy/irf/psf/parametric.py
@@ -373,10 +373,9 @@ class PSFKing(ParametricPSF):
             Containment
         """
         with np.errstate(divide="ignore", invalid="ignore"):
-            term_1 = -((1 + rad ** 2 / (2 * gamma * sigma ** 2)) ** -gamma)
-            term_2 = rad ** 2 + 2 * gamma * sigma ** 2
-            term_3 = 2 * gamma * sigma ** 2
-            containment = term_1 * term_2 / term_3
+            powterm = 1 - gamma
+            term = (1 + rad ** 2 / (2 * gamma * sigma ** 2)) ** powterm
+            containment = 1 - term
 
         return containment
 


### PR DESCRIPTION
In the course of utilizing Gammapy for data analysis in my PhD thesis I use the King function parameterizations for PSFs. After viewing multiple PSF diagnostic plots, the containment calculated in the current iteration of class PSFKing(ParametricPSF) is only one single value in multiple PSF diagnostic plots, and therefore does not appear to be calculated correctly. The current calculation reads:

 >         with np.errstate(divide="ignore", invalid="ignore"):
>                         term_1 = -((1 + rad ** 2 / (2 * gamma * sigma ** 2)) ** -gamma)
>                         term_2 = rad ** 2 + 2 * gamma * sigma ** 2
>                         term_3 = 2 * gamma * sigma ** 2
>                         containment = term_1 * term_2 / 
>         return containment

I derived the integration equations for the symmetric King function and they are different than those in the evaluate_containment calculation in class PSFKing(ParametricPSF) in parametric.py. The change is:

>         with np.errstate(divide="ignore", invalid="ignore"):
>             powterm = 1 - gamma
>             term = (1 + rad ** 2 / (2 * gamma * sigma ** 2)) ** powterm
>             containment = 1 - term
>         return containment

The changes are only a few lines of code. After changing these lines in parametric.py, the PSF diagnostic plots now appear much more reasonable and the trends in the diagnostic plots are consistent with parameter and integration plots created by the author of this pull request. A compiled version of Gammapy with this change has been used to perform complete Gammapy 3D analyses. Therefore, it is the opinion of this author that the pull request is ready for review and merging.

