### PR TITLE
Fix WcsNDMap upsampling along axis

### DIFF
--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -297,7 +297,7 @@ class WcsNDMap(WcsMap):
             ) + idx[2:]
         else:
             pix = list(idx)
-            idx_ax = self.geom.axes.index(axis_name)
+            idx_ax = 2 + self.geom.axes.index(axis_name)
             pix[idx_ax] = (pix[idx_ax] - 0.5 * (factor - 1)) / factor
 
         if preserve_counts:

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -297,7 +297,7 @@ class WcsNDMap(WcsMap):
             ) + idx[2:]
         else:
             pix = list(idx)
-            idx_ax = 2 + self.geom.axes.index(axis_name)
+            idx_ax = self.geom.axes_names.index(axis_name)
             pix[idx_ax] = (pix[idx_ax] - 0.5 * (factor - 1)) / factor
 
         if preserve_counts:

--- a/gammapy/maps/wcs/tests/test_ndmap.py
+++ b/gammapy/maps/wcs/tests/test_ndmap.py
@@ -420,13 +420,19 @@ def test_wcsndmap_upsample(npix, binsz, frame, proj, skydir, axes):
 
 def test_wcsndmap_upsample_axis():
     axis = MapAxis.from_edges([1, 2, 3, 4], name="test")
-    geom = WcsGeom.create(npix=(4, 4), axes=[axis])
-    m = WcsNDMap(geom, unit="m2")
-    m.data += 1
-
+    geom = WcsGeom.create(npix=(2, 2), axes=[axis])
+    test_nodes = np.arange(3)
+    test_data =  test_nodes.reshape(3, 1, 1)
+    spatial_data = np.zeros((2, 2))
+    data = spatial_data + 0.5 * test_data
+    m = WcsNDMap(geom, unit="m2",data=data)
+ 
     m2 = m.upsample(2, preserve_counts=True, axis_name="test")
-    assert m2.data.shape == (6, 4, 4)
+    assert m2.data.shape == (6, 2, 2)
     assert_allclose(m.data.sum(), m2.data.sum())
+    
+    assert_allclose(m2.data[:,0,0], [0,0,0.25,0.25,0.5, 0.5])
+
 
 
 def test_wcsndmap_downsample_axis():


### PR DESCRIPTION
This PR fix the axis index used in NDmap upsampling in case an axis_name is given, and modify the relevant test such as the test map data are not all the same. 
(Required for #3862)