### PR TITLE
Revert sed node type change in FluxMaps

### DIFF
--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -445,14 +445,11 @@ class FluxMaps:
         return data
 
     @staticmethod
-    def _change_energy_axis_node_type(input_map, node_type="center"):
+    def _use_center_as_labels(input_map):
         """Change the node_type of the input map."""
         energy_axis = input_map.geom.axes["energy"]
-        new_axis = energy_axis.to_node_type(node_type)
-        geom = input_map.geom.replace_axis(axis=new_axis)
-        return Map.from_geom(
-            geom, data=input_map.data, unit=input_map.unit, meta=input_map.meta
-        )
+        energy_axis.use_center_as_plot_labels = True
+        return input_map
 
     @property
     def npred_excess_ref(self):
@@ -606,52 +603,52 @@ class FluxMaps:
     @property
     def dnde(self):
         """Return differential flux (dnde) SED values."""
-        return self._change_energy_axis_node_type(self.norm * self.dnde_ref)
+        return self._use_center_as_labels(self.norm * self.dnde_ref)
 
     @property
     def dnde_err(self):
         """Return differential flux (dnde) SED errors."""
-        return self._change_energy_axis_node_type(self.norm_err * self.dnde_ref)
+        return self._use_center_as_labels(self.norm_err * self.dnde_ref)
 
     @property
     def dnde_errn(self):
         """Return differential flux (dnde) SED negative errors."""
-        return self._change_energy_axis_node_type(self.norm_errn * self.dnde_ref)
+        return self._use_center_as_labels(self.norm_errn * self.dnde_ref)
 
     @property
     def dnde_errp(self):
         """Return differential flux (dnde) SED positive errors."""
-        return self._change_energy_axis_node_type(self.norm_errp * self.dnde_ref)
+        return self._use_center_as_labels(self.norm_errp * self.dnde_ref)
 
     @property
     def dnde_ul(self):
         """Return differential flux (dnde) SED upper limit."""
-        return self._change_energy_axis_node_type(self.norm_ul * self.dnde_ref)
+        return self._use_center_as_labels(self.norm_ul * self.dnde_ref)
 
     @property
     def e2dnde(self):
         """Return differential energy flux (e2dnde) SED values."""
-        return self._change_energy_axis_node_type(self.norm * self.e2dnde_ref)
+        return self._use_center_as_labels(self.norm * self.e2dnde_ref)
 
     @property
     def e2dnde_err(self):
         """Return differential energy flux (e2dnde) SED errors."""
-        return self._change_energy_axis_node_type(self.norm_err * self.e2dnde_ref)
+        return self._use_center_as_labels(self.norm_err * self.e2dnde_ref)
 
     @property
     def e2dnde_errn(self):
         """Return differential energy flux (e2dnde) SED negative errors."""
-        return self._change_energy_axis_node_type(self.norm_errn * self.e2dnde_ref)
+        return self._use_center_as_labels(self.norm_errn * self.e2dnde_ref)
 
     @property
     def e2dnde_errp(self):
         """Return differential energy flux (e2dnde) SED positive errors."""
-        return self._change_energy_axis_node_type(self.norm_errp * self.e2dnde_ref)
+        return self._use_center_as_labels(self.norm_errp * self.e2dnde_ref)
 
     @property
     def e2dnde_ul(self):
         """Return differential energy flux (e2dnde) SED upper limit."""
-        return self._change_energy_axis_node_type(self.norm_ul * self.e2dnde_ref)
+        return self._use_center_as_labels(self.norm_ul * self.e2dnde_ref)
 
     @property
     def flux(self):

--- a/gammapy/estimators/map/tests/test_core.py
+++ b/gammapy/estimators/map/tests/test_core.py
@@ -428,23 +428,6 @@ def test_flux_map_from_dict_inconsistent_units(wcs_flux_map, reference_model):
     assert flux_map.norm_err.unit == ""
 
 
-def test_flux_map_check_node_types(
-    wcs_flux_map, region_map_flux_estimate, reference_model
-):
-    ref_map = FluxMaps(wcs_flux_map, reference_model)
-    ref_region_map = FluxMaps(region_map_flux_estimate, reference_model)
-
-    assert ref_map.dnde.geom.axes[0].node_type == "center"
-    assert ref_map.e2dnde.geom.axes[0].node_type == "center"
-    assert ref_map.flux.geom.axes[0].node_type == "edges"
-    assert ref_map.eflux.geom.axes[0].node_type == "edges"
-
-    assert ref_region_map.dnde_err.geom.axes[0].node_type == "center"
-    assert ref_region_map.e2dnde_ul.geom.axes[0].node_type == "center"
-    assert ref_region_map.flux_err.geom.axes[0].node_type == "edges"
-    assert ref_region_map.eflux_ul.geom.axes[0].node_type == "edges"
-
-
 def test_flux_map_iter_by_axis():
     axis1 = MapAxis.from_energy_edges((0.1, 1.0, 10.0), unit="TeV")
     axis2 = TimeMapAxis.from_time_bounds(

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -135,6 +135,7 @@ class MapAxis:
             raise ValueError(f"Invalid node type: {node_type!r}")
 
         self._nbin = nbin
+        self._use_center_as_plot_labels = None
 
     def assert_name(self, required_name):
         """Assert axis name if a specific one is required.
@@ -268,16 +269,28 @@ class MapAxis:
         )
 
     @property
+    def use_center_as_plot_labels(self):
+        """Use center as plot labels"""
+        if self._use_center_as_plot_labels is not None:
+            return self._use_center_as_plot_labels
+
+        return self.node_type == "center"
+
+    @use_center_as_plot_labels.setter
+    def use_center_as_plot_labels(self, value):
+        """Use center as plot labels"""
+        self._use_center_as_plot_labels = bool(value)
+
+    @property
     def as_plot_labels(self):
         """Return list of axis plot labels"""
-        if self.node_type == "edges":
+        if self.use_center_as_plot_labels:
+            labels = [f"{val:.2e}" for val in self.center]
+        else:
             labels = [
                 f"{val_min:.2e} - {val_max:.2e}"
                 for val_min, val_max in self.iter_by_edges
             ]
-        else:
-            labels = [f"{val:.2e}" for val in self.center]
-
         return labels
 
     @property


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request reverts the application of the `_change_energy_axis_node_type ` method in `FluxPoints`. On closer inspection I noticed:
- With the current solution the flux points plotting would invent again the flux point edges and plot inconsistent width of TS profiles and flux points
- Same for the serialization, when serializing to a differential sed type the information on the bin width is lost

To solve the plotting issue #3766, I introduce a flag named `MapAxis.use_center_as_plot_labels`, which allows to overwrite the plot labels used independent of the node type.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
