### PR TITLE
Add Observations clustering by IRFs quality

### DIFF
--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -782,7 +782,7 @@ class Observations(collections.abc.MutableSequence):
             default_linkage_kwargs.update(linkage_kwargs)
 
         pairwise_distances = sch.distance.pdist(features)
-        linkage = sch.linkage(pairwise_distances, method="ward")
+        linkage = sch.linkage(pairwise_distances, **default_linkage_kwargs)
 
         default_fcluster_kwargs = dict(criterion="maxclust", t=3)
         if fcluster_kwargs is not None:

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -777,6 +777,13 @@ class Observations(collections.abc.MutableSequence):
             Scaled features
         """
 
+        if standard_scaler:
+            features = features.copy()
+            for kf in range(features.shape[1]):
+                features[:, kf] = (features[:, kf] - features[:, kf].mean()) / features[
+                    :, kf
+                ].std()
+
         default_linkage_kwargs = dict(method="ward", metric="euclidean")
         if linkage_kwargs is not None:
             default_linkage_kwargs.update(linkage_kwargs)
@@ -788,13 +795,6 @@ class Observations(collections.abc.MutableSequence):
         if fcluster_kwargs is not None:
             default_fcluster_kwargs.update(fcluster_kwargs)
         ind_clusters = sch.fcluster(linkage, **default_fcluster_kwargs)
-
-        if standard_scaler:
-            features = features.copy()
-            for kf in range(features.shape[1]):
-                features[:, kf] = (features[:, kf] - features[:, kf].mean()) / features[
-                    :, kf
-                ].std()
 
         obs_clusters = []
         for ind in np.unique(ind_clusters):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -693,101 +693,117 @@ class Observations(collections.abc.MutableSequence):
     def _ipython_key_completions_(self):
         return self.ids
 
-    def get_features(self, coord, names=["edisp-bias", "edisp-res", "psf-radius"], containment_faction=0.68):
-        """ Get features from irfs properties at a given position.
-            Used for observations clustering.
-            
-            Parameters
-            ----------
-            coord : `~gammapy.maps.MapCoord`
-                Coordinates in lon, lat, energy_true
-            names : list of str
-                IRFs properties to be considered.
-                Available options are ["edisp-bias", "edisp-res", "psf-radius"]
-                (all used by default).
-                
-            containment_faction : float
-                Containment_faction to compute the `psf-radius`.
-                Default is 68%.               
+    def get_features(
+        self,
+        coord,
+        names=["edisp-bias", "edisp-res", "psf-radius"],
+        containment_faction=0.68,
+    ):
+        """Get features from irfs properties at a given position.
+        Used for observations clustering.
 
-            Returns
-            -------
-            features : array
-                Features
-                
+        Parameters
+        ----------
+        coord : `~gammapy.maps.MapCoord`
+            Coordinate in lon, lat, energy_true to evaluate the IRFs.
+        names : list of str
+            IRFs properties to be considered.
+            Available options are ["edisp-bias", "edisp-res", "psf-radius"]
+            (all used by default).
+        containment_faction : float
+            Containment_faction to compute the `psf-radius`.
+            Default is 68%.
+
+        Returns
+        -------
+        features : array
+            Features
+
         """
 
         n_obs = len(self)
         n_features = len(names)
         features = np.zeros((n_obs, n_features))
-        for ko, obs, in enumerate(self):
-            offset_max = np.minimum(obs.psf.axes["offset"].center[-1],
-                                    obs.edisp.axes["offset"].center[-1])
+        for (
+            ko,
+            obs,
+        ) in enumerate(self):
+            offset_max = np.minimum(
+                obs.psf.axes["offset"].center[-1], obs.edisp.axes["offset"].center[-1]
+            )
             for kf, name in enumerate(names):
-                offset = np.minimum(coord.skycoord.separation(obs.pointing_radec)[0],
-                                    offset_max)
+                offset = np.minimum(
+                    coord.skycoord.separation(obs.pointing_radec)[0], offset_max
+                )
                 energy_true = coord["energy_true"][0]
                 edisp_kernel = obs.edisp.to_edisp_kernel(offset)
                 if name == "edisp-res":
-                    features[ko,kf] = edisp_kernel.get_bias(energy_true)
+                    features[ko, kf] = edisp_kernel.get_bias(energy_true)
                 if name == "edisp-bias":
-                    features[ko,kf] = edisp_kernel.get_resolution(energy_true)
+                    features[ko, kf] = edisp_kernel.get_resolution(energy_true)
                 if name == "psf-radius":
