### PR TITLE
Better handling of regions with inhomogeneous frames in RegionGeom

### DIFF
--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -55,7 +55,7 @@ def compound_region_center(compound_region):
     if len(regions) == 1:
         return regions[0].center
 
-    positions = SkyCoord([region.center for region in regions])
+    positions = SkyCoord([region.center.icrs for region in regions])
 
     def f(x, coords):
         """Function to minimize"""

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -63,7 +63,7 @@ def compound_region_center(compound_region):
         center = SkyCoord(lon * u.deg, lat * u.deg)
         return np.sum(center.separation(coords).deg)
 
-    ra, dec = positions.icrs.ra.wrap_at("180d").deg, positions.icrs.dec.deg
+    ra, dec = positions.ra.wrap_at("180d").deg, positions.dec.deg
 
     ub = np.array([np.max(ra), np.max(dec)])
     lb = np.array([np.min(ra), np.min(dec)])

--- a/gammapy/utils/tests/test_regions.py
+++ b/gammapy/utils/tests/test_regions.py
@@ -58,6 +58,20 @@ def test_compound_region_center_concentric():
     assert_allclose(center.galactic.b, 0 * u.deg, atol=1e-6)
 
 
+def test_compound_region_center_inomogeneous_frames():
+    region_icrs = Regions.parse("icrs;circle(1,1,0.1)", format="ds9")[0]
+    region_galactic = Regions.parse("galactic;circle(1,1,0.1)", format="ds9")[0]
+
+    regions = Regions([region_icrs, region_galactic])
+
+    region = regions_to_compound_region(regions)
+
+    center = compound_region_center(region)
+
+    assert_allclose(center.galactic.l.wrap_at("180d"), 28.011753 * u.deg, atol=1e-6)
+    assert_allclose(center.galactic.b, -37.463676 * u.deg, atol=1e-6)
+
+
 def test_spherical_circle_sky_region():
     region = SphericalCircleSkyRegion(
         center=SkyCoord(10 * u.deg, 20 * u.deg), radius=10 * u.deg

--- a/gammapy/utils/tests/test_regions.py
+++ b/gammapy/utils/tests/test_regions.py
@@ -68,8 +68,8 @@ def test_compound_region_center_inomogeneous_frames():
 
     center = compound_region_center(region)
 
-    assert_allclose(center.galactic.l.wrap_at("180d"), 28.011753 * u.deg, atol=1e-6)
-    assert_allclose(center.galactic.b, -37.463676 * u.deg, atol=1e-6)
+    assert_allclose(center.galactic.l.wrap_at("180d"), 28.01 * u.deg, atol=1e-2)
+    assert_allclose(center.galactic.b, -37.46 * u.deg, atol=1e-2)
 
 
 def test_spherical_circle_sky_region():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request addresses the following issue: `RegionGeom.from_regions(regions=regions)` fails if `regions` contain regions with different center coordinate frames.

To reproduce: 
```
from gammapy.maps.region import RegionGeom
from regions import Regions, CircleSkyRegion
from astropy.coordinates import SkyCoord
import astropy.units as u

c1 = CircleSkyRegion(SkyCoord(0, 0, unit=u.deg, frame="icrs"), radius=1*u.deg)
c2 = CircleSkyRegion(SkyCoord(0, 0, unit=u.deg, frame="galactic"), radius=1*u.deg)

regions = Regions([c1, c2])
RegionGeom.from_regions(regions=regions)
```
Which yields
```
ValueError: List of inputs don't have equivalent frames: <SkyCoord (Galactic): (l, b) in deg
    (0., 0.)> != <SkyCoord (ICRS): (ra, dec) in deg
    (0., 0.)>
```
To fix it it was sufficient to convert all region centers to the `icrs` frame in the `compound_region_center` function defined in `gammapy.utils.regions`.


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
