### PR TITLE
Fix wrong name in required hdus

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -302,7 +302,7 @@ class DataStore:
                 f"{difference} is not a valid hdu key. Choose from: {ALL_IRFS}"
             )
 
-        required_hdus = {"event", "gti"}.union(required_irf)
+        required_hdus = {"events", "gti"}.union(required_irf)
 
         missing_hdus = []
         for hdu in ALL_HDUS:


### PR DESCRIPTION
Signed-off-by: Maximilian Linhoff <maximilian.linhoff@tu-dortmund.de>

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes a typo in `gamma/data/data_store.py` that prevented an error from being raised early for a missing `events` HDU.



