### PR TITLE
Backport PR #4173 : Remove exception for non-standard OBS_MODE in FixedPointingInfo

### DIFF
--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -30,15 +30,19 @@ class PointingMode(Enum):
 
     For ground-based instruments, the most common options will be:
     * POINTING: The telescope observes a fixed position in the ICRS frame
-    * DRIFT: The telscope observes a fixed position in the AltAz frame
+    * DRIFT: The telescope observes a fixed position in the AltAz frame
 
+    Gammapy only supports fixed pointing positions over the whole observation
+    (either in equatorial or horizontal coordinates).
     OGIP also defines RASTER, SLEW and SCAN. These cannot be treated using
     a fixed pointing position in either frame, so they would require the
     pointing table, which is at the moment not supported by gammapy.
 
-    The H.E.S.S. data releases uses the not-defined value "WOBBLE",
-    which we assume to be the same as "POINTING", making the assumption
-    that one observation only contains a single wobble position.
+    Data releases based on gadf v0.2 do not have consistent OBS_MODE keyword
+    e.g. the H.E.S.S. data releases uses the not-defined value "WOBBLE".
+    For all gadf data, we assume OBS_MODE to be the same as "POINTING",
+    unless it is set to "DRIFT", making the assumption that one observation
+    only contains a single fixed position.
     """
 
     POINTING = auto()
@@ -46,15 +50,13 @@ class PointingMode(Enum):
 
     @staticmethod
     def from_gadf_string(val):
-        # OBS_MODE is not well-defined in GADF 0.2, HESS and MAGIC
-        # filled some variation of "WOBBLE" for the open crab paper
-        if val.upper() in ("POINTING", "WOBBLE"):
-            return PointingMode.POINTING
-
+        # OBS_MODE is not well-defined and not mandatory in GADF 0.2
+        # We always assume that the observations are pointing observations
+        # unless the OBS_MODE is set to DRIFT
         if val.upper() == "DRIFT":
             return PointingMode.DRIFT
-
-        raise ValueError(f"Unsupported pointing mode: {val}")
+        else:
+            return PointingMode.POINTING
 
 
 class FixedPointingInfo:

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -134,7 +135,15 @@ def test_altaz_without_location(caplog):
         assert np.isnan(altaz.az.value)
 
 
-def test_fixed_pointing_info_fixed_icrs():
+@pytest.mark.parametrize(
+    ("obs_mode"),
+    [
+        ("POINTING"),
+        ("WOBBLE"),
+        ("SCAN"),
+    ],
+)
+def test_fixed_pointing_info_fixed_icrs(obs_mode):
     location = observatory_locations["cta_south"]
     start = Time("2020-11-01T03:00:00")
     stop = Time("2020-11-01T03:15:00")
@@ -145,6 +154,7 @@ def test_fixed_pointing_info_fixed_icrs():
     meta["TSTART"] = time_relative_to_ref(start, meta).to_value(u.s)
     meta["TSTOP"] = time_relative_to_ref(stop, meta).to_value(u.s)
     meta.update(earth_location_to_dict(location))
+    meta["OBS_MODE"] = obs_mode
     meta["RA_PNT"] = pointing_icrs.ra.deg
     meta["DEC_PNT"] = pointing_icrs.dec.deg
 


### PR DESCRIPTION
Remove exception for non-standard OBS_MODE in FixedPointingInfo

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request backports #4173 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
