### PR TITLE
Fix bug in safe mask computation for SpectrumDatasetOnOff

### DIFF
--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -235,11 +235,10 @@ class SafeMaskMaker(Maker):
             else:
                 edisp = edisp.get_edisp_kernel(position=self.position)
         else:
+            e_reco = dataset._geom.axes["energy"]
             if position:
-                e_reco = dataset._geom.axes["energy"].edges
                 edisp = edisp.get_edisp_kernel(position=position, energy_axis=e_reco)
             else:
-                e_reco = dataset._geom.axes["energy"].edges
                 edisp = edisp.get_edisp_kernel(
                     position=self.position, energy_axis=e_reco
                 )


### PR DESCRIPTION
**Description**
This PR fixes a bug in the safe mask computation, specifically for the `edisp-bias` method. The edges of an energy axis were passed instead of the axis itself.
A test for this bug has been added as well.
