### PR TITLE
Correct CountsStatistic documentation plots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ help:
 	@echo '     make clean         Remove auto-generated files'
 	@echo '     pytest             Run Gammapy tests (give folder or filename and options)'
 	@echo '     make test-cov      Run all tests and measure coverage'
-	@echo '     make docs          Build documentation locally'
+	@echo '     make docs-sphinx   Build documentation locally'
 	@echo ''
 
 clean:

--- a/docs/user-guide/stats/plot_cash_errors.py
+++ b/docs/user-guide/stats/plot_cash_errors.py
@@ -27,14 +27,14 @@ plt.ylabel(r"Cash statistic value, TS ")
 
 plt.hlines(
     count_statistic.stat_max + 1,
-    xmin=excess + errn,
+    xmin=excess - errn,
     xmax=excess + errp,
     linestyle="dotted",
     color="r",
     label="1 sigma (68% C.L.)",
 )
 plt.vlines(
-    excess + errn,
+    excess - errn,
     ymin=ymin,
     ymax=count_statistic.stat_max + 1,
     linestyle="dotted",
@@ -50,14 +50,14 @@ plt.vlines(
 
 plt.hlines(
     count_statistic.stat_max + 4,
-    xmin=excess + errn_2sigma,
+    xmin=excess - errn_2sigma,
     xmax=excess + errp_2sigma,
     linestyle="dashed",
     color="b",
     label="2 sigma (95% C.L.)",
 )
 plt.vlines(
-    excess + errn_2sigma,
+    excess - errn_2sigma,
     ymin=ymin,
     ymax=count_statistic.stat_max + 4,
     linestyle="dashed",

--- a/docs/user-guide/stats/plot_wstat_errors.py
+++ b/docs/user-guide/stats/plot_wstat_errors.py
@@ -28,14 +28,14 @@ plt.ylabel(r"WStat value, TS ")
 
 plt.hlines(
     count_statistic.stat_max + 1,
-    xmin=excess + errn,
+    xmin=excess - errn,
     xmax=excess + errp,
     linestyle="dotted",
     color="r",
     label="1 sigma (68% C.L.)",
 )
 plt.vlines(
-    excess + errn,
+    excess - errn,
     ymin=ymin,
     ymax=count_statistic.stat_max + 1,
     linestyle="dotted",
@@ -51,14 +51,14 @@ plt.vlines(
 
 plt.hlines(
     count_statistic.stat_max + 4,
-    xmin=excess + errn_2sigma,
+    xmin=excess - errn_2sigma,
     xmax=excess + errp_2sigma,
     linestyle="dashed",
     color="b",
     label="2 sigma (95% C.L.)",
 )
 plt.vlines(
-    excess + errn_2sigma,
+    excess - errn_2sigma,
     ymin=ymin,
     ymax=count_statistic.stat_max + 4,
     linestyle="dashed",


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects a problem with `CountsStatistic` documentation plots that appeared after #4089 was merged.
See https://docs.gammapy.org/dev/user-guide/stats/plot_wstat_errors.png

The documentation in the Makefile is also modified to correctly give the `make docs-sphinx` command instead of `make docs` which is no longer valid.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
