### PR TITLE
Fix error bars on plot_excess method of SpectrumDataset and SpectrumDatasetOnOff and plot_residuals_spectral

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -972,8 +972,6 @@ class MapDataset(Dataset):
 
         if method == "diff":
             yerr = excess_error
-        elif method == "diff/model":
-            yerr = excess_error/npred_spec.data
         elif method == "diff/sqrt(model)":
             yerr = excess_error/np.sqrt(npred_spec.data)
         else:

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -915,6 +915,8 @@ class MapDataset(Dataset):
         The residuals are extracted from the provided region, and the normalization
         used for its computation can be controlled using the method parameter.
 
+        The error bars are computed using the uncertainty on the excess with a symmetric assumption.
+
         Parameters
         ----------
         ax : `~matplotlib.axes.Axes`

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -205,10 +205,13 @@ class PlotMixin:
         kwargs_excess = kwargs_excess or {}
         kwargs_npred_signal = kwargs_npred_signal or {}
 
+        # Determine the uncertainty on yerr
+        yerr = (-self._counts_statistic.compute_errn(), self._counts_statistic.compute_errp())
+
         plot_kwargs = kwargs.copy()
         plot_kwargs.update(kwargs_excess)
         plot_kwargs.setdefault("label", "Excess counts")
-        ax = self.excess.plot(ax, yerr=np.sqrt(np.abs(self.excess.data)), **plot_kwargs)
+        ax = self.excess.plot(ax, yerr=yerr, **plot_kwargs)
 
         plot_kwargs = kwargs.copy()
         plot_kwargs.update(kwargs_npred_signal)

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -205,7 +205,7 @@ class PlotMixin:
         kwargs_npred_signal = kwargs_npred_signal or {}
 
         # Determine the uncertainty on yerr
-        yerr = (-self._counts_statistic.compute_errn(), self._counts_statistic.compute_errp())
+        yerr = -self._counts_statistic.error
 
         plot_kwargs = kwargs.copy()
         plot_kwargs.update(kwargs_excess)

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -205,7 +205,7 @@ class PlotMixin:
         kwargs_npred_signal = kwargs_npred_signal or {}
 
         # Determine the uncertainty on yerr
-        yerr = -self._counts_statistic.error
+        yerr = self._counts_statistic.error
 
         plot_kwargs = kwargs.copy()
         plot_kwargs.update(kwargs_excess)

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -170,6 +170,8 @@ class PlotMixin:
     ):
         """Plot excess and predicted signal.
 
+        The error bars are computed with a symmetric assumption on the excess.
+
         Parameters
         ----------
         ax : `~matplotlib.axes.Axes`
@@ -204,7 +206,7 @@ class PlotMixin:
         kwargs_excess = kwargs_excess or {}
         kwargs_npred_signal = kwargs_npred_signal or {}
 
-        # Determine the uncertainty on yerr
+        # Determine the uncertainty on the excess
         yerr = self._counts_statistic.error
 
         plot_kwargs = kwargs.copy()

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
-import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
 from gammapy.utils.scripts import make_path


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a for solving issue  #3971 about the incorrect size of the error bars on plot created by the method plot_excess of SpectrumDataset and SpectrumDatasetOnOff. This also add correct error bar computation for all the method of the plot_residuals_spectral method used by all Datasets.

**Dear reviewer**
This is pull request is ready for review.
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
