### PR TITLE
FluxPointsDataset support model with spatial template and NormSpectralModel

### DIFF
--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -17,14 +17,15 @@ log = logging.getLogger(__name__)
 __all__ = ["FluxPointsDataset"]
 
 
-def _get_reference_model(energy_edges, model):
+def _get_reference_model(energy_edges, model, margin_percent=70):
     if isinstance(model.spatial_model, TemplateSpatialModel):
         geom = model.spatial_model.map.geom
-        if geom.is_image:
-            energy_axis = MapAxis.from_energy_bounds(
-                energy_edges[0], energy_edges[-1], nbin=10, per_decade=True
-            )
-            geom = geom.to_cube([energy_axis])
+        emin = energy_edges[0] * (1 - margin_percent / 100)
+        emax = energy_edges[-1] * (1 + margin_percent / 100)
+        energy_axis = MapAxis.from_energy_bounds(
+            emin, emax, nbin=20, per_decade=True, name="energy_true"
+        )
+        geom = geom.to_image().to_cube([energy_axis])
         return Models([model]).to_template_spectral_model(geom)
     else:
         return model.spectral_model

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import numpy as np
+from scipy.interpolate import interp1d
 from astropy import units as u
 from astropy.io import fits
 from astropy.table import Table
@@ -283,7 +284,26 @@ class FluxPointsDataset(Dataset):
         """Compute predicted flux."""
         flux = 0.0
         for model in self.models:
