### PR TITLE
Add template generation of quickstart in documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 PROJECT = gammapy
 CYTHON ?= cython
+version = dev
+release = $(version)
 
 help:
 	@echo ''
@@ -94,11 +96,13 @@ clean-nb:
 	python -m gammapy jupyter --src=docs --r strip
 
 docs-sphinx:
+	cd docs && python generate_quickstart.py $(release)
 	cd docs && python -m sphinx . _build/html -b html -j auto
 
 docs-all:
-	python -m gammapy jupyter tar --out docs/_downloads/notebooks-dev.tar
+	python -m gammapy jupyter tar --out docs/_downloads/notebooks-$(release).tar
 	python -m gammapy.utils.notebooks_process --src="$(src)"
+	cd docs && python generate_quickstart.py $(release)
 	cd docs && python -m sphinx . _build/html -b html -j auto
 	python -m gammapy.utils.notebooks_links --src="$(src)"
 

--- a/docs/generate_quickstart.py
+++ b/docs/generate_quickstart.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+#
+# Builds quickstart section for Gammapy documentation
+import sys
+#from gammapy import __version__ as version
+
+template_quickstart = """
+.. _quickstart-setup:
+
+Quickstart Setup
+----------------
+
+The best way to get started and learn Gammapy are the :ref:`tutorials`. For
+convenience we provide a pre-defined conda environment file, so you can
+get additional useful packages together with Gammapy in a virtual isolated
+environment. First install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`__
+and then just execute the following commands in the terminal:
+
+.. code-block:: bash
+
+    $ curl -O https://gammapy.org/download/install/gammapy-version-environment.yml
+    $ conda env create -f gammapy-version-environment.yml
+
+.. note::
+
+    On Windows, you have to open up the conda environment file and delete the
+    lines with ``sherpa`` and ``healpy``. Those are optional dependencies that
+    currently aren't available on Windows.
+
+Once the environment has been created you can activate it using:
+
+.. code-block:: bash
+
+    $ conda activate gammapy-version
+"""
+
+template_download = """
+.. _download-datasets:
+
+You can now proceed to download the Gammapy tutorial notebooks and the example
+datasets. The total size to download is ~180 MB. Select the location where you
+want to install the datasets and proceed with the following commands:
+
+.. code-block:: bash
+
+    $ gammapy download notebooks --release version
+    $ gammapy download datasets
+    $ export GAMMAPY_DATA=$PWD/gammapy-datasets
+    
+ou might want to put the definition of the ``$GAMMAPY_DATA`` environment
+variable in your shell profile setup file that is executed when you open a new
+terminal (for example ``$HOME/.bash_profile``).
+
+.. note::
+
+    If you are not using the ``bash`` shell, handling of shell environment variables
+    might be different, e.g. in some shells the command to use is ``set`` or something
+    else instead of ``export``, and also the profile setup file will be different.
+    On Windows, you should set the ``GAMMAPY_DATA`` environment variable in the
+    "Environment Variables" settings dialog, as explained e.g.
+    `here <https://docs.python.org/3/using/windows.html#excursus-setting-environment-variables>`__
+
+Finally start a notebook server by executing:
+
+.. code-block:: bash
+
+    $ cd notebooks
+    $ jupyter notebook
+    
+"""
+
+def replace_version(template_str, version):
+    new_content = template_str.replace("version", version)
+    return new_content
+
+def main():
+    version = sys.argv[1]
+    fp = open('getting-started/quickstart.inc', 'w')
+    if "dev" not in version:
+        fp.write(replace_version(template_quickstart, version))
+
+    fp = open('getting-started/download.inc', 'w')
+    if "dev" not in version:
+        fp.write(replace_version(template_download, version))
+
+if __name__ == "__main__":
+    main()

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -55,63 +55,11 @@ Installation
         :text: Learn more
         :classes: btn-secondary stretched-link
 
-.. _quickstart-setup:
+.. include:: quickstart.inc
 
-Quickstart Setup
-----------------
+.. include:: download.inc
 
-The best way to get started and learn Gammapy are the :ref:`tutorials`. For
-convenience we provide a pre-defined conda environment file, so you can
-get additional useful packages together with Gammapy in a virtual isolated
-environment. First install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`__
-and then just execute the following commands in the terminal:
 
-.. code-block:: bash
-
-    $ curl -O https://gammapy.org/download/install/gammapy-0.20.1-environment.yml
-    $ conda env create -f gammapy-0.20.1-environment.yml
-
-.. note::
-
-    On Windows, you have to open up the conda environment file and delete the
-    lines with ``sherpa`` and ``healpy``. Those are optional dependencies that
-    currently aren't available on Windows.
-
-Once the environment has been created you can activate it using:
-
-.. code-block:: bash
-
-    $ conda activate gammapy-0.20.1
-
-You can now proceed to download the Gammapy tutorial notebooks and the example
-datasets. The total size to download is ~180 MB. Select the location where you
-want to install the datasets and proceed with the following commands:
-
-.. code-block:: bash
-
-    $ gammapy download notebooks --release 0.20.1
-    $ gammapy download datasets
-    $ export GAMMAPY_DATA=$PWD/gammapy-datasets
-
-You might want to put the definition of the ``$GAMMAPY_DATA`` environment
-variable in your shell profile setup file that is executed when you open a new
-terminal (for example ``$HOME/.bash_profile``).
-
-.. note::
-
-    If you are not using the ``bash`` shell, handling of shell environment variables
-    might be different, e.g. in some shells the command to use is ``set`` or something
-    else instead of ``export``, and also the profile setup file will be different.
-    On Windows, you should set the ``GAMMAPY_DATA`` environment variable in the
-    "Environment Variables" settings dialog, as explained e.g.
-    `here <https://docs.python.org/3/using/windows.html#excursus-setting-environment-variables>`__
-
-Finally start a notebook server by executing:
-
-.. code-block:: bash
-
-    $ cd notebooks
-    $ jupyter notebook
 
 If you are new to conda, Python and Jupyter, maybe also read the :ref:`using-gammapy` guide.
 If you encountered any issues you can check the :ref:`troubleshoot` guide.


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a proposal to help simplify the release process w.r.t. doc generation.

- First the Makefile is modified to avoid the necessity of performing part of step 3 described in dev doc:
```
In the 0.14/docs/_downloads folder, rename notebooks-dev.tar file as notebooks-0.14.tar.
```
- Second a python script is added to generate the quick start and gammapy download sections of the getting started
  - The section is included for a release but not for a dev version. This avoids the inconsistency with the versioning in the dev doc.
- Third the Makefile is adapted to automatically create the files before compiling the doc.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This is a proposal two remove two manual steps in the release process. It is a first step towards a possible automation of the doc deployment.

Some of the solutions proposed are not ideal e.g. having the text of the quick start in a python script is not very intuitive.

Note that it is not possible to use the sphinx substitution mechanism in the `code-block` hence the proposal to programmatically generate the code block. 

Note that this requires testing. But I am not sure where to put the tests.