### PR TITLE
Remove iminuit version constraint

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,7 +27,7 @@ dependencies:
   - regions>=0.5
   - matplotlib>=3.4
   - scipy
-  - iminuit>=2.8.0,<2.13
+  - iminuit>=2.8.0
   # test dependencies
   - codecov
   - pytest=6

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -310,11 +310,12 @@ def test_stat_contour():
     x = result["y"]
     assert len(x) in [10,11]       # Behavior changed after iminuit>=2.13
     assert_allclose(x[0], 299, rtol=1e-5)
-    assert_allclose(x[-1], 299.133975, rtol=1e-5)
+    assert_allclose(x[9], 299.133975, rtol=1e-5)
     y = result["z"]
-    assert_allclose(len(y), 10)
+    assert len(x)==len(y)
+    assert len(y) in [10,11]
     assert_allclose(y[0], 0.04, rtol=1e-5)
-    assert_allclose(y[-1], 0.54, rtol=1e-5)
+    assert_allclose(y[9], 0.54, rtol=1e-5)
 
     # Check that original value state wasn't changed
     assert_allclose(dataset.models.parameters["y"].value, 300)

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -308,7 +308,7 @@ def test_stat_contour():
     assert result["success"]
 
     x = result["y"]
-    assert_allclose(len(x), 10)
+    assert len(x) in [10,11]       # Behavior changed after iminuit>=2.13
     assert_allclose(x[0], 299, rtol=1e-5)
     assert_allclose(x[-1], 299.133975, rtol=1e-5)
     y = result["z"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     pyyaml>=5.1
     click>=7.0
     pydantic>=1.4
-    iminuit>=2.8.0,<2.13
+    iminuit>=2.8.0
     matplotlib>=3.4
 
 [options.entry_points]


### PR DESCRIPTION
Signed-off-by: Terrier <rterrier@apc.in2p3.fr>

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request removes the iminuit<2.13 constraint which is no longer necessary after #4047 . The failing test is modifed to support both cases.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
