### PR TITLE
Adapt Astropy and Numpy versions in tox configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
             tox_env: 'codestyle'
           - os: ubuntu-latest
             python: '3.8'
-            tox_env: 'py38-test-alldeps-astropylts-numpy119'
+            tox_env: 'py38-test-alldeps-astropylts-numpy120'
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'py38-test-alldeps-astropylts-numpy120'
+          - os: ubuntu-latest
+            python: '3.8'
+            tox_env: 'oldestdeps'
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'oldestdeps'
+          - os: ubuntu-latest
+            python: '3.8'
+            tox_env: 'devdeps'
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/first-interaction@v1
+      continue-on-error: true
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: 'Merci! We will respond to your issue shortly. In the meantime, try `import gammapy; gammapy.song()`'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,21 +1,14 @@
 include README.rst
 include LONG_DESCRIPTION.rst
-include CHANGES.rst
 include environment-dev.yml
 include setup.cfg
 include LICENSE.rst
 include pyproject.toml
 
-recursive-include gammapy *.pyx *.pxd *.c *.h
+recursive-include gammapy *.pyx *.c
 recursive-include docs *
 recursive-include examples *
 recursive-include dev *
 recursive-include scripts *
-
-prune build
-prune docs/_build
-prune docs/api
-prune docs/notebooks
-prune docs/_static/notebooks
 
 global-exclude *.pyc *.o

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,3 @@ recursive-include gammapy *.pyx *.c
 recursive-include docs *
 recursive-include examples *
 recursive-include dev *
-recursive-include scripts *
-
-global-exclude *.pyc *.o

--- a/gammapy/analysis/config/example-3d.yaml
+++ b/gammapy/analysis/config/example-3d.yaml
@@ -16,7 +16,7 @@ datasets:
             offset_max: 2.5 deg
         axes:
             energy: {min: 1 TeV, max: 10 TeV, nbins: 4}
-            energy_true: {min: 1 TeV, max: 10 TeV, nbins: 5}
+            energy_true: {min: 0.7 TeV, max: 12 TeV, nbins: 10}
     map_selection: ['counts', 'exposure', 'background', 'psf', 'edisp']
     safe_mask:
         methods: ['offset-max']
@@ -26,7 +26,7 @@ datasets:
         parameters: {method: 'scale'}
 
 fit:
-    fit_range: {min: 1 TeV, max: 10 TeV}
+    fit_range: {min: 1 TeV, max: 10.1 TeV}
 
 flux_points:
     energy: {min: 1 TeV, max: 10 TeV, nbins: 2}

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -388,10 +388,10 @@ def test_analysis_3d():
     assert len(table) == 2
     dnde = table["dnde"].quantity
 
-    assert_allclose(dnde[0].value, 1.339052e-11, rtol=1e-2)
-    assert_allclose(dnde[-1].value, 2.772374e-13, rtol=1e-2)
-    assert_allclose(res["index"].value, 3.097613, rtol=1e-2)
-    assert_allclose(res["tilt"].value, -0.207792, rtol=1e-2)
+    assert_allclose(dnde[0].value, 1.2722e-11, rtol=1e-2)
+    assert_allclose(dnde[-1].value, 4.054128e-13, rtol=1e-2)
+    assert_allclose(res["index"].value, 2.772814, rtol=1e-2)
+    assert_allclose(res["tilt"].value, -0.133436, rtol=1e-2)
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -42,8 +42,10 @@ def observations_cta_dc1():
 
 @pytest.fixture()
 def spectrum_dataset_gc():
-    e_reco = MapAxis.from_edges(np.logspace(0, 2, 5) * u.TeV, name="energy")
-    e_true = MapAxis.from_edges(np.logspace(-1, 2, 13) * u.TeV, name="energy_true")
+    e_reco = MapAxis.from_energy_edges(np.logspace(0, 2, 5) * u.TeV, name="energy")
+    e_true = MapAxis.from_energy_edges(
+        np.logspace(-1, 2, 13) * u.TeV, name="energy_true"
+    )
     geom = RegionGeom.create("galactic;circle(0, 0, 0.11)", axes=[e_reco])
     return SpectrumDataset.create(geom=geom, energy_axis_true=e_true)
 
@@ -60,8 +62,10 @@ def spectrum_dataset_magic_crab():
 
 @pytest.fixture()
 def spectrum_dataset_crab():
