### PR TITLE
add action workflow to update citation.cff when doing a release

### DIFF
--- a/.github/workflows/updatecff.yml
+++ b/.github/workflows/updatecff.yml
@@ -1,0 +1,30 @@
+name: updatecff
+
+on:
+  tags:
+    - '*'
+
+jobs:
+  update:
+    name: "updatecff"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out a copy of the repository
+        uses: actions/checkout@v2
+
+      - name: Update CITATION.cff release date
+        run: python dev/citationcff.py
+
+      - name: Check whether the citation metadata from CITATION.cff is valid
+        uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: "--validate"
+
+      - name: commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4.1.6
+        if: success()
+        with:
+          commit_author: GitHub Actions <actions@github.com>
+          commit_message: commit metadata files
+
+        

--- a/dev/citationcff.py
+++ b/dev/citationcff.py
@@ -1,0 +1,8 @@
+import yaml
+from pathlib import Path
+from datetime import date
+
+citation_path = Path(__file__).parent.joinpath('CITATION.cff')
+cita = yaml.safe_load(open(citation_path).read())
+cita['date-released'] = date.today()
+yaml.safe_dump(cita, open(citation_path, 'w'))

--- a/dev/citationcff.py
+++ b/dev/citationcff.py
@@ -2,7 +2,7 @@ import yaml
 from pathlib import Path
 from datetime import date
 
-citation_path = Path(__file__).parent.joinpath('CITATION.cff')
+citation_path = Path(__file__).parents[1].joinpath('CITATION.cff')
 cita = yaml.safe_load(open(citation_path).read())
 cita['date-released'] = date.today()
 yaml.safe_dump(cita, open(citation_path, 'w'))


### PR DESCRIPTION
**Description**
Introduces an action to update `CITATION.cff` release date when doing a new release in order to solve #3953 

**Dear reviewer**

I am not sure either this is the solution gammapy team would prefer to solve that issue, nor if it would actually work, so some feedback would be welcome.

Potential issue with that PR:
- if that action breaks for some reason (e.g. invalid `CITATION.cff`), it will break the tag release
- the codemeta conversion action should come after
- I am not actually sure if the action are run before Zenodo fetch the new tag and produces a new record

