### PR TITLE
Add plot_rgb() function in gammapy.visualization

### DIFF
--- a/gammapy/visualization/__init__.py
+++ b/gammapy/visualization/__init__.py
@@ -3,7 +3,7 @@ from .heatmap import annotate_heatmap, plot_heatmap
 from .panel import MapPanelPlotter
 from .utils import (
     plot_contour_line,
-    plot_rgb,
+    plot_map_rgb,
     plot_spectrum_datasets_off_regions,
     plot_theta_squared_table,
 )
@@ -15,7 +15,7 @@ __all__ = [
     "MapPanelPlotter",
     "plot_contour_line",
     "plot_heatmap",
-    "plot_rgb",
+    "plot_map_rgb",
     "plot_spectrum_datasets_off_regions",
     "plot_theta_squared_table",
 ]

--- a/gammapy/visualization/__init__.py
+++ b/gammapy/visualization/__init__.py
@@ -3,6 +3,7 @@ from .heatmap import annotate_heatmap, plot_heatmap
 from .panel import MapPanelPlotter
 from .utils import (
     plot_contour_line,
+    plot_rgb,
     plot_spectrum_datasets_off_regions,
     plot_theta_squared_table,
 )
@@ -14,6 +15,7 @@ __all__ = [
     "MapPanelPlotter",
     "plot_contour_line",
     "plot_heatmap",
+    "plot_rgb",
     "plot_spectrum_datasets_off_regions",
     "plot_theta_squared_table",
 ]

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -1,18 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import numpy as np
+import astropy.units as u
 from numpy.testing import assert_allclose
 from astropy.table import Table
 import matplotlib
 import matplotlib.pyplot as plt
 from packaging import version
-from gammapy.utils.testing import mpl_plot_check
+from gammapy.utils.testing import mpl_plot_check, requires_data
+from gammapy.maps import Map
 from gammapy.visualization import (
     plot_contour_line,
+    plot_rgb,
     plot_spectrum_datasets_off_regions,
     plot_theta_squared_table,
 )
