### PR TITLE
Remove version switch url template

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,6 +140,7 @@ html_theme_options = {
     # toc options
     "collapse_navigation": False,
     "navigation_depth": 2,
+    "show_prev_next": False,
     # links in menu
     "icon_links": [
         {
@@ -160,7 +161,6 @@ html_theme_options = {
     ],
     "switcher": {
         "json_url": "https://docs.gammapy.org/stable/switcher.json",
-        "url_template": "https://docs.gammapy.org/{version}/",
         "version_match": switch_version,
     },
     "navbar_end": ["version-switcher", "navbar-icon-links"],


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes to the hard-coded url in the `switcher.json` file, the use of `url-template` is deprecated (see https://github.com/pydata/pydata-sphinx-theme/pull/655).

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
