### PR TITLE
Fix inconsistency between NMCID and number of MID* keywords in `MapDatasetEventSampler`

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -88,11 +88,11 @@ class MapDatasetEventSampler:
             table = self._sample_coord_time(npred, temporal_model, dataset.gti)
             if len(table) > 0:
                 table["MC_ID"] = idx + 1
-                table.meta["MID{:05d}".format(idx + 1)] = idx + 1
-                table.meta["MMN{:05d}".format(idx + 1)] = evaluator.model.name
             else:
                 mcid = table.Column(name="MC_ID", length=0, dtype=int)
                 table.add_column(mcid)
+            table.meta["MID{:05d}".format(idx + 1)] = idx + 1
+            table.meta["MMN{:05d}".format(idx + 1)] = evaluator.model.name
             events_all.append(EventList(table))
 
         return EventList.from_stack(events_all)

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -86,13 +86,15 @@ class MapDatasetEventSampler:
                 temporal_model = evaluator.model.temporal_model
 
             table = self._sample_coord_time(npred, temporal_model, dataset.gti)
-            if len(table) > 0:
-                table["MC_ID"] = idx + 1
-            else:
+
+            if len(table) == 0:
                 mcid = table.Column(name="MC_ID", length=0, dtype=int)
                 table.add_column(mcid)
+
+            table["MC_ID"] = idx + 1
             table.meta["MID{:05d}".format(idx + 1)] = idx + 1
             table.meta["MMN{:05d}".format(idx + 1)] = evaluator.model.name
+
             events_all.append(EventList(table))
 
         return EventList.from_stack(events_all)


### PR DESCRIPTION
I've found the possibility of an inconsistency between the value given in the NMCID keyword and the number of MID* keywords in the header of an event list obtained from `MapDatasetEventSampler`. 
NMCID indicates the total number of MID* keywords. However, currently if `MapDatasetEventSampler` does not simulate any event for a given source (i.e. a very faint source), the corresponding MID keywords is not stored but but the NMCID value counts it anyway.
This PR tries to fix this issue. 