### PR TITLE
Introduce consistent .rename_axes and .rename API for maps

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -340,15 +340,22 @@ class MapAxis:
                 unit=self.unit,
             )
     
-    def rename(self, new_name):
+    def rename(self, new_name, copy=True):
         """Rename the axis.
     
         Parameters
         ----------
         new_name : str
-            The new name for the column
+            The new name for the axis.
+        copy : bool
+            Copy or change in place.
         """
-        self._name = new_name
+        if copy:
+            axis = self.copy()
+        else:
+            axis=self
+        axis._name = new_name
+        return axis
 
     def format_plot_xaxis(self, ax):
         """Format plot axis
@@ -2055,7 +2062,7 @@ class MapAxes(Sequence):
             raise ValueError(message)
 
 
-    def rename(self, names, new_names):
+    def rename(self, names, new_names, copy=True):
         """Rename the axes.
     
         Parameters
@@ -2063,15 +2070,21 @@ class MapAxes(Sequence):
         names : list or str
             Names of the axes
         new_names : list or str
-            New names of the axes (list must be of same length than `names`)
+            New names of the axes (list must be of same length than `names`).
+        copy : bool
+            Copy or change in place.
         """
+        if copy:
+            axes = self.copy()
+        else:
+            axes = self
         if isinstance(names, str):
             names = [names]
         if isinstance(new_names, str):
             new_names = [new_names]
         for name, new_name in zip(names, new_names):
-            self[name].rename(new_name)
-
+            self[name].rename(new_name, copy=False)
+        return axes
 
     @property
     def center_coord(self):

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -102,7 +102,9 @@ class MapAxis:
 
     # TODO: Cache an interpolation object?
     def __init__(self, nodes, interp="lin", name="", node_type="edges", unit=""):
-        self._name = name
+        
+        if not isinstance(name, str):
+            raise TypeError(f"Name must be a string, got: {type(name)!r}")
 
         if len(nodes) != len(np.unique(nodes)):
             raise ValueError("MapAxis: node values must be unique")
@@ -116,6 +118,7 @@ class MapAxis:
         else:
             nodes = np.array(nodes)
 
+        self._name = name
         self._unit = u.Unit(unit)
         self._nodes = nodes.astype(float)
         self._node_type = node_type
@@ -2060,7 +2063,7 @@ class MapAxes(Sequence):
             raise ValueError(message)
 
 
-    def rename(self, names, new_names):
+    def rename_axes(self, names, new_names):
         """Rename the axes.
     
         Parameters
@@ -2082,7 +2085,7 @@ class MapAxes(Sequence):
             new_names = [new_names]
         for name, new_name in zip(names, new_names):
             axes[name]._name = new_name
-        return axes
+        return  axes
 
     @property
     def center_coord(self):

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -339,6 +339,16 @@ class MapAxis:
                 node_type=node_type,
                 unit=self.unit,
             )
+    
+    def rename(self, new_name):
+        """Rename the axis.
+    
+        Parameters
+        ----------
+        new_name : str
+            The new name for the column
+        """
+        self._name = new_name
 
     def format_plot_xaxis(self, ax):
         """Format plot axis
@@ -2043,6 +2053,25 @@ class MapAxes(Sequence):
 
         except ValueError:
             raise ValueError(message)
+
+
+    def rename(self, names, new_names):
+        """Rename the axes.
+    
+        Parameters
+        ----------
+        names : list or str
+            Names of the axes
+        new_names : list or str
+            New names of the axes (list must be of same length than `names`)
+        """
+        if isinstance(names, str):
+            names = [names]
+        if isinstance(new_names, str):
+            new_names = [new_names]
+        for name, new_name in zip(names, new_names):
+            self[name].rename(new_name)
+
 
     @property
     def center_coord(self):

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -340,22 +340,20 @@ class MapAxis:
                 unit=self.unit,
             )
     
-    def rename(self, new_name, copy=True):
+    def rename(self, new_name):
         """Rename the axis.
     
         Parameters
         ----------
         new_name : str
             The new name for the axis.
-        copy : bool
-            Copy or change in place.
+
+        Returns
+        -------
+        axis : `~gammapy.maps.MapAxis`
+            Renamed MapAxis
         """
-        if copy:
-            axis = self.copy()
-        else:
-            axis=self
-        axis._name = new_name
-        return axis
+        return self.copy(name=new_name)
 
     def format_plot_xaxis(self, ax):
         """Format plot axis
