### PR TITLE
Fix the SafeMaskMaker 

### DIFF
--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -170,6 +170,13 @@ class SafeMaskMaker(Maker):
             position = geom.center_skydir
 
         aeff = exposure.get_spectrum(position) / exposure.meta["livetime"]
+        if np.amax(aeff.data) <= 0.1:
+            log.warning(
+                f"No safe energy band can be defined for the dataset {dataset.name}"
+            )
+            empty_data = np.zeros(geom.data_shape, dtype=bool)
+            return Map.from_geom(geom, data=empty_data, dtype='bool')
+
         model = TemplateSpectralModel.from_region_map(aeff)
 
         energy_true = model.energy
@@ -313,10 +320,10 @@ class SafeMaskMaker(Maker):
             mask_safe &= self.make_mask_energy_aeff_default(dataset, observation)
 
         if "aeff-max" in self.methods:
-            mask_safe &= self.make_mask_energy_aeff_max(dataset)
+            mask_safe &= self.make_mask_energy_aeff_max(dataset, observation)
 
         if "edisp-bias" in self.methods:
-            mask_safe &= self.make_mask_energy_edisp_bias(dataset)
+            mask_safe &= self.make_mask_energy_edisp_bias(dataset, observation)
 
         if "bkg-peak" in self.methods:
             mask_safe &= self.make_mask_energy_bkg_peak(dataset)

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -170,7 +170,7 @@ class SafeMaskMaker(Maker):
             position = geom.center_skydir
 
         aeff = exposure.get_spectrum(position) / exposure.meta["livetime"]
-        if not np.any(aeff.data) > 0.1:
+        if not np.any(aeff.data > 0.):
             log.warning(
                 f"No safe energy band can be defined for the dataset {dataset.name}: setting mask_safe to False"
             )

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -172,7 +172,7 @@ class SafeMaskMaker(Maker):
         aeff = exposure.get_spectrum(position) / exposure.meta["livetime"]
         if not np.any(aeff.data > 0.):
             log.warning(
-                f"No safe energy band can be defined for the dataset {dataset.name}: setting mask_safe to False"
+                f"Effective area is all zero at [{position.to_string('dms')}]. No safe energy band can be defined for the dataset '{dataset.name}': setting `mask_safe` to all False."
             )
             return Map.from_geom(geom, data=False, dtype='bool')
 

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -170,12 +170,11 @@ class SafeMaskMaker(Maker):
             position = geom.center_skydir
 
         aeff = exposure.get_spectrum(position) / exposure.meta["livetime"]
-        if np.amax(aeff.data) <= 0.1:
+        if not np.any(aeff.data) > 0.1:
             log.warning(
-                f"No safe energy band can be defined for the dataset {dataset.name}"
+                f"No safe energy band can be defined for the dataset {dataset.name}: Setting mask_safe to False"
             )
-            empty_data = np.zeros(geom.data_shape, dtype=bool)
-            return Map.from_geom(geom, data=empty_data, dtype='bool')
+            return Map.from_geom(geom, data=False, dtype='bool')
 
         model = TemplateSpectralModel.from_region_map(aeff)
 

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -172,7 +172,7 @@ class SafeMaskMaker(Maker):
         aeff = exposure.get_spectrum(position) / exposure.meta["livetime"]
         if not np.any(aeff.data) > 0.1:
             log.warning(
-                f"No safe energy band can be defined for the dataset {dataset.name}: Setting mask_safe to False"
+                f"No safe energy band can be defined for the dataset {dataset.name}: setting mask_safe to False"
             )
             return Map.from_geom(geom, data=False, dtype='bool')
 

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -4,7 +4,6 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
-from astropy.coordinates import SkyCoord
 from gammapy.data import DataStore
 from gammapy.datasets import MapDataset
 from gammapy.makers import MapDatasetMaker, SafeMaskMaker
@@ -53,10 +52,10 @@ def dataset(observation_cta_1dc):
 @pytest.fixture(scope="session")
 def shifted_dataset(observation_cta_1dc):
     axis = MapAxis.from_bounds(
-        0.1, 10, nbin=16, unit="TeV", name="energy", interp="log"
+        0.1, 1, nbin=5, unit="TeV", name="energy", interp="log"
     )
     axis_true = MapAxis.from_bounds(
-        0.1, 50, nbin=30, unit="TeV", name="energy_true", interp="log"
+        0.1, 2, nbin=10, unit="TeV", name="energy_true", interp="log"
     )
     skydir = observation_cta_1dc.pointing_radec.directional_offset_by(position_angle=0. * u.deg, separation=10 * u.deg)
     geom = WcsGeom.create(

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -134,12 +134,8 @@ def test_safe_mask_maker_aeff_max_fixed_offset(dataset, observation_cta_1dc):
     mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset, observation=observation_cta_1dc)
     assert_allclose(mask_aeff_max.data.sum(), 726)
 
