### PR TITLE
Replace deprecated numpy type aliases

### DIFF
--- a/gammapy/estimators/map/tests/test_core.py
+++ b/gammapy/estimators/map/tests/test_core.py
@@ -408,7 +408,7 @@ def test_get_flux_point_missing_map(wcs_flux_map, reference_model):
     assert_allclose(table["norm_err"], [0.1, 0.1])
     assert_allclose(table["norm_ul"], [2, 2])
     assert "norm_errn" not in table.columns
-    assert table["success"].data.dtype == np.dtype(np.bool)
+    assert table["success"].data.dtype == np.dtype(bool)
 
 
 def test_flux_map_from_dict_inconsistent_units(wcs_flux_map, reference_model):

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -328,9 +328,9 @@ class EDispKernel(IRF):
 
         rows = self.pdf_matrix.shape[0]
         n_grp = []
-        f_chan = np.ndarray(dtype=np.object, shape=rows)
-        n_chan = np.ndarray(dtype=np.object, shape=rows)
-        matrix = np.ndarray(dtype=np.object, shape=rows)
+        f_chan = np.ndarray(dtype=object, shape=rows)
+        n_chan = np.ndarray(dtype=object, shape=rows)
+        matrix = np.ndarray(dtype=object, shape=rows)
 
         # Make RMF type matrix
         for idx, row in enumerate(self.data):

--- a/gammapy/maps/region/tests/test_ndmap.py
+++ b/gammapy/maps/region/tests/test_ndmap.py
@@ -175,7 +175,7 @@ def test_region_nd_map_misc(region_map):
     assert_allclose(stacked.data.sum(), 30)
 
     stacked = region_map.copy()
-    weights = Map.from_geom(region_map.geom, dtype=np.int)
+    weights = Map.from_geom(region_map.geom, dtype=np.int_)
     stacked.stack(region_map, weights=weights)
     assert_allclose(stacked.data.sum(), 15)
 

--- a/gammapy/maps/tests/test_maps.py
+++ b/gammapy/maps/tests/test_maps.py
@@ -84,5 +84,5 @@ def test_maps_from_geom():
     assert len(maps_kwargs) == 3
     assert maps_kwargs["map1"].unit == "cm2s"
     assert maps_kwargs["map1"].data.dtype == np.float64
-    assert maps_kwargs["map2"].data.dtype == np.bool
+    assert maps_kwargs["map2"].data.dtype == bool
     assert maps_kwargs["map3"].data[2, 2] == 12

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -247,10 +247,10 @@ def test_update_from_dict():
     }
     par.update_from_dict(data)
     assert par.name == "test"
-    assert par.factor == 3
-    assert par.value == 3e-10
+    assert_allclose(par.factor, 3)
+    assert_allclose(par.value, 3e-10)
     assert par.unit == "GeV"
-    assert par.min == 0
+    assert_allclose(par.min, 0)
     assert par.max is np.nan
     assert par.frozen
     data = {


### PR DESCRIPTION
Replace deprecated numpy type aliases.
See https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
