### PR TITLE
Provide initial implementations of _repr_html_

### DIFF
--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import json
+import html
 import logging
 from collections import defaultdict
 from enum import Enum
@@ -107,6 +108,12 @@ class GammapyBaseConfig(BaseModel):
             Quantity: lambda v: f"{v.value} {v.unit}",
             Time: lambda v: f"{v.value}",
         }
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
 
 class SkyCoordConfig(GammapyBaseConfig):

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Session class driving the high level interface API"""
+import html
 import logging
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
@@ -55,6 +56,12 @@ class Analysis:
         self.fit = Fit()
         self.fit_result = None
         self.flux_points = None
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     def models(self):

--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Dark matter profiles."""
 import abc
+import html
 import numpy as np
 import astropy.units as u
 from gammapy.modeling import Parameter, Parameters
@@ -29,6 +30,12 @@ class DMProfile(abc.ABC):
         """Call evaluate method of derived classes."""
         kwargs = {par.name: par.quantity for par in self.parameters}
         return self.evaluate(radius, **kwargs)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def scale_to_local_density(self):
         """Scale to local density."""

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utilities to compute J-factor maps."""
+import html
 import numpy as np
 import astropy.units as u
 
@@ -30,6 +31,12 @@ class JFactory:
         self.profile = profile
         self.distance = distance
         self.annihilation = annihilation
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def compute_differential_jfactor(self, ndecade=1e4):
         r"""Compute differential J-Factor.

--- a/gammapy/astro/source/pulsar.py
+++ b/gammapy/astro/source/pulsar.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Pulsar source models."""
+import html
 import numpy as np
 from astropy.units import Quantity
 
@@ -35,6 +36,12 @@ class SimplePulsar:
         self.P_dot = P_dot
         self.I = I  # noqa: E741
         self.R = R
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     def luminosity_spindown(self):

--- a/gammapy/astro/source/pwn.py
+++ b/gammapy/astro/source/pwn.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Pulsar wind nebula (PWN) source models."""
+import html
 import numpy as np
 import scipy.optimize
 import astropy.constants
@@ -48,6 +49,12 @@ class PWN:
         self.morphology = morphology
         if age is not None:
             self.age = Quantity(age, "yr")
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def _radius_free_expansion(self, t):
         """Radius at age t during free expansion phase.

--- a/gammapy/astro/source/snr.py
+++ b/gammapy/astro/source/snr.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Supernova remnant (SNR) source models."""
+import html
 import numpy as np
 import astropy.constants
 from astropy.units import Quantity
@@ -50,6 +51,12 @@ class SNR:
         self.spectral_index = spectral_index
         if age is not None:
             self.age = Quantity(age, "yr")
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def radius(self, t):
         r"""Outer shell radius at age t.

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -3,6 +3,7 @@
 import abc
 import numbers
 from copy import deepcopy
+import html
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
@@ -55,6 +56,12 @@ class SourceCatalogObject:
         self.data = Bunch(**data)
         if data_extended:
             self.data_extended = Bunch(**data_extended)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     def name(self):
@@ -133,6 +140,12 @@ class SourceCatalog(abc.ABC):
                     if not alias == "":
                         names[alias.strip()] = idx
         return names
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def row_index(self, name):
         """Look up row index of source by name.

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -2,6 +2,7 @@
 import logging
 import subprocess
 from copy import copy
+import html
 from pathlib import Path
 import numpy as np
 from astropy import units as u
@@ -83,6 +84,12 @@ class DataStore:
 
     def __str__(self):
         return self.info(show=False)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     def obs_ids(self):

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -2,6 +2,7 @@
 import collections
 import copy
 import logging
+import html
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import AltAz, Angle, SkyCoord, angular_separation
@@ -87,6 +88,12 @@ class EventList:
 
     def __init__(self, table):
         self.table = table
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @classmethod
     def read(cls, filename, **kwargs):

--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import copy
+import html
 import logging
 
 __all__ = ["ObservationFilter"]
@@ -47,6 +48,12 @@ class ObservationFilter:
     def __init__(self, time_filter=None, event_filters=None):
         self.time_filter = time_filter
         self.event_filters = event_filters or []
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     def livetime_fraction(self):

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import copy
+import html
 from operator import le, lt
 import numpy as np
 import astropy.units as u