-    import copy
-    mask_aeff_max_bis = copy.copy(mask_aeff_max)
-    mask_aeff_max_bis.data = 0
     with pytest.raises(ValueError):
-        mask_aeff_max_bis = safe_mask_maker.make_mask_energy_aeff_max(dataset)
-    assert_allclose(mask_aeff_max_bis.data.sum(), 0)
+        mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset)
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -1,8 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import logging
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from gammapy.data import DataStore
 from gammapy.datasets import MapDataset
 from gammapy.makers import MapDatasetMaker, SafeMaskMaker
@@ -48,6 +50,25 @@ def dataset(observation_cta_1dc):
     return dataset_maker.run(dataset=empty_dataset, observation=observation_cta_1dc)
 
 
+@pytest.fixture(scope="session")
+def shifted_dataset(observation_cta_1dc):
+    axis = MapAxis.from_bounds(
+        0.1, 10, nbin=16, unit="TeV", name="energy", interp="log"
+    )
+    axis_true = MapAxis.from_bounds(
+        0.1, 50, nbin=30, unit="TeV", name="energy_true", interp="log"
+    )
+    skydir = observation_cta_1dc.pointing_radec.directional_offset_by(position_angle=0. * u.deg, separation=10 * u.deg)
+    geom = WcsGeom.create(
+        npix=(11, 11), axes=[axis], skydir=skydir
+    )
+
+    empty_dataset = MapDataset.create(geom=geom, energy_axis_true=axis_true, name="shifted")
+    dataset_maker = MapDatasetMaker()
+    return dataset_maker.run(dataset=empty_dataset, observation=observation_cta_1dc)
+
+
+
 @requires_data()
 def test_safe_mask_maker_offset_max(dataset, observation_cta_1dc):
     safe_mask_maker = SafeMaskMaker(
@@ -86,6 +107,40 @@ def test_safe_mask_maker_aeff_max(dataset, observation_cta_1dc):
     mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset)
 
     assert_allclose(mask_aeff_max.data.sum(), 1210)
+
+
+@requires_data()
+def test_safe_mask_maker_aeff_max_fixed_observation(dataset, shifted_dataset, observation_cta_1dc, caplog):
+    safe_mask_maker = SafeMaskMaker(methods=["aeff-max"], aeff_percent=20)
+
+    mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset, observation=observation_cta_1dc)
+    assert_allclose(mask_aeff_max.data.sum(), 847)
+
+    with caplog.at_level(logging.WARNING):
+        mask_aeff_max_bis = safe_mask_maker.make_mask_energy_aeff_max(shifted_dataset, observation=observation_cta_1dc)
+
+    assert len(caplog.record_tuples) == 1
+    assert caplog.record_tuples[0] == (
+        "gammapy.makers.safe",
+        logging.WARNING,
+        "No safe energy band can be defined for the dataset shifted: setting mask_safe to False",
+    )
+    assert_allclose(mask_aeff_max_bis.data.sum(), 0)
+
+
+@requires_data()
+def test_safe_mask_maker_aeff_max_fixed_offset(dataset, observation_cta_1dc):
+    safe_mask_maker = SafeMaskMaker(methods=["aeff-max"], aeff_percent=20, fixed_offset=5*u.deg)
+
+    mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset, observation=observation_cta_1dc)
+    assert_allclose(mask_aeff_max.data.sum(), 726)
+
+    import copy
+    mask_aeff_max_bis = copy.copy(mask_aeff_max)
+    mask_aeff_max_bis.data = 0
+    with pytest.raises(ValueError):
+        mask_aeff_max_bis = safe_mask_maker.make_mask_energy_aeff_max(dataset)
+    assert_allclose(mask_aeff_max_bis.data.sum(), 0)
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -122,7 +122,7 @@ def test_safe_mask_maker_aeff_max_fixed_observation(dataset, shifted_dataset, ob
     assert caplog.record_tuples[0] == (
         "gammapy.makers.safe",
         logging.WARNING,
-        "No safe energy band can be defined for the dataset shifted: setting mask_safe to False",
+        "Effective area is all zero at [267d40m52.368168s -19d36m27s]. No safe energy band can be defined for the dataset 'shifted': setting `mask_safe` to all False.",
     )
     assert_allclose(mask_aeff_max_bis.data.sum(), 0)
 


### PR DESCRIPTION
**Description**
This pull request is associated to the issue #3984. It fixes 2 things as discussed during the last dev call
- return an empty mask when the effective area is null (issue #3983)
- propagate correctly the observation in the mask function (issue #3984)

**Dear reviewer**
This PR is aimed for the bug release V0.20.2