### PR TITLE
Deprecate load_cta_irfs, replace usage with load_irf_dict_from_file

### DIFF
--- a/docs/user-guide/irf/index.rst
+++ b/docs/user-guide/irf/index.rst
@@ -100,7 +100,7 @@ Using gammapy.irf
     :add-heading:
 
 
-.. minigallery:: gammapy.irf.load_cta_irfs
+.. minigallery:: gammapy.irf.load_irf_dict_from_file
     :add-heading:
 
 

--- a/examples/tutorials/analysis-1d/cta_sensitivity.py
+++ b/examples/tutorials/analysis-1d/cta_sensitivity.py
@@ -40,7 +40,7 @@ from IPython.display import display
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.estimators import SensitivityEstimator
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import SpectrumDatasetMaker
 from gammapy.maps import MapAxis, RegionGeom
 
@@ -78,7 +78,7 @@ empty_dataset = SpectrumDataset.create(geom=geom, energy_axis_true=energy_axis_t
 # We extract the 1D IRFs from the full 3D IRFs provided by CTA.
 #
 
-irfs = load_cta_irfs(
+irfs = load_irf_dict_from_file(
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
 location = observatory_locations["cta_south"]

--- a/examples/tutorials/analysis-1d/spectrum_simulation.py
+++ b/examples/tutorials/analysis-1d/spectrum_simulation.py
@@ -37,11 +37,11 @@ distribution of fitted parameters is consistent with the input values.**
 Proposed approach
 -----------------
 
-We will use the following classes:
+We will use the following classes and functions:
 
 -  `~gammapy.datasets.SpectrumDatasetOnOff`
 -  `~gammapy.datasets.SpectrumDataset`
--  `~gammapy.irf.load_cta_irfs`
+-  `~gammapy.irf.load_irf_dict_from_file`
 -  `~gammapy.modeling.models.PowerLawSpectralModel`
 
 """
@@ -62,7 +62,7 @@ import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import Datasets, SpectrumDataset, SpectrumDatasetOnOff
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import SpectrumDatasetMaker
 from gammapy.maps import MapAxis, RegionGeom
 from gammapy.modeling import Fit
@@ -120,7 +120,7 @@ model = SkyModel(spectral_model=model_simu, name="source")
 ######################################################################
 # Load the IRFs
 # In this simulation, we use the CTA-1DC irfs shipped with gammapy.
-irfs = load_cta_irfs(
+irfs = load_irf_dict_from_file(
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
 

--- a/examples/tutorials/analysis-3d/event_sampling.py
+++ b/examples/tutorials/analysis-3d/event_sampling.py
@@ -95,7 +95,7 @@ import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import DataStore, Observation, observatory_locations
 from gammapy.datasets import MapDataset, MapDatasetEventSampler
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import MapDatasetMaker
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling import Fit
@@ -144,7 +144,7 @@ livetime = 1 * u.hr
 # Now you can create the observation:
 #
 
-irfs = load_cta_irfs(path / irf_filename)
+irfs = load_irf_dict_from_file(path / irf_filename)
 location = observatory_locations["cta_south"]
 
 observation = Observation.create(
@@ -518,7 +518,7 @@ irf_paths = [path / irf_filename] * n_obs
 events_paths = []
 
 for idx, tstart in enumerate(tstarts):
-    irfs = load_cta_irfs(irf_paths[idx])
+    irfs = load_irf_dict_from_file(irf_paths[idx])
     observation = Observation.create(
         obs_id=idx,
         pointing=pointing,

--- a/examples/tutorials/analysis-3d/simulate_3d.py
+++ b/examples/tutorials/analysis-3d/simulate_3d.py
@@ -36,7 +36,7 @@ Proposed approach
 Here we can’t use the regular observation objects that are connected to
 a `DataStore`. Instead we will create a fake
 `~gammapy.data.Observation` that contain some pointing information and
-the CTA 1DC IRFs (that are loaded with `~gammapy.irf.load_cta_irfs`).
+the CTA 1DC IRFs (that are loaded with `~gammapy.irf.load_irf_dict_from_file`).
 
 Then we will create a `~gammapy.datasets.MapDataset` geometry and
 create it with the `~gammapy.makers.MapDatasetMaker`.
@@ -63,7 +63,7 @@ import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import MapDataset
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import MapDatasetMaker, SafeMaskMaker
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.modeling import Fit
@@ -89,7 +89,7 @@ from gammapy.modeling.models import (
 #
 
 # Loading IRFs
-irfs = load_cta_irfs(
+irfs = load_irf_dict_from_file(
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
 

--- a/examples/tutorials/analysis-time/light_curve_simulation.py
+++ b/examples/tutorials/analysis-time/light_curve_simulation.py
@@ -83,7 +83,7 @@ log = logging.getLogger(__name__)
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import Datasets, FluxPointsDataset, SpectrumDataset
 from gammapy.estimators import LightCurveEstimator
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import SpectrumDatasetMaker
 from gammapy.maps import MapAxis, RegionGeom, TimeMapAxis
 from gammapy.modeling import Fit
@@ -119,7 +119,7 @@ TimeMapAxis.time_format = "iso"
 #
 
 # Loading IRFs
-irfs = load_cta_irfs(
+irfs = load_irf_dict_from_file(
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
 

--- a/examples/tutorials/data/cta.py
+++ b/examples/tutorials/data/cta.py
@@ -67,7 +67,7 @@ from astropy import units as u
 import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import DataStore, EventList
-from gammapy.irf import EffectiveAreaTable2D, load_cta_irfs
+from gammapy.irf import EffectiveAreaTable2D, load_irf_dict_from_file
 
 ######################################################################
 # Check setup
@@ -239,7 +239,7 @@ print(observation.aeff)
 irf_filename = (
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
-irfs = load_cta_irfs(irf_filename)
+irfs = load_irf_dict_from_file(irf_filename)
 print(irfs)
 
 
@@ -368,10 +368,10 @@ plt.show()
 
 # !ls caldb/data/cta/prod3b-v2/bcf
 
-# irfs1 = load_cta_irfs("caldb/data/cta/prod3b-v2/bcf/South_z20_50h/irf_file.fits")
+# irfs1 = load_irf_dict_from_file("caldb/data/cta/prod3b-v2/bcf/South_z20_50h/irf_file.fits")
 # irfs1["aeff"].plot_energy_dependence()
 
-# irfs2 = load_cta_irfs("caldb/data/cta/prod3b-v2/bcf/South_z40_50h/irf_file.fits")
+# irfs2 = load_irf_dict_from_file("caldb/data/cta/prod3b-v2/bcf/South_z40_50h/irf_file.fits")
 # irfs2["aeff"].plot_energy_dependence()
 
 

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -7,7 +7,7 @@ from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
 from gammapy.data import DataStore, Observation
-from gammapy.irf import PSF3D, load_cta_irfs
+from gammapy.irf import PSF3D, load_irf_dict_from_file
 from gammapy.utils.fits import HDULocation
 from gammapy.utils.testing import (
     assert_skycoord_allclose,
@@ -219,7 +219,7 @@ def test_observations_select_time_time_intervals_list(data_store):
 def test_observation_cta_1dc():
     ontime = 5.0 * u.hr
     pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -10,7 +10,7 @@ from astropy.time import Time
 from gammapy.data import GTI, DataStore, Observation
 from gammapy.datasets import MapDataset, MapDatasetEventSampler
 from gammapy.datasets.tests.test_map import get_map_dataset
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import MapDatasetMaker
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.modeling.models import (
@@ -147,7 +147,7 @@ def test_mde_sample_sources(dataset, models):
 
 @requires_data()
 def test_mde_sample_weak_src(dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 10.0 * u.hr
@@ -234,7 +234,7 @@ def test_mde_sample_edisp(dataset, models):
 
 @requires_data()
 def test_event_det_coords(dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 1.0 * u.hr
@@ -261,7 +261,7 @@ def test_event_det_coords(dataset, models):
 
 @requires_data()
 def test_mde_run(dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 1.0 * u.hr
@@ -357,7 +357,7 @@ def test_mde_run(dataset, models):
 
 @requires_data()
 def test_irf_alpha_config(dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
     )
     livetime = 1.0 * u.hr
@@ -378,7 +378,7 @@ def test_irf_alpha_config(dataset, models):
 
 @requires_data()
 def test_mde_run_switchoff(dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 1.0 * u.hr
@@ -415,7 +415,7 @@ def test_mde_run_switchoff(dataset, models):
 
 @requires_data()
 def test_events_datastore(tmp_path, dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 10.0 * u.hr
@@ -443,7 +443,7 @@ def test_events_datastore(tmp_path, dataset, models):
 
 @requires_data()
 def test_MC_ID(model_alternative):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 0.1 * u.hr
@@ -499,7 +499,7 @@ def test_MC_ID(model_alternative):
 
 @requires_data()
 def test_MC_ID_NMCID(model_alternative):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 0.1 * u.hr

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -9,7 +9,7 @@ from gammapy.data import Observation
 from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
 from gammapy.datasets.spectrum import SpectrumDataset
 from gammapy.estimators import FluxPoints, FluxPointsEstimator
-from gammapy.irf import EDispKernelMap, EffectiveAreaTable2D, load_cta_irfs
+from gammapy.irf import EDispKernelMap, EffectiveAreaTable2D, load_irf_dict_from_file
 from gammapy.makers import MapDatasetMaker
 from gammapy.makers.utils import make_map_exposure_true_energy
 from gammapy.maps import MapAxis, RegionGeom, RegionNDMap, WcsGeom
@@ -96,7 +96,7 @@ def create_fpe(model):
 
 
 def simulate_map_dataset(random_state=0, name=None):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
 

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -202,6 +202,35 @@ def load_cta_irfs(filename):
     return dict(aeff=aeff, bkg=bkg, edisp=edisp, psf=psf)
 
 
+class UnknownHDUClass(IOError):
+    """Raised when a file contains an unknown HDUCLASS"""
+
+
+def _get_hdu_type_and_class(header):
+    """Get gammapy hdu_type and class from FITS header
+
+    Contains a workaround to support CTA 1DC irf file.
+    """
+    hdu_clas2 = header.get("HDUCLAS2", "")
+    hdu_clas4 = header.get("HDUCLAS4", "")
+
+    clas2_to_type = {"rpsf": "psf", "eff_area": "aeff"}
+    hdu_type = clas2_to_type.get(hdu_clas2.lower(), hdu_clas2.lower())
+    hdu_class = hdu_clas4.lower()
+
+    if hdu_type not in HDUIndexTable.VALID_HDU_TYPE:
+        raise UnknownHDUClass(f"HDUCLAS2={hdu_clas2}, HDUCLAS4={hdu_clas4}")
+
+    # workaround for CTA 1DC files with non-compliant HDUCLAS4 names
+    if hdu_class not in HDUIndexTable.VALID_HDU_CLASS:
+        hdu_class = f"{hdu_type}_{hdu_class}"
+
+    if hdu_class not in HDUIndexTable.VALID_HDU_CLASS:
+        raise UnknownHDUClass(f"HDUCLAS2={hdu_clas2}, HDUCLAS4={hdu_clas4}")
+
+    return hdu_type, hdu_class
+
+
 def load_irf_dict_from_file(filename):
     """Load all available IRF components from given file into a dict.
 
@@ -222,41 +251,41 @@ def load_irf_dict_from_file(filename):
     from .rad_max import RadMax2D
 
     filename = make_path(filename)
-
-    hdulist = fits.open(make_path(filename))
-
+    hdulist = fits.open(filename)
     irf_dict = {}
-
     is_pointlike = False
 
     for hdu in hdulist:
-        hdu_class = hdu.header.get("HDUCLAS1", "").lower()
+        hdu_clas1 = hdu.header.get("HDUCLAS1", "").lower()
 
-        if hdu_class == "response":
-            hdu_class = hdu.header.get("HDUCLAS4", "").lower()
-
-            is_pointlike |= hdu.header["HDUCLAS3"] == "POINT-LIKE"
-
-            loc = HDULocation(
-                hdu_class=hdu_class,
-                hdu_name=hdu.name,
-                file_dir=filename.parent,
-                file_name=filename.name,
-            )
-
-            for name in HDUIndexTable.VALID_HDU_TYPE:
-                if name in hdu_class:
-                    if name in irf_dict.keys():
-                        log.warning(f"more than one HDU of {name} type found")
-                        log.warning(
-                            f"loaded the {irf_dict[name].meta['EXTNAME']} HDU in the dictionary"
-                        )
-                        continue
-                    data = loc.load()
-                    # TODO: maybe introduce IRF.type attribute...
-                    irf_dict[name] = data
-        else:  # not an IRF component
+        # not an IRF component
+        if hdu_clas1 != "response":
             continue
+
+        is_pointlike |= hdu.header.get("HDUCLAS3") == "POINT-LIKE"
+
+        try:
+            hdu_type, hdu_class = _get_hdu_type_and_class(hdu.header)
+        except UnknownHDUClass as e:
+            log.warning("File has unknown class %s", e)
+            continue
+
+        loc = HDULocation(
+            hdu_class=hdu_class,
+            hdu_name=hdu.name,
+            file_dir=filename.parent,
+            file_name=filename.name,
+        )
+
+        if hdu_type in irf_dict.keys():
+            log.warning(f"more than one HDU of {hdu_type} type found")
+            log.warning(
+                f"loaded the {irf_dict[hdu_type].meta['EXTNAME']} HDU in the dictionary"
+            )
+            continue
+
+        data = loc.load()
+        irf_dict[hdu_type] = data
 
     if is_pointlike and "rad_max" not in irf_dict:
         irf_dict["rad_max"] = RadMax2D.from_irf(irf_dict["aeff"])

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -4,6 +4,7 @@ from astropy.io import fits
 from gammapy.data.hdu_index_table import HDUIndexTable
 from gammapy.utils.fits import HDULocation
 from gammapy.utils.scripts import make_path
+from gammapy.utils.deprecation import deprecated
 
 __all__ = ["load_cta_irfs", "load_irf_dict_from_file"]
 
@@ -141,8 +142,14 @@ def gadf_is_pointlike(header):
     return header.get("HDUCLAS3") == "POINT-LIKE"
 
 
+@deprecated("v1.1", alternative="load_irf_dict_from_file")
 def load_cta_irfs(filename):
-    """load CTA instrument response function and return a dictionary container.
+    """Load IRFs from file as written by the CTA DC1 into a dict
+
+    This function has a hardcoded list of IRF types and HDU names
+    and does not check what types of IRFs are actually present in the file.
+
+    Please use `load_irf_dict_from_file` instead..
 
     The IRF format should be compliant with the one discussed
     at http://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/.
@@ -196,8 +203,9 @@ def load_cta_irfs(filename):
 
 
 def load_irf_dict_from_file(filename):
-    """Open a fits file and generate a dictionary containing the Gammapy objects
-    corresponding to the IRF components stored
+    """Load all available IRF components from given file into a dict.
+
+    If multiple IRFs of the same type are present, the first encountered is returned.
 
     Parameters
     ----------

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -38,13 +38,13 @@ class PSFMap(IRFMap):
         from astropy.coordinates import SkyCoord
         from gammapy.maps import WcsGeom, MapAxis
         from gammapy.data import Observation
-        from gammapy.irf import load_cta_irfs
+        from gammapy.irf import load_irf_dict_from_file
         from gammapy.makers import MapDatasetMaker
 
         # Define observation
         pointing = SkyCoord("0d", "0d")
         filename = "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
-        irfs = load_cta_irfs(filename)
+        irfs = load_irf_dict_from_file(filename)
         obs = Observation.create(pointing=pointing, irfs=irfs, livetime="1h")
 
         # Create WcsGeom

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -9,6 +9,7 @@ from gammapy.irf import (
     Background3D,
     EffectiveAreaTable2D,
     EnergyDispersion2D,
+    EnergyDependentMultiGaussPSF,
     RadMax2D,
     load_cta_irfs,
     load_irf_dict_from_file,
@@ -291,3 +292,16 @@ class TestIRFWrite:
 
         read_bkg = Background3D.read(path, hdu="BACKGROUND")
         assert_allclose(read_bkg.quantity, self.bkg_data)
+
+
+@requires_data()
+def test_load_irf_dict_from_file_cta():
+    """Test that CTA IRFs can be loaded and evaluated."""
+    irf = load_irf_dict_from_file(
+        "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+    )
+    assert set(irf.keys()) == {"aeff", "edisp", "psf", "bkg"}
+    assert isinstance(irf["aeff"], EffectiveAreaTable2D)
+    assert isinstance(irf["edisp"], EnergyDispersion2D)
+    assert isinstance(irf["psf"], EnergyDependentMultiGaussPSF)
+    assert isinstance(irf["bkg"], Background3D)

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -15,14 +16,16 @@ from gammapy.irf import (
 from gammapy.maps import MapAxis
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import requires_data
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 
 
 @requires_data()
 def test_cta_irf():
     """Test that CTA IRFs can be loaded and evaluated."""
-    irf = load_cta_irfs(
-        "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
-    )
+    with pytest.warns(GammapyDeprecationWarning):
+        irf = load_cta_irfs(
+            "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+        )
 
     energy = Quantity(1, "TeV")
     offset = Quantity(3, "deg")
@@ -48,9 +51,10 @@ def test_cta_irf():
 @requires_data()
 def test_cta_irf_alpha_config_south():
     """Test that CTA IRFs can be loaded and evaluated."""
-    irf = load_cta_irfs(
-        "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
-    )
+    with pytest.warns(GammapyDeprecationWarning):
+        irf = load_cta_irfs(
+            "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
+        )
 
     energy = Quantity(1, "TeV")
     offset = Quantity(3, "deg")
@@ -76,9 +80,10 @@ def test_cta_irf_alpha_config_south():
 @requires_data()
 def test_cta_irf_alpha_config_north():
     """Test that CTA IRFs can be loaded and evaluated."""
-    irf = load_cta_irfs(
-        "$GAMMAPY_DATA/cta-caldb/Prod5-North-20deg-AverageAz-4LSTs09MSTs.180000s-v0.1.fits.gz"
-    )
+    with pytest.warns(GammapyDeprecationWarning):
+        irf = load_cta_irfs(
+            "$GAMMAPY_DATA/cta-caldb/Prod5-North-20deg-AverageAz-4LSTs09MSTs.180000s-v0.1.fits.gz"
+        )
 
     energy = Quantity(1, "TeV")
     offset = Quantity(3, "deg")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

In a recent exchange, people were trying to use `load_cta_irfs` for IRFs for CTA they produced themselves using pyirf, however, the function hard codes both the expected IRF classes and the HDU names and performs no checks if the actual data file contains those or other entries.

This method is generally named (for CTA! but has actually nothing CTA specific other than the combination of IRFs and HDU names used) but has hard coded specifics. It should be deprecated / removed to avoid such confusion in the future.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
