### PR TITLE
Implement is_allclose methods consistently

### DIFF
--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -559,8 +559,8 @@ class IRF(metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        other : the irf to compare against
-            `gammapy.irfs.IRF`
+        other : `gammapy.irfs.IRF`
+            The irf to compare against
         rtol_axes : float
             Relative tolerance for the axes comparison.
         atol_axes : float

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -571,7 +571,7 @@ class IRF(metaclass=abc.ABCMeta):
         Returns
         -------
         is_allclose : bool
-            Wheter th IRF is all close.
+            Whether the IRF is all close.
         """
         if not isinstance(other, self.__class__):
             return TypeError(f"Cannot compare {type(self)} and {type(other)}")

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -554,31 +554,40 @@ class IRF(metaclass=abc.ABCMeta):
             data=data, axes=axes, meta=self.meta.copy(), unit=self.unit
         )
 
-    def data_allclose(self, other, **kwargs):
+    def is_allclose(self, other, rtol_axes=1e-3, atol_axes=1e-6, **kwargs):
         """Compare two data IRFs for equivalency
 
         Parameters
         ----------
         other : the irf to compare against
             `gammapy.irfs.IRF`
-        kwargs : dict
+        rtol_axes : float
+            Relative tolerance for the axes comparison.
+        atol_axes : float
+            Relative tolerance for the axes comparison.
+        **kwargs : dict
                 keywords passed to `numpy.allclose`
-                The default tolerance is rtol=1e-3
 
         Returns
         -------
-        state : bool
+        is_allclose : bool
+            Wheter th IRF is all close.
         """
+        if not isinstance(other, self.__class__):
+            return TypeError(f"Cannot compare {type(self)} and {type(other)}")
 
-        kwargs.setdefault("rtol", 1e-3)
         if self.data.shape != other.data.shape:
             return False
-        return np.allclose(self.quantity, other.quantity, **kwargs)
+
+        axes_eq = self.axes.is_allclose(other.axes, rtol=rtol_axes, atol=atol_axes)
+        data_eq = np.allclose(self.quantity, other.quantity, **kwargs)
+        return axes_eq and data_eq
 
     def __eq__(self, other):
-        class_eq = isinstance(other, self.__class__)
-        axes_eq = self.axes == other.axes
-        return bool(class_eq and axes_eq and self.data_allclose(other))
+        if not isinstance(other, self.__class__):
+            return False
+
+        return self.is_allclose(other=other, rtol=1e-3, rtol_axes=1e-6)
 
 
 class IRFMap:

--- a/gammapy/irf/psf/parametric.py
+++ b/gammapy/irf/psf/parametric.py
@@ -248,27 +248,39 @@ class ParametricPSF(PSF):
         value = self.evaluate_direct(rad=rad, **pars)
         return value
 
-    def data_allclose(self, other, **kwargs):
-        """Compare two PSF data for equivalency
+    def is_allclose(self, other, rtol_axes=1e-3, atol_axes=1e-6, **kwargs):
+        """Compare two data IRFs for equivalency
 
         Parameters
         ----------
         other : the irf to compare against
-                    `gammapy.irfs.IRF`
-        kwargs : dict
+            `gammapy.irfs.ParametricPSF`
+        rtol_axes : float
+            Relative tolerance for the axes comparison.
+        atol_axes : float
+            Relative tolerance for the axes comparison.
+        **kwargs : dict
                 keywords passed to `numpy.allclose`
 
         Returns
         -------
-        state : bool
+        is_allclose : bool
+            Whether the IRF is all close.
         """
+        if not isinstance(other, self.__class__):
+            return TypeError(f"Cannot compare {type(self)} and {type(other)}")
+
+        data_eq = True
+
         for key in self.quantity.keys():
             if self.quantity[key].shape != other.quantity[key].shape:
                 return False
-            if not np.allclose(self.quantity[key], other.quantity[key], **kwargs):
-                return False
 
-        return True
+            data_eq &= np.allclose(self.quantity[key], other.quantity[key], **kwargs)
+
+        axes_eq = self.axes.is_allclose(other.axes, rtol=rtol_axes, atol=atol_axes)
+        return axes_eq and data_eq
+
 
 
 def get_sigmas_and_norms(**kwargs):

--- a/gammapy/irf/psf/parametric.py
+++ b/gammapy/irf/psf/parametric.py
@@ -31,7 +31,7 @@ class ParametricPSF(PSF):
     @property
     @abc.abstractmethod
     def required_parameters(self):
-        pass
+        return []
 
     @abc.abstractmethod
     def evaluate_direct(self, rad, **kwargs):
@@ -253,8 +253,8 @@ class ParametricPSF(PSF):
 
         Parameters
         ----------
-        other : the irf to compare against
-            `gammapy.irfs.ParametricPSF`
+        other : `gammapy.irfs.ParametricPSF`
+            The PSF to compare against
         rtol_axes : float
             Relative tolerance for the axes comparison.
         atol_axes : float
@@ -280,7 +280,6 @@ class ParametricPSF(PSF):
 
         axes_eq = self.axes.is_allclose(other.axes, rtol=rtol_axes, atol=atol_axes)
         return axes_eq and data_eq
-
 
 
 def get_sigmas_and_norms(**kwargs):

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1633,6 +1633,35 @@ class Map(abc.ABC):
         data = self.quantity.to_value(unit)
         return self.from_geom(self.geom, data=data, unit=unit)
 
+    def is_allclose(self, other, rtol_axes=1e-3, atol_axes=1e-6, **kwargs):
+        """Compare two Maps for close equivalency
+
+        Parameters
+        ----------
+        other : `gammapy.maps.Map`
+            The Map to compare against
+        rtol_axes : float
+            Relative tolerance for the axes comparison.
+        atol_axes : float
+            Relative tolerance for the axes comparison.
+        **kwargs : dict
+                keywords passed to `numpy.allclose`
+
+        Returns
+        -------
+        is_allclose : bool
+            Whether the Map is all close.
+        """
+        if not isinstance(other, self.__class__):
+            return TypeError(f"Cannot compare {type(self)} and {type(other)}")
+
+        if self.data.shape != other.data.shape:
+            return False
+
+        axes_eq = self.axes.is_allclose(other.axes, rtol=rtol_axes, atol=atol_axes)
+        data_eq = np.allclose(self.quantity, other.quantity, **kwargs)
+        return axes_eq and data_eq
+
     def __repr__(self):
         geom = self.geom.__class__.__name__
         axes = ["skycoord"] if self.geom.is_hpx else ["lon", "lat"]

--- a/gammapy/maps/hpx/geom.py
+++ b/gammapy/maps/hpx/geom.py
@@ -1377,27 +1377,48 @@ class HpxGeom(Geom):
             f"\tcenter     : {lon:.1f} deg, {lat:.1f} deg\n"
         )
 
