### PR TITLE
Fix `LightCurveTemplateTemporalModel.evaluate`

### DIFF
--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -489,7 +489,6 @@ class LightCurveTemplateTemporalModel(TemporalModel):
             self.filename = str(make_path(path))
             self.table.write(self.filename, overwrite=overwrite)
 
-    @lazyproperty
     def _interpolator(self, ext=0):
         x = self._time.value
         y = self.table["NORM"].data
@@ -526,7 +525,8 @@ class LightCurveTemplateTemporalModel(TemporalModel):
         norm : array_like
             Norm at the given times.
         """
-        return self._interpolator(time, ext=ext)
+        spl = self._interpolator(ext=ext)
+        return spl(time)
 
     def integral(self, t_min, t_max):
         """Evaluate the integrated flux within the given time intervals
@@ -542,8 +542,8 @@ class LightCurveTemplateTemporalModel(TemporalModel):
         norm: The model integrated flux
         """
 
-        n1 = self._interpolator.antiderivative()(t_max.mjd)
-        n2 = self._interpolator.antiderivative()(t_min.mjd)
+        n1 = self._interpolator().antiderivative()(t_max.mjd)
+        n2 = self._interpolator().antiderivative()(t_min.mjd)
         return u.Quantity(n1 - n2, "day") / self.time_sum(t_min, t_max)
 
     @classmethod

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -38,13 +38,12 @@ def test_light_curve_str(light_curve):
 
 @requires_data()
 def test_light_curve_evaluate(light_curve):
-    t = Time(59500, format="mjd")
-    val = light_curve(t)
-    assert_allclose(val, 0.015512, rtol=1e-5)
-
     t = Time(46300, format="mjd")
     val = light_curve.evaluate(t.mjd, ext=3)
     assert_allclose(val, 0.01551196, rtol=1e-5)
+
+    val = light_curve.evaluate([59001.5, 59016.0])
+    assert_allclose(val, [0.02611184, 0.02172046], rtol=1e-5)
 
 
 def ph_curve(x, amplitude=0.5, x0=0.01):


### PR DESCRIPTION
**Description**
This pull request fixes the issue mentioned here: #3639 .

**Dear reviewer**
The `_interpolator` function is return and the code is adapted accordingly.
The issue for me is that the interpolator function is built each time the user wants an evaluation at a given time, which is a lost of time. If you agree, I propose that the interpolator function is built in the init function and saves into a variable of the class. Or, there is a magic python decorator...
