### PR TITLE
Colour blind friendly visualisations

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -589,9 +589,9 @@
         }
     ],
     "codeRepository": "https://github.com/gammapy/gammapy",
-    "datePublished": "2020-11-19",
+    "datePublished": "2022-06-17",
     "description": "Gammapy analyzes gamma-ray data and creates sky images, spectra and lightcurves, from event lists and instrument response information; it can also determine the position, morphology and spectra of gamma-ray sources. It is used to analyze data from H.E.S.S., Fermi-LAT, and the Cherenkov Telescope Array (CTA).",
-    "identifier": "https://doi.org/10.5281/zenodo.5721467",
+    "identifier": "https://doi.org/10.5281/zenodo.6552377",
     "keywords": [
         "Astronomy",
         "Gamma-rays",
@@ -600,7 +600,7 @@
     "license": "https://spdx.org/licenses/BSD-3-Clause",
     "name": "Gammapy: Python toolbox for gamma-ray astronomy",
     "url": "https://github.com/gammapy/gammapy",
-    "softwareVersion": 0.19,
+    "softwareVersion": "0.20.1",
     "maintainer": {
         "@id": "https://orcid.org/0000-0003-4568-7005",
         "@type": "Person",

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -233,3 +233,30 @@ to your code:
     pbar.SHOW_PROGRESS_BAR = True
 
 .. accordion-footer::
+
+.. accordion-footer::
+
+.. accordion-header::
+    :id: collapseHowToSixteen
+    :title: Colour blind friendly visualisations
+
+The CTA observatory released a document describing best practices for data visualisation in a way friendly to
+color-blind people: `CTAO document <https://www.cta-observatory.org/wp-content/uploads/2020/10/CTA_ColourBlindness_BestPractices2.pdf>`_.
+As the Gammapy visualisations are using the library `matplotlib` that provides color styles, it is possible to adapt the
+colors of the Gammapy plots in order to follow these practices.
+
+To use them, you should add into your notebooks or scripts the following lines after the Gammapy imports:
+
+.. testcode::
+
+    import matplotlib.style as style
+    style.use('tableau-colorblind10')
+
+or
+
+.. testcode::
+
+    import matplotlib.style as style
+    style.use('seaborn-colorblind')
+
+.. accordion-footer::

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -234,8 +234,6 @@ to your code:
 
 .. accordion-footer::
 
-.. accordion-footer::
-
 .. accordion-header::
     :id: collapseHowToSixteen
     :title: Colour blind friendly visualisations

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -236,14 +236,27 @@ to your code:
 
 .. accordion-header::
     :id: collapseHowToSixteen
-    :title: Color-blind friendly visualisations
+    :title: Changing plotting style and color-blind friendly visualizations
 
-The CTA observatory released a document describing best practices for data visualisation in a way friendly to
-color-blind people: `CTAO document <https://www.cta-observatory.org/wp-content/uploads/2020/10/CTA_ColourBlindness_BestPractices2.pdf>`_.
-As the Gammapy visualisations are using the library `matplotlib` that provides color styles, it is possible to adapt the
-colors of the Gammapy plots in order to follow these practices.
+As the Gammapy visualisations are using the library `matplotlib` that provides color styles, it is possible to change the
+default colors map of the Gammapy plots. Using using the
+`style sheet of matplotlib <https://matplotlib.org/stable/gallery/style_sheets/style_sheets_reference.html>`_, you
+should add into your notebooks or scripts the following lines after the Gammapy imports:
 
-To use them, you should add into your notebooks or scripts the following lines after the Gammapy imports:
+.. testcode::
+
+    import matplotlib.style as style
+    style.use('XXXX')
+    # with XXXX from `print(plt.style.available)`
+
+Note that you can create your own style with matplotlib (see
+`here <https://matplotlib.org/stable/tutorials/introductory/customizing.html>`_ and
+`here <https://matplotlib.org/stable/tutorials/colors/colormaps.html>`_)
+
+The CTA observatory released a document describing best practices for **data visualisation in a way friendly to
+color-blind people**:
+`CTAO document <https://www.cta-observatory.org/wp-content/uploads/2020/10/CTA_ColourBlindness_BestPractices2.pdf>`_. To
+use them, you should add into your notebooks or scripts the following lines after the Gammapy imports:
 
 .. testcode::
 

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -236,7 +236,7 @@ to your code:
 
 .. accordion-header::
     :id: collapseHowToSixteen
-    :title: Colour blind friendly visualisations
+    :title: Color-blind friendly visualisations
 
 The CTA observatory released a document describing best practices for data visualisation in a way friendly to
 color-blind people: `CTAO document <https://www.cta-observatory.org/wp-content/uploads/2020/10/CTA_ColourBlindness_BestPractices2.pdf>`_.

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -243,7 +243,7 @@ default colors map of the Gammapy plots. Using using the
 `style sheet of matplotlib <https://matplotlib.org/stable/gallery/style_sheets/style_sheets_reference.html>`_, you
 should add into your notebooks or scripts the following lines after the Gammapy imports:
 
-.. testcode::
+.. code::
 
     import matplotlib.style as style
     style.use('XXXX')
@@ -258,14 +258,14 @@ color-blind people**:
 `CTAO document <https://www.cta-observatory.org/wp-content/uploads/2020/10/CTA_ColourBlindness_BestPractices2.pdf>`_. To
 use them, you should add into your notebooks or scripts the following lines after the Gammapy imports:
 
-.. testcode::
+.. code::
 
     import matplotlib.style as style
     style.use('tableau-colorblind10')
 
 or
 
-.. testcode::
+.. code::
 
     import matplotlib.style as style
     style.use('seaborn-colorblind')


### PR DESCRIPTION
**Description**
This pull request is associated to the issue #3079 . It proposes a new section of our HowTos...

**Dear reviewer**
Following our discussions during the last dev call, I dis some tests. Here are the differences:
Without: 
![aeff_without](https://user-images.githubusercontent.com/16781593/181777006-782d9e8a-4900-4b77-a8c2-8640d9d1313d.png)

With:
![aeff_with](https://user-images.githubusercontent.com/16781593/181777066-f7d81aab-b20f-459d-812f-c226c7c85a38.png)


Without:
![psf_without](https://user-images.githubusercontent.com/16781593/181777110-887d28f2-c3e7-4852-be18-26ebfb09bcb4.png)

With:
![psf_with](https://user-images.githubusercontent.com/16781593/181777143-b28f29e2-d18a-4267-8edb-4ee9eb47e072.png)


It seems to work nicely and efficiently without adding code into Gammapy.