-    def __eq__(self, other):
+    def is_allclose(self, other, rtol_axes=1e-6, atol_axes=1e-6):
+        """Compare two data IRFs for equivalency
+
+        Parameters
+        ----------
+        other :  `HpxGeom`
+            Geom to compare against
+        rtol_axes : float
+            Relative tolerance for the axes comparison.
+        atol_axes : float
+            Relative tolerance for the axes comparison.
+
+        Returns
+        -------
+        is_allclose : bool
+            Whether the geometry is all close.
+        """
         if not isinstance(other, self.__class__):
-            return False
+            return TypeError(f"Cannot compare {type(self)} and {type(other)}")
 
         if self.is_allsky and not other.is_allsky:
             return False
 
-        # check overall shape and axes compatibility
         if self.data_shape != other.data_shape:
             return False
 
-        for axis, otheraxis in zip(self.axes, other.axes):
-            if axis != otheraxis:
-                return False
+        axes_eq = self.axes.is_allclose(other.axes, rtol=rtol_axes, atol=atol_axes)
 
-        return (
+        hpx_eq = (
             self.nside == other.nside
             and self.frame == other.frame
             and self.order == other.order
             and self.nest == other.nest
         )
+
+        return axes_eq and hpx_eq
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        return self.is_allclose(other=other)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/gammapy/maps/hpx/geom.py
+++ b/gammapy/maps/hpx/geom.py
@@ -1379,10 +1379,10 @@ class HpxGeom(Geom):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
+            return False
 
         if self.is_allsky and not other.is_allsky:
-            return NotImplemented
+            return False
 
         # check overall shape and axes compatibility
         if self.data_shape != other.data_shape:

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -583,8 +583,8 @@ class RegionGeom(Geom):
 
         Parameters
         ----------
-        other : the irf to compare against
-            `gammapy.irfs.IRF`
+        other : `RegionGeom`
+            Geom to compare against.
         rtol_axes : float
             Relative tolerance for the axes comparison.
         atol_axes : float

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -578,17 +578,39 @@ class RegionGeom(Geom):
             f"\tcenter     : {lon:.1f} deg, {lat:.1f} deg\n"
         )
 