@@ -2062,7 +2060,7 @@ class MapAxes(Sequence):
             raise ValueError(message)
 
 
-    def rename(self, names, new_names, copy=True):
+    def rename(self, names, new_names):
         """Rename the axes.
     
         Parameters
@@ -2071,19 +2069,19 @@ class MapAxes(Sequence):
             Names of the axes
         new_names : list or str
             New names of the axes (list must be of same length than `names`).
-        copy : bool
-            Copy or change in place.
+        
+        Returns
+        -------
+        axes : `MapAxes`
+            Renamed Map axes object
         """
-        if copy:
-            axes = self.copy()
-        else:
-            axes = self
+        axes = self.copy()
         if isinstance(names, str):
             names = [names]
         if isinstance(new_names, str):
             new_names = [new_names]
         for name, new_name in zip(names, new_names):
-            self[name].rename(new_name, copy=False)
+            axes[name]._name = new_name
         return axes
 
     @property

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -132,6 +132,25 @@ class Map(abc.ABC):
         self.data = val.value
         self._unit = val.unit
 
+    def rename_axes(self, names, new_names):
+        """Rename the Map axes.
+    
+        Parameters
+        ----------
+        names : list or str
+            Names of the axes.
+        new_names : list or str
+            New names of the axes (list must be of same length than `names`).
+
+        Returns
+        -------
+        geom : `~Map`
+            Renamed Map.
+        """
+        map_copy = self.copy()
+        map_copy._geom = map_copy.geom.rename_axes(names, new_names)
+        return map_copy
+
     @staticmethod
     def create(**kwargs):
         """Create an empty map object.

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -147,9 +147,8 @@ class Map(abc.ABC):
         geom : `~Map`
             Renamed Map.
         """
-        map_copy = self.copy()
-        map_copy._geom = map_copy.geom.rename_axes(names, new_names)
-        return map_copy
+        geom = self.geom.rename_axes(names=names, new_names=new_names)
+        return self._init_copy(geom=geom)
 
     @staticmethod
     def create(**kwargs):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -365,9 +365,8 @@ class Geom(abc.ABC):
         geom : `~Geom`
             Renamed geometry.
         """
-        geom = self.copy()
-        geom._axes = geom.axes.rename(names, new_names)
-        return geom
+        axes = self.axes.rename(names=names, new_names=new_names)
+        return self._init_copy(axes=axes)
 
     @property
     def as_energy_true(self):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -365,7 +365,7 @@ class Geom(abc.ABC):
         geom : `~Geom`
             Renamed geometry.
         """
-        axes = self.axes.rename(names=names, new_names=new_names)
+        axes = self.axes.rename_axes(names=names, new_names=new_names)
         return self._init_copy(axes=axes)
 
     @property

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -350,7 +350,7 @@ class Geom(abc.ABC):
         return self._init_copy(axes=axes)
 
 
-    def rename_axes(self, names, new_names, copy=True):
+    def rename_axes(self, names, new_names):
         """Rename the axes in place.
     
         Parameters
@@ -359,19 +359,14 @@ class Geom(abc.ABC):
             Names of the axes.
         new_names : list or str
             New names of the axes (list must be of same length than `names`).
-        copy : bool
-            Copy or change in place.
+
+        Returns
+        -------
+        geom : `~Geom`
+            Renamed geometry.
         """
-        if copy:
-            geom = self.copy()
-        else:
-            geom = self
-        if isinstance(names, str):
-            names = [names]
-        if isinstance(new_names, str):
-            new_names = [new_names]
-        for name, new_name in zip(names, new_names):
-            geom._axes[name].rename(new_name, copy=False)
+        geom = self.copy()
+        geom._axes = geom.axes.rename(names, new_names)
         return geom
 
     @property

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -371,7 +371,7 @@ class Geom(abc.ABC):
     @property
     def as_energy_true(self):
         """If the geom contains an energy axis rename it to energy true"""
-        return  self.rename_axes("energy", "energy_true", copy=True)
+        return  self.rename_axes(name="energy", new_name="energy_true")
 
 
     @property

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -349,11 +349,30 @@ class Geom(abc.ABC):
         axes = self.axes.slice_by_idx(slices)
         return self._init_copy(axes=axes)
 