@@ -64,6 +65,12 @@ class GTI:
         if reference_time is None:
             reference_time = TIME_REF_DEFAULT
         self._time_ref = Time(reference_time)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @staticmethod
     def _validate_table(table):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import collections.abc
 import copy
+import html
 import inspect
 import itertools
 import logging
@@ -94,6 +95,12 @@ class Observation:
         self._pointing = pointing
         self._location = location
         self.obs_filter = obs_filter or ObservationFilter()
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     def rad_max(self):

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import html
 import logging
 import warnings
 from enum import Enum, auto
@@ -184,6 +185,12 @@ class FixedPointingInfo:
             self._mode = PointingMode.DRIFT
             self._fixed_icrs = None
             self._fixed_altaz = fixed_altaz
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @classmethod
     def from_fits_header(cls, header):

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -2,6 +2,7 @@
 import abc
 import collections.abc
 import copy
+import html
 import logging
 import numpy as np
 from astropy import units as u
@@ -34,6 +35,12 @@ class Dataset(abc.ABC):
         "diff/model": "(data - model) / model",
         "diff/sqrt(model)": "(data - model) / sqrt(model)",
     }
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     @abc.abstractmethod
@@ -358,6 +365,12 @@ class Datasets(collections.abc.MutableSequence):
             str_ += f"\tModels     : {names}\n\n"
 
         return str_.expandtabs(tabsize=2)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def copy(self):
         """A deep copy."""

--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import html
 import logging
 import numpy as np
 import astropy.units as u
@@ -94,6 +95,12 @@ class MapEvaluator:
         if self.exposure is not None:
             if not self.geom.is_region or self.geom.region is not None:
                 self.update_spatial_oversampling_factor(self.geom)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def reset_cache_properties(self):
         """Reset cached properties."""

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Simulate observations."""
+import html
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord, SkyOffsetFrame
@@ -38,6 +39,12 @@ class MapDatasetEventSampler:
         self.random_state = get_random_state(random_state)
         self.oversample_energy_factor = oversample_energy_factor
         self.t_delta = t_delta
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def _make_table(self, coords, time_ref):
         """Create a table for sampled events.

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -661,7 +661,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
     result = fit.run(datasets=datasets)
 
     assert result.success
-    assert "minuit" in repr(result)
+    assert "minuit" in str(result)
 
     npred = dataset_1.npred().data.sum()
     assert_allclose(npred, 7525.790688, rtol=1e-3)
@@ -735,7 +735,7 @@ def test_map_fit_linked(sky_model, geom, geom_etrue):
     result = fit.run(datasets=datasets)
 
     assert result.success
-    assert "minuit" in repr(result)
+    assert "minuit" in str(result)
 
     assert sky_model2.parameters["index"] is sky_model.parameters["index"]
     assert sky_model2.parameters["reference"] is sky_model.parameters["reference"]

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -172,7 +172,7 @@ def test_fit(spectrum_dataset):
     fit = Fit()
     result = fit.run(datasets=[spectrum_dataset])
     assert result.success
-    assert "minuit" in repr(result)
+    assert "minuit" in str(result)
 
     npred = spectrum_dataset.npred().data.sum()
     assert_allclose(npred, 907012.186399, rtol=1e-3)

--- a/gammapy/estimators/core.py
+++ b/gammapy/estimators/core.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import abc
+import html
 import inspect
 from copy import deepcopy
 import numpy as np
@@ -88,3 +89,9 @@ class Estimator(abc.ABC):
                 s += f"\t{name:{max_len}s}: {value}\n"
 
         return s.expandtabs(tabsize=2)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -56,7 +56,6 @@ def convolved_map_dataset_counts_statistics(dataset, kernel, mask, correlate_off
             n_on_conv.data, n_off.data, alpha.data, npred_sig_convolve.data
         )
     else:
-
         npred = dataset.npred() * mask
         background_conv = npred.convolve(kernel_data)
         return CashCountsStatistic(n_on_conv.data, background_conv.data)

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -1,4 +1,5 @@
 import abc
+import html
 import logging
 from copy import deepcopy
 from enum import Enum
