### PR TITLE
Allow reading of IRF files with single-value axes

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1300,8 +1300,12 @@ class MapAxis:
             if hduclass in {"BKG", "RAD_MAX"} and column_prefix == "ENERG":
                 name = "energy"
 
-            edges_lo = table[f"{column_prefix}_LO"].quantity[0]
-            edges_hi = table[f"{column_prefix}_HI"].quantity[0]
+            edges_lo = table[f"{column_prefix}_LO"].quantity
+            edges_hi = table[f"{column_prefix}_HI"].quantity
+            # usually the axes arrays are stored with one extra (single-column) dimension
+            if edges_lo.ndim > 1:
+                edges_lo = edges_lo[0]
+                edges_hi = edges_hi[0]
 
             if np.allclose(edges_hi, edges_lo):
                 axis = MapAxis.from_nodes(edges_hi, interp=interp, name=name)

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -757,3 +757,9 @@ def test_time_map_axis_format_plot_xaxis(time_intervals):
 
     ax1 = axis.format_plot_xaxis(ax=ax)
     assert ax1.xaxis.label.properties()["text"] == "Time [iso]"
+
+
+def test_single_valued_axis():
+    theta_values = np.array([0.5]) * u.deg
+    table = Table(data=[theta_values, theta_values], names=["THETA_LO", "THETA_HI"])
+    _ = MapAxis.from_table(table, format="gadf-dl3", column_prefix="THETA")

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -760,6 +760,13 @@ def test_time_map_axis_format_plot_xaxis(time_intervals):
 
 
 def test_single_valued_axis():
+    # this will be interpreted as a scalar value
+    # that is against the specifications, but we allow it nevertheless
     theta_values = np.array([0.5]) * u.deg
+    table = Table(data=[theta_values, theta_values], names=["THETA_LO", "THETA_HI"])
+    _ = MapAxis.from_table(table, format="gadf-dl3", column_prefix="THETA")
+
+    # this is a proper array-like axis with just a single value
+    theta_values = np.array([[0.5]]) * u.deg
     table = Table(data=[theta_values, theta_values], names=["THETA_LO", "THETA_HI"])
     _ = MapAxis.from_table(table, format="gadf-dl3", column_prefix="THETA")


### PR DESCRIPTION
**Description**
I found that it is not possible to read IRF files if they have a single-valued axis. Specifically, I was trying to read [this file](https://github.com/gammapy/gammapy/files/10093286/aeff.fits.gz) using `EffectiveAreaTable2D.read`, which has a single entry in the `THETA_LO` / `THETA_HI` axis. This resulted in the following error:

```python
----> 1 aeff = EffectiveAreaTable2D.read('aeff.fits.gz')

File /lfs/l7/hess/users/mohrmann/software/anaconda3/envs/gammapy-1.0/lib/python3.9/site-packages/gammapy/irf/core.py:434, in IRF.read(cls, filename, hdu, format)
    417 """Read from file.
    418 
    419 Parameters
   (...)
    431     IRF class
    432 """
    433 with fits.open(str(make_path(filename)), memmap=False) as hdulist:
--> 434     return cls.from_hdulist(hdulist, hdu=hdu)

File /lfs/l7/hess/users/mohrmann/software/anaconda3/envs/gammapy-1.0/lib/python3.9/site-packages/gammapy/irf/core.py:413, in IRF.from_hdulist(cls, hdulist, hdu, format)
    410 if hdu is None:
    411     hdu = IRF_DL3_HDU_SPECIFICATION[cls.tag]["extname"]
--> 413 return cls.from_table(Table.read(hdulist[hdu]), format=format)

File /lfs/l7/hess/users/mohrmann/software/anaconda3/envs/gammapy-1.0/lib/python3.9/site-packages/gammapy/irf/core.py:452, in IRF.from_table(cls, table, format)
    436 @classmethod
    437 def from_table(cls, table, format="gadf-dl3"):
    438     """Read from `~astropy.table.Table`.
    439 
    440     Parameters
   (...)
    450         IRF class.
    451     """
--> 452     axes = MapAxes.from_table(table=table, format=format)
    453     axes = axes[cls.required_axes]
    454     column_name = IRF_DL3_HDU_SPECIFICATION[cls.tag]["column_name"]

File /lfs/l7/hess/users/mohrmann/software/anaconda3/envs/gammapy-1.0/lib/python3.9/site-packages/gammapy/maps/axes.py:1999, in MapAxes.from_table(cls, table, format)
   1997 for column_prefix in IRF_DL3_AXES_SPECIFICATION:
   1998     try:
-> 1999         axis = MapAxis.from_table(
   2000             table, format=format, column_prefix=column_prefix
   2001         )
   2002     except KeyError:
   2003         continue

File /lfs/l7/hess/users/mohrmann/software/anaconda3/envs/gammapy-1.0/lib/python3.9/site-packages/gammapy/maps/axes.py:1307, in MapAxis.from_table(cls, table, format, idx, column_prefix)
   1304 edges_hi = table[f"{column_prefix}_HI"].quantity[0]
   1306 if np.allclose(edges_hi, edges_lo):
-> 1307     axis = MapAxis.from_nodes(edges_hi, interp=interp, name=name)
   1308 else:
   1309     edges = edges_from_lo_hi(edges_lo, edges_hi)

File /lfs/l7/hess/users/mohrmann/software/anaconda3/envs/gammapy-1.0/lib/python3.9/site-packages/gammapy/maps/axes.py:615, in MapAxis.from_nodes(cls, nodes, **kwargs)
    598 @classmethod
    599 def from_nodes(cls, nodes, **kwargs):
    600     """Generate an axis object from a sequence of nodes (bin centers).
    601 
    602     This will create a sequence of bins with edges half-way
   (...)
    613         coordinates.  Default: 'lin'.
    614     """
--> 615     if len(nodes) < 1:
    616         raise ValueError("Nodes array must have at least one element.")
    618     return cls(nodes, node_type="center", **kwargs)

File /lfs/l7/hess/users/mohrmann/software/anaconda3/envs/gammapy-1.0/lib/python3.9/site-packages/astropy/units/quantity.py:1249, in Quantity.__len__(self)
   1247 def __len__(self):
   1248     if self.isscalar:
-> 1249         raise TypeError("'{cls}' object with a scalar value has no "
   1250                         "len()".format(cls=self.__class__.__name__))
   1251     else:
   1252         return len(self.value)

TypeError: 'Quantity' object with a scalar value has no len()
```

This PR fixes this problem by checking the dimensionality of the array read from the FITS file.