-    e_reco = MapAxis.from_edges(np.logspace(0, 2, 5) * u.TeV, name="energy")
-    e_true = MapAxis.from_edges(np.logspace(-0.5, 2, 11) * u.TeV, name="energy_true")
+    e_reco = MapAxis.from_energy_edges(np.logspace(0, 2, 5) * u.TeV)
+    e_true = MapAxis.from_energy_edges(
+        np.logspace(-0.5, 2, 11) * u.TeV, name="energy_true"
+    )
     geom = RegionGeom.create(
         "icrs;circle(83.63, 22.01, 0.11)", axes=[e_reco], binsz_wcs="0.01deg"
     )
@@ -70,7 +74,9 @@ def spectrum_dataset_crab():
 
 @pytest.fixture()
 def spectrum_dataset_crab_fine():
-    e_true = MapAxis.from_edges(np.logspace(-2, 2.5, 109) * u.TeV, name="energy_true")
+    e_true = MapAxis.from_energy_edges(
+        np.logspace(-2, 2.5, 109) * u.TeV, name="energy_true"
+    )
     e_reco = MapAxis.from_energy_edges(np.logspace(-2, 2, 73) * u.TeV)
     geom = RegionGeom.create("icrs;circle(83.63, 22.01, 0.11)", axes=[e_reco])
     return SpectrumDataset.create(geom=geom, energy_axis_true=e_true)
@@ -123,8 +129,8 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_crab, observations_hes
         datasets.append(dataset)
 
     # Exposure
-    assert_allclose(datasets[0].exposure.data.sum(), 7374718644.757894)
-    assert_allclose(datasets[1].exposure.data.sum(), 6691006466.659032)
+    assert_allclose(datasets[0].exposure.data.sum(), 7.3111e09)
+    assert_allclose(datasets[1].exposure.data.sum(), 6.634534e09)
 
     # Background
     assert_allclose(datasets[0].npred_background().data.sum(), 7.7429157, rtol=1e-5)
@@ -217,7 +223,7 @@ def test_safe_mask_maker_dc1(spectrum_dataset_gc, observations_cta_dc1):
     maker = SpectrumDatasetMaker()
     dataset = maker.run(spectrum_dataset_gc, obs)
     dataset = safe_mask_maker.run(dataset, obs)
-    assert_allclose(dataset.energy_range[0], 3.162278, rtol=1e-3)
+    assert_allclose(dataset.energy_range[0], 1, rtol=1e-3)
     assert dataset.energy_range[0].unit == "TeV"
 
 
@@ -279,7 +285,7 @@ class TestSpectrumMakerChain:
             (
                 dict(containment_correction=False),
                 dict(
-                    n_on=125, sigma=18.953014, aeff=580254.9 * u.m**2, edisp=0.23635
+                    n_on=125, sigma=18.953014, aeff=580254.9 * u.m**2, edisp=0.235864
                 ),
             ),
             (
@@ -288,7 +294,7 @@ class TestSpectrumMakerChain:
                     n_on=125,
                     sigma=18.953014,
                     aeff=375314.356461 * u.m**2,
-                    edisp=0.23635,
+                    edisp=0.235864,
                 ),
             ),
         ],

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1255,7 +1255,7 @@ class Map(abc.ABC):
                 if axis.name == "energy" or axis.name == "energy_true":
                     info = (
                         f"{energy_unit_format(axis.edges[idx])} - "
-                        "{energy_unit_format(axis.edges[idx+1])}"
+                        f"{energy_unit_format(axis.edges[idx+1])}"
                     )
                 else:
                     info = f"{axis.edges[idx]:.1f} - {axis.edges[idx + 1]:.1f} "

--- a/gammapy/maps/wcs/tests/test_ndmap.py
+++ b/gammapy/maps/wcs/tests/test_ndmap.py
@@ -721,7 +721,7 @@ def get_npred_map():
     )
 
     spatial_model = GaussianSpatialModel(
-        lon_0="0 deg", lat_0="0 deg", sigma="0.2 deg", frame="galactic"
+        lon_0="0.015 deg", lat_0="-0.037 deg", sigma="0.2 deg", frame="galactic"
     )
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     skymodel = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
@@ -740,9 +740,9 @@ def test_map_sampling():
     coords = nmap.sample_coord(n_events=2, random_state=0)
 
     assert len(coords["lon"]) == 2