-                    psf_radius = obs.psf.containment_radius(fraction=containment_faction,
-                                                         offset=offset,
-                                                         energy_true=energy_true)
-                    features[ko,kf] = psf_radius.value
+                    psf_radius = obs.psf.containment_radius(
+                        fraction=containment_faction,
+                        offset=offset,
+                        energy_true=energy_true,
+                    )
+                    features[ko, kf] = psf_radius.value
         return features
 
-    def hierarchical_clustering(self, features, linkage_kwargs=None, fcluster_kwargs=None, standard_scaler=False):
-        """ Hierarchical clustering of obsevrations using given features.
-            
-            Parameters
-            ----------
-            features : array
-                (N x M) array with N observations and M features,
-            linkage_kwargs : dict
-                Arguments forwarded to `scipy.cluster.hierarchy.linkage`
-            fcluster_kwargs : dict
-                Arguments forwarded to `scipy.cluster.hierarchy.fcluster`
-            standard_scaler : bool
-                Standardize features by removing the mean and scaling to unit variance.
-                Default is False.                
+    def hierarchical_clustering(
+        self, features, linkage_kwargs=None, fcluster_kwargs=None, standard_scaler=False
+    ):
+        """Hierarchical clustering of obsevrations using given features.
 
-            Returns
-            -------
-            obs_clusters : list of `~gammapy.data.Observations`
-                A new Observations instance for each cluster identified
-            ind_clusters : array
-                Array of cluster ID
-            features : array
-                Scaled features
+        Parameters
+        ----------
+        features : array
+            (N x M) array with N observations and M features.
+        linkage_kwargs : dict
+            Arguments forwarded to `scipy.cluster.hierarchy.linkage`
+        fcluster_kwargs : dict
+            Arguments forwarded to `scipy.cluster.hierarchy.fcluster`
+        standard_scaler : bool
+            Standardize features by removing the mean and scaling to unit variance.
+            Default is False.
+
+        Returns
+        -------
+        obs_clusters : list of `~gammapy.data.Observations`
+            List of Observations instance, one instance for each cluster.
+        ind_clusters : array
+            Array of cluster ID
+        features : array
+            Scaled features
         """
-        
-        default_linkage_kwargs=dict(method='ward', metric='euclidean')
+
+        default_linkage_kwargs = dict(method="ward", metric="euclidean")
         if linkage_kwargs is not None:
             default_linkage_kwargs.update(linkage_kwargs)
-        
+
         pairwise_distances = sch.distance.pdist(features)
-        linkage = sch.linkage(pairwise_distances, method='ward')
-        
-        default_fcluster_kwargs=dict(criterion="maxclust", t=3)
+        linkage = sch.linkage(pairwise_distances, method="ward")
+
+        default_fcluster_kwargs = dict(criterion="maxclust", t=3)
         if fcluster_kwargs is not None:
             default_fcluster_kwargs.update(fcluster_kwargs)
         ind_clusters = sch.fcluster(linkage, **default_fcluster_kwargs)
 
         if standard_scaler:
-            features=features.copy()
+            features = features.copy()
             for kf in range(features.shape[1]):
-                features[:,kf] = (features[:,kf]-features[:,kf].mean())/features[:,kf].std()
+                features[:, kf] = (features[:, kf] - features[:, kf].mean()) / features[
+                    :, kf
+                ].std()
 
         obs_clusters = []
         for ind in np.unique(ind_clusters):
-            observations = self.__class__([obs for k, obs in enumerate(self) if ind_clusters[k]==ind])
+            observations = self.__class__(
+                [obs for k, obs in enumerate(self) if ind_clusters[k] == ind]
+            )
             obs_clusters.append(observations)
-            
+
         return obs_clusters, ind_clusters, features
-            
 
 
 class ObservationChecker(Checker):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -6,7 +6,6 @@ import logging
 import warnings
 from itertools import zip_longest
 import numpy as np
-import scipy.cluster.hierarchy as sch
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
@@ -750,60 +749,26 @@ class Observations(collections.abc.MutableSequence):
                     features[ko, kf] = psf_radius.value
         return features
 
-    def hierarchical_clustering(
-        self, features, linkage_kwargs=None, fcluster_kwargs=None, standard_scaler=False
-    ):
-        """Hierarchical clustering of obsevrations using given features.
+    def split(self, groups_id):
+        """Split obsevations in multiple groups of observations
 
         Parameters
         ----------
-        features : array
-            (N x M) array with N observations and M features.
-        linkage_kwargs : dict
-            Arguments forwarded to `scipy.cluster.hierarchy.linkage`
-        fcluster_kwargs : dict
-            Arguments forwarded to `scipy.cluster.hierarchy.fcluster`
-        standard_scaler : bool
-            Standardize features by removing the mean and scaling to unit variance.
-            Default is False.
+        cluster_id : array
+            Array of cluster ID
 
         Returns
         -------
         obs_clusters : list of `~gammapy.data.Observations`
-            List of Observations instance, one instance for each cluster.
-        ind_clusters : array
-            Array of cluster ID
-        features : array
-            Scaled features
+            List of Observations instance, one instance for each group.
         """
