### PR TITLE
MNT: Raise error rather than silently proceed

### DIFF
--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -20,6 +20,7 @@ def progress_download(source, destination):
         from tqdm import tqdm
     except ImportError:
         log.error("To use gammapy download install the tqdm and requests packages")
+        raise
         return
 
     destination.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This has tricked me a bit, I don't think it has any sense to proceed if any of the dependencies for the download are missing. Compare the two tracebacks:

```
INFO:gammapy.scripts.download:Downloading datasets from https://github.com/gammapy/gammapy-data/tarball/master
ERROR:gammapy.scripts.download:To use gammapy download install the tqdm and requests packages
INFO:gammapy.scripts.download:Extracting gammapy-datasets/datasets.tar.gz
Traceback (most recent call last):
  File "/Users/bsipocz/.pyenv/versions/3.10.0/bin/gammapy", line 33, in <module>
    sys.exit(load_entry_point('gammapy', 'console_scripts', 'gammapy')())
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/bsipocz/munka/devel/gammapy/gammapy/scripts/download.py", line 119, in cli_download_datasets
    extract_bundle(tar_destination_file, localfolder)
  File "/Users/bsipocz/munka/devel/gammapy/gammapy/scripts/download.py", line 54, in extract_bundle
    with tarfile.open(bundle) as tar:
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/tarfile.py", line 1613, in open
    return func(name, "r", fileobj, **kwargs)
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/tarfile.py", line 1679, in gzopen
    fileobj = GzipFile(name, mode + "b", compresslevel, fileobj)
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/gzip.py", line 174, in __init__
    fileobj = self.myfileobj = builtins.open(filename, mode or 'rb')
FileNotFoundError: [Errno 2] No such file or directory: 'gammapy-datasets/datasets.tar.gz'
```


vs 

```
INFO:gammapy.scripts.download:Downloading datasets from https://github.com/gammapy/gammapy-data/tarball/master
ERROR:gammapy.scripts.download:To use gammapy download install the tqdm and requests packages
Traceback (most recent call last):
  File "/Users/bsipocz/.pyenv/versions/3.10.0/bin/gammapy", line 33, in <module>
    sys.exit(load_entry_point('gammapy', 'console_scripts', 'gammapy')())
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/bsipocz/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/bsipocz/munka/devel/gammapy/gammapy/scripts/download.py", line 118, in cli_download_datasets
    progress_download(TAR_DATASETS, tar_destination_file)
  File "/Users/bsipocz/munka/devel/gammapy/gammapy/scripts/download.py", line 21, in progress_download
    from tqdm import tqdm
ModuleNotFoundError: No module named 'tqdm'
```