### PR TITLE
Fix parameters min/max display in serialization 

### DIFF
--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -158,7 +158,7 @@ class ModelBase:
                 for item in ["min", "max", "error", "interp", "scale_method", "is_norm"]:
                     default = init[item]
 
-                    if par[item] == default or np.isnan(par[item]):
+                    if par[item] == default or (np.isnan(par[item]) and np.isnan(default)):
                         del par[item]
 
                 if not par["frozen"]:

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -158,7 +158,7 @@ class ModelBase:
                 for item in ["min", "max", "error", "interp", "scale_method"]:
                     default = init[item]
 
-                    if par[item] == default or np.isnan(default):
+                    if par[item] == default or np.isnan(par[item]):
                         del par[item]
 
                 if not par["frozen"]:

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -155,7 +155,7 @@ class ModelBase:
         if not full_output:
             for par, par_default in zip(params, self.default_parameters):
                 init = par_default.to_dict()
-                for item in ["min", "max", "error", "interp", "scale_method"]:
+                for item in ["min", "max", "error", "interp", "scale_method", "is_norm"]:
                     default = init[item]
 
                     if par[item] == default or np.isnan(par[item]):

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -339,3 +339,26 @@ def test_link_label(models):
             assert "reference" in line
             n_link += 1
     assert n_link == 2
+
+
+def test_to_dict_not_default():
+    
+    model = PowerLawSpectralModel()
+    model.index.min=-1
+    model.index.max=-5
+    model.index.frozen=True
+    mdict = model.to_dict(full_output=False)
+
+    index_dict = mdict["spectral"]["parameters"][0]
+    assert "min" in index_dict
+    assert "max" in index_dict
+    assert "frozen" in index_dict
+    assert "error" not in index_dict
+    assert "interp" not in index_dict
+    assert "scale_method" not in index_dict
+    assert "is_norm" not in index_dict
+
+    model_2 = model.from_dict(mdict)
+    assert model_2.index.min == model.index.min
+    assert model_2.index.max == model.index.max
+    assert model_2.index.frozen == model.index.frozen


### PR DESCRIPTION
This PR fix a bug in model serialization where the min/max different from default were never shown for nan default.
(Also modified model.to_dict such `is_norm` is hidden if `full_output=False`).