### PR TITLE
Avoid evaluator update if model not contributes

### DIFF
--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -107,6 +107,8 @@ class MapEvaluator:
     def needs_update(self):
         """Check whether the model component has drifted away from its support."""
         # TODO: simplify and clean up
+        if not self.contributes:
+            return False
         if isinstance(self.model, TemplateNPredModel):
             return False
         elif self.exposure is None:

--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -109,7 +109,7 @@ class MapEvaluator:
         # TODO: simplify and clean up
         if isinstance(self.model, TemplateNPredModel):
             return False
-        if not self.contributes:
+        elif not self.contributes:
             return False
         elif self.exposure is None:
             return True

--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -107,9 +107,9 @@ class MapEvaluator:
     def needs_update(self):
         """Check whether the model component has drifted away from its support."""
         # TODO: simplify and clean up
-        if not self.contributes:
-            return False
         if isinstance(self.model, TemplateNPredModel):
+            return False
+        if not self.contributes:
             return False
         elif self.exposure is None:
             return True


### PR DESCRIPTION
Currently if a model contributes inside the dataset but outside the mask+psf_margin its evaluator will be updated at each optimizer call. This cause a serious performance drop if ones want to reduce mask_fit to fit only a subregion within the dataset. This PR simply adds a check on contributes in need_update to solve this. 