### PR TITLE
simplification of np.array(set(labels))

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2803,12 +2803,12 @@ class LabelMapAxis:
     node_type = "label"
 
     def __init__(self, labels, name=""):
-        unique_labels = set(labels)
+        unique_labels = np.unique(labels)
 
         if not len(unique_labels) == len(labels):
             raise ValueError("Node labels must be unique")
 
-        self._labels = np.array(labels)
+        self._labels = unique_labels
         self._name = name
 
     @property


### PR DESCRIPTION
Simplification of unique_labels using np.unique instead of sets. Avoids calling again the conversion to np.array at the end of the function.

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request was suggested in issue #4117 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
