### PR TITLE
Usage of Compound spectral models for a SkyModel

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -589,9 +589,9 @@
         }
     ],
     "codeRepository": "https://github.com/gammapy/gammapy",
-    "datePublished": "2020-11-19",
+    "datePublished": "2022-06-17",
     "description": "Gammapy analyzes gamma-ray data and creates sky images, spectra and lightcurves, from event lists and instrument response information; it can also determine the position, morphology and spectra of gamma-ray sources. It is used to analyze data from H.E.S.S., Fermi-LAT, and the Cherenkov Telescope Array (CTA).",
-    "identifier": "https://doi.org/10.5281/zenodo.5721467",
+    "identifier": "https://doi.org/10.5281/zenodo.6552377",
     "keywords": [
         "Astronomy",
         "Gamma-rays",
@@ -600,7 +600,7 @@
     "license": "https://spdx.org/licenses/BSD-3-Clause",
     "name": "Gammapy: Python toolbox for gamma-ray astronomy",
     "url": "https://github.com/gammapy/gammapy",
-    "softwareVersion": 0.19,
+    "softwareVersion": "0.20.1",
     "maintainer": {
         "@id": "https://orcid.org/0000-0003-4568-7005",
         "@type": "Person",

--- a/examples/models/spectral/plot_compound.py
+++ b/examples/models/spectral/plot_compound.py
@@ -39,7 +39,7 @@ plt.grid(which="both")
 
 # Multiplication of two spectral models
 nlp = LogParabolaNormSpectralModel(
-    amplitude="1e-1", reference="10 TeV", alpha=2.0, beta=1.0
+    norm="1e-1", reference="10 TeV", alpha=2.0, beta=1.0
 )
 # Info: need to freeze the amplitude to avoid degeneracy when fitting
 nlp.amplitude.frozen = True

--- a/examples/models/spectral/plot_compound.py
+++ b/examples/models/spectral/plot_compound.py
@@ -42,7 +42,7 @@ nlp = LogParabolaNormSpectralModel(
     norm="1e-1", reference="10 TeV", alpha=2.0, beta=1.0
 )
 # Info: need to freeze the amplitude to avoid degeneracy when fitting
-nlp.amplitude.frozen = True
+nlp.norm.frozen = True
 model_mul = nlp * pwl
 model_mul.plot(energy_bounds)
 plt.grid(which="both")

--- a/examples/models/spectral/plot_compound.py
+++ b/examples/models/spectral/plot_compound.py
@@ -18,7 +18,6 @@ import matplotlib.pyplot as plt
 from gammapy.modeling.models import (
     CompoundSpectralModel,
     LogParabolaSpectralModel,
-    LogParabolaNormSpectralModel,
     Models,
     PowerLawSpectralModel,
     SkyModel,
@@ -32,20 +31,10 @@ lp = LogParabolaSpectralModel(
     amplitude="1e-12 cm-2 s-1 TeV-1", reference="10 TeV", alpha=2.0, beta=1.0
 )
 
-# Sum of two spectral models
 model_add = CompoundSpectralModel(pwl, lp, operator.add)
 model_add.plot(energy_bounds)
 plt.grid(which="both")
 
-# Multiplication of two spectral models
-nlp = LogParabolaNormSpectralModel(
-    norm="1e-1", reference="10 TeV", alpha=2.0, beta=1.0
-)
-# Info: need to freeze the amplitude to avoid degeneracy when fitting
-nlp.norm.frozen = True
-model_mul = nlp * pwl
-model_mul.plot(energy_bounds)
-plt.grid(which="both")
 
 # %%
 # YAML representation

--- a/examples/models/spectral/plot_compound.py
+++ b/examples/models/spectral/plot_compound.py
@@ -18,6 +18,7 @@ import matplotlib.pyplot as plt
 from gammapy.modeling.models import (
     CompoundSpectralModel,
     LogParabolaSpectralModel,
+    LogParabolaNormSpectralModel,
     Models,
     PowerLawSpectralModel,
     SkyModel,
@@ -31,10 +32,19 @@ lp = LogParabolaSpectralModel(
     amplitude="1e-12 cm-2 s-1 TeV-1", reference="10 TeV", alpha=2.0, beta=1.0
 )
 
-# freeze the amplitude to avoid degeneracy when fitting
-lp.amplitude.frozen = True
-model = CompoundSpectralModel(pwl, lp, operator.add)
-model.plot(energy_bounds)
+# Sum of two spectral models
+model_add = CompoundSpectralModel(pwl, lp, operator.add)
+model_add.plot(energy_bounds)
+plt.grid(which="both")
+
+# Multiplication of two spectral models
+nlp = LogParabolaNormSpectralModel(
+    amplitude="1e-1", reference="10 TeV", alpha=2.0, beta=1.0
+)
+# Info: need to freeze the amplitude to avoid degeneracy when fitting
+nlp.amplitude.frozen = True
+model_mul = nlp * pwl
+model_mul.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%
@@ -42,7 +52,7 @@ plt.grid(which="both")
 # -------------------
 # Here is an example YAML file using the model:
 
-model = SkyModel(spectral_model=model, name="compound-model")
-models = Models([model])
+sky_model = SkyModel(spectral_model=model_add, name="add-compound-model")
+models = Models([sky_model])
 
 print(models.to_yaml())

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Cube models (axes: lon, lat, energy)."""
-import operator
 
 import numpy as np
 import astropy.units as u

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -13,7 +13,7 @@ from gammapy.utils.fits import LazyFitsData
 from gammapy.utils.scripts import make_name, make_path
 from .core import Model, ModelBase, Models
 from .spatial import ConstantSpatialModel, SpatialModel
-from .spectral import PowerLawNormSpectralModel, SpectralModel, TemplateSpectralModel, CompoundSpectralModel
+from .spectral import PowerLawNormSpectralModel, SpectralModel, TemplateSpectralModel
 from .temporal import TemporalModel
 
 __all__ = [
@@ -78,16 +78,6 @@ class SkyModel(ModelBase):
             raise ValueError(
                 "Spectral model used with SkyModel requires a norm type parameter."
             )
-
-        if isinstance(self.spectral_model, CompoundSpectralModel):
-            is_free_norm = np.array(
-                [par.is_norm for par in spectral_model.parameters.free_parameters]
-            )
-
-            if self.spectral_model.operator is operator.mul and np.sum(is_free_norm) > 1:
-                raise ValueError(
-                    "The multiplicative compound spectral model can only have a single free norm type parameter."
-                )
 
         super().__init__()
 

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import operator
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -21,6 +22,8 @@ from gammapy.modeling.models import (
     PointSpatialModel,
     PowerLawNormSpectralModel,
     PowerLawSpectralModel,
+    LogParabolaSpectralModel,
+    LogParabolaNormSpectralModel,
     SkyModel,
     SpatialModel,
     TemplateNPredModel,
@@ -688,3 +691,49 @@ def test_integrate_geom():
     integral = sky_model.integrate_geom(geom).data
 
     assert_allclose(integral / 1e-12, [[[5.299]], [[2.460]], [[1.142]]], rtol=1e-3)
+
+
+def test_compound_spectral_model(caplog):
+    spatial_model = GaussianSpatialModel(
+        lon_0="3 deg", lat_0="4 deg", sigma="3 deg", frame="galactic"
+    )
+    pwl = PowerLawSpectralModel(
+        index=2, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV"
+    )
+    lp = LogParabolaSpectralModel(
+        amplitude="1e-12 cm-2 s-1 TeV-1", reference="10 TeV", alpha=2.0, beta=1.0
+    )
+    temporal_model = ConstantTemporalModel()
+
+    # Addition of the spectral models
+    spectral_model = CompoundSpectralModel(pwl, lp, operator.add)
+    m = SkyModel(
+        spatial_model=spatial_model,
+        spectral_model=spectral_model,
+        temporal_model=temporal_model,
+        name="source-1",
+    )
+    assert_allclose(m.spectral_model(5*u.TeV).value, 2.87e-12, rtol=1e-2)
+
+    # Multiplication of the spectral models with several free norm parameters
+    nlp = LogParabolaNormSpectralModel(
+        norm="1e-1", reference="10 TeV", alpha=2.0, beta=1.0
+    )
+    spectral_model = CompoundSpectralModel(pwl, nlp, operator.mul)
+    with pytest.raises(ValueError):
+        m = SkyModel(
+            spatial_model=spatial_model,
+            spectral_model=spectral_model,
+            temporal_model=temporal_model,
+            name="source-1",
+            )
+
+    # Multiplication of the spectral models with only one free norm parameter
+    nlp.norm.frozen = True
+    m = SkyModel(
+        spatial_model=spatial_model,
+        spectral_model=spectral_model,
+        temporal_model=temporal_model,
+        name="source-1",
+    )
+    assert_allclose(m.spectral_model(5*u.TeV).value, 9.89e-14, rtol=1e-2)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -23,7 +23,6 @@ from gammapy.modeling.models import (
     PowerLawNormSpectralModel,
     PowerLawSpectralModel,
     LogParabolaSpectralModel,
-    LogParabolaNormSpectralModel,
     SkyModel,
     SpatialModel,
     TemplateNPredModel,
@@ -705,7 +704,6 @@ def test_compound_spectral_model(caplog):
     )
     temporal_model = ConstantTemporalModel()
 
-    # Addition of the spectral models
     spectral_model = CompoundSpectralModel(pwl, lp, operator.add)
     m = SkyModel(
         spatial_model=spatial_model,
@@ -715,25 +713,3 @@ def test_compound_spectral_model(caplog):
     )
     assert_allclose(m.spectral_model(5*u.TeV).value, 2.87e-12, rtol=1e-2)
 
-    # Multiplication of the spectral models with several free norm parameters
-    nlp = LogParabolaNormSpectralModel(
-        norm="1e-1", reference="10 TeV", alpha=2.0, beta=1.0
-    )
-    spectral_model = CompoundSpectralModel(pwl, nlp, operator.mul)
-    with pytest.raises(ValueError):
-        m = SkyModel(
-            spatial_model=spatial_model,
-            spectral_model=spectral_model,
-            temporal_model=temporal_model,
-            name="source-1",
-            )
-
-    # Multiplication of the spectral models with only one free norm parameter
-    nlp.norm.frozen = True
-    m = SkyModel(
-        spatial_model=spatial_model,
-        spectral_model=spectral_model,
-        temporal_model=temporal_model,
-        name="source-1",
-    )
-    assert_allclose(m.spectral_model(5*u.TeV).value, 9.89e-14, rtol=1e-2)


### PR DESCRIPTION

**Description**
This pull request allows to fix the issue associated to the sum of compound models mentioned in the Issue #4008 . The sum of spectral models is allowed without restriction. Concerning the multiplication, one checks if there is only one free norm parameter in order to avoid degeneracy.
This scheme will allow:
- sum any spectral models without restriction (new feature)
- multiply spectral models if there is only 1 free norm parameter

**Dear reviewer**
The fix is implemented. A new test function about compound model is added.
I have tried to fix the associated model gallery section. Let me know if its content is pedagogical enough. Also, I have not realised the associated CI test.