### PR TITLE
Implement IRF.slice_by_idx()

### DIFF
--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -554,6 +554,30 @@ class IRF(metaclass=abc.ABCMeta):
             data=data, axes=axes, meta=self.meta.copy(), unit=self.unit
         )
 
+    def slice_by_idx(self, slices):
+        """Slice sub IRF from IRF object.
+
+        Parameters
+        ----------
+        slices : dict
+            Dict of axes names and `slice` object pairs. Contains one
+            element for each non-spatial dimension. Axes not specified in the
+            dict are kept unchanged.
+
+        Returns
+        -------
+        sliced : `IRF`
+            Sliced IRF object.
+        """
+        axes = self.axes.slice_by_idx(slices)
+
+        if axes.names != self.axes.names:
+            raise ValueError(f"Indexing not supported got {slice}")
+
+        slices = tuple([slices.get(ax.name, slice(None)) for ax in self.axes])
+        data = self.data[slices]
+        return self.__class__(axes=axes, data=data, unit=self.unit, meta=self.meta)
+
     def is_allclose(self, other, rtol_axes=1e-3, atol_axes=1e-6, **kwargs):
         """Compare two data IRFs for equivalency
 

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -571,8 +571,11 @@ class IRF(metaclass=abc.ABCMeta):
         """
         axes = self.axes.slice_by_idx(slices)
 
-        if axes.names != self.axes.names:
-            raise ValueError(f"Indexing not supported got {slice}")
+        diff = set(self.axes.names).difference(axes.names)
+
+        if diff:
+            diff_slice = {key: value for key, value in slices.items() if key in diff}
+            raise ValueError(f"Integer indexing not supported, got {diff_slice}")
 
         slices = tuple([slices.get(ax.name, slice(None)) for ax in self.axes])
         data = self.data[slices]

--- a/gammapy/irf/tests/test_core.py
+++ b/gammapy/irf/tests/test_core.py
@@ -61,3 +61,7 @@ def test_slice_by_idx():
     assert irf_sliced.axes["offset"].nbin == 2
     assert irf_sliced.axes["energy"].nbin == 4
 
+    with pytest.raises(ValueError) as exc_info:
+        _ = irf.slice_by_idx({"energy": 3, "offset": 7})
+
+    assert str(exc_info.value) == "Integer indexing not supported, got {'energy': 3, 'offset': 7}"

--- a/gammapy/irf/tests/test_core.py
+++ b/gammapy/irf/tests/test_core.py
@@ -39,3 +39,25 @@ def test_immutable():
 
     with pytest.raises(AttributeError):
         test_irf.fov_alignment = FoVAlignment.ALTAZ
+
+
+def test_slice_by_idx():
+    energy_axis = MapAxis.from_energy_bounds(10, 100, 10, unit="TeV", name="energy")
+    offset_axis = MapAxis.from_bounds(0, 2.5, 5, unit="deg", name="offset")
+    data = np.full((10, 5), 1)
+
+    irf = TestIRF(axes=[energy_axis, offset_axis], data=data, unit=u.deg)
+
+    irf_sliced = irf.slice_by_idx({"energy": slice(3, 7)})
+    assert irf_sliced.data.shape == (4, 5)
+    assert irf_sliced.axes["energy"].nbin == 4
+
+    irf_sliced = irf.slice_by_idx({"offset": slice(3, 5)})
+    assert irf_sliced.data.shape == (10, 2)
+    assert irf_sliced.axes["offset"].nbin == 2
+
+    irf_sliced = irf.slice_by_idx({"energy": slice(3, 7), "offset": slice(3, 5)})
+    assert irf_sliced.data.shape == (4, 2)
+    assert irf_sliced.axes["offset"].nbin == 2
+    assert irf_sliced.axes["energy"].nbin == 4
+


### PR DESCRIPTION
I came across a use-case for this method in context of the Gammapy paper, so I decided to just implement it here. It includes:
- Implement `IRF.slice_by_idx()`
- A unit test in `gammapy/irf/tests/test_core.py`

Currently there is no support for integer indexing such as `.slice_by_idx({"energy": 0})`, as we have more maps. This is because for IRFs we have fixed axes names, so we cannot drop an axes from the IRF definition.