### PR TITLE
Return correct covariance matrix on CovarianceResult

### DIFF
--- a/examples/tutorials/api/fitting.py
+++ b/examples/tutorials/api/fitting.py
@@ -202,12 +202,13 @@ result_minuit.trace
 
 
 ######################################################################
-# Check that the fitted values and errors for all parameters are
-# reasonable, and no fitted parameter value is “too close” - or even
-# outside - its allowed min-max range
+# The fitted models are copied on the `~gammapy.modeling.FitResult` object.
+# They can be inspected to check that the fitted values and errors
+# for all parameters are reasonable, and no fitted parameter value is “too close”
+# - or even outside - its allowed min-max range
 #
 
-result_minuit.parameters.to_table()
+result_minuit.models.to_parameter_table()
 
 
 ######################################################################
@@ -249,19 +250,24 @@ for ax, par in zip(axes, crab_model.parameters.free_parameters):
 # Covariance and parameters errors
 # --------------------------------
 #
-# After the fit the covariance matrix is attached to the model. You can
-# get the error on a specific parameter by accessing the `~gammapy.modeling.Parameter.error`
-# attribute:
-#
+# After the fit the covariance matrix is attached to the models copy
+# stored on the `~gammapy.modeling.FitResult` object.
+# You can access it directly with:
 
-crab_model.spectral_model.alpha.error
-
+print(result_minuit.models.covariance)
 
 ######################################################################
 # And you can plot the total parameter correlation as well:
 #
 
-crab_model.covariance.plot_correlation()
+result_minuit.models.covariance.plot_correlation()
+
+# The covariance information is also propagated to the individual models
+# Therefore, one can also get the error on a specific parameter by directly
+# accessing the `~gammapy.modeling.Parameter.error` attribute:
+#
+
+crab_model.spectral_model.alpha.error
 
 
 ######################################################################

--- a/examples/tutorials/api/fitting.py
+++ b/examples/tutorials/api/fitting.py
@@ -208,7 +208,7 @@ result_minuit.trace
 # - or even outside - its allowed min-max range
 #
 
-result_minuit.models.to_parameter_table()
+result_minuit.models.to_parameters_table()
 
 
 ######################################################################

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -169,6 +169,10 @@ class Fit:
 
         covariance_result = self.covariance(datasets=datasets)
 
+        optimize_result.models.covariance = Covariance(
+            optimize_result.models.parameters, covariance_result.matrix
+        )
+
         return FitResult(
             optimize_result=optimize_result,
             covariance_result=covariance_result,
@@ -269,9 +273,10 @@ class Fit:
                 parameters=unique_pars, function=datasets.stat_sum, **kwargs
             )
 
-            datasets.models.covariance = Covariance.from_factor_matrix(
+            matrix = Covariance.from_factor_matrix(
                 parameters=parameters, matrix=factor_matrix
             )
+            datasets.models.covariance = matrix
 
         # TODO: decide what to return, and fill the info correctly!
         return CovarianceResult(

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -284,7 +284,7 @@ class Fit:
             method=method,
             success=info["success"],
             message=info["message"],
-            matrix=datasets.models.covariance.data.copy(),
+            matrix=matrix.data.copy(),
         )
 
     def confidence(self, datasets, parameter, sigma=1, reoptimize=True):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is the result of the discussion in #4149 . It sets the correct covariance matrix on the `CovarianceResult` plus it adds the `Covariance` object on the `FitResult.models` so that all the information should be available inside it.

One should find a proper place to test this.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