+
+    def rename_axes(self, names, new_names):
+        """Rename the axes in place.
+    
+        Parameters
+        ----------
+        names : list or str
+            Names of the axes
+        new_names : list or str
+            New names of the axes (list must be of same length than `names`)
+        """
+        if isinstance(names, str):
+            names = [names]
+        if isinstance(new_names, str):
+            new_names = [new_names]
+        for name, new_name in zip(names, new_names):
+            self._axes[name].rename(new_name)
+
     @property
     def as_energy_true(self):
         """If the geom contains an energy axis rename it to energy true"""
         energy_axis = self.axes["energy"].copy(name="energy_true")
         return self.to_image().to_cube([energy_axis])
+
 
     @property
     def has_energy_axis(self):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -351,7 +351,7 @@ class Geom(abc.ABC):
 
 
     def rename_axes(self, names, new_names):
-        """Rename the axes in place.
+        """Rename axes contained in the geometry
     
         Parameters
         ----------

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -371,7 +371,7 @@ class Geom(abc.ABC):
     @property
     def as_energy_true(self):
         """If the geom contains an energy axis rename it to energy true"""
-        return  self.rename_axes(name="energy", new_name="energy_true")
+        return  self.rename_axes(names="energy", new_names="energy_true")
 
 
     @property

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -350,28 +350,34 @@ class Geom(abc.ABC):
         return self._init_copy(axes=axes)
 
 
-    def rename_axes(self, names, new_names):
+    def rename_axes(self, names, new_names, copy=True):
         """Rename the axes in place.
     
         Parameters
         ----------
         names : list or str
-            Names of the axes
+            Names of the axes.
         new_names : list or str
-            New names of the axes (list must be of same length than `names`)
+            New names of the axes (list must be of same length than `names`).
+        copy : bool
+            Copy or change in place.
         """
+        if copy:
+            geom = self.copy()
+        else:
+            geom = self
         if isinstance(names, str):
             names = [names]
         if isinstance(new_names, str):
             new_names = [new_names]
         for name, new_name in zip(names, new_names):
-            self._axes[name].rename(new_name)
+            geom._axes[name].rename(new_name, copy=False)
+        return geom
 
     @property
     def as_energy_true(self):
         """If the geom contains an energy axis rename it to energy true"""
-        energy_axis = self.axes["energy"].copy(name="energy_true")
-        return self.to_image().to_cube([energy_axis])
+        return  self.rename_axes("energy", "energy_true", copy=True)
 
 
     @property

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -286,22 +286,13 @@ def test_rename():
     axis = axis_1.rename("energy_true")
     assert axis_1.name == "energy"
     assert axis.name == "energy_true"
-
-    axis = axis_1.rename("energy_true", copy=False)
-    assert axis_1.name == "energy_true"
-    assert axis.name == "energy_true"
     
     axis_2 = MapAxis.from_bounds(0, 1, nbin=2, unit="deg", name="rad")
-    axis_2.rename("angle", copy=False)
-    assert axis_2.name == "angle"
 
     axes = MapAxes([axis_1, axis_2])
-    axes.rename(["energy_true", "angle"],["energy", "rad"], copy=False)
-    assert axes.names == ["energy", "rad"]
+    axes = axes.rename(["energy", "rad"], ["energy_true", "angle"])
+    assert axes.names == ["energy_true", "angle"]
   
-    axes.rename("energy", "energy_true", copy=False)
-    assert axes.names == ["energy_true", "rad"]
-
 
 @pytest.mark.parametrize(("edges", "interp"), MAP_AXIS_INTERP)
 def test_mapaxis_init_from_edges(edges, interp):

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -283,18 +283,23 @@ def test_map_axes_pad():
 
 def test_rename():
     axis_1 = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=1)
-    axis_1.rename("energy_true")
-    assert axis_1.name == "energy_true"
+    axis = axis_1.rename("energy_true")
+    assert axis_1.name == "energy"
+    assert axis.name == "energy_true"
 
+    axis = axis_1.rename("energy_true", copy=False)
+    assert axis_1.name == "energy_true"
+    assert axis.name == "energy_true"
+    
     axis_2 = MapAxis.from_bounds(0, 1, nbin=2, unit="deg", name="rad")
-    axis_2.rename("angle")
+    axis_2.rename("angle", copy=False)
     assert axis_2.name == "angle"
 
     axes = MapAxes([axis_1, axis_2])