@@ -246,6 +247,12 @@ class IRF(metaclass=abc.ABCMeta):
         str_ += f"\tunit  : {self.unit}\n"
         str_ += f"\tdtype : {self.data.dtype}\n"
         return str_.expandtabs(tabsize=2)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def evaluate(self, method=None, **kwargs):
         """Evaluate IRF

--- a/gammapy/irf/psf/kernel.py
+++ b/gammapy/irf/psf/kernel.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import html
 import numpy as np
 import astropy.units as u
 import matplotlib.pyplot as plt
@@ -57,6 +58,12 @@ class PSFKernel:
 
         if normalize:
             self.normalize()
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def normalize(self):
         """Force normalisation of the kernel"""

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import html
 import logging
 from abc import ABCMeta, abstractmethod
 from itertools import combinations
@@ -90,6 +91,12 @@ class RegionsFinder(metaclass=ABCMeta):
     def __init__(self, binsz=0.01 * u.deg):
         """Create a new RegionFinder"""
         self.binsz = Angle(binsz)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @abstractmethod
     def run(self, region, center, exclusion_mask=None):

--- a/gammapy/makers/core.py
+++ b/gammapy/makers/core.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import abc
+import html
 import numpy as np
 
 __all__ = ["Maker"]
@@ -34,3 +35,9 @@ class Maker(abc.ABC):
                 s += f"\t{name:{max_len}s}: {value}\n"
 
         return s.expandtabs(tabsize=2)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import copy
+import html
 import inspect
 import logging
 from collections.abc import Sequence
@@ -147,6 +148,12 @@ class MapAxis:
 
         self._nbin = nbin
         self._use_center_as_plot_labels = None
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def assert_name(self, required_name):
         """Assert axis name if a specific one is required.
@@ -1425,6 +1432,12 @@ class MapAxes(Sequence):
         self._axes = axes
         self._n_spatial_axes = n_spatial_axes
 
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
+
     @property
     def primary_axis(self):
         """Primary extra axis, defined as the one longest
@@ -2225,6 +2238,12 @@ class TimeMapAxis:
         delta = edges_min[1:] - edges_max[:-1]
         if np.any(delta < 0 * u.s):
             raise ValueError("Time intervals must not overlap.")
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     def is_contiguous(self):
@@ -3164,6 +3183,12 @@ class LabelMapAxis:
         str_ += fmt.format("node type", self.node_type)
         str_ += fmt.format("labels", "{0}".format(list(self._labels)))
         return str_.expandtabs(tabsize=2)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def is_allclose(self, other, **kwargs):
         """Check if other map axis is all close.

--- a/gammapy/maps/coord.py
+++ b/gammapy/maps/coord.py
@@ -298,7 +298,7 @@ class MapCoord:
         """Copy `MapCoord` object."""
         return copy.deepcopy(self)
 
