### PR TITLE
Fix the plot height when there is a color bar in Background.plot_at_energy()

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -589,9 +589,9 @@
         }
     ],
     "codeRepository": "https://github.com/gammapy/gammapy",
-    "datePublished": "2020-11-19",
+    "datePublished": "2022-06-17",
     "description": "Gammapy analyzes gamma-ray data and creates sky images, spectra and lightcurves, from event lists and instrument response information; it can also determine the position, morphology and spectra of gamma-ray sources. It is used to analyze data from H.E.S.S., Fermi-LAT, and the Cherenkov Telescope Array (CTA).",
-    "identifier": "https://doi.org/10.5281/zenodo.5721467",
+    "identifier": "https://doi.org/10.5281/zenodo.6552377",
     "keywords": [
         "Astronomy",
         "Gamma-rays",
@@ -600,7 +600,7 @@
     "license": "https://spdx.org/licenses/BSD-3-Clause",
     "name": "Gammapy: Python toolbox for gamma-ray astronomy",
     "url": "https://github.com/gammapy/gammapy",
-    "softwareVersion": 0.19,
+    "softwareVersion": "0.20.1",
     "maintainer": {
         "@id": "https://orcid.org/0000-0003-4568-7005",
         "@type": "Person",

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -174,8 +174,11 @@ class Background3D(BackgroundIRF):
         cols = min(ncols, n)
         rows = 1 + (n - 1) // cols
         width = 12
+        cfraction = 0.
+        if add_cbar:
+            cfraction = 0.15
         if figsize is None:
-            figsize = (width, width * rows / cols)
+            figsize = (width, rows * width // (cols * (1+cfraction)))
 
         fig, axes = plt.subplots(
             ncols=cols,
@@ -202,7 +205,8 @@ class Background3D(BackgroundIRF):
             ax.set_title(str(ee))
             if add_cbar:
                 label = f"Background [{bkg.unit}]"
-                ax.figure.colorbar(caxes, ax=ax, label=label)
+                cbar = ax.figure.colorbar(caxes, ax=ax, label=label)
+                cbar.formatter.set_powerlimits((0, 0))
 
             row, col = np.unravel_index(i, shape=(rows, cols))
             if col > 0:

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -205,7 +205,7 @@ class Background3D(BackgroundIRF):
             ax.set_title(str(ee))
             if add_cbar:
                 label = f"Background [{bkg.unit}]"
-                cbar = ax.figure.colorbar(caxes, ax=ax, label=label)
+                cbar = ax.figure.colorbar(caxes, ax=ax, label=label, fraction=cfraction)
                 cbar.formatter.set_powerlimits((0, 0))
 
             row, col = np.unravel_index(i, shape=(rows, cols))
@@ -213,6 +213,7 @@ class Background3D(BackgroundIRF):
                 ax.set_ylabel("")
             if row < rows - 1:
                 ax.set_xlabel("")
+            ax.set_aspect('equal', 'box')
 
 
 class Background2D(BackgroundIRF):


### PR DESCRIPTION

**Description**
This pull request is associated to the Issue #4036 . The plot function `background.plot_at_energy()` deforms the sub-panel plot, with an height different from the width. 

**Dear reviewer**
The issue is coming to the fact that the height computation was not taking into account of the existence or not of the color bar. With the color bar, the plot itself is smaller than the sub-panel width.
This PR fixes most of the distorsion, even if one still does not correct for the axis label size and the inter-panel margins.
