### PR TITLE
Fix bug in `TemplateSpatialModel.evaluate`

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1125,8 +1125,6 @@ class TemplateSpatialModel(SpatialModel):
     def read(cls, filename, normalize=True, **kwargs):
         """Read spatial template model from FITS image.
         If unit is not given in the FITS header the default is ``sr-1``.
-        Note that, if the TemplateMap has negative values, these are
-        clipped.
 
         Parameters
         ----------
@@ -1141,6 +1139,10 @@ class TemplateSpatialModel(SpatialModel):
         return cls(m, normalize=normalize, filename=filename)
 
     def evaluate(self, lon, lat, energy=None):
+        """Evaluate the model at given coordinates.
+        Note that, if the map data assume negative values, these are
+        clipped to zero.
+        """
         coord = {
             "lon": lon.to_value("deg"),
             "lat": lat.to_value("deg"),

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1147,6 +1147,7 @@ class TemplateSpatialModel(SpatialModel):
             coord["energy_true"] = energy
 
         val = self.map.interp_by_coord(coord, **self._interp_kwargs)
+        val = np.clip(val, 0, a_max=None)
         return u.Quantity(val, self.map.unit, copy=False)
 
     @property

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1125,6 +1125,8 @@ class TemplateSpatialModel(SpatialModel):
     def read(cls, filename, normalize=True, **kwargs):
         """Read spatial template model from FITS image.
         If unit is not given in the FITS header the default is ``sr-1``.
+        Note that, if the TemplateMap has negative values, these are
+        clipped.
 
         Parameters
         ----------

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -468,3 +468,16 @@ def test_integrate_geom_energy_axis():
     integral = model.integrate_geom(geom).data
 
     assert_allclose(integral, 1, rtol=0.0001)
+
+
+def test_temlatemap_clip():
+    model_map = Map.create(map_type="wcs", width=(2, 2), binsz=0.5, unit="sr-1")
+    model_map.data += 1.0
+    model = TemplateSpatialModel(model_map)
+    model.map.data = model.map.data * -1
+    
+    lon = np.array([0, 0.2, 0.3]) * u.deg
+    lat = np.array([0, 0.2, 0.3]) * u.deg
+
+    val = model.evaluate(lon,lat)
+    assert_allclose(val, 0, rtol=0.0001)


### PR DESCRIPTION
In very rare case, it may happen that the evaluation of a `TemplateSpatialModel` model provide negative values. This PR aims at fixing this issue.