### PR TITLE
Add tag on DM Annihilation spectral model

### DIFF
--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -177,6 +177,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         interp="log",
         is_norm=True,
     )
+    tag = ["DarkMatterAnnihilationSpectralModel", "dm-annihilation"]
 
     def __init__(self, mass, channel, scale=scale.quantity, jfactor=1, z=0, k=2):
         self.k = k

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -226,7 +226,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
             Dark matter annihilation spectral model
         """
         data = data["spectral"]
-        type = data.pop("type")
+        data.pop("type")
         parameters = data.pop("parameters")
         scale = [p["value"] for p in parameters if p["name"] == "scale"][0]
         return cls(scale=scale, **data)

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -213,15 +213,22 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
 
     @classmethod
     def from_dict(cls, data):
+        """Create spectral model from dict
+
+        Parameters
+        ----------
+        data : dict
+            Dict with model data
+
+        Returns
+        -------
+        model : `DarkMatterAnnihilationSpectralModel`
+            Dark matter annihilation spectral model
+        """
         data = data["spectral"]
-
-        channel = data["channel"]
-        mass = u.Quantity(data["mass"])
-        jfactor = u.Quantity(data["jfactor"])
-        z = data["z"]
-        k = data["k"]
-
-        scale = [p["value"] for p in data["parameters"] if p["name"] == "scale"][0]
-        return cls(mass, channel, scale=scale, jfactor=jfactor, z=z, k=k)
+        type = data.pop("type")
+        parameters = data.pop("parameters")
+        scale = [p["value"] for p in parameters if p["name"] == "scale"][0]
+        return cls(scale=scale, **data)
 
 SPECTRAL_MODEL_REGISTRY.append(DarkMatterAnnihilationSpectralModel)

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -2,6 +2,7 @@
 import pytest
 import astropy.units as u
 from gammapy.astro.darkmatter import DarkMatterAnnihilationSpectralModel, PrimaryFlux
+from gammapy.modeling.models import SkyModel, Models
 from gammapy.utils.testing import assert_quantity_allclose, requires_data
 
 
@@ -32,7 +33,15 @@ def test_DMAnnihilation():
     )
     differential_flux = model.evaluate(energy=1 * u.TeV, scale=1).to("cm-2 s-1 TeV-1")
 
+    sky_model = SkyModel(
+        spectral_model=model,
+        name="skymodel",
+    )
+    models = Models([sky_model])
+    models.write("tmp.yaml", overwrite=True)
+
     assert_quantity_allclose(integral_flux.value, 6.19575457e-14, rtol=1e-3)
     assert_quantity_allclose(differential_flux.value, 2.97506768e-16, rtol=1e-3)
 
     assert model.scale.is_norm
+

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.astro.darkmatter import DarkMatterAnnihilationSpectralModel, PrimaryFlux
 from gammapy.modeling.models import SkyModel, Models
@@ -39,9 +40,13 @@ def test_DMAnnihilation():
     )
     models = Models([sky_model])
     models.write("tmp.yaml", overwrite=True)
+    new_models = Models.read("tmp.yaml")
 
     assert_quantity_allclose(integral_flux.value, 6.19575457e-14, rtol=1e-3)
     assert_quantity_allclose(differential_flux.value, 2.97506768e-16, rtol=1e-3)
 
     assert model.scale.is_norm
+    assert new_models[0].spectral_model.channel == model.channel
+    assert new_models[0].spectral_model.z == model.z
+    assert_allclose(new_models[0].spectral_model.jfactor.value, model.jfactor.value)
 

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -49,4 +49,6 @@ def test_DMAnnihilation():
     assert new_models[0].spectral_model.channel == model.channel
     assert new_models[0].spectral_model.z == model.z
     assert_allclose(new_models[0].spectral_model.jfactor.value, model.jfactor.value)
+    assert new_models[0].spectral_model.mass.value == 5
+    assert new_models[0].spectral_model.mass.unit == u.TeV
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request solves #4056  by simply adding a `tag` on `DarkMatterAnnihilationSpectralModel` with short name `dm-annihilation`.
Note that DM spatial models are not usable in `SkyModel` as they are not regular `SpatialModel`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