-            flux_model = model.spectral_model(self.data.energy_ref)
+            if isinstance(model.spatial_model, TemplateSpatialModel):
+                geom = model.spatial_model.map.geom
+                spatial_integ = model.spatial_model.integrate_geom(geom)
+                uspatial = spatial_integ.unit
+                spatial_integ.data[~np.isfinite(spatial_integ.data)] = np.nan
+                if model.spatial_model.is_energy_dependent:
+                    spatial_integ = np.nansum(spatial_integ.data, axis=(1, 2))
+                    energy = geom.axes[0].center.to(self.data.energy_ref.unit)
+                    interp = interp1d(
+                        np.log10(energy.value), np.log10(spatial_integ), kind="linear"
+                    )
+                    spatial_integ = (
+                        10 ** interp(np.log10(self.data.energy_ref.value)) * uspatial
+                    )
+                else:
+                    spatial_integ = np.nansum(spatial_integ.data) * uspatial
+                spectral_values = model.spectral_model(self.data.energy_ref)
+                flux_model = spectral_values * spatial_integ
+            else:
+                flux_model = model.spectral_model(self.data.energy_ref)
 
             if model.temporal_model is not None:
                 integral = model.temporal_model.integral(

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -17,11 +17,11 @@ log = logging.getLogger(__name__)
 __all__ = ["FluxPointsDataset"]
 
 
-def _get_reference_model(energy_edges, model, margin_percent=70):
+def _get_reference_model(model, energy_bounds, margin_percent=70):
     if isinstance(model.spatial_model, TemplateSpatialModel):
         geom = model.spatial_model.map.geom
-        emin = energy_edges[0] * (1 - margin_percent / 100)
-        emax = energy_edges[-1] * (1 + margin_percent / 100)
+        emin = energy_bounds[0] * (1 - margin_percent / 100)
+        emax = energy_bounds[-1] * (1 + margin_percent / 100)
         energy_axis = MapAxis.from_energy_bounds(
             emin, emax, nbin=20, per_decade=True, name="energy_true"
         )
@@ -297,7 +297,7 @@ class FluxPointsDataset(Dataset):
         """Compute predicted flux."""
         flux = 0.0
         for model in self.models:
-            reference_model = _get_reference_model(self._energy_bounds, model)
+            reference_model = _get_reference_model(model, self._energy_bounds)
             flux_model = reference_model(self.data.energy_ref)
 
             if model.temporal_model is not None:

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -114,12 +114,6 @@ class FluxEstimator(ParameterEstimator):
             Scale spectral model
         """
         ref_model = models[self.source].spectral_model
-
-        if ref_model.is_norm_spectral_model:
-            raise ValueError(
-                "Instances of `NormSpectralModel` are not supported for flux point estimation."
-            )
-
         scale_model = ScaleSpectralModel(ref_model)
 
         norms = ref_model.parameters.norm_parameters

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -146,7 +146,7 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
         )
 
         table = Table(rows, meta=meta)
-        model = _get_reference_model(self.energy_edges, datasets.models[self.source])
+        model = _get_reference_model(datasets.models[self.source], self.energy_edges)
         return FluxPoints.from_table(
             table=table,
             reference_model=model.copy(),
@@ -183,7 +183,7 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
         else:
             log.warning(f"No dataset contribute in range {energy_min}-{energy_max}")
             model = _get_reference_model(
-                self.energy_edges, datasets.models[self.source]
+                datasets.models[self.source], self.energy_edges
             )
             return self._nan_result(datasets, model, energy_min, energy_max)
 

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -7,12 +7,7 @@ from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.table import Table
 from gammapy.data import Observation
 from gammapy.data.pointing import FixedPointingInfo
-from gammapy.datasets import (
-    Datasets,
-    FluxPointsDataset,
-    MapDataset,
-    SpectrumDatasetOnOff,
-)
+from gammapy.datasets import FluxPointsDataset, MapDataset, SpectrumDatasetOnOff
 from gammapy.datasets.spectrum import SpectrumDataset
 from gammapy.estimators import FluxPoints, FluxPointsEstimator
 from gammapy.irf import EDispKernelMap, EffectiveAreaTable2D, load_irf_dict_from_file
@@ -32,14 +27,6 @@ from gammapy.modeling.models import (
 )
 from gammapy.utils import parallel
 from gammapy.utils.testing import requires_data, requires_dependency
-
-
-@pytest.fixture(scope="session")
-def fermi_datasets():
-    filename = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml"
-    filename_models = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml"
-
-    return Datasets.read(filename=filename, filename_models=filename_models)
 
 
 # TODO: use pre-generated data instead
@@ -629,11 +616,6 @@ def test_fpe_non_uniform_datasets():
 
 @requires_data()
 def test_flux_points_estimator_norm_spectral_model(fermi_datasets):
-
-    filename = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml"
-    filename_models = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml"
-
-    fermi_datasets = Datasets.read(filename=filename, filename_models=filename_models)
 
     energy_edges = [10, 30, 100, 300, 1000] * u.GeV
 

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -622,6 +622,7 @@ def test_fpe_non_uniform_datasets():
         fpe.run(datasets=[dataset_1, dataset_2])
 
 
+@requires_data()
 def test_flux_points_estimator_norm_spectral_model(fermi_datasets):
 
     energy_edges = [10, 30, 100, 300, 1000] * u.GeV

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -7,7 +7,12 @@ from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.table import Table
 from gammapy.data import Observation
 from gammapy.data.pointing import FixedPointingInfo
-from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
+from gammapy.datasets import (
+    Datasets,
+    FluxPointsDataset,
+    MapDataset,
+    SpectrumDatasetOnOff,
+)
 from gammapy.datasets.spectrum import SpectrumDataset
 from gammapy.estimators import FluxPoints, FluxPointsEstimator
 from gammapy.irf import EDispKernelMap, EffectiveAreaTable2D, load_irf_dict_from_file
@@ -17,12 +22,12 @@ from gammapy.maps import MapAxis, RegionGeom, RegionNDMap, WcsGeom
 from gammapy.modeling import Fit
 from gammapy.modeling.models import (
     ExpCutoffPowerLawSpectralModel,
-    PiecewiseNormSpectralModel,
     FoVBackgroundModel,
     GaussianSpatialModel,
+    Models,
+    PiecewiseNormSpectralModel,
     PowerLawSpectralModel,
     SkyModel,
-    Models,
     TemplateSpatialModel,
 )
 from gammapy.utils import parallel

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -29,6 +29,15 @@ from gammapy.utils import parallel
 from gammapy.utils.testing import requires_data, requires_dependency
 
 
+@pytest.fixture()
+def fermi_datasets():
+    from gammapy.datasets import Datasets
+
+    filename = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml"
+    filename_models = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml"
+    return Datasets.read(filename=filename, filename_models=filename_models)
+
+
 # TODO: use pre-generated data instead
 def simulate_spectrum_dataset(model, random_state=0):
     energy_edges = np.logspace(-0.5, 1.5, 21) * u.TeV

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -630,6 +630,11 @@ def test_fpe_non_uniform_datasets():
 @requires_data()
 def test_flux_points_estimator_norm_spectral_model(fermi_datasets):
 
+    filename = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml"
+    filename_models = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml"
+
+    fermi_datasets = Datasets.read(filename=filename, filename_models=filename_models)
+
     energy_edges = [10, 30, 100, 300, 1000] * u.GeV
 
     model_ref = fermi_datasets.models["Crab Nebula"]
@@ -644,7 +649,12 @@ def test_flux_points_estimator_norm_spectral_model(fermi_datasets):
     flux_pred_ref = flux_points_dataset.flux_pred()
 
     models = Models([model_ref])
-    geom = fermi_datasets[0].exposure.geom
+    geom = fermi_datasets[0].exposure.geom.to_image()
+    energy_axis = MapAxis.from_energy_bounds(
+        3 * u.GeV, 1.7 * u.TeV, nbin=30, per_decade=True, name="energy_true"
+    )
+    geom = geom.to_cube([energy_axis])
+
     model = models.to_template_sky_model(geom, name="test")
     fermi_datasets.models = [fermi_datasets[0].background_model, model]
     estimator = FluxPointsEstimator(
@@ -654,7 +664,7 @@ def test_flux_points_estimator_norm_spectral_model(fermi_datasets):
 
     flux_points_dataset = FluxPointsDataset(data=flux_points, models=model)
     flux_pred = flux_points_dataset.flux_pred()
-    assert_allclose(flux_pred, flux_pred_ref, rtol=1e-5)
+    assert_allclose(flux_pred, flux_pred_ref, rtol=2e-4)
 
     # test model 2d
     norms = (
@@ -667,4 +677,4 @@ def test_flux_points_estimator_norm_spectral_model(fermi_datasets):
     model.spectral_model = PiecewiseNormSpectralModel(geom.axes[0].center, norms)
     flux_points_dataset = FluxPointsDataset(data=flux_points, models=model)
     flux_pred = flux_points_dataset.flux_pred()
-    assert_allclose(flux_pred, flux_pred_ref, rtol=1e-5)
+    assert_allclose(flux_pred, flux_pred_ref, rtol=2e-4)

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -5,14 +5,12 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
 from gammapy.estimators.flux import FluxEstimator
-from gammapy.maps import MapAxis, WcsNDMap
 from gammapy.modeling.models import (
     Models,
     NaimaSpectralModel,
     PowerLawNormSpectralModel,
     PowerLawSpectralModel,
     SkyModel,
-    TemplateSpatialModel,
 )
 from gammapy.utils.testing import requires_data, requires_dependency
 

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -148,19 +148,6 @@ def test_flux_estimator_norm_range():
     assert scale_model.norm.interp == "log"
 
 
-def test_flux_estimator_norm_spectral_model():
-    energy = MapAxis.from_energy_bounds(0.1, 10, 3.0, unit="TeV", name="energy_true")
-    template = WcsNDMap.create(npix=10, axes=[energy], unit="cm-2 s-1 sr-1 TeV-1")
-    spatial = TemplateSpatialModel(template, normalize=False)
-    spectral = PowerLawNormSpectralModel()
-    model = SkyModel(spectral_model=spectral, spatial_model=spatial, name="test")
-
-    estimator = FluxEstimator(source="test", selection_optional=[], reoptimize=True)
-
-    with pytest.raises(ValueError, match="`NormSpectralModel` are not supported"):
-        estimator.get_scale_model(Models([model]))
-
-
 def test_flux_estimator_compound_model():
     pl = PowerLawSpectralModel()
     pl.amplitude.min = 1e-15

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -16,14 +16,6 @@ from gammapy.utils.testing import requires_data, requires_dependency
 
 
 @pytest.fixture(scope="session")
-def fermi_datasets():
-    filename = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml"
-    filename_models = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml"
-
-    return Datasets.read(filename=filename, filename_models=filename_models)
-
-
-@pytest.fixture(scope="session")
 def hess_datasets():
     datasets = Datasets()
     pwl = PowerLawSpectralModel(amplitude="3.5e-11 cm-2s-1TeV-1", index=2.7)

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -15,6 +15,15 @@ from gammapy.modeling.models import (
 from gammapy.utils.testing import requires_data, requires_dependency
 
 
+@pytest.fixture()
+def fermi_datasets():
+    from gammapy.datasets import Datasets
+
+    filename = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml"
+    filename_models = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml"
+    return Datasets.read(filename=filename, filename_models=filename_models)
+
+
 @pytest.fixture(scope="session")
 def hess_datasets():
     datasets = Datasets()

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -991,7 +991,10 @@ class DatasetModels(collections.abc.Sequence):
         )
 
     def to_template_spectral_model(self, geom, mask=None):
-        """Merge a list of models into a single `~gammapy.modeling.models.TemplateSpectralModel`
+        """Merge a list of models into a single `~gammapy.modeling.models.TemplateSpectralModel`.
+
+        For each model the spatial component is intergated over the given geom where the mask is true
+        and multiplied by the spectral component value in each energy bin.
 
         Parameters
         ----------

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -1018,9 +1018,10 @@ class DatasetModels(collections.abc.Sequence):
         values = 0
         for m in self:
             dnde = m.spectral_model(energy)
-            spatial_integ = m.spatial_model.integrate_geom(geom) * mask
+            spatial_integ = m.spatial_model.integrate_geom(geom)
+            masked_integ = spatial_integ.data * np.isfinite(spatial_integ.data) * mask
             spatial_integ.data[~np.isfinite(spatial_integ.data)] = np.nan
-            dnde *= np.nansum(spatial_integ.data, axis=(1, 2)) * spatial_integ.unit
+            dnde *= masked_integ.sum(axis=(1, 2)) * spatial_integ.unit
             values += dnde
         return TemplateSpectralModel(energy, values)
 

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -996,13 +996,13 @@ class DatasetModels(collections.abc.Sequence):
         Parameters
         ----------
         geom : `Geom`
-            Map geometry the evaluate model.
-        mask :  `Map`
+            Map geometry on which the template model is computed.
+        mask :  `Map` with bool dtype.
             Evaluate the model only where the mask is True.
 
         Returns
         -------
-        model : `TemplateSpectralModel`
+        model : `~gammapy.modeling.models.TemplateSpectralModel`
             Template spectral model.
         """
 

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -999,8 +999,6 @@ class DatasetModels(collections.abc.Sequence):
             Map geometry the evaluate model.
         mask :  `Map`
             Evaluate the model only where the mask is True.
-        maks : `~gammapy.modeling.models.SpectralModel`
-            One of the NormSpectralMdel
 
         Returns
         -------

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -993,14 +993,14 @@ class DatasetModels(collections.abc.Sequence):
     def to_template_spectral_model(self, geom, mask=None):
         """Merge a list of models into a single `~gammapy.modeling.models.TemplateSpectralModel`.
 
-        For each model the spatial component is intergated over the given geom where the mask is true
+        For each model the spatial component is integrated over the given geometry where the mask is true
         and multiplied by the spectral component value in each energy bin.
 
         Parameters
         ----------
-        geom : `Geom`
+        geom : `~gammapy.maps.Geom`
             Map geometry on which the template model is computed.
-        mask :  `Map` with bool dtype.
+        mask :  `~gammapy.maps.Map` with bool dtype.
             Evaluate the model only where the mask is True.
 
         Returns

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -268,6 +268,17 @@ class SpatialModel(ModelBase):
         data["spatial"]["parameters"] = data["spatial"].pop("parameters")
         return data
 
+    @property
+    def _evaluation_geom(self):
+        if isinstance(self, TemplateSpatialModel):
+            geom = self.map.geom
+        else:
+            width = 2 * max(self.evaluation_radius, 0.1 * u.deg)
+            geom = WcsGeom.create(
+                skydir=self.position, frame=self.frame, width=width, binsz=0.02
+            )
+        return geom
+
     def _get_plot_map(self, geom):
         if self.evaluation_radius is None and geom is None:
             raise ValueError(
@@ -275,13 +286,8 @@ class SpatialModel(ModelBase):
             )
 
         if geom is None:
-            if isinstance(self, TemplateSpatialModel):
-                geom = self.map.geom
-            else:
-                width = 2 * max(self.evaluation_radius, 0.1 * u.deg)
-                geom = WcsGeom.create(
-                    skydir=self.position, frame=self.frame, width=width, binsz=0.02
-                )
+            geom = self._evaluation_geom
+
         data = self.evaluate_geom(geom)
         return Map.from_geom(geom, data=data.value, unit=data.unit)
 


### PR DESCRIPTION
This PR change the `.flux_pred()` method in FluxPointsDataset in order to support reference models relying on spatial template and NormSpectralModel.
This should resolve #4019.