### PR TITLE
Added an evaluate method for CompoundSpectralModel

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -3,6 +3,7 @@
 import logging
 import operator
 import os
+from pathlib import Path
 import numpy as np
 import scipy.optimize
 import scipy.special
@@ -12,7 +13,6 @@ from astropy.table import Table
 from astropy.utils.decorators import classproperty
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
-from pathlib import Path
 from gammapy.maps import MapAxis, RegionNDMap
 from gammapy.modeling import Parameter, Parameters
 from gammapy.utils.integrate import trapz_loglog
@@ -656,6 +656,13 @@ class CompoundSpectralModel(SpectralModel):
                 "operator": self.operator.__name__,
             }
         }
+
+    def evaluate(self, energy, *args):
+        args1 = args[: len(self.model1.parameters)]
+        args2 = args[len(self.model1.parameters) :]
+        val1 = self.model1.evaluate(energy, *args1)
+        val2 = self.model2.evaluate(energy, *args2)
+        return self.operator(val1, val2)
 
     @classmethod
     def from_dict(cls, data):

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -670,6 +670,27 @@ def test_template_spectral_model_compound():
     assert np.allclose(new_model(energy), 2 * values)
 
 
+def test_evaluate_spectral_model_compound():
+    energy = [1.00e06, 1.25e06, 1.58e06, 1.99e06] * u.MeV
+    model = TEST_MODELS[-2]["model"]
+    values = model.evaluate(energy, *[p.quantity for p in model.parameters])
+    assert_allclose(values, model(energy))
+
+    model = TEST_MODELS[-3]["model"]
+    values = model.evaluate(energy, *[p.quantity for p in model.parameters])
+    assert_allclose(values, model(energy))
+
+
+def test_evaluate_nested_spectral_model_compound():
+    energy = [1.00e06, 1.25e06, 1.58e06, 1.99e06] * u.MeV
+    model1 = TEST_MODELS[-2]["model"]
+    model2 = TEST_MODELS[-3]["model"]
+
+    model = model1 + model2
+    values = model.evaluate(energy, *[p.quantity for p in model.parameters])
+    assert_allclose(values, model(energy))
+
+
 @requires_dependency("naima")
 class TestNaimaModel:
     # Used to test model value at 2 TeV


### PR DESCRIPTION
Signed-off-by: Lucas Gréaux <lucas.greaux@ijclab.in2p3.fr>

This pull request adds an evaluate method to the CompoundSpectralModel. This method allows to evaluate spectral models without having to modify the values of the parameters. This could be a first step towards the evaluation of spectral models on numpy arrays, which would greatly enhance the speed at which multiple evaluations are performed.