### PR TITLE
Computation of the WcsMap kernel at the nearest valid exposure

### DIFF
--- a/gammapy/datasets/utils.py
+++ b/gammapy/datasets/utils.py
@@ -23,3 +23,12 @@ def get_axes(ax1, ax2, width, height, args1, args2, kwargs1=None, kwargs2=None):
         raise ValueError("Either both or no Axes must be provided")
 
     return ax1, ax2
+
+
+def get_nearest_valid_exposure_position(exposure, position=None):
+    import numpy as np
+    mask_exposure = exposure > 0.0*exposure.unit
+    mask_exposure = mask_exposure.reduce_over_axes(func=np.logical_or)
+    if not position:
+        position = mask_exposure.geom.center_skydir
+    return mask_exposure.mask_nearest_position(position)

--- a/gammapy/datasets/utils.py
+++ b/gammapy/datasets/utils.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 def get_figure(fig, width, height):
     import matplotlib.pyplot as plt
 
@@ -26,7 +29,6 @@ def get_axes(ax1, ax2, width, height, args1, args2, kwargs1=None, kwargs2=None):
 
 
 def get_nearest_valid_exposure_position(exposure, position=None):
-    import numpy as np
     mask_exposure = exposure > 0.0*exposure.unit
     mask_exposure = mask_exposure.reduce_over_axes(func=np.logical_or)
     if not position:

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -59,6 +59,7 @@ def input_dataset():
     mask2D_data[0:40, :] = False
     mask2D = Map.from_geom(geom=counts2D.geom, data=mask2D_data)
     mask = mask2D.to_cube([energy])
