### PR TITLE
Add support for spatial model correction on background models

### DIFF
--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -588,9 +588,12 @@ class FoVBackgroundModel(ModelBase):
     ----------
     spectral_model : `~gammapy.modeling.models.SpectralModel`
         Normalized spectral model.
+        Default is `~gammapy.modeling.models.PowerLawNormSpectralModel`
     dataset_name : str
         Dataset name
-
+    spatial_model : `~gammapy.modeling.models.SpatialModel`
+        Unitless Spatial model (unit is dropped on evaluation if defined).
+        Default is None.
     """
 
     tag = ["FoVBackgroundModel", "fov-bkg"]
@@ -773,15 +776,15 @@ class TemplateNPredModel(ModelBase):
     ----------
     map : `~gammapy.maps.Map`
         Background model map
-    spatial_model : `~gammapy.modeling.models.SpatialModel`
-        Norm spatial model,
-        default is None.
     spectral_model : `~gammapy.modeling.models.SpectralModel`
         Normalized spectral model,
         default is `~gammapy.modeling.models.PowerLawNormSpectralModel`
     copy_data : bool
         Create a deepcopy of the map data or directly use the original. True by
         default, can be turned to False to save memory in case of large maps.
+    spatial_model : `~gammapy.modeling.models.SpatialModel`
+        Unitless Spatial model (unit is dropped on evaluation if defined).
+        Default is None.
     """
 
     tag = "TemplateNPredModel"

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -607,7 +607,7 @@ class FoVBackgroundModel(ModelBase):
         if not spectral_model.is_norm_spectral_model:
             raise ValueError("A norm spectral model is required.")
 
-        self._spectral_model = None
+        self._spatial_model = None
         self._spectral_model = spectral_model
         super().__init__()
 
@@ -657,14 +657,13 @@ class FoVBackgroundModel(ModelBase):
     def evaluate_geom(self, geom):
         """Evaluate map"""
         coords = geom.get_coord(sparse=True)
-        return self.evaluate(**coords._data) 
-
+        return self.evaluate(**coords._data)
 
     def evaluate(self, energy, lon=None, lat=None):
         """Evaluate model"""
-        value = self.spectral_model(energy) 
+        value = self.spectral_model(energy)
         if self.spatial_model is not None and lon is not None and lat is not None:
-            return self.spatial_model(lon,lat,energy).value * value
+            return self.spatial_model(lon, lat, energy).value * value
         else:
             return value
 
