### PR TITLE
Safe mask range on the 1D spectrum tutorial

### DIFF
--- a/docs/tutorials/analysis/1D/spectral_analysis.ipynb
+++ b/docs/tutorials/analysis/1D/spectral_analysis.ipynb
@@ -506,7 +506,8 @@
    "outputs": [],
    "source": [
     "ax_spectrum, ax_residuals = datasets[0].plot_fit()\n",
-    "ax_spectrum.set_ylim(0.1, 40)"
+    "ax_spectrum.set_ylim(0.1, 40)\n",
+    "datasets[0].plot_masks(ax=ax_spectrum);"
    ]
   },
   {
@@ -789,7 +790,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.2"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,
@@ -797,9 +798,9 @@
    "autocomplete": true,
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1.0,
+   "current_citInitial": 1,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 1.0,
+   "eqNumInitial": 1,
    "hotkeys": {
     "equation": "Ctrl-E",
     "itemize": "Ctrl-I"


### PR DESCRIPTION

**Description**
This simple PR add the line to add the safe mask range on the figure of the count spectra, at the image of the tutorial of the 1D spectrum for extended sources.