-    def __repr__(self):
+    def __str__(self):
         return (
             f"{self.__class__.__name__}\n\n"
             f"\taxes     : {list(self._data.keys())}\n"

--- a/gammapy/maps/coord.py
+++ b/gammapy/maps/coord.py
@@ -1,4 +1,5 @@
 import copy
+import html
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -62,6 +63,12 @@ class MapCoord:
 
     def __iter__(self):
         return iter(self._data.values())
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     def ndim(self):

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import abc
 import copy
+import html
 import inspect
 import json
 from collections import OrderedDict
@@ -54,6 +55,12 @@ class Map(abc.ABC):
             self.meta = {}
         else:
             self.meta = meta
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def _init_copy(self, **kwargs):
         """Init map instance by copying missing init arguments from self."""

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1787,7 +1787,7 @@ class Map(abc.ABC):
         data_eq = np.allclose(self.quantity, other.quantity, **kwargs)
         return axes_eq and data_eq
 
-    def __repr__(self):
+    def __str__(self):
         geom = self.geom.__class__.__name__
         axes = ["skycoord"] if self.geom.is_hpx else ["lon", "lat"]
         axes = axes + [_.name for _ in self.geom.axes]

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import abc
 import copy
+import html
 import inspect
 import logging
 import numpy as np
@@ -68,6 +69,12 @@ class Geom(abc.ABC):
             if func is not None:
                 state[key] = func
         return state
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     @abc.abstractmethod

--- a/gammapy/maps/hpx/geom.py
+++ b/gammapy/maps/hpx/geom.py
@@ -1365,7 +1365,7 @@ class HpxGeom(Geom):
 
         return Quantity(hp.nside2pixarea(self.nside), "sr")
 
-    def __repr__(self):
+    def __str__(self):
         lon, lat = self.center_skydir.data.lon.deg, self.center_skydir.data.lat.deg
         return (
             f"{self.__class__.__name__}\n\n"

--- a/gammapy/maps/hpx/io.py
+++ b/gammapy/maps/hpx/io.py
@@ -1,4 +1,5 @@
 import copy
+import html
 
 
 class HpxConv:
@@ -12,6 +13,12 @@ class HpxConv:
         self.bands_hdu = kwargs.get("bands_hdu", "EBOUNDS")
         self.quantity_type = kwargs.get("quantity_type", "integral")
         self.frame = kwargs.get("frame", "COORDSYS")
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def colname(self, indx):
         return f"{self.colstring}{indx}"

--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -998,7 +998,6 @@ class HpxNDMap(HpxMap):
             return 180.0 - (180.0 - x + t) % 360.0
 
         for i, (x, y) in enumerate(zip(phi, theta)):
-
             lon, lat = np.degrees(x), np.degrees(np.pi / 2.0 - y)
             # Add a small offset to avoid vertices wrapping to the
             # other size of the projection

--- a/gammapy/maps/hpx/tests/test_geom.py
+++ b/gammapy/maps/hpx/tests/test_geom.py
@@ -773,10 +773,10 @@ def test_hpx_geom_to_wcs_tiles():
     assert_allclose(tiles[0].width, [[21.987113], [21.987113]] * u.deg)
 
 
-def test_geom_repr():
+def test_geom_str():
     geom = HpxGeom(nside=8)
-    assert geom.__class__.__name__ in repr(geom)
-    assert "nside" in repr(geom)
+    assert geom.__class__.__name__ in str(geom)
+    assert "nside" in str(geom)
 
 
 hpx_equality_test_geoms = [

--- a/gammapy/maps/hpx/utils.py
+++ b/gammapy/maps/hpx/utils.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import html
 import re
 import numpy as np
 from astropy.utils import lazyproperty
@@ -274,6 +275,12 @@ class HpxToWcsMapping:
         self._ipix = ipix
         self._mult_val = mult_val
         self._npix = npix
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     def hpx(self):

--- a/gammapy/maps/maps.py
+++ b/gammapy/maps/maps.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from collections.abc import MutableMapping
+import html
 from astropy.io import fits
 from gammapy.maps import Map
 from gammapy.utils.scripts import make_path
@@ -65,6 +66,12 @@ class Maps(MutableMapping):
             str_ += f"\t dtype\t : {value.data.dtype}\n"
             str_ += "\n"
         return str_
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def to_hdulist(self, hdu_bands="BANDS"):
         """Convert map dictionary to list of HDUs.

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -596,7 +596,7 @@ class RegionGeom(Geom):
         """
         return cls.from_regions(regions=region, **kwargs)
 
-    def __repr__(self):
+    def __str__(self):
         axes = ["lon", "lat"] + [_.name for _ in self.axes]
         try:
             frame = self.center_skydir.frame.name

--- a/gammapy/maps/region/tests/test_geom.py
+++ b/gammapy/maps/region/tests/test_geom.py
@@ -281,12 +281,12 @@ def test_downsample(region):
     assert_allclose(geom_down.axes[0].edges.value, [1.0, 10.0], rtol=1e-5)
 
 
-def test_repr(region):
+def test_str(region):
     axis = MapAxis.from_edges([1, 3.162278, 10] * u.TeV, name="energy", interp="log")
     geom = RegionGeom.create(region, axes=[axis])
 
-    assert "RegionGeom" in repr(geom)
-    assert "CircleSkyRegion" in repr(geom)
+    assert "RegionGeom" in str(geom)
+    assert "CircleSkyRegion" in str(geom)
 
 
 def test_eq(region):

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -55,7 +55,7 @@ def test_map_copy(binsz, width, map_type, skydir, axes, unit):
     )
 
     m_copy = m.copy()
-    assert repr(m) == repr(m_copy)
+    assert str(m) == str(m_copy)
 
     m_copy = m.copy(unit="cm-2 s-1")
     assert m_copy.unit == "cm-2 s-1"

--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -1045,7 +1045,7 @@ class WcsGeom(Geom):
         shape = (1,) * len(self.axes) + structure.shape
         return structure.reshape(shape)
 
-    def __repr__(self):
+    def __str__(self):
         lon = self.center_skydir.data.lon.deg
         lat = self.center_skydir.data.lat.deg
         lon_ref, lat_ref = self.wcs.wcs.crval

--- a/gammapy/maps/wcs/tests/test_geom.py
+++ b/gammapy/maps/wcs/tests/test_geom.py
@@ -380,12 +380,12 @@ def test_wcs_geom_get_pix_coords():
         assert_allclose(idx[0, 0, 0], desired)
 
 
-def test_geom_repr():
+def test_geom_str():
     geom = WcsGeom.create(
         skydir=(0, 0), npix=(10, 4), binsz=50, frame="galactic", proj="AIT"
     )
 
-    str_info = repr(geom)
+    str_info = str(geom)
     assert geom.__class__.__name__ in str_info
     assert "wcs ref" in str_info
     assert "center" in str_info

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -571,7 +571,7 @@ class FitStepResult:
         """Optimizer status message."""
         return self._message
 
-    def __repr__(self):
+    def __str__(self):
         return (
             f"{self.__class__.__name__}\n\n"
             f"\tbackend    : {self.backend}\n"
@@ -641,11 +641,11 @@ class OptimizeResult(FitStepResult):
         """Value of the fit statistic at minimum."""
         return self._total_stat
 
-    def __repr__(self):
-        str_ = super().__repr__()
-        str_ += f"\tnfev       : {self.nfev}\n"
-        str_ += f"\ttotal stat : {self.total_stat:.2f}\n\n"
-        return str_
+    def __str__(self):
+        string = super().__str__()
+        string += f"\tnfev       : {self.nfev}\n"
+        string += f"\ttotal stat : {self.total_stat:.2f}\n\n"
+        return string
 
 
 class FitResult:
@@ -736,15 +736,15 @@ class FitResult:
         """Optimize result"""
         return self._covariance_result
 
-    def __repr__(self):
-        str_ = ""
+    def __str__(self):
+        string = ""
         if self.optimize_result:
-            str_ += str(self.optimize_result)
+            string += str(self.optimize_result)
 
         if self.covariance_result:
-            str_ += str(self.covariance_result)
+            string += str(self.covariance_result)
 
-        return str_
+        return string
 
     def _repr_html_(self):
         try:

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import html
 import itertools
 import logging
 import numpy as np
@@ -136,6 +137,12 @@ class Fit:
         self.covariance_opts = covariance_opts
         self.confidence_opts = confidence_opts
         self._minuit = None
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     @deprecated(
@@ -573,6 +580,12 @@ class FitStepResult:
             f"\tmessage    : {self.message}\n"
         )
 
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
+
 
 class CovarianceResult(FitStepResult):
     """Covariance result object."""
@@ -732,3 +745,9 @@ class FitResult:
             str_ += str(self.covariance_result)
 
         return str_
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"

--- a/gammapy/modeling/likelihood.py
+++ b/gammapy/modeling/likelihood.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import html
 
 __all__ = ["Likelihood"]
 
@@ -45,3 +46,9 @@ class Likelihood:
             self.store_trace_iteration(total_stat)
 
         return total_stat
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import collections.abc
 import copy
+import html
 import logging
 from os.path import split
 import numpy as np
@@ -240,6 +241,12 @@ class ModelBase:
         if len(self.parameters) > 0:
             string += f"\n{self.parameters.to_table()}"
         return string
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     def frozen(self):
@@ -617,6 +624,12 @@ class DatasetModels(collections.abc.Sequence):
             str_ += str(model)
 
         return str_.expandtabs(tabsize=2)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def __add__(self, other):
         if isinstance(other, (Models, list)):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -2,6 +2,7 @@
 """Model parameter classes."""
 import collections.abc
 import copy
+import html
 import itertools
 import logging
 import numpy as np
@@ -399,6 +400,12 @@ class Parameter:
             f"min={self.min!r}, max={self.max!r}, frozen={self.frozen!r}, id={hex(id(self))})"
         )
 
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
+
     def copy(self):
         """A deep copy"""
         return copy.deepcopy(self)
@@ -477,6 +484,12 @@ class Parameters(collections.abc.Sequence):
             parameters = list(parameters)
 
         self._parameters = parameters
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def check_limits(self):
         """Check parameter limits and emit a warning"""

--- a/gammapy/stats/counts_statistic.py
+++ b/gammapy/stats/counts_statistic.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import abc
+import html
 import numpy as np
 from scipy.special import lambertw
 from scipy.stats import chi2
@@ -74,6 +75,12 @@ class CountsStatistic(abc.ABC):
         str_ = str_.format(**info)
 
         return str_.expandtabs(tabsize=2)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def info_dict(self):
         """A dictionary of the relevant quantities

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import html
 import logging
 import sys
 import astropy.units as u
@@ -40,6 +41,12 @@ class HDULocation:
         self.hdu_name = hdu_name
         self.cache = cache
         self.format = format
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def info(self, file=None):
         """Print some summary info to stdout."""

--- a/gammapy/utils/gauss.py
+++ b/gammapy/utils/gauss.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Multi-Gaussian distribution utilities (Gammapy internal)."""
+import html
 import numpy as np
 from astropy import units as u
 from gammapy.utils.roots import find_roots
@@ -18,6 +19,12 @@ class Gauss2DPDF:
 
     def __init__(self, sigma=1):
         self.sigma = sigma
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     @property
     def _sigma2(self):

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Interpolation utilities"""
+import html
 from itertools import compress
 import numpy as np
 import scipy.interpolate
@@ -52,7 +53,6 @@ class ScaledRegularGridInterpolator:
         axis=None,
         **kwargs,
     ):
-
         if points_scale is None:
             points_scale = ["lin"] * len(points)
 
@@ -89,6 +89,12 @@ class ScaledRegularGridInterpolator:
             self._interpolate = scipy.interpolate.interp1d(
                 points_scaled[0], values_scaled, axis=axis
             )
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def _scale_points(self, points):
         points_scaled = [scale(p) for p, scale in zip(points, self.scale_points)]
@@ -162,6 +168,12 @@ class InterpolationScale:
                 self._unit = values.unit
                 values = values.value
         return self._scale(values)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def inverse(self, values):
         values = self._inverse(values)

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import html
 import numpy as np
 from .utils import get_random_state
 
@@ -37,6 +38,12 @@ class InverseCDFSampler:
 
             self.pdf = pdf[self.sortindex]
             self.cdf = np.cumsum(self.pdf)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"
 
     def sample_axis(self):
         """Sample along a given axis.

--- a/gammapy/utils/registry.py
+++ b/gammapy/utils/registry.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import html
+
 __all__ = ["Registry"]
 
 
@@ -22,3 +24,9 @@ class Registry(list):
             info += f"{item.__name__:{len_max}s}: {item.tag} \n"
 
         return info.expandtabs(tabsize=2)
+
+    def _repr_html_(self):
+        try:
+            return self.to_html()
+        except AttributeError:
+            return f"<pre>{html.escape(str(self))}</pre>"


### PR DESCRIPTION
This pull request provides an initial implementation of #3921.

A stub implementation of `_repr_html_` is provided for most of the Gammapy classes (often only through their base classes), for use in Jupyter notebooks (resulting in nicer representations of variables).
Later commits & PRs can implement an explicit `to_html()` method, that will be automatically picked up by `_repr_html_`. If these are not provided (as is the case as of this PR), `_repr_html_` defaults to using the `__str__` implementation, which ultimately defaults to using `__repr__` if `__str__` is not provided.

I have also added a section on `_repr_html_` and `to_html` in the development documentation, just below the "repr, str and info" section at the bottom of the `dev_howto.rst` file, where it seems to fit in nicely.

I have taken the liberty of changing a few `__repr__` implementations to `__str__` implementations, which seems to be more semantically correct; these are `__repr__` implementations that produce nicely formatted ("human readable") output, which is more suited for `__str__`. This did require changing ten unit tests as well.

I have not implemented any unit tests. This does reduce test coverage, but I felt that this would require testing `_repr_html_` for every class (not just base classes), to test that it equals `str(<some_instance>)`.
I think it makes more sense to provide unit tests for each implementation of `to_html()`, where such a unit test can verify that both `to_html()` returns the correct HTML, and `_repr_html_` returns the result of `to_html()`.