-    axes.rename(["energy_true", "angle"],["energy", "rad"])
+    axes.rename(["energy_true", "angle"],["energy", "rad"], copy=False)
     assert axes.names == ["energy", "rad"]
   
-    axes.rename("energy", "energy_true")
+    axes.rename("energy", "energy_true", copy=False)
     assert axes.names == ["energy_true", "rad"]
 
 

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -69,6 +69,10 @@ def test_mapaxis_repr():
     axis = MapAxis([1, 2, 3], name="test")
     assert "MapAxis" in repr(axis)
 
+def test_mapaxis_invalid_name():
+    with pytest.raises(TypeError):
+        MapAxis([1, 2, 3], name=1)
+
 
 @pytest.mark.parametrize(
     ("nodes", "interp", "node_type", "unit", "name", "result"),
@@ -290,7 +294,7 @@ def test_rename():
     axis_2 = MapAxis.from_bounds(0, 1, nbin=2, unit="deg", name="rad")
 
     axes = MapAxes([axis_1, axis_2])
-    axes = axes.rename(["energy", "rad"], ["energy_true", "angle"])
+    axes = axes.rename_axes(["energy", "rad"], ["energy_true", "angle"])
     assert axes.names == ["energy_true", "angle"]
   
 

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -281,6 +281,22 @@ def test_map_axes_pad():
 
     assert_allclose(axes["energy"].edges, [0.1, 1, 10, 100] * u.TeV)
 
+def test_rename():
+    axis_1 = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=1)
+    axis_1.rename("energy_true")
+    assert axis_1.name == "energy_true"
+
+    axis_2 = MapAxis.from_bounds(0, 1, nbin=2, unit="deg", name="rad")
+    axis_2.rename("angle")
+    assert axis_2.name == "angle"
+
+    axes = MapAxes([axis_1, axis_2])
+    axes.rename(["energy_true", "angle"],["energy", "rad"])
+    assert axes.names == ["energy", "rad"]
+  
+    axes.rename("energy", "energy_true")
+    assert axes.names == ["energy_true", "rad"]
+
 
 @pytest.mark.parametrize(("edges", "interp"), MAP_AXIS_INTERP)
 def test_mapaxis_init_from_edges(edges, interp):

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -594,7 +594,9 @@ def test_rename_axes():
     m_4d = Map.create(
         binsz=1.0, width=(10, 5), frame="galactic", axes=[energy_axis, time_axis]
     )
-    geom = m_4d.geom
-    geom.rename_axes("energy", "energy_true")
+    geom = m_4d.geom.rename_axes("energy", "energy_true")
+    assert m_4d.geom.axes.names == ["energy", "time"]
     assert geom.axes.names == ["energy_true", "time"]
 
+    m_4d.geom.rename_axes("energy", "energy_true", copy=False)
+    assert m_4d.geom.axes.names == ["energy_true", "time"]

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -598,5 +598,6 @@ def test_rename_axes():
     assert m_4d.geom.axes.names == ["energy", "time"]
     assert geom.axes.names == ["energy_true", "time"]
 
-    m_4d.geom.rename_axes("energy", "energy_true", copy=False)
-    assert m_4d.geom.axes.names == ["energy_true", "time"]
+    new_map = m_4d.rename_axes("energy", "energy_true")
+    assert m_4d.geom.axes.names == ["energy", "time"]
+    assert new_map.geom.axes.names == ["energy_true", "time"]

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -579,3 +579,22 @@ def test_split_by_axis():
     )
     maps = m_4d.split_by_axis("time")
     assert len(maps) == 3
+    
+def test_rename_axes():
+    time_axis = MapAxis.from_bounds(
+        0,
+        24,
+        nbin=3,
+        unit="hour",
+        name="time",
+    )
+    energy_axis = MapAxis.from_bounds(
+        1, 100, nbin=2, unit="TeV", name="energy", interp="log"
+    )
+    m_4d = Map.create(
+        binsz=1.0, width=(10, 5), frame="galactic", axes=[energy_axis, time_axis]
+    )
+    geom = m_4d.geom
+    geom.rename_axes("energy", "energy_true")
+    assert geom.axes.names == ["energy_true", "time"]
+


### PR DESCRIPTION
Rename Geom axes
-could be used in https://github.com/gammapy/gammapy/pull/4018#discussion_r913135787
-could be used in `Geom.as_energy_true`
-could  also be useful to rename axes of FITS maps that do not follow the expected convention.