### PR TITLE
Set reasonable error message case of no free parameters for optimisation

### DIFF
--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -126,7 +126,7 @@ class ParameterEstimator(Estimator):
             # compute ts value
             parameter.value = self.null_value
 
-            if self.reoptimize:
+            if self._reoptimize:
                 parameter.frozen = True
                 _ = self.fit.optimize(datasets=datasets)
 
@@ -167,7 +167,7 @@ class ParameterEstimator(Estimator):
             datasets=datasets,
             parameter=parameter,
             sigma=self.n_sigma,
-            reoptimize=self.reoptimize,
+            reoptimize=self._reoptimize,
         )
 
         return {
@@ -204,7 +204,7 @@ class ParameterEstimator(Estimator):
         self.fit.optimize(datasets=datasets)
 
         profile = self.fit.stat_profile(
-            datasets=datasets, parameter=parameter, reoptimize=self.reoptimize
+            datasets=datasets, parameter=parameter, reoptimize=self._reoptimize
         )
 
         return {
@@ -238,7 +238,7 @@ class ParameterEstimator(Estimator):
             datasets=datasets,
             parameter=parameter,
             sigma=self.n_sigma_ul,
-            reoptimize=self.reoptimize,
+            reoptimize=self._reoptimize,
         )
         return {f"{parameter.name}_ul": res["errp"] + parameter.value}
 
@@ -308,14 +308,16 @@ class ParameterEstimator(Estimator):
 
         with datasets.parameters.restore_status():
 
+            self._reoptimize = self.reoptimize
+
             if len(datasets.parameters.free_parameters.names) == 1:
                 if self.reoptimize:
                     log.warning(
                         f"No free parameters to reoptimize. Setting reoptimize to False"
                     )
-                    self.reoptimize = False
+                self._reoptimize = False
 
-            if not self.reoptimize:
+            if not self._reoptimize:
                 datasets.parameters.freeze_all()
                 parameter.frozen = False
 

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -308,6 +308,13 @@ class ParameterEstimator(Estimator):
 
         with datasets.parameters.restore_status():
 
+            if len(datasets.parameters.free_parameters.names) == 1:
+                if self.reoptimize:
+                    log.warning(
+                        f"No free parameters to reoptimize. Setting reoptimize to False"
+                    )
+                    self.reoptimize = False
+
             if not self.reoptimize:
                 datasets.parameters.freeze_all()
                 parameter.frozen = False

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -126,7 +126,7 @@ class ParameterEstimator(Estimator):
             # compute ts value
             parameter.value = self.null_value
 
-            if self._reoptimize:
+            if self.reoptimize:
                 parameter.frozen = True
                 _ = self.fit.optimize(datasets=datasets)
 
@@ -167,7 +167,7 @@ class ParameterEstimator(Estimator):
             datasets=datasets,
             parameter=parameter,
             sigma=self.n_sigma,
-            reoptimize=self._reoptimize,
+            reoptimize=self.reoptimize,
         )
 
         return {
@@ -204,7 +204,7 @@ class ParameterEstimator(Estimator):
         self.fit.optimize(datasets=datasets)
 
         profile = self.fit.stat_profile(
-            datasets=datasets, parameter=parameter, reoptimize=self._reoptimize
+            datasets=datasets, parameter=parameter, reoptimize=self.reoptimize
         )
 
         return {
@@ -238,7 +238,7 @@ class ParameterEstimator(Estimator):
             datasets=datasets,
             parameter=parameter,
             sigma=self.n_sigma_ul,
-            reoptimize=self._reoptimize,
+            reoptimize=self.reoptimize,
         )
         return {f"{parameter.name}_ul": res["errp"] + parameter.value}
 
@@ -308,16 +308,7 @@ class ParameterEstimator(Estimator):
 
         with datasets.parameters.restore_status():
 
-            self._reoptimize = self.reoptimize
-
-            if len(datasets.parameters.free_parameters.names) == 1:
-                if self.reoptimize:
-                    log.warning(
-                        f"No free parameters to reoptimize. Setting reoptimize to False"
-                    )
-                self._reoptimize = False
-
-            if not self._reoptimize:
+            if not self.reoptimize:
                 datasets.parameters.freeze_all()
                 parameter.frozen = False
 

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -373,6 +373,24 @@ def test_run_map_pwl_reoptimize(fpe_map_pwl_reoptimize):
 
 
 @requires_data()
+def test_reoptimize_no_free_parameters(fpe_pwl, fpe_map_pwl, caplog):
+    # test spectra
+    datasets, fpe = fpe_pwl
+    fpe.reoptimize = True
+    fp = fpe.run(datasets)
+    assert "WARNING" in [record.levelname for record in caplog.records]
+    message = "No free parameters to reoptimize. Setting reoptimize to False"
+    assert message in [record.message for record in caplog.records]
+
+    # test map
+    datasets, fpe = fpe_map_pwl
+    fpe.reoptimize = True
+    fpe.selection_optional = None
+    fp = fpe.run(datasets)
+    assert "WARNING" in [record.levelname for record in caplog.records]
+
+
+@requires_data()
 def test_flux_points_estimator_no_norm_scan(fpe_pwl, tmpdir):
     datasets, fpe = fpe_pwl
     fpe.selection_optional = None

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -374,14 +374,11 @@ def test_run_map_pwl_reoptimize(fpe_map_pwl_reoptimize):
 
 @requires_data()
 def test_reoptimize_no_free_parameters(fpe_pwl, caplog):
-    # test spectra
     datasets, fpe = fpe_pwl
     fpe.reoptimize = True
-    fp = fpe.run(datasets)
-    assert "WARNING" in [record.levelname for record in caplog.records]
-    message = "No free parameters to reoptimize. Setting reoptimize to False"
-    assert message in [record.message for record in caplog.records]
-    assert fpe.reoptimize is True
+    with pytest.raises(ValueError, match="No free parameters for fitting"):
+        fpe.run(datasets)
+    fpe.reoptimize = False
 
 
 @requires_data()

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -381,6 +381,7 @@ def test_reoptimize_no_free_parameters(fpe_pwl, caplog):
     assert "WARNING" in [record.levelname for record in caplog.records]
     message = "No free parameters to reoptimize. Setting reoptimize to False"
     assert message in [record.message for record in caplog.records]
+    assert fpe.reoptimize is True
 
 
 @requires_data()

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -373,7 +373,7 @@ def test_run_map_pwl_reoptimize(fpe_map_pwl_reoptimize):
 
 
 @requires_data()
-def test_reoptimize_no_free_parameters(fpe_pwl, fpe_map_pwl, caplog):
+def test_reoptimize_no_free_parameters(fpe_pwl, caplog):
     # test spectra
     datasets, fpe = fpe_pwl
     fpe.reoptimize = True
@@ -381,13 +381,6 @@ def test_reoptimize_no_free_parameters(fpe_pwl, fpe_map_pwl, caplog):
     assert "WARNING" in [record.levelname for record in caplog.records]
     message = "No free parameters to reoptimize. Setting reoptimize to False"
     assert message in [record.message for record in caplog.records]
-
-    # test map
-    datasets, fpe = fpe_map_pwl
-    fpe.reoptimize = True
-    fpe.selection_optional = None
-    fp = fpe.run(datasets)
-    assert "WARNING" in [record.levelname for record in caplog.records]
 
 
 @requires_data()

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -184,6 +184,9 @@ class Fit:
         datasets, parameters = self._parse_datasets(datasets=datasets)
         datasets.parameters.check_limits()
 
+        if len(parameters.free_parameters.names) == 0:
+            raise ValueError("No free parameters for fitting")
+
         parameters.autoscale()
 
         kwargs = self.optimize_opts.copy()

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -184,7 +184,6 @@ class Fit:
         datasets, parameters = self._parse_datasets(datasets=datasets)
         datasets.parameters.check_limits()
 
-        print(parameters.free_parameters.names)
         if len(parameters.free_parameters.names) == 0:
             raise ValueError("No free parameters for fitting")
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -184,6 +184,7 @@ class Fit:
         datasets, parameters = self._parse_datasets(datasets=datasets)
         datasets.parameters.check_limits()
 
+        print(parameters.free_parameters.names)
         if len(parameters.free_parameters.names) == 0:
             raise ValueError("No free parameters for fitting")
 

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -124,7 +124,7 @@ def test_run_no_free_parameters():
     for par in dataset.models.parameters.free_parameters:
         par.frozen = True
     fit = Fit()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="No free parameters for fitting"):
         fit.run(dataset)
 
 

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -119,6 +119,15 @@ def test_run(backend):
     assert_allclose(pars["z"].error, 1, rtol=1e-7)
 
 
+def test_run_no_free_parameters():
+    dataset = MyDataset()
+    for par in dataset.models.parameters.free_parameters:
+        par.frozen = True
+    fit = Fit()
+    with pytest.raises(ValueError):
+        fit.run(dataset)
+
+
 @pytest.mark.parametrize("backend", ["minuit"])
 def test_run_linked(backend):
     dataset = MyDataset()


### PR DESCRIPTION
This PR sets `FluxEstimator.reoptimize = False` in case there are no free parameters to reoptimize