@@ -708,7 +707,10 @@ class FoVBackgroundModel(ModelBase):
         data : dict
             Data dictionary
         """
-        from gammapy.modeling.models import SPECTRAL_MODEL_REGISTRY, SPATIAL_MODEL_REGISTRY
+        from gammapy.modeling.models import (
+            SPECTRAL_MODEL_REGISTRY,
+            SPATIAL_MODEL_REGISTRY,
+        )
 
         spectral_data = data.get("spectral")
         if spectral_data is not None:
@@ -716,7 +718,7 @@ class FoVBackgroundModel(ModelBase):
             spectral_model = model_class.from_dict(spectral_data)
         else:
             spectral_model = None
-            
+
         spatial_data = data.get("spatial")
         if spatial_data is not None:
             model_class = SPATIAL_MODEL_REGISTRY.get_cls(spatial_data["type"])
@@ -906,7 +908,10 @@ class TemplateNPredModel(ModelBase):
 
     @classmethod
     def from_dict(cls, data):
-        from gammapy.modeling.models import SPECTRAL_MODEL_REGISTRY, SPATIAL_MODEL_REGISTRY
+        from gammapy.modeling.models import (
+            SPECTRAL_MODEL_REGISTRY,
+            SPATIAL_MODEL_REGISTRY,
+        )
 
         spectral_data = data.get("spectral")
         if spectral_data is not None:
@@ -914,7 +919,7 @@ class TemplateNPredModel(ModelBase):
             spectral_model = model_class.from_dict(spectral_data)
         else:
             spectral_model = None
-            
+
         spatial_data = data.get("spatial")
         if spatial_data is not None:
             model_class = SPATIAL_MODEL_REGISTRY.get_cls(spatial_data["type"])

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -595,7 +595,7 @@ class FoVBackgroundModel(ModelBase):
 
     tag = ["FoVBackgroundModel", "fov-bkg"]
 
-    def __init__(self, spatial_model=None, spectral_model=None, dataset_name=None):
+    def __init__(self, spectral_model=None, dataset_name=None, spatial_model=None):
         if dataset_name is None:
             raise ValueError("Dataset name a is required argument")
 

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -793,12 +793,12 @@ class TemplateNPredModel(ModelBase):
     def __init__(
         self,
         map,
-        spatial_model=None,
         spectral_model=None,
         name=None,
         filename=None,
         datasets_names=None,
         copy_data=True,
+        spatial_model=None,
     ):
         if isinstance(map, Map):
             axis = map.geom.axes["energy"]

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -662,12 +662,16 @@ class FoVBackgroundModel(ModelBase):
     def evaluate(self, energy, lon=None, lat=None):
         """Evaluate model"""
         value = self.spectral_model(energy)
-        if self.spatial_model is not None and lon is not None and lat is not None:
-            if self.spatial_model.is_energy_dependent:
-                return self.spatial_model(lon, lat, energy).value * value
+        if self.spatial_model is not None:
+            if lon is not None and lat is not None:
+                if self.spatial_model.is_energy_dependent:
+                    return self.spatial_model(lon, lat, energy).value * value
+                else:
+                    return self.spatial_model(lon, lat).value * value
             else:
-                return self.spatial_model(lon, lat).value * value
-
+                raise ValueError(
+                    "lon and lat are required if a spatial model is defined"
+                )
         else:
             return value
 
@@ -712,8 +716,8 @@ class FoVBackgroundModel(ModelBase):
             Data dictionary
         """
         from gammapy.modeling.models import (
-            SPECTRAL_MODEL_REGISTRY,
             SPATIAL_MODEL_REGISTRY,
+            SPECTRAL_MODEL_REGISTRY,
         )
 
         spectral_data = data.get("spectral")
@@ -913,8 +917,8 @@ class TemplateNPredModel(ModelBase):
     @classmethod
     def from_dict(cls, data):
         from gammapy.modeling.models import (
-            SPECTRAL_MODEL_REGISTRY,
             SPATIAL_MODEL_REGISTRY,
+            SPECTRAL_MODEL_REGISTRY,
         )
 
         spectral_data = data.get("spectral")

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -753,12 +753,13 @@ def test_spatial_model_background(background):
     twice = FoVBackgroundModel(
         spatial_model=spatial_model2, dataset_name="test"
     ).evaluate_geom(geom)
-    assert_allclose(twice, reference)
+    assert_allclose(twice, reference * 2)
 
 
 def test_spatial_model_io_background(background):
 
     spatial_model = ConstantSpatialModel(frame="galactic")
+
     model = TemplateNPredModel(background, spatial_model=None)
     model_dict = model.to_dict()
     assert "spatial" not in model_dict
@@ -772,6 +773,5 @@ def test_spatial_model_io_background(background):
     assert "spatial" not in model_dict
 
     model = FoVBackgroundModel(spatial_model=spatial_model, dataset_name="test")
-    model = TemplateNPredModel(background, spatial_model=spatial_model)
     model_dict = model.to_dict()
     assert "spatial" in model_dict

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -763,15 +763,23 @@ def test_spatial_model_io_background(background):
     model = TemplateNPredModel(background, spatial_model=None)
     model_dict = model.to_dict()
     assert "spatial" not in model_dict
+    new_model = TemplateNPredModel.from_dict(model_dict)
+    assert new_model.spatial_model is None
 
     model = TemplateNPredModel(background, spatial_model=spatial_model)
     model_dict = model.to_dict()
     assert "spatial" in model_dict
+    new_model = TemplateNPredModel.from_dict(model_dict)
+    assert isinstance(new_model.spatial_model, ConstantSpatialModel)
 
     model = FoVBackgroundModel(spatial_model=None, dataset_name="test")
     model_dict = model.to_dict()
     assert "spatial" not in model_dict
