### PR TITLE
Adapt Observation.peek according to available hdus

### DIFF
--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -891,10 +891,20 @@ class EventList:
         m = m.smooth(width=0.5)
         return m
 
-    def plot_image(self, allsky=False):
-        """Quick look counts map sky plot."""
+    def plot_image(self, ax=None, allsky=False):
+        """Quick look counts map sky plot.
+
+        Parameters
+        ----------
+        ax : `~matplotlib.pyplot.Axes`
+            Axes to plot on.
+        allsky :  bool,
+            Whether to plot on an all sky geom
+        """
+        if ax is None:
+            ax = plt.gca()
         m = self._counts_image(allsky=allsky)
-        m.plot(stretch="sqrt")
+        m.plot(ax=ax, stretch="sqrt")
 
 
 class EventListChecker(Checker):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -354,9 +354,10 @@ class Observation:
         figsize : tuple
             Figure size
         """
-        plot_hdus = self.available_hdus
-        if "gti" in plot_hdus:
-            plot_hdus.remove("gti")
+
+        plottable_hds = ["events", "aeff", "psf", "edisp", "bkg", "rad_max"]
+
+        plot_hdus = list(set(self.available_hdus) & set(plottable_hds))
 
         n_irfs = len(plot_hdus)
 

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -50,22 +50,6 @@ def test_observation_peek(data_store, caplog):
         with mpl_plot_check():
             obs.peek()
 
-        obs.bkg = None
-
-        with mpl_plot_check():
-            obs.peek()
-
-        message = "No background model found for obs 23523."
-        assert message in [record.message for record in caplog.records]
-
-        obs.psf = None
-        with mpl_plot_check():
-            obs.peek()
-
-        assert "WARNING" in [record.levelname for record in caplog.records]
-        message = "No PSF found for obs 23523."
-        assert message in [record.message for record in caplog.records]
-
 
 @requires_data()
 @pytest.mark.parametrize(

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import logging
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -41,14 +41,21 @@ def test_observation(data_store):
 
 
 @requires_data()
-def test_observation_peek(data_store, caplog):
-    with caplog.at_level(logging.WARNING):
-        obs = Observation.read(
-            "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
-        )
+def test_observation_peek(data_store):
 
-        with mpl_plot_check():
-            obs.peek()
+    obs = Observation.read(
+        "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
+    )
+
+    with mpl_plot_check():
+        obs.peek()
+
+    obs_with_radmax = Observation.read(
+        "$GAMMAPY_DATA/magic/rad_max/data/20131004_05029747_DL3_CrabNebula-W0.40+035.fits"
+    )
+
+    with mpl_plot_check():
+        obs_with_radmax.peek()
 
 
 @requires_data()

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -295,7 +295,7 @@ class Background2D(BackgroundIRF):
         offset_axis.format_plot_yaxis(ax=ax)
 
         if add_cbar:
-            label = f"Background rate ({self.unit})"
+            label = f"Background rate [{self.unit}]"
             ax.figure.colorbar(caxes, ax=ax, label=label)
 
     def plot_offset_dependence(self, ax=None, energy=None, **kwargs):

--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -250,7 +250,7 @@ class EnergyDispersion2D(IRF):
         migra.format_plot_yaxis(ax=ax)
 
         if add_cbar:
-            label = "Probability density (A.U.)"
+            label = "Probability density [A.U]."
             ax.figure.colorbar(caxes, ax=ax, label=label)
 
         return ax

--- a/gammapy/irf/psf/core.py
+++ b/gammapy/irf/psf/core.py
@@ -3,6 +3,7 @@ import numpy as np
 from astropy import units as u
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
+import matplotlib.ticker as mtick
 from gammapy.utils.array import array_stats_str
 from ..core import IRF
 
@@ -156,7 +157,8 @@ class PSF(IRF):
 
         energy_true.format_plot_xaxis(ax=ax)
         ax.legend(loc="best")
-        ax.set_ylabel(f"Containment radius ({ax.yaxis.units})")
+        ax.set_ylabel(f"Containment radius [{ax.yaxis.units}]")
+        ax.yaxis.set_major_formatter(mtick.FormatStrFormatter('%.1e'))
         return ax
 
     def plot_containment_radius(self, ax=None, fraction=0.68, add_cbar=True, **kwargs):

--- a/gammapy/irf/rad_max.py
+++ b/gammapy/irf/rad_max.py
@@ -111,7 +111,7 @@ class RadMax2D(IRF):
         energy_axis.format_plot_xaxis(ax=ax)
         ax.set_ylim(0 * u.deg, None)
         ax.legend(loc="best")
-        ax.set_ylabel(f"Rad max. ({ax.yaxis.units})")
+        ax.set_ylabel(f"Rad max. [{ax.yaxis.units}]")
         ax.yaxis.set_major_formatter("{x:.1f}")
         return ax
 


### PR DESCRIPTION
This addresses #3963 .

I have removed the warnings for the irrelevant hdus as they are unnecessarily confusing.

While implementing this PR, I realised that our `peek` methods arguments vary (eg `Observation.peek` takes `figsize` whereas `EventList.peek()` does not). It might be good to homogenise.