### PR TITLE
Move binder configuration to gammapy-webpage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,15 @@ jobs:
           - os: ubuntu-latest
             python: '3.9'
             tox_env: 'py39-test-alldeps-cov'
-            gammapy_data_path: /home/runner/work/gammapy/gammapy/gammapy-datasets
+            gammapy_data_path: /home/runner/work/gammapy/gammapy/gammapy-datasets/dev
           - os: macos-latest
             python: '3.9'
             tox_env: 'py39-test'
-            gammapy_data_path: /Users/runner/work/gammapy/gammapy/gammapy-datasets
+            gammapy_data_path: /Users/runner/work/gammapy/gammapy/gammapy-datasets/dev
           - os: windows-latest
             python: '3.9'
             tox_env: 'py39-test-alldeps'
-            gammapy_data_path:  D:\a\gammapy\gammapy\gammapy-datasets
+            gammapy_data_path:  D:\a\gammapy\gammapy\gammapy-datasets\dev
           - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-alldeps'
@@ -85,7 +85,7 @@ jobs:
         shell: bash -l {0}
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
-      GAMMAPY_DATA: /home/runner/work/gammapy/gammapy/gammapy-datasets
+      GAMMAPY_DATA: /home/runner/work/gammapy/gammapy/gammapy-datasets/dev
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ test-cov:
 
 docs-sphinx:
 	cd docs && python -m sphinx . _build/html -b html -j auto
-	cp docs/binder/runtime.txt docs/_build/html/binder
 
 docs-show:
 	python docs/serve.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -250,16 +250,17 @@ automodsumm_inherited_members = True
 # http://www.sphinx-doc.org/en/stable/config.html#confval-suppress_warnings
 suppress_warnings = ["ref.citation"]
 
+branch = "master" if switch_version == "dev" else f"v{switch_version}"
 
 binder_config = {
     # Required keys
     "org": "gammapy",
-    "repo": "gammapy-docs",
-    "branch": "main",  # Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
+    "repo": "gammapy-webpage",
+    "branch": branch,  # Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
     "binderhub_url": "https://mybinder.org",  # Any URL of a binderhub deployment. Must be full URL (e.g. https://mybinder.org).
     "dependencies": "./binder/requirements.txt",
-    "notebooks_dir": "docs/dev/notebooks",
-    "use_jupyter_lab": False,
+    "notebooks_dir": f"notebooks/{switch_version}",
+    "use_jupyter_lab": True,
 }
 
 # nitpicky = True

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -34,7 +34,7 @@ want to install the datasets and proceed with the following commands:
 
     $ gammapy download notebooks
     $ gammapy download datasets
-    $ export GAMMAPY_DATA=$PWD/gammapy-datasets
+    $ export GAMMAPY_DATA=$PWD/gammapy-datasets/|release|
 
 You might want to put the definition of the ``$GAMMAPY_DATA`` environment
 variable in your shell profile setup file that is executed when you open a new

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -176,7 +176,7 @@ def cli_download_datasets(release, out):
     """Download datasets"""
     index = DownloadIndex(release=release)
 
-    localfolder = Path(out)
+    localfolder = Path(out) / index.release
     log.info(f"Downloading datasets from {index.datasets_url}")
     tar_destination_file = localfolder / "datasets.tar.gz"
     progress_download(index.datasets_url, tar_destination_file)

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -63,5 +63,5 @@ def test_cli_download_datasets(tmp_path):
 
     args = ["download", "datasets", option_out]
     result = run_cli(cli, args)
-    assert tmp_path.exists()
+    assert (tmp_path / "dev").exists()
     assert "GAMMAPY_DATA" in result.output


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request moves the binder configuration to `gammapy-webpage` and thus keeps the current setup.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
