### PR TITLE
return models.positions in same frame

### DIFF
--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -146,8 +146,7 @@ class ModelBase:
         return copy.deepcopy(self)
 
     def to_dict(self, full_output=False):
-        """Create dict for YAML serialisation
-        """
+        """Create dict for YAML serialisation"""
         tag = self.tag[0] if isinstance(self.tag, list) else self.tag
         params = self.parameters.to_dict()
 
@@ -482,7 +481,6 @@ class DatasetModels(collections.abc.Sequence):
                 params_shared.append(param)
         for param in params_shared:
             param._link_label_io = param.name + "@" + make_name()
-
 
     def to_dict(self, full_output=False, overwrite_templates=False):
         """Convert to dict."""
@@ -892,7 +890,7 @@ class DatasetModels(collections.abc.Sequence):
 
         for model in self.select(tag="sky-model"):
             if model.position:
-                positions.append(model.position)
+                positions.append(model.position.icrs)
             else:
                 log.warning(
                     f"Skipping model {model.name} - no spatial component present"
@@ -954,10 +952,7 @@ class DatasetModels(collections.abc.Sequence):
         regions = self.to_regions()
         geom = RegionGeom.from_regions(regions=regions)
         return geom.plot_region(
-            ax=ax,
-            kwargs_point=kwargs_point,
-            path_effect=path_effect,
-            **kwargs
+            ax=ax, kwargs_point=kwargs_point, path_effect=path_effect, **kwargs
         )
 
     def plot_positions(self, ax=None, **kwargs):

--- a/gammapy/modeling/models/tests/test_core.py
+++ b/gammapy/modeling/models/tests/test_core.py
@@ -237,8 +237,23 @@ def test_plot_models(caplog):
     ]
 
 
+def test_positions():
+    p1 = Model.create(
+        "pl",
+        model_type="spectral",
+    )
+    g1 = Model.create("gauss", model_type="spatial")
+    m1 = SkyModel(spectral_model=p1, spatial_model=g1, name="m1")
+    g3 = Model.create("gauss", model_type="spatial", frame="galactic")
+    m3 = SkyModel(spectral_model=p1, spatial_model=g3, name="m3")
+    models = Models([m1, m3])
+    pos = models.positions
+    assert_allclose(pos.galactic[0].l.value, 96.337, rtol=1e-3)
+
+
 def test_parameter_name():
     with pytest.raises(RuntimeError):
+
         class MyTestModel:
             par = Parameter("wrong-name", value=3)
 


### PR DESCRIPTION
If different models were defined in different frames (`galactic` vs `icrs`, which can be the case when using template models, specially the fermi diffuse ones), `models.positions` fails because `SkyCoord(positions)` needs all `positions` in the same frame.

A very tiny fix - `models.positions` is by default in `icrs` now, can be trivially converted to galactic. Also added a test 