-    assert_allclose(coords.skycoord.icrs.ra.deg, [266.307081, 266.442255], rtol=1e-5)
-    assert_allclose(coords.skycoord.icrs.dec.deg, [-28.753408, -28.742696], rtol=1e-5)
-    assert_allclose(coords["energy_true"].data, [2.755397, 1.72316], rtol=1e-5)
+    assert_allclose(coords.skycoord.icrs.ra.deg, [266.204197, 266.451241], rtol=1e-5)
+    assert_allclose(coords.skycoord.icrs.dec.deg, [-28.862369, -29.075469], rtol=1e-5)
+    assert_allclose(coords["energy_true"].data, [2.363293, 2.342388], rtol=1e-5)
 
     assert coords["lon"].unit == "deg"
     assert coords["lat"].unit == "deg"

--- a/gammapy/maps/wcs/tests/test_ndmap.py
+++ b/gammapy/maps/wcs/tests/test_ndmap.py
@@ -6,7 +6,6 @@ import astropy.units as u
 from astropy.convolution import Box2DKernel, Gaussian2DKernel
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-from astropy.table import Table
 from regions import CircleSkyRegion, PointSkyRegion, RectangleSkyRegion
 from gammapy.datasets.map import MapEvaluator
 from gammapy.irf import PSFKernel, PSFMap
@@ -739,17 +738,11 @@ def test_map_sampling():
 
     nmap = WcsNDMap(geom=eval.geom, data=npred.data)
     coords = nmap.sample_coord(n_events=2, random_state=0)
-    skycoord = coords.skycoord
 
-    events = Table()
-    events["RA_TRUE"] = skycoord.icrs.ra
-    events["DEC_TRUE"] = skycoord.icrs.dec
-    events["ENERGY_TRUE"] = coords["energy_true"]
-
-    assert len(events) == 2
-    assert_allclose(events["RA_TRUE"].data, [266.307081, 266.442255], rtol=1e-5)
-    assert_allclose(events["DEC_TRUE"].data, [-28.753408, -28.742696], rtol=1e-5)
-    assert_allclose(events["ENERGY_TRUE"].data, [2.755397, 1.72316], rtol=1e-5)
+    assert len(coords["lon"]) == 2
+    assert_allclose(coords.skycoord.icrs.ra.deg, [266.307081, 266.442255], rtol=1e-5)
+    assert_allclose(coords.skycoord.icrs.dec.deg, [-28.753408, -28.742696], rtol=1e-5)
+    assert_allclose(coords["energy_true"].data, [2.755397, 1.72316], rtol=1e-5)
 
     assert coords["lon"].unit == "deg"
     assert coords["lat"].unit == "deg"

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from numpy.testing import assert_allclose
 from astropy.table import Table
 import matplotlib.pyplot as plt
-from matplotlib import colors
 from gammapy.utils.testing import mpl_plot_check
 from gammapy.visualization import (
     plot_contour_line,
@@ -35,11 +33,6 @@ def test_plot_spectrum_datasets_off_regions():
         ax=ax, datasets=[dataset_1, dataset_2, dataset_3]
     )
 
-    actual = colors.to_rgba(ax.patches[0].get_edgecolor())
-    assert_allclose(actual, (0.121569, 0.466667, 0.705882, 1.0), rtol=1e-2)
-
-    actual = colors.to_rgba(ax.patches[2].get_edgecolor())
-    assert_allclose(actual, (1.0, 0.498039, 0.054902, 1.0), rtol=1e-2)
     assert ax.lines[0].get_color() in ["green", "C0"]
 
 

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -1,7 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 import numpy as np
+from numpy.testing import assert_allclose
 from astropy.table import Table
+import matplotlib
 import matplotlib.pyplot as plt
+from packaging import version
 from gammapy.utils.testing import mpl_plot_check
 from gammapy.visualization import (
     plot_contour_line,
@@ -10,6 +14,10 @@ from gammapy.visualization import (
 )
 
 
+@pytest.mark.skipif(
+    version.parse(matplotlib.__version__) < version.parse("3.5"),
+    reason="Requires matplotlib 3.5 or higher",
+)
 def test_plot_spectrum_datasets_off_regions():
     from gammapy.datasets import SpectrumDatasetOnOff
     from gammapy.maps import Map, RegionNDMap
@@ -33,6 +41,11 @@ def test_plot_spectrum_datasets_off_regions():
         ax=ax, datasets=[dataset_1, dataset_2, dataset_3]
     )
 