+    new_model = FoVBackgroundModel.from_dict(model_dict)
+    assert new_model.spatial_model is None
 
     model = FoVBackgroundModel(spatial_model=spatial_model, dataset_name="test")
     model_dict = model.to_dict()
     assert "spatial" in model_dict
+    new_model = FoVBackgroundModel.from_dict(model_dict)
+    assert isinstance(new_model.spatial_model, ConstantSpatialModel)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -754,3 +754,24 @@ def test_spatial_model_background(background):
         spatial_model=spatial_model2, dataset_name="test"
     ).evaluate_geom(geom)
     assert_allclose(twice, reference)
+
+
+def test_spatial_model_io_background(background):
+
+    spatial_model = ConstantSpatialModel(frame="galactic")
+    model = TemplateNPredModel(background, spatial_model=None)
+    model_dict = model.to_dict()
+    assert "spatial" not in model_dict
+
+    model = TemplateNPredModel(background, spatial_model=spatial_model)
+    model_dict = model.to_dict()
+    assert "spatial" in model_dict
+
+    model = FoVBackgroundModel(spatial_model=None, dataset_name="test")
+    model_dict = model.to_dict()
+    assert "spatial" not in model_dict
+
+    model = FoVBackgroundModel(spatial_model=spatial_model, dataset_name="test")
+    model = TemplateNPredModel(background, spatial_model=spatial_model)
+    model_dict = model.to_dict()
+    assert "spatial" in model_dict

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -15,6 +15,7 @@ from gammapy.maps import Map, MapAxis, RegionGeom, RegionNDMap, WcsGeom
 from gammapy.modeling import Parameter
 from gammapy.modeling.models import (
     CompoundSpectralModel,
+    ConstantSpatialModel,
     ConstantSpectralModel,
     ConstantTemporalModel,
     GaussianSpatialModel,
@@ -28,6 +29,7 @@ from gammapy.modeling.models import (
     TemplateNPredModel,
     TemplateSpatialModel,
     create_fermi_isotropic_diffuse_model,
+    FoVBackgroundModel,
 )
 from gammapy.utils.testing import mpl_plot_check, requires_data
 
@@ -720,3 +722,35 @@ def test_sky_model_contributes_point_region():
     geom = RegionGeom.create("icrs;point(0.05, 0.05)", binsz_wcs="0.01 deg")
     mask = RegionNDMap.from_geom(geom)
     assert np.any(model.contributes(mask))
+
+
+def test_spatial_model_background(background):
+
+    geom = background.geom
+
+    spatial_model = ConstantSpatialModel(frame="galactic")
+    reference_npred = TemplateNPredModel(background, spatial_model=None).evaluate()
+    identical_npred = TemplateNPredModel(
+        background, spatial_model=spatial_model
+    ).evaluate()
+    assert_allclose(identical_npred, reference_npred)
+
+    reference = FoVBackgroundModel(
+        spatial_model=None, dataset_name="test"
+    ).evaluate_geom(geom)
+    identical = FoVBackgroundModel(
+        spatial_model=spatial_model, dataset_name="test"
+    ).evaluate_geom(geom)
+    assert_allclose(identical, reference)
+
+    spatial_model2 = ConstantSpatialModel(frame="galactic")
+    spatial_model2.value.value = 2
+    twice_npred = TemplateNPredModel(
+        background, spatial_model=spatial_model2
+    ).evaluate()
+    assert_allclose(twice_npred, reference_npred * 2)
+
+    twice = FoVBackgroundModel(
+        spatial_model=spatial_model2, dataset_name="test"
+    ).evaluate_geom(geom)
+    assert_allclose(twice, reference)


### PR DESCRIPTION
Follow-up PR from #4208.
Allow to apply `spatial_model` corrections to `FoVBackgroundModel` and `TemplateNPredModel`.
It can possibly work with all the spatial model  already implemented, even is it was designed for the `PiecewiseNormModel` introduced in #4208.