### PR TITLE
Correct issue with test_safe_mask_maker_dc1

### DIFF
--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -223,7 +223,7 @@ def test_safe_mask_maker_dc1(spectrum_dataset_gc, observations_cta_dc1):
     maker = SpectrumDatasetMaker()
     dataset = maker.run(spectrum_dataset_gc, obs)
     dataset = safe_mask_maker.run(dataset, obs)
-    assert_allclose(dataset.energy_range[0], 1, rtol=1e-3)
+    assert_allclose(dataset.energy_range[0].data, 1, rtol=1e-3)
     assert dataset.energy_range[0].unit == "TeV"
 
 


### PR DESCRIPTION
Signed-off-by: Régis Terrier <rterrier@apc.in2p3.fr>

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects an issue with test_safe_mask_maker_dc1 in makers/tests/test_spectrum.py

The `assert_allclose(dataset.energy_range[0], 1, rtol=1e-3)` statement is incorrect since `dataset.energy_range[0]`is a `RegionMap`. The test was silently passing up to now but might the origin of the recent fail in ubuntu python3.9 environment.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
