### PR TITLE
Correct bug with ReflectedRegionFinder and PointSkyRegion

### DIFF
--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -384,7 +384,9 @@ class ReflectedRegionsFinder(RegionsFinder):
             WCS for the determined regions
         """
         if isinstance(region, PointSkyRegion):
-            raise TypeError("ReflectedRegionFinder does not work with PointSkyRegion.")
+            raise TypeError(
+                "ReflectedRegionFinder does not work with PointSkyRegion. Use WobbleRegionFinder instead."
+            )
 
         regions = []
 

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -383,6 +383,9 @@ class ReflectedRegionsFinder(RegionsFinder):
         wcs: `~astropy.wcs.WCS`
             WCS for the determined regions
         """
+        if isinstance(region, PointSkyRegion):
+            raise TypeError("ReflectedRegionFinder does not work with PointSkyRegion.")
+
         regions = []
 
         reference_geom = self._create_reference_geometry(region, center)

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -385,7 +385,7 @@ class ReflectedRegionsFinder(RegionsFinder):
         """
         if isinstance(region, PointSkyRegion):
             raise TypeError(
-                "ReflectedRegionFinder does not work with PointSkyRegion. Use WobbleRegionFinder instead."
+                "ReflectedRegionsFinder does not work with PointSkyRegion. Use WobbleRegionsFinder instead."
             )
 
         regions = []

--- a/gammapy/makers/background/tests/test_reflected.py
+++ b/gammapy/makers/background/tests/test_reflected.py
@@ -454,5 +454,5 @@ def test_reflected_bkg_maker_fixed_rad_max_bad(
     dataset_empty = SpectrumDataset.create(geom=geom_point_shape)
 
     dataset = maker.run(dataset_empty, obs)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         reflected_bkg_maker.run(dataset, obs)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects a bug that was not seen by tests. The `ReflectedRegionFinder` should fail if the region is `PointSkyRegion`. The error raised previously happened not to be raised at the right place. It appeared in the CI of #4133 
This PR corrects for this by explicitly testing if the input region is `PointSkyRegion` and raises a `TypeError` if it is the case.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
