### PR TITLE
Correct links in documentation

### DIFF
--- a/docs/development/dev_howto.rst
+++ b/docs/development/dev_howto.rst
@@ -281,8 +281,7 @@ Another option is to pass an integer seed to every function that generates rando
     stuff1 = make_some_random_stuff(random_state=seed)
     stuff2 = make_more_random_stuff(random_state=seed)
 
-This pattern was inspired by the way
-`scikit-learn handles random numbers <http://scikit-learn.org/stable/developers/#random-numbers>`__.
+This pattern was inspired by the way scikit-learn handles random numbers.
 We have changed the ``None`` option of ``sklearn.utils.check_random_state`` to ``'global-rng'``,
 because we felt that this meaning for ``None`` was confusing given that `numpy.random.RandomState`
 uses a different meaning (for which we use the option ``'global-rng'``).

--- a/docs/development/pigs/pig-018.rst
+++ b/docs/development/pigs/pig-018.rst
@@ -311,7 +311,7 @@ weeks, but also in 2020 and after.
 .. _Scipy documentation user survey:  https://forms.gle/eK3x2ohJs1sLPJEk8
 .. _Google season of docs: https://developers.google.com/season-of-docs/
 .. _documentation principles: https://www.writethedocs.org/guide/writing/docs-principles/
-.. _Gammapy changelog: https://docs.gammapy.org/dev/changelog.html
+.. _Gammapy changelog: https://docs.gammapy.org/0.19/changelog.html
 .. _maps: https://docs.gammapy.org/0.14/maps/index.html
 .. _modeling: https://docs.gammapy.org/0.14/modeling/index.html
 .. _cube: https://docs.gammapy.org/0.14/cube/index.html

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -126,7 +126,7 @@
 .. _Fermi-LAT time systems in a nutshell: https://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_Data/Time_in_ScienceTools.html
 .. _FTOOLS: https://heasarc.gsfc.nasa.gov/ftools/ftools_menu.html
 .. _XSpec: https://heasarc.gsfc.nasa.gov/xanadu/xspec/
-.. _XSpec manual statistics page: https://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
+.. _XSpec manual statistics page: https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
 .. _Sherpa statistics page: https://cxc.cfa.harvard.edu/sherpa/statistics
 .. _XML schema: https://en.wikipedia.org/wiki/XML_schema
 .. _setuptools console_scripts entry point: https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html

--- a/docs/tutorials/api/makers.ipynb
+++ b/docs/tutorials/api/makers.ipynb
@@ -227,7 +227,7 @@
     "If the background energy dependent morphology is well reproduced by the background model\n",
     "stored in the IRF, it might be that its normalization is incorrect and that some spectral\n",
     "corrections are necessary. This is made possible thanks to the `~gammapy.makers.FoVBackgroundMaker`.\n",
-    "This technique is recommended in most 3D data reductions. For more details and usage, see [fov_background](https://docs.gammapy.org/dev/makers/fov.html).\n",
+    "This technique is recommended in most 3D data reductions. For more details and usage, see [fov_background](../../user-guide/makers/fov.rst).\n",
     "\n",
     "Here we are going to use a `~gammapy.makers.FoVBackgroundMaker` that will rescale the background model to the data excluding the region where a known source is present. For more details on the way to create exclusion masks see the [mask maps](mask_maps.ipynb) notebook.\n"
    ]
@@ -263,7 +263,7 @@
     "in the `~gammapy.makers.RingBackgroundMaker` which transforms the Dataset in a `MapDatasetOnOff`.\n",
     "This technique is mostly used for imaging, and should not be applied for 3D modeling and fitting.\n",
     "\n",
-    "For more details and usage, see [ring_background](https://docs.gammapy.org/dev/makers/ring.html).\n",
+    "For more details and usage, see [ring_background](../../user-guide/makers/ring.rst).\n",
     "\n",
     "\n",
     "### Reflected regions background\n",
