### PR TITLE
Modify ci.yml to allow devdeps run to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,12 @@ jobs:
     name: Black check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: psf/black@stable
   ci-runs:
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allowed_fail}}
+    continue-on-error: ${{ matrix.experimental }}
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
     strategy:
@@ -21,37 +21,46 @@ jobs:
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'py38-test-alldeps'
+            experimental: false
           - os: ubuntu-latest
             python: '3.9'
             tox_env: 'py39-test-alldeps-cov'
             gammapy_data_path: /home/runner/work/gammapy/gammapy/gammapy-datasets/dev
+            experimental: false
           - os: macos-latest
             python: '3.9'
             tox_env: 'py39-test'
             gammapy_data_path: /Users/runner/work/gammapy/gammapy/gammapy-datasets/dev
+            experimental: false
           - os: windows-latest
             python: '3.9'
             tox_env: 'py39-test-alldeps'
             gammapy_data_path:  D:\a\gammapy\gammapy\gammapy-datasets\dev
+            experimental: false
           - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-alldeps'
+            experimental: false
           - os: ubuntu-latest
             python: '3.9'
             tox_env: 'py39-test'
+            experimental: false
           - os: ubuntu-latest
             python: '3.9'
             tox_env: 'codestyle'
+            experimental: false
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'py38-test-alldeps-astropylts-numpy120'
+            experimental: false
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'oldestdeps'
+            experimental: false
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'devdeps'
-            allowed_fail: true
+            experimental: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
   ci-runs:
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.allowed_fail }}
     env:
-      PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
+      PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscopegit commit
     strategy:
       fail-fast: true
       matrix:
@@ -21,46 +21,46 @@ jobs:
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'py38-test-alldeps'
-            experimental: false
+            allowed_fail: false
           - os: ubuntu-latest
             python: '3.9'
             tox_env: 'py39-test-alldeps-cov'
             gammapy_data_path: /home/runner/work/gammapy/gammapy/gammapy-datasets/dev
-            experimental: false
+            allowed_fail: false
           - os: macos-latest
             python: '3.9'
             tox_env: 'py39-test'
             gammapy_data_path: /Users/runner/work/gammapy/gammapy/gammapy-datasets/dev
-            experimental: false
+            allowed_fail: false
           - os: windows-latest
             python: '3.9'
             tox_env: 'py39-test-alldeps'
             gammapy_data_path:  D:\a\gammapy\gammapy\gammapy-datasets\dev
-            experimental: false
+            allowed_fail: false
           - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-alldeps'
-            experimental: false
+            allowed_fail: false
           - os: ubuntu-latest
             python: '3.9'
             tox_env: 'py39-test'
-            experimental: false
+            allowed_fail: false
           - os: ubuntu-latest
             python: '3.9'
             tox_env: 'codestyle'
-            experimental: false
+            allowed_fail: false
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'py38-test-alldeps-astropylts-numpy120'
-            experimental: false
+            allowed_fail: false
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'oldestdeps'
-            experimental: false
+            allowed_fail: false
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'devdeps'
-            experimental: true
+            allowed_fail: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -142,7 +142,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: create and activate env
         uses: mamba-org/provision-with-micromamba@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install base dependencies
@@ -115,7 +115,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install base dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   ci-runs:
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allowed_fail}}
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
     strategy:
@@ -50,6 +51,7 @@ jobs:
           - os: ubuntu-latest
             python: '3.8'
             tox_env: 'devdeps'
+            allowed_fail: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allowed_fail }}
     env:
-      PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscopegit commit
+      PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies the ci-runs matrix to use the `continue-on-error` variable.  It is set to `false` for all runs except `devdeps`.

To remove deprecation warnings in the ci, the version number of actions/setup-python and actions/checkout have been upgraded.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
