### PR TITLE
Fix inhomogeneous array shape deprecation

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -184,7 +184,7 @@ class SpectralModel(ModelBase):
 
         f_cov = df_dp.T @ self.covariance @ df_dp
         f_err = np.sqrt(np.diagonal(f_cov))
-        return u.Quantity([f_0.value, f_err], unit=f_0.unit)
+        return u.Quantity([np.atleast_1d(f_0.value), f_err], unit=f_0.unit)
 
     def evaluate_error(self, energy, epsilon=1e-4):
         """Evaluate spectral model with error propagation.

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -184,7 +184,7 @@ class SpectralModel(ModelBase):
 
         f_cov = df_dp.T @ self.covariance @ df_dp
         f_err = np.sqrt(np.diagonal(f_cov))
-        return u.Quantity([np.atleast_1d(f_0.value), f_err], unit=f_0.unit)
+        return u.Quantity([np.atleast_1d(f_0.value), f_err], unit=f_0.unit).squeeze()
 
     def evaluate_error(self, energy, epsilon=1e-4):
         """Evaluate spectral model with error propagation.

--- a/gammapy/visualization/panel.py
+++ b/gammapy/visualization/panel.py
@@ -44,12 +44,12 @@ class MapPanelPlotter:
         aspect = ax.bbox.width / ax.bbox.height
 
         # compute width and height in world coordinates
-        height = np.abs(p["ylim"].diff())
+        height = np.abs(p["ylim"].diff()[0])
         width = aspect * height
 
         left, bottom = p["xlim"][0].wrap_at("180d"), p["ylim"][0]
 
-        width_all = np.abs(p["xlim"].wrap_at("180d").diff())
+        width_all = np.abs(p["xlim"].wrap_at("180d").diff()[0])
         xoverlap = ((p["npanels"] * width) - width_all) / (p["npanels"] - 1.0)
         if xoverlap < 0:
             raise ValueError(
@@ -58,7 +58,7 @@ class MapPanelPlotter:
             )
 
         left = left - panel * (width - xoverlap)
-        return left[0], bottom, width, height
+        return left, bottom, width, height
 
     def _set_ax_fov(self, ax, panel):
         left, bottom, width, height = self._get_ax_extend(ax, panel)


### PR DESCRIPTION
Fix `SpectralModel._propagate_error` method to avoid passing array with inhomogeneous shape to Quantity which is now deprecated :
"VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated."
