### PR TITLE
Fix IO for  EBLAbsorptionNormSpectralModel 

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -12,6 +12,7 @@ from astropy.table import Table
 from astropy.utils.decorators import classproperty
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
+from pathlib import Path
 from gammapy.maps import MapAxis, RegionNDMap
 from gammapy.modeling import Parameter, Parameters
 from gammapy.utils.integrate import trapz_loglog
@@ -52,6 +53,11 @@ __all__ = [
     "SuperExpCutoffPowerLaw4FGLSpectralModel",
     "TemplateSpectralModel",
 ]
+
+EBL_DATA_BUILTIN = {}
+EBL_DATA_BUILTIN["franceschini"] = "$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz"
+EBL_DATA_BUILTIN["dominguez"] = "$GAMMAPY_DATA/ebl/ebl_dominguez11.fits.gz"
+EBL_DATA_BUILTIN["finke"] = "$GAMMAPY_DATA/ebl/frd_abs.fits.gz"
 
 
 def scale_plot_flux(flux, energy_power=0):
@@ -1859,12 +1865,12 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
                     data["filename"], redshift=redshift, alpha_norm=alpha_norm
                 )
             else:
-                for reference in ["franceschini", "dominguez", "finke"]:
-                    if reference in data["filename"]:
+                for reference, filename in EBL_DATA_BUILTIN.items():
+                    if Path(filename).stem in data["filename"]:
                         return cls.read_builtin(
                             reference, redshift=redshift, alpha_norm=alpha_norm
                         )
-                raise IOError('File {data["filename"} not found')
+                raise IOError(f'File {data["filename"]} not found')
         else:
             energy = u.Quantity(data["energy"]["data"], data["energy"]["unit"])
             param = u.Quantity(data["param"]["data"], data["param"]["unit"])
@@ -1929,7 +1935,7 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
     def read_builtin(
         cls, reference="dominguez", redshift=0.1, alpha_norm=1, interp_kwargs=None
     ):
-        """Read  from one of the built-in absorption models.
+        """Read from one of the built-in absorption models.
 
         Parameters
         ----------
@@ -1950,13 +1956,12 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
             `Link <https://ui.adsabs.harvard.edu/abs/2010ApJ...712..238F>`__
 
         """
-        models = {}
-        models["franceschini"] = "$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz"
-        models["dominguez"] = "$GAMMAPY_DATA/ebl/ebl_dominguez11.fits.gz"
-        models["finke"] = "$GAMMAPY_DATA/ebl/frd_abs.fits.gz"
 
         return cls.read(
-            models[reference], redshift, alpha_norm, interp_kwargs=interp_kwargs
+            EBL_DATA_BUILTIN[reference],
+            redshift,
+            alpha_norm,
+            interp_kwargs=interp_kwargs,
         )
 
     def evaluate(self, energy, redshift, alpha_norm):

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1854,7 +1854,7 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
             p["value"] for p in data["parameters"] if p["name"] == "alpha_norm"
         ][0]
         if "filename" in data:
-            if os.exists(data["filename"]):
+            if os.path.exists(data["filename"]):
                 return cls.read(
                     data["filename"], redshift=redshift, alpha_norm=alpha_norm
                 )

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -165,6 +165,51 @@ def test_piecewise_norm_spectral_model_io():
 
 
 @requires_data()
+def test_absorption_io_invalid_path(tmp_path):
+    dominguez = EBLAbsorptionNormSpectralModel.read_builtin("dominguez", redshift=0.5)
+    dominguez.filename = "/not/a/valid/path/dominguez.fits"
+    assert len(dominguez.parameters) == 2
+
+    model_dict = dominguez.to_dict()
+    parnames = [_["name"] for _ in model_dict["spectral"]["parameters"]]
+    assert parnames == [
+        "alpha_norm",
+        "redshift",
+    ]
+    new_model = EBLAbsorptionNormSpectralModel.from_dict(model_dict)
+
+    assert new_model.redshift.value == 0.5
+    assert new_model.alpha_norm.name == "alpha_norm"
+    assert new_model.alpha_norm.value == 1
+    assert_allclose(new_model.energy, dominguez.energy)
+    assert_allclose(new_model.param, dominguez.param)
+    assert len(new_model.parameters) == 2
+
+
+@requires_data()
+def test_absorption_io_no_filename(tmp_path):
+    dominguez = EBLAbsorptionNormSpectralModel.read_builtin("dominguez", redshift=0.5)
+    dominguez.filename = None
+    assert len(dominguez.parameters) == 2
+
+    model_dict = dominguez.to_dict()
+    parnames = [_["name"] for _ in model_dict["spectral"]["parameters"]]
+    assert parnames == [
+        "alpha_norm",
+        "redshift",
+    ]
+
+    new_model = EBLAbsorptionNormSpectralModel.from_dict(model_dict)
+
+    assert new_model.redshift.value == 0.5
+    assert new_model.alpha_norm.name == "alpha_norm"
+    assert new_model.alpha_norm.value == 1
+    assert_allclose(new_model.energy, dominguez.energy)
+    assert_allclose(new_model.param, dominguez.param)
+    assert len(new_model.parameters) == 2
+
+
+@requires_data()
 def test_absorption_io(tmp_path):
     dominguez = EBLAbsorptionNormSpectralModel.read_builtin("dominguez", redshift=0.5)
     assert len(dominguez.parameters) == 2

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -167,7 +167,7 @@ def test_piecewise_norm_spectral_model_io():
 @requires_data()
 def test_absorption_io_invalid_path(tmp_path):
     dominguez = EBLAbsorptionNormSpectralModel.read_builtin("dominguez", redshift=0.5)
-    dominguez.filename = "/not/a/valid/path/dominguez.fits"
+    dominguez.filename = "/not/a/valid/path/ebl_dominguez11.fits.gz"
     assert len(dominguez.parameters) == 2
 
     model_dict = dominguez.to_dict()
@@ -184,6 +184,11 @@ def test_absorption_io_invalid_path(tmp_path):
     assert_allclose(new_model.energy, dominguez.energy)
     assert_allclose(new_model.param, dominguez.param)
     assert len(new_model.parameters) == 2
+
+    dominguez.filename = "/not/a/valid/path/dominguez.fits.gz"
+    model_dict = dominguez.to_dict()
+    with pytest.raises(IOError):
+        EBLAbsorptionNormSpectralModel.from_dict(model_dict)
 
 
 @requires_data()


### PR DESCRIPTION
This PR fix the IO of the EBLAbsorptionNormSpectralModel in case a filename is not given, and in case the filename point to a built-in model written on another machine.