### PR TITLE
Remove unneeded table util function

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -6,9 +6,10 @@ from copy import deepcopy
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
+from astropy.table import Table
 from gammapy.maps import TimeMapAxis
 from gammapy.modeling.models import Models
-from gammapy.utils.table import table_from_row_data, table_row_to_dict
+from gammapy.utils.table import table_row_to_dict
 
 __all__ = ["SourceCatalog", "SourceCatalogObject"]
 
@@ -69,7 +70,7 @@ class SourceCatalogObject:
     @property
     def position(self):
         """Source position (`~astropy.coordinates.SkyCoord`)."""
-        table = table_from_row_data([self.data])
+        table = Table([self.data])
         return _skycoord_from_table(table)[0]
 
 

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -9,7 +9,6 @@ from astropy.table import Table, vstack
 from gammapy.data import GTI
 from gammapy.modeling.models import DatasetModels, Models
 from gammapy.utils.scripts import make_name, make_path, read_yaml, write_yaml
-from gammapy.utils.table import table_from_row_data
 
 log = logging.getLogger(__name__)
 
@@ -498,7 +497,7 @@ class Datasets(collections.abc.MutableSequence):
 
             rows.append(row)
 
-        return table_from_row_data(rows=rows)
+        return Table(rows)
 
     # TODO: merge with meta table?
     @property

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -2,11 +2,11 @@
 import logging
 import numpy as np
 from astropy import units as u
+from astropy.table import Table
 from gammapy.datasets import Datasets
 from gammapy.maps import MapAxis
 from gammapy.modeling import Fit
 from gammapy.utils.pbar import progress_bar
-from gammapy.utils.table import table_from_row_data
 from ..flux import FluxEstimator
 from .core import FluxPoints
 
@@ -123,7 +123,7 @@ class FluxPointsEstimator(FluxEstimator):
             "sed_type_init": "likelihood",
         }
 
-        table = table_from_row_data(rows=rows, meta=meta)
+        table = Table(rows, meta=meta)
         model = datasets.models[self.source]
         return FluxPoints.from_table(
             table=table,

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -2,8 +2,8 @@
 import itertools
 import logging
 import numpy as np
+from astropy.table import Table
 from gammapy.utils.pbar import progress_bar
-from gammapy.utils.table import table_from_row_data
 from .covariance import Covariance
 from .iminuit import (
     confidence_iminuit,
@@ -217,7 +217,7 @@ class Fit:
             self._minuit = optimizer
             kwargs["method"] = "migrad"
 
-        trace = table_from_row_data(info.pop("trace"))
+        trace = Table(info.pop("trace"))
 
         if self.store_trace:
             idx = [

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -6,8 +6,8 @@ import itertools
 import logging
 import numpy as np
 from astropy import units as u
+from astropy.table import Table
 from gammapy.utils.interpolation import interpolation_scale
-from gammapy.utils.table import table_from_row_data
 
 __all__ = ["Parameter", "Parameters"]
 
@@ -615,7 +615,7 @@ class Parameters(collections.abc.Sequence):
                 if key in d:
                     del d[key]
             rows.append({**dict(type=p.type), **d})
-        table = table_from_row_data(rows)
+        table = Table(rows)
 
         table["value"].format = ".4e"
         for name in ["error", "min", "max"]:

--- a/gammapy/utils/table.py
+++ b/gammapy/utils/table.py
@@ -4,6 +4,7 @@ import numpy as np
 from astropy.table import Table
 from astropy.units import Quantity
 from .units import standardise_unit
+from .deprecation import deprecated
 
 __all__ = [
     "hstack_columns",
@@ -91,6 +92,7 @@ def table_row_to_dict(row, make_quantity=True):
     return data
 
 
+@deprecated("v1.1", alternative="astropy.table.Table")
 def table_from_row_data(rows, **kwargs):
     """Helper function to create table objects from row data.
 

--- a/gammapy/utils/tests/test_table.py
+++ b/gammapy/utils/tests/test_table.py
@@ -3,6 +3,7 @@ import pytest
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Column, Table
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.table import (
     table_from_row_data,
     table_row_to_dict,
@@ -43,7 +44,10 @@ def test_table_row_to_dict(table):
 
 def test_table_from_row_data():
     rows = [dict(a=1, b=1 * u.m, c="x"), dict(a=2, b=2 * u.km, c="yy")]
-    table = table_from_row_data(rows)
+
+    with pytest.warns(GammapyDeprecationWarning):
+        table = table_from_row_data(rows)
+
     assert isinstance(table, Table)
     assert table["b"].unit == "m"
     assert_allclose(table["b"].data, [1, 2000])


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request removes an unneeded function that nowadays is just supported by astropy out of the box.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->


Do we consider these `util` functions as part of the public API? If yes, the function should be deprecated but kept, right?