### PR TITLE
Change _check_intervals from PhaseBackgroundMaker

### DIFF
--- a/gammapy/makers/background/phase.py
+++ b/gammapy/makers/background/phase.py
@@ -120,7 +120,7 @@ class PhaseBackgroundMaker(Maker):
 
     @staticmethod
     def _check_intervals(intervals):
-        
+       """Split phase intervals that go below phase 0 and above phase 1""" 
         if isinstance(intervals, tuple):
             intervals = [intervals]
 

--- a/gammapy/makers/background/phase.py
+++ b/gammapy/makers/background/phase.py
@@ -13,9 +13,6 @@ class PhaseBackgroundMaker(Maker):
 
     TODO: For a usage example see future notebook.
 
-    TODO: The phase interval has to be between 0 and 1.
-    Cases like [-0.1, 0.1], for example, are still not supported.
-
     Parameters
     ----------
     on_phase : `tuple` or list of tuples
@@ -69,7 +66,7 @@ class PhaseBackgroundMaker(Maker):
         return self._make_counts(dataset, observation, self.off_phase)
 
     def make_counts(self, dataset, observation):
-        """Make off counts.
+        """Make on counts.
 
         Parameters
         ----------
@@ -80,8 +77,8 @@ class PhaseBackgroundMaker(Maker):
 
         Returns
         -------