-
-        if standard_scaler:
-            features = features.copy()
-            for kf in range(features.shape[1]):
-                features[:, kf] = (features[:, kf] - features[:, kf].mean()) / features[
-                    :, kf
-                ].std()
-
-        default_linkage_kwargs = dict(method="ward", metric="euclidean")
-        if linkage_kwargs is not None:
-            default_linkage_kwargs.update(linkage_kwargs)
-
-        pairwise_distances = sch.distance.pdist(features)
-        linkage = sch.linkage(pairwise_distances, **default_linkage_kwargs)
-
-        default_fcluster_kwargs = dict(criterion="maxclust", t=3)
-        if fcluster_kwargs is not None:
-            default_fcluster_kwargs.update(fcluster_kwargs)
-        ind_clusters = sch.fcluster(linkage, **default_fcluster_kwargs)
-
         obs_clusters = []
-        for ind in np.unique(ind_clusters):
+        for ind in np.unique(groups_id):
             observations = self.__class__(
-                [obs for k, obs in enumerate(self) if ind_clusters[k] == ind]
+                [obs for k, obs in enumerate(self) if groups_id[k] == ind]
             )
             obs_clusters.append(observations)
-
-        return obs_clusters, ind_clusters, features
+        return obs_clusters
 
 
 class ObservationChecker(Checker):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -736,9 +736,9 @@ class Observations(collections.abc.MutableSequence):
                 )
                 energy_true = coord["energy_true"][0]
                 edisp_kernel = obs.edisp.to_edisp_kernel(offset)
-                if name == "edisp-res":
-                    features[ko, kf] = edisp_kernel.get_bias(energy_true)
                 if name == "edisp-bias":
