### PR TITLE
Fixed test failure after introducing new MAGIC RAD_MAX files (gammapy-data #27)

### DIFF
--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -277,12 +277,12 @@ def test_dataset_maker_spectrum_rad_max(observations_magic_rad_max):
     assert counts.unit == ""
     assert counts_off is not None, "Extracting off counts failed"
     assert counts_off.unit == ""
-    assert_allclose(counts.data.sum(), 950, rtol=1e-5)
-    assert_allclose(counts_off.data.sum(), 518, rtol=1e-5)
+    assert_allclose(counts.data.sum(), 964, rtol=1e-5)
+    assert_allclose(counts_off.data.sum(), 530, rtol=1e-5)
 
     exposure = dataset_on_off.exposure
     assert exposure.unit == "m2 s"
-    assert_allclose(exposure.data.mean(), 67838458.245686, rtol=1e-5)
+    assert_allclose(exposure.data.mean(), 68067647.733834, rtol=1e-5)
 
 
 @requires_data()


### PR DESCRIPTION
This PR fixes the failing tests due to the [new version of the MAGIC RAD_MAX files in gammapy-data](https://github.com/gammapy/gammapy-data/pull/27).

The number of counts and the exposure slightly changed because the values of the hadronness and theta2 cuts changed wrt to the previous converted version. The change is minimal anyhow.

Cheers! 