-        counts_off : `RegionNDMap`
-            Off counts.
+        counts : `RegionNDMap`
+            On counts.
         """
         return self._make_counts(dataset, observation, self.on_phase)
 

--- a/gammapy/makers/background/phase.py
+++ b/gammapy/makers/background/phase.py
@@ -117,13 +117,13 @@ class PhaseBackgroundMaker(Maker):
 
     @staticmethod
     def _check_intervals(intervals):
-       """Split phase intervals that go below phase 0 and above phase 1""" 
+        """Split phase intervals that go below phase 0 and above phase 1"""
         if isinstance(intervals, tuple):
             intervals = [intervals]
 
         for phase_interval in intervals:
-            if phase_interval[0]%1 > phase_interval[1]%1:
+            if phase_interval[0] % 1 > phase_interval[1] % 1:
                 intervals.remove(phase_interval)
-                intervals.append([phase_interval[0]%1, 1])
-                intervals.append([0, phase_interval[1]%1])
+                intervals.append([phase_interval[0] % 1, 1])
+                intervals.append([0, phase_interval[1] % 1])
         return intervals

--- a/gammapy/makers/background/phase.py
+++ b/gammapy/makers/background/phase.py
@@ -105,13 +105,13 @@ class PhaseBackgroundMaker(Maker):
 
         acceptance_off = RegionNDMap.from_geom(geom=dataset.counts.geom)
         acceptance_off.data = np.sum([_[1] - _[0] for _ in self.off_phase])
-        
+
         dataset_on_off = SpectrumDatasetOnOff.from_spectrum_dataset(
-            dataset=dataset,                
+            dataset=dataset,
             counts_off=counts_off,
             acceptance=acceptance,
             acceptance_off=acceptance_off,
-            )
+        )
         dataset_on_off.counts = counts
         return dataset_on_off
 

--- a/gammapy/makers/background/phase.py
+++ b/gammapy/makers/background/phase.py
@@ -108,13 +108,13 @@ class PhaseBackgroundMaker(Maker):
 
         acceptance_off = RegionNDMap.from_geom(geom=dataset.counts.geom)
         acceptance_off.data = np.sum([_[1] - _[0] for _ in self.off_phase])
-
+        
         dataset_on_off = SpectrumDatasetOnOff.from_spectrum_dataset(
-            dataset=dataset,
+            dataset=dataset,                
             counts_off=counts_off,
             acceptance=acceptance,
             acceptance_off=acceptance_off,
-        )
+            )
         dataset_on_off.counts = counts
         return dataset_on_off
 

--- a/gammapy/makers/background/phase.py
+++ b/gammapy/makers/background/phase.py
@@ -120,13 +120,13 @@ class PhaseBackgroundMaker(Maker):
 
     @staticmethod
     def _check_intervals(intervals):
-        """Split phase intervals that go beyond phase 1"""
+        
         if isinstance(intervals, tuple):
             intervals = [intervals]
 
         for phase_interval in intervals:
-            if phase_interval[0] > phase_interval[1]:
+            if phase_interval[0]%1 > phase_interval[1]%1:
                 intervals.remove(phase_interval)
-                intervals.append([phase_interval[0], 1])
-                intervals.append([0, phase_interval[1]])
+                intervals.append([phase_interval[0]%1, 1])
+                intervals.append([0, phase_interval[1]%1])
         return intervals

--- a/gammapy/makers/background/tests/test_phase.py
+++ b/gammapy/makers/background/tests/test_phase.py
@@ -67,5 +67,4 @@ def test_run(observations, phase_bkg_maker):
     ],
 )
 def test_check_phase_intervals(pars):
-    #assert PhaseBackgroundMaker._check_intervals(pars["p_in"]) == pars["p_out"]
     assert_allclose(PhaseBackgroundMaker._check_intervals(pars["p_in"]), pars["p_out"], rtol = 1e-5)

--- a/gammapy/makers/background/tests/test_phase.py
+++ b/gammapy/makers/background/tests/test_phase.py
@@ -63,8 +63,10 @@ def test_run(observations, phase_bkg_maker):
         {"p_in": [[0.9, 0.1]], "p_out": [[0.9, 1], [0, 0.1]]},
         {"p_in": [[-0.2, 0.1]], "p_out": [[0.8, 1], [0, 0.1]]},
         {"p_in": [[0.8, 1.2]], "p_out": [[0.8, 1], [0, 0.2]]},
-        {"p_in": [[0.2, 0.4], [0.8, 0.9]], "p_out":[[0.2, 0.4], [0.8, 0.9]]}, 
+        {"p_in": [[0.2, 0.4], [0.8, 0.9]], "p_out": [[0.2, 0.4], [0.8, 0.9]]},
     ],
 )
 def test_check_phase_intervals(pars):
-    assert_allclose(PhaseBackgroundMaker._check_intervals(pars["p_in"]), pars["p_out"], rtol = 1e-5)
+    assert_allclose(
+        PhaseBackgroundMaker._check_intervals(pars["p_in"]), pars["p_out"], rtol=1e-5
+    )

--- a/gammapy/makers/background/tests/test_phase.py
+++ b/gammapy/makers/background/tests/test_phase.py
@@ -66,4 +66,5 @@ def test_run(observations, phase_bkg_maker):
     ],
 )
 def test_check_phase_intervals(pars):
-    assert PhaseBackgroundMaker._check_intervals(pars["p_in"]) == pars["p_out"]
+    #assert PhaseBackgroundMaker._check_intervals(pars["p_in"]) == pars["p_out"]
+    assert_allclose(PhaseBackgroundMaker._check_intervals(pars["p_in"]), pars["p_out"], rtol = 1e-5)

--- a/gammapy/makers/background/tests/test_phase.py
+++ b/gammapy/makers/background/tests/test_phase.py
@@ -63,6 +63,7 @@ def test_run(observations, phase_bkg_maker):
         {"p_in": [[0.9, 0.1]], "p_out": [[0.9, 1], [0, 0.1]]},
         {"p_in": [[-0.2, 0.1]], "p_out": [[0.8, 1], [0, 0.1]]},
         {"p_in": [[0.8, 1.2]], "p_out": [[0.8, 1], [0, 0.2]]},
+        {"p_in": [[0.2, 0.4], [0.8, 0.9]], "p_out":[[0.2, 0.4], [0.8, 0.9]]}, 
     ],
 )
 def test_check_phase_intervals(pars):

--- a/gammapy/makers/background/tests/test_phase.py
+++ b/gammapy/makers/background/tests/test_phase.py
@@ -61,6 +61,8 @@ def test_run(observations, phase_bkg_maker):
     [
         {"p_in": [[0.2, 0.3]], "p_out": [[0.2, 0.3]]},
         {"p_in": [[0.9, 0.1]], "p_out": [[0.9, 1], [0, 0.1]]},
+        {"p_in": [[-0.2, 0.1]], "p_out": [[0.8, 1], [0, 0.1]]},
+        {"p_in": [[0.8, 1.2]], "p_out": [[0.8, 1], [0, 0.2]]},
     ],
 )
 def test_check_phase_intervals(pars):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request slightly modify _check_interval from PhaseBackgroundMaker to satisfy more phase definition, namely being able to define phase outside of the [0,1], such as [0.8, 1.2] or [-0.2, 1.2] to define a phase range from [[0.8, 1], [0,0.2].

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