-    def __eq__(self, other):
-        # check overall shape and axes compatibility
+    def is_allclose(self, other, rtol_axes=1e-6, atol_axes=1e-6):
+        """Compare two data IRFs for equivalency
+
+        Parameters
+        ----------
+        other : the irf to compare against
+            `gammapy.irfs.IRF`
+        rtol_axes : float
+            Relative tolerance for the axes comparison.
+        atol_axes : float
+            Relative tolerance for the axes comparison.
+
+        Returns
+        -------
+        is_allclose : bool
+            Whether the IRF is all close.
+        """
+        if not isinstance(other, self.__class__):
+            return TypeError(f"Cannot compare {type(self)} and {type(other)}")
+
         if self.data_shape != other.data_shape:
             return False
 
-        for axis, otheraxis in zip(self.axes, other.axes):
-            if axis != otheraxis:
-                return False
+        axes_eq = self.axes.is_allclose(other.axes, rtol=rtol_axes, atol=atol_axes)
+        # TODO: compare regions based on masks...
+        regions_eq = True
+        return axes_eq and regions_eq
 
-        # TODO: compare regions
-        return True
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        return self.is_allclose(other=other)
 
     def _to_region_table(self):
         """Export region to a FITS region table."""

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -593,7 +593,7 @@ class RegionGeom(Geom):
         Returns
         -------
         is_allclose : bool
-            Whether the IRF is all close.
+            Whether the geometry is all close.
         """
         if not isinstance(other, self.__class__):
             return TypeError(f"Cannot compare {type(self)} and {type(other)}")

--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -1143,7 +1143,7 @@ class WcsGeom(Geom):
         Returns
         -------
         is_allclose : bool
-            Whether the IRF is all close.
+            Whether the geometry is all close.
         """
         if not isinstance(other, self.__class__):
             return TypeError(f"Cannot compare {type(self)} and {type(other)}")
@@ -1156,7 +1156,7 @@ class WcsGeom(Geom):
         # check WCS consistency with a priori tolerance of 1e-6
         # cmp=1 parameter ensures no comparison with ancillary information
         # see https://github.com/astropy/astropy/pull/4522/files
-        wcs_eq = self.wcs.wcs.compare(other.wcs.wcs, cmp=2, tolerance=rtol_wcs)
+        wcs_eq = self.wcs.wcs.compare(other.wcs.wcs, cmp=1, tolerance=rtol_wcs)
 
         return axes_eq and wcs_eq
 

--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -1126,19 +1126,19 @@ class WcsGeom(Geom):
         # check WCS consistency with a priori tolerance of 1e-6
         return self.wcs.wcs.compare(other.wcs.wcs, cmp=2, tolerance=tolerance)
 
-    def is_allclose(self, other, rtol_wcs=1e-6, rtol_axes=1e-6, atol_axes=1e-6):
+    def is_allclose(self, other, rtol_axes=1e-6, atol_axes=1e-6, rtol_wcs=1e-6):
         """Compare two data IRFs for equivalency
 
         Parameters
         ----------
-        other : the irf to compare against
-            `gammapy.irfs.IRF`
-        rtol_wcs : float
-            Relative tolerance for the wcs comparison.
+        other :  `WcsGeom`
+            Geom to compare against
         rtol_axes : float
             Relative tolerance for the axes comparison.
         atol_axes : float
             Relative tolerance for the axes comparison.
+        rtol_wcs : float
+            Relative tolerance for the wcs comparison.
 
         Returns
         -------


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a follow up to #3887 and implements `.is_allclose()` methods consistently for `MapAxis`, `MapAxes`, `IRF`, `Map`, `RegionGeom`, `WcsGeom` and `HpxGeom`.

I decided to develop `IRF.data_allclose` further and let it also check the equality of the axes with a given tolerance.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