+    actual = ax.patches[0].get_edgecolor()
+    assert_allclose(actual, (0.121569, 0.466667, 0.705882, 1.0), rtol=1e-2)
+
+    actual = ax.patches[2].get_edgecolor()
+    assert_allclose(actual, (1.0, 0.498039, 0.054902, 1.0), rtol=1e-2)
     assert ax.lines[0].get_color() in ["green", "C0"]
 
 

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -3,6 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.table import Table
 import matplotlib.pyplot as plt
+from matplotlib import colors
 from gammapy.utils.testing import mpl_plot_check
 from gammapy.visualization import (
     plot_contour_line,
@@ -34,12 +35,11 @@ def test_plot_spectrum_datasets_off_regions():
         ax=ax, datasets=[dataset_1, dataset_2, dataset_3]
     )
 
-    assert_allclose(
-        ax.patches[0].get_edgecolor(), (0.121569, 0.466667, 0.705882, 1.0), rtol=1e-2
-    )
-    assert_allclose(
-        ax.patches[2].get_edgecolor(), (1.0, 0.498039, 0.054902, 1.0), rtol=1e-2
-    )
+    actual = colors.to_rgba(ax.patches[0].get_edgecolor())
+    assert_allclose(actual, (0.121569, 0.466667, 0.705882, 1.0), rtol=1e-2)
+
+    actual = colors.to_rgba(ax.patches[2].get_edgecolor())
+    assert_allclose(actual, (1.0, 0.498039, 0.054902, 1.0), rtol=1e-2)
     assert ax.lines[0].get_color() in ["green", "C0"]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ packages = find:
 python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    numpy>=1.19,<1.23
+    numpy>=1.20
     scipy>=1.4
     astropy>=5.0
     regions>=0.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,10 @@ deps =
     oldestdeps: iminuit==2.8.*
     
     devdeps: :NIGHTLY:numpy
+    devdeps: :NIGHTLY:scipy
+    devdeps: :NIGHTLY:matplotlib
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: git+https://github.com/scikit-hep/iminuit.git#egg=iminuit
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 minversion = 2.0
 envlist =
     py{38,39,310}-test{,-alldeps,-devdeps}{,-cov}
-    py{38,39,310}-test-numpy{119,120,121}
-    py{38,39,310}-test-astropy{40,50,lts}
+    py{38,39,310}-test-numpy{120,121,122,123}
+    py{38,39,310}-test-astropy{50,lts}
     build_docs
     linkcheck
     codestyle
@@ -39,10 +39,10 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy119: with numpy 1.19.*
     numpy120: with numpy 1.20.*
     numpy121: with numpy 1.21.*
-    astropy40: with astropy 4.0.*
+    numpy122: with numpy 1.22.*
+    numpy123: with numpy 1.23.*
     astropy50: with astropy 5.0.*
     astropylts: with the latest astropy LTS
 
@@ -50,11 +50,11 @@ description =
 deps =
 
     cov: coverage
-    numpy119: numpy==1.19.*
     numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*
+    numpy122: numpy==1.22.*
+    numpy123: numpy==1.23.*
 
-    astropy40: astropy==4.0.*
     astropy50: astropy==5.0.*
     astropylts: astropy==5.0.*
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,16 @@ deps =
     astropy50: astropy==5.0.*
     astropylts: astropy==5.0.*
 
+    oldestdeps: numpy==1.20.*
+    oldestdeps: matplotlib==3.4.*
+    oldestdeps: scipy==1.4.*
+    oldestdeps: pyyaml==5.1.*
+    oldestdeps: astropy==5.0.*
+    oldestdeps: click==7.0.*
+    oldestdeps: regions==0.5.*
+    oldestdeps: pydantic==1.4.*
+    oldestdeps: iminuit==2.8.*
+    
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
 

--- a/tox.ini
+++ b/tox.ini
@@ -68,9 +68,9 @@ deps =
     oldestdeps: pydantic==1.4.*
     oldestdeps: iminuit==2.8.*
     
-    devdeps: :NIGHTLY:numpy
-    devdeps: :NIGHTLY:scipy
-    devdeps: :NIGHTLY:matplotlib
+    devdeps: scipy>=0.0.dev0
+    devdeps: numpy>=0.0.dev0
+    devdeps: matplotlib>=0.0.dev0
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
     devdeps: git+https://github.com/scikit-hep/iminuit.git#egg=iminuit
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request drops the support for Numpy 1.19 and remove the Astropy 4.0 configuration from `tox.ini`.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