@@ -276,7 +276,7 @@
     "`SpectrumDataset` in a `SpectrumDatasetOnOff`. This technique is only used for 1D spectral\n",
     "analysis.\n",
     "\n",
-    "For more details and usage, see [reflected_background](https://docs.gammapy.org/dev/makers/reflected.html).\n",
+    "For more details and usage, see [reflected_background](../../user-guide/makers/reflected.rst).\n",
     "\n",
     "\n",
     "## Data reduction loop\n",
@@ -418,7 +418,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -432,7 +432,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.13"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/docs/tutorials/api/mask_maps.ipynb
+++ b/docs/tutorials/api/mask_maps.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "Note that a dataset contains also a `mask_safe` attribute that is created and filled during \n",
     "data reduction. It is not to be modified directly by users. The `mask_safe` is defined only from \n",
-    "the options passed to the `~gammapy.makers.SafeMaskMaker` (More details [here](https://docs.gammapy.org/dev/makers/index.html#safe-data-range-handling)).\n",
+    "the options passed to the `~gammapy.makers.SafeMaskMaker` (More details [here](makers.ipynb#safe-data-range-handling)).\n",
     "\n",
     "### Exclusion masks\n",
     "\n",
@@ -724,7 +724,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -738,7 +738,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.13"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/docs/tutorials/data/hess.ipynb
+++ b/docs/tutorials/data/hess.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "[H.E.S.S.](https://www.mpi-hd.mpg.de/hfm/HESS/) is an array of gamma-ray telescopes located in Namibia. Gammapy is regularly used and fully supports H.E.S.S. high level data analysis, after export to the current [open data level 3 format](https://gamma-astro-data-formats.readthedocs.io/).\n",
     "\n",
-    "The H.E.S.S. data is private, and H.E.S.S. analysis is mostly documented and discussed at https://hess-confluence.desy.de/ and in H.E.S.S.-internal communication channels. However, in 2018, a small sub-set of archival H.E.S.S. data was publicly released, called the [H.E.S.S. DL3 DR1](https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/), the data level 3, data release number 1. This dataset is 50 MB in size and is used in many Gammapy analysis tutorials, and can be downloaded via [gammapy download](https://docs.gammapy.org/dev/scripts/index.html?highlight=download).\n",
+    "The H.E.S.S. data is private, and H.E.S.S. analysis is mostly documented and discussed at https://hess-confluence.desy.de/ and in H.E.S.S.-internal communication channels. However, in 2018, a small sub-set of archival H.E.S.S. data was publicly released, called the [H.E.S.S. DL3 DR1](https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/), the data level 3, data release number 1. This dataset is 50 MB in size and is used in many Gammapy analysis tutorials, and can be downloaded via [gammapy download](https://docs.gammapy.org/dev/getting-started/index.html#quickstart-setup).\n",
     "\n",
     "This notebook is a quick introduction to this specific DR1 release. It briefly describes H.E.S.S. data and instrument responses and show a simple exploration of the data with the creation of theta-squared plot.\n",
     "\n",