-
 
 @pytest.mark.skipif(
     version.parse(matplotlib.__version__) < version.parse("3.5"),
@@ -83,3 +85,13 @@ def test_plot_theta2_distribution():
     # open a new figure to avoid
     plt.figure()
     plot_theta_squared_table(table=table)
+
+@requires_data()
+def test_plot_rgb():
+    map_ = Map.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
+    kwargs = {"stretch": 0.5, "Q": 1, "minimum": 0.15}
+    with mpl_plot_check():
+        plot_rgb(map_, [0.1, 0.2, 0.5, 10] * u.TeV, **kwargs)
+
+    with pytest.raises(ValueError):
+        plot_rgb(map_, [0.1, 0.2, 10] * u.TeV, **kwargs)

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -7,7 +7,7 @@ from astropy.table import Table
 import matplotlib
 import matplotlib.pyplot as plt
 from packaging import version
-from gammapy.maps import Map, MapAxis
+from gammapy.maps import Map, MapAxis, WcsNDMap
 from gammapy.utils.testing import mpl_plot_check, requires_data
 from gammapy.visualization import (
     plot_contour_line,
@@ -91,17 +91,22 @@ def test_plot_theta2_distribution():
 @requires_data()
 def test_plot_map_rgb():
     map_ = Map.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
-    kwargs = {"stretch": 0.5, "Q": 1, "minimum": 0.15}
 
     with pytest.raises(ValueError):
-        plot_map_rgb(map_, **kwargs)
+        plot_map_rgb(map_)
 
     with pytest.raises(ValueError):
-        plot_map_rgb(map_.sum_over_axes(keepdims=False), **kwargs)
+        plot_map_rgb(map_.sum_over_axes(keepdims=False))
+
+    axis = MapAxis([0, 1, 2, 3], node_type="edges")
+    map_allsky = WcsNDMap.create(binsz=10 * u.deg, axes=[axis])
+    with mpl_plot_check():
+        plot_map_rgb(map_allsky)
 
     axis_rgb = MapAxis.from_energy_edges(
         [0.1, 0.2, 0.5, 10], unit=u.TeV, name="energy", interp="log"
     )
     map_ = map_.resample_axis(axis_rgb)
+    kwargs = {"stretch": 0.5, "Q": 1, "minimum": 0.15}
     with mpl_plot_check():
         plot_map_rgb(map_, **kwargs)

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -96,6 +96,9 @@ def test_plot_map_rgb():
     with pytest.raises(ValueError):
         plot_map_rgb(map_, **kwargs)
 
+    with pytest.raises(ValueError):
+        plot_map_rgb(map_.sum_over_axes(keepdims=False), **kwargs)
+
     axis_rgb = MapAxis.from_energy_edges(
         [0.1, 0.2, 0.5, 10], unit=u.TeV, name="energy", interp="log"
     )

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -1,17 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import numpy as np
-import astropy.units as u
 from numpy.testing import assert_allclose
+import astropy.units as u
 from astropy.table import Table
 import matplotlib
 import matplotlib.pyplot as plt
 from packaging import version
+from gammapy.maps import Map, MapAxis
 from gammapy.utils.testing import mpl_plot_check, requires_data
-from gammapy.maps import Map
 from gammapy.visualization import (
     plot_contour_line,
-    plot_rgb,
+    plot_map_rgb,
     plot_spectrum_datasets_off_regions,
     plot_theta_squared_table,
 )
@@ -89,14 +89,16 @@ def test_plot_theta2_distribution():
 
 
 @requires_data()
-def test_plot_rgb():
+def test_plot_map_rgb():
     map_ = Map.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
     kwargs = {"stretch": 0.5, "Q": 1, "minimum": 0.15}
+
+    with pytest.raises(ValueError):
+        plot_map_rgb(map_, **kwargs)
+
+    axis_rgb = MapAxis.from_energy_edges(
+        [0.1, 0.2, 0.5, 10], unit=u.TeV, name="energy", interp="log"
+    )
+    map_ = map_.resample_axis(axis_rgb)
     with mpl_plot_check():
-        plot_rgb(map_, [0.1, 0.2, 0.5, 10] * u.TeV, **kwargs)
-
-    with pytest.raises(ValueError):
-        plot_rgb(map_, **kwargs)
-
-    with pytest.raises(ValueError):
-        plot_rgb(map_, [0.1, 0.2, 10] * u.TeV, **kwargs)
+        plot_map_rgb(map_, **kwargs)

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -16,6 +16,7 @@ from gammapy.visualization import (
     plot_theta_squared_table,
 )
 
+
 @pytest.mark.skipif(
     version.parse(matplotlib.__version__) < version.parse("3.5"),
     reason="Requires matplotlib 3.5 or higher",
@@ -85,6 +86,7 @@ def test_plot_theta2_distribution():
     # open a new figure to avoid
     plt.figure()
     plot_theta_squared_table(table=table)
+
 
 @requires_data()
 def test_plot_rgb():

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -96,4 +96,7 @@ def test_plot_rgb():
         plot_rgb(map_, [0.1, 0.2, 0.5, 10] * u.TeV, **kwargs)
 
     with pytest.raises(ValueError):
+        plot_rgb(map_, **kwargs)
+
+    with pytest.raises(ValueError):
         plot_rgb(map_, [0.1, 0.2, 10] * u.TeV, **kwargs)

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -47,6 +47,7 @@ def plot_rgb(map_, energy_edges=None, ax=None, **kwargs):
 
     Examples
     --------
+    >>> from gammapy.visualization.utils import plot_rgb
     >>> from gammapy.maps import Map
     >>> import astropy.units as u
     >>> map_ = Map.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -58,8 +58,7 @@ def plot_map_rgb(map_, ax=None, **kwargs):
     >>> plot_rgb(map_.smooth(0.08*u.deg), **kwargs)
     """
     geom = map_.geom
-    axes = geom.axes
-    if len(axes) != 1 or axes[0].nbin != 3:
+    if len(geom.axes) != 1 or geom.axes[0].nbin != 3:
         raise ValueError(
             "One non-spatial axis with exactly 3 bins is needed to plot an RGB image"
         )

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -55,7 +55,7 @@ def plot_map_rgb(map_, ax=None, **kwargs):
     >>> )
     >>> map_ = map_.resample_axis(axis_rgb)
     >>> kwargs = {"stretch": 0.5, "Q": 1, "minimum": 0.15}
-    >>> plot_rgb(map_.smooth(0.08*u.deg), **kwargs)
+    >>> plot_map_rgb(map_.smooth(0.08*u.deg), **kwargs)
     """
     geom = map_.geom
     if len(geom.axes) != 1 or geom.axes[0].nbin != 3:

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -56,10 +56,7 @@ def plot_rgb(map_, energy_edges=None, ax=None, **kwargs):
         raise ValueError("Exactly 3 energy bins are needed to plot an RGB image")
 
     axis_rgb = MapAxis.from_energy_edges(
-        energy_edges.value,
-        unit=energy_edges.unit,
-        name="energy",
-        interp=axis.interp
+        energy_edges.value, unit=energy_edges.unit, name="energy", interp=axis.interp
     )
     map_rgb = map_.resample_axis(axis_rgb)
 

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -26,16 +26,14 @@ def plot_map_rgb(map_, ax=None, **kwargs):
     """
     Plot RGB image on matplotlib WCS axes.
 
-    This function is based on the `~astropy.visualization.make_lupton_rgb` function, and it
-    assumes that the input map has exactly three z-axis bins. If that were not the case, you
-    can resample the z-axis of your map as shown in the code example below.
+    This function is based on the `~astropy.visualization.make_lupton_rgb` function. The input map must
+    contain 1 non-spatial axis with exactly 3 bins. If this is not the case, the map has to be resampled
+    before using the `plot_map_rgb` function (e.g. as shown in the code example below).
 
     Parameters
     ----------
     map_ : `~gammapy.maps.WcsNDMap`
-        WCS map. If energy edges are not provided, the map should contain exactly 3 energy bins.
-    energy_edges : `~astropy.units.Quantity`, float
-        Energy edges (an iterable of length 4) defining exactly 3 energy bins.
+        WCS map. The map must contain 1 non-spatial axis with exactly 3 bins.
     ax : `~astropy.visualization.wcsaxes.WCSAxes`, optional
         WCS axis object to plot on.
     **kwargs : dict
@@ -48,7 +46,7 @@ def plot_map_rgb(map_, ax=None, **kwargs):
 
     Examples
     --------
-    >>> from gammapy.visualization.utils import plot_rgb
+    >>> from gammapy.visualization.utils import plot_map_rgb
     >>> from gammapy.maps import Map, MapAxis
     >>> import astropy.units as u
     >>> map_ = Map.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
@@ -60,7 +58,8 @@ def plot_map_rgb(map_, ax=None, **kwargs):
     >>> plot_rgb(map_.smooth(0.08*u.deg), **kwargs)
     """
     geom = map_.geom
-    if geom.axes[0].nbin != 3:
+    axes = geom.axes
+    if len(axes) != 1 or axes[0].nbin != 3:
         raise ValueError(
             "One non-spatial axis with exactly 3 bins is needed to plot an RGB image"
         )

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -44,6 +44,14 @@ def plot_rgb(map_, energy_edges=None, ax=None, **kwargs):
     -------
     ax : `~astropy.visualization.wcsaxes.WCSAxes`
         WCS axis object
+
+    Examples
+    --------
+    >>> from gammapy.maps import Map
+    >>> import astropy.units as u
+    >>> map_ = Map.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
+    >>> kwargs = {"stretch": 0.5, "Q": 1, "minimum": 0.15}
+    >>> plot_rgb(map_.smooth(0.08*u.deg), [0.1, 0.2, 0.5, 10] * u.TeV, **kwargs)
     """
     axis = map_.geom.axes["energy"]
     if not energy_edges:

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -74,6 +74,7 @@ def plot_map_rgb(map_, ax=None, **kwargs):
     else:
         ax = map_._plot_format(ax)
 
+    # without this the axis limits are changed when calling scatter
     ax.autoscale(enable=False)
 
     return ax


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request addresses #3967 

Right now, all plot customization is done via the `kwargs` passed to `astropy.visualization.make_lupton_rgb(...)`. Is that sufficient, or more degrees of freedom should be allowed?

Also, it only works for `Wcs` maps. I guess we can expect the user to convert `Hpx` maps to `Wcs` before plotting...

The docstring example produces the following plot:
![image](https://user-images.githubusercontent.com/47325742/202217286-1db84856-048d-44a3-9d96-c5f89653e31f.png)

