### PR TITLE
Fix issue #3983

### DIFF
--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -217,7 +217,7 @@ class ExcessMapEstimator(Estimator):
         elif dataset.mask_safe:
             mask = dataset.mask_safe
         else:
-            mask = np.ones(dataset.data_shape, dtype=bool)
+            mask = Map.from_geom(geom, data=np.ones(dataset.data_shape), dtype=bool)
 
         counts_stat = convolved_map_dataset_counts_statistics(
             dataset, kernel, mask, self.correlate_off

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -217,7 +217,7 @@ class ExcessMapEstimator(Estimator):
         elif dataset.mask_safe:
             mask = dataset.mask_safe
         else:
-            mask = Map.from_geom(geom, data=np.ones(dataset.data_shape), dtype=bool)
+            mask = Map.from_geom(geom, data=True, dtype=bool)
 
         counts_stat = convolved_map_dataset_counts_statistics(
             dataset, kernel, mask, self.correlate_off

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -162,6 +162,22 @@ def test_significance_map_estimator_map_dataset_exposure(simple_dataset):
     assert_allclose(result["npred_excess"].data.sum(), 19733.602, rtol=1e-3)
     assert_allclose(result["sqrt_ts"].data[0, 10, 10], 4.217129, rtol=1e-3)
 
+    # without mask safe
+    simple_dataset_no_mask = MapDataset(counts=simple_dataset.counts,
+                                exposure = simple_dataset.exposure,
+                                background = simple_dataset.background,
+                                psf = simple_dataset.psf,
+                                edisp = simple_dataset.edisp)
+
+    simple_dataset_no_mask.models = [model]
+    simple_dataset_no_mask.npred()
+
+    result_no_mask = estimator.run(simple_dataset_no_mask)
+    assert_allclose(result_no_mask["npred_excess"].data.sum(), 19733.602, rtol=1e-3)
+    assert_allclose(result_no_mask["sqrt_ts"].data[0, 10, 10], 4.217129, rtol=1e-3)
+
+
+
 
 def test_excess_map_estimator_map_dataset_on_off_no_correlation(
     simple_dataset_on_off,

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -170,7 +170,6 @@ def test_significance_map_estimator_map_dataset_exposure(simple_dataset):
                                 edisp = simple_dataset.edisp)
 
     simple_dataset_no_mask.models = [model]
-    simple_dataset_no_mask.npred()
 
     result_no_mask = estimator.run(simple_dataset_no_mask)
     assert_allclose(result_no_mask["npred_excess"].data.sum(), 19733.602, rtol=1e-3)


### PR DESCRIPTION
This PR fixes issue #3983 and makes the mask a `Map` object when the input dataset doesn't have one.

It also expands one of the tests so that this situation is covered.