@@ -313,7 +313,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -327,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/starting/analysis_1.ipynb
+++ b/docs/tutorials/starting/analysis_1.ipynb
@@ -118,7 +118,7 @@
    "source": [
     "We want to use Crab runs from the H.E.S.S. DL3-DR1. We define here the datastore and a cone search of observations pointing with 5 degrees of the Crab nebula. Parameters can be set directly or as a python dict.\n",
     "\n",
-    "PS: do not forget to setup your environment variable _$GAMMAPY\\_DATA_ to your local directory containing the H.E.S.S. DL3-DR1 as described in [getting started](https://docs.gammapy.org/dev/getting-started/index.html#download-tutorials)."
+    "PS: do not forget to setup your environment variable _$GAMMAPY\\_DATA_ to your local directory containing the H.E.S.S. DL3-DR1 as described in [getting started](../../getting-started/index.rst#quickstart-setup)."
    ]
   },
   {
@@ -711,7 +711,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/tutorials/starting/overview.ipynb
+++ b/docs/tutorials/starting/overview.ipynb
@@ -222,7 +222,7 @@
    "id": "bbd51d4d",
    "metadata": {},
    "source": [
-    "To show the image on the screen we can use the ``plot`` method. It basically calls [plt.imshow](http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.imshow), passing the `gc_3fhl.data` attribute but in addition handles axis with world coordinates using [astropy.visualization.wcsaxes](https://docs.astropy.org/en/stable/visualization/wcsaxes/) and defines some defaults for nicer plots (e.g. the colormap 'afmhot'):"
+    "To show the image on the screen we can use the ``plot`` method. It basically calls [plt.imshow](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html), passing the `gc_3fhl.data` attribute but in addition handles axis with world coordinates using [astropy.visualization.wcsaxes](https://docs.astropy.org/en/stable/visualization/wcsaxes/) and defines some defaults for nicer plots (e.g. the colormap 'afmhot'):"
    ]
   },
   {
@@ -598,7 +598,7 @@
     "### Exercises\n",
     "\n",
     "* Try to load the Fermi-LAT 2FHL catalog and check the total number of sources it contains.\n",
-    "* Select all the sources from the 2FHL catalog which are contained in the Galactic Center region. The methods `~gammapy.maps.WcsGeom.contains()` and `~gammapy.catalog.SourceCatalog.positions` might be helpful for this. Add markers for all these sources and try to add labels with the source names. The function [ax.text()](http://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.text.html#matplotlib.axes.Axes.text) might be also helpful.\n",
+    "* Select all the sources from the 2FHL catalog which are contained in the Galactic Center region. The methods `~gammapy.maps.WcsGeom.contains()` and `~gammapy.catalog.SourceCatalog.positions` might be helpful for this. Add markers for all these sources and try to add labels with the source names. \n",
     "* Try to find the source class of the object at position ra=68.6803, dec=9.3331\n",
     " "
    ]
@@ -833,7 +833,7 @@
  "metadata": {
   "file_extension": ".py",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -847,13 +847,13 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.13"
   },
   "mimetype": "text/x-python",
   "name": "python",
   "npconvert_exporter": "python",
   "pygments_lexer": "ipython3",
-  "version": 3.0
+  "version": 3
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1209,7 +1209,7 @@ class SourceCatalogObject3FHL(SourceCatalogObjectFermiBase):
 class SourceCatalog3FGL(SourceCatalog):
     """Fermi-LAT 3FGL source catalog.
 
-    - https://ui.adsabs.harvard.edu/#abs/2015ApJS..218...23A
+    - https://ui.adsabs.harvard.edu/abs/2015ApJS..218...23A
     - https://fermi.gsfc.nasa.gov/ssc/data/access/lat/4yr_catalog/
 
     One source is represented by `~gammapy.catalog.SourceCatalogObject3FGL`.

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -28,7 +28,7 @@ class FluxPointsEstimator(FluxEstimator):
     for details.
 
     The method is also described in the Fermi-LAT catalog paper
-    https://ui.adsabs.harvard.edu/#abs/2015ApJS..218...23A
+    https://ui.adsabs.harvard.edu/abs/2015ApJS..218...23A
     or the HESS Galactic Plane Survey paper
     https://ui.adsabs.harvard.edu/#abs/2018A%26A...612A...1H
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -119,7 +119,7 @@ def make_map_background_irf(
         - If a `~astropy.coordinates.SkyCoord` is passed, FOV frame rotation is not taken into account.
     ontime : `~astropy.units.Quantity`
         Observation ontime. i.e. not corrected for deadtime
-        see https://gamma-astro-data-formats.readthedocs.io/en/stable/irfs/full_enclosure/bkg/index.html#notes)
+        see https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/full_enclosure/bkg/index.html#notes)
     bkg : `~gammapy.irf.Background3D`
         Background rate model
     geom : `~gammapy.maps.WcsGeom`


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects a number of broken links in the documentation. In particular, there are links to the main documentation in the notebooks that were given as absolute path to the html file.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
