### PR TITLE
Avoid unnecessary copy in Map.stack

### DIFF
--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -421,7 +421,8 @@ class HpxNDMap(HpxMap):
 
         data = other.quantity.to_value(self.unit)
 
-        if nan_to_num:
+        if nan_to_num and np.any(~np.isfinite(data)):
+            data = data.copy()
             data[~np.isfinite(data)] = 0
 
         if weights is not None:

--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -421,9 +421,11 @@ class HpxNDMap(HpxMap):
 
         data = other.quantity.to_value(self.unit)
 
-        if nan_to_num and np.any(~np.isfinite(data)):
-            data = data.copy()
-            data[~np.isfinite(data)] = 0
+        if nan_to_num:
+            not_finite = ~np.isfinite(data)
+            if np.any(not_finite):
+                data = data.copy()
+                data[not_finite] = 0
 
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():

--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -422,7 +422,6 @@ class HpxNDMap(HpxMap):
         data = other.quantity.to_value(self.unit)
 
         if nan_to_num:
-            data = data.copy()
             data[~np.isfinite(data)] = 0
 
         if weights is not None:

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -642,7 +642,8 @@ class RegionNDMap(Map):
 
         # TODO: re-think stacking of regions. Is making the union reasonable?
         # self.geom.union(other.geom)
-        if nan_to_num:
+        if nan_to_num and np.any(~np.isfinite(data)):
+            data = data.copy()
             data[~np.isfinite(data)] = 0
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -643,7 +643,6 @@ class RegionNDMap(Map):
         # TODO: re-think stacking of regions. Is making the union reasonable?
         # self.geom.union(other.geom)
         if nan_to_num:
-            data = data.copy()
             data[~np.isfinite(data)] = 0
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -642,9 +642,11 @@ class RegionNDMap(Map):
 
         # TODO: re-think stacking of regions. Is making the union reasonable?
         # self.geom.union(other.geom)
-        if nan_to_num and np.any(~np.isfinite(data)):
-            data = data.copy()
-            data[~np.isfinite(data)] = 0
+        if nan_to_num:
+            not_finite = ~np.isfinite(data)
+            if np.any(not_finite):
+                data = data.copy()
+                data[not_finite] = 0
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():
                 raise ValueError("Incompatible geoms between map and weights")

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -848,7 +848,6 @@ class WcsNDMap(WcsMap):
 
         data = other.quantity[cutout_slices].to_value(self.unit)
         if nan_to_num:
-            data = data.copy()
             data[~np.isfinite(data)] = 0
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -847,9 +847,11 @@ class WcsNDMap(WcsMap):
             )
 
         data = other.quantity[cutout_slices].to_value(self.unit)
-        if nan_to_num and np.any(~np.isfinite(data)):
-            data = data.copy()
-            data[~np.isfinite(data)] = 0
+        if nan_to_num:
+            not_finite = ~np.isfinite(data)
+            if np.any(not_finite):
+                data = data.copy()
+                data[not_finite] = 0
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():
                 raise ValueError("Incompatible spatial geoms between map and weights")

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -847,7 +847,8 @@ class WcsNDMap(WcsMap):
             )
 
         data = other.quantity[cutout_slices].to_value(self.unit)
-        if nan_to_num:
+        if nan_to_num and np.any(~np.isfinite(data)):
+            data = data.copy()
             data[~np.isfinite(data)] = 0
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():


### PR DESCRIPTION
Remove unnecessary copy in Map.stack before replacing nan values