### PR TITLE
Use linebreaks in passenv list in tox.ini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install 'tox<4'
+          python -m pip install tox
       - name: download datasets
         if: ${{ matrix.gammapy_data_path }}
         run: |
@@ -121,7 +121,7 @@ jobs:
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install 'tox<4'
+          python -m pip install tox
       - name: download datasets
         run: |
           python -m pip install tqdm requests

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,16 @@ indexserver =
 setenv = MPLBACKEND=agg
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS GAMMAPY_DATA PKG_CONFIG_PATH
+passenv = 
+    HOME
+    WINDIR
+    LC_ALL
+    LC_CTYPE
+    CC
+    CI
+    TRAVIS
+    GAMMAPY_DATA
+    PKG_CONFIG_PATH
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description*

<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

The current dev docs build fails, because in the latest version of `tox` the `passenv` variable does not allow to use whitespace anymore in the same line. This PR introduces line breaks instead, which is better readable anyway...

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
