### PR TITLE
Implement PsfKernel.peek() and MapEvaluator.peek()

### DIFF
--- a/docs/tutorials/api/datasets.ipynb
+++ b/docs/tutorials/api/datasets.ipynb
@@ -1047,11 +1047,48 @@
     ")\n",
     "print(datasets_sliced.energy_ranges)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "049be356-8798-437f-b9f6-9755b4d82e7d",
+   "metadata": {},
+   "source": [
+    "## MapEvaluator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "906b6b6a-d017-4cff-8844-ad2eda09fca0",
+   "metadata": {},
+   "source": [
+    "The `MapEvaluator` is responsible for evaluating a sky model on a map and returning a map of the predicted counts, by convolving the model with IRFs. This is an essential step for the fitting procedure. \n",
+    "\n",
+    "For standard use cases, one is not supposed to interact with the `MapEvaluator` directly, since the model evaluation is automatically carried out under the hood. Howaver, for debugging purposes, one may occasionally need to check the content of the `MapEvaluator`. A quick way to do so is the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57d372e1-9b4e-4d3f-843a-7e6f935540ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evaluator = dataset_cta.evaluators[\"gc\"]\n",
+    "evaluator.peek()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73e59c72-8f5f-4614-8941-50bb6ac22d7d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1065,7 +1102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/gammapy/datasets/__init__.py
+++ b/gammapy/datasets/__init__.py
@@ -3,6 +3,7 @@ from .core import Dataset, Datasets
 from .flux_points import FluxPointsDataset
 from .io import OGIPDatasetReader, OGIPDatasetWriter
 from .map import MapDataset, MapDatasetOnOff, create_map_dataset_geoms
+from .evaluator import MapEvaluator
 from .simulate import MapDatasetEventSampler
 from .spectrum import SpectrumDataset, SpectrumDatasetOnOff
 
@@ -10,6 +11,7 @@ DATASET_REGISTRY = Registry(
     [
         MapDataset,
         MapDatasetOnOff,
+        MapEvaluator,
         SpectrumDataset,
         SpectrumDatasetOnOff,
         FluxPointsDataset,
@@ -27,6 +29,7 @@ __all__ = [
     "MapDataset",
     "MapDatasetEventSampler",
     "MapDatasetOnOff",
+    "MapEvaluator",
     "OGIPDatasetWriter",
     "OGIPDatasetReader",
     "SpectrumDataset",

--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -511,9 +511,9 @@ class MapEvaluator:
         fig, axes = plt.subplots(
             ncols=2,
             nrows=3,
-            #subplot_kw={"projection": self._geom.wcs},
+            subplot_kw={"projection": self.exposure.geom.wcs},
             figsize=figsize,
-            gridspec_kw={"hspace": 0.2, "wspace": 0.2},
+            gridspec_kw={"hspace": 0.2, "wspace": 0.3},
         )
 
         axes = axes.flat
@@ -526,18 +526,20 @@ class MapEvaluator:
         self.exposure.sum_over_axes().plot(ax=axes[1], add_cbar=True)
         plot_mask(ax=axes[1], mask=self.mask, hatches=["///"], colors="w")
 
-        axes[2].set_title("Energy bias")
-        self.edisp.plot_bias(ax=axes[2])
+        axes[2].set_title("Energy-integrated PSF kernel")
+        self.psf.plot_kernel(ax=axes[2], add_cbar=True)
 
-        axes[3].set_title("Energy dispersion matrix")
-        self.edisp.plot_matrix(ax=axes[3])
+        axes[3].set_title("PSF kernel at 1 TeV")
+        self.psf.plot_kernel(ax=axes[3], add_cbar=True, energy=1*u.TeV)
 
-        axes[4].set_title("Containment radius at center of map")
-        self.psf.plot_containment_radius_vs_energy(ax=axes[4])
+        axes[4].remove()
+        ax4 = fig.add_subplot(3, 2, 5)
+        ax4.set_title("Energy bias")
+        self.edisp.plot_bias(ax=ax4)
 
-        axes[5].set_title("Containment radius at 1 TeV")
-        self.containment_radius_map(energy_true=1 * u.TeV).plot(
-            ax=axes[5], add_cbar=True
-        )
+        axes[5].remove()
+        ax5 = fig.add_subplot(3, 2, 6)
+        ax5.set_title("Energy dispersion matrix")
+        self.edisp.plot_matrix(ax=ax5)
 
 

--- a/gammapy/datasets/tests/test_evaluator.py
+++ b/gammapy/datasets/tests/test_evaluator.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -16,9 +17,10 @@ from gammapy.modeling.models import (
     SkyModel,
 )
 from gammapy.utils.gauss import Gauss2DPDF
+from gammapy.utils.testing import mpl_plot_check
 
-
-def test_compute_flux_spatial():
+@pytest.fixture
+def evaluator():
     center = SkyCoord("0 deg", "0 deg", frame="galactic")
     region = CircleSkyRegion(center=center, radius=0.1 * u.deg)
 
@@ -42,7 +44,9 @@ def test_compute_flux_spatial():
     geom = RegionGeom(region, axes=[energy_axis_true], binsz_wcs="0.01deg")
     psf = PSFKernel.from_gauss(geom.to_wcs_geom(), sigma="0.1 deg")
 
-    evaluator = MapEvaluator(model=model[0], exposure=exposure_region, psf=psf)
+    return MapEvaluator(model=model[0], exposure=exposure_region, psf=psf)
+
+def test_compute_flux_spatial(evaluator):
     flux = evaluator.compute_flux_spatial()
 
     g = Gauss2DPDF(0.1)
@@ -50,31 +54,10 @@ def test_compute_flux_spatial():
     assert_allclose(flux.value, reference, rtol=0.003)
 
 
-def test_compute_flux_spatial_no_psf():
+def test_compute_flux_spatial_no_psf(evaluator):
     # check that spatial integration is not performed in the absence of a psf
-    center = SkyCoord("0 deg", "0 deg", frame="galactic")
-    region = CircleSkyRegion(center=center, radius=0.1 * u.deg)
-
-    nbin = 2
-    energy_axis_true = MapAxis.from_energy_bounds(
-        ".1 TeV", "10 TeV", nbin=nbin, name="energy_true"
-    )
-
-    spectral_model = ConstantSpectralModel()
-    spatial_model = GaussianSpatialModel(
-        lon_0=0 * u.deg, lat_0=0 * u.deg, frame="galactic", sigma="0.1 deg"
-    )
-
-    models = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)
-    model = Models(models)
-
-    exposure_region = RegionNDMap.create(
-        region, axes=[energy_axis_true], unit="m2 s", data=1.0
-    )
-
-    evaluator = MapEvaluator(model=model[0], exposure=exposure_region)
+    evaluator.psf = None
     flux = evaluator.compute_flux_spatial()
-
     assert_allclose(flux, 1.0)
 
 
@@ -154,3 +137,7 @@ def test_compute_npred_sign():
     assert (npred_pos.data == -npred_neg.data).all()
     assert np.all(npred_pos.data >= 0)
     assert np.all(npred_neg.data <= 0)
+
+def test_peek(evaluator):
+    with mpl_plot_check():
+        evaluator.peek()

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -523,6 +523,6 @@ class PSFMap(IRFMap):
         self.exposure_map.reduce_over_axes().plot(ax=axes[2], add_cbar=True)
 
         axes[3].set_title("Containment radius at 1 TeV")
-        self.containment_radius_map(energy_true=2 * u.TeV).plot(
+        self.containment_radius_map(energy_true=1 * u.TeV).plot(
             ax=axes[3], add_cbar=True
         )

--- a/gammapy/irf/psf/tests/test_kernel.py
+++ b/gammapy/irf/psf/tests/test_kernel.py
@@ -1,28 +1,33 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.irf import PSFKernel
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.modeling.models import DiskSpatialModel
+from gammapy.utils.testing import mpl_plot_check
 
-
-def test_psf_kernel_from_gauss_read_write(tmp_path):
+@pytest.fixture
+def kernel_gaussian():
     sigma = 0.5 * u.deg
     binsz = 0.1 * u.deg
-    geom = WcsGeom.create(binsz=binsz, npix=150, axes=[MapAxis((0, 1, 2))])
+    geom = WcsGeom.create(binsz=binsz, npix=150, axes=[MapAxis((0, 1, 2), unit=u.TeV, name="energy_true")])
 
-    kernel = PSFKernel.from_gauss(geom, sigma)
+    return PSFKernel.from_gauss(geom, sigma)
 
+def test_psf_kernel_from_gauss(kernel_gaussian):
     # Check that both maps are identical
-    assert_allclose(kernel.psf_kernel_map.data[0], kernel.psf_kernel_map.data[1])
+    assert_allclose(kernel_gaussian.psf_kernel_map.data[0], kernel_gaussian.psf_kernel_map.data[1])
 
     # Is there an odd number of pixels
-    assert_allclose(np.array(kernel.psf_kernel_map.geom.npix) % 2, 1)
+    assert_allclose(np.array(kernel_gaussian.psf_kernel_map.geom.npix) % 2, 1)
 
-    kernel.write(tmp_path / "tmp.fits", overwrite=True)
+
+def test_psf_kernel_read_write(kernel_gaussian, tmp_path):
+    kernel_gaussian.write(tmp_path / "tmp.fits", overwrite=True)
     kernel2 = PSFKernel.read(tmp_path / "tmp.fits")
-    assert_allclose(kernel.psf_kernel_map.data, kernel2.psf_kernel_map.data)
+    assert_allclose(kernel_gaussian.psf_kernel_map.data, kernel2.psf_kernel_map.data)
 
 
 def test_psf_kernel_to_image():
@@ -54,3 +59,11 @@ def test_psf_kernel_to_image():
     assert_allclose(kernel_image_2.psf_kernel_map.data[0, 25, 25], 0.037555, atol=1e-5)
     assert_allclose(kernel_image_2.psf_kernel_map.data[0, 22, 22], 0.007752, atol=1e-5)
     assert_allclose(kernel_image_2.psf_kernel_map.data[0, 20, 20], 0.0, atol=1e-5)
+
+def test_plot_kernel(kernel_gaussian):
+    with mpl_plot_check():
+        kernel_gaussian.plot_kernel()
+
+def test_peek(kernel_gaussian):
+    with mpl_plot_check():
+        kernel_gaussian.peek()


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request addresses #3764 , by adding a `MapEvaluator.peek()` method. For consistency (and to simplify the code) I also added a plot and a peek method for the `PsfKernel`.

Example plots:

`PsfKernel.peek()`
![image](https://user-images.githubusercontent.com/47325742/189723378-3a404e44-682c-4435-b0cf-90198d7c692e.png)



`MapEvaluator.peek()`
![image](https://user-images.githubusercontent.com/47325742/189723296-5a11de1f-0142-4e46-9eee-b080049df2c2.png)
