### PR TITLE
Allow for DRIFT mode observations in the MapDatasetMaker

### DIFF
--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -131,8 +131,6 @@ class FixedPointingInfo:
         obs_mode = self.meta.get("OBS_MODE")
         if obs_mode is None:
             return PointingMode.POINTING
-        if np.size(obs_mode)>1 and "POINTING" in [i.upper() for i in obs_mode]:
-            return PointingMode.POINTING
         return PointingMode.from_gadf_string(obs_mode)
 
     @lazyproperty

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -131,6 +131,8 @@ class FixedPointingInfo:
         obs_mode = self.meta.get("OBS_MODE")
         if obs_mode is None:
             return PointingMode.POINTING
+        if np.size(obs_mode)>1 and "POINTING" in [i.upper() for i in obs_mode]:
+            return PointingMode.POINTING
         return PointingMode.from_gadf_string(obs_mode)
 
     @lazyproperty

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -328,9 +328,13 @@ class MapDatasetMaker(Maker):
         meta_table = Table()
         meta_table["TELESCOP"] = [observation.aeff.meta.get("TELESCOP", "Unknown")]
         meta_table["OBS_ID"] = [observation.obs_id]
-        meta_table["RA_PNT"] = [observation.pointing_radec.icrs.ra.deg] * u.deg
-        meta_table["DEC_PNT"] = [observation.pointing_radec.icrs.dec.deg] * u.deg
-
+        meta_table["OBS_MODE"] = [str(observation.fixed_pointing_info.mode).split('.')[-1]]
+        if meta_table["OBS_MODE"] == "POINTING":
+            meta_table["RA_PNT"] = [observation.pointing_radec.icrs.ra.deg] * u.deg
+            meta_table["DEC_PNT"] = [observation.pointing_radec.icrs.dec.deg] * u.deg
+        elif meta_table["OBS_MODE"] == "DRIFT":
+            meta_table["ALT_PNT"] = [observation.fixed_pointing_info.fixed_altaz.alt.deg] * u.deg
+            meta_table["AZ_PNT"] = [observation.fixed_pointing_info.fixed_altaz.az.deg] * u.deg
         return meta_table
 
     def run(self, dataset, observation):

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -4,6 +4,7 @@ import astropy.units as u
 from astropy.table import Table
 from regions import PointSkyRegion
 from gammapy.irf import EDispKernelMap, PSFMap
+from gammapy.data.pointing import PointingMode
 from gammapy.maps import Map
 from .core import Maker
 from .utils import (
@@ -328,11 +329,12 @@ class MapDatasetMaker(Maker):
         meta_table = Table()
         meta_table["TELESCOP"] = [observation.aeff.meta.get("TELESCOP", "Unknown")]
         meta_table["OBS_ID"] = [observation.obs_id]
-        meta_table["OBS_MODE"] = [str(observation.fixed_pointing_info.mode).split('.')[-1]]
-        if meta_table["OBS_MODE"] == "POINTING":
+        if observation.fixed_pointing_info.mode == PointingMode.POINTING:
+            meta_table["OBS_MODE"] = "POINTING"
             meta_table["RA_PNT"] = [observation.pointing_radec.icrs.ra.deg] * u.deg
             meta_table["DEC_PNT"] = [observation.pointing_radec.icrs.dec.deg] * u.deg
-        elif meta_table["OBS_MODE"] == "DRIFT":
+        elif observation.fixed_pointing_info.mode == PointingMode.DRIFT:
+            meta_table["OBS_MODE"] = "DRIFT"
             meta_table["ALT_PNT"] = [observation.fixed_pointing_info.fixed_altaz.alt.deg] * u.deg
             meta_table["AZ_PNT"] = [observation.fixed_pointing_info.fixed_altaz.az.deg] * u.deg
         return meta_table

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -228,6 +228,7 @@ def test_make_meta_table(observations):
     assert_allclose(map_dataset_meta_table["RA_PNT"], 267.68121338)
     assert_allclose(map_dataset_meta_table["DEC_PNT"], -29.6075)
     assert_allclose(map_dataset_meta_table["OBS_ID"], 110380)
+    assert map_dataset_meta_table["OBS_MODE"] == "POINTING"
 
 
 @requires_data()


### PR DESCRIPTION
**Description**
Something changed between 0.19 and 0.20 leading to an error in the `MapDatasetMaker` if the observation table has no RA/DEC pointing information. Before, the `observation.pointing_radec` would have `nan` as values, but now it throws an error. Which occurs when constructing the meta table during the data reduction in 0.20.1

This pull request adds the `OBS_MODE` keyword to the dataset meta table, and consequently, the pointing info required is the one defined by the observation mode.

