### PR TITLE
Backport PR #4164: Consistent Interpolation scale for bkg 2d and 3d

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -236,8 +236,6 @@ class Background2D(BackgroundIRF):
     tag = "bkg_2d"
     required_axes = ["energy", "offset"]
     default_unit = u.s**-1 * u.MeV**-1 * u.sr**-1
-    default_interp_kwargs = dict(bounds_error=False, fill_value=0.0)
-    """Default Interpolation kwargs."""
 
     def to_3d(self):
         """ "Convert to Background3D"""

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -281,7 +281,7 @@ def bkg_2d():
 
     offset = [0, 1, 2, 3] * u.deg
     offset_axis = MapAxis.from_edges(offset, name="offset")
-    data = np.zeros((2, 3))
+    data = np.ones((2, 3))
     data[1, 0] = 2
     data[1, 1] = 4
     return Background2D(
@@ -295,22 +295,22 @@ def test_background_2d_evaluate(bkg_2d):
 
     # Evaluate at log center between nodes in energy
     res = bkg_2d.evaluate(offset=[1, 0.5] * u.deg, energy=[1, 1] * u.TeV)
-    assert_allclose(res.value, [0, 0])
+    assert_allclose(res.value, [1, 1])
     assert res.shape == (2,)
     assert res.unit == "s-1 MeV-1 sr-1"
 
     res = bkg_2d.evaluate(offset=[1, 0.5] * u.deg, energy=[100, 100] * u.TeV)
-    assert_allclose(res.value, [3, 2])
+    assert_allclose(res.value, [2.8284, 2], rtol=1e-4)
     res = bkg_2d.evaluate(
         offset=[[1, 0.5], [1, 0.5]] * u.deg,
         energy=[[1, 1], [100, 100]] * u.TeV,
     )
 
-    assert_allclose(res.value, [[0, 0], [3, 2]])
+    assert_allclose(res.value, [[1, 1], [2.8284, 2]], rtol=1e-4)
     assert res.shape == (2, 2)
 
     res = bkg_2d.evaluate(offset=[1, 1] * u.deg, energy=[1, 100] * u.TeV)
-    assert_allclose(res.value, [0, 3])
+    assert_allclose(res.value, [1, 2.8284], rtol=1e-4)
     assert res.shape == (2,)
 
 
@@ -350,24 +350,24 @@ def test_background_2d_integrate(bkg_2d):
     )
 
     assert rate.shape == (1,)
-    assert_allclose(rate.to("s-1 sr-1").value[0], [0, 0])
+    assert_allclose(rate.to("s-1 sr-1").value[0], 304211.869056)
 
     rate = bkg_2d.integrate_log_log(
         offset=[1, 0.5] * u.deg, energy=[1, 100] * u.TeV, axis_name="energy"
     )
-    assert_allclose(rate.to("s-1 sr-1").value, 0)
+    assert_allclose(rate.to("s-1 sr-1").value[0], 1.7296602e08)
 
     rate = bkg_2d.integrate_log_log(
         offset=[[1, 0.5], [1, 0.5]] * u.deg, energy=[1, 100] * u.TeV, axis_name="energy"
     )
     assert rate.shape == (1, 2)
-    assert_allclose(rate.value, [[0, 198]])
+    assert_allclose(rate.value, [[99, 198]])
 
 
 def test_to_3d(bkg_2d):
     bkg_3d = bkg_2d.to_3d()
     assert bkg_3d.data.shape == (2, 6, 6)
-    assert_allclose(bkg_3d.data[1, 1, 1], 1.51, rtol=0.1)
+    assert_allclose(bkg_3d.data[1, 3, 3], 2.31, rtol=0.1)
 
     # assert you get back same after goint to 2d
     # need high rtol due to interpolation effects?

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -35,6 +35,10 @@ class MapDatasetMaker(Maker):
     background_interp_missing_data: bool
         Interpolate missing values in background 3d map.
         Default is True, have to be set to True for CTA IRF.
+    background_pad_offset: bool
+        Pad one bin in offset for 2d background map.
+        This avoid extrapolation at edges and use the nearest value.
+        Default is True.
 
     Examples
     --------
@@ -102,9 +106,11 @@ class MapDatasetMaker(Maker):
         selection=None,
         background_oversampling=None,
         background_interp_missing_data=True,
+        background_pad_offset=True,
     ):
         self.background_oversampling = background_oversampling
         self.background_interp_missing_data = background_interp_missing_data
+        self.background_pad_offset = background_pad_offset
         if selection is None:
             selection = self.available_selection
 
@@ -222,6 +228,9 @@ class MapDatasetMaker(Maker):
 
         if self.background_interp_missing_data:
             bkg.interp_missing_data(axis_name="energy")
+
+        if self.background_pad_offset and bkg.has_offset_axis:
+            bkg = bkg.pad(1, mode="edge", axis_name="offset")
 
         return make_map_background_irf(
             pointing=observation.fixed_pointing_info,

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -17,7 +17,7 @@ from gammapy.data import (
 )
 from gammapy.datasets import MapDataset
 from gammapy.datasets.map import RAD_AXIS_DEFAULT
-from gammapy.irf import EDispKernelMap, EDispMap, PSFMap
+from gammapy.irf import EDispKernelMap, EDispMap, PSFMap, Background2D
 from gammapy.makers import FoVBackgroundMaker, MapDatasetMaker, SafeMaskMaker
 from gammapy.maps import HpxGeom, Map, MapAxis, WcsGeom
 from gammapy.utils.testing import requires_data, requires_dependency
@@ -509,3 +509,30 @@ def test_dataset_hawc():
         assert_allclose(dataset.exposure.data.sum(), results[which][0])
         assert_allclose(dataset.counts.data.sum(), results[which][1])
         assert_allclose(dataset.background.data.sum(), results[which][2])
+
+
+@requires_data()
+def test_make_background_2d(observations):
+    filename = "$GAMMAPY_DATA/tests/irf/bkg_2d_full_example.fits"
+    bkg = Background2D.read(filename)
+    # TODO: better example file for 2d bkg
+    bkg.axes[0]._unit = "TeV"
+    bkg.axes[1]._unit = "deg"
+    bkg._unit = "s-1 TeV-1 sr-1"
+
+    obs = observations[0]
+
+    obs.bkg = bkg
+
+    geom_reco = geom(ebounds=[0.1, 1, 10])
+    e_true = MapAxis.from_edges(
+        [0.1, 0.5, 2.5, 10.0], name="energy_true", unit="TeV", interp="log"
+    )
+
+    reference = MapDataset.create(
+        geom=geom_reco, energy_axis_true=e_true, binsz_irf=1.0
+    )
+    maker_obs = MapDatasetMaker(selection=["background"], background_pad_offset=True)
+
+    map_dataset = maker_obs.run(reference, obs)
+    assert_allclose(map_dataset.background.data.sum(), 17636.60091226549)

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -184,7 +184,7 @@ def test_map_background_2d(bkg_2d, fixed_pointing_info):
         geom=geom,
     )
 
-    assert_allclose(bkg.data[:, 1, 1], [1.80822, 0.183287], rtol=1e-5)
+    assert_allclose(bkg.data[:, 1, 1], [1.869025, 0.186903], rtol=1e-5)
 
     # Check that function works also passing the FixedPointingInfo
     bkg_fpi = make_map_background_irf(


### PR DESCRIPTION
Consistent Interpolation scale for bkg 2d and 3d

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request backports #4164 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
