### PR TITLE
Fix failing test because of scipy 1.9.3

### DIFF
--- a/gammapy/modeling/tests/test_covariance.py
+++ b/gammapy/modeling/tests/test_covariance.py
@@ -51,9 +51,10 @@ def test_get_subcovariance(covariance_diagonal, covariance):
 
 
 def test_scipy_mvn(covariance):
-    mvn = covariance.scipy_mvn
+    # Adapt test because scipy 1.9.3 does not work with semi positive matrices of rank one
+    mvn = Covariance(covariance.parameters, np.array([[1, 0.5], [0.5, 1]])).scipy_mvn
     value = mvn.pdf(2)
-    assert_allclose(value, 0.2489, rtol=1e-3)
+    assert_allclose(value, 0.094354, rtol=1e-3)
 
 
 def test_plot_correlation(covariance_diagonal):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a patch for failing test with scipy 1.9.3
The issue is that `multivariate_normal` is now failing with a matrix of rank 1.  The test is changed to have a rank 2 matrix instead. This is likely a bug in scipy.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
