### PR TITLE
Correct safe mask parameters in spectral analysis with the HLI tutorial

### DIFF
--- a/examples/tutorials/analysis-1d/spectral_analysis_hli.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_hli.py
@@ -112,8 +112,8 @@ datasets:
     on_region: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 0.11 deg}
     containment_correction: true
     safe_mask:
-       methods: ['offset-max']
-       parameters: {offset_max: 2.0 deg}
+       methods: ['aeff-default', 'aeff-max']
+       parameters: {aeff_percent: 0.1}
     background:
         method: reflected
 fit:

--- a/examples/tutorials/analysis-1d/spectral_analysis_hli.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_hli.py
@@ -394,6 +394,7 @@ model_1d.to_parameters_table()
 ax_spectrum, ax_residuals = analysis.datasets[0].plot_fit()
 ax_spectrum.set_ylim(0.1, 200)
 ax_spectrum.set_xlim(0.2, 60)
+ax_residuals.set_xlim(0.2, 60)
 analysis.datasets[0].plot_masks(ax=ax_spectrum)
 
 


### PR DESCRIPTION

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request .corrects the configuration applied to the `Analysis` class in the spectral analysis tutorial. The `SafeMaskMaker` parameters were using the maximum offset, where it should be using the effective area criterion.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
