### PR TITLE
Modify Makefile to add release number to notebook tar file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 PROJECT = gammapy
 CYTHON ?= cython
+version = dev
+release = $(version)
 
 help:
 	@echo ''
@@ -97,7 +99,7 @@ docs-sphinx:
 	cd docs && python -m sphinx . _build/html -b html -j auto
 
 docs-all:
-	python -m gammapy jupyter tar --out docs/_downloads/notebooks-dev.tar
+	python -m gammapy jupyter tar --out docs/_downloads/notebooks-$(release).tar
 	python -m gammapy.utils.notebooks_process --src="$(src)"
 	cd docs && python -m sphinx . _build/html -b html -j auto
 	python -m gammapy.utils.notebooks_links --src="$(src)"

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -62,14 +62,9 @@ Steps for the day of the release:
 
    * `<https://docs.astropy.org/en/stable/development/astropy-package-template.html>`__.
 
-#. In the `gammapy repo <https://github.com/gammapy/gammapy>`__:
-
-   * Edit ``docs/getting-started/index.rst`` and change the version numbers in the text.
-
 #. In the `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__:
 
    * Copy the ``docs/dev`` folder as a new ``docs/0.14`` folder.
-   * In the ``0.14/docs/_downloads`` folder, rename ``notebooks-dev.tar`` file as ``notebooks-0.14.tar``.
    * Edit ``stable/index.html`` to point to ``0.14/index.html``.
    * Edit ``stable/switcher.json`` to add the new version.
 

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -64,7 +64,7 @@ Steps for the day of the release:
 
 #. In the `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__:
 
-   * Copy the ``docs/dev`` folder as a new ``docs/0.14`` folder.
+   * Follow the stable documentation procedure.
    * Edit ``stable/index.html`` to point to ``0.14/index.html``.
    * Edit ``stable/switcher.json`` to add the new version.
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies the `Makefile` so that `make docs-all release=0.20.1` produces directly notebooks-0.20.1.tar. This avoids a manual operation in the release process.

The release how to documentation is updated.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
