### PR TITLE
Adapt tutorial figure handling

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -315,7 +315,7 @@ sphinx_gallery_conf = {
     "reset_modules": ("matplotlib",),
     "within_subsection_order": FileNameSortKey,
     "download_all_examples": True,
-    "capture_repr": (),
+    "capture_repr": ("_repr_html_", "__repr__"),
     "nested_sections": False,
     "min_reported_time": 10,
     "show_memory": False,

--- a/examples/models/spectral/plot_absorbed.py
+++ b/examples/models/spectral/plot_absorbed.py
@@ -41,19 +41,23 @@ franceschini = EBLAbsorptionNormSpectralModel.read_builtin(
 )
 finke = EBLAbsorptionNormSpectralModel.read_builtin("finke", redshift=redshift)
 
-plt.figure()
+fig, (ax_ebl, ax_model) = plt.subplots(
+    nrows=1, ncols=2, figsize=(10, 4), gridspec_kw={"left": 0.08, "right": 0.96}
+)
+
 energy_bounds = [0.08, 3] * u.TeV
 opts = dict(energy_bounds=energy_bounds, xunits=u.TeV)
-franceschini.plot(label="Franceschini 2008", **opts)
-finke.plot(label="Finke 2010", **opts)
-dominguez.plot(label="Dominguez 2011", **opts)
 
-plt.ylabel(r"Absorption coefficient [$\exp{(-\tau(E))}$]")
-plt.xlim(energy_bounds.value)
-plt.ylim(1e-4, 2)
-plt.title(f"EBL models (z={redshift})")
-plt.grid(which="both")
-plt.legend(loc="best")
+franceschini.plot(ax=ax_ebl, label="Franceschini 2008", **opts)
+finke.plot(ax=ax_ebl, label="Finke 2010", **opts)
+dominguez.plot(ax=ax_ebl, label="Dominguez 2011", **opts)
+
+ax_ebl.set_ylabel(r"Absorption coefficient [$\exp{(-\tau(E))}$]")
+ax_ebl.set_xlim(energy_bounds.value)
+ax_ebl.set_ylim(1e-4, 2)
+ax_ebl.set_title(f"EBL models (z={redshift})")
+ax_ebl.grid(which="both")
+ax_ebl.legend(loc="best")
 
 
 # Spectral model corresponding to PKS 2155-304 (quiescent state)
@@ -69,10 +73,12 @@ absorption = EBLAbsorptionNormSpectralModel.read_builtin("dominguez", redshift=r
 model = pwl * absorption
 
 energy_bounds = [0.1, 100] * u.TeV
-plt.figure()
-model.plot(energy_bounds)
-plt.grid(which="both")
-plt.ylim(1e-24, 1e-8)
+
+model.plot(energy_bounds, ax=ax_model)
+ax_model.grid(which="both")
+ax_model.set_ylim(1e-24, 1e-8)
+ax_model.set_title("Absorbed Power Law")
+plt.show()
 
 # %%
 # YAML representation

--- a/examples/tutorials/analysis-1d/cta_sensitivity.py
+++ b/examples/tutorials/analysis-1d/cta_sensitivity.py
@@ -23,19 +23,20 @@ We will be using the following Gammapy class:
 """
 
 
-######################################################################
-# Setup
-# -----
-#
-# As usual, we’ll start with some setup …
-#
-
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+
+######################################################################
+# Setup
+# -----
+#
+# As usual, we’ll start with some setup …
+#
+from IPython.display import display
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.estimators import SensitivityEstimator
@@ -143,7 +144,7 @@ sensitivity_table = sensitivity_estimator.run(dataset_on_off)
 #
 
 # Show the results table
-print(sensitivity_table)
+display(sensitivity_table)
 
 # Save it to file (could use e.g. format of CSV or ECSV or FITS)
 # sensitivity_table.write('sensitivity.ecsv', format='ascii.ecsv')
@@ -152,7 +153,9 @@ print(sensitivity_table)
 t = sensitivity_table
 
 is_s = t["criterion"] == "significance"
-plt.plot(
+
+fig, ax = plt.subplots()
+ax.plot(
     t["energy"][is_s],
     t["e2dnde"][is_s],
     "s-",
@@ -161,9 +164,9 @@ plt.plot(
 )
 
 is_g = t["criterion"] == "gamma"
-plt.plot(t["energy"][is_g], t["e2dnde"][is_g], "*-", color="blue", label="gamma")
+ax.plot(t["energy"][is_g], t["e2dnde"][is_g], "*-", color="blue", label="gamma")
 is_bkg_syst = t["criterion"] == "bkg"
-plt.plot(
+ax.plot(
     t["energy"][is_bkg_syst],
     t["e2dnde"][is_bkg_syst],
     "v-",
@@ -171,10 +174,10 @@ plt.plot(
     label="bkg syst",
 )
 
-plt.loglog()
-plt.xlabel(f"Energy ({t['energy'].unit})")
-plt.ylabel(f"Sensitivity ({t['e2dnde'].unit})")
-plt.legend()
+ax.loglog()
+ax.set_xlabel(f"Energy ({t['energy'].unit})")
+ax.set_ylabel(f"Sensitivity ({t['e2dnde'].unit})")
+ax.legend()
 
 
 ######################################################################
@@ -197,6 +200,7 @@ ax2.set_ylabel(f"ON region radius ({on_radii.unit})", color="red")
 ax2.semilogy(t["energy"], on_radii, color="red", label="PSF68")
 ax2.tick_params(axis="y", labelcolor="red")
 ax2.set_ylim(0.01, 0.5)
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/analysis-1d/extended_source_spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/extended_source_spectral_analysis.py
@@ -85,13 +85,13 @@ Setup
 As usual, we’ll start with some general imports…
 
 """
-
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
 from regions import CircleSkyRegion
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.data import DataStore
 from gammapy.datasets import Datasets, SpectrumDataset
 from gammapy.makers import (
@@ -237,7 +237,7 @@ for obs in observations:
     # Append dataset to the list
     datasets.append(dataset)
 
-print(datasets.meta_table)
+display(datasets.meta_table)
 
 
 ######################################################################
@@ -261,30 +261,32 @@ datasets[0].peek()
 
 info_table = datasets.info_table(cumulative=True)
 
-print(info_table)
+display(info_table)
 
-fig = plt.figure(figsize=(10, 6))
-ax = fig.add_subplot(121)
-ax.plot(
+######################################################################
+# And make the correponding plots
+
+fig, (ax_excess, ax_sqrt_ts) = plt.subplots(figsize=(10, 4), ncols=2, nrows=1)
+ax_excess.plot(
     info_table["livetime"].to("h"),
     info_table["excess"],
     marker="o",
     ls="none",
 )
+ax_excess.set_title("Excess")
+ax_excess.set_xlabel("Livetime [h]")
+ax_excess.set_ylabel("Excess events")
 
-plt.xlabel("Livetime [h]")
-plt.ylabel("Excess events")
-
-ax = fig.add_subplot(122)
-ax.plot(
+ax_sqrt_ts.plot(
     info_table["livetime"].to("h"),
     info_table["sqrt_ts"],
     marker="o",
     ls="none",
 )
 
-plt.xlabel("Livetime [h]")
-plt.ylabel("Sqrt(TS)")
+ax_sqrt_ts.set_title("Sqrt(TS)")
+ax_sqrt_ts.set_xlabel("Livetime [h]")
+ax_sqrt_ts.set_ylabel("Sqrt(TS)")
 
 
 ######################################################################
@@ -321,7 +323,7 @@ print(result_joint)
 # First the fitted parameters values and their errors.
 #
 
-print(datasets.models.to_parameters_table())
+display(datasets.models.to_parameters_table())
 
 
 ######################################################################
@@ -336,5 +338,7 @@ reduced = datasets.stack_reduce()
 reduced.models = model
 # Plot the result
 
+plt.figure()
 ax_spectrum, ax_residuals = reduced.plot_fit()
 reduced.plot_masks(ax=ax_spectrum)
+plt.show()

--- a/examples/tutorials/analysis-1d/spectral_analysis_hli.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_hli.py
@@ -64,15 +64,16 @@ In summary, we have to:
 """
 
 
-######################################################################
-# Setup
-# -----
-#
-
 from pathlib import Path
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+
+######################################################################
+# Setup
+# -----
+#
+from IPython.display import display
 from gammapy.analysis import Analysis, AnalysisConfig
 from gammapy.modeling.models import Models
 
@@ -383,7 +384,7 @@ analysis.run_fit()
 
 print(analysis.fit_result)
 
-print(model_1d.to_parameters_table())
+display(model_1d.to_parameters_table())
 
 
 ######################################################################
@@ -426,15 +427,15 @@ with filename.open("r") as f:
 analysis.get_flux_points()
 
 crab_fp = analysis.flux_points.data
-crab_fp.to_table(sed_type="dnde", formatted=True)
+crab_fp_table = crab_fp.to_table(sed_type="dnde", formatted=True)
+display(crab_fp_table)
 
 
 ######################################################################
 # Let’s plot the flux points with their likelihood profile
 #
-
-plt.figure(figsize=(10, 8))
-ax_sed = crab_fp.plot(sed_type="e2dnde", color="darkorange")
+fig, ax_sed = plt.subplots()
+crab_fp.plot(ax=ax_sed, sed_type="e2dnde", color="darkorange")
 ax_sed.set_ylim(1.0e-12, 2.0e-10)
 ax_sed.set_xlim(0.5, 40)
 crab_fp.plot_ts_profiles(ax=ax_sed, sed_type="e2dnde")
@@ -463,10 +464,10 @@ analysis.flux_points.write(filename, overwrite=True)
 # We can plot of the spectral fit with its error band overlaid with the
 # flux points:
 #
-
 ax_sed, ax_residuals = analysis.flux_points.plot_fit()
 ax_sed.set_ylim(1.0e-12, 1.0e-9)
 ax_sed.set_xlim(0.5, 40)
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
@@ -100,19 +100,20 @@ a 1D likelihood fit, exactly as illustrated in the previous example.
 
 """
 
-######################################################################
-# Setup
-# -----
-#
-# As usual, we’ll start with some setup …
-#
-
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import PointSkyRegion
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+
+######################################################################
+# Setup
+# -----
+#
+# As usual, we’ll start with some setup …
+#
+from IPython.display import display
 from gammapy.data import DataStore
 from gammapy.datasets import Datasets, SpectrumDataset
 from gammapy.makers import (
@@ -165,8 +166,8 @@ print(rad_max)
 # We can also plot the rad max value against the energy:
 #
 
-plt.figure()
-ax = rad_max.plot_rad_max_vs_energy()
+fig, ax = plt.subplots()
+rad_max.plot_rad_max_vs_energy(ax=ax)
 
 
 ######################################################################
@@ -302,14 +303,13 @@ print(result)
 # and check the best-fit parameters
 #
 
-print(datasets.models.to_parameters_table())
+display(datasets.models.to_parameters_table())
 
 
 ######################################################################
 # A simple way to inspect the model residuals is using the function
 # `~SpectrumDataset.plot_fit()`
 #
-plt.figure()
 ax_spectrum, ax_residuals = datasets[0].plot_fit()
 ax_spectrum.set_ylim(0.1, 120)
 
@@ -328,12 +328,13 @@ ax_spectrum.set_ylim(0.1, 120)
 # by
 # MAGIC <https://ui.adsabs.harvard.edu/abs/2015JHEAp...5...30A/abstract>`__.
 #
-plt.figure()
+fig, ax = plt.subplots()
 plot_kwargs = {
     "energy_bounds": [0.08, 20] * u.TeV,
     "sed_type": "e2dnde",
     "yunits": u.Unit("TeV cm-2 s-1"),
     "xunits": u.GeV,
+    "ax": ax,
 }
 
 crab_magic_lp = create_crab_spectral_model("magic_lp")
@@ -344,5 +345,6 @@ best_fit_model.spectral_model.plot(
 best_fit_model.spectral_model.plot_error(facecolor="crimson", alpha=0.4, **plot_kwargs)
 crab_magic_lp.plot(ls="--", lw=1.5, color="k", label="MAGIC reference", **plot_kwargs)
 
-plt.legend()
-plt.ylim([1e-13, 1e-10])
+ax.legend()
+ax.set_ylim([1e-13, 1e-10])
+plt.show()

--- a/examples/tutorials/analysis-1d/spectrum_simulation.py
+++ b/examples/tutorials/analysis-1d/spectrum_simulation.py
@@ -47,11 +47,6 @@ We will use the following classes:
 """
 
 
-######################################################################
-# Setup
-# -----
-#
-
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
@@ -59,6 +54,12 @@ from regions import CircleSkyRegion
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+
+######################################################################
+# Setup
+# -----
+#
+from IPython.display import display
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import Datasets, SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.irf import load_cta_irfs
@@ -190,7 +191,7 @@ for idx in range(n_obs):
     datasets.append(dataset_fake)
 
 table = datasets.info_table()
-print(table)
+display(table)
 
 
 ######################################################################
@@ -232,12 +233,13 @@ for dataset in datasets:
 # very well with the spectrum that we initially injected.
 #
 
-plt.figure()
+fig, ax = plt.subplots()
 index = np.array([_["index"] for _ in results])
-plt.hist(index, bins=10, alpha=0.5)
-plt.axvline(x=model_simu.parameters["index"].value, color="red")
-plt.xlabel("Reconstructed spectral index")
+ax.hist(index, bins=10, alpha=0.5)
+ax.axvline(x=model_simu.parameters["index"].value, color="red")
+ax.set_xlabel("Reconstructed spectral index")
 print(f"index: {index.mean()} += {index.std()}")
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/analysis-2d/detect.py
+++ b/examples/tutorials/analysis-2d/detect.py
@@ -54,6 +54,7 @@ import astropy.units as u
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.datasets import MapDataset
 from gammapy.estimators import ASmoothMapEstimator, TSMapEstimator
 from gammapy.estimators.utils import find_peaks
@@ -121,7 +122,7 @@ scales = u.Quantity(np.arange(0.05, 1, 0.05), unit="deg")
 smooth = ASmoothMapEstimator(threshold=3, scales=scales, energy_edges=[10, 500] * u.GeV)
 images = smooth.run(dataset)
 
-plt.figure(figsize=(15, 5))
+plt.figure(figsize=(9, 5))
 images["flux"].plot(add_cbar=True, stretch="asinh")
 
 
@@ -163,10 +164,13 @@ maps = estimator.run(dataset)
 # ~~~~~~~~~~~~~~~~~~~~~
 #
 
-plt.figure(figsize=(15, 5))
-ax1 = plt.subplot(131, projection=counts.geom.wcs)
-ax2 = plt.subplot(132, projection=counts.geom.wcs)
-ax3 = plt.subplot(133, projection=counts.geom.wcs)
+fig, (ax1, ax2, ax3) = plt.subplots(
+    ncols=3,
+    figsize=(15, 3),
+    subplot_kw={"projection": counts.geom.wcs},
+    gridspec_kw={"left": 0.1, "right": 0.98},
+)
+
 maps["sqrt_ts"].plot(ax=ax1, add_cbar=True)
 ax1.set_title("Significance map")
 maps["flux"].plot(ax=ax2, add_cbar=True, stretch="sqrt", vmin=0)
@@ -187,11 +191,10 @@ ax3.set_title("Iteration map")
 
 sources = find_peaks(maps["sqrt_ts"], threshold=5, min_distance="0.25 deg")
 nsou = len(sources)
-print(sources)
+display(sources)
 
 # Plot sources on top of significance sky image
-plt.figure(figsize=(15, 5))
-
+plt.figure(figsize=(9, 5))
 ax = maps["sqrt_ts"].plot(add_cbar=True)
 
 ax.scatter(
@@ -204,6 +207,7 @@ ax.scatter(
     s=600,
     lw=1.5,
 )
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/analysis-2d/modeling_2D.py
+++ b/examples/tutorials/analysis-2d/modeling_2D.py
@@ -37,21 +37,18 @@ an integrated power law.
 """
 
 
+# %matplotlib inline
+import astropy.units as u
+import matplotlib.pyplot as plt
+
 ######################################################################
 # Setup
 # -----
 #
 # As usual, we’ll start with some general imports…
 #
-
-import logging
-
-# %matplotlib inline
-import astropy.units as u
+from IPython.display import display
 from gammapy.analysis import Analysis, AnalysisConfig
-
-log = logging.getLogger(__name__)
-
 
 ######################################################################
 # Check setup
@@ -146,7 +143,7 @@ print(analysis.datasets["stacked"].exposure)
 # We can have a quick look of these maps in the following way:
 #
 
-analysis.datasets["stacked"].counts.reduce_over_axes().plot(vmax=5)
+analysis.datasets["stacked"].counts.reduce_over_axes().plot(vmax=10, add_cbar=True)
 
 
 ######################################################################
@@ -206,4 +203,5 @@ analysis.datasets["stacked"].background_model.parameters["tilt"].frozen = True
 analysis.run_fit()
 
 # To see the best fit values along with the errors
-print(analysis.models.to_parameters_table())
+display(analysis.models.to_parameters_table())
+plt.show()

--- a/examples/tutorials/analysis-2d/ring_background.py
+++ b/examples/tutorials/analysis-2d/ring_background.py
@@ -235,9 +235,9 @@ significance_map = lima_maps["sqrt_ts"]
 excess_map = lima_maps["npred_excess"]
 
 # We can plot the excess and significance maps
-plt.figure(figsize=(10, 5))
-ax1 = plt.subplot(121, projection=significance_map.geom.wcs)
-ax2 = plt.subplot(122, projection=excess_map.geom.wcs)
+fig, (ax1, ax2) = plt.subplots(
+    figsize=(11, 5), subplot_kw={"projection": lima_maps.geom.wcs}, ncols=2
+)
 
 ax1.set_title("Significance map")
 significance_map.plot(ax=ax1, add_cbar=True)
@@ -259,8 +259,8 @@ significance_map_off = significance_map * exclusion_mask
 significance_all = significance_map.data[np.isfinite(significance_map.data)]
 significance_off = significance_map_off.data[np.isfinite(significance_map_off.data)]
 
-plt.figure()
-plt.hist(
+fig, ax = plt.subplots()
+ax.hist(
     significance_all,
     density=True,
     alpha=0.5,
@@ -269,7 +269,7 @@ plt.hist(
     bins=21,
 )
 
-plt.hist(
+ax.hist(
     significance_off,
     density=True,
     alpha=0.5,
@@ -282,12 +282,13 @@ plt.hist(
 mu, std = norm.fit(significance_off)
 x = np.linspace(-8, 8, 50)
 p = norm.pdf(x, mu, std)
-plt.plot(x, p, lw=2, color="black")
-plt.legend()
-plt.xlabel("Significance")
-plt.yscale("log")
-plt.ylim(1e-5, 1)
+ax.plot(x, p, lw=2, color="black")
+ax.legend()
+ax.set_xlabel("Significance")
+ax.set_yscale("log")
+ax.set_ylim(1e-5, 1)
 xmin, xmax = np.min(significance_all), np.max(significance_all)
-plt.xlim(xmin, xmax)
+ax.set_xlim(xmin, xmax)
 
 print(f"Fit results: mu = {mu:.2f}, std = {std:.2f}")
+plt.show()

--- a/examples/tutorials/analysis-3d/analysis_mwl.py
+++ b/examples/tutorials/analysis-3d/analysis_mwl.py
@@ -249,12 +249,12 @@ flux_points_hess = FluxPointsEstimator(
 #
 
 # display spectrum and flux points
-plt.figure(figsize=(8, 6))
+fig, ax = plt.subplots(figsize=(8, 6))
 
 energy_bounds = [0.01, 300] * u.TeV
 sed_type = "e2dnde"
 
-ax = crab_spec.plot(energy_bounds=energy_bounds, sed_type=sed_type, label="Model")
+crab_spec.plot(ax=ax, energy_bounds=energy_bounds, sed_type=sed_type, label="Model")
 crab_spec.plot_error(ax=ax, energy_bounds=energy_bounds, sed_type=sed_type)
 
 flux_points_fermi.plot(ax=ax, sed_type=sed_type, label="Fermi-LAT")
@@ -262,4 +262,5 @@ flux_points_hess.plot(ax=ax, sed_type=sed_type, label="HESS")
 flux_points_hawc.plot(ax=ax, sed_type=sed_type, label="HAWC")
 
 ax.set_xlim(energy_bounds)
-plt.legend()
+ax.legend()
+plt.show()

--- a/examples/tutorials/analysis-3d/event_sampling.py
+++ b/examples/tutorials/analysis-3d/event_sampling.py
@@ -82,16 +82,17 @@ We will work with the following functions and classes:
 # As usual, let’s start with some general imports…
 #
 
-# %matplotlib inline
-
 from pathlib import Path
 import numpy as np
 import astropy.units as u
-import matplotlib.pyplot as plt
 from astropy.coordinates import Angle, SkyCoord
 from astropy.io import fits
 from astropy.time import Time
 from regions import CircleSkyRegion
+import matplotlib.pyplot as plt
+
+# %matplotlib inline
+from IPython.display import display
 from gammapy.data import DataStore, Observation, observatory_locations
 from gammapy.datasets import MapDataset, MapDatasetEventSampler
 from gammapy.irf import load_cta_irfs
@@ -289,7 +290,6 @@ print(f"Background events: {(events.table['MC_ID'] == 0).sum()}")
 # We can inspect the properties of the simulated events as follows:
 #
 
-plt.figure()
 events.select_offset([0, 1] * u.deg).peek()
 
 
@@ -322,8 +322,8 @@ hdu_all.writeto("./event_sampling/events_0001.fits", overwrite=True)
 #
 
 counts = Map.from_geom(geom)
-plt.figure()
 counts.fill_events(events)
+plt.figure()
 counts.sum_over_axes().plot(add_cbar=True)
 
 
@@ -448,7 +448,6 @@ src_events = events.select_region(on_region)
 # Then we can have a quick look to the data with the `peek` function:
 #
 
-plt.figure()
 src_events.peek()
 
 
@@ -494,7 +493,6 @@ print(dataset.models)
 sampler = MapDatasetEventSampler(random_state=0)
 events = sampler.run(dataset, observation)
 
-plt.figure()
 events.select_offset([0, 1] * u.deg).peek()
 
 
@@ -518,6 +516,7 @@ livetimes = [1, 1, 1] * u.hr
 n_obs = len(tstarts)
 irf_paths = [path / irf_filename] * n_obs
 events_paths = []
+
 for idx, tstart in enumerate(tstarts):
     irfs = load_cta_irfs(irf_paths[idx])
     observation = Observation.create(
@@ -547,7 +546,7 @@ for idx, tstart in enumerate(tstarts):
 path = Path("./event_sampling/")
 events_paths = list(path.rglob("events*.fits"))
 data_store = DataStore.from_events_files(events_paths, irf_paths)
-print(data_store.obs_table)
+display(data_store.obs_table)
 
 
 ######################################################################
@@ -557,8 +556,9 @@ print(data_store.obs_table)
 #
 
 observations = data_store.get_observations()
-plt.figure()
 observations[0].peek()
+
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/analysis-3d/flux_profiles.py
+++ b/examples/tutorials/analysis-3d/flux_profiles.py
@@ -36,17 +36,18 @@ run the actually profile extraction using the `~gammapy.estimators.FluxProfileEs
 """
 
 
-######################################################################
-# Setup
-# -----
-#
-
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+
+######################################################################
+# Setup
+# -----
+#
+from IPython.display import display
 from gammapy.datasets import MapDataset
 from gammapy.estimators import FluxPoints, FluxProfileEstimator
 from gammapy.maps import RegionGeom
@@ -77,7 +78,6 @@ dataset = MapDataset.read(
 ######################################################################
 # This is what the counts image we will work with looks like:
 #
-plt.figure()
 counts_image = dataset.counts.sum_over_axes()
 counts_image.smooth("0.1 deg").plot(stretch="sqrt")
 
@@ -232,7 +232,7 @@ ax.set_yscale("linear")
 #
 
 table = profile.to_table(format="profile", formatted=True)
-table
+display(table)
 
 
 ######################################################################
@@ -299,3 +299,6 @@ fig, ax = plt.subplots()
 profile_high.plot(ax=ax, sed_type="eflux", color="tab:orange")
 profile_high.plot_ts_profiles(ax=ax, sed_type="eflux")
 ax.set_yscale("linear")
+
+
+plt.show()

--- a/examples/tutorials/analysis-3d/simulate_3d.py
+++ b/examples/tutorials/analysis-3d/simulate_3d.py
@@ -54,12 +54,13 @@ the dataset and fake the count data.
 # --------------------
 #
 
-# %matplotlib inline
-
 import numpy as np
 import astropy.units as u
-import matplotlib.pyplot as plt
 from astropy.coordinates import SkyCoord
+import matplotlib.pyplot as plt
+
+# %matplotlib inline
+from IPython.display import display
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import MapDataset
 from gammapy.irf import load_cta_irfs
@@ -219,4 +220,6 @@ print(
 # Get the errors on the fitted parameters from the parameter table
 #
 
-print(result.parameters.to_table())
+display(result.parameters.to_table())
+
+plt.show()

--- a/examples/tutorials/analysis-time/light_curve.py
+++ b/examples/tutorials/analysis-time/light_curve.py
@@ -58,6 +58,7 @@ from astropy.time import Time
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.analysis import Analysis, AnalysisConfig
 from gammapy.estimators import LightCurveEstimator
 from gammapy.modeling.models import (
@@ -212,12 +213,15 @@ lc_3d = lc_maker_3d.run(analysis_3d.datasets)
 
 # Example showing how to change just before plotting the threshold on the signal significance
 # (points vs upper limits), even if this has no effect with this data set.
-plt.figure()
+fig, ax = plt.subplots(
+    figsize=(8, 6),
+    gridspec_kw={"left": 0.16, "bottom": 0.2, "top": 0.98, "right": 0.98},
+)
 lc_3d.sqrt_ts_threshold_ul = 5
-lc_3d.plot(axis_name="time")
+lc_3d.plot(ax=ax, axis_name="time")
 
 table = lc_3d.to_table(format="lightcurve", sed_type="flux")
-print(table["time_min", "time_max", "e_min", "e_max", "flux", "flux_err"])
+display(table["time_min", "time_max", "e_min", "e_max", "flux", "flux_err"])
 
 
 ######################################################################
@@ -319,7 +323,7 @@ lc_1d = lc_maker_1d.run(analysis_1d.datasets)
 
 print(lc_1d.geom.axes.names)
 
-print(lc_1d.to_table(sed_type="flux", format="lightcurve"))
+display(lc_1d.to_table(sed_type="flux", format="lightcurve"))
 
 
 ######################################################################
@@ -330,8 +334,11 @@ print(lc_1d.to_table(sed_type="flux", format="lightcurve"))
 # figure:
 #
 
-plt.figure()
-ax = lc_1d.plot(marker="o", label="1D")
+fig, ax = plt.subplots(
+    figsize=(8, 6),
+    gridspec_kw={"left": 0.16, "bottom": 0.2, "top": 0.98, "right": 0.98},
+)
+lc_1d.plot(ax=ax, marker="o", label="1D")
 lc_3d.plot(ax=ax, marker="o", label="3D")
 plt.legend()
 
@@ -369,11 +376,15 @@ lc_maker_1d = LightCurveEstimator(
 
 nightwise_lc = lc_maker_1d.run(analysis_1d.datasets)
 
-plt.figure()
-nightwise_lc.plot(color="tab:orange")
-ax = nightwise_lc.plot_ts_profiles()
+fig, ax = plt.subplots(
+    figsize=(8, 6),
+    gridspec_kw={"left": 0.16, "bottom": 0.2, "top": 0.98, "right": 0.98},
+)
+nightwise_lc.plot(ax=ax, color="tab:orange")
+nightwise_lc.plot_ts_profiles(ax=ax)
 ax.set_ylim(1e-12, 3e-12)
 
+plt.show()
 
 ######################################################################
 # What next?

--- a/examples/tutorials/analysis-time/light_curve_flare.py
+++ b/examples/tutorials/analysis-time/light_curve_flare.py
@@ -64,13 +64,13 @@ As usual, we’ll start with some general imports…
 
 import logging
 import numpy as np
-
-# %matplotlib inline
-import matplotlib.pyplot as plt
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
 from astropy.time import Time
 from regions import CircleSkyRegion
+
+# %matplotlib inline
+import matplotlib.pyplot as plt
 
 log = logging.getLogger(__name__)
 
@@ -295,5 +295,6 @@ lc_1d = lc_maker_1d.run(datasets)
 ######################################################################
 # Finally we plot the result for the 1D lightcurve:
 #
-plt.figure()
+plt.figure(figsize=(8, 6))
 lc_1d.plot(marker="o")
+plt.show()

--- a/examples/tutorials/analysis-time/light_curve_simulation.py
+++ b/examples/tutorials/analysis-time/light_curve_simulation.py
@@ -58,11 +58,6 @@ As usual, we’ll start with some general imports…
 """
 
 
-######################################################################
-# Setup
-# -----
-#
-
 import logging
 import numpy as np
 import astropy.units as u
@@ -71,6 +66,12 @@ from astropy.time import Time
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+
+######################################################################
+# Setup
+# -----
+#
+from IPython.display import display
 
 log = logging.getLogger(__name__)
 
@@ -157,7 +158,7 @@ model_simu = SkyModel(
 )
 
 # Look at the model
-model_simu.parameters.to_table()
+display(model_simu.parameters.to_table())
 
 
 ######################################################################
@@ -206,7 +207,7 @@ for idx in range(n_obs):
 # quick look into our datasets.
 #
 
-print(datasets.info_table())
+display(datasets.info_table())
 
 
 ######################################################################
@@ -237,8 +238,11 @@ lc_maker_1d = LightCurveEstimator(
 )
 lc_1d = lc_maker_1d.run(datasets)
 
-plt.figure()
-ax = lc_1d.plot(marker="o", axis_name="time", sed_type="flux")
+fig, ax = plt.subplots(
+    figsize=(8, 6),
+    gridspec_kw={"left": 0.16, "bottom": 0.2, "top": 0.98, "right": 0.98},
+)
+lc_1d.plot(ax=ax, marker="o", axis_name="time", sed_type="flux")
 
 
 ######################################################################
@@ -302,15 +306,18 @@ result = fit.run(datasets=datasets)
 # temporal model in relative units for one particular energy range
 #
 
-plt.figure()
+fig, ax = plt.subplots(
+    figsize=(8, 6),
+    gridspec_kw={"left": 0.16, "bottom": 0.2, "top": 0.98, "right": 0.98},
+)
 lc_1TeV_10TeV = lc_1d.slice_by_idx({"energy": slice(2, 3)})
-ax = lc_1TeV_10TeV.plot(sed_type="norm", axis_name="time")
+lc_1TeV_10TeV.plot(ax=ax, sed_type="norm", axis_name="time")
 
 time_range = lc_1TeV_10TeV.geom.axes["time"].time_bounds
 temporal_model1.plot(ax=ax, time_range=time_range, label="Best fit model")
 
 ax.set_yscale("linear")
-plt.legend()
+ax.legend()
 
 
 ######################################################################
@@ -337,7 +344,7 @@ model2 = SkyModel(
     name="model-test2",
 )
 
-print(model2.parameters.to_table())
+display(model2.parameters.to_table())
 
 datasets.models = model2
 
@@ -346,9 +353,9 @@ datasets.models = model2
 fit = Fit()
 result = fit.run(datasets=datasets)
 
-print(result.parameters.to_table())
+display(result.parameters.to_table())
 
-
+plt.show()
 ######################################################################
 # We see that the fitted parameters are consistent between fitting flux
 # points and datasets, and match well with the simulated ones

--- a/examples/tutorials/analysis-time/pulsar_analysis.py
+++ b/examples/tutorials/analysis-time/pulsar_analysis.py
@@ -30,11 +30,13 @@ packages like Tempo2 or `PINT <https://nanograv-pint.readthedocs.io>`__.
 # in the CTA 1DC dataset shipped with Gammapy.
 #
 
-# %matplotlib inline
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 import matplotlib.pyplot as plt
+
+# %matplotlib inline
+from IPython.display import display
 from gammapy.data import DataStore
 from gammapy.datasets import Datasets, FluxPointsDataset, SpectrumDataset
 from gammapy.estimators import FluxPointsEstimator
@@ -89,7 +91,7 @@ print(events_vela)
 phases = events_vela.table["PHASE"]
 
 # Let's take a look at the first 10 phases
-print(phases[:10])
+display(phases[:10])
 
 
 ######################################################################
@@ -113,8 +115,8 @@ bin_center = (bin_edges[:-1] + bin_edges[1:]) / 2
 # Poissonian uncertainty on each bin
 values_err = np.sqrt(values)
 
-plt.figure()
-plt.bar(
+fig, ax = plt.subplots()
+ax.bar(
     x=bin_center,
     height=values,
     width=bin_width,
@@ -123,10 +125,10 @@ plt.bar(
     edgecolor="black",
     yerr=values_err,
 )
-plt.xlim(0, 1)
-plt.xlabel("Phase")
-plt.ylabel("Counts")
-plt.title(f"Phasogram with angular cut of {on_radius}")
+ax.set_xlim(0, 1)
+ax.set_xlabel("Phase")
+ax.set_ylabel("Counts")
+ax.set_title(f"Phasogram with angular cut of {on_radius}")
 
 
 ######################################################################
@@ -150,8 +152,8 @@ bkg = count_bkg / nbins / (off_phase_range[1] - off_phase_range[0])
 bkg_err = np.sqrt(count_bkg) / nbins / (off_phase_range[1] - off_phase_range[0])
 
 # Let's redo the same plot for the basis
-plt.figure()
-plt.bar(
+fig, ax = plt.subplots()
+ax.bar(
     x=bin_center,
     height=values,
     width=bin_width,
@@ -166,19 +168,19 @@ x_bkg = np.linspace(0, 1, 50)
 
 kwargs = {"color": "black", "alpha": 0.5, "ls": "--", "lw": 2}
 
-plt.plot(x_bkg, (bkg - bkg_err) * np.ones_like(x_bkg), **kwargs)
-plt.plot(x_bkg, (bkg + bkg_err) * np.ones_like(x_bkg), **kwargs)
+ax.plot(x_bkg, (bkg - bkg_err) * np.ones_like(x_bkg), **kwargs)
+ax.plot(x_bkg, (bkg + bkg_err) * np.ones_like(x_bkg), **kwargs)
 
-plt.fill_between(
+ax.fill_between(
     x_bkg, bkg - bkg_err, bkg + bkg_err, facecolor="grey", alpha=0.5
 )  # grey area for the background level
 
 # Let's make patches for the on and off phase zones
-on_patch = plt.axvspan(
+on_patch = ax.axvspan(
     on_phase_range[0], on_phase_range[1], alpha=0.3, color="gray", ec="black"
 )
 
-off_patch = plt.axvspan(
+off_patch = ax.axvspan(
     off_phase_range[0],
     off_phase_range[1],
     alpha=0.4,
@@ -188,12 +190,12 @@ off_patch = plt.axvspan(
 )
 
 # Legends "ON" and "OFF"
-plt.text(0.55, 5, "ON", color="black", fontsize=17, ha="center")
-plt.text(0.895, 5, "OFF", color="black", fontsize=17, ha="center")
-plt.xlabel("Phase")
-plt.ylabel("Counts")
-plt.xlim(0, 1)
-plt.title(f"Phasogram with angular cut of {on_radius}")
+ax.text(0.55, 5, "ON", color="black", fontsize=17, ha="center")
+ax.text(0.895, 5, "OFF", color="black", fontsize=17, ha="center")
+ax.set_xlabel("Phase")
+ax.set_ylabel("Counts")
+ax.set_xlim(0, 1)
+ax.set_title(f"Phasogram with angular cut of {on_radius}")
 
 
 ######################################################################
@@ -280,7 +282,6 @@ for obs in obs_list_vela:
 # Now let’s a look at the datasets we just created:
 #
 
-plt.figure()
 datasets[0].peek()
 
 
@@ -340,7 +341,6 @@ flux_points_dataset = FluxPointsDataset(data=flux_points, models=model)
 # Now we can plot.
 #
 
-plt.figure()
 ax_spectrum, ax_residuals = flux_points_dataset.plot_fit()
 
 ax_spectrum.set_ylim([1e-14, 3e-11])
@@ -357,6 +357,7 @@ spec_model_true.plot(
 
 ax_spectrum.legend(loc="best")
 
+plt.show()
 
 ######################################################################
 # This tutorial suffers a bit from the lack of statistics: there were 9

--- a/examples/tutorials/api/astro_dark_matter.py
+++ b/examples/tutorials/api/astro_dark_matter.py
@@ -87,7 +87,6 @@ print("DISTANCE_GC:", profiles.DMProfile.DISTANCE_GC)
 # J-Factor map for the Galactic Centre region
 #
 
-plt.figure()
 profile = profiles.NFWProfile()
 
 # Adopt standard values used in HESS
@@ -103,6 +102,7 @@ jfactory = JFactory(geom=geom, profile=profile, distance=profiles.DMProfile.DIST
 jfact = jfactory.compute_jfactor()
 
 jfact_map = WcsNDMap(geom=geom, data=jfact.value, unit=jfact.unit)
+plt.figure()
 ax = jfact_map.plot(cmap="viridis", norm=LogNorm(), add_cbar=True)
 plt.title(f"J-Factor [{jfact_map.unit}]")
 
@@ -132,8 +132,7 @@ print(
 fluxes = PrimaryFlux(mDM="1 TeV", channel="eL")
 print(fluxes.allowed_channels)
 
-plt.figure()
-fig, axes = plt.subplots(4, 1, figsize=(6, 16))
+fig, axes = plt.subplots(4, 1, figsize=(4, 16))
 mDMs = [0.01, 0.1, 1, 10] * u.TeV
 
 for mDM, ax in zip(mDMs, axes):
@@ -152,7 +151,7 @@ for mDM, ax in zip(mDMs, axes):
         )
 
 axes[0].legend()
-plt.subplots_adjust(hspace=0.5)
+plt.subplots_adjust(hspace=0.9)
 
 
 ######################################################################
@@ -175,3 +174,5 @@ ax = flux_map.plot(cmap="viridis", norm=LogNorm(), add_cbar=True)
 plt.title(
     f"Flux [{int_flux.unit}]\n m$_{{DM}}$={fluxes.mDM.to('TeV')}, channel={fluxes.channel}"
 )
+
+plt.show()

--- a/examples/tutorials/api/catalog.py
+++ b/examples/tutorials/api/catalog.py
@@ -88,7 +88,8 @@ print(CATALOG_REGISTRY)
 
 # # # !ls -1 $GAMMAPY_DATA/catalogs
 
-""
+# %%
+
 # # # !ls -1 $GAMMAPY_DATA/catalogs/fermi
 
 
@@ -125,7 +126,7 @@ print("Number of sources :", len(catalog.table))
 catalog = CATALOG_REGISTRY.get_cls("3fgl")()
 print(catalog)
 
-""
+# %%
 # Let's load the source catalogs we will use throughout this tutorial
 catalog_gammacat = CATALOG_REGISTRY.get_cls("gamma-cat")()
 catalog_3fhl = CATALOG_REGISTRY.get_cls("3fhl")()
@@ -149,10 +150,10 @@ catalog_hgps = CATALOG_REGISTRY.get_cls("hgps")()
 
 print(type(catalog_3fhl.table))
 
-""
+# %%
 print(len(catalog_3fhl.table))
 
-""
+# %%
 display(catalog_3fhl.table[:3][["Source_Name", "RAJ2000", "DEJ2000"]])
 
 
@@ -184,17 +185,17 @@ print(catalog_3fhl.positions[:3])
 source = catalog_4fgl[49]
 print(source)
 
-""
+# %%
 print(source.row_index, source.name)
 
-""
+# %%
 source = catalog_4fgl["4FGL J0010.8-2154"]
 print(source.row_index, source.name)
 
-""
+# %%
 print(source.data["ASSOC1"])
 
-""
+# %%
 source = catalog_4fgl["PKS 0008-222"]
 print(source.row_index, source.name)
 
@@ -212,7 +213,7 @@ print(source.row_index, source.name)
 
 print(source.data["Npred"])
 
-""
+# %%
 print(source.data["GLON"], source.data["GLAT"])
 
 
@@ -243,11 +244,11 @@ for k, source in enumerate(catalog_3fhl):
         mask_bright[k] = True
         print(f"{source.row_index:<7d} {source.name:20s} {flux:.3g}")
 
-""
+# %%
 catalog_3fhl_bright = catalog_3fhl[mask_bright]
 print(catalog_3fhl_bright)
 
-""
+# %%
 print(catalog_3fhl_bright.table["Source_Name"])
 
 
@@ -260,7 +261,6 @@ print(catalog_3fhl_bright.table["Source_Name"])
 source = catalog_4fgl["PKS 0008-222"]
 mask_roi = source.position.separation(catalog_4fgl.positions) < 5 * u.deg
 
-""
 catalog_4fgl_roi = catalog_4fgl[mask_roi]
 print("Number of sources :", len(catalog_4fgl_roi.table))
 
@@ -285,20 +285,19 @@ print("Number of sources :", len(catalog_4fgl_roi.table))
 
 source = catalog_4fgl["PKS 2155-304"]
 
-""
 model = source.sky_model()
 print(model)
 
-""
+# %%
 print(model)
 
-""
+# %%
 print(model.spatial_model)
 
-""
+# %%
 print(model.spectral_model)
 
-""
+# %%
 plt.figure()
 energy_bounds = (100 * u.MeV, 100 * u.GeV)
 opts = dict(sed_type="e2dnde", yunits=u.Unit("TeV cm-2 s-1"))
@@ -370,13 +369,13 @@ display(catalog_hgps.table_large_scale_component[:5])
 source = catalog_4fgl["PKS 2155-304"]
 flux_points = source.flux_points
 
-""
+
 print(flux_points)
 
-""
+# %%
 display(flux_points.to_table(sed_type="flux"))
 
-""
+# %%
 plt.figure()
 flux_points.plot(sed_type="e2dnde")
 
@@ -392,13 +391,12 @@ flux_points.plot(sed_type="e2dnde")
 
 lightcurve = catalog_4fgl["4FGL J0349.8-2103"].lightcurve()
 
-""
 print(lightcurve)
 
-""
+# %%
 display(lightcurve.to_table(format="lightcurve", sed_type="flux"))
 
-""
+# %%
 plt.figure()
 lightcurve.plot()
 
@@ -422,8 +420,8 @@ print(source)
 
 help(source.info)
 
-""
+# %%
 print(source.info("associations"))
 
-""
+# %%
 plt.show()

--- a/examples/tutorials/api/catalog.py
+++ b/examples/tutorials/api/catalog.py
@@ -48,10 +48,12 @@ Further information is available at `~gammapy.catalog`.
 
 """
 
-# %matplotlib inline
-import matplotlib.pyplot as plt
 import numpy as np
 import astropy.units as u
+
+# %matplotlib inline
+import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.catalog import CATALOG_REGISTRY
 
 ######################################################################
@@ -151,7 +153,7 @@ print(type(catalog_3fhl.table))
 print(len(catalog_3fhl.table))
 
 ""
-print(catalog_3fhl.table[:3][["Source_Name", "RAJ2000", "DEJ2000"]])
+display(catalog_3fhl.table[:3][["Source_Name", "RAJ2000", "DEJ2000"]])
 
 
 ######################################################################
@@ -352,7 +354,7 @@ discarded_spatial = [
 #
 
 # here we show the 5 first elements of the table
-print(catalog_hgps.table_large_scale_component[:5])
+display(catalog_hgps.table_large_scale_component[:5])
 # you can also try :
 # help(catalog_hgps.large_scale_component)
 
@@ -372,7 +374,7 @@ flux_points = source.flux_points
 print(flux_points)
 
 ""
-print(flux_points.to_table(sed_type="flux"))
+display(flux_points.to_table(sed_type="flux"))
 
 ""
 plt.figure()
@@ -394,7 +396,7 @@ lightcurve = catalog_4fgl["4FGL J0349.8-2103"].lightcurve()
 print(lightcurve)
 
 ""
-print(lightcurve.to_table(format="lightcurve", sed_type="flux"))
+display(lightcurve.to_table(format="lightcurve", sed_type="flux"))
 
 ""
 plt.figure()
@@ -424,3 +426,4 @@ help(source.info)
 print(source.info("associations"))
 
 ""
+plt.show()

--- a/examples/tutorials/api/datasets.py
+++ b/examples/tutorials/api/datasets.py
@@ -183,7 +183,7 @@ print(dataset_cta.psf)
 radius = dataset_cta.psf.containment_radius(energy_true=1 * u.TeV, fraction=0.95)
 print(radius)
 
-""
+# %%
 
 plt.figure()
 edisp_kernel = dataset_cta.edisp.get_edisp_kernel()
@@ -467,11 +467,11 @@ fp_dataset.plot_spectrum()
 
 print(fp_dataset.mask_safe)  # Note: the mask here is simply a numpy array
 
-""
+# %%
 
 print(fp_dataset.data)  # is a `FluxPoints` object
 
-""
+# %%
 
 print(fp_dataset.data_shape())  # number of data points
 
@@ -582,6 +582,6 @@ print(stacked)
 datasets_sliced = datasets.slice_by_energy(energy_min="1 TeV", energy_max="10 TeV")
 print(datasets_sliced.energy_ranges)
 
-""
+# %%
 
 plt.show()

--- a/examples/tutorials/api/datasets.py
+++ b/examples/tutorials/api/datasets.py
@@ -25,6 +25,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
 import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.data import GTI
 from gammapy.datasets import (
     Datasets,

--- a/examples/tutorials/api/datasets.py
+++ b/examples/tutorials/api/datasets.py
@@ -157,7 +157,6 @@ print(dataset_cta.info_dict())
 # For a quick view, use
 #
 
-plt.figure()
 dataset_cta.peek()
 
 
@@ -183,10 +182,11 @@ print(dataset_cta.psf)
 radius = dataset_cta.psf.containment_radius(energy_true=1 * u.TeV, fraction=0.95)
 print(radius)
 
+""
+
 plt.figure()
-ax = plt.subplot()
 edisp_kernel = dataset_cta.edisp.get_edisp_kernel()
-edisp_kernel.plot_matrix(ax=ax)
+edisp_kernel.plot_matrix()
 
 
 ######################################################################
@@ -273,7 +273,7 @@ npred_background.sum_over_axes().plot()
 
 # eg: to see the safe data range
 
-plt.figure()
+# plt.figure()
 dataset_cta.mask_safe.plot_grid()
 
 
@@ -283,7 +283,6 @@ dataset_cta.mask_safe.plot_grid()
 
 # To apply a mask fit - in enegy and space
 
-plt.figure()
 region = CircleSkyRegion(SkyCoord("0d", "0d", frame="galactic"), 1.5 * u.deg)
 
 geom = dataset_cta.counts.geom
@@ -307,12 +306,12 @@ dataset_cta.mask_fit.plot_grid(vmin=0, vmax=1, add_cbar=True)
 
 e_min, e_max = dataset_cta.energy_range
 
-# To see the lower energy threshold at each point
+# To see the low energy threshold at each point
 
 plt.figure()
 e_min.plot(add_cbar=True)
 
-# To see the lower energy threshold at each point
+# To see the high energy threshold at each point
 
 plt.figure()
 e_max.plot(add_cbar=True)
@@ -338,7 +337,6 @@ cutout.counts.sum_over_axes().plot()
 # It is also possible to slice a `~gammapy.datasets.MapDataset` in energy:
 #
 
-plt.figure()
 sliced = dataset_cta.slice_by_energy(
     energy_min=1 * u.TeV, energy_max=5 * u.TeV, name="slice-energy"
 )
@@ -350,7 +348,6 @@ sliced.counts.plot_grid()
 # datasets such as `~gammapy.datasets.MapDataset.mask_fit`:
 #
 
-plt.figure()
 sliced.mask_fit.plot_grid()
 
 
@@ -372,7 +369,6 @@ downsampled.counts.sum_over_axes().plot()
 # And the same downsampling process is possible along the energy axis:
 #
 
-plt.figure()
 downsampled_energy = dataset_cta.downsample(
     factor=5, axis_name="energy", name="downsampled-energy"
 )
@@ -392,7 +388,6 @@ print(downsampled_energy, dataset_cta)
 # energy binning using:
 #
 
-plt.figure()
 energy_axis_new = MapAxis.from_energy_edges([0.1, 0.3, 1, 3, 10] * u.TeV)
 resampled = dataset_cta.resample_energy_axis(energy_axis=energy_axis_new)
 resampled.counts.plot_grid(ncols=2)
@@ -471,7 +466,11 @@ fp_dataset.plot_spectrum()
 
 print(fp_dataset.mask_safe)  # Note: the mask here is simply a numpy array
 
+""
+
 print(fp_dataset.data)  # is a `FluxPoints` object
+
+""
 
 print(fp_dataset.data_shape())  # number of data points
 
@@ -515,7 +514,7 @@ print(datasets)
 # `~gammapy.datasets.Dataset.info_dict()`:
 #
 
-print(datasets.info_table())  # quick info of all datasets
+display(datasets.info_table())  # quick info of all datasets
 
 print(datasets.names)  # unique name of each dataset
 
@@ -581,3 +580,7 @@ print(stacked)
 
 datasets_sliced = datasets.slice_by_energy(energy_min="1 TeV", energy_max="10 TeV")
 print(datasets_sliced.energy_ranges)
+
+""
+
+plt.show()

--- a/examples/tutorials/api/fitting.py
+++ b/examples/tutorials/api/fitting.py
@@ -38,6 +38,7 @@ from itertools import combinations
 import numpy as np
 from astropy import units as u
 import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
 from gammapy.modeling import Fit
 from gammapy.modeling.models import LogParabolaSpectralModel, SkyModel
@@ -180,7 +181,11 @@ result_minuit = fit.run(datasets)
 
 print(result_scipy)
 
+""
+
 print(results_simplex)
+
+""
 
 print(result_minuit)
 
@@ -198,7 +203,7 @@ print(fit.minuit)
 # properly
 #
 
-print(result_minuit.trace)
+display(result_minuit.trace)
 
 
 ######################################################################
@@ -208,7 +213,7 @@ print(result_minuit.trace)
 # - or even outside - its allowed min-max range
 #
 
-print(result_minuit.models.to_parameters_table())
+display(result_minuit.models.to_parameters_table())
 
 
 ######################################################################
@@ -230,9 +235,9 @@ for ax, par in zip(axes, datasets.parameters.free_parameters):
     name = datasets.models.parameters_unique_names[idx]
     profile = fit.stat_profile(datasets=datasets, parameter=par)
     ax.plot(profile[f"{name}_scan"], profile["stat_scan"] - total_stat)
-    ax.set_xlabel(f"{par.unit}")
+    ax.set_xlabel(f"{par.name} {par.unit}")
     ax.set_ylabel("Delta TS")
-    ax.set_title(f"{name}: {par.value:.1e} +- {par.error:.1e}")
+    ax.set_title(f"{name}:\n {par.value:.1e} +- {par.error:.1e}")
 
 
 ######################################################################
@@ -257,7 +262,6 @@ print(result_minuit.models.covariance)
 # And you can plot the total parameter correlation as well:
 #
 
-plt.figure()
 result_minuit.models.covariance.plot_correlation()
 
 # The covariance information is also propagated to the individual models
@@ -515,6 +519,7 @@ levels = [1, 2]
 contours = ax.contour(x_values, y_values, stat_surface, levels=levels, colors="white")
 ax.clabel(contours, fmt="%.0f, $\\sigma$", inline=3, fontsize=15)
 
+plt.show()
 
 ######################################################################
 # Note that, if computed with `reoptimize=True`, this plot would be

--- a/examples/tutorials/api/fitting.py
+++ b/examples/tutorials/api/fitting.py
@@ -181,11 +181,11 @@ result_minuit = fit.run(datasets)
 
 print(result_scipy)
 
-""
+# %%
 
 print(results_simplex)
 
-""
+# %%
 
 print(result_minuit)
 

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -19,9 +19,10 @@ Setup
 """
 
 import numpy as np
-import matplotlib.pyplot as plt
 from astropy import units as u
 from regions import CircleSkyRegion
+import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.data import DataStore
 from gammapy.datasets import Datasets, MapDataset, SpectrumDataset
 from gammapy.makers import (
@@ -337,3 +338,5 @@ for observation in observations:
     dataset_on_off = safe_mask_masker.run(dataset_on_off, observation)
     datasets.append(dataset_on_off)
 print(datasets)
+
+plt.show()

--- a/examples/tutorials/api/maps.py
+++ b/examples/tutorials/api/maps.py
@@ -50,7 +50,6 @@ import os
 # %matplotlib inline
 import numpy as np
 from astropy import units as u
-import matplotlib.pyplot as plt
 from astropy.convolution import convolve
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
@@ -886,5 +885,6 @@ m_iem_gc.plot_interactive(add_cbar=True, stretch="sqrt", rc_params=rc_params)
 # `vmax` options:
 #
 
-plt.figure()
 counts_3d.plot_grid(ncols=4, figsize=(16, 12), vmin=0, vmax=100, stretch="log")
+
+plt.show()

--- a/examples/tutorials/api/mask_maps.py
+++ b/examples/tutorials/api/mask_maps.py
@@ -195,7 +195,6 @@ dataset.mask_fit &= mask_map
 # Let’s check the result and plot the full mask.
 #
 
-plt.figure()
 _ = dataset.mask_fit.plot_grid(ncols=5, vmin=0, vmax=1, figsize=(14, 3))
 
 
@@ -457,6 +456,7 @@ dataset.mask_fit = mask_fit
 plt.figure()
 dataset.mask_fit.sum_over_axes().plot()
 
+plt.show()
 
 ######################################################################
 # Reading and writing masks

--- a/examples/tutorials/api/model_management.py
+++ b/examples/tutorials/api/model_management.py
@@ -57,9 +57,10 @@ Setup
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
+import matplotlib.pyplot as plt
 
 # %matplotlib inline
-import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.datasets import Datasets, MapDataset
 from gammapy.maps import Map
 from gammapy.modeling.models import (
@@ -117,7 +118,7 @@ ax2.set_title("CTA counts")
 ######################################################################
 #
 
-print(datasets.info_table(cumulative=False))
+display(datasets.info_table(cumulative=False))
 
 ######################################################################
 #
@@ -400,6 +401,7 @@ for ax, dataset in zip([ax1, ax2], datasets):
     dataset.models.plot_regions(ax=ax, color="white")
     ax.set_title(dataset.name)
 
+plt.show()
 
 ######################################################################
 # Freezing and unfreezing model parameters

--- a/examples/tutorials/api/models.py
+++ b/examples/tutorials/api/models.py
@@ -426,10 +426,10 @@ print(model_without_name.name)
 
 print(model.spectral_model)
 
-
+# %%
 print(model.spatial_model)
 
-
+# %%
 print(model.temporal_model)
 
 

--- a/examples/tutorials/api/models.py
+++ b/examples/tutorials/api/models.py
@@ -425,7 +425,11 @@ print(model_without_name.name)
 
 print(model.spectral_model)
 
+""
+
 print(model.spatial_model)
+
+""
 
 print(model.temporal_model)
 
@@ -500,7 +504,7 @@ model.spectral_model.index.min = 1.0
 model.spectral_model.index.max = 5.0
 
 # Visualise the model as a table
-model.parameters.to_table().show_in_notebook()
+display(model.parameters.to_table())
 
 
 ######################################################################
@@ -822,9 +826,9 @@ energy_axis = MapAxis.from_energy_bounds(
 )
 geom = WcsGeom.create(skydir=(0, 0), width=5.0 * u.deg, binsz=0.1, axes=[energy_axis])
 
-plt.figure()
 spatial_model.plot_grid(geom=geom, add_cbar=True, figsize=(14, 3))
 
+plt.show()
 
 ######################################################################
 # For computational purposes, it is useful to specify a

--- a/examples/tutorials/api/models.py
+++ b/examples/tutorials/api/models.py
@@ -30,6 +30,7 @@ data.
 import numpy as np
 from astropy import units as u
 import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.maps import Map, MapAxis, WcsGeom
 
 ######################################################################
@@ -425,11 +426,9 @@ print(model_without_name.name)
 
 print(model.spectral_model)
 
-""
 
 print(model.spatial_model)
 
-""
 
 print(model.temporal_model)
 

--- a/examples/tutorials/data/cta.py
+++ b/examples/tutorials/data/cta.py
@@ -59,10 +59,13 @@ Setup
 
 """
 
-# %matplotlib inline
 import os
 from pathlib import Path
 from astropy import units as u
+
+# %matplotlib inline
+import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.data import DataStore, EventList
 from gammapy.irf import EffectiveAreaTable2D, load_cta_irfs
 
@@ -150,7 +153,7 @@ print(data_store)
 data_store.obs_table[["OBS_ID", "GLON_PNT", "GLAT_PNT", "IRF"]]
 
 observation = data_store.obs(110380)
-observation
+print(observation)
 
 
 ######################################################################
@@ -190,7 +193,7 @@ events = EventList.read(
 # Here we print the data from the first 5 events listed in the table:
 #
 
-print(events.table[:5])
+display(events.table[:5])
 
 ######################################################################
 # And show a summary plot:
@@ -231,7 +234,7 @@ events.peek()
 #    when using the DC1 IRFs for some analyses.
 #
 
-observation.aeff
+print(observation.aeff)
 
 irf_filename = (
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
@@ -247,7 +250,7 @@ print(irfs)
 
 # Equivalent alternative way to load IRFs directly
 aeff = EffectiveAreaTable2D.read(irf_filename, hdu="EFFECTIVE AREA")
-aeff
+print(aeff)
 
 irfs["aeff"].peek()
 
@@ -297,6 +300,7 @@ irfs["bkg"].plot_at_energy(
     ["100 GeV", "500 GeV", "1 TeV", "3 TeV", "10 TeV", "100 TeV"]
 )
 
+plt.show()
 
 ######################################################################
 # Source models

--- a/examples/tutorials/data/fermi_lat.py
+++ b/examples/tutorials/data/fermi_lat.py
@@ -63,8 +63,9 @@ from astropy.coordinates import SkyCoord
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.data import EventList
-from gammapy.datasets import MapDataset, Datasets
+from gammapy.datasets import Datasets, MapDataset
 from gammapy.irf import EDispKernelMap, PSFMap
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling import Fit
@@ -105,9 +106,9 @@ print(events)
 # event class, event type etc.
 #
 
-events.table.colnames
+print(events.table.colnames)
 
-events.table[:5][["ENERGY", "RA", "DEC"]]
+display(events.table[:5][["ENERGY", "RA", "DEC"]])
 
 print(events.time[0].iso)
 print(events.time[-1].iso)
@@ -154,8 +155,9 @@ counts = Map.create(
 # multiple times when executing the `fill_by_coord` multiple times.
 counts.fill_events(events)
 
-counts.geom.axes[0]
+print(counts.geom.axes[0])
 
+plt.figure()
 counts.sum_over_axes().smooth(2).plot(stretch="sqrt", vmax=30)
 
 
@@ -187,6 +189,7 @@ exposure_hpx = Map.read("$GAMMAPY_DATA/fermi_3fhl/fermi_3fhl_exposure_cube_hpx.f
 print(exposure_hpx.geom)
 print(exposure_hpx.geom.axes[0])
 
+plt.figure()
 exposure_hpx.plot()
 
 ######################################################################
@@ -207,6 +210,7 @@ print(exposure.geom.axes[0])
 
 ######################################################################
 # Exposure is almost constant across the field of view
+plt.figure()
 exposure.slice_by_idx({"energy_true": 0}).plot(add_cbar=True)
 
 ######################################################################
@@ -249,7 +253,7 @@ diffuse_iem = SkyModel(
 ######################################################################
 # Let’s look at the map of first energy band of the cube:
 #
-
+plt.figure()
 template_diffuse.map.slice_by_idx({"energy_true": 0}).plot(add_cbar=True)
 
 
@@ -258,6 +262,7 @@ template_diffuse.map.slice_by_idx({"energy_true": 0}).plot(add_cbar=True)
 #
 
 dnde = template_diffuse.map.to_region_nd_map(region=gc_pos)
+plt.figure()
 dnde.plot()
 plt.xlabel("Energy (GeV)")
 plt.ylabel("Flux (cm-2 s-1 MeV-1 sr-1)")
@@ -282,7 +287,7 @@ diffuse_iso = create_fermi_isotropic_diffuse_model(
 ######################################################################
 # We can plot the model in the energy range between 50 GeV and 2000 GeV:
 #
-
+plt.figure()
 energy_bounds = [50, 2000] * u.GeV
 diffuse_iso.spectral_model.plot(energy_bounds, yunits=u.Unit("1 / (cm2 MeV s)"))
 
@@ -311,7 +316,6 @@ print(psf)
 
 plt.figure(figsize=(8, 5))
 psf.plot_containment_radius_vs_energy()
-plt.show()
 
 
 ######################################################################
@@ -339,6 +343,7 @@ plt.legend()
 psf_kernel = psf.get_psf_kernel(
     position=geom.center_skydir, geom=geom, max_radius="1 deg"
 )
+plt.figure()
 psf_kernel.to_image().psf_kernel_map.plot(stretch="log", add_cbar=True)
 
 
@@ -354,6 +359,7 @@ edisp = EDispKernelMap.from_diagonal_response(
     energy_axis_true=e_true, energy_axis=energy_axis
 )
 
+plt.figure()
 edisp.get_edisp_kernel().plot_matrix()
 
 
@@ -397,6 +403,8 @@ print(result)
 print(models)
 
 residual = counts - dataset.npred()
+
+plt.figure()
 residual.sum_over_axes().smooth("0.1 deg").plot(
     cmap="coolwarm", vmin=-3, vmax=3, add_cbar=True
 )
@@ -417,6 +425,7 @@ datasets_read = Datasets.read(
 )
 print(datasets_read)
 
+plt.show()
 ######################################################################
 # Exercises
 # ---------

--- a/examples/tutorials/data/hess.py
+++ b/examples/tutorials/data/hess.py
@@ -40,9 +40,8 @@ release 1.
 
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-
-# %matplotlib inline
 import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.data import DataStore
 from gammapy.makers import MapDatasetMaker
 from gammapy.makers.utils import make_theta_squared_table
@@ -77,7 +76,7 @@ data_store.info()
 ######################################################################
 # Preview an excerpt from the observtaion table
 
-print(data_store.obs_table[:2][["OBS_ID", "DATE-OBS", "RA_PNT", "DEC_PNT", "OBJECT"]])
+display(data_store.obs_table[:2][["OBS_ID", "DATE-OBS", "RA_PNT", "DEC_PNT", "OBJECT"]])
 
 ######################################################################
 # Get a single obervation
@@ -105,6 +104,7 @@ obs.psf.peek()
 
 ######################################################################
 # Peek the background rate
+plt.figure()
 obs.bkg.to_2d().plot()
 
 
@@ -179,6 +179,7 @@ for obs in observations:
     livetime.stack(lv_obs)
 
 # Plot
+plt.figure()
 ax = livetime.plot(add_cbar=True)
 
 # Add the pointing position on top
@@ -190,6 +191,7 @@ for obs in observations:
         color="black",
     )
 
+plt.show()
 
 ######################################################################
 # Exercises


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a follow up to #4174. It adapts the following:

- Do not use `plt.figure()` where figures are created internally
- Use `display()` to show tables. This defaults to prints for scripts and html for notebooks (however I noticed it does not seem to work with sphinx gallery....)
- Call `plt.show()` at the end of tutorials to make sure plots are shown when executed as script.


ToDo:
- [x] Adapt `data` tutorials
- [x] Adapt `api` tutorials

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