+
     name = "test-dataset"
     return MapDataset(
         counts=counts,

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -116,7 +116,6 @@ def test_compute_ts_map(input_dataset):
     assert_allclose(kernel.data.sum(), 1.0)
 
     result = ts_estimator.run(input_dataset)
-
     assert_allclose(result["ts"].data[0, 99, 99], 1704.23, rtol=1e-2)
     assert_allclose(result["niter"].data[0, 99, 99], 7)
     assert_allclose(result["flux"].data[0, 99, 99], 1.02e-09, rtol=1e-2)

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose, assert_raises
+from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import Angle
 from gammapy.datasets import MapDataset
@@ -273,5 +273,5 @@ def test_compute_ts_map_with_hole(fake_dataset):
     assert_allclose(kernel.data.sum(), 1.0)
 
     holes_dataset.exposure.data[...] = 0.
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         kernel = ts_estimator.estimate_kernel(dataset=holes_dataset)

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -259,7 +259,7 @@ def test_ts_map_with_model(fake_dataset):
 def test_compute_ts_map_with_hole(fake_dataset):
     """Test of compute_ts_image with a null exposure at the center of the map"""
     i, j, ie = fake_dataset.exposure.geom.center_pix
-    fake_dataset.exposure.data[:, int(i), int(j)] = 0.
+    fake_dataset.exposure.data[:, np.int_(i), np.int_(j)] = 0.
 
     spatial_model = GaussianSpatialModel(sigma="0.1 deg")
     spectral_model = PowerLawSpectralModel(index=2)

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -239,7 +239,13 @@ class TSMapEstimator(Estimator):
         # Creating exposure map with exposure at map center
         exposure = Map.from_geom(geom, unit="cm2 s1")
         exposure_center = dataset.exposure.to_region_nd_map(geom.center_skydir)
-        exposure.data[...] = exposure_center.data
+        if np.sum(exposure_center.data) > 0:
+            exposure.data[...] = exposure_center.data
+        else:
+            # TODO: if one applies the mask here, one supposes that energy=energy_true
+            # mean = np.mean(dataset.exposure.data[dataset.mask.data])
+            mean = np.mean(dataset.exposure.data)
+            exposure.data[...] = mean
 
         # We use global evaluation mode to not modify the geometry
         evaluator = MapEvaluator(model=model)

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -243,7 +243,7 @@ class TSMapEstimator(Estimator):
         exposure_position = dataset.exposure.to_region_nd_map(position)
         if not np.any(exposure_position.data):
             raise ValueError("The exposure is null. Impossible to convolve the model with the PSFKernel.")
-        exposure.data[...] = exposure_position.data
+        exposure.data[...] = exposure_position.quantity.to_value(exposure.unit)
 
         # We use global evaluation mode to not modify the geometry
         evaluator = MapEvaluator(model=model)

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -242,7 +242,7 @@ class TSMapEstimator(Estimator):
         position = get_nearest_valid_exposure_position(dataset.exposure, geom.center_skydir)
         exposure_position = dataset.exposure.to_region_nd_map(position)
         if not np.any(exposure_position.data):
-            raise ValueError("The exposure is null. Impossible to convolve the model with the PSFKernel.")
+            raise ValueError("No valid exposure. Impossible to compute kernel for TS Map.")
         exposure.data[...] = exposure_position.quantity.to_value(exposure.unit)
 
         # We use global evaluation mode to not modify the geometry

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -239,6 +239,8 @@ class TSMapEstimator(Estimator):
         # Creating exposure map with the mean non-null exposure
         exposure = Map.from_geom(geom, unit="cm2 s1")
         exposure_mask = (dataset.exposure.data > 0.) & np.isfinite(dataset.exposure.data)
+        if dataset.mask:
+            exposure_mask &= dataset.mask.data
         exposure.data[...] = np.mean(dataset.exposure.quantity[exposure_mask].to_value(exposure.unit))
 
         # We use global evaluation mode to not modify the geometry

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -239,12 +239,10 @@ class TSMapEstimator(Estimator):
         # Creating exposure map with the mean non-null exposure
         exposure = Map.from_geom(geom, unit="cm2 s1")
         exposure_mask = (dataset.exposure.data > 0.) & np.isfinite(dataset.exposure.data)
-        # Does not work as the 'energy' axis names are different for the exposure and the mask
-        # if dataset.mask:
-        #     exposure_spatial = exposure.reduce_over_axes(func=np.logical_or).data
-        #     mask_spatial = dataset.mask.reduce_over_axes(func=np.logical_or).data
-        #     exposure_mask &= mask_spatial.interp_to_geom(exposure_spatial)[np.newaxis, :, :]
-        #     # exposure_mask &= dataset.mask.interp_to_geom(dataset.exposure.geom).data
+        if dataset.mask:
+            local_mask = dataset.mask.copy()
+            local_mask.geom._axes[0]._name = "energy_true"
+            exposure_mask &= local_mask.interp_to_geom(dataset.exposure.geom).data
         if not np.any(exposure_mask):
             raise ValueError("The exposure is null. Impossible to convolve the model with the PSFKernel.")
 

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -238,7 +238,8 @@ class TSMapEstimator(Estimator):
 
         # Creating exposure map with the mean non-null exposure
         exposure = Map.from_geom(geom, unit="cm2 s1")
-        exposure.data[...] = np.mean(dataset.exposure.data[dataset.exposure.data > 0.])
+        exposure_mask = (dataset.exposure.data > 0.) & np.isfinite(dataset.exposure.data)
+        exposure.data[...] = np.mean(dataset.exposure.quantity[exposure_mask].to_value(exposure.unit))
 
         # We use global evaluation mode to not modify the geometry
         evaluator = MapEvaluator(model=model)

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -239,8 +239,15 @@ class TSMapEstimator(Estimator):
         # Creating exposure map with the mean non-null exposure
         exposure = Map.from_geom(geom, unit="cm2 s1")
         exposure_mask = (dataset.exposure.data > 0.) & np.isfinite(dataset.exposure.data)
-        if dataset.mask:
-            exposure_mask &= dataset.mask.data
+        # Does not work as the 'energy' axis names are different for the exposure and the mask
+        # if dataset.mask:
+        #     exposure_spatial = exposure.reduce_over_axes(func=np.logical_or).data
+        #     mask_spatial = dataset.mask.reduce_over_axes(func=np.logical_or).data
+        #     exposure_mask &= mask_spatial.interp_to_geom(exposure_spatial)[np.newaxis, :, :]
+        #     # exposure_mask &= dataset.mask.interp_to_geom(dataset.exposure.geom).data
+        if not np.any(exposure_mask):
+            raise ValueError("The exposure is null. Impossible to convolve the model with the PSFKernel.")
+
         exposure.data[...] = np.mean(dataset.exposure.quantity[exposure_mask].to_value(exposure.unit))
 
         # We use global evaluation mode to not modify the geometry

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -238,12 +238,12 @@ class TSMapEstimator(Estimator):
         model.spatial_model.position = geom.center_skydir
 
         # Creating exposure map with the mean non-null exposure
-        exposure = Map.from_geom(geom, unit="cm2 s1")
+        exposure = Map.from_geom(geom, unit=dataset.exposure.unit)
         position = get_nearest_valid_exposure_position(dataset.exposure, geom.center_skydir)
         exposure_position = dataset.exposure.to_region_nd_map(position)
         if not np.any(exposure_position.data):
             raise ValueError("No valid exposure. Impossible to compute kernel for TS Map.")
-        exposure.data[...] = exposure_position.quantity.to_value(exposure.unit)
+        exposure.data[...] = exposure_position.data
 
         # We use global evaluation mode to not modify the geometry
         evaluator = MapEvaluator(model=model)

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -216,7 +216,7 @@ class TSMapEstimator(Estimator):
     def estimate_kernel(self, dataset):
         """Get the convolution kernel for the input dataset.
 
-        Convolves the model with the IRFs.
+        Convolves the model with the IRFs at the center of the dataset (or at the nearest position with non-null exposure).
 
         Parameters
         ----------

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -240,9 +240,9 @@ class TSMapEstimator(Estimator):
         exposure = Map.from_geom(geom, unit="cm2 s1")
         exposure_mask = (dataset.exposure.data > 0.) & np.isfinite(dataset.exposure.data)
         if dataset.mask:
-            local_mask = dataset.mask.copy()
-            local_mask.geom._axes[0]._name = "energy_true"
-            exposure_mask &= local_mask.interp_to_geom(dataset.exposure.geom).data
+            target_geom = dataset.exposure.geom.copy()
+            target_geom._axes[0]._name = "energy"
+            exposure_mask &= dataset.mask.interp_to_geom(target_geom).data
         if not np.any(exposure_mask):
             raise ValueError("The exposure is null. Impossible to convolve the model with the PSFKernel.")
 


### PR DESCRIPTION
**Description**

This pull request fixes the bug mentioned in the Issue #3707. It changes the computation of the kernel, previously done with the exposure at the centre of the map and now with the mean non-null exposure over the whole map.

**Dear reviewer**
In addition to the change of the computation logics, I have added a test on the kernel values and also a test with a map with bins with null exposure.