+                    features[ko, kf] = edisp_kernel.get_bias(energy_true)
+                if name == "edisp-res":
                     features[ko, kf] = edisp_kernel.get_resolution(energy_true)
                 if name == "psf-radius":
                     psf_radius = obs.psf.containment_radius(

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -692,26 +692,26 @@ class Observations(collections.abc.MutableSequence):
     def _ipython_key_completions_(self):
         return self.ids
 
-    def split(self, groups_id):
+    def group_by_label(self, labels):
         """Split obsevations in multiple groups of observations
 
         Parameters
         ----------
-        cluster_id : array
-            Array of cluster ID
+        labels : array
+            Array of group labels
 
         Returns
         -------
-        obs_clusters : list of `~gammapy.data.Observations`
-            List of Observations instance, one instance for each group.
+        obs_clusters : dict of `~gammapy.data.Observations`
+            dict of Observations instance, one instance for each group.
         """
-        obs_clusters = []
-        for ind in np.unique(groups_id):
+        obs_groups = {}
+        for label in np.unique(labels):
             observations = self.__class__(
-                [obs for k, obs in enumerate(self) if groups_id[k] == ind]
+                [obs for k, obs in enumerate(self) if labels[k] == label]
             )
-            obs_clusters.append(observations)
-        return obs_clusters
+            obs_groups[f"group_{label}"] = observations
+        return obs_groups
 
 
 class ObservationChecker(Checker):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -692,63 +692,6 @@ class Observations(collections.abc.MutableSequence):
     def _ipython_key_completions_(self):
         return self.ids
 
-    def get_features(
-        self,
-        coord,
-        names=["edisp-bias", "edisp-res", "psf-radius"],
-        containment_faction=0.68,
-    ):
-        """Get features from irfs properties at a given position.
-        Used for observations clustering.
-
-        Parameters
-        ----------
-        coord : `~gammapy.maps.MapCoord`
-            Coordinate in lon, lat, energy_true to evaluate the IRFs.
-        names : list of str
-            IRFs properties to be considered.
-            Available options are ["edisp-bias", "edisp-res", "psf-radius"]
-            (all used by default).
-        containment_faction : float
-            Containment_faction to compute the `psf-radius`.
-            Default is 68%.
-
-        Returns
-        -------
-        features : array
-            Features
-
-        """
-
-        n_obs = len(self)
-        n_features = len(names)
-        features = np.zeros((n_obs, n_features))
-        for (
-            ko,
-            obs,
-        ) in enumerate(self):
-            offset_max = np.minimum(
-                obs.psf.axes["offset"].center[-1], obs.edisp.axes["offset"].center[-1]
-            )
-            for kf, name in enumerate(names):
-                offset = np.minimum(
-                    coord.skycoord.separation(obs.pointing_radec)[0], offset_max
-                )
-                energy_true = coord["energy_true"][0]
-                edisp_kernel = obs.edisp.to_edisp_kernel(offset)
-                if name == "edisp-bias":
-                    features[ko, kf] = edisp_kernel.get_bias(energy_true)
-                if name == "edisp-res":
-                    features[ko, kf] = edisp_kernel.get_resolution(energy_true)
-                if name == "psf-radius":
-                    psf_radius = obs.psf.containment_radius(
-                        fraction=containment_faction,
-                        offset=offset,
-                        energy_true=energy_true,
-                    )
-                    features[ko, kf] = psf_radius.value
-        return features
-
     def split(self, groups_id):
         """Split obsevations in multiple groups of observations
 

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -11,6 +11,7 @@ from gammapy.irf import PSF3D, load_irf_dict_from_file
 from gammapy.data.pointing import FixedPointingInfo, PointingMode
 from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.data.utils import get_irfs_features
+from gammapy.utils.cluster import hierarchical_clustering
 from gammapy.utils.fits import HDULocation
 from gammapy.utils.testing import (
     assert_skycoord_allclose,

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -10,6 +10,7 @@ from gammapy.data import DataStore, Observation
 from gammapy.irf import PSF3D, load_irf_dict_from_file
 from gammapy.data.pointing import FixedPointingInfo, PointingMode
 from gammapy.utils.deprecation import GammapyDeprecationWarning
+from gammapy.data.utils import get_irfs_features
 from gammapy.utils.fits import HDULocation
 from gammapy.utils.testing import (
     assert_skycoord_allclose,
@@ -430,7 +431,7 @@ def test_observations_clustering(data_store):
     coord_dict = dict(lon=83.63308, lat=22.01450, energy_true="1 TeV")
     coord = MapCoord(coord_dict, frame="icrs")
     names = ["edisp-bias", "edisp-res", "psf-radius"]
-    features = observations.get_features(coord, names)
+    features = get_irfs_features(observations, coord, names)
 
     n_features = len(names)
     assert features.shape == (len(observations), n_features)

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -12,6 +12,7 @@ from gammapy.irf import PSF3D, load_irf_dict_from_file
 from gammapy.data.pointing import FixedPointingInfo, PointingMode
 from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.fits import HDULocation
+from gammapy.estimators.utils import hierarchical_clustering
 from gammapy.utils.testing import (
     assert_skycoord_allclose,
     assert_time_allclose,
@@ -436,10 +437,9 @@ def test_observations_clustering(data_store):
     n_features = len(names)
     assert features.shape == (len(observations), n_features)
 
-    obs_clusters, ind_clusters, features = observations.hierarchical_clustering(
-        features, standard_scaler=True
-    )
+    ind_clusters, features = hierarchical_clustering(features, standard_scaler=True)
 
+    obs_clusters = observations.split(ind_clusters)
     for k in range(n_features):
         assert_allclose(features[:, k].mean(), 0, atol=1e-7)
         assert_allclose(features[:, k].std(), 1, atol=1e-7)

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -6,13 +6,11 @@ import astropy.units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
-from gammapy.maps import MapCoord
 from gammapy.data import DataStore, Observation
 from gammapy.irf import PSF3D, load_irf_dict_from_file
 from gammapy.data.pointing import FixedPointingInfo, PointingMode
 from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.fits import HDULocation
-from gammapy.estimators.utils import hierarchical_clustering
 from gammapy.utils.testing import (
     assert_skycoord_allclose,
     assert_time_allclose,
@@ -436,6 +434,22 @@ def test_observations_clustering(data_store):
 
     n_features = len(names)
     assert features.shape == (len(observations), n_features)
+
+    ind_clusters, features = hierarchical_clustering(
+        features, linkage_kwargs={"method": "complete"}, fcluster_kwargs={"t": 2}
+    )
+
+    assert np.all(
+        ind_clusters
+        == np.array(
+            [
+                1,
+                1,
+                2,
+                2,
+            ]
+        )
+    )
 
     ind_clusters, features = hierarchical_clustering(features, standard_scaler=True)
 

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -7,12 +7,11 @@ from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
 from gammapy.data import DataStore, Observation
+from gammapy.data.pointing import FixedPointingInfo, PointingMode
 from gammapy.data.utils import get_irfs_features
 from gammapy.irf import PSF3D, load_irf_dict_from_file
-from gammapy.data.pointing import FixedPointingInfo, PointingMode
-from gammapy.utils.deprecation import GammapyDeprecationWarning
-from gammapy.data.utils import get_irfs_features
 from gammapy.utils.cluster import hierarchical_clustering
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.fits import HDULocation
 from gammapy.utils.testing import (
     assert_skycoord_allclose,
@@ -437,7 +436,13 @@ def test_observations_clustering(data_store):
     )
 
     n_features = len(names)
-    features_array = np.array([features[col].data for col in features.columns]).T
+    features_array = np.array(
+        [
+            features[col].data
+            for col in features.columns
+            if col not in ["obs_id", "dataset_name"]
+        ]
+    ).T
     assert features_array.shape == (len(observations), n_features)
 
     features = hierarchical_clustering(
@@ -464,7 +469,13 @@ def test_observations_clustering(data_store):
         apply_standard_scaler=True,
     )
     features = hierarchical_clustering(features)
-    features_array = np.array([features[col].data for col in features.columns]).T
+    features_array = np.array(
+        [
+            features[col].data
+            for col in features.columns
+            if col not in ["obs_id", "dataset_name"]
+        ]
+    ).T
 
     obs_clusters = observations.group_by_label(features["labels"])
     for k in range(n_features):

--- a/gammapy/data/utils.py
+++ b/gammapy/data/utils.py
@@ -6,7 +6,7 @@ def get_irfs_features(
     observations,
     coord,
     names=["edisp-bias", "edisp-res", "psf-radius"],
-    containment_faction=0.68,
+    containment_fraction=0.68,
 ):
     """Get features from irfs properties at a given position.
     Used for observations clustering.
@@ -19,8 +19,8 @@ def get_irfs_features(
         IRFs properties to be considered.
         Available options are ["edisp-bias", "edisp-res", "psf-radius"]
         (all used by default).
-    containment_faction : float
-        Containment_faction to compute the `psf-radius`.
+    containment_fraction : float
+        Containment_fraction to compute the `psf-radius`.
         Default is 68%.
 
     Returns
@@ -52,7 +52,7 @@ def get_irfs_features(
                 features[ko, kf] = edisp_kernel.get_resolution(energy_true)
             if name == "psf-radius":
                 psf_radius = obs.psf.containment_radius(
-                    fraction=containment_faction,
+                    fraction=containment_fraction,
                     offset=offset,
                     energy_true=energy_true,
                 )

--- a/gammapy/data/utils.py
+++ b/gammapy/data/utils.py
@@ -1,0 +1,60 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+
+
+def get_irfs_features(
+    observations,
+    coord,
+    names=["edisp-bias", "edisp-res", "psf-radius"],
+    containment_faction=0.68,
+):
+    """Get features from irfs properties at a given position.
+    Used for observations clustering.
+
+    Parameters
+    ----------
+    coord : `~gammapy.maps.MapCoord`
+        Coordinate in lon, lat, energy_true to evaluate the IRFs.
+    names : list of str
+        IRFs properties to be considered.
+        Available options are ["edisp-bias", "edisp-res", "psf-radius"]
+        (all used by default).
+    containment_faction : float
+        Containment_faction to compute the `psf-radius`.
+        Default is 68%.
+
+    Returns
+    -------
+    features : array
+        Features
+
+    """
+
+    n_obs = len(observations)
+    n_features = len(names)
+    features = np.zeros((n_obs, n_features))
+    for (
+        ko,
+        obs,
+    ) in enumerate(observations):
+        offset_max = np.minimum(
+            obs.psf.axes["offset"].center[-1], obs.edisp.axes["offset"].center[-1]
+        )
+        for kf, name in enumerate(names):
+            offset = np.minimum(
+                coord.skycoord.separation(obs.pointing_radec)[0], offset_max
+            )
+            energy_true = coord["energy_true"][0]
+            edisp_kernel = obs.edisp.to_edisp_kernel(offset)
+            if name == "edisp-bias":
+                features[ko, kf] = edisp_kernel.get_bias(energy_true)
+            if name == "edisp-res":
+                features[ko, kf] = edisp_kernel.get_resolution(energy_true)
+            if name == "psf-radius":
+                psf_radius = obs.psf.containment_radius(
+                    fraction=containment_faction,
+                    offset=offset,
+                    energy_true=energy_true,
+                )
+                features[ko, kf] = psf_radius.value
+    return features

--- a/gammapy/data/utils.py
+++ b/gammapy/data/utils.py
@@ -1,20 +1,33 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
+import astropy.units as u
+from astropy.table import Table
+from gammapy.irf import EDispKernelMap, PSFMap
+from gammapy.utils.cluster import standard_scaler
 
 
 def get_irfs_features(
     observations,
-    coord,
+    energy_true,
+    position=None,
+    fixed_offset=None,
     names=["edisp-bias", "edisp-res", "psf-radius"],
     containment_fraction=0.68,
+    apply_standard_scaler=False,
 ):
     """Get features from irfs properties at a given position.
     Used for observations clustering.
 
     Parameters
     ----------
-    coord : `~gammapy.maps.MapCoord`
-        Coordinate in lon, lat, energy_true to evaluate the IRFs.
+    energy_true : `~astropy.units.Quantity`
+        Energy true at which to compute the containment radius
+    position : `~astropy.coordinates.SkyCoord`
+        Sky position.
+    fixed_offset : `~astropy.coordinates.Angle`
+        Offset calculated from the pointing position.
+        If neither the position nor fixed_offset is specified,
+        it uses the position of the center of the map by default.
     names : list of str
         IRFs properties to be considered.
         Available options are ["edisp-bias", "edisp-res", "psf-radius"]
@@ -22,39 +35,81 @@ def get_irfs_features(
     containment_fraction : float
         Containment_fraction to compute the `psf-radius`.
         Default is 68%.
+    standard_scaler : bool
+        Compute standardize features by removing the mean and scaling to unit variance.
+        Default is False.
 
     Returns
     -------
-    features : array
-        Features
+    features : `~astropy.table.Table`
+        Features table
 
     """
 
+    if position and fixed_offset:
+        raise ValueError(
+            "`position` and `fixed_offset` arguments are mutually exclusive"
+        )
+
     n_obs = len(observations)
     n_features = len(names)
-    features = np.zeros((n_obs, n_features))
+    data = np.zeros((n_obs, n_features))
+    units = [u.Unit("")] * n_features
     for (
         ko,
         obs,
     ) in enumerate(observations):
         psf_kwargs = dict(fraction=containment_fraction, energy_true=energy_true)
         if isinstance(obs.psf, PSFMap) and isinstance(obs.edisp, EDispKernelMap):
-            edisp_kernel = obs.edisp.get_edisp_kernel(position=coord.skycoord[0])
-            psf_kwargs["position"] = coord.skycoord[0]
+            if position is None:
+                position = obs.psf.psf_map.geom.center_skydir
+            edisp_kernel = obs.edisp.get_edisp_kernel(position=position)
+            psf_kwargs["position"] = position
         else:
-            offset_max = np.minimum(
-                obs.psf.axes["offset"].center[-1], obs.edisp.axes["offset"].center[-1]
-            )
-            offset = np.minimum(
-                coord.skycoord.separation(obs.pointing_radec)[0], offset_max
-            )
+            if fixed_offset is None:
+                if position is None:
+                    offset = 0 * u.deg
+                else:
+                    offset_max = np.minimum(
+                        obs.psf.axes["offset"].center[-1],
+                        obs.edisp.axes["offset"].center[-1],
+                    )
+                    offset = np.minimum(
+                        position.separation(obs.pointing_radec), offset_max
+                    )
+            else:
+                offset = fixed_offset
             edisp_kernel = obs.edisp.to_edisp_kernel(offset)
             psf_kwargs["offset"] = offset
         for kf, name in enumerate(names):
             if name == "edisp-bias":
-                features[ko, kf] = edisp_kernel.get_bias(energy_true)
+                data[ko, kf] = edisp_kernel.get_bias(energy_true)
             if name == "edisp-res":
-                features[ko, kf] = edisp_kernel.get_resolution(energy_true)
+                data[ko, kf] = edisp_kernel.get_resolution(energy_true)
             if name == "psf-radius":
-                features[ko, kf] = obs.psf.containment_radius(**psf_kwargs).value
+                containment_radius = obs.psf.containment_radius(**psf_kwargs).to("deg")
+                data[ko, kf] = containment_radius.value
+                units[kf] = u.deg
+
+    features = Table()
+    for kf, name in enumerate(names):
+        features[name] = data[:, kf]
+
+    if apply_standard_scaler:
+        features = standard_scaler(features)
+
+    features.meta = dict(
+        obs_ids=observations.ids,
+        names=names,
+        energy_true=energy_true,
+        fixed_offset=fixed_offset,
+        containment_fraction=containment_fraction,
+        apply_standard_scaler=apply_standard_scaler,
+    )
+
+    if position:
+        features.meta["lon"] = position.galactic.l
+        features.meta["lat"] = position.galactic.l
+        features.meta["frame"] = "galactic"
+
     return features

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-import scipy.ndimage
 import scipy.cluster.hierarchy as sch
+import scipy.ndimage
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
@@ -14,7 +14,12 @@ from gammapy.modeling.models import (
     SkyModel,
 )
 
-__all__ = ["estimate_exposure_reco_energy", "find_peaks", "resample_energy_edges"]
+__all__ = [
+    "estimate_exposure_reco_energy",
+    "find_peaks",
+    "hierarchical_clustering",
+    "resample_energy_edges",
+]
 
 
 def find_peaks(image, threshold, min_distance=1):

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-import scipy.cluster.hierarchy as sch
 import scipy.ndimage
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -17,7 +16,6 @@ from gammapy.modeling.models import (
 __all__ = [
     "estimate_exposure_reco_energy",
     "find_peaks",
-    "hierarchical_clustering",
     "resample_energy_edges",
 ]
 
@@ -116,53 +114,6 @@ def find_peaks(image, threshold, min_distance=1):
     table.reverse()
 
     return table
-
-
-def hierarchical_clustering(
-    features, linkage_kwargs=None, fcluster_kwargs=None, standard_scaler=False
-):
-    """Hierarchical clustering of obsevrations using given features.
-
-    Parameters
-    ----------
-    features : array
-        (N x M) array with N observations and M features.
-    linkage_kwargs : dict
-        Arguments forwarded to `scipy.cluster.hierarchy.linkage`
-    fcluster_kwargs : dict
-        Arguments forwarded to `scipy.cluster.hierarchy.fcluster`
-    standard_scaler : bool
-        Standardize features by removing the mean and scaling to unit variance.
-        Default is False.
-
-    Returns
-    -------
-    ind_clusters : array
-        Array of cluster ID
-    features : array
-        Scaled features
-    """
-
-    if standard_scaler:
-        features = features.copy()
-        for kf in range(features.shape[1]):
-            features[:, kf] = (features[:, kf] - features[:, kf].mean()) / features[
-                :, kf
-            ].std()
-
-    default_linkage_kwargs = dict(method="ward", metric="euclidean")
-    if linkage_kwargs is not None:
-        default_linkage_kwargs.update(linkage_kwargs)
-
-    pairwise_distances = sch.distance.pdist(features)
-    linkage = sch.linkage(pairwise_distances, **default_linkage_kwargs)
-
-    default_fcluster_kwargs = dict(criterion="maxclust", t=3)
-    if fcluster_kwargs is not None:
-        default_fcluster_kwargs.update(fcluster_kwargs)
-    ind_clusters = sch.fcluster(linkage, **default_fcluster_kwargs)
-
-    return ind_clusters, features
 
 
 def estimate_exposure_reco_energy(dataset, spectral_model=None, normalize=True):

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 import scipy.ndimage
+import scipy.cluster.hierarchy as sch
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
@@ -110,6 +111,53 @@ def find_peaks(image, threshold, min_distance=1):
     table.reverse()
 
     return table
+
+
+def hierarchical_clustering(
+    features, linkage_kwargs=None, fcluster_kwargs=None, standard_scaler=False
+):
+    """Hierarchical clustering of obsevrations using given features.
+
+    Parameters
+    ----------
+    features : array
+        (N x M) array with N observations and M features.
+    linkage_kwargs : dict
+        Arguments forwarded to `scipy.cluster.hierarchy.linkage`
+    fcluster_kwargs : dict
+        Arguments forwarded to `scipy.cluster.hierarchy.fcluster`
+    standard_scaler : bool
+        Standardize features by removing the mean and scaling to unit variance.
+        Default is False.
+
+    Returns
+    -------
+    ind_clusters : array
+        Array of cluster ID
+    features : array
+        Scaled features
+    """
+
+    if standard_scaler:
+        features = features.copy()
+        for kf in range(features.shape[1]):
+            features[:, kf] = (features[:, kf] - features[:, kf].mean()) / features[
+                :, kf
+            ].std()
+
+    default_linkage_kwargs = dict(method="ward", metric="euclidean")
+    if linkage_kwargs is not None:
+        default_linkage_kwargs.update(linkage_kwargs)
+
+    pairwise_distances = sch.distance.pdist(features)
+    linkage = sch.linkage(pairwise_distances, **default_linkage_kwargs)
+
+    default_fcluster_kwargs = dict(criterion="maxclust", t=3)
+    if fcluster_kwargs is not None:
+        default_fcluster_kwargs.update(fcluster_kwargs)
+    ind_clusters = sch.fcluster(linkage, **default_fcluster_kwargs)
+
+    return ind_clusters, features
 
 
 def estimate_exposure_reco_energy(dataset, spectral_model=None, normalize=True):

--- a/gammapy/utils/cluster.py
+++ b/gammapy/utils/cluster.py
@@ -1,0 +1,51 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Utils for hierarchical/agglomerative clustering."""
+
+import scipy.cluster.hierarchy as sch
+
+
+def hierarchical_clustering(
+    features, linkage_kwargs=None, fcluster_kwargs=None, standard_scaler=False
+):
+    """Hierarchical clustering using given features.
+
+    Parameters
+    ----------
+    features : array
+        (N x M) array with N observations and M features.
+    linkage_kwargs : dict
+        Arguments forwarded to `scipy.cluster.hierarchy.linkage`
+    fcluster_kwargs : dict
+        Arguments forwarded to `scipy.cluster.hierarchy.fcluster`
+    standard_scaler : bool
+        Standardize features by removing the mean and scaling to unit variance.
+        Default is False.
+
+    Returns
+    -------
+    ind_clusters : array
+        Array of cluster ID
+    features : array
+        Scaled features
+    """
+
+    if standard_scaler:
+        features = features.copy()
+        for kf in range(features.shape[1]):
+            features[:, kf] = (features[:, kf] - features[:, kf].mean()) / features[
+                :, kf
+            ].std()
+
+    default_linkage_kwargs = dict(method="ward", metric="euclidean")
+    if linkage_kwargs is not None:
+        default_linkage_kwargs.update(linkage_kwargs)
+
+    pairwise_distances = sch.distance.pdist(features)
+    linkage = sch.linkage(pairwise_distances, **default_linkage_kwargs)
+
+    default_fcluster_kwargs = dict(criterion="maxclust", t=3)
+    if fcluster_kwargs is not None:
+        default_fcluster_kwargs.update(fcluster_kwargs)
+    ind_clusters = sch.fcluster(linkage, **default_fcluster_kwargs)
+
+    return ind_clusters, features

--- a/gammapy/utils/cluster.py
+++ b/gammapy/utils/cluster.py
@@ -6,7 +6,9 @@ import scipy.cluster.hierarchy as sch
 
 
 def standard_scaler(features):
-    """Compute standardize features by removing the mean and scaling to unit variance.
+    """Compute standardized features by removing the mean and scaling to unit variance:
+       .. math::
+           f_\text{scaled} = \frac{f-\text{mean}(f)}{\text{std}(f)} .
 
     Parameters
     ----------
@@ -16,13 +18,14 @@ def standard_scaler(features):
     Returns
     -------
     scaled_features : `~astropy.table.Table`
-        Table containing the scaled features.
+        Table containing the scaled features (dimensionless).
 
     """
     scaled_features = features.copy()
     for col in scaled_features.columns:
-        data = scaled_features[col].data
-        scaled_features[col] = (data - data.mean()) / data.std()
+        if col not in ["obs_id", "dataset_name"]:
+            data = scaled_features[col].data
+            scaled_features[col] = (data - data.mean()) / data.std()
     return scaled_features
 
 
@@ -49,7 +52,13 @@ def hierarchical_clustering(
     """
 
     features = features.copy()
-    features_array = np.array([features[col].data for col in features.columns]).T
+    features_array = np.array(
+        [
+            features[col].data
+            for col in features.columns
+            if col not in ["obs_id", "dataset_name"]
+        ]
+    ).T
 
     default_linkage_kwargs = dict(method="ward", metric="euclidean")
     if linkage_kwargs is not None:


### PR DESCRIPTION
Add Observations clustering by IRFs quality.
The clusters of observations obtained can be used to stack only observations with similar edisp and psf. Alternatively it could be used to select only the group of observations with the best edisp and psf.