### PR TITLE
Reactivate gammapy download command

### DIFF
--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -73,6 +73,7 @@ Steps for the day of the release:
    * Mention the release on the front page and on the news page.
    * In the ``download/install`` folder, copy ``gammapy-0.13-environment.yml`` file as ``gammapy-0.14-environment.yml``.
    * Adapt the dependency conda env name and versions as required in this file.
+   * Adapt the ``download/index.json`` file to include the new version.
 
 #. Finally:
 

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -32,7 +32,7 @@ want to install the datasets and proceed with the following commands:
 
 .. substitution-code-block:: bash
 
-    $ gammapy download notebooks --release |release|
+    $ gammapy download notebooks
     $ gammapy download datasets
     $ export GAMMAPY_DATA=$PWD/gammapy-datasets
 

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -41,7 +41,7 @@ class DownloadIndex:
 
         if self.release not in data:
             raise ValueError(
-                f"Download not available for release {self.release}, choose from {data.keys()}"
+                f"Download not available for release {self.release}, choose from: {list(data.keys())}"
             )
 
         return data[self.release]

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -5,13 +5,55 @@ import tarfile
 from pathlib import Path
 import click
 from gammapy import __version__
+from astropy.utils import lazyproperty
 
 log = logging.getLogger(__name__)
 
 BUNDLESIZE = 152  # in MB
-ENVS_BASE_URL = "https://gammapy.org/download/install"
-NBTAR_BASE_URL = "https://docs.gammapy.org"
-TAR_DATASETS = "https://github.com/gammapy/gammapy-data/tarball/master"
+GAMMAPY_BASE_URL = "https://gammapy.org/download/"
+
+
+class DownloadIndex:
+    """Download index"""
+    _notebooks_key = "notebooks"
+    _datasets_key = "datasets"
+    _environment_key = "conda-environment"
+    _index_json = "index.json"
+
+    def __init__(self, release=__version__):
+        
+        if "dev" in release:
+            release = "dev"
+        
+        self.release = release
+
+    @lazyproperty
+    def index(self):
+        """Index for a given release"""
+        import requests
+
+        response = requests.get(GAMMAPY_BASE_URL + self._index_json)
+        data = response.json()
+
+        if self.release not in data:
+            raise ValueError(f"Download not available for release {self.release}, choose from {data.keys()}")
+        
+        return data[self.release]
+
+    @property
+    def notebooks_url(self):
+        """Notebooks URL"""
+        return self.index[self._notebooks_key]
+
+    @property
+    def environment_url(self):
+        """Environment URL"""
+        return self.index[self._environment_key]
+
+    @property
+    def datasets_url(self):
+        """Datasets URL"""
+        return self.index[self._datasets_key]
 
 
 def progress_download(source, destination):
@@ -86,15 +128,15 @@ def show_info_datasets(outfolder):
 def cli_download_notebooks(release, out):
     """Download notebooks"""
     localfolder = Path(out) / release
-    url_file_env = f"{ENVS_BASE_URL}/gammapy-{release}-environment.yml"
-    if release == "dev":
-        url_file_env = "https://raw.githubusercontent.com/gammapy/gammapy/master/environment-dev.yml"
 
-    yaml_destination_file = localfolder / f"gammapy-{release}-environment.yml"
-    progress_download(url_file_env, yaml_destination_file)
-    url_tar_notebooks = f"{NBTAR_BASE_URL}/{release}/_downloads/notebooks-{release}.tar"
-    tar_destination_file = localfolder / f"notebooks_{release}.tar"
-    progress_download(url_tar_notebooks, tar_destination_file)
+    index = DownloadIndex(release=release)
+
+    filename = localfolder / f"gammapy-{index.release}-environment.yml"
+    progress_download(index.environment_url, filename)
+
+    tar_destination_file = localfolder / f"notebooks_{release}.tar"    
+    progress_download(index.notebooks_url, tar_destination_file)
+    
     my_tar = tarfile.open(tar_destination_file)
     my_tar.extractall(localfolder)
     my_tar.close()
@@ -103,18 +145,22 @@ def cli_download_notebooks(release, out):
 
 
 @click.command(name="datasets")
+@click.option("--release", required=True, help="Number of stable release - ex: 0.18.2)")
 @click.option(
     "--out",
     default="gammapy-datasets",
     help="Destination folder.",
     show_default=True,
 )
-def cli_download_datasets(out):
+def cli_download_datasets(release, out):
     """Download datasets"""
+    index = DownloadIndex(release=release)
+
     localfolder = Path(out)
-    log.info(f"Downloading datasets from {TAR_DATASETS}")
+    log.info(f"Downloading datasets from {index.datasets_url}")
     tar_destination_file = localfolder / "datasets.tar.gz"
-    progress_download(TAR_DATASETS, tar_destination_file)
+    progress_download(index.datasets_url, tar_destination_file)
+    
     log.info(f"Extracting {tar_destination_file}")
     extract_bundle(tar_destination_file, localfolder)
     Path(tar_destination_file).unlink()

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -18,7 +18,6 @@ def test_cli_download_help():
     assert "Usage" in result.output
 
 
-@pytest.mark.xfail
 @pytest.mark.remote_data
 def test_cli_download_notebooks(tmp_path, config):
     args = [

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -43,7 +43,7 @@ def test_cli_download_notebooks_dev(tmp_path):
         "download",
         "notebooks",
         f"--out={tmp_path}",
-        f"--release=dev",
+        "--release=dev",
     ]
     run_cli(cli, args)
     assert (tmp_path / "dev" / "gammapy-dev-environment.yml").exists()

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -7,9 +7,9 @@ from gammapy.utils.testing import run_cli
 @pytest.fixture(scope="session")
 def config():
     return {
-        "release": "dev",
+        "release": "0.20",
         "notebook": "overview",
-        "envfilename": "gammapy-dev-environment.yml",
+        "envfilename": "gammapy-0.20-environment.yml",
     }
 
 
@@ -19,7 +19,7 @@ def test_cli_download_help():
 
 
 @pytest.mark.remote_data
-def test_cli_download_notebooks(tmp_path, config):
+def test_cli_download_notebooks_stable(tmp_path, config):
     args = [
         "download",
         "notebooks",
@@ -38,7 +38,26 @@ def test_cli_download_notebooks(tmp_path, config):
 
 
 @pytest.mark.remote_data
-def test_cli_download_datasets(tmp_path, config):
+def test_cli_download_notebooks_dev(tmp_path):
+    args = [
+        "download",
+        "notebooks",
+        f"--out={tmp_path}",
+        f"--release=dev",
+    ]
+    run_cli(cli, args)
+    assert (tmp_path / "dev" / "gammapy-dev-environment.yml").exists()
+    assert (
+        tmp_path
+        / "dev"
+        / "starting"
+        / "analysis_1.ipynb"
+    ).exists()
+
+
+@pytest.mark.remote_data
+def test_cli_download_datasets(tmp_path):
+    # TODO: this test downloads all datasets which is really slow...
     option_out = f"--out={tmp_path}"
 
     args = ["download", "datasets", option_out]


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request reactivates the `gammapy download` command and adapts it to work with the archive file created by `sphinx-gallery`. For this I introduced a download index file here: https://github.com/gammapy/gammapy-webpage/blob/gh-pages/download/index.json

This allows us to declare the files to download independently of the code base. I additionally added the index for datasets, which allows us to address #4062 even after we have tagged v1.0.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
