### PR TITLE
Adds built-in Franceschini (2018) and Saldana-Lopez (2021) EBL models

### DIFF
--- a/examples/models/spectral/plot_absorbed.py
+++ b/examples/models/spectral/plot_absorbed.py
@@ -40,6 +40,12 @@ franceschini = EBLAbsorptionNormSpectralModel.read_builtin(
     "franceschini", redshift=redshift
 )
 finke = EBLAbsorptionNormSpectralModel.read_builtin("finke", redshift=redshift)
+franceschini17 = EBLAbsorptionNormSpectralModel.read_builtin(
+    "franceschini17", redshift=redshift
+)
+saldana21 = EBLAbsorptionNormSpectralModel.read_builtin(
+    "saldana-lopez21", redshift=redshift
+)
 
 fig, (ax_ebl, ax_model) = plt.subplots(
     nrows=1, ncols=2, figsize=(10, 4), gridspec_kw={"left": 0.08, "right": 0.96}
@@ -51,6 +57,8 @@ opts = dict(energy_bounds=energy_bounds, xunits=u.TeV)
 franceschini.plot(ax=ax_ebl, label="Franceschini 2008", **opts)
 finke.plot(ax=ax_ebl, label="Finke 2010", **opts)
 dominguez.plot(ax=ax_ebl, label="Dominguez 2011", **opts)
+franceschini17.plot(ax=ax_ebl, label="Franceschni 2017", **opts)
+saldana21.plot(ax=ax_ebl, label="Saldana-Lopez 2021", **opts)
 
 ax_ebl.set_ylabel(r"Absorption coefficient [$\exp{(-\tau(E))}$]")
 ax_ebl.set_xlim(energy_bounds.value)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1955,13 +1955,16 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
 
         References
         ----------
-        .. [1] Franceschini et al., "Extragalactic optical-infrared background radiation, its time evolution and the cosmic photon-photon opacity",  # noqa: E501
+        .. [1] Franceschini et al. (2008), "Extragalactic optical-infrared background radiation, its time evolution and the cosmic photon-photon opacity",  # noqa: E501
             `Link <https://ui.adsabs.harvard.edu/abs/2008A%26A...487..837F>`__
         .. [2] Dominguez et al., " Extragalactic background light inferred from AEGIS galaxy-SED-type fractions"  # noqa: E501
             `Link <https://ui.adsabs.harvard.edu/abs/2011MNRAS.410.2556D>`__
         .. [3] Finke et al., "Modeling the Extragalactic Background Light from Stars and Dust"
             `Link <https://ui.adsabs.harvard.edu/abs/2010ApJ...712..238F>`__
-
+        .. [4] Franceschini et al. (2017), "The extragalactic background light revisited and the cosmic photon-photon opacity"
+            `Link <https://ui.adsabs.harvard.edu/abs/2017A%26A...603A..34F/abstract>`__
+        .. [5] Saldana-Lopez et al. (2021) "An observational determination of the evolving extragalactic background light from the multiwavelength HST/CANDELS survey in the Fermi and CTA era"
+            `Link <https://ui.adsabs.harvard.edu/abs/2021MNRAS.507.5144S/abstract>`__
         """
 
         return cls.read(

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1957,9 +1957,9 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
         ----------
         .. [1] Franceschini et al. (2008), "Extragalactic optical-infrared background radiation, its time evolution and the cosmic photon-photon opacity",  # noqa: E501
             `Link <https://ui.adsabs.harvard.edu/abs/2008A%26A...487..837F>`__
-        .. [2] Dominguez et al., " Extragalactic background light inferred from AEGIS galaxy-SED-type fractions"  # noqa: E501
+        .. [2] Dominguez et al. (2011), " Extragalactic background light inferred from AEGIS galaxy-SED-type fractions"  # noqa: E501
             `Link <https://ui.adsabs.harvard.edu/abs/2011MNRAS.410.2556D>`__
-        .. [3] Finke et al., "Modeling the Extragalactic Background Light from Stars and Dust"
+        .. [3] Finke et al. (2010), "Modeling the Extragalactic Background Light from Stars and Dust"
             `Link <https://ui.adsabs.harvard.edu/abs/2010ApJ...712..238F>`__
         .. [4] Franceschini et al. (2017), "The extragalactic background light revisited and the cosmic photon-photon opacity"
             `Link <https://ui.adsabs.harvard.edu/abs/2017A%26A...603A..34F/abstract>`__

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -58,6 +58,8 @@ EBL_DATA_BUILTIN = {}
 EBL_DATA_BUILTIN["franceschini"] = "$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz"
 EBL_DATA_BUILTIN["dominguez"] = "$GAMMAPY_DATA/ebl/ebl_dominguez11.fits.gz"
 EBL_DATA_BUILTIN["finke"] = "$GAMMAPY_DATA/ebl/frd_abs.fits.gz"
+EBL_DATA_BUILTIN["franceschini17"] = "$GAMMAPY_DATA/ebl/ebl_franceschini_2017.fits.gz"
+EBL_DATA_BUILTIN["saldana-lopez21"] = "$GAMMAPY_DATA/ebl/ebl_saldana-lopez_2021.fits.gz"
 
 
 def scale_plot_flux(flux, energy_power=0):


### PR DESCRIPTION
Paired with [PR 29 in gammapy-data](https://github.com/gammapy/gammapy-data/pull/29) this PR adds the EBL models of Franceschini (2018) and Saldana-Lopez (2021).

Solves #4055.

What to do with the tests? It seems to me that no test uses all the built-in models available: there is one testing that a `TemplateSpectralModel` [can read one of the EBL file](https://github.com/gammapy/gammapy/blob/main/gammapy/modeling/models/tests/test_spectral.py#L540) and [one that checks its extrapolation](https://github.com/gammapy/gammapy/blob/main/gammapy/modeling/models/tests/test_spectral.py#L589). Then another [one tests the effect of the absorption](https://github.com/gammapy/gammapy/blob/main/gammapy/modeling/models/tests/test_spectral.py#L550). There are some files untouched by the tests, should we add a test involving all the built-in models?