### PR TITLE
Modified CI workflow to let devdeps fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
     strategy:
-      fail-fast: true
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        allowed_fail = [false]
         include:
           - os: ubuntu-latest
             python: '3.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
   ci-runs:
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}$
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -60,6 +60,7 @@ jobs:
             python: '3.8'
             tox_env: 'devdeps'
             experimental: true
+    continue-on-error: ${{ matrix.experimental }}$
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,36 +21,46 @@ jobs:
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'py38-test-alldeps'
+            experimental: false
           - os: ubuntu-latest
             python: '3.9'
             tox_env: 'py39-test-alldeps-cov'
             gammapy_data_path: /home/runner/work/gammapy/gammapy/gammapy-datasets/dev
+            experimental: false
           - os: macos-latest
             python: '3.9'
             tox_env: 'py39-test'
             gammapy_data_path: /Users/runner/work/gammapy/gammapy/gammapy-datasets/dev
+            experimental: false
           - os: windows-latest
             python: '3.9'
             tox_env: 'py39-test-alldeps'
             gammapy_data_path:  D:\a\gammapy\gammapy\gammapy-datasets\dev
+            experimental: false
           - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-alldeps'
+            experimental: false
           - os: ubuntu-latest
             python: '3.9'
             tox_env: 'py39-test'
+            experimental: false
           - os: ubuntu-latest
             python: '3.9'
             tox_env: 'codestyle'
+            experimental: false
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'py38-test-alldeps-astropylts-numpy120'
+            experimental: false
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'oldestdeps'
+            experimental: false
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'devdeps'
+            experimental: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   ci-runs:
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}$
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,11 @@ jobs:
   ci-runs:
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allowed_fail }}
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
     strategy:
       fail-fast: true
       matrix:
-        allowed_fail = [false]
         include:
           - os: ubuntu-latest
             python: '3.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'devdeps'
-            allowed_fail: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   ci-runs:
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allowed_fail}}
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
     strategy:
@@ -50,6 +51,7 @@ jobs:
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'devdeps'
+            allowed_fail: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   ci-runs:
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allowed_fail}}
+    continue-on-error: ${{ matrix.allowed_fail }}
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
     strategy:


### PR DESCRIPTION
Signed-off-by: Régis Terrier <rterrier@apc.in2p3.fr>

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies ci.yml to include a `continue-on-error`  property in the ci matrix. It is set to `true` for the devdeps run.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
