### PR TITLE
Add energy support for a template temporal model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install 'tox<4'
+          python -m pip install tox
       - name: download datasets
         if: ${{ matrix.gammapy_data_path }}
         run: |
@@ -121,7 +121,7 @@ jobs:
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install 'tox<4'
+          python -m pip install tox
       - name: download datasets
         run: |
           python -m pip install tqdm requests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             allowed_fail: false
           - os: ubuntu-latest
             python: '3.8'
-            tox_env: 'py38-test-alldeps-astropylts-numpy120'
+            tox_env: 'py38-test-alldeps-astropylts-numpy121'
             allowed_fail: false
           - os: ubuntu-latest
             python: '3.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
+        with:
+          version: "22.6.0"
   ci-runs:
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,13 +1,14 @@
 name: Build dev docs
 on: push
+
 jobs:
   dispatch-docs:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Dispatch Gammapy Docs
-          uses: peter-evans/repository-dispatch@v2
-          with:
-            token: ${{ secrets.REMOTE_DISPATCH }}
-            repository: gammapy/gammapy-docs
-            event-type: dev-docs
-            
+    if: github.repository_owner == 'gammapy'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Gammapy Docs
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REMOTE_DISPATCH }}
+          repository: gammapy/gammapy-docs
+          event-type: dev-docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,9 @@ jobs:
           password: ${{ secrets.PYPI_TOKEN }}
 
   release-github:
-    if: github.repository_owner == 'gammapy'
+    if: github.repository_owner == 'gammapy' && !contains(github.ref_name, 'rc')
     needs: release-pypi
     runs-on: ubuntu-latest
-    if:  ${{ !contains(github.ref_name, 'rc') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release-pypi:
+    if: github.repository_owner == 'gammapy'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,7 +28,9 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
+
   release-github:
+    if: github.repository_owner == 'gammapy'
     needs: release-pypi
     runs-on: ubuntu-latest
     if:  ${{ !contains(github.ref_name, 'rc') }}
@@ -39,7 +42,9 @@ jobs:
         with:
           body: |
             Gammapy is a Python package for gamma-ray astronomy. See [changelog for this release](https://github.com/gammapy/gammapy/blob/main/docs/release-notes/${{ github.ref_name }}.rst).
+
   dispatch-docs:
+    if: github.repository_owner == 'gammapy'
     needs: release-pypi
     runs-on: ubuntu-latest
     steps:
@@ -50,7 +55,9 @@ jobs:
           repository: gammapy/gammapy-docs
           event-type: release
           client-payload: '{"release": "${{ github.ref_name }}"}'
+
   dispatch-webpage:
+    if: github.repository_owner == 'gammapy'
     needs: release-github
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html#integration-with-pre-commit
   - repo: https://github.com/pycqa/isort
-    rev: 5.6.4
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,8 @@
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4701488.svg?style=flat
     :target: https://doi.org/10.5281/zenodo.4701488
 
-.. image:: https://archive.softwareheritage.org/badge/swh:1:dir:02e8a702ef6c9558a9f96d99bf6b9f41b5edcd34/
-    :target: https://archive.softwareheritage.org/swh:1:dir:02e8a702ef6c9558a9f96d99bf6b9f41b5edcd34;origin=https://github.com/gammapy/gammapy;visit=swh:1:snp:11294b68ac9dcb4aeefaa784e7fb7afba7d61402;anchor=swh:1:rev:89f67e3014c3673704ea6eeb8ad3ad0b844a3426
-
+.. image:: https://archive.softwareheritage.org/badge/swh:1:dir:27e81770f5e2e977017789ef5aa4a35978137fa6/
+    :target: https://archive.softwareheritage.org/swh:1:dir:27e81770f5e2e977017789ef5aa4a35978137fa6;origin=https://github.com/gammapy/gammapy;visit=swh:1:snp:6017d488cdb0faaa2373663b86f751eafdf2a1d5;anchor=swh:1:rev:e2591a43bc04db8e51e693d0711c21ac0738203c
 
 
 Gammapy
@@ -70,21 +69,16 @@ Status shields
 
 (mostly useful for developers)
 
+* .. image:: https://app.codacy.com/project/badge/Grade/9c32a21a915d4a28823f3b44a99a2810
+    :target: https://www.codacy.com/gh/gammapy/gammapy/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=gammapy/gammapy&amp;utm_campaign=Badge_Grade
+    :alt: Codacy
+
 * .. image:: https://github.com/gammapy/gammapy/workflows/CI/badge.svg?style=flat
     :target: https://github.com/gammapy/gammapy/actions
     :alt: GitHub actions CI
 
 * .. image:: https://codecov.io/gh/gammapy/gammapy/branch/master/graph/badge.svg?style=flat
     :target: https://codecov.io/gh/gammapy/gammapy
-
-* .. image:: https://img.shields.io/lgtm/grade/python/g/gammapy/gammapy.svg?logo=lgtm&logoWidth=18
-    :target: https://lgtm.com/projects/g/gammapy/gammapy/context:python
-    :alt: LGTM
-
-* .. image:: https://app.codacy.com/project/badge/Grade/9c32a21a915d4a28823f3b44a99a2810
-    :target: https://www.codacy.com/gh/gammapy/gammapy/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=gammapy/gammapy&amp;utm_campaign=Badge_Grade
-    :alt: Codacy
-
 
 Note if you cloned this repository before Oct 7th 2022
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -11,8 +11,12 @@ Documentation building
 
 Generating the HTML docs for Gammapy is straight-forward::
 
-    make docs-all
+    make docs-sphinx
     make docs-show
+
+Or one can equivalently use tox::
+
+     tox -e build_docs
 
 Generating the PDF docs is more complex.
 This should work::

--- a/docs/development/intro.rst
+++ b/docs/development/intro.rst
@@ -56,7 +56,7 @@ Four solutions exist:
 2. You can sign each of your commits with the command: "``git commit -s``".
 
 If you have authored a commit that is missing its ‘Signed-off-by’ line, you can amend your commits and push them to
-GitHub: "``git commit --amend --noedit --signoff``"
+GitHub: "``git commit --amend --no-edit --signoff``"
 (see also this `How To <https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md#how-to-add-sign-offs-retroactively>`_).
 
 3. You can make an alias of the command "``git commit -s``", e.g.

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -8,6 +8,14 @@ This is the list of changes to Gammapy between each release. For full details,
 see the `commit logs <https://github.com/gammapy/gammapy/commits/main>`_.
 A complete list of Gammapy contributors is at https://gammapy.org/team.html
 
+Version 1.0.1
+-------------
+
+.. toctree::
+   :maxdepth: 2
+
+   v1.0.1
+
 Version 1.0
 -----------
 

--- a/docs/release-notes/v1.0.1.rst
+++ b/docs/release-notes/v1.0.1.rst
@@ -1,0 +1,54 @@
+.. include:: ../references.txt
+
+.. _gammapy_1p0p1_release:
+
+1.0.1 (March 14th, 2023)
+------------------------
+
+Summary
+~~~~~~~
+
+- Released Mar 14th, 2023
+- 9 contributors
+- 31 pull requests since v1.0 (not all listed below)
+
+This is the first bug-fix after v1.0. Several minor bugs and typos in the documentation are corrected.
+
+- Few corrections have been made to improve the performance of the models evaluation in particular for 1d 
+  spectral analyses.
+- The "TIMESYS" keyword was not properly exported to the lightcurve table format. This is now corrected.
+- An issue with interpolation in scipy 1.10 is causing problems in Gammapy. This specific version is
+  excluded from dependencies. The minimal numpy version is now 1.21.
+- Models created from files with a parameter scale different than one were incorrect and this will be fixed 
+  by this patch. Note that by default gammapy always serializes the parameters with a scale of unity, so this bug 
+  affected only files written by hand with a scale different from one.
+- Datasets serialization now correctly supports PSF in reconstructed energies used in HAWC analyses.
+
+
+Contributors
+~~~~~~~~~~~~
+
+- Arnau Aguasca
+- Axel Donath
+- Bruno Khelifi
+- Maximilian Linhoff
+- Lars Mohrmann
+- Maxime Régeard
+- Quentin Remy
+- Atreyee Sinha
+- Régis Terrier
+
+Pull Requests
+~~~~~~~~~~~~~
+
+This list is incomplete.
+
+- [#4359] Fix interpolation values_scale in TemplateSpatialModel (Quentin Remy)
+- [#4344] Fix norm_only_changed in MapEvaluator (Quentin Remy)
+- [#4336] Change label units within parentheses to brackets (Arnau Aguasca)
+- [#4324] Fix Parameter init if scale is not one (Quentin Remy)
+- [#4301] Add TIMESYS to lightcurve table meta (Régis Terrier)
+- [#4275] Remove safe mask in background stacking (Atreyee Sinha)
+- [#4268] Add an HowTo for the fit non-convergence (Bruno Khelifi)
+- [#4231] Fix bug in safe mask computation for SpectrumDatasetOnOff (Lars Mohrmann)
+- [#4221] Fix wrong name in required hdus (Maximilian Linhoff)

--- a/docs/release-notes/v1.0.rst
+++ b/docs/release-notes/v1.0.rst
@@ -3,7 +3,7 @@
 .. _gammapy_1p0_release:
 
 1.0 (November 10th, 2022)
------------------------
+-------------------------
 
 Summary
 ~~~~~~~
@@ -72,7 +72,7 @@ Bug fixes and improvements
 *gammapy.irf*
 
 - The interpolation scheme of the energy axis was incorrectly set to "linear" by default for the
-`~gammapy.irf.Background2D`. It is now set to "log".
+ `~gammapy.irf.Background2D`. It is now set to "log".
 
 *gammapy.makers*
 

--- a/docs/release-notes/v1.1.rst
+++ b/docs/release-notes/v1.1.rst
@@ -1,4 +1,4 @@
-.. _gammapy_1p0_release:
+.. _gammapy_1p1_release:
 
 1.0 (unreleased)
 ----------------

--- a/docs/user-guide/astro/population/plot_spiral_arm_models.py
+++ b/docs/user-guide/astro/population/plot_spiral_arm_models.py
@@ -32,8 +32,8 @@ for spiralarm_index in range(4):
 
 ax_cartesian.plot(vallee_spiral.bar["x"], vallee_spiral.bar["y"])
 
-ax_cartesian.set_xlabel("x (kpc)")
-ax_cartesian.set_ylabel("y (kpc)")
+ax_cartesian.set_xlabel("x [kpc]")
+ax_cartesian.set_ylabel("y [kpc]")
 ax_cartesian.set_xlim(-12, 12)
 ax_cartesian.set_ylim(-15, 12)
 ax_cartesian.legend(ncol=2, loc="lower right")

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -158,6 +158,28 @@ one for each time bin.
 .. accordion-footer::
 
 .. accordion-header::
+    :id: collapseHowToOne
+    :title: Improve fit convergence with constraints on the source position
+
+It happens that a 3D fit does not converge with warning messages indicating that the
+scanned positions of the model are outside the valid IRF map range. The type of warning message is:
+::
+
+    Position <SkyCoord (ICRS): (ra, dec) in deg
+      (329.71693826, -33.18392464)> is outside valid IRF map range, using nearest IRF defined within
+
+This issue might happen when the position of a model has no defined range. The minimizer
+might scan positions outside the spatial range in which the IRFs are computed and then it gets lost.
+
+The simple solution is to add a physically-motivated range on the model's position, e.g. within
+the field of view or around an excess position. Most of the time, this tip solves the issue.
+The documentation of the
+`models sub-package <https://docs.gammapy.org/1.0/tutorials/api/models.html#modifying-model-parameters>`_
+explains how to add a validity range of a model parameter.
+
+.. accordion-footer::
+
+.. accordion-header::
     :id: collapseHowToTwelve
     :title: Reduce memory budget for large datasets
 

--- a/docs/user-guide/irf/index.rst
+++ b/docs/user-guide/irf/index.rst
@@ -100,7 +100,7 @@ Using gammapy.irf
     :add-heading:
 
 
-.. minigallery:: gammapy.irf.load_cta_irfs
+.. minigallery:: gammapy.irf.load_irf_dict_from_file
     :add-heading:
 
 

--- a/examples/models/spatial/plot_gen_gauss.py
+++ b/examples/models/spatial/plot_gen_gauss.py
@@ -23,7 +23,7 @@ if ellipticity tend to one and radius is large or :math:`\eta` much larger than 
 The effective radius is given by:
 
 .. math::
-    \r_{rm eff}(\text{lon}, \text{lat}) = \sqrt{
+    r_{rm eff}(\text{lon}, \text{lat}) = \sqrt{
         (r_M \sin(\Delta \phi))^2 +
         (r_m \cos(\Delta \phi))^2
     }.

--- a/examples/models/spectral/plot_broken_powerlaw.py
+++ b/examples/models/spectral/plot_broken_powerlaw.py
@@ -9,7 +9,7 @@ This model parametrises a broken power law spectrum.
 It is defined by the following equation:
 
 .. math::
-    \phi(E) = phi_0 \cdot \begin{cases}
+    \phi(E) = \phi_0 \cdot \begin{cases}
                           \left( \frac{E}{E_{break}} \right)^{-\Gamma1} & \text{if } E < E_{break} \\
                           \left( \frac{E}{E_{break}} \right)^{-\Gamma2} & \text{otherwise}
                          \end{cases}

--- a/examples/models/spectral/plot_super_exp_cutoff_powerlaw_4fgl.py
+++ b/examples/models/spectral/plot_super_exp_cutoff_powerlaw_4fgl.py
@@ -10,16 +10,7 @@ It is defined by the following equation:
 
 .. math::
 
-
-    \phi(e) =
-            \begin{cases}
-                \phi_0 \cdot \left(\frac{E}{E_0}\right)^{\frac{\a}{\Gamma_2} -\Gamma_1} \cdot \exp \left(
-                  \frac{\a}{\Gamma_2^2} \left( 1 - \left(\frac{E}{E_0}\right)^{\frac{\a}{\Gamma_2} \right)
-              \right)&
-                              \\
-                \phi_0 \cdot \left(\frac{E}{E_0}\right)^{ -\Gamma_1 - \frac{\a}{2} \ln \frac{E}{E_0} - \frac{\a \Gamma_2}{6} \ln^2 \frac{E}{E_0} - \frac{\a \Gamma_2^2}{24} \ln^3 \frac{E}{E_0}}\\
-                0 & \text{for } \left| \Gamma_2 \ln \frac{E}{E_0}  \right|
-            \end{cases}
+\phi(E) = \begin{cases} \phi_0 \cdot \left(\frac{E}{E_0}\right)^{\frac{a}{\Gamma_2} -\Gamma_1} \cdot \exp \left( \frac{a}{\Gamma_2^2}\left( 1 - \left(\frac{E}{E_0}\right)^{\Gamma_2} \right) \right) \\ \phi_0 \cdot \left(\frac{E}{E_0}\right)^{ -\Gamma_1 - \frac{a}{2} \ln \frac{E}{E_0} - \frac{a \Gamma_2}{6} \ln^2 \frac{E}{E_0} - \frac{a \Gamma_2^2}{24} \ln^3 \frac{E}{E_0}} & \text{for } \left| \Gamma_2 \ln \frac{E}{E_0} \right| < 10^{-2} \end{cases}
 
 See Equation (2) and (3) in https://arxiv.org/pdf/2201.11184.pdf
 """

--- a/examples/models/spectral/plot_super_exp_cutoff_powerlaw_4fgl.py
+++ b/examples/models/spectral/plot_super_exp_cutoff_powerlaw_4fgl.py
@@ -10,7 +10,7 @@ It is defined by the following equation:
 
 .. math::
 
-\phi(E) = \begin{cases} \phi_0 \cdot \left(\frac{E}{E_0}\right)^{\frac{a}{\Gamma_2} -\Gamma_1} \cdot \exp \left( \frac{a}{\Gamma_2^2}\left( 1 - \left(\frac{E}{E_0}\right)^{\Gamma_2} \right) \right) \\ \phi_0 \cdot \left(\frac{E}{E_0}\right)^{ -\Gamma_1 - \frac{a}{2} \ln \frac{E}{E_0} - \frac{a \Gamma_2}{6} \ln^2 \frac{E}{E_0} - \frac{a \Gamma_2^2}{24} \ln^3 \frac{E}{E_0}} & \text{for } \left| \Gamma_2 \ln \frac{E}{E_0} \right| < 10^{-2} \end{cases}
+    \phi(E) = \begin{cases} \phi_0 \cdot \left(\frac{E}{E_0}\right)^{\frac{a}{\Gamma_2} -\Gamma_1} \cdot \exp \left( \frac{a}{\Gamma_2^2}\left( 1 - \left(\frac{E}{E_0}\right)^{\Gamma_2} \right) \right) \\ \phi_0 \cdot \left(\frac{E}{E_0}\right)^{ -\Gamma_1 - \frac{a}{2} \ln \frac{E}{E_0} - \frac{a \Gamma_2}{6} \ln^2 \frac{E}{E_0} - \frac{a \Gamma_2^2}{24} \ln^3 \frac{E}{E_0}} & \text{for } \left| \Gamma_2 \ln \frac{E}{E_0} \right| < 10^{-2} \end{cases}
 
 See Equation (2) and (3) in https://arxiv.org/pdf/2201.11184.pdf
 """

--- a/examples/tutorials/analysis-1d/cta_sensitivity.py
+++ b/examples/tutorials/analysis-1d/cta_sensitivity.py
@@ -40,7 +40,7 @@ from IPython.display import display
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.estimators import SensitivityEstimator
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import SpectrumDatasetMaker
 from gammapy.maps import MapAxis, RegionGeom
 
@@ -78,7 +78,7 @@ empty_dataset = SpectrumDataset.create(geom=geom, energy_axis_true=energy_axis_t
 # We extract the 1D IRFs from the full 3D IRFs provided by CTA.
 #
 
-irfs = load_cta_irfs(
+irfs = load_irf_dict_from_file(
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
 location = observatory_locations["cta_south"]

--- a/examples/tutorials/analysis-1d/cta_sensitivity.py
+++ b/examples/tutorials/analysis-1d/cta_sensitivity.py
@@ -175,8 +175,8 @@ ax.plot(
 )
 
 ax.loglog()
-ax.set_xlabel(f"Energy ({t['energy'].unit})")
-ax.set_ylabel(f"Sensitivity ({t['e2dnde'].unit})")
+ax.set_xlabel(f"Energy [{t['energy'].unit}]")
+ax.set_ylabel(f"Sensitivity [{t['e2dnde'].unit}]")
 ax.legend()
 
 
@@ -192,11 +192,11 @@ fig, ax1 = plt.subplots()
 ax1.plot(t["energy"], t["background"], "o-", color="black", label="blackground")
 
 ax1.loglog()
-ax1.set_xlabel(f"Energy ({t['energy'].unit})")
+ax1.set_xlabel(f"Energy [{t['energy'].unit}]")
 ax1.set_ylabel("Expected number of bkg counts")
 
 ax2 = ax1.twinx()
-ax2.set_ylabel(f"ON region radius ({on_radii.unit})", color="red")
+ax2.set_ylabel(f"ON region radius [{on_radii.unit}]", color="red")
 ax2.semilogy(t["energy"], on_radii, color="red", label="PSF68")
 ax2.tick_params(axis="y", labelcolor="red")
 ax2.set_ylim(0.01, 0.5)

--- a/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
@@ -47,15 +47,15 @@ the same :math:`\\theta` cut is applied at all energies and offsets, `a
 keyword <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max>`__
 is added to the header of the data units containing IRF components. This
 should be used to define the size of the ON and OFF regions; \* in case
-an energy- (and offset-) dependent :math:`\theta` cut is applied, its
+an energy- (and offset-) dependent :math:`\\theta` cut is applied, its
 values are stored in additional `FITS` data unit, named
 ``RAD_MAX_2D` <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max-2d>`__.
 
 `Gammapy` provides a class to automatically read these values,
 `~gammapy.irf.RadMax2D`, for both cases (fixed or energy-dependent
-:math:`\theta` cut). In this notebook we will focus on how to perform a
+:math:`\\theta` cut). In this notebook we will focus on how to perform a
 spectral extraction with a point-like IRF with an energy-dependent
-:math:`\theta` cut. We remark that in this case a
+:math:`\\theta` cut. We remark that in this case a
 `~regions.PointSkyRegion` (and not a `~regions.CircleSkyRegion`)
 should be used to define the ON region. If a geometry based on a
 `~regions.PointSkyRegion` is fed to the spectra and the background
@@ -76,14 +76,14 @@ Introduction
 
 We load two MAGIC observations in the
 `gammapy-data <https://github.com/gammapy/gammapy-data>`__ containing
-IRF component with a :math:`\theta` cut.
+IRF component with a :math:`\\theta` cut.
 
 We define the ON region, this time as a `~regions.PointSkyRegion` instead of a
 `CircleSkyRegion`, i.e. we specify only the center of our ON region.
 We create a `RegionGeom` adding to the region the estimated energy
 axis of the `~gammapy.datasets.SpectrumDataset` object we want to
 produce. The corresponding dataset maker will automatically use the
-:math:`\theta` values in `~gammapy.irf.RadMax2D` to set the
+:math:`\\theta` values in `~gammapy.irf.RadMax2D` to set the
 appropriate ON region sizes (based on the offset on the observation and
 on the estimated energy binning).
 

--- a/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
@@ -220,7 +220,7 @@ dataset_maker = SpectrumDatasetMaker(
     containment_correction=False, selection=["counts", "exposure", "edisp"]
 )
 
-# tell the background maker to use the WobbleRegionsFinder, let us use 1 off
+# tell the background maker to use the WobbleRegionsFinder, let us use 3 off
 region_finder = WobbleRegionsFinder(n_off_regions=3)
 bkg_maker = ReflectedRegionsBackgroundMaker(region_finder=region_finder)
 

--- a/examples/tutorials/analysis-1d/spectrum_simulation.py
+++ b/examples/tutorials/analysis-1d/spectrum_simulation.py
@@ -37,11 +37,11 @@ distribution of fitted parameters is consistent with the input values.**
 Proposed approach
 -----------------
 
-We will use the following classes:
+We will use the following classes and functions:
 
 -  `~gammapy.datasets.SpectrumDatasetOnOff`
 -  `~gammapy.datasets.SpectrumDataset`
--  `~gammapy.irf.load_cta_irfs`
+-  `~gammapy.irf.load_irf_dict_from_file`
 -  `~gammapy.modeling.models.PowerLawSpectralModel`
 
 """
@@ -62,7 +62,7 @@ import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import Datasets, SpectrumDataset, SpectrumDatasetOnOff
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import SpectrumDatasetMaker
 from gammapy.maps import MapAxis, RegionGeom
 from gammapy.modeling import Fit
@@ -120,7 +120,7 @@ model = SkyModel(spectral_model=model_simu, name="source")
 ######################################################################
 # Load the IRFs
 # In this simulation, we use the CTA-1DC irfs shipped with gammapy.
-irfs = load_cta_irfs(
+irfs = load_irf_dict_from_file(
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
 

--- a/examples/tutorials/analysis-1d/spectrum_simulation.py
+++ b/examples/tutorials/analysis-1d/spectrum_simulation.py
@@ -10,7 +10,7 @@ Prerequisites
 
 -  Knowledge of spectral extraction and datasets used in gammapy, see
    for instance the :doc:`spectral analysis
-   tutorial </tutorials/analysis-1d/spectral_analysis`
+   tutorial </tutorials/analysis-1d/spectral_analysis>`
 
 Context
 -------

--- a/examples/tutorials/analysis-3d/cta_data_analysis.py
+++ b/examples/tutorials/analysis-3d/cta_data_analysis.py
@@ -129,7 +129,7 @@ maker = MapDatasetMaker(selection=["counts", "background", "exposure", "psf"])
 maker_safe_mask = SafeMaskMaker(methods=["offset-max"], offset_max=2.5 * u.deg)
 
 for obs in observations:
-    cutout = stacked.cutout(obs.pointing_radec, width="5 deg")
+    cutout = stacked.cutout(obs.get_pointing_icrs(obs.tmid), width="5 deg")
     dataset = maker.run(cutout, obs)
     dataset = maker_safe_mask.run(dataset, obs)
     stacked.stack(dataset)
@@ -292,7 +292,7 @@ plot_spectrum_datasets_off_regions(datasets, ax=ax)
 # Model fit
 # ~~~~~~~~~
 #
-# The next step is to fit a spectral model, using all data (i.e. a
+# The next step is to fit a spectral model, using all data (i.e. a
 # “global” fit, using all energies).
 #
 

--- a/examples/tutorials/analysis-3d/event_sampling.py
+++ b/examples/tutorials/analysis-3d/event_sampling.py
@@ -95,7 +95,7 @@ import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import DataStore, Observation, observatory_locations
 from gammapy.datasets import MapDataset, MapDatasetEventSampler
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import MapDatasetMaker
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling import Fit
@@ -144,7 +144,7 @@ livetime = 1 * u.hr
 # Now you can create the observation:
 #
 
-irfs = load_cta_irfs(path / irf_filename)
+irfs = load_irf_dict_from_file(path / irf_filename)
 location = observatory_locations["cta_south"]
 
 observation = Observation.create(
@@ -518,7 +518,7 @@ irf_paths = [path / irf_filename] * n_obs
 events_paths = []
 
 for idx, tstart in enumerate(tstarts):
-    irfs = load_cta_irfs(irf_paths[idx])
+    irfs = load_irf_dict_from_file(irf_paths[idx])
     observation = Observation.create(
         obs_id=idx,
         pointing=pointing,

--- a/examples/tutorials/analysis-3d/flux_profiles.py
+++ b/examples/tutorials/analysis-3d/flux_profiles.py
@@ -201,7 +201,7 @@ fig, ax = plt.subplots()
 for quantity in quantities:
     profile[quantity].plot(ax=ax, label=quantity.title())
 
-ax.set_ylabel("Counts ")
+ax.set_ylabel("Counts")
 
 
 ######################################################################

--- a/examples/tutorials/analysis-3d/simulate_3d.py
+++ b/examples/tutorials/analysis-3d/simulate_3d.py
@@ -82,10 +82,7 @@ from gammapy.modeling.models import (
 
 
 ######################################################################
-# We will simulate using the CTA-1DC IRFs shipped with gammapy. Note that
-# for dedictaed CTA simulations, you can simply use
-# ``Observation.from_caldb()` <>`__ without having to externally load
-# the IRFs
+# We will simulate using the CTA-1DC IRFs shipped with gammapy
 #
 
 # Loading IRFs

--- a/examples/tutorials/analysis-3d/simulate_3d.py
+++ b/examples/tutorials/analysis-3d/simulate_3d.py
@@ -36,7 +36,7 @@ Proposed approach
 Here we can’t use the regular observation objects that are connected to
 a `DataStore`. Instead we will create a fake
 `~gammapy.data.Observation` that contain some pointing information and
-the CTA 1DC IRFs (that are loaded with `~gammapy.irf.load_cta_irfs`).
+the CTA 1DC IRFs (that are loaded with `~gammapy.irf.load_irf_dict_from_file`).
 
 Then we will create a `~gammapy.datasets.MapDataset` geometry and
 create it with the `~gammapy.makers.MapDatasetMaker`.
@@ -63,7 +63,7 @@ import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import MapDataset
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import MapDatasetMaker, SafeMaskMaker
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.modeling import Fit
@@ -89,7 +89,7 @@ from gammapy.modeling.models import (
 #
 
 # Loading IRFs
-irfs = load_cta_irfs(
+irfs = load_irf_dict_from_file(
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
 

--- a/examples/tutorials/analysis-time/light_curve_flare.py
+++ b/examples/tutorials/analysis-time/light_curve_flare.py
@@ -8,7 +8,7 @@ Prerequisites
 -------------
 
 -  Understanding of how the light curve estimator works, please refer to
-   the :doc:`light curve notebook </tutorials/analysis-time/light_curve`.
+   the :doc:`light curve notebook </tutorials/analysis-time/light_curve>`.
 
 Context
 -------

--- a/examples/tutorials/analysis-time/light_curve_simulation.py
+++ b/examples/tutorials/analysis-time/light_curve_simulation.py
@@ -83,7 +83,7 @@ log = logging.getLogger(__name__)
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import Datasets, FluxPointsDataset, SpectrumDataset
 from gammapy.estimators import LightCurveEstimator
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import SpectrumDatasetMaker
 from gammapy.maps import MapAxis, RegionGeom, TimeMapAxis
 from gammapy.modeling import Fit
@@ -119,7 +119,7 @@ TimeMapAxis.time_format = "iso"
 #
 
 # Loading IRFs
-irfs = load_cta_irfs(
+irfs = load_irf_dict_from_file(
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
 

--- a/examples/tutorials/api/fitting.py
+++ b/examples/tutorials/api/fitting.py
@@ -236,7 +236,7 @@ for ax, par in zip(axes, datasets.parameters.free_parameters):
     name = datasets.models.parameters_unique_names[idx]
     profile = fit.stat_profile(datasets=datasets, parameter=par)
     ax.plot(profile[f"{name}_scan"], profile["stat_scan"] - total_stat)
-    ax.set_xlabel(f"{par.name} {par.unit}")
+    ax.set_xlabel(f"{par.name} [{par.unit}]")
     ax.set_ylabel("Delta TS")
     ax.set_title(f"{name}:\n {par.value:.1e} +- {par.error:.1e}")
 

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -144,7 +144,7 @@ dataset.counts.sum_over_axes().plot(stretch="sqrt", add_cbar=True)
 #
 # Note that currently some methods computing a safe energy range
 # ("aeff-default", "aeff-max" and "edisp-bias") determine a true energy range and
-#  apply it to reconstructed energy, effectively neglecting the energy dispersion.
+# apply it to reconstructed energy, effectively neglecting the energy dispersion.
 #
 # Multiple methods can be combined. Here is an example :
 #

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -259,7 +259,7 @@ safe_mask_maker = SafeMaskMaker(
 stacked = MapDataset.create(geom)
 
 for obs in observations:
-    local_dataset = stacked.cutout(obs.pointing_radec, width="6 deg")
+    local_dataset = stacked.cutout(obs.get_pointing_icrs(obs.tmid), width="6 deg")
     dataset = dataset_maker.run(local_dataset, obs)
     dataset = safe_mask_maker.run(dataset, obs)
     dataset = fov_bkg_maker.run(dataset)

--- a/examples/tutorials/api/mask_maps.py
+++ b/examples/tutorials/api/mask_maps.py
@@ -47,7 +47,7 @@ sub-section.
 
 The `mask_fit` also can be used to exclude sources or complex regions
 for which we don’t have good enough models. In that case the masking is
-an extra security, it is prefereable to include the available models
+an extra security, it is preferable to include the available models
 even if the sources are masked and frozen.
 
 Note that a dataset contains also a `mask_safe` attribute that is

--- a/examples/tutorials/data/cta.py
+++ b/examples/tutorials/data/cta.py
@@ -67,7 +67,7 @@ from astropy import units as u
 import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import DataStore, EventList
-from gammapy.irf import EffectiveAreaTable2D, load_cta_irfs
+from gammapy.irf import EffectiveAreaTable2D, load_irf_dict_from_file
 
 ######################################################################
 # Check setup
@@ -239,7 +239,7 @@ print(observation.aeff)
 irf_filename = (
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
-irfs = load_cta_irfs(irf_filename)
+irfs = load_irf_dict_from_file(irf_filename)
 print(irfs)
 
 
@@ -368,10 +368,10 @@ plt.show()
 
 # !ls caldb/data/cta/prod3b-v2/bcf
 
-# irfs1 = load_cta_irfs("caldb/data/cta/prod3b-v2/bcf/South_z20_50h/irf_file.fits")
+# irfs1 = load_irf_dict_from_file("caldb/data/cta/prod3b-v2/bcf/South_z20_50h/irf_file.fits")
 # irfs1["aeff"].plot_energy_dependence()
 
-# irfs2 = load_cta_irfs("caldb/data/cta/prod3b-v2/bcf/South_z40_50h/irf_file.fits")
+# irfs2 = load_irf_dict_from_file("caldb/data/cta/prod3b-v2/bcf/South_z40_50h/irf_file.fits")
 # irfs2["aeff"].plot_energy_dependence()
 
 

--- a/examples/tutorials/data/hess.py
+++ b/examples/tutorials/data/hess.py
@@ -169,7 +169,9 @@ geom = WcsGeom.create(
 # compute
 livetime = Map.from_geom(geom, unit=u.hr)
 for obs in observations:
-    geom_obs = geom.cutout(position=obs.pointing_radec, width=2.0 * offset_max)
+    geom_obs = geom.cutout(
+        position=obs.get_pointing_icrs(obs.tmid), width=2.0 * offset_max
+    )
     exposure = MapDatasetMaker.make_exposure(geom=geom_obs, observation=obs)
     on_axis = obs.aeff.evaluate(
         offset=0.0 * u.deg, energy_true=geom.axes["energy_true"].center
@@ -185,8 +187,8 @@ ax = livetime.plot(add_cbar=True)
 # Add the pointing position on top
 for obs in observations:
     ax.plot(
-        obs.pointing_radec.to_pixel(wcs=ax.wcs)[0],
-        obs.pointing_radec.to_pixel(wcs=ax.wcs)[1],
+        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax.wcs)[0],
+        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax.wcs)[1],
         "+",
         color="black",
     )

--- a/examples/tutorials/starting/analysis_2.py
+++ b/examples/tutorials/starting/analysis_2.py
@@ -206,7 +206,7 @@ maker_fov = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
 for obs in observations:
     # First a cutout of the target map is produced
     cutout = stacked.cutout(
-        obs.pointing_radec, width=2 * offset_max, name=f"obs-{obs.obs_id}"
+        obs.get_pointing_icrs(obs.tmid), width=2 * offset_max, name=f"obs-{obs.obs_id}"
     )
     # A MapDataset is filled in this cutout geometry
     dataset = maker.run(cutout, obs)

--- a/gammapy/data/__init__.py
+++ b/gammapy/data/__init__.py
@@ -8,7 +8,7 @@ from .hdu_index_table import HDUIndexTable
 from .obs_table import ObservationTable
 from .observations import Observation, Observations
 from .observers import observatory_locations
-from .pointing import FixedPointingInfo, PointingInfo
+from .pointing import FixedPointingInfo, PointingInfo, PointingMode
 
 __all__ = [
     "DataStore",
@@ -22,4 +22,5 @@ __all__ = [
     "ObservationTable",
     "observatory_locations",
     "PointingInfo",
+    "PointingMode",
 ]

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -322,11 +322,11 @@ class DataStore:
                 f"Required HDUs {missing_hdus} not found in observation {obs_id}"
             )
 
-        # if we didn't find the pointing hdu, extract FixedPointingInfo from events
-        if "pointing" not in kwargs:
-            pointing_location = copy(kwargs["events"])
-            pointing_location.hdu_class = "pointing"
-            kwargs["pointing"] = pointing_location
+        # TODO: right now, gammapy doesn't support using the pointing table of GADF
+        # so we always pass the events location here to be read into a FixedPointingInfo
+        pointing_location = copy(kwargs["events"])
+        pointing_location.hdu_class = "pointing"
+        kwargs["pointing"] = pointing_location
 
         return Observation(**kwargs)
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import subprocess
+from copy import copy
 from pathlib import Path
 import numpy as np
 from astropy import units as u
@@ -15,7 +16,7 @@ from .observations import Observation, ObservationChecker, Observations
 __all__ = ["DataStore"]
 
 ALL_IRFS = ["aeff", "edisp", "psf", "bkg", "rad_max"]
-ALL_HDUS = ["events", "gti"] + ALL_IRFS
+ALL_HDUS = ["events", "gti", "pointing"] + ALL_IRFS
 REQUIRED_IRFS = {
     "full-enclosure": {"aeff", "edisp", "psf", "bkg"},
     "point-like": {"aeff", "edisp"},
@@ -320,6 +321,12 @@ class DataStore:
             raise MissingRequiredHDU(
                 f"Required HDUs {missing_hdus} not found in observation {obs_id}"
             )
+
+        # if we didn't find the pointing hdu, extract FixedPointingInfo from events
+        if "pointing" not in kwargs:
+            pointing_location = copy(kwargs["events"])
+            pointing_location.hdu_class = "pointing"
+            kwargs["pointing"] = pointing_location
 
         return Observation(**kwargs)
 

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -475,7 +475,7 @@ class EventList:
         time = self.table["TIME"]
         time = time - np.min(time)
 
-        ax.set_xlabel("Time (sec)")
+        ax.set_xlabel("Time [sec]")
         ax.set_ylabel("Counts")
         y, x_edges = np.histogram(time, bins=20)
 
@@ -559,7 +559,7 @@ class EventList:
         with quantity_support():
             ax.hist(offset2, **kwargs)
 
-        ax.set_xlabel(f"Offset^2 ({ax.xaxis.units})")
+        ax.set_xlabel(f"Offset^2 [{ax.xaxis.units}]")
         ax.set_ylabel("Counts")
         return ax
 

--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -17,7 +17,16 @@ class HDUIndexTable(Table):
     See :ref:`gadf:hdu-index`.
     """
 
-    VALID_HDU_TYPE = ["events", "gti", "aeff", "edisp", "psf", "bkg", "rad_max"]
+    VALID_HDU_TYPE = [
+        "events",
+        "gti",
+        "aeff",
+        "edisp",
+        "psf",
+        "bkg",
+        "rad_max",
+        "pointing",
+    ]
     """Valid values for `HDU_TYPE`."""
 
     VALID_HDU_CLASS = [
@@ -31,6 +40,7 @@ class HDUIndexTable(Table):
         "bkg_2d",
         "bkg_3d",
         "rad_max_2d",
+        "pointing",
     ]
     """Valid values for `HDU_CLASS`."""
 

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -3,6 +3,7 @@ import collections.abc
 import copy
 import inspect
 import logging
+import warnings
 from itertools import zip_longest
 import numpy as np
 import astropy.units as u
@@ -13,6 +14,7 @@ from astropy.units import Quantity
 from astropy.utils import lazyproperty
 import matplotlib.pyplot as plt
 from gammapy import __version__
+from gammapy.utils.deprecation import GammapyDeprecationWarning, deprecated
 from gammapy.utils.fits import LazyFitsData, earth_location_to_dict
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import Checker
@@ -62,6 +64,7 @@ class Observation:
     _rad_max = LazyFitsData(cache=False)
     _events = LazyFitsData(cache=False)
     _gti = LazyFitsData(cache=False)
+    _pointing = LazyFitsData(cache=True)
 
     def __init__(
         self,
@@ -75,6 +78,8 @@ class Observation:
         rad_max=None,
         events=None,
         obs_filter=None,
+        pointing=None,
+        location=None,
     ):
         self.obs_id = obs_id
         self._obs_info = obs_info
@@ -85,6 +90,8 @@ class Observation:
         self._rad_max = rad_max
         self._gti = gti
         self._events = events
+        self._pointing = pointing
+        self._location = location
         self.obs_filter = obs_filter or ObservationFilter()
 
     @property
@@ -142,10 +149,12 @@ class Observation:
     ):
         """Create obs info dict from in memory data"""
         obs_info = {
-            "RA_PNT": pointing.icrs.ra.deg,
-            "DEC_PNT": pointing.icrs.dec.deg,
             "DEADC": 1 - deadtime_fraction,
         }
+        if isinstance(pointing, SkyCoord):
+            obs_info["RA_PNT"] = pointing.icrs.ra.deg
+            obs_info["DEC_PNT"] = pointing.icrs.dec.deg
+
         obs_info.update(time_ref_to_dict(reference_time))
         obs_info["TSTART"] = time_relative_to_ref(time_start, obs_info).to_value(u.s)
         obs_info["TSTOP"] = time_relative_to_ref(time_stop, obs_info).to_value(u.s)
@@ -174,8 +183,8 @@ class Observation:
 
         Parameters
         ----------
-        pointing : `~astropy.coordinates.SkyCoord`
-            Pointing position
+        pointing : `~gammapy.data.FixedPointingInfo` or `~astropy.coordinates.SkyCoord`
+            Pointing information
         obs_id : int
             Observation ID as identifier
         livetime : ~astropy.units.Quantity`
@@ -204,7 +213,6 @@ class Observation:
             tstop = tstart + Quantity(livetime)
 
         gti = GTI.create(tstart, tstop, reference_time=reference_time)
-
         obs_info = cls._get_obs_info(
             pointing=pointing,
             deadtime_fraction=deadtime_fraction,
@@ -213,6 +221,13 @@ class Observation:
             reference_time=reference_time,
             location=location,
         )
+
+        if not isinstance(pointing, FixedPointingInfo):
+            warnings.warn(
+                "Pointing will be required to be provided as FixedPointingInfo",
+                GammapyDeprecationWarning,
+            )
+            pointing = FixedPointingInfo.from_fits_header(obs_info)
 
         return cls(
             obs_id=obs_id,
@@ -223,6 +238,8 @@ class Observation:
             edisp=irfs.get("edisp"),
             psf=irfs.get("psf"),
             rad_max=irfs.get("rad_max"),
+            pointing=pointing,
+            location=location,
         )
 
     @property
@@ -234,6 +251,11 @@ class Observation:
     def tstop(self):
         """Observation stop time (`~astropy.time.Time`)."""
         return self.gti.time_stop[0]
+
+    @property
+    def tmid(self):
+        """Midpoint between start and stop time"""
+        return self.tstart + 0.5 * (self.tstop - self.tstart)
 
     @property
     def observation_time_duration(self):
@@ -286,29 +308,56 @@ class Observation:
             )
         return meta
 
+    @property
+    def pointing(self):
+        if self._pointing is None:
+            self._pointing = FixedPointingInfo.from_fits_header(self.obs_info)
+        return self._pointing
+
+    def get_pointing_altaz(self, time):
+        """Get the pointing in altaz for given time"""
+        return self.pointing.get_altaz(time, self.observatory_earth_location)
+
+    def get_pointing_icrs(self, time):
+        """Get the pointing in icrs for given time"""
+        return self.pointing.get_icrs(time, self.observatory_earth_location)
+
     @lazyproperty
+    @deprecated(
+        "v1.1",
+        message="Use observation.pointing or observation.get_pointing_{{altaz,icrs}} instead",
+    )
     def fixed_pointing_info(self):
         """Fixed pointing info for this observation (`FixedPointingInfo`)."""
-        return FixedPointingInfo(self.obs_info)
+        return self._pointing
 
     @property
+    @deprecated("v1.1", message="Use observation.get_pointing_icrs(time) instead")
     def pointing_radec(self):
         """Pointing RA / DEC sky coordinates (`~astropy.coordinates.SkyCoord`)."""
         return self.fixed_pointing_info.radec
 
     @property
+    @deprecated("v1.1", message="Use observation.get_pointing_altaz(time) instead")
     def pointing_altaz(self):
         return self.fixed_pointing_info.altaz
 
     @property
+    @deprecated("v1.1", message="Use observation.get_pointing_altaz(time).zen instead")
     def pointing_zen(self):
         """Pointing zenith angle sky (`~astropy.units.Quantity`)."""
-        return self.fixed_pointing_info.altaz.zen
+        return self.get_pointing_altaz(self.tmid).zen
 
     @property
     def observatory_earth_location(self):
         """Observatory location (`~astropy.coordinates.EarthLocation`)."""
-        return self.fixed_pointing_info.location
+        if self._location is not None:
+            return self._location
+
+        # for now we catch the deprecation warning until we store location on the observation properly
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=GammapyDeprecationWarning)
+            return self.fixed_pointing_info.location
 
     @lazyproperty
     def target_radec(self):
@@ -325,8 +374,9 @@ class Observation:
         return self.obs_info.get("MUONEFF", 1)
 
     def __str__(self):
-        ra = self.pointing_radec.ra.deg
-        dec = self.pointing_radec.dec.deg
+        pointing = self.get_pointing_icrs(self.tmid)
+        ra = pointing.ra.deg
+        dec = pointing.dec.deg
 
         pointing = f"{ra:.1f} deg, {dec:.1f} deg\n"
         # TODO: Which target was observed?
@@ -460,6 +510,7 @@ class Observation:
             gti=gti,
             obs_info=obs_info,
             obs_id=obs_info.get("OBS_ID"),
+            pointing=FixedPointingInfo.from_fits_header(obs_info),
             **irf_dict,
         )
 
@@ -491,7 +542,9 @@ class Observation:
 
         events = self.events
         if events is not None:
-            hdul.append(events.to_table_hdu(format=format))
+            events_hdu = events.to_table_hdu(format=format)
+            events_hdu.header.update(self.pointing.to_fits_header())
+            hdul.append(events_hdu)
 
         gti = self.gti
         if gti is not None:
@@ -542,7 +595,11 @@ class Observation:
             argnames.remove("self")
 
             for name in argnames:
-                value = getattr(self, name)
+                if name == "location":
+                    attr = "observatory_earth_location"
+                else:
+                    attr = name
+                value = getattr(self, attr)
                 kwargs.setdefault(name, copy.deepcopy(value))
             return self.__class__(**kwargs)
 

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -692,6 +692,27 @@ class Observations(collections.abc.MutableSequence):
     def _ipython_key_completions_(self):
         return self.ids
 
+    def group_by_label(self, labels):
+        """Split obsevations in multiple groups of observations
+
+        Parameters
+        ----------
+        labels : array
+            Array of group labels
+
+        Returns
+        -------
+        obs_clusters : dict of `~gammapy.data.Observations`
+            dict of Observations instance, one instance for each group.
+        """
+        obs_groups = {}
+        for label in np.unique(labels):
+            observations = self.__class__(
+                [obs for k, obs in enumerate(self) if labels[k] == label]
+            )
+            obs_groups[f"group_{label}"] = observations
+        return obs_groups
+
 
 class ObservationChecker(Checker):
     """Check an observation.

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
+import warnings
 from enum import Enum, auto
 import numpy as np
 import scipy.interpolate
@@ -10,12 +11,14 @@ from astropy.coordinates import (
     SkyCoord,
     UnitSphericalRepresentation,
 )
+from astropy.io import fits
 from astropy.table import Table
 from astropy.units import Quantity
 from astropy.utils import lazyproperty
-from gammapy.utils.fits import earth_location_from_dict
+from gammapy.utils.deprecation import GammapyDeprecationWarning, deprecated
+from gammapy.utils.fits import earth_location_from_dict, earth_location_to_dict
 from gammapy.utils.scripts import make_path
-from gammapy.utils.time import time_ref_from_dict
+from gammapy.utils.time import time_ref_from_dict, time_ref_to_dict, time_to_fits_header
 
 log = logging.getLogger(__name__)
 
@@ -67,45 +70,232 @@ class FixedPointingInfo:
     Parameters
     ----------
     meta : `~astropy.table.Table.meta`
-        Meta header info from Table on pointing
+        Meta header info from Table on pointing.
+        Passing this is deprecated, provide ``mode`` and ``fixed_icrs`` or ``fixed_altaz``
+        instead or use `FixedPointingInfo.from_fits_header` instead.
+    mode : `PointingMode`
+        How the telescope was pointing during the observation
+    fixed_icrs : SkyCoord in ICRS frame
+        Mandatory if mode is `PointingMode.POINTING`, the ICRS coordinates that are fixed
+        for the duration of the observation.
+    fixed_altaz : SkyCoord in AltAz frame
+        Mandatory if mode is `PointingMode.DRIFT`, the AltAz coordinates that are fixed
+        for the duration of the observation.
 
     Examples
     --------
-    >>> from gammapy.data import PointingInfo
-    >>> path = '$GAMMAPY_DATA/tests/pointing_table.fits.gz'
-    >>> pointing_info = PointingInfo.read(path)
+    >>> from gammapy.data import FixedPointingInfo, PointingMode
+    >>> from astropy.coordinates import SkyCoord
+    >>> import astropy.units as u
+    >>> fixed_icrs = SkyCoord(83.633 * u.deg, 22.014 * u.deg, frame="icrs")
+    >>> pointing_info = FixedPointingInfo(mode=PointingMode.POINTING, fixed_icrs=fixed_icrs)
     >>> print(pointing_info)
-    Pointing info:
+    FixedPointingInfo:
     <BLANKLINE>
-    Location:     GeodeticLocation(lon=<Longitude 16.50022222 deg>, lat=<Latitude -23.27177778 deg>, height=<Quantity 1835. m>)  # noqa: E501
-    MJDREFI, MJDREFF, TIMESYS = (51910, 0.000742870370370241, 'TT')
-    Time ref:     2001-01-01T00:01:04.184
-    Time ref:     51910.00074287037 MJD (TT)
-    Duration:     1586.0000000000018 sec = 0.44055555555555603 hours
-    Table length: 100
-    <BLANKLINE>
-    START:
-    Time:  2004-01-21T19:50:02.184
-    Time:  53025.826414166666 MJD (TT)
-    RADEC: 83.6333 24.5144 deg
-    ALTAZ: 11.4575 41.3409 deg
-    <BLANKLINE>
-    <BLANKLINE>
-    END:
-    Time:  2004-01-21T20:16:28.184
-    Time:  53025.844770648146 MJD (TT)
-    RADEC: 83.6333 24.5144 deg
-    ALTAZ: 3.44573 42.1319 deg
-    <BLANKLINE>
-    <BLANKLINE>
-
-    Note: In order to reproduce the example you need the tests datasets folder.
-    You may download it with the command
-    ``gammapy download datasets --tests --out $GAMMAPY_DATA``
+    mode:        PointingMode.POINTING
+    coordinates: <SkyCoord (ICRS): (ra, dec) in deg
+        (83.633, 22.014)>
     """
 
-    def __init__(self, meta):
-        self.meta = meta
+    def __init__(
+        self,
+        meta=None,
+        mode=None,
+        fixed_icrs=None,
+        fixed_altaz=None,
+        # these have nothing really to do with pointing_info
+        # needed for backwards compatibility but should be removed and accessed
+        # from the observation, not the pointing info.
+        location=None,
+        time_start=None,
+        time_stop=None,
+        time_ref=None,
+        legacy_altaz=None,  # store altaz given for mode=POINTING separately so it can be removed easily
+    ):
+        self._meta = None
+
+        # TODO: for backwards compatibility, remove in 2.0
+        # and make other keywards required
+        if meta is not None:
+            warnings.warn(
+                "Initializing a FixedPointingInfo using a `meta` dict is deprecated",
+                GammapyDeprecationWarning,
+            )
+            self._meta = meta
+            self.__dict__.update(self.from_fits_header(meta).__dict__)
+            return
+
+        if not isinstance(mode, PointingMode):
+            raise TypeError(f"mode must be an instance of PointingMode, got {mode!r}")
+
+        self._mode = mode
+        self._location = location
+        self._time_start = time_start
+        self._time_stop = time_stop
+        self._time_ref = time_ref
+        self._legacy_altaz = legacy_altaz or AltAz(np.nan * u.deg, np.nan * u.deg)
+
+        if mode is PointingMode.POINTING:
+            if fixed_icrs is None:
+                raise ValueError("fixed_icrs is mandatory for PointingMode.POINTING")
+
+            if np.isnan(fixed_icrs.ra.value) or np.isnan(fixed_icrs.dec.value):
+                warnings.warn(
+                    "In future, fixed_icrs must have non-nan values",
+                    GammapyDeprecationWarning,
+                )
+
+            self._fixed_icrs = fixed_icrs
+            self._fixed_altaz = None
+
+        elif mode is PointingMode.DRIFT:
+            if fixed_altaz is None:
+                raise ValueError("pointing_altaz is required for PointingMode.DRIFT")
+
+            if fixed_icrs is not None:
+                raise ValueError("fixed_icrs is excluded for PointingMode.DRIFT")
+
+            self._fixed_altaz = fixed_altaz
+            self._fixed_icrs = None
+        else:
+            raise ValueError(f"Unsupported pointing mode for FixedPointingInfo: {mode}")
+
+    @classmethod
+    def from_fits_header(cls, header):
+        """
+        Parse FixedPointingInfo from the given fits header
+
+        Parameters
+        ----------
+        header : astropy.fits.Header
+            Header to parse, e.g. from a GADF EVENTS HDU.
+            Currently, only GADF is supported.
+
+        Returns
+        -------
+        pointing: FixedPointingInfo
+            The FixedPointingInfo instance filled from the given header
+        """
+        obs_mode = header.get("OBS_MODE", "POINTING")
+        mode = PointingMode.from_gadf_string(obs_mode)
+        try:
+            location = earth_location_from_dict(header)
+        except KeyError:
+            location = None
+
+        # we allow missing RA_PNT / DEC_PNT in POINTING for some reason...
+        # FIXME: actually enforce this to be present instead of using nan
+        ra = u.Quantity(header.get("RA_PNT", np.nan), u.deg)
+        dec = u.Quantity(header.get("DEC_PNT", np.nan), u.deg)
+        alt = header.get("ALT_PNT")
+        az = header.get("AZ_PNT")
+        legacy_altaz = None
+
+        fixed_icrs = None
+        pointing_altaz = None
+
+        # we can be more strict with DRIFT, as support was only added recently
+        if mode is PointingMode.DRIFT:
+            if alt is None or az is None:
+                raise IOError(
+                    "Keywords ALT_PNT and AZ_PNT are required for OBSMODE=DRIFT"
+                )
+            pointing_altaz = AltAz(alt=alt * u.deg, az=az * u.deg)
+        else:
+            fixed_icrs = SkyCoord(ra, dec)
+            if np.isnan(ra.value) or np.isnan(dec.value):
+                warnings.warn(
+                    "RA_PNT / DEC_PNT will be required in a future version of"
+                    " gammapy for pointing-mode POINTING",
+                    GammapyDeprecationWarning,
+                )
+            # store given altaz also for POINTING for backwards compatibility,
+            # FIXME: remove in 2.0
+            if alt is not None and az is not None:
+                legacy_altaz = AltAz(alt=alt * u.deg, az=az * u.deg)
+
+        time_start = header.get("TSTART")
+        time_stop = header.get("TSTOP")
+        time_ref = None
+
+        if time_start is not None or time_stop is not None:
+            time_ref = time_ref_from_dict(header)
+            time_unit = u.Unit(header.get("TIMEUNIT", "s"), format="fits")
+
+            if time_start is not None:
+                time_start = time_ref + u.Quantity(time_start, time_unit)
+
+            if time_stop is not None:
+                time_stop = time_ref + u.Quantity(time_stop, time_unit)
+
+        return cls(
+            mode=mode,
+            location=location,
+            fixed_icrs=fixed_icrs,
+            fixed_altaz=pointing_altaz,
+            time_start=time_start,
+            time_stop=time_stop,
+            time_ref=time_ref,
+            legacy_altaz=legacy_altaz,
+        )
+
+    def to_fits_header(self, format="gadf", version="0.3", time_ref=None):
+        """
+        Convert this FixedPointingInfo object into a fits header for the given format
+
+        Parameters
+        ----------
+        format : str
+            Format, currently only "gadf" is supported
+        version : str
+            Version of the ``format``, this function currently supports
+            gadf versions 0.2 and 0.3.
+        time_ref : astropy.time.Time or None
+            Reference time for storing the time related information in fits format
+
+        Returns
+        -------
+        header : astropy.fits.Header
+            Header with fixed pointing information filled for the requested format
+        """
+        if format != "gadf":
+            raise ValueError(f'Only the "gadf" format supported, got {format}')
+
+        if version not in {"0.2", "0.3"}:
+            raise ValueError(f"Unsupported version {version} for format {format}")
+
+        if self.mode == PointingMode.DRIFT and version == "0.2":
+            raise ValueError("mode=DRIFT is only supported by GADF 0.3")
+
+        header = fits.Header()
+        if self.mode is PointingMode.POINTING:
+            header["OBS_MODE"] = "POINTING"
+            header["RA_PNT"] = self.fixed_icrs.ra.deg, u.deg.to_string("fits")
+            header["DEC_PNT"] = self.fixed_icrs.dec.deg, u.deg.to_string("fits")
+        elif self.mode is PointingMode.POINTING:
+            header["OBS_MODE"] = "DRIFT"
+            header["AZ_PNT"] = self.fixed_altaz.az.deg, u.deg.to_string("fits")
+            header["ALT_PNT"] = self.fixed_altaz.alt.deg, u.deg.to_string("fits")
+
+        # FIXME: remove in 2.0
+        if self._legacy_altaz is not None and not np.isnan(
+            self._legacy_altaz.alt.value
+        ):
+            header["AZ_PNT"] = self._legacy_altaz.az.deg, u.deg.to_string("fits")
+            header["ALT_PNT"] = self._legacy_altaz.alt.deg, u.deg.to_string("fits")
+
+        if self._time_start is not None:
+            header["TSTART"] = time_to_fits_header(self._time_start, epoch=time_ref)
+        if self._time_stop is not None:
+            header["TSTOP"] = time_to_fits_header(self._time_start, epoch=time_ref)
+
+        if self._time_start is not None or self._time_stop is not None:
+            header.update(time_ref_to_dict(time_ref))
+
+        if self._location is not None:
+            header.update(earth_location_to_dict(self._location))
+
+        return header
 
     @classmethod
     def read(cls, filename, hdu="EVENTS"):
@@ -124,120 +314,32 @@ class FixedPointingInfo:
             Pointing info object
         """
         filename = make_path(filename)
-        table = Table.read(filename, hdu=hdu)
-        return cls(meta=table.meta)
+        header = fits.getheader(filename, extname=hdu)
+        return cls.from_fits_header(header)
 
-    @lazyproperty
+    @property
     def mode(self):
         """See `PointingMode`, if not present, assume POINTING"""
-        obs_mode = self.meta.get("OBS_MODE")
-        if obs_mode is None:
-            return PointingMode.POINTING
-        return PointingMode.from_gadf_string(obs_mode)
+        return self._mode
 
-    @lazyproperty
-    def location(self):
-        """Observatory location (`~astropy.coordinates.EarthLocation`)."""
-        return earth_location_from_dict(self.meta)
-
-    @lazyproperty
-    def time_ref(self):
-        """Time reference (`~astropy.time.Time`)."""
-        return time_ref_from_dict(self.meta)
-
-    @lazyproperty
-    def time_start(self):
-        """Start time (`~astropy.time.Time`)."""
-        t_start = Quantity(self.meta["TSTART"], "second")
-        return self.time_ref + t_start
-
-    @lazyproperty
-    def time_stop(self):
-        """Stop time (`~astropy.time.Time`)."""
-        t_stop = Quantity(self.meta["TSTOP"], "second")
-        return self.time_ref + t_stop
-
-    @lazyproperty
-    def obstime(self):
-        """Average observation time for the observation (`~astropy.time.Time`)."""
-        return self.time_start + self.duration / 2
-
-    @lazyproperty
-    def duration(self):
-        """Pointing duration (`~astropy.time.TimeDelta`).
-
-        The time difference between the TSTART and TSTOP.
-        """
-        return self.time_stop - self.time_start
-
-    @lazyproperty
-    def radec(self):
-        """
-        RA/DEC pointing position from table (`~astropy.coordinates.SkyCoord`).
-
-        Use `get_icrs` to get the pointing at a specific time, correctly
-        handling different pointing modes.
-        """
-        ra = self.meta["RA_PNT"]
-        dec = self.meta["DEC_PNT"]
-        return SkyCoord(ra, dec, unit="deg", frame="icrs")
-
-    @lazyproperty
-    def altaz_frame(self):
-        """ALT / AZ frame (`~astropy.coordinates.AltAz`)."""
-        return AltAz(obstime=self.obstime, location=self.location)
-
-    @lazyproperty
-    def altaz(self):
-        """
-        ALT/AZ pointing position computed from RA/DEC (`~astropy.coordinates.SkyCoord`)
-        for the midpoint of the run.
-
-        Use `get_altaz` to get the pointing at a specific time, correctly
-        handling different pointing modes.
-        """
-        try:
-            frame = self.altaz_frame
-        except KeyError:
-            log.warning(
-                "Location or time information missing,"
-                " using ALT_PNT/AZ_PNT and incomplete frame"
-            )
-            return SkyCoord(
-                alt=self.meta.get("ALT_PNT", np.nan),
-                az=self.meta.get("AZ_PNT", np.nan),
-                unit=u.deg,
-                frame=AltAz(),
-            )
-
-        return self.radec.transform_to(frame)
-
-    @lazyproperty
+    @property
     def fixed_altaz(self):
         """The fixed coordinates in AltAz of the observation.
 
         None if not a DRIFT observation
         """
-        if self.mode != PointingMode.DRIFT:
-            return None
+        return self._fixed_altaz
 
-        alt = u.Quantity(self.meta["ALT_PNT"], u.deg)
-        az = u.Quantity(self.meta["AZ_PNT"], u.deg)
-        return SkyCoord(alt=alt, az=az, frame=self.altaz_frame)
-
-    @lazyproperty
+    @property
     def fixed_icrs(self):
         """
         The fixed coordinates in ICRS of the observation.
 
         None if not a POINTING observation
         """
-        if self.mode != PointingMode.POINTING:
-            return None
+        return self._fixed_icrs
 
-        return self.radec
-
-    def get_icrs(self, obstime):
+    def get_icrs(self, obstime=None, location=None) -> SkyCoord:
         """
         Get the pointing position in ICRS frame for a given time.
 
@@ -252,17 +354,22 @@ class FixedPointingInfo:
         ----------
         obstime: `astropy.time.Time`
             Time for which to get the pointing position in ICRS frame
+        location: `astropy.coordinates.EarthLocation`
+            Observatory location, only needed for drift observations to transform
+            from horizontal coordinates to ICRS.
         """
         if self.mode == PointingMode.POINTING:
-            icrs = self.fixed_icrs
-            return SkyCoord(ra=icrs.ra, dec=icrs.dec, obstime=obstime, frame="icrs")
+            return SkyCoord(self._fixed_icrs.data, location=location, obstime=obstime)
 
         if self.mode == PointingMode.DRIFT:
-            return self.get_altaz(obstime).icrs
+            if obstime is None:
+                obstime = self.obstime
+
+            return self.get_altaz(obstime, location=location).icrs
 
         raise ValueError(f"Unsupported pointing mode: {self.mode}.")
 
-    def get_altaz(self, obstime):
+    def get_altaz(self, obstime=None, location=None) -> SkyCoord:
         """
         Get the pointing position in AltAz frame for a given time.
 
@@ -277,21 +384,129 @@ class FixedPointingInfo:
         ----------
         obstime: `astropy.time.Time`
             Time for which to get the pointing position in AltAz frame
+        location: `astropy.coordinates.EarthLocation`
+            Observatory location, only needed for pointing observations to transform
+            from ICRS to horizontal coordinates.
         """
-        frame = AltAz(location=self.location, obstime=obstime)
+        location = location if location is not None else self.location
+        frame = AltAz(location=location, obstime=obstime)
 
         if self.mode == PointingMode.POINTING:
             return self.fixed_icrs.transform_to(frame)
 
         if self.mode == PointingMode.DRIFT:
             # see https://github.com/astropy/astropy/issues/12965
+            alt = self.fixed_altaz.alt
+            az = self.fixed_altaz.az
             return SkyCoord(
-                alt=np.full(obstime.shape, self.fixed_altaz.alt.deg) * u.deg,
-                az=np.full(obstime.shape, self.fixed_altaz.az.deg) * u.deg,
+                alt=u.Quantity(np.full(obstime.shape, alt.deg), u.deg, copy=False),
+                az=u.Quantity(np.full(obstime.shape, az.deg), u.deg, copy=False),
                 frame=frame,
             )
 
         raise ValueError(f"Unsupported pointing mode: {self.mode}.")
+
+    # the rest is deprecated...
+    @property
+    @deprecated("1.1")
+    def meta(self):
+        if self._meta is not None:
+            return self._meta
+        return dict(self.to_fits_header(time_ref=self._time_ref))
+
+    @property
+    @deprecated("1.1")
+    def location(self):
+        """Observatory location (`~astropy.coordinates.EarthLocation`)."""
+        return self._location
+
+    @property
+    @deprecated("1.1")
+    def time_start(self):
+        """Start time (`~astropy.time.Time`)."""
+        return self._time_start
+
+    @property
+    @deprecated("1.1")
+    def time_stop(self):
+        """Stop time (`~astropy.time.Time`)."""
+        warnings.warn(
+            "Accessing time information through pointing is deprecated",
+            DeprecationWarning,
+        )
+        return self._time_stop
+
+    @property
+    @deprecated("1.1")
+    def time_ref(self):
+        """Reference time (`~astropy.time.Time`)."""
+        return self._time_ref
+
+    @lazyproperty
+    @deprecated("1.1")
+    def obstime(self):
+        """Average observation time for the observation (`~astropy.time.Time`)."""
+        if self.time_start is None or self.duration is None:
+            return None
+        return self.time_start + self.duration / 2
+
+    @lazyproperty
+    @deprecated("1.1")
+    def duration(self):
+        """Pointing duration (`~astropy.time.TimeDelta`).
+
+        The time difference between the TSTART and TSTOP.
+        """
+        if self.time_start is None or self.time_stop is None:
+            return None
+        return self.time_stop - self.time_start
+
+    @lazyproperty
+    @deprecated("1.1")
+    def radec(self):
+        """
+        RA/DEC pointing position from table (`~astropy.coordinates.SkyCoord`).
+
+        Use `get_icrs` to get the pointing at a specific time, correctly
+        handling different pointing modes.
+        """
+        return self._fixed_icrs
+
+    @lazyproperty
+    @deprecated("1.1")
+    def altaz_frame(self):
+        """ALT / AZ frame (`~astropy.coordinates.AltAz`)."""
+        return AltAz(obstime=self.obstime, location=self.location)
+
+    @lazyproperty
+    @deprecated("1.1")
+    def altaz(self):
+        """
+        ALT/AZ pointing position computed from RA/DEC (`~astropy.coordinates.SkyCoord`)
+        for the midpoint of the run.
+
+        Use `get_altaz` to get the pointing at a specific time, correctly
+        handling different pointing modes.
+        """
+        frame = AltAz(location=self.location, obstime=self.obstime)
+        if frame.location is None or frame.obstime is None:
+            log.warning(
+                "Location or time information missing,"
+                " using ALT_PNT/AZ_PNT and incomplete frame"
+            )
+            return self._legacy_altaz
+
+        return self.radec.transform_to(frame)
+
+    def __str__(self):
+        coordinates = (
+            self.fixed_icrs if self.mode == PointingMode.POINTING else self.fixed_altaz
+        )
+        return (
+            "FixedPointingInfo:\n\n"
+            f"mode:        {self.mode}\n"
+            f"coordinates: {coordinates}"
+        )
 
 
 class PointingInfo:
@@ -311,7 +526,7 @@ class PointingInfo:
     >>> print(pointing_info)
     Pointing info:
     <BLANKLINE>
-    Location:     GeodeticLocation(lon=<Longitude 16.50022222 deg>, lat=<Latitude -23.27177778 deg>, height=<Quantity 1835. m>) # noqa: E501
+    Location:     GeodeticLocation(lon=<Longitude 16.50022222 deg>, lat=<Latitude -23.27177778 deg>, height=<Quantity 1835. m>)
     MJDREFI, MJDREFF, TIMESYS = (51910, 0.000742870370370241, 'TT')
     Time ref:     2001-01-01T00:01:04.184
     Time ref:     51910.00074287037 MJD (TT)

--- a/gammapy/data/tests/test_hdu_index_table.py
+++ b/gammapy/data/tests/test_hdu_index_table.py
@@ -111,7 +111,7 @@ def test_hdu_index_table_hd_hap(capfd):
         hdu_index.hdu_location(obs_id=23523, hdu_type="invalid")
     msg = (
         "Invalid hdu_type: invalid. Valid values are: ['events', 'gti', 'aeff', "
-        "'edisp', 'psf', 'bkg', 'rad_max']"
+        "'edisp', 'psf', 'bkg', 'rad_max', 'pointing']"
     )
     assert str(excinfo.value) == msg
 
@@ -119,7 +119,7 @@ def test_hdu_index_table_hd_hap(capfd):
         hdu_index.hdu_location(obs_id=23523, hdu_class="invalid")
     msg = (
         "Invalid hdu_class: invalid. Valid values are: ['events', 'gti', 'aeff_2d', 'edisp_2d', "
-        "'psf_table', 'psf_3gauss', 'psf_king', 'bkg_2d', 'bkg_3d', 'rad_max_2d']"
+        "'psf_table', 'psf_3gauss', 'psf_king', 'bkg_2d', 'bkg_3d', 'rad_max_2d', 'pointing']"
     )
     assert str(excinfo.value) == msg
 

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -7,7 +7,7 @@ from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
 from gammapy.data import DataStore, Observation
-from gammapy.irf import PSF3D, load_cta_irfs
+from gammapy.irf import PSF3D, load_irf_dict_from_file
 from gammapy.utils.fits import HDULocation
 from gammapy.utils.testing import (
     assert_skycoord_allclose,
@@ -219,7 +219,7 @@ def test_observations_select_time_time_intervals_list(data_store):
 def test_observation_cta_1dc():
     ontime = 5.0 * u.hr
     pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
 

--- a/gammapy/data/utils.py
+++ b/gammapy/data/utils.py
@@ -80,7 +80,7 @@ def get_irfs_features(
                         obs.edisp.axes["offset"].center[-1],
                     )
                     offset = np.minimum(
-                        position.separation(obs.pointing_radec), offset_max
+                        position.separation(obs.get_pointing_icrs(obs.tmid)), offset_max
                     )
             else:
                 offset = fixed_offset

--- a/gammapy/data/utils.py
+++ b/gammapy/data/utils.py
@@ -1,0 +1,117 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+import astropy.units as u
+from astropy.table import Column, Table
+from gammapy.irf import EDispKernelMap, PSFMap
+from gammapy.utils.cluster import standard_scaler
+
+
+def get_irfs_features(
+    observations,
+    energy_true,
+    position=None,
+    fixed_offset=None,
+    names=None,
+    containment_fraction=0.68,
+    apply_standard_scaler=False,
+):
+    """Get features from irfs properties at a given position.
+    Used for observations clustering.
+
+    Parameters
+    ----------
+    observations : `~gammapy.data.Observations`
+        Container holding a list of `~gammapy.data.Observation`
+    energy_true : `~astropy.units.Quantity`
+        Energy true at which to compute the containment radius
+    position : `~astropy.coordinates.SkyCoord`
+        Sky position.
+    fixed_offset : `~astropy.coordinates.Angle`
+        Offset calculated from the pointing position.
+        If neither the position nor fixed_offset is specified,
+        it uses the position of the center of the map by default.
+    names : list of str
+        IRFs properties to be considered.
+        Available options are ["edisp-bias", "edisp-res", "psf-radius"]
+        (all used by default).
+    containment_fraction : float
+        Containment_fraction to compute the `psf-radius`.
+        Default is 68%.
+    standard_scaler : bool
+        Compute standardize features by removing the mean and scaling to unit variance.
+        Default is False.
+
+    Returns
+    -------
+    features : `~astropy.table.Table`
+        Features table
+
+    """
+
+    if names is None:
+        names = ["edisp-bias", "edisp-res", "psf-radius"]
+
+    if position and fixed_offset:
+        raise ValueError(
+            "`position` and `fixed_offset` arguments are mutually exclusive"
+        )
+
+    n_obs = len(observations)
+    n_features = len(names)
+    data = np.zeros((n_obs, n_features))
+    units = [u.Unit("")] * n_features
+    for (
+        ko,
+        obs,
+    ) in enumerate(observations):
+        psf_kwargs = dict(fraction=containment_fraction, energy_true=energy_true)
+        if isinstance(obs.psf, PSFMap) and isinstance(obs.edisp, EDispKernelMap):
+            if position is None:
+                position = obs.psf.psf_map.geom.center_skydir
+            edisp_kernel = obs.edisp.get_edisp_kernel(position=position)
+            psf_kwargs["position"] = position
+        else:
+            if fixed_offset is None:
+                if position is None:
+                    offset = 0 * u.deg
+                else:
+                    offset_max = np.minimum(
+                        obs.psf.axes["offset"].center[-1],
+                        obs.edisp.axes["offset"].center[-1],
+                    )
+                    offset = np.minimum(
+                        position.separation(obs.pointing_radec), offset_max
+                    )
+            else:
+                offset = fixed_offset
+            edisp_kernel = obs.edisp.to_edisp_kernel(offset)
+            psf_kwargs["offset"] = offset
+        for kf, name in enumerate(names):
+            if name == "edisp-bias":
+                data[ko, kf] = edisp_kernel.get_bias(energy_true)
+            if name == "edisp-res":
+                data[ko, kf] = edisp_kernel.get_resolution(energy_true)
+            if name == "psf-radius":
+                containment_radius = obs.psf.containment_radius(**psf_kwargs).to("deg")
+                data[ko, kf] = containment_radius.value
+                units[kf] = u.deg
+
+    features = Table(data, names=names, units=units)
+    features.add_column(Column(observations.ids, name="obs_id"), index=0)
+
+    if apply_standard_scaler:
+        features = standard_scaler(features)
+
+    features.meta = dict(
+        energy_true=energy_true,
+        fixed_offset=fixed_offset,
+        containment_fraction=containment_fraction,
+        apply_standard_scaler=apply_standard_scaler,
+    )
+
+    if position:
+        features.meta["lon"] = position.galactic.l
+        features.meta["lat"] = position.galactic.b
+        features.meta["frame"] = "galactic"
+
+    return features

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -216,7 +216,7 @@ class Datasets(collections.abc.MutableSequence):
         return np.array(contributions)
 
     def stat_sum(self):
-        """Compute joint likelihood"""
+        """Compute joint statistic function value"""
         stat_sum = 0
         # TODO: add parallel evaluation of likelihoods
         for dataset in self:

--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -8,6 +8,7 @@ from regions import CircleSkyRegion
 import matplotlib.pyplot as plt
 from gammapy.maps import HpxNDMap, Map, RegionNDMap, WcsNDMap
 from gammapy.modeling.models import PointSpatialModel, TemplateNPredModel
+from .utils import apply_edisp
 
 PSF_CONTAINMENT = 0.999
 CUTOUT_MARGIN = 0.1 * u.deg
@@ -348,7 +349,7 @@ class MapEvaluator:
         npred_reco : `~gammapy.maps.Map`
             Predicted counts in reco energy bins
         """
-        return npred.apply_edisp(self.edisp)
+        return apply_edisp(npred, self.edisp)
 
     @lazyproperty
     def _compute_npred(self):

--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -10,6 +10,7 @@ from gammapy.maps import HpxNDMap, Map, RegionNDMap, WcsNDMap
 from gammapy.modeling.models import PointSpatialModel, TemplateNPredModel
 from .utils import apply_edisp
 
+PSF_MAX_RADIUS = None
 PSF_CONTAINMENT = 0.999
 CUTOUT_MARGIN = 0.1 * u.deg
 
@@ -193,6 +194,7 @@ class MapEvaluator:
                     position=self.model.position,
                     geom=geom_psf,
                     containment=PSF_CONTAINMENT,
+                    max_radius=PSF_MAX_RADIUS,
                 )
 
         if self.evaluation_mode == "local":

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1187,29 +1187,14 @@ class MapDataset(Dataset):
             )
 
         if "EDISP" in hdulist:
-            edisp_map = Map.from_hdulist(hdulist, hdu="edisp", format=format)
-
-            try:
-                exposure_map = Map.from_hdulist(
-                    hdulist, hdu="edisp_exposure", format=format
-                )
-            except KeyError:
-                exposure_map = None
-
-            if edisp_map.geom.axes[0].name == "energy":
-                kwargs["edisp"] = EDispKernelMap(edisp_map, exposure_map)
-            else:
-                kwargs["edisp"] = EDispMap(edisp_map, exposure_map)
+            kwargs["edisp"] = EDispMap.from_hdulist(
+                hdulist, hdu="edisp", exposure_hdu="edisp_exposure", format=format
+            )
 
         if "PSF" in hdulist:
-            psf_map = Map.from_hdulist(hdulist, hdu="psf", format=format)
-            try:
-                exposure_map = Map.from_hdulist(
-                    hdulist, hdu="psf_exposure", format=format
-                )
-            except KeyError:
-                exposure_map = None
-            kwargs["psf"] = PSFMap(psf_map, exposure_map)
+            kwargs["psf"] = PSFMap.from_hdulist(
+                hdulist, hdu="psf", exposure_hdu="psf_exposure", format=format
+            )
 
         if "MASK_SAFE" in hdulist:
             mask_safe = Map.from_hdulist(hdulist, hdu="mask_safe", format=format)
@@ -1267,7 +1252,7 @@ class MapDataset(Dataset):
             )
 
         kwargs["edisp"] = HDULocation(
-            hdu_class="edisp_kernel_map",
+            hdu_class="edisp_map",
             file_dir=path.parent,
             file_name=path.name,
             hdu_name="EDISP",

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2061,10 +2061,10 @@ class MapDatasetOnOff(MapDataset):
             Alpha map
         """
         with np.errstate(invalid="ignore", divide="ignore"):
-            alpha = self.acceptance / self.acceptance_off
+            data = self.acceptance.quantity / self.acceptance_off.quantity
+        data = np.nan_to_num(data)
 
-        alpha.data = np.nan_to_num(alpha.data)
-        return alpha
+        return Map.from_geom(self._geom, data=data.to_value(""), unit="")
 
     def npred_background(self):
         """Predicted background counts estimated from the marginalized likelihood estimate.

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -783,7 +783,7 @@ class MapDataset(Dataset):
 
         if self.stat_type == "cash":
             if self.background and other.background:
-                background = self.npred_background() * self.mask_safe
+                background = self.npred_background()
                 background.stack(
                     other.npred_background(),
                     weights=other.mask_safe,

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -815,7 +815,7 @@ class MapDataset(Dataset):
             self.meta_table = other.meta_table.copy()
 
     def stat_array(self):
-        """Likelihood per bin given the current model parameters"""
+        """Statistic function value per bin given the current model parameters"""
         return cash(n_on=self.counts.data, mu_on=self.npred().data)
 
     def residuals(self, method="diff", **kwargs):
@@ -1080,7 +1080,7 @@ class MapDataset(Dataset):
         return ax_spatial, ax_spectral
 
     def stat_sum(self):
-        """Total likelihood given the current model parameters."""
+        """Total statistic function value given the current model parameters."""
         counts, npred = self.counts.data.astype(float), self.npred().data
 
         if self.mask is not None:
@@ -2128,7 +2128,7 @@ class MapDatasetOnOff(MapDataset):
         return self.alpha * self.counts_off
 
     def stat_array(self):
-        """Likelihood per bin given the current model parameters"""
+        """Statistic function value per bin given the current model parameters"""
         mu_sig = self.npred_signal().data
         on_stat_ = wstat(
             n_on=self.counts.data,
@@ -2356,7 +2356,7 @@ class MapDatasetOnOff(MapDataset):
         super().stack(other, nan_to_num=nan_to_num)
 
     def stat_sum(self):
-        """Total likelihood given the current model parameters."""
+        """Total statistic function value given the current model parameters."""
         return Dataset.stat_sum(self)
 
     def fake(self, npred_background, random_state="random-seed"):

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -4,10 +4,11 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord, SkyOffsetFrame
 from astropy.table import Table
+from regions import PointSkyRegion
 import gammapy
 from gammapy.data import EventList, observatory_locations
-from gammapy.maps import MapCoord
-from gammapy.modeling.models import ConstantTemporalModel
+from gammapy.maps import MapAxis, MapCoord, RegionGeom
+from gammapy.modeling.models import ConstantTemporalModel, PointSpatialModel
 from gammapy.utils.random import get_random_state
 
 __all__ = ["MapDatasetEventSampler"]
@@ -26,30 +27,126 @@ class MapDatasetEventSampler:
     def __init__(self, random_state="random-seed"):
         self.random_state = get_random_state(random_state)
 
-    def _sample_coord_time(self, npred, temporal_model, gti):
-        data = npred.data[np.isfinite(npred.data)]
-        n_events = self.random_state.poisson(np.sum(data))
+    def _make_table(self, coords, time_ref):
+        """Create a table for sampled events.
 
-        coords = npred.sample_coord(n_events=n_events, random_state=self.random_state)
+        Parameters
+        ----------
+        coords : `~gammapy.maps.MapCoord`
+            Coordinates of the sampled events.
+        time_ref : `~astropy.time.Time`
+            reference time of the event list.
 
+        Returns
+        -------
+        table : `~astropy.table.Table`
+            Table of the sampled events.
+        """
         table = Table()
         try:
             energy = coords["energy_true"]
         except KeyError:
             energy = coords["energy"]
 
+        table["TIME"] = (coords["time"] - time_ref).to("s")
         table["ENERGY_TRUE"] = energy
         table["RA_TRUE"] = coords.skycoord.icrs.ra.to("deg")
         table["DEC_TRUE"] = coords.skycoord.icrs.dec.to("deg")
 
+        return table
+
+    def _evaluate_timevar_source(self, dataset, evaluator, time_axis=None):
+        """Calculate Npred for a given `dataset.model` by evaluating
+        it in region geometry.
+
+        Parameters
+        ----------
+        dataset : `~gammapy.datasets.MapDataset`
+            Map dataset.
+        evaluator : `~gammapy.datasets.evaluators.MapEvaluator`
+            Map evaluator.
+        time_axis : `~gammapy.Maps.MapAxis`
+            Axis of the time.
+
+        Returns
+        -------
+        npred : `~gammapy.maps.Map`
+            Npred map.
+        """
+        energy_axis = MapAxis.from_edges(
+            dataset.geoms["geom"].axes["energy"].edges, name="energy_true"
+        )
+
+        target = evaluator.model.spatial_model.position
+        on_region = PointSkyRegion(center=target)
+        region_geom = RegionGeom.create(on_region, axes=[energy_axis])
+
+        flux = evaluator.model.evaluate_geom(region_geom.to_wcs_geom(), gti=dataset.gti)
+        region_exposure = dataset.exposure.to_region_nd_map(region_geom.center_skydir)
+
+        npred = flux * region_exposure * dataset.geoms["geom"].bin_volume()
+
+        return npred
+
+    def _sample_coord_time_energy(self, dataset, evaluator, t_delta="1 s"):
+        """Sample model components of a source with time-dependent spectrum.
+
+        Parameters
+        ----------
+        dataset : `~gammapy.datasets.MapDataset`
+            Map dataset.
+        evaluator : `~gammapy.datasets.evaluators.MapEvaluator`
+            Map evaluator.
+        t_delta : `~astropy.units.Quantity`
+            Minimum step time.
+
+        Returns
+        -------
+        table : `~astropy.table.Table`
+            Table of sampled events.
+        """
+        if not isinstance(evaluator.model.spatial_model, PointSpatialModel):
+            raise TypeError(
+                f"Event sampler expects PointSpatialModel for a time varying source. Got {evaluator.model.spatial_model} instead."
+            )
+
+        else:
+            raise NotImplementedError("The functionality is not yet implemented")
+
+        return
+
+    def _sample_coord_time(self, npred, temporal_model, gti):
+        """Sample model components of a time-varying source.
+
+        Parameters
+        ----------
+        npred : `~gammapy.dataset.MapDataset`
+            Npred map.
+        temporal_model : `~gammapy.modeling.models\
+            temporal model of the source.
+        gti : `~gammapy.data.GTI`
+             GTI of the dataset
+
+        Returns
+        -------
+        table : `~astropy.table.Table`
+            Table of sampled events.
+        """
+        data = npred.data[np.isfinite(npred.data)]
+        n_events = self.random_state.poisson(np.sum(data))
+
+        coords = npred.sample_coord(n_events=n_events, random_state=self.random_state)
+
         time_start, time_stop, time_ref = (gti.time_start, gti.time_stop, gti.time_ref)
-        time = temporal_model.sample_time(
+        coords["time"] = temporal_model.sample_time(
             n_events=n_events,
             t_min=time_start,
             t_max=time_stop,
             random_state=self.random_state,
         )
-        table["TIME"] = u.Quantity(((time.mjd - time_ref.mjd) * u.day).to(u.s)).to("s")
+
+        table = self._make_table(coords, time_ref)
+
         return table
 
     def sample_sources(self, dataset):
@@ -77,15 +174,19 @@ class MapDatasetEventSampler:
                     dataset.mask,
                 )
 
-            flux = evaluator.compute_flux()
-            npred = evaluator.apply_exposure(flux)
-
             if evaluator.model.temporal_model is None:
                 temporal_model = ConstantTemporalModel()
             else:
                 temporal_model = evaluator.model.temporal_model
 
-            table = self._sample_coord_time(npred, temporal_model, dataset.gti)
+            if (
+                temporal_model == "TemplateTemporalModel"
+            ):  # check the condition when the format model is defined
+                table = self._sample_coord_time_energy(dataset, evaluator)
+            else:
+                flux = evaluator.compute_flux()
+                npred = evaluator.apply_exposure(flux)
+                table = self._sample_coord_time(npred, temporal_model, dataset.gti)
 
             if len(table) == 0:
                 mcid = table.Column(name="MC_ID", length=0, dtype=int)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -925,12 +925,21 @@ def test_stack(sky_model):
 
     assert_allclose(npred_b.data.sum(), 1459.985035, 1e-5)
     assert_allclose(stacked.npred_background().data.sum(), 1360.00, 1e-5)
+    assert_allclose(stacked.background.data.sum(), 1360, 1e-5)
     assert_allclose(stacked.counts.data.sum(), 9000, 1e-5)
     assert_allclose(stacked.mask_safe.data.sum(), 4600)
     assert_allclose(stacked.mask_fit.data.sum(), 4600)
     assert_allclose(stacked.exposure.data.sum(), 1.6e11)
 
     assert_allclose(stacked.meta_table["OBS_ID"][0], [0, 1])
+
+    # stacking when no safe masks are defined
+    dataset1 = MapDataset(counts=cnt1, background=bkg1)
+    stacked = MapDataset.from_geoms(**dataset1.geoms)
+    for i in range(3):
+        stacked.stack(dataset1)
+    assert_allclose(stacked.background.data.sum(), 2880.0, 1e-5)
+    assert_allclose(stacked.counts.data.sum(), 14400.0, 1e-5)
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -19,6 +19,7 @@ from gammapy.modeling.models import (
     GaussianSpatialModel,
     LightCurveTemplateTemporalModel,
     Models,
+    PointSpatialModel,
     PowerLawSpectralModel,
     SkyModel,
 )
@@ -122,6 +123,25 @@ def dataset():
     )
 
     return dataset
+
+
+@requires_data()
+def test_sample_coord_time_energy(dataset, models):
+    models[0].spatial_model = None
+    dataset.models = models
+    evaluator = dataset.evaluators["test-source"]
+    sampler = MapDatasetEventSampler(random_state=0)
+    with pytest.raises(TypeError):
+        sampler._sample_coord_time_energy(dataset, evaluator)
+
+    models[0].spatial_model = PointSpatialModel(
+        lon_0="0 deg", lat_0="0 deg", frame="galactic"
+    )
+    dataset.models = models
+    evaluator = dataset.evaluators["test-source"]
+    sampler = MapDatasetEventSampler(random_state=0)
+    with pytest.raises(NotImplementedError):
+        sampler._sample_coord_time_energy(dataset, evaluator)
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -8,6 +8,7 @@ from astropy.io import fits
 from astropy.table import Table
 from astropy.time import Time
 from gammapy.data import GTI, DataStore, Observation
+from gammapy.data.pointing import FixedPointingInfo, PointingMode
 from gammapy.datasets import MapDataset, MapDatasetEventSampler
 from gammapy.datasets.tests.test_map import get_map_dataset
 from gammapy.irf import load_irf_dict_from_file
@@ -151,7 +152,10 @@ def test_mde_sample_weak_src(dataset, models):
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 10.0 * u.hr
-    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    pointing = FixedPointingInfo(
+        mode=PointingMode.POINTING,
+        fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
+    )
     obs = Observation.create(
         obs_id=1001,
         pointing=pointing,
@@ -238,7 +242,10 @@ def test_event_det_coords(dataset, models):
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 1.0 * u.hr
-    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    pointing = FixedPointingInfo(
+        mode=PointingMode.POINTING,
+        fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
+    )
     obs = Observation.create(
         obs_id=1001,
         pointing=pointing,
@@ -265,7 +272,10 @@ def test_mde_run(dataset, models):
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 1.0 * u.hr
-    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    pointing = FixedPointingInfo(
+        mode=PointingMode.POINTING,
+        fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
+    )
     obs = Observation.create(
         obs_id=1001,
         pointing=pointing,
@@ -361,7 +371,10 @@ def test_irf_alpha_config(dataset, models):
         "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
     )
     livetime = 1.0 * u.hr
-    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    pointing = FixedPointingInfo(
+        mode=PointingMode.POINTING,
+        fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
+    )
     obs = Observation.create(
         obs_id=1001,
         pointing=pointing,
@@ -382,7 +395,10 @@ def test_mde_run_switchoff(dataset, models):
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 1.0 * u.hr
-    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    pointing = FixedPointingInfo(
+        mode=PointingMode.POINTING,
+        fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
+    )
     obs = Observation.create(
         obs_id=1001,
         pointing=pointing,
@@ -419,7 +435,10 @@ def test_events_datastore(tmp_path, dataset, models):
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 10.0 * u.hr
-    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    pointing = FixedPointingInfo(
+        mode=PointingMode.POINTING,
+        fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
+    )
     obs = Observation.create(
         obs_id=1001,
         pointing=pointing,
@@ -447,7 +466,8 @@ def test_MC_ID(model_alternative):
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 0.1 * u.hr
-    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    skydir = SkyCoord(0, 0, unit="deg", frame="galactic")
+    pointing = FixedPointingInfo(mode=PointingMode.POINTING, fixed_icrs=skydir.icrs)
     obs = Observation.create(
         obs_id=1001,
         pointing=pointing,
@@ -465,7 +485,7 @@ def test_MC_ID(model_alternative):
     migra_axis = MapAxis.from_bounds(0.5, 2, nbin=150, node_type="edges", name="migra")
 
     geom = WcsGeom.create(
-        skydir=pointing,
+        skydir=skydir,
         width=(2, 2),
         binsz=0.06,
         frame="icrs",
@@ -503,7 +523,8 @@ def test_MC_ID_NMCID(model_alternative):
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 0.1 * u.hr
-    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    skydir = SkyCoord(0, 0, unit="deg", frame="galactic")
+    pointing = FixedPointingInfo(mode=PointingMode.POINTING, fixed_icrs=skydir.icrs)
     obs = Observation.create(
         obs_id=1001,
         pointing=pointing,
@@ -521,7 +542,7 @@ def test_MC_ID_NMCID(model_alternative):
     migra_axis = MapAxis.from_bounds(0.5, 2, nbin=150, node_type="edges", name="migra")
 
     geom = WcsGeom.create(
-        skydir=pointing,
+        skydir=skydir,
         width=(2, 2),
         binsz=0.06,
         frame="icrs",

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -10,7 +10,7 @@ from astropy.time import Time
 from gammapy.data import GTI, DataStore, Observation
 from gammapy.datasets import MapDataset, MapDatasetEventSampler
 from gammapy.datasets.tests.test_map import get_map_dataset
-from gammapy.irf import load_cta_irfs
+from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import MapDatasetMaker
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.modeling.models import (
@@ -147,7 +147,7 @@ def test_mde_sample_sources(dataset, models):
 
 @requires_data()
 def test_mde_sample_weak_src(dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 10.0 * u.hr
@@ -234,7 +234,7 @@ def test_mde_sample_edisp(dataset, models):
 
 @requires_data()
 def test_event_det_coords(dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 1.0 * u.hr
@@ -261,7 +261,7 @@ def test_event_det_coords(dataset, models):
 
 @requires_data()
 def test_mde_run(dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 1.0 * u.hr
@@ -357,7 +357,7 @@ def test_mde_run(dataset, models):
 
 @requires_data()
 def test_irf_alpha_config(dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
     )
     livetime = 1.0 * u.hr
@@ -378,7 +378,7 @@ def test_irf_alpha_config(dataset, models):
 
 @requires_data()
 def test_mde_run_switchoff(dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 1.0 * u.hr
@@ -415,7 +415,7 @@ def test_mde_run_switchoff(dataset, models):
 
 @requires_data()
 def test_events_datastore(tmp_path, dataset, models):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 10.0 * u.hr
@@ -443,7 +443,7 @@ def test_events_datastore(tmp_path, dataset, models):
 
 @requires_data()
 def test_MC_ID(model_alternative):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 0.1 * u.hr
@@ -499,7 +499,7 @@ def test_MC_ID(model_alternative):
 
 @requires_data()
 def test_MC_ID_NMCID(model_alternative):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     livetime = 0.1 * u.hr

--- a/gammapy/datasets/tests/test_utils.py
+++ b/gammapy/datasets/tests/test_utils.py
@@ -1,0 +1,37 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from gammapy.irf import EDispKernel
+from gammapy.maps import Map, MapAxis
+from ..utils import apply_edisp
+
+
+@pytest.fixture
+def region_map_true():
+    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=6, name="energy_true")
+    m = Map.create(
+        region="icrs;circle(83.63, 21.51, 1)",
+        map_type="region",
+        axes=[axis],
+        unit="1/TeV",
+    )
+    m.data = np.arange(m.data.size, dtype=float).reshape(m.geom.data_shape)
+    return m
+
+
+def test_apply_edisp(region_map_true):
+    e_true = region_map_true.geom.axes[0]
+    e_reco = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
+
+    edisp = EDispKernel.from_diagonal_response(
+        energy_axis_true=e_true, energy_axis=e_reco
+    )
+
+    m = apply_edisp(region_map_true, edisp)
+    assert m.geom.data_shape == (3, 1, 1)
+
+    e_reco = m.geom.axes[0].edges
+    assert e_reco.unit == "TeV"
+    assert m.geom.axes[0].name == "energy"
+    assert_allclose(e_reco[[0, -1]].value, [1, 10])

--- a/gammapy/datasets/utils.py
+++ b/gammapy/datasets/utils.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
+from gammapy.maps import Map
 
 
 def apply_edisp(input_map, edisp):
@@ -30,7 +31,7 @@ def apply_edisp(input_map, edisp):
         energy_axis = input_map.geom.axes["energy_true"].copy(name="energy")
 
     geom = input_map.geom.to_image().to_cube(axes=[energy_axis])
-    return input_map._init_copy(geom=geom, data=data)
+    return Map.from_geom(geom=geom, data=data, unit=input_map.unit)
 
 
 def get_figure(fig, width, height):

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -68,7 +68,7 @@ class ExcessMapEstimator(Estimator):
     If a model is set on the dataset the excess map estimator will compute the
     excess taking into account the predicted counts of the model.
 
-    Note:
+    .. note::
 
         By default the excess estimator correlates the off counts as well to avoid
         artifacts at the edges of the :term:`FoV` for stacked on-off datasets.

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -68,7 +68,7 @@ class ExcessMapEstimator(Estimator):
     If a model is set on the dataset the excess map estimator will compute the
     excess taking into account the predicted counts of the model.
 
-    ..note::
+    Note:
 
         By default the excess estimator correlates the off counts as well to avoid
         artifacts at the edges of the :term:`FoV` for stacked on-off datasets.

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import Angle
-from gammapy.datasets import MapDataset
+from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.estimators import TSMapEstimator
 from gammapy.irf import EDispKernelMap, PSFMap
 from gammapy.maps import Map, MapAxis, WcsGeom
@@ -275,3 +275,14 @@ def test_compute_ts_map_with_hole(fake_dataset):
     holes_dataset.exposure.data[...] = 0.0
     with pytest.raises(ValueError):
         kernel = ts_estimator.estimate_kernel(dataset=holes_dataset)
+
+
+def test_MapDatasetOnOff_error():
+    """Test raise error when applying TSMapEStimator to MapDatasetOnOff"""
+    axis = MapAxis.from_edges([1, 10] * u.TeV, name="energy")
+    geom = WcsGeom.create(width=1, axes=[axis])
+    dataset_on_off = MapDatasetOnOff.create(geom)
+
+    ts_estimator = TSMapEstimator()
+    with pytest.raises(TypeError):
+        ts_estimator.run(dataset=dataset_on_off)

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -468,6 +468,8 @@ class TSMapEstimator(Estimator):
                 * flux_ul : upper limit map
 
         """
+        if dataset.stat_type != "cash":
+            raise TypeError(f"{type(dataset)} is not a valid type for {self.__class__}")
         dataset_models = dataset.models
 
         pad_width = self.estimate_pad_width(dataset=dataset)

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -614,7 +614,7 @@ class FluxPoints(FluxMaps):
 
         axis.format_plot_xaxis(ax=ax)
 
-        ax.set_ylabel(f"{sed_type} ({ax.yaxis.units})")
+        ax.set_ylabel(f"{sed_type} [{ax.yaxis.units}]")
         ax.set_yscale("log")
 
         if add_cbar:

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy import stats
 from astropy.io.registry import IORegistryError
 from astropy.table import Table, vstack
+from astropy.time import Time
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from gammapy.maps import MapAxis, Maps, RegionNDMap, TimeMapAxis
@@ -14,6 +15,7 @@ from gammapy.modeling.models.spectral import scale_plot_flux
 from gammapy.modeling.scipy import stat_profile_ul_scipy
 from gammapy.utils.scripts import make_path
 from gammapy.utils.table import table_standardise_units_copy
+from gammapy.utils.time import time_ref_to_dict
 from ..map.core import DEFAULT_UNIT, FluxMaps
 
 __all__ = ["FluxPoints"]
@@ -387,6 +389,12 @@ class FluxPoints(FluxMaps):
                 tables.append(table_flat)
 
             table = vstack(tables)
+
+            # serialize with reference time set to mjd=0.0
+            ref_time = Time(0.0, format="mjd", scale=time_axis.reference_time.scale)
+            table.meta.update(time_ref_to_dict(ref_time, scale=ref_time.scale))
+            table.meta["TIMEUNIT"] = "d"
+
         elif format == "binned-time-series":
             message = (
                 "Format 'binned-time-series' support a single time axis "

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -62,7 +62,7 @@ class FluxPointsEstimator(FluxEstimator):
     fit : `Fit`
         Fit instance specifying the backend and fit options.
     reoptimize : bool
-        Re-optimize other free model parameters. Default is True.
+        Re-optimize other free model parameters. Default is False.
     sum_over_energy_groups : bool
         Whether to sum over the energy groups or fit the norm on the full energy
         grid.

--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -14,7 +14,7 @@ from gammapy.estimators.points.tests.test_sed import (
 )
 from gammapy.modeling import Fit
 from gammapy.modeling.models import FoVBackgroundModel, PowerLawSpectralModel, SkyModel
-from gammapy.utils.testing import mpl_plot_check, requires_data
+from gammapy.utils.testing import assert_time_allclose, mpl_plot_check, requires_data
 
 
 @pytest.fixture(scope="session")
@@ -229,8 +229,8 @@ def test_lightcurve_estimator_spectrum_datasets():
     # Doing a LC on one hour bin
     datasets = get_spectrum_datasets()
     time_intervals = [
-        Time(["2010-01-01T00:00:00", "2010-01-01T01:00:00"]),
-        Time(["2010-01-01T01:00:00", "2010-01-01T02:00:00"]),
+        Time(["2010-01-01T00:00:00", "2010-01-01T01:00:00"]).tt,
+        Time(["2010-01-01T01:00:00", "2010-01-01T02:00:00"]).tt,
     ]
 
     estimator = LightCurveEstimator(
@@ -265,6 +265,10 @@ def test_lightcurve_estimator_spectrum_datasets():
         [[224.058304, 19.074405, 2063.75636]],
         rtol=1e-5,
     )
+    assert table.meta["TIMESYS"] == "tt"
+    assert table.meta["TIMEUNIT"] == "d"
+    assert table.meta["MJDREFF"] == 0
+    assert table.meta["MJDREFI"] == 0
 
     # TODO: fix reference model I/O
     fp = FluxPoints.from_table(
@@ -273,6 +277,12 @@ def test_lightcurve_estimator_spectrum_datasets():
     assert fp.norm.geom.axes.names == ["energy", "time"]
     assert fp.counts.geom.axes.names == ["dataset", "energy", "time"]
     assert fp.stat_scan.geom.axes.names == ["norm", "energy", "time"]
+    assert_time_allclose(
+        fp.geom.axes["time"].time_min, lightcurve.geom.axes["time"].time_min
+    )
+    assert_time_allclose(
+        fp.geom.axes["time"].time_max, lightcurve.geom.axes["time"].time_max
+    )
 
 
 @requires_data()

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -9,7 +9,7 @@ from gammapy.data import Observation
 from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
 from gammapy.datasets.spectrum import SpectrumDataset
 from gammapy.estimators import FluxPoints, FluxPointsEstimator
-from gammapy.irf import EDispKernelMap, EffectiveAreaTable2D, load_cta_irfs
+from gammapy.irf import EDispKernelMap, EffectiveAreaTable2D, load_irf_dict_from_file
 from gammapy.makers import MapDatasetMaker
 from gammapy.makers.utils import make_map_exposure_true_energy
 from gammapy.maps import MapAxis, RegionGeom, RegionNDMap, WcsGeom
@@ -96,7 +96,7 @@ def create_fpe(model):
 
 
 def simulate_map_dataset(random_state=0, name=None):
-    irfs = load_cta_irfs(
+    irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
 

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -6,6 +6,7 @@ from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.table import Table
 from gammapy.data import Observation
+from gammapy.data.pointing import FixedPointingInfo, PointingMode
 from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
 from gammapy.datasets.spectrum import SpectrumDataset
 from gammapy.estimators import FluxPoints, FluxPointsEstimator
@@ -101,6 +102,7 @@ def simulate_map_dataset(random_state=0, name=None):
     )
 
     skydir = SkyCoord("0 deg", "0 deg", frame="galactic")
+    pointing = FixedPointingInfo(mode=PointingMode.POINTING, fixed_icrs=skydir.icrs)
     energy_edges = np.logspace(-1, 2, 15) * u.TeV
     energy_axis = MapAxis.from_edges(edges=energy_edges, name="energy", interp="log")
 
@@ -115,7 +117,7 @@ def simulate_map_dataset(random_state=0, name=None):
     skymodel = SkyModel(spatial_model=gauss, spectral_model=pwl, name="source")
 
     obs = Observation.create(
-        pointing=skydir,
+        pointing=pointing,
         livetime=1 * u.h,
         irfs=irfs,
         location=EarthLocation(lon="-70d18m58.84s", lat="-24d41m0.34s", height="2000m"),

--- a/gammapy/estimators/profile.py
+++ b/gammapy/estimators/profile.py
@@ -325,7 +325,7 @@ class ImageProfile:
         kwargs.setdefault("alpha", 0.5)
 
         ax.fill_between(x, ymin, ymax, **kwargs)
-        ax.set_xlabel("x (deg)")
+        ax.set_xlabel("x [deg]")
         ax.set_ylabel("profile")
         return ax
 

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -13,7 +13,11 @@ from gammapy.modeling.models import (
     SkyModel,
 )
 
-__all__ = ["estimate_exposure_reco_energy", "find_peaks", "resample_energy_edges"]
+__all__ = [
+    "estimate_exposure_reco_energy",
+    "find_peaks",
+    "resample_energy_edges",
+]
 
 
 def find_peaks(image, threshold, min_distance=1):

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -338,7 +338,7 @@ class Background2D(BackgroundIRF):
                 ax.plot(offset_axis.center, bkg, label=label, **kwargs)
 
         offset_axis.format_plot_xaxis(ax=ax)
-        ax.set_ylabel(f"Background rate ({ax.yaxis.units})")
+        ax.set_ylabel(f"Background rate [{ax.yaxis.units}]")
         ax.set_yscale("log")
         ax.legend(loc="upper right")
         return ax
@@ -377,7 +377,7 @@ class Background2D(BackgroundIRF):
 
         energy_axis.format_plot_xaxis(ax=ax)
         ax.set_yscale("log")
-        ax.set_ylabel(f"Background rate ({ax.yaxis.units})")
+        ax.set_ylabel(f"Background rate [{ax.yaxis.units}]")
         ax.legend(loc="best")
         return ax
 
@@ -408,7 +408,7 @@ class Background2D(BackgroundIRF):
 
         energy_axis.format_plot_xaxis(ax=ax)
         ax.set_yscale("log")
-        ax.set_ylabel(f"Background rate ({ax.yaxis.units})")
+        ax.set_ylabel(f"Background rate [{ax.yaxis.units}]")
         ax.legend(loc="best")
         return ax
 

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -97,6 +97,8 @@ class Background3D(BackgroundIRF):
         Data array.
     unit : str or `~astropy.units.Unit`
         Data unit usually ``s^-1 MeV^-1 sr^-1``
+    fov_alignment: `~gammapy.irf.FoVAlignment`
+        The orientation of the field of view coordinate system.
     meta : dict
         Meta data
 

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -484,6 +484,9 @@ class IRF(metaclass=abc.ABCMeta):
 
             table.meta.update(spec["mandatory_keywords"])
 
+            if "FOVALIGN" in table.meta:
+                table.meta["FOVALIGN"] = self.fov_alignment.value
+
             if self.is_pointlike:
                 table.meta["HDUCLAS3"] = "POINT-LIKE"
             else:

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -723,6 +723,8 @@ class IRFMap:
         irf_map : `IRFMap`
             IRF map.
         """
+
+        output_class = cls
         if format == "gadf":
             if hdu is None:
                 hdu = IRF_MAP_HDU_SPECIFICATION[cls.tag]
@@ -743,6 +745,16 @@ class IRFMap:
                 )
             else:
                 exposure_map = None
+
+            if cls.tag == "psf_map" and "energy" in irf_map.geom.axes.names:
+                from .psf import RecoPSFMap
+
+                output_class = RecoPSFMap
+            if cls.tag == "edisp_map" and irf_map.geom.axes[0].name == "energy":
+                from .edisp import EDispKernelMap
+
+                output_class = EDispKernelMap
+
         elif format == "gtpsf":
             rad_axis = MapAxis.from_table_hdu(hdulist["THETA"], format=format)
 
@@ -761,7 +773,7 @@ class IRFMap:
         else:
             raise ValueError(f"Format {format} not supported")
 
-        return cls(irf_map, exposure_map)
+        return output_class(irf_map, exposure_map)
 
     @classmethod
     def read(cls, filename, format="gadf", hdu=None):

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -2,9 +2,9 @@
 import logging
 from astropy.io import fits
 from gammapy.data.hdu_index_table import HDUIndexTable
+from gammapy.utils.deprecation import deprecated
 from gammapy.utils.fits import HDULocation
 from gammapy.utils.scripts import make_path
-from gammapy.utils.deprecation import deprecated
 
 __all__ = ["load_cta_irfs", "load_irf_dict_from_file"]
 
@@ -44,6 +44,7 @@ IRF_DL3_HDU_SPECIFICATION = {
             "HDUCLAS2": "BKG",
             "HDUCLAS3": "FULL-ENCLOSURE",  # added here to have HDUCLASN in order
             "HDUCLAS4": "BKG_3D",
+            "FOVALIGN": "RADEC",
         },
     },
     "bkg_2d": {

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -4,6 +4,7 @@ from astropy.io import fits
 from gammapy.data.hdu_index_table import HDUIndexTable
 from gammapy.utils.fits import HDULocation
 from gammapy.utils.scripts import make_path
+from gammapy.utils.deprecation import deprecated
 
 __all__ = ["load_cta_irfs", "load_irf_dict_from_file"]
 
@@ -141,8 +142,14 @@ def gadf_is_pointlike(header):
     return header.get("HDUCLAS3") == "POINT-LIKE"
 
 
+@deprecated("v1.1", alternative="load_irf_dict_from_file")
 def load_cta_irfs(filename):
-    """load CTA instrument response function and return a dictionary container.
+    """Load IRFs from file as written by the CTA DC1 into a dict
+
+    This function has a hardcoded list of IRF types and HDU names
+    and does not check what types of IRFs are actually present in the file.
+
+    Please use `load_irf_dict_from_file` instead..
 
     The IRF format should be compliant with the one discussed
     at http://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/.
@@ -195,9 +202,39 @@ def load_cta_irfs(filename):
     return dict(aeff=aeff, bkg=bkg, edisp=edisp, psf=psf)
 
 
+class UnknownHDUClass(IOError):
+    """Raised when a file contains an unknown HDUCLASS"""
+
+
+def _get_hdu_type_and_class(header):
+    """Get gammapy hdu_type and class from FITS header
+
+    Contains a workaround to support CTA 1DC irf file.
+    """
+    hdu_clas2 = header.get("HDUCLAS2", "")
+    hdu_clas4 = header.get("HDUCLAS4", "")
+
+    clas2_to_type = {"rpsf": "psf", "eff_area": "aeff"}
+    hdu_type = clas2_to_type.get(hdu_clas2.lower(), hdu_clas2.lower())
+    hdu_class = hdu_clas4.lower()
+
+    if hdu_type not in HDUIndexTable.VALID_HDU_TYPE:
+        raise UnknownHDUClass(f"HDUCLAS2={hdu_clas2}, HDUCLAS4={hdu_clas4}")
+
+    # workaround for CTA 1DC files with non-compliant HDUCLAS4 names
+    if hdu_class not in HDUIndexTable.VALID_HDU_CLASS:
+        hdu_class = f"{hdu_type}_{hdu_class}"
+
+    if hdu_class not in HDUIndexTable.VALID_HDU_CLASS:
+        raise UnknownHDUClass(f"HDUCLAS2={hdu_clas2}, HDUCLAS4={hdu_clas4}")
+
+    return hdu_type, hdu_class
+
+
 def load_irf_dict_from_file(filename):
-    """Open a fits file and generate a dictionary containing the Gammapy objects
-    corresponding to the IRF components stored
+    """Load all available IRF components from given file into a dict.
+
+    If multiple IRFs of the same type are present, the first encountered is returned.
 
     Parameters
     ----------
@@ -214,41 +251,41 @@ def load_irf_dict_from_file(filename):
     from .rad_max import RadMax2D
 
     filename = make_path(filename)
-
-    hdulist = fits.open(make_path(filename))
-
+    hdulist = fits.open(filename)
     irf_dict = {}
-
     is_pointlike = False
 
     for hdu in hdulist:
-        hdu_class = hdu.header.get("HDUCLAS1", "").lower()
+        hdu_clas1 = hdu.header.get("HDUCLAS1", "").lower()
 
-        if hdu_class == "response":
-            hdu_class = hdu.header.get("HDUCLAS4", "").lower()
-
-            is_pointlike |= hdu.header["HDUCLAS3"] == "POINT-LIKE"
-
-            loc = HDULocation(
-                hdu_class=hdu_class,
-                hdu_name=hdu.name,
-                file_dir=filename.parent,
-                file_name=filename.name,
-            )
-
-            for name in HDUIndexTable.VALID_HDU_TYPE:
-                if name in hdu_class:
-                    if name in irf_dict.keys():
-                        log.warning(f"more than one HDU of {name} type found")
-                        log.warning(
-                            f"loaded the {irf_dict[name].meta['EXTNAME']} HDU in the dictionary"
-                        )
-                        continue
-                    data = loc.load()
-                    # TODO: maybe introduce IRF.type attribute...
-                    irf_dict[name] = data
-        else:  # not an IRF component
+        # not an IRF component
+        if hdu_clas1 != "response":
             continue
+
+        is_pointlike |= hdu.header.get("HDUCLAS3") == "POINT-LIKE"
+
+        try:
+            hdu_type, hdu_class = _get_hdu_type_and_class(hdu.header)
+        except UnknownHDUClass as e:
+            log.warning("File has unknown class %s", e)
+            continue
+
+        loc = HDULocation(
+            hdu_class=hdu_class,
+            hdu_name=hdu.name,
+            file_dir=filename.parent,
+            file_name=filename.name,
+        )
+
+        if hdu_type in irf_dict.keys():
+            log.warning(f"more than one HDU of {hdu_type} type found")
+            log.warning(
+                f"loaded the {irf_dict[hdu_type].meta['EXTNAME']} HDU in the dictionary"
+            )
+            continue
+
+        data = loc.load()
+        irf_dict[hdu_type] = data
 
     if is_pointlike and "rad_max" not in irf_dict:
         irf_dict["rad_max"] = RadMax2D.from_irf(irf_dict["aeff"])

--- a/gammapy/irf/psf/core.py
+++ b/gammapy/irf/psf/core.py
@@ -248,7 +248,7 @@ class PSF(IRF):
         rad.format_plot_xaxis(ax=ax)
 
         ax.set_yscale("log")
-        ax.set_ylabel(f"PSF ({ax.yaxis.units})")
+        ax.set_ylabel(f"PSF [{ax.yaxis.units}]")
         plt.legend()
         return ax
 

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -454,7 +454,7 @@ class PSFMap(IRFMap):
         ax.legend(loc="best")
         ax.yaxis.set_major_formatter(FormatStrFormatter("%.2f"))
         energy_axis.format_plot_xaxis(ax=ax)
-        ax.set_ylabel(f"Containment radius ({ax.yaxis.units})")
+        ax.set_ylabel(f"Containment radius [{ax.yaxis.units}]")
         return ax
 
     def plot_psf_vs_rad(self, ax=None, energy_true=[0.1, 1, 10] * u.TeV, **kwargs):
@@ -494,8 +494,8 @@ class PSFMap(IRFMap):
                 ax.plot(rad, psf_value, label=label, **kwargs)
 
         ax.set_yscale("log")
-        ax.set_xlabel(f"Rad ({ax.xaxis.units})")
-        ax.set_ylabel(f"PSF ({ax.yaxis.units})")
+        ax.set_xlabel(f"Rad [{ax.xaxis.units}]")
+        ax.set_ylabel(f"PSF [{ax.yaxis.units}]")
         ax.xaxis.set_major_formatter(FormatStrFormatter("%.2f"))
         plt.legend()
         return ax

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -38,13 +38,13 @@ class PSFMap(IRFMap):
         from astropy.coordinates import SkyCoord
         from gammapy.maps import WcsGeom, MapAxis
         from gammapy.data import Observation
-        from gammapy.irf import load_cta_irfs
+        from gammapy.irf import load_irf_dict_from_file
         from gammapy.makers import MapDatasetMaker
 
         # Define observation
         pointing = SkyCoord("0d", "0d")
         filename = "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
-        irfs = load_cta_irfs(filename)
+        irfs = load_irf_dict_from_file(filename)
         obs = Observation.create(pointing=pointing, irfs=irfs, livetime="1h")
 
         # Create WcsGeom

--- a/gammapy/irf/psf/tests/test_map.py
+++ b/gammapy/irf/psf/tests/test_map.py
@@ -567,6 +567,25 @@ def test_psf_map_reco_hawc():
     assert "energy" in reco_psf_map.psf_map.geom.axes.names
     assert reco_psf_map.energy_name == "energy"
     assert reco_psf_map.required_axes == ["rad", "energy"]
+    assert reco_psf_map.exposure_map is None
+
+    with mpl_plot_check():
+        reco_psf_map.plot_containment_radius_vs_energy()
+
+    with mpl_plot_check():
+        reco_psf_map.plot_psf_vs_rad()
+
+    assert_allclose(
+        reco_psf_map.containment_radius(0.68, [1, 2] * u.TeV),
+        [0.001, 0.43733357] * u.deg,
+    )
+
+    reco_psf_map = PSFMap.read(filename, format="gadf")
+    assert isinstance(reco_psf_map, RecoPSFMap)
+    assert "energy" in reco_psf_map.psf_map.geom.axes.names
+    assert reco_psf_map.energy_name == "energy"
+    assert reco_psf_map.required_axes == ["rad", "energy"]
+    assert reco_psf_map.exposure_map is None
 
     with mpl_plot_check():
         reco_psf_map.plot_containment_radius_vs_energy()

--- a/gammapy/irf/psf/tests/test_map.py
+++ b/gammapy/irf/psf/tests/test_map.py
@@ -244,13 +244,16 @@ def test_sample_coord_gauss():
 def make_psf_map_obs(geom, obs):
     exposure_map = make_map_exposure_true_energy(
         geom=geom.squash(axis_name="rad"),
-        pointing=obs.pointing_radec,
+        pointing=obs.get_pointing_icrs(obs.tmid),
         aeff=obs.aeff,
         livetime=obs.observation_live_time_duration,
     )
 
     psf_map = make_psf_map(
-        geom=geom, psf=obs.psf, pointing=obs.pointing_radec, exposure_map=exposure_map
+        geom=geom,
+        psf=obs.psf,
+        pointing=obs.get_pointing_icrs(obs.tmid),
+        exposure_map=exposure_map,
     )
     return psf_map
 

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -80,6 +80,7 @@ def test_to_table():
     hdu = aeff.to_table_hdu()
     assert_equal(hdu.data["ENERG_LO"][0], aeff.axes["energy_true"].edges[:-1].value)
     assert hdu.header["TUNIT1"] == aeff.axes["energy_true"].unit
+    assert "FOVALIGN" not in hdu.header
 
 
 def test_to_table_is_pointlike():

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -8,6 +9,7 @@ from gammapy.irf import (
     Background3D,
     EffectiveAreaTable2D,
     EnergyDispersion2D,
+    EnergyDependentMultiGaussPSF,
     RadMax2D,
     load_cta_irfs,
     load_irf_dict_from_file,
@@ -15,14 +17,16 @@ from gammapy.irf import (
 from gammapy.maps import MapAxis
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import requires_data
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 
 
 @requires_data()
 def test_cta_irf():
     """Test that CTA IRFs can be loaded and evaluated."""
-    irf = load_cta_irfs(
-        "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
-    )
+    with pytest.warns(GammapyDeprecationWarning):
+        irf = load_cta_irfs(
+            "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+        )
 
     energy = Quantity(1, "TeV")
     offset = Quantity(3, "deg")
@@ -48,9 +52,10 @@ def test_cta_irf():
 @requires_data()
 def test_cta_irf_alpha_config_south():
     """Test that CTA IRFs can be loaded and evaluated."""
-    irf = load_cta_irfs(
-        "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
-    )
+    with pytest.warns(GammapyDeprecationWarning):
+        irf = load_cta_irfs(
+            "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
+        )
 
     energy = Quantity(1, "TeV")
     offset = Quantity(3, "deg")
@@ -76,9 +81,10 @@ def test_cta_irf_alpha_config_south():
 @requires_data()
 def test_cta_irf_alpha_config_north():
     """Test that CTA IRFs can be loaded and evaluated."""
-    irf = load_cta_irfs(
-        "$GAMMAPY_DATA/cta-caldb/Prod5-North-20deg-AverageAz-4LSTs09MSTs.180000s-v0.1.fits.gz"
-    )
+    with pytest.warns(GammapyDeprecationWarning):
+        irf = load_cta_irfs(
+            "$GAMMAPY_DATA/cta-caldb/Prod5-North-20deg-AverageAz-4LSTs09MSTs.180000s-v0.1.fits.gz"
+        )
 
     energy = Quantity(1, "TeV")
     offset = Quantity(3, "deg")
@@ -286,3 +292,16 @@ class TestIRFWrite:
 
         read_bkg = Background3D.read(path, hdu="BACKGROUND")
         assert_allclose(read_bkg.quantity, self.bkg_data)
+
+
+@requires_data()
+def test_load_irf_dict_from_file_cta():
+    """Test that CTA IRFs can be loaded and evaluated."""
+    irf = load_irf_dict_from_file(
+        "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+    )
+    assert set(irf.keys()) == {"aeff", "edisp", "psf", "bkg"}
+    assert isinstance(irf["aeff"], EffectiveAreaTable2D)
+    assert isinstance(irf["edisp"], EnergyDispersion2D)
+    assert isinstance(irf["psf"], EnergyDependentMultiGaussPSF)
+    assert isinstance(irf["bkg"], Background3D)

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -512,7 +512,7 @@ class ReflectedRegionsBackgroundMaker(Maker):
             )
 
         regions_off, wcs = self.region_finder.run(
-            center=observation.pointing_radec,
+            center=observation.get_pointing_icrs(observation.tmid),
             region=geom.region,
             exclusion_mask=self.exclusion_mask,
         )

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -60,7 +60,7 @@ def obs_dataset(geom, observation):
 
     reference = MapDataset.create(geom)
     cutout = reference.cutout(
-        observation.pointing_radec, width="4 deg", name="test-fov"
+        observation.get_pointing_icrs(observation.tmid), width="4 deg", name="test-fov"
     )
 
     dataset = map_dataset_maker.run(cutout, observation)

--- a/gammapy/makers/background/tests/test_ring.py
+++ b/gammapy/makers/background/tests/test_ring.py
@@ -56,7 +56,7 @@ def test_ring_bkg_maker(geom, observations, exclusion_mask):
     datasets = []
 
     for obs in observations:
-        cutout = reference.cutout(obs.pointing_radec, width="4 deg")
+        cutout = reference.cutout(obs.get_pointing_icrs(obs.tmid), width="4 deg")
         dataset = map_dataset_maker.run(cutout, obs)
         dataset = safe_mask_maker.run(dataset, obs)
         dataset = dataset.to_image()
@@ -127,7 +127,9 @@ def test_adaptive_ring_bkg_maker(pars, geom, observations, exclusion_mask):
 
     obs = observations[pars["obs_idx"]]
 
-    dataset = MapDataset.create(geom).cutout(obs.pointing_radec, width="4 deg")
+    dataset = MapDataset.create(geom).cutout(
+        obs.get_pointing_icrs(obs.tmid), width="4 deg"
+    )
     dataset = map_dataset_maker.run(dataset, obs)
     dataset = safe_mask_maker.run(dataset, obs)
 

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -362,7 +362,7 @@ class MapDatasetMaker(Maker):
 
         return meta_table
 
-    def run(self, dataset, observation):
+    def run(self, dataset, observation, ignore_meta=False):
         """Make map dataset.
 
         Parameters
@@ -378,7 +378,8 @@ class MapDatasetMaker(Maker):
             Map dataset.
         """
         kwargs = {"gti": observation.gti}
-        kwargs["meta_table"] = self.make_meta_table(observation)
+        if not ignore_meta:
+            kwargs["meta_table"] = self.make_meta_table(observation)
 
         mask_safe = Map.from_geom(dataset.counts.geom, dtype=bool)
         mask_safe.data[...] = True

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -362,7 +362,7 @@ class MapDatasetMaker(Maker):
 
         return meta_table
 
-    def run(self, dataset, observation, ignore_meta=False):
+    def run(self, dataset, observation):
         """Make map dataset.
 
         Parameters
@@ -378,8 +378,7 @@ class MapDatasetMaker(Maker):
             Map dataset.
         """
         kwargs = {"gti": observation.gti}
-        if not ignore_meta:
-            kwargs["meta_table"] = self.make_meta_table(observation)
+        kwargs["meta_table"] = self.make_meta_table(observation)
 
         mask_safe = Map.from_geom(dataset.counts.geom, dtype=bool)
         mask_safe.data[...] = True

--- a/gammapy/makers/reduce.py
+++ b/gammapy/makers/reduce.py
@@ -89,7 +89,7 @@ class DatasetsMaker(Maker):
 
         if self._apply_cutout:
             cutouts_kwargs = {
-                "position": observation.pointing_radec.galactic,
+                "position": observation.get_pointing_icrs(observation.tmid).galactic,
                 "width": self.cutout_width,
                 "mode": self.cutout_mode,
             }

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -102,7 +102,9 @@ class SafeMaskMaker(Maker):
         if observation is None:
             raise ValueError("Method 'offset-max' requires an observation object.")
 
-        separation = dataset._geom.separation(observation.pointing_radec)
+        separation = dataset._geom.separation(
+            observation.get_pointing_icrs(observation.tmid)
+        )
         return separation < self.offset_max
 
     @staticmethod
@@ -163,7 +165,9 @@ class SafeMaskMaker(Maker):
 
         if self.fixed_offset is not None:
             if observation:
-                position = observation.pointing_radec.directional_offset_by(
+                position = observation.get_pointing_icrs(
+                    observation.tmid
+                ).directional_offset_by(
                     position_angle=0.0 * u.deg, separation=self.fixed_offset
                 )
             else:
@@ -221,7 +225,8 @@ class SafeMaskMaker(Maker):
 
         if self.fixed_offset is not None:
             if observation:
-                position = observation.pointing_radec.directional_offset_by(
+                pointing = observation.get_pointing_icrs(observation.tmid)
+                position = pointing.directional_offset_by(
                     position_angle=0 * u.deg, separation=self.fixed_offset
                 )
             else:

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -82,7 +82,7 @@ class SpectrumDatasetMaker(MapDatasetMaker):
                 raise TypeError(
                     "Containment correction only supported for circular regions."
                 )
-            offset = geom.separation(observation.pointing_radec)
+            offset = geom.separation(observation.get_pointing_icrs(observation.tmid))
             containment = observation.psf.containment(
                 rad=geom.region.radius,
                 offset=offset,

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -11,13 +11,15 @@ from gammapy.data import (
     GTI,
     DataStore,
     EventList,
+    FixedPointingInfo,
     HDUIndexTable,
     Observation,
     ObservationTable,
+    PointingMode,
 )
 from gammapy.datasets import MapDataset
 from gammapy.datasets.map import RAD_AXIS_DEFAULT
-from gammapy.irf import EDispKernelMap, EDispMap, PSFMap, Background2D
+from gammapy.irf import Background2D, EDispKernelMap, EDispMap, PSFMap
 from gammapy.makers import FoVBackgroundMaker, MapDatasetMaker, SafeMaskMaker
 from gammapy.maps import HpxGeom, Map, MapAxis, WcsGeom
 from gammapy.utils.testing import requires_data, requires_dependency
@@ -148,7 +150,7 @@ def test_map_maker(pars, observations):
     safe_mask_maker = SafeMaskMaker(methods=["offset-max"], offset_max="2 deg")
 
     for obs in observations:
-        cutout = stacked.cutout(position=obs.pointing_radec, width="4 deg")
+        cutout = stacked.cutout(position=obs.get_pointing_icrs(obs.tmid), width="4 deg")
         dataset = maker.run(cutout, obs)
         dataset = safe_mask_maker.run(dataset, obs)
         stacked.stack(dataset)
@@ -338,7 +340,6 @@ def test_interpolate_map_dataset():
     # define observation
     obs = Observation(
         obs_id=0,
-        obs_info={"RA_PNT": 0.0, "DEC_PNT": 0.0},
         gti=gti,
         aeff=aeff_map,
         edisp=edispmap,
@@ -346,6 +347,9 @@ def test_interpolate_map_dataset():
         bkg=bkg_map,
         events=events,
         obs_filter=None,
+        pointing=FixedPointingInfo(
+            mode=PointingMode.POINTING, fixed_icrs=SkyCoord(0 * u.deg, 0 * u.deg)
+        ),
     )
 
     # define analysis geometry

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -366,13 +366,13 @@ def test_dataset_maker_spectrum_rad_max_all_excluded(
 
     # excludes all possible off regions
     exclusion_region = CircleSkyRegion(
-        center=observation.pointing_radec,
+        center=observation.get_pointing_icrs(observation.tmid),
         radius=1 * u.deg,
     )
     geom = WcsGeom.create(
         npix=(150, 150),
         binsz=0.05,
-        skydir=observation.pointing_radec,
+        skydir=observation.get_pointing_icrs(observation.tmid),
         proj="TAN",
         frame="icrs",
     )

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -41,9 +41,8 @@ def dataset(observation_cta_1dc):
     axis_true = MapAxis.from_bounds(
         0.1, 50, nbin=30, unit="TeV", name="energy_true", interp="log"
     )
-    geom = WcsGeom.create(
-        npix=(11, 11), axes=[axis], skydir=observation_cta_1dc.pointing_radec
-    )
+    pointing = observation_cta_1dc.get_pointing_icrs(observation_cta_1dc.tmid)
+    geom = WcsGeom.create(npix=(11, 11), axes=[axis], skydir=pointing)
 
     empty_dataset = MapDataset.create(geom=geom, energy_axis_true=axis_true)
     dataset_maker = MapDatasetMaker()
@@ -56,7 +55,8 @@ def shifted_dataset(observation_cta_1dc):
     axis_true = MapAxis.from_bounds(
         0.1, 2, nbin=10, unit="TeV", name="energy_true", interp="log"
     )
-    skydir = observation_cta_1dc.pointing_radec.directional_offset_by(
+    pointing = observation_cta_1dc.get_pointing_icrs(observation_cta_1dc.tmid)
+    skydir = pointing.directional_offset_by(
         position_angle=0.0 * u.deg, separation=10 * u.deg
     )
     geom = WcsGeom.create(npix=(11, 11), axes=[axis], skydir=skydir)
@@ -78,7 +78,8 @@ def spectrum_dataset_on_off(observation_cta_1dc):
     )
     axis_migra = MapAxis.from_bounds(0.2, 5.0, nbin=48, name="migra")
 
-    region = CircleSkyRegion(observation_cta_1dc.pointing_radec, radius=0.3 * u.deg)
+    pointing = observation_cta_1dc.get_pointing_icrs(observation_cta_1dc.tmid)
+    region = CircleSkyRegion(pointing, radius=0.3 * u.deg)
     geom = RegionGeom.create(region, axes=[axis])
 
     return SpectrumDatasetOnOff.create(
@@ -88,8 +89,10 @@ def spectrum_dataset_on_off(observation_cta_1dc):
 
 @requires_data()
 def test_safe_mask_maker_offset_max(dataset, observation_cta_1dc):
+    pointing = observation_cta_1dc.get_pointing_icrs(observation_cta_1dc.tmid)
     safe_mask_maker = SafeMaskMaker(
-        offset_max="3 deg", position=observation_cta_1dc.pointing_radec
+        offset_max="3 deg",
+        position=pointing,
     )
 
     mask_offset = safe_mask_maker.make_mask_offset_max(
@@ -100,7 +103,8 @@ def test_safe_mask_maker_offset_max(dataset, observation_cta_1dc):
 
 @requires_data()
 def test_safe_mask_maker_aeff_default(dataset, observation_cta_1dc, caplog):
-    safe_mask_maker = SafeMaskMaker(position=observation_cta_1dc.pointing_radec)
+    pointing = observation_cta_1dc.get_pointing_icrs(observation_cta_1dc.tmid)
+    safe_mask_maker = SafeMaskMaker(position=pointing)
 
     mask_energy_aeff_default = safe_mask_maker.make_mask_energy_aeff_default(
         dataset=dataset, observation=observation_cta_1dc
@@ -119,7 +123,8 @@ def test_safe_mask_maker_aeff_default(dataset, observation_cta_1dc, caplog):
 
 @requires_data()
 def test_safe_mask_maker_aeff_max(dataset, observation_cta_1dc):
-    safe_mask_maker = SafeMaskMaker(position=observation_cta_1dc.pointing_radec)
+    pointing = observation_cta_1dc.get_pointing_icrs(observation_cta_1dc.tmid)
+    safe_mask_maker = SafeMaskMaker(position=pointing)
 
     mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset)
 
@@ -180,9 +185,8 @@ def test_safe_mask_maker_offset_max_fixed_offset(dataset, observation_cta_1dc):
 
 @requires_data()
 def test_safe_mask_maker_edisp_bias(dataset, observation_cta_1dc):
-    safe_mask_maker = SafeMaskMaker(
-        bias_percent=0.02, position=observation_cta_1dc.pointing_radec
-    )
+    pointing = observation_cta_1dc.get_pointing_icrs(observation_cta_1dc.tmid)
+    safe_mask_maker = SafeMaskMaker(bias_percent=0.02, position=pointing)
 
     mask_edisp_bias = safe_mask_maker.make_mask_energy_edisp_bias(dataset=dataset)
     assert_allclose(mask_edisp_bias.data.sum(), 1815)
@@ -214,7 +218,8 @@ def test_safe_mask_maker_edisp_bias_fixed_offset(dataset, observation_cta_1dc):
 
 @requires_data()
 def test_safe_mask_maker_bkg_peak(dataset, observation_cta_1dc):
-    safe_mask_maker = SafeMaskMaker(position=observation_cta_1dc.pointing_radec)
+    pointing = observation_cta_1dc.get_pointing_icrs(observation_cta_1dc.tmid)
+    safe_mask_maker = SafeMaskMaker(position=pointing)
 
     mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
     assert_allclose(mask_bkg_peak.data.sum(), 1936)
@@ -222,15 +227,14 @@ def test_safe_mask_maker_bkg_peak(dataset, observation_cta_1dc):
 
 @requires_data()
 def test_safe_mask_maker_bkg_peak_first_bin(dataset, observation_cta_1dc):
-    safe_mask_maker = SafeMaskMaker(position=observation_cta_1dc.pointing_radec)
+    pointing = observation_cta_1dc.get_pointing_icrs(observation_cta_1dc.tmid)
+    safe_mask_maker = SafeMaskMaker(position=pointing)
 
     dataset_maker = MapDatasetMaker()
 
     axis = MapAxis.from_bounds(1.0, 10, nbin=6, unit="TeV", name="energy", interp="log")
 
-    geom = WcsGeom.create(
-        npix=(5, 5), axes=[axis], skydir=observation_cta_1dc.pointing_radec
-    )
+    geom = WcsGeom.create(npix=(5, 5), axes=[axis], skydir=pointing)
     empty_dataset = MapDataset.create(geom=geom)
     dataset = dataset_maker.run(empty_dataset, observation_cta_1dc)
     mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
@@ -238,7 +242,7 @@ def test_safe_mask_maker_bkg_peak_first_bin(dataset, observation_cta_1dc):
 
 
 @requires_data()
-def test_safe_mask_maker_no_root(dataset, observation_cta_1dc):
+def test_safe_mask_maker_no_root(dataset):
     safe_mask_maker_noroot = SafeMaskMaker(
         offset_max="3 deg", aeff_percent=-10, bias_percent=-10
     )
@@ -251,6 +255,7 @@ def test_safe_mask_maker_no_root(dataset, observation_cta_1dc):
 @requires_data()
 def test_safe_mask_maker_bkg_invalid(observations_hess_dl3):
     obs = observations_hess_dl3[0]
+    pointing = obs.get_pointing_icrs(obs.tmid)
 
     axis = MapAxis.from_bounds(
         0.1, 10, nbin=16, unit="TeV", name="energy", interp="log"
@@ -258,7 +263,7 @@ def test_safe_mask_maker_bkg_invalid(observations_hess_dl3):
     axis_true = MapAxis.from_bounds(
         0.1, 50, nbin=30, unit="TeV", name="energy_true", interp="log"
     )
-    geom = WcsGeom.create(npix=(9, 9), axes=[axis], skydir=obs.pointing_radec)
+    geom = WcsGeom.create(npix=(9, 9), axes=[axis], skydir=pointing)
 
     empty_dataset = MapDataset.create(geom=geom, energy_axis_true=axis_true)
     dataset_maker = MapDatasetMaker()

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -887,7 +887,8 @@ class MapAxis:
 
         for arg in argnames:
             value = getattr(self, "_" + arg)
-            kwargs.setdefault(arg, copy.deepcopy(value))
+            if arg not in kwargs:
+                kwargs[arg] = copy.deepcopy(value)
 
         return self.__class__(**kwargs)
 
@@ -2565,7 +2566,8 @@ class TimeMapAxis:
 
         for arg in argnames:
             value = getattr(self, "_" + arg)
-            kwargs.setdefault(arg, copy.deepcopy(value))
+            if arg not in kwargs:
+                kwargs[arg] = copy.deepcopy(value)
 
         return self.__class__(**kwargs)
 

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2696,11 +2696,27 @@ class TimeMapAxis:
         elif format == "lightcurve":
             # TODO: is this a good format? It just supports mjd...
             name = "time"
-            scale = table.meta.get("TIMESYS", "utc")
-            time_min = Time(table["time_min"].data, format="mjd", scale=scale)
-            time_max = Time(table["time_max"].data, format="mjd", scale=scale)
-            reference_time = Time("2001-01-01T00:00:00")
-            reference_time.format = "mjd"
+            time_ref_dict = dict(
+                MJDREFF=table.meta.get("MJDREFF", 0),
+                MJDREFI=table.meta.get("MJDREFI", 0),
+                TIMESYS=table.meta.get("TIMESYS", "utc"),
+                TIMEUNIT=table.meta.get("TIMEUNIT", "d"),
+            )
+            reference_time = time_ref_from_dict(time_ref_dict, format="mjd")
+            time_min = reference_time + table["time_min"].data * u.Unit(
+                time_ref_dict["TIMEUNIT"]
+            )
+            time_max = reference_time + table["time_max"].data * u.Unit(
+                time_ref_dict["TIMEUNIT"]
+            )
+
+            if reference_time.mjd == 0:
+                # change to a more recent reference time
+                reference_time = Time(
+                    "2001-01-01T00:00:00", scale=time_ref_dict["TIMESYS"]
+                )
+                reference_time.format = "mjd"
+
             edges_min = (time_min - reference_time).to("s")
             edges_max = (time_max - reference_time).to("s")
         else:

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -63,7 +63,8 @@ class Map(abc.ABC):
 
         for arg in argnames:
             value = getattr(self, "_" + arg)
-            kwargs.setdefault(arg, copy.deepcopy(value))
+            if arg not in kwargs:
+                kwargs[arg] = copy.deepcopy(value)
 
         return self.from_geom(**kwargs)
 
@@ -1409,7 +1410,7 @@ class Map(abc.ABC):
             energy_axis = self.geom.axes["energy_true"].copy(name="energy")
 
         geom = self.geom.to_image().to_cube(axes=[energy_axis])
-        return self._init_copy(geom=geom, data=data)
+        return self.__class__(geom=geom, data=data, unit=self.unit)
 
     def mask_nearest_position(self, position):
         """Given a sky coordinate return nearest valid position in the mask

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -998,8 +998,8 @@ class Map(abc.ABC):
         if preserve_counts:
             if geom.ndim > 2 and geom.axes[0] != self.geom.axes[0]:
                 raise ValueError(
-                    f"Energy axis do not match: expected {self.geom.axes[0]},"
-                    " but got {geom.axes[0]}."
+                    f"Energy axes do not match, expected: \n {self.geom.axes[0]},"
+                    f" but got: \n {geom.axes[0]}."
                 )
             map_copy.data /= map_copy.geom.solid_angle().to_value("deg2")
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -8,6 +8,7 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 import matplotlib.pyplot as plt
+from gammapy.utils.deprecation import deprecated
 from gammapy.utils.random import InverseCDFSampler, get_random_state
 from gammapy.utils.scripts import make_path
 from gammapy.utils.units import energy_unit_format
@@ -1382,6 +1383,7 @@ class Map(abc.ABC):
 
         return self._init_copy(**kwargs)
 
+    @deprecated("v1.1", alternative="gammapy.datasets.apply_edisp")
     def apply_edisp(self, edisp):
         """Apply energy dispersion to map. Requires energy axis.
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -585,7 +585,8 @@ class Geom(abc.ABC):
 
         for arg in argnames:
             value = getattr(self, "_" + arg)
-            kwargs.setdefault(arg, copy.deepcopy(value))
+            if arg not in kwargs:
+                kwargs[arg] = copy.deepcopy(value)
 
         return self.__class__(**kwargs)
 

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -462,7 +462,7 @@ class RegionGeom(Geom):
             RegionGeom with the added axes.
         """
         axes = copy.deepcopy(self.axes) + axes
-        return self._init_copy(axes=axes)
+        return self._init_copy(region=self.region, wcs=self.wcs, axes=axes)
 
     def to_image(self):
         """Remove non-spatial axes to create a 2D region.
@@ -472,7 +472,7 @@ class RegionGeom(Geom):
         region : `~RegionGeom`
             RegionGeom without any non-spatial axes.
         """
-        return self._init_copy(axes=None)
+        return self._init_copy(region=self.region, wcs=self.wcs, axes=None)
 
     def upsample(self, factor, axis_name=None):
         """Upsample a non-spatial dimension of the region by a given factor.
@@ -483,7 +483,7 @@ class RegionGeom(Geom):
             RegionGeom with the upsampled axis.
         """
         axes = self.axes.upsample(factor=factor, axis_name=axis_name)
-        return self._init_copy(axes=axes)
+        return self._init_copy(region=self.region, wcs=self.wcs, axes=axes)
 
     def downsample(self, factor, axis_name):
         """Downsample a non-spatial dimension of the region by a given factor.
@@ -494,7 +494,7 @@ class RegionGeom(Geom):
             RegionGeom with the downsampled axis.
         """
         axes = self.axes.downsample(factor=factor, axis_name=axis_name)
-        return self._init_copy(axes=axes)
+        return self._init_copy(region=self.region, wcs=self.wcs, axes=axes)
 
     def pix_to_coord(self, pix):
         lon = np.where(

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -9,6 +9,7 @@ from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator, StatProfileScale
 from gammapy.utils.scripts import make_path
+from gammapy.utils.time import time_ref_from_dict, time_ref_to_dict
 from ..axes import MapAxes
 from ..core import Map
 from ..geom import pix_tuple_to_idx
@@ -516,6 +517,10 @@ class RegionNDMap(Map):
         if format in ["ogip", "ogip-sherpa", "ogip-arf", "ogip-arf-sherpa"]:
             hdulist.append(fits.BinTableHDU(table))
         elif format == "gadf":
+            if self.meta.setdefault("MJDREFI"):
+                t_ref = time_ref_from_dict(self.meta)
+                time_ref_dict = time_ref_to_dict(t_ref)
+                table.meta.update(time_ref_dict)
             table.meta.update(self.geom.axes.to_header())
             hdulist.append(fits.BinTableHDU(table, name=hdu))
         else:

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -562,6 +562,26 @@ def test_from_table_time_axis():
     assert_allclose(axis.time_mid[0].mjd, 53778.25)
 
 
+def test_from_table_time_axis_lightcurve_format():
+    t0 = Time("2006-02-12", scale="tt")
+    t_min = np.linspace(0, 10, 10) * u.d
+    t_max = t_min + 12 * u.h
+
+    table = Table()
+    table["time_min"] = t_min.to_value("h")
+    table["time_max"] = t_max.to_value("h")
+    table.meta.update(time_ref_to_dict(t0))
+    table.meta["TIMEUNIT"] = "h"
+
+    axis = TimeMapAxis.from_table(table, format="lightcurve")
+
+    assert axis.nbin == 10
+    assert_allclose(axis.time_mid[0].mjd, 53778.25)
+    assert axis.time_mid.scale == "tt"
+    t0.format = "mjd"
+    assert_time_allclose(axis.reference_time, t0)
+
+
 @requires_data()
 def test_from_gti_time_axis():
     filename = "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"

--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -877,10 +877,9 @@ class WcsGeom(Geom):
 
         binsz = self.pixel_scales
         width_npix = np.clip((width / binsz).to_value(""), 1, None)
-        width = width_npix * binsz
 
         if odd_npix:
-            width = round_up_to_odd(width_npix)
+            width_npix = round_up_to_odd(width_npix)
 
         dummy_data = np.empty(self.to_image().data_shape, dtype=bool)
         c2d = Cutout2D(
@@ -888,7 +887,7 @@ class WcsGeom(Geom):
             wcs=self.wcs,
             position=position,
             # Cutout2D takes size with order (lat, lon)
-            size=width[::-1],
+            size=width_npix[::-1],
             mode=mode,
         )
         return self._init_copy(wcs=c2d.wcs, npix=c2d.shape[::-1])

--- a/gammapy/maps/wcs/tests/test_geom.py
+++ b/gammapy/maps/wcs/tests/test_geom.py
@@ -620,3 +620,13 @@ def test_wcs_geom_to_even_npix():
     geom_even = geom.to_even_npix()
 
     assert geom_even.data_shape == (4, 4)
+
+
+def test_wcs_geom_no_zero_shape_cut():
+    geom = WcsGeom.create(skydir=(0, 2.5), binsz=(360, 5), width=(360, 180))
+    skydir = SkyCoord(110.0, 75.0, unit="deg", frame="icrs")
+
+    geom_cut = geom.cutout(skydir, width=5)
+
+    assert geom_cut.data_shape != (1, 0)
+    assert geom_cut.data_shape == (1, 1)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -702,7 +702,7 @@ class FoVBackgroundModel(ModelBase):
         spectral_data = data.get("spectral")
         if spectral_data is not None:
             model_class = SPECTRAL_MODEL_REGISTRY.get_cls(spectral_data["type"])
-            spectral_model = model_class.from_dict(spectral_data)
+            spectral_model = model_class.from_dict({"spectral": spectral_data})
         else:
             spectral_model = None
 
@@ -883,7 +883,7 @@ class TemplateNPredModel(ModelBase):
 
         if spectral_data is not None:
             model_class = SPECTRAL_MODEL_REGISTRY.get_cls(spectral_data["type"])
-            spectral_model = model_class.from_dict(spectral_data)
+            spectral_model = model_class.from_dict({"spectral": spectral_data})
         else:
             spectral_model = None
 

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1086,7 +1086,7 @@ class TemplateSpatialModel(SpatialModel):
         Normalize the input map so that it integrates to unity.
     interp_kwargs : dict
         Interpolation keyword arguments passed to `gammapy.maps.Map.interp_by_coord`.
-        Default arguments are {'method': 'linear', 'fill_value': 0}.
+        Default arguments are {'method': 'linear', 'fill_value': 0, "values_scale": "log"}.
     Filename : str
         Name of the map file
     copy_data : bool
@@ -1139,6 +1139,7 @@ class TemplateSpatialModel(SpatialModel):
         interp_kwargs = {} if interp_kwargs is None else interp_kwargs
         interp_kwargs.setdefault("method", "linear")
         interp_kwargs.setdefault("fill_value", 0)
+        interp_kwargs.setdefault("values_scale", "log")
 
         self._interp_kwargs = interp_kwargs
         self.filename = filename

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -20,6 +20,7 @@ import matplotlib.pyplot as plt
 from gammapy.maps import Map, WcsGeom
 from gammapy.modeling import Parameter
 from gammapy.modeling.covariance import copy_covariance
+from gammapy.utils.deprecation import deprecated
 from gammapy.utils.gauss import Gauss2DPDF
 from gammapy.utils.regions import region_circle_to_ellipse, region_to_frame
 from gammapy.utils.scripts import make_path
@@ -301,7 +302,31 @@ class SpatialModel(ModelBase):
             )
         return m.plot(ax=ax, **kwargs)
 
+    @deprecated("v1.0.1", alternative="plot_interactive")
     def plot_interative(self, ax=None, geom=None, **kwargs):
+        """Plot spatial model.
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axis
+        geom : `~gammapy.maps.WcsGeom`, optional
+            Geom to use for plotting.
+        **kwargs : dict
+            Keyword arguments passed to `~gammapy.maps.WcsMap.plot()`
+
+        Returns
+        -------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axis
+        """
+
+        m = self._get_plot_map(geom)
+        if m.geom.is_image:
+            raise TypeError("Use .plot() for 2D Maps")
+        m.plot_interactive(ax=ax, **kwargs)
+
+    def plot_interactive(self, ax=None, geom=None, **kwargs):
         """Plot spatial model.
 
         Parameters
@@ -1246,7 +1271,13 @@ class TemplateSpatialModel(SpatialModel):
             geom = self.map.geom
         super().plot(ax=ax, geom=geom, **kwargs)
 
+    @deprecated("v1.0.1", alternative="plot_interactive")
     def plot_interative(self, ax=None, geom=None, **kwargs):
         if geom is None:
             geom = self.map.geom
-        super().plot_interative(ax=ax, geom=geom, **kwargs)
+        super().plot_interactive(ax=ax, geom=geom, **kwargs)
+
+    def plot_interactive(self, ax=None, geom=None, **kwargs):
+        if geom is None:
+            geom = self.map.geom
+        super().plot_interactive(ax=ax, geom=geom, **kwargs)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1678,7 +1678,10 @@ class TemplateSpectralModel(SpectralModel):
         data = data["spectral"]
         energy = u.Quantity(data["energy"]["data"], data["energy"]["unit"])
         values = u.Quantity(data["values"]["data"], data["values"]["unit"])
-        norm = [p["value"] for p in data["parameters"] if p["name"] == "norm"][0]
+        if "parameters" in data.keys():
+            norm = [p["value"] for p in data["parameters"] if p["name"] == "norm"][0]
+        else:
+            norm = 1.0
         return cls(energy=energy, values=values, norm=norm)
 
     @classmethod

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -524,8 +524,9 @@ class SpectralModel(ModelBase):
         ----------
         energy : `~astropy.units.Quantity`
             Energy at which to estimate the index
-        epsilon : float
+        epsilon : float, optional
             Fractional energy increment to use for determining the spectral index.
+            default = 1e-5
 
         Returns
         -------
@@ -535,6 +536,26 @@ class SpectralModel(ModelBase):
         f1 = self(energy)
         f2 = self(energy * (1 + epsilon))
         return np.log(f1 / f2) / np.log(1 + epsilon)
+
+    def spectral_index_error(self, energy, epsilon=1e-5):
+        """Evaluate the error on spectral index at the given energy
+
+        Parameters
+        ----------
+        energy : `~astropy.units.Quantity`
+            Energy at which to estimate the index
+        epsilon : float, optional
+            Fractional energy increment to use for determining the spectral index
+            default = 1e-5
+
+        Returns
+        -------
+        index, index_error : tuple of float
+            Estimated spectral index and its error
+        """
+        return self._propagate_error(
+            epsilon=epsilon, fct=self.spectral_index, energy=energy
+        )
 
     def inverse(self, value, energy_min=0.1 * u.TeV, energy_max=100 * u.TeV):
         """Return energy for a given function value of the spectral model.

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -13,6 +13,7 @@ from gammapy.utils.random import InverseCDFSampler, get_random_state
 from gammapy.utils.scripts import make_path
 from gammapy.utils.time import time_ref_from_dict
 from .core import ModelBase, _build_parameters_from_dict
+from .utils import _read_cta_sdc
 
 __all__ = [
     "ConstantTemporalModel",
@@ -464,12 +465,6 @@ class LightCurveTemplateTemporalModel(TemporalModel):
         if (map.data < 0).any():
             log.warning("Map has negative values. Check and fix this!")
 
-        if map.geom.has_energy_axis:
-            raise NotImplementedError(
-                "LightCurveTemplateTemporalModel does not"
-                f" support energy axis, got {map.geom.axes.names}"
-            )
-
         self.map = map.copy()
         super().__init__()
 
@@ -481,19 +476,29 @@ class LightCurveTemplateTemporalModel(TemporalModel):
     def __str__(self):
         start_time = self.t_ref.quantity + self.map.geom.axes["time"].edges[0]
         end_time = self.t_ref.quantity + self.map.geom.axes["time"].edges[-1]
-        norm_min = np.min(self.map.data)
-        norm_max = np.max(self.map.data)
+        norm_min = np.nanmin(self.map.data)
+        norm_max = np.nanmax(self.map.data)
 
         prnt = (
-            f"{self.__class__.__name__} model summary:\n "
+            f"{self.__class__.__name__} model summary:\n\n "
             f"Reference time: {self.t_ref.value} MJD \n "
             f"Start time: {start_time.value} MJD \n "
             f"End time: {end_time.value} MJD \n "
             f"Norm min: {norm_min} \n"
-            f"Norm max: {norm_max}"
+            f"Norm max: {norm_max} \n"
         )
 
+        if self.is_energy_dependent:
+            energy_min = self.map.geom.axes["energy"].edges[0]
+            energy_max = self.map.geom.axes["energy"].edges[-1]
+            prnt1 = f"Energy min: {energy_min} \n" f"Energy max: {energy_max} \n"
+            prnt = prnt + prnt1
+
         return prnt
+
+    @property
+    def is_energy_dependent(self):
+        return self.map.geom.has_energy_axis
 
     @classmethod
     def from_table(cls, table, filename=None):
@@ -524,7 +529,6 @@ class LightCurveTemplateTemporalModel(TemporalModel):
         m = RegionNDMap.create(
             region=None, axes=axes, meta=table.meta, data=table["NORM"]
         )
-
         return cls(m, t_ref=t_ref, filename=filename)
 
     @classmethod
@@ -535,8 +539,9 @@ class LightCurveTemplateTemporalModel(TemporalModel):
         ----------
         filename : str
             Name of file to read
-        format : {"table", "map"}
+        format : {"table", "map", "cta-sdc"}
             Format of the input file.
+            The cta-sdc model is only supported for the CTA Science Data Challenge
 
         Returns
         -------
@@ -553,13 +558,26 @@ class LightCurveTemplateTemporalModel(TemporalModel):
             t_ref = time_ref_from_dict(m.meta)
             return cls(m, t_ref=t_ref, filename=filename)
 
+        elif format == "cta-sdc":
+            m, t_ref = _read_cta_sdc(filename)
+            return cls(m, t_ref=t_ref, filename=filename)
+
         else:
             raise ValueError(
-                f"Not a valid format: '{format}', choose from: {'table', 'map'}"
+                f"Not a valid format: '{format}', choose from: {'table', 'map', 'cta-sdc'}"
             )
+
+    def integral(self, t_min, t_max, oversampling_factor=100, **kwargs):
+        if self.is_energy_dependent:
+            raise NotImplementedError("Not supported for energy dependent models")
+        return super().integral(t_min, t_max, oversampling_factor, **kwargs)
 
     def to_table(self):
         """Convert model to an astropy table"""
+
+        if self.is_energy_dependent:
+            raise NotImplementedError("Not supported for energy dependent models")
+
         table = Table(
             data=[self.map.geom.axes["time"].center, self.map.quantity],
             names=["TIME", "NORM"],
@@ -582,7 +600,6 @@ class LightCurveTemplateTemporalModel(TemporalModel):
 
         if self.filename is None:
             raise IOError("Missing filename")
-
         if format == "table":
             table = self.to_table()
             table.write(filename, overwrite=overwrite)
@@ -591,14 +608,17 @@ class LightCurveTemplateTemporalModel(TemporalModel):
         else:
             raise ValueError("Not a valid format, choose from ['map', 'table']")
 
-    def evaluate(self, time, t_ref=None):
+    def evaluate(self, time, t_ref=None, energy=None):
         """Evaluate the model at given coordinates."""
-
         if t_ref is None:
             t_ref = Time(self.t_ref.value, format="mjd")
-
         t = (time - t_ref).to_value(self.map.geom.axes["time"].unit)
         coords = {"time": t}
+        if self.is_energy_dependent:
+            if energy is None:
+                coords["energy"] = self.map.geom.axes["energy"].center.reshape(-1, 1)
+            else:
+                coords["energy"] = energy.reshape(-1, 1)
         val = self.map.interp_by_coord(coords)
         val = np.clip(val, 0, a_max=None)
         return u.Quantity(val, self.map.unit, copy=False)
@@ -617,6 +637,53 @@ class LightCurveTemplateTemporalModel(TemporalModel):
         data["temporal"]["format"] = format
         data["temporal"]["unit"] = str(self.map.unit)
         return data
+
+    def plot(self, time_range, energy=None, ax=None, n_points=100, **kwargs):
+        """
+        Plot Temporal Model.
+
+        Parameters
+        ----------
+        time_range : `~astropy.time.Time`
+            times to plot the model
+        energy : `~astropy.units.quantity`
+            energies to compute the model at for energy dependent models, optional
+        ax : `~matplotlib.axes.Axes`, optional
+            Axis to plot on
+        n_points : int
+            Number of bins to plot model
+        **kwargs : dict
+            Keywords forwarded to `~matplotlib.pyplot.errorbar`
+
+        Returns
+        -------
+        ax : `~matplotlib.axes.Axes`, optional
+            axis
+        """
+        if not self.is_energy_dependent:
+            super().plot(time_range=time_range, ax=ax, n_points=n_points, **kwargs)
+        else:
+            time_min, time_max = time_range
+            time_axis = TimeMapAxis.from_time_bounds(
+                time_min=time_min, time_max=time_max, nbin=n_points
+            )
+            if energy is None:
+                energy_axis = self.map.geom.axes["energy"]
+            else:
+                energy_axis = MapAxis.from_nodes(
+                    nodes=energy, name="energy", interp="log"
+                )
+
+            m = RegionNDMap.create(region=None, axes=[time_axis, energy_axis])
+            # kwargs.setdefault("marker", "None")
+            # kwargs.setdefault("ls", "-")
+            # kwargs.setdefault("xerr", None)
+            m.quantity = self.evaluate(
+                time=time_axis.time_mid, energy=energy_axis.center
+            )
+            ax = m.plot(axis_name="time", ax=ax, **kwargs)
+            ax.set_ylabel("Norm / A.U.")
+            return ax, m
 
 
 class PowerLawTemporalModel(TemporalModel):

--- a/gammapy/modeling/models/tests/data/examples.yaml
+++ b/gammapy/modeling/models/tests/data/examples.yaml
@@ -30,14 +30,14 @@ components:
     type: PointSpatialModel
     parameters:
     - name: lon_0
-      value: -50.
+      value: -0.5
       scale: 0.01
       unit: deg
       min: -180.0
       max: 180.0
       frozen: true
     - name: lat_0
-      value: -0.05
+      value: -0.0005
       scale: 0.01
       unit: deg
       min: -90.0
@@ -68,7 +68,7 @@ components:
       max: .nan
       frozen: true
     - name: lambda_
-      value: 0.06
+      value: 0.006
       scale: 0.1
       unit: TeV-1
       min: .nan

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -427,7 +427,7 @@ class Test_Template_with_cube:
         val = model.evaluate(0 * u.deg, 0 * u.deg, 100 * u.GeV)
         assert val.unit == "cm-2 s-1 MeV-1 sr-1"
         assert val.shape == (1,)
-        assert_allclose(val.value, 1.396424e-12, rtol=1e-5)
+        assert_allclose(val.value, 1.395156e-12, rtol=1e-5)
 
     @staticmethod
     def test_evaluation_radius(diffuse_model):

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -12,6 +12,7 @@ from gammapy.modeling.models import (
     ConstantTemporalModel,
     EBLAbsorptionNormSpectralModel,
     ExpDecayTemporalModel,
+    FoVBackgroundModel,
     GaussianTemporalModel,
     LinearTemporalModel,
     LogParabolaSpectralModel,
@@ -161,6 +162,14 @@ def test_piecewise_norm_spectral_model_io():
     assert_allclose(new_model.parameters[0].value, 2)
     assert_allclose(new_model.energy, energy)
     assert_allclose(new_model.norms, [2, 5, 3, 0.5])
+
+    bkg = FoVBackgroundModel(spectral_model=model, dataset_name="")
+    bkg_dict = bkg.to_dict()
+    new_bkg = FoVBackgroundModel.from_dict(bkg_dict)
+
+    assert_allclose(new_bkg.spectral_model.parameters[0].value, 2)
+    assert_allclose(new_bkg.spectral_model.energy, energy)
+    assert_allclose(new_bkg.spectral_model.norms, [2, 5, 3, 0.5])
 
 
 @requires_data()

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -336,7 +336,7 @@ def test_sky_diffuse_map(caplog):
     assert isinstance(model.to_region(), RectangleSkyRegion)
 
     with pytest.raises(TypeError):
-        model.plot_interative()
+        model.plot_interactive()
 
     with pytest.raises(TypeError):
         model.plot_grid()

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -323,7 +323,7 @@ def test_sky_diffuse_map(caplog):
     ]
 
     assert val.unit == "sr-1"
-    desired = [3269.178107, 0]
+    desired = [3265.6559, 0]
     assert_allclose(val.value, desired)
 
     res = model.evaluate_geom(model.map.geom)

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -953,6 +953,18 @@ class TestSpectralModelErrorPropagation:
         assert_allclose(out.data, [4.119e-11, 8.157e-12], rtol=1e-3)
 
 
+def test_logpar_index_error():
+    model = LogParabolaSpectralModel(
+        amplitude=3.81e-11 / u.cm**2 / u.s / u.TeV,
+        reference=1 * u.TeV,
+        alpha=2.19,
+        beta=0.226,
+    )
+    model.alpha.error = 0.4
+    out = model.spectral_index_error(energy=1.0 * u.TeV)
+    assert_allclose(out, [2.19, 0.4], rtol=1e-3)
+
+
 def test_dnde_error_ecpl_model():
     # Regression test for ECPL model
     # https://github.com/gammapy/gammapy/issues/2007

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -46,6 +46,24 @@ def test_light_curve_evaluate(light_curve):
     assert_allclose(val, 0.015512, rtol=1e-5)
 
 
+@requires_data()
+def test_energy_dependent_lightcurve():
+    filename = "$GAMMAPY_DATA/gravitational_waves/GW_example_DC_file.fits.gz"
+    mod = LightCurveTemplateTemporalModel.read(filename, format="cta-sdc")
+
+    assert mod.is_energy_dependent == True
+
+    t = Time(55555.6157407407, format="mjd")
+    val = mod.evaluate(t, energy=[0.3, 2] * u.TeV)
+    assert_allclose(val, [[2.36248483e-21, 4.34347110e-23]], rtol=1e-5)
+
+    with mpl_plot_check():
+        mod.plot(
+            time_range=(Time(55555.50, format="mjd"), Time(55563.0, format="mjd")),
+            energy=[0.3, 2] * u.TeV,
+        )
+
+
 def ph_curve(x, amplitude=0.5, x0=0.01):
     return 100.0 + amplitude * np.sin(2 * np.pi * (x - x0) / 1.0)
 

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -55,7 +55,7 @@ def test_energy_dependent_lightcurve():
 
     t = Time(55555.6157407407, format="mjd")
     val = mod.evaluate(t, energy=[0.3, 2] * u.TeV)
-    assert_allclose(val, [[2.36248483e-21, 4.34347110e-23]], rtol=1e-5)
+    assert_allclose(val.data, [[2.36248483e-21], [4.34347110e-23]], rtol=1e-5)
 
     with mpl_plot_check():
         mod.plot(

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -51,7 +51,7 @@ def test_energy_dependent_lightcurve():
     filename = "$GAMMAPY_DATA/gravitational_waves/GW_example_DC_file.fits.gz"
     mod = LightCurveTemplateTemporalModel.read(filename, format="cta-sdc")
 
-    assert mod.is_energy_dependent == True
+    assert mod.is_energy_dependent is True
 
     t = Time(55555.6157407407, format="mjd")
     val = mod.evaluate(t, energy=[0.3, 2] * u.TeV)

--- a/gammapy/modeling/models/utils.py
+++ b/gammapy/modeling/models/utils.py
@@ -39,6 +39,7 @@ def _read_cta_sdc(filename):
                 region=PointSkyRegion(center=position),
                 axes=[energy_axis, time_axis],
                 data=np.array(list(data.data) * u.Unit(data.header["UNITS"])),
+                meta=time_header,
             ),
             time_ref,
         )

--- a/gammapy/modeling/models/utils.py
+++ b/gammapy/modeling/models/utils.py
@@ -1,6 +1,8 @@
 import numpy as np
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.io import fits
+from regions import PointSkyRegion
 from gammapy.maps import MapAxis, RegionNDMap
 from gammapy.utils.time import time_ref_from_dict
 
@@ -9,6 +11,11 @@ def _read_cta_sdc(filename):
     """To create a `LightCurveTemplateTemporalModel`
     from the cta-sdc files. This format is subject to change"""
     with fits.open(filename) as hdul:
+        position = SkyCoord(
+            ra=hdul[0].header["LONG"] * u.deg,
+            dec=hdul[0].header["LAT"] * u.deg,
+            frame="icrs",
+        )
 
         energy_hdu = hdul["ENERGIES"]
         energy_axis = MapAxis.from_nodes(
@@ -29,7 +36,7 @@ def _read_cta_sdc(filename):
         data = hdul["SPECTRA"]
         return (
             RegionNDMap.create(
-                region=None,
+                region=PointSkyRegion(center=position),
                 axes=[energy_axis, time_axis],
                 data=np.array(list(data.data) * u.Unit(data.header["UNITS"])),
             ),

--- a/gammapy/modeling/models/utils.py
+++ b/gammapy/modeling/models/utils.py
@@ -1,0 +1,37 @@
+import numpy as np
+from astropy import units as u
+from astropy.io import fits
+from gammapy.maps import MapAxis, RegionNDMap
+from gammapy.utils.time import time_ref_from_dict
+
+
+def _read_cta_sdc(filename):
+    """To create a `LightCurveTemplateTemporalModel`
+    from the cta-sdc files. This format is subject to change"""
+    with fits.open(filename) as hdul:
+
+        energy_hdu = hdul["ENERGIES"]
+        energy_axis = MapAxis.from_nodes(
+            nodes=energy_hdu.data,
+            unit=energy_hdu.header["TUNIT1"],
+            name="energy",
+            interp="log",
+        )
+        time_hdu = hdul["TIMES"]
+        time_header = time_hdu.header
+        time_header.setdefault("MJDREFI", 0.5)
+        time_header.setdefault("MJDREFF", 55555)
+        time_min = time_hdu.data["Initial Time"]
+        time_max = time_hdu.data["Final Time"]
+        edges = np.append(time_min, time_max[-1]) * u.Unit(time_header["TUNIT1"])
+        time_ref = time_ref_from_dict(time_header)
+        time_axis = MapAxis.from_edges(edges=edges, name="time")
+        data = hdul["SPECTRA"]
+        return (
+            RegionNDMap.create(
+                region=None,
+                axes=[energy_axis, time_axis],
+                data=np.array(list(data.data) * u.Unit(data.header["UNITS"])),
+            ),
+            time_ref,
+        )

--- a/gammapy/modeling/models/utils.py
+++ b/gammapy/modeling/models/utils.py
@@ -25,7 +25,7 @@ def _read_cta_sdc(filename):
         time_max = time_hdu.data["Final Time"]
         edges = np.append(time_min, time_max[-1]) * u.Unit(time_header["TUNIT1"])
         time_ref = time_ref_from_dict(time_header)
-        time_axis = MapAxis.from_edges(edges=edges, name="time")
+        time_axis = MapAxis.from_edges(edges=edges, name="time", interp="log")
         data = hdul["SPECTRA"]
         return (
             RegionNDMap.create(

--- a/gammapy/modeling/models/utils.py
+++ b/gammapy/modeling/models/utils.py
@@ -19,8 +19,8 @@ def _read_cta_sdc(filename):
         )
         time_hdu = hdul["TIMES"]
         time_header = time_hdu.header
-        time_header.setdefault("MJDREFI", 0.5)
-        time_header.setdefault("MJDREFF", 55555)
+        time_header.setdefault("MJDREFF", 0.5)
+        time_header.setdefault("MJDREFI", 55555)
         time_min = time_hdu.data["Initial Time"]
         time_max = time_hdu.data["Final Time"]
         edges = np.append(time_min, time_max[-1]) * u.Unit(time_header["TUNIT1"])

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -134,7 +134,7 @@ class Parameter:
             self.value = val.value
             self.unit = val.unit
         else:
-            self.factor = value
+            self.value = float(value)
             self.unit = unit
 
         self.scan_min = scan_min

--- a/gammapy/modeling/tests/test_iminuit.py
+++ b/gammapy/modeling/tests/test_iminuit.py
@@ -10,8 +10,8 @@ pytest.importorskip("iminuit")
 
 class MyModel(ModelBase):
     x = Parameter("x", 2.1, error=0.2)
-    y = Parameter("y", 3.1, scale=1e5, error=3e4)
-    z = Parameter("z", 4.1, scale=1e-5, error=4e-6)
+    y = Parameter("y", 3.1e5, scale=1e5, error=3e4)
+    z = Parameter("z", 4.1e-5, scale=1e-5, error=4e-6)
     name = "test"
     datasets_names = ["test"]
 

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -38,7 +38,7 @@ def test_parameter_outside_limit(caplog):
 
 def test_parameter_scale():
     # Basic check how scale is used for value, min, max
-    par = Parameter("spam", 42, "deg", 10, 400, 500)
+    par = Parameter("spam", 420, "deg", 10, 400, 500)
 
     assert par.value == 420
     assert par.min == 400
@@ -52,7 +52,7 @@ def test_parameter_scale():
 
 
 def test_parameter_quantity():
-    par = Parameter("spam", 42, "deg", 10)
+    par = Parameter("spam", 420, "deg", 10)
 
     quantity = par.quantity
     assert quantity.unit == "deg"

--- a/gammapy/modeling/tests/test_scipy.py
+++ b/gammapy/modeling/tests/test_scipy.py
@@ -28,8 +28,8 @@ class MyDataset:
 @pytest.fixture()
 def pars():
     x = Parameter("x", 2.1)
-    y = Parameter("y", 3.1, scale=1e5)
-    z = Parameter("z", 4.1, scale=1e-5)
+    y = Parameter("y", 3.1e5, scale=1e5)
+    z = Parameter("z", 4.1e-5, scale=1e-5)
     return Parameters([x, y, z])
 
 

--- a/gammapy/modeling/tests/test_sherpa.py
+++ b/gammapy/modeling/tests/test_sherpa.py
@@ -25,8 +25,8 @@ class MyDataset:
 @pytest.fixture()
 def pars():
     x = Parameter("x", 2.1)
-    y = Parameter("y", 3.1, scale=1e5)
-    z = Parameter("z", 4.1, scale=1e-5)
+    y = Parameter("y", 3.1e5, scale=1e5)
+    z = Parameter("z", 4.1e-5, scale=1e-5)
     return Parameters([x, y, z])
 
 

--- a/gammapy/stats/tests/test_counts_statistic.py
+++ b/gammapy/stats/tests/test_counts_statistic.py
@@ -249,3 +249,32 @@ def test_wstat_sum():
     assert stat_sum.n_on.shape == (3,)
     assert_allclose(stat_sum.n_on, (20, 40, 60))
     assert_allclose(stat_sum.n_bkg, (10, 14, 26))
+
+
+def test_CountStatistic_str():
+    cash = CashCountsStatistic(n_on=4, mu_bkg=2)
+    assert "Predicted background counts" in str(cash)
+    assert "CashCountsStatistic" in str(cash)
+    assert "Total significance" in str(cash)
+
+    wstat = WStatCountsStatistic(n_on=5, n_off=4, alpha=0.2, mu_sig=2)
+    assert "Off counts" in str(wstat)
+    assert "alpha " in str(wstat)
+    assert "Total counts " in str(wstat)
+    assert "WStatCountsStatistic" in str(wstat)
+
+
+def test_counts_statistic_infodict():
+    c1 = CashCountsStatistic(n_on=[3, 6], mu_bkg=[2, 1])
+    info_dict = c1.sum().info_dict()
+    assert_allclose(info_dict["n_on"], 9)
+    assert_allclose(info_dict["significance"], 2.788, rtol=1e-3)
+
+    w1 = WStatCountsStatistic(n_on=[3, 6], n_off=[2, 1], alpha=[1, 2])
+    info_dict = w1.info_dict()
+    assert_allclose(info_dict["n_off"], [2, 1])
+    assert_allclose(info_dict["significance"], [0.44872, 1.14942], rtol=1e-3)
+
+    info_dict = w1.sum().info_dict()
+    assert_allclose(info_dict["excess"], 5.0)
+    assert_allclose(info_dict["significance"], 1.288731, rtol=1e-3)

--- a/gammapy/stats/tests/test_utils.py
+++ b/gammapy/stats/tests/test_utils.py
@@ -1,0 +1,21 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from numpy.testing import assert_allclose
+from gammapy.stats.utils import sigma_to_ts, ts_to_sigma
+
+
+def test_sigma_ts_conversion():
+
+    sigma_ref = 3
+    ts_ref = 9
+    df = 1
+    ts = sigma_to_ts(3, df=df)
+    assert_allclose(ts, ts_ref)
+    sigma = ts_to_sigma(ts, df=df)
+    assert_allclose(sigma, sigma_ref)
+
+    df = 2
+    ts_ref = 11.829158
+    ts = sigma_to_ts(3, df=df)
+    assert_allclose(ts, ts_ref)
+    sigma = ts_to_sigma(ts, df=df)
+    assert_allclose(sigma, sigma_ref)

--- a/gammapy/stats/utils.py
+++ b/gammapy/stats/utils.py
@@ -1,0 +1,52 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from scipy.stats import chi2
+
+
+def sigma_to_ts(n_sigma, df=1):
+    """Convert number of sigma to delta ts according to the Wilks' theorem.
+    The theorem is valid only if :
+    - the two hypotheses tested can be defined in the same parameters space
+    - the true value is not at the boundary of this parameters space
+    Reference:  https://en.wikipedia.org/wiki/Wilks%27_theorem
+
+    Parameters
+    ----------
+    n_sigma : float
+        Significance in number of sigma.
+    df : int
+        Number of degree of freedom.
+
+    Returns
+    -------
+    ts : float
+        Test statistic
+    """
+
+    p_value = chi2.sf(n_sigma**2, df=1)
+    return chi2.isf(p_value, df=df)
+
+
+def ts_to_sigma(ts, df=1):
+    """Convert delta ts to number of sigma according to the Wilks' theorem.
+    The theorem is valid only if :
+    - the two hypotheses tested can be defined in the same parameters space
+    - the true value is not at the boundary of this parameters space
+    Reference:  https://en.wikipedia.org/wiki/Wilks%27_theorem
+
+    Parameters
+    ----------
+    ts : float
+        Test statistic
+    df : int
+        Number of degree of freedom.
+
+    Returns
+    -------
+    n_sigma : float
+        Significance in number of sigma.
+    """
+
+    p_value = chi2.sf(ts, df=df)
+    return np.sqrt(chi2.isf(p_value, df=1))

--- a/gammapy/utils/cluster.py
+++ b/gammapy/utils/cluster.py
@@ -1,0 +1,76 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Utils for hierarchical/agglomerative clustering."""
+
+import numpy as np
+import scipy.cluster.hierarchy as sch
+
+
+def standard_scaler(features):
+    """Compute standardized features by removing the mean and scaling to unit variance:
+       .. math::
+           f_\text{scaled} = \frac{f-\text{mean}(f)}{\text{std}(f)} .
+
+    Parameters
+    ----------
+    features : `~astropy.table.Table`
+        Table containing the features
+
+    Returns
+    -------
+    scaled_features : `~astropy.table.Table`
+        Table containing the scaled features (dimensionless).
+
+    """
+    scaled_features = features.copy()
+    for col in scaled_features.columns:
+        if col not in ["obs_id", "dataset_name"]:
+            data = scaled_features[col].data
+            scaled_features[col] = (data - data.mean()) / data.std()
+    return scaled_features
+
+
+def hierarchical_clustering(
+    features, linkage_kwargs=None, fcluster_kwargs=None, standard_scaler=False
+):
+    """Hierarchical clustering using given features.
+
+    Parameters
+    ----------
+    features : `~astropy.table.Table`
+        Table containing the features
+    linkage_kwargs : dict
+        Arguments forwarded to `scipy.cluster.hierarchy.linkage`
+    fcluster_kwargs : dict
+        Arguments forwarded to `scipy.cluster.hierarchy.fcluster`
+
+
+    Returns
+    -------
+    features : `~astropy.table.Table`
+        Table containing the features and an extra column for the groups labels.
+
+    """
+
+    features = features.copy()
+    features_array = np.array(
+        [
+            features[col].data
+            for col in features.columns
+            if col not in ["obs_id", "dataset_name"]
+        ]
+    ).T
+
+    default_linkage_kwargs = dict(method="ward", metric="euclidean")
+    if linkage_kwargs is not None:
+        default_linkage_kwargs.update(linkage_kwargs)
+
+    pairwise_distances = sch.distance.pdist(features_array)
+    linkage = sch.linkage(pairwise_distances, **default_linkage_kwargs)
+
+    default_fcluster_kwargs = dict(criterion="maxclust", t=3)
+    if fcluster_kwargs is not None:
+        default_fcluster_kwargs.update(fcluster_kwargs)
+    labels = sch.fcluster(linkage, **default_fcluster_kwargs)
+
+    features["labels"] = labels
+    return features

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -94,6 +94,11 @@ class HDULocation:
             from gammapy.maps import Map
 
             return Map.read(filename, hdu=hdu, format=self.format)
+        elif hdu_class == "pointing":
+            # FIXME: support loading the pointing table
+            from gammapy.data import FixedPointingInfo
+
+            return FixedPointingInfo.read(filename, hdu=hdu)
         else:
             cls = IRF_REGISTRY.get_cls(hdu_class)
 

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -21,6 +21,7 @@ from regions import (
     CircleAnnulusSkyRegion,
     CircleSkyRegion,
     CompoundSkyRegion,
+    EllipseSkyRegion,
     RectangleSkyRegion,
     Regions,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "make_concentric_annulus_sky_regions",
     "make_orthogonal_rectangle_sky_regions",
     "regions_to_compound_region",
+    "region_to_frame",
 ]
 
 
@@ -231,3 +233,45 @@ def make_concentric_annulus_sky_regions(
         regions.append(region)
 
     return regions
+
+
+def region_to_frame(region, frame):
+    """Convert a region to a different frame
+
+    Parameters
+    ----------
+    region : `~regions.SkyRegion`
+        region to transform
+    frame : "icrs" or "galactic"
+        frame to tranform the region into
+
+    Returns
+    -------
+    region_new : `~regions.SkyRegion`
+        region in the given frame
+    """
+    from gammapy.maps import WcsGeom
+
+    wcs = WcsGeom.create(skydir=region.center, binsz=0.01, frame=frame).wcs
+    region_new = region.to_pixel(wcs).to_sky(wcs)
+    return region_new
+
+
+def region_circle_to_ellipse(region):
+    """Convert a CircleSkyRegion to an EllipseSkyRegion
+
+    Parameters
+    ----------
+    region : `~regions.CircleSkyRegion`
+        region to transform
+
+    Returns
+    -------
+    region_new : `~regions.EllipseSkyRegion`
+        Elliptical region with same major and minor axis
+    """
+
+    region_new = EllipseSkyRegion(
+        center=region.center, width=region.radius, height=region.radius
+    )
+    return region_new

--- a/gammapy/utils/tests/test_regions.py
+++ b/gammapy/utils/tests/test_regions.py
@@ -10,10 +10,12 @@ stable, so need to establish a bit what works and what doesn't.
 from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-from regions import Regions
+from regions import CircleSkyRegion, EllipseSkyRegion, Regions
 from gammapy.utils.regions import (
     SphericalCircleSkyRegion,
     compound_region_center,
+    region_circle_to_ellipse,
+    region_to_frame,
     regions_to_compound_region,
 )
 
@@ -80,3 +82,23 @@ def test_spherical_circle_sky_region():
     coord = SkyCoord([20.1, 22] * u.deg, 20 * u.deg)
     mask = region.contains(coord)
     assert_equal(mask, [True, False])
+
+
+def test_region_to_frame():
+    region = EllipseSkyRegion(
+        center=SkyCoord(20, 17, unit="deg"),
+        height=0.3 * u.deg,
+        width=1.0 * u.deg,
+        angle=30 * u.deg,
+    )
+    region_new = region_to_frame(region, "galactic")
+    assert_allclose(region_new.angle, 20.946 * u.deg, rtol=1e-3)
+    assert_allclose(region_new.center.l, region.center.galactic.l, rtol=1e-3)
+
+
+def test_region_circle_to_ellipse():
+    region = CircleSkyRegion(center=SkyCoord(20, 17, unit="deg"), radius=1.0 * u.deg)
+    region_new = region_circle_to_ellipse(region)
+    assert_allclose(region_new.height, region.radius, rtol=1e-3)
+    assert_allclose(region_new.width, region.radius, rtol=1e-3)
+    assert_allclose(region_new.angle, 0.0 * u.deg, rtol=1e-3)

--- a/gammapy/utils/time.py
+++ b/gammapy/utils/time.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Time related utility functions."""
 import numpy as np
+import astropy.units as u
 from astropy.time import Time, TimeDelta
 
 __all__ = [
@@ -13,6 +14,67 @@ __all__ = [
 # TODO: implement and document this properly.
 # see https://github.com/gammapy/gammapy/issues/284
 TIME_REF_FERMI = Time("2001-01-01T00:00:00")
+
+#: Default epoch gammapy uses for FITS files (MJDREF)
+#: 0 MJD, TT
+DEFAULT_EPOCH = Time(0, format="mjd", scale="tt")
+
+
+def time_to_fits(time, epoch=None, unit=u.s):
+    """Convert time to fits format.
+
+    Times are stored as duration since an epoch in FITS.
+
+
+    Parameters
+    ----------
+    time : `~astropy.time.Time`
+        time to be converted
+    epoch : `astropy.time.Time`
+        epoch to use for the time. The corresponding keywords must
+        be stored in the same FITS header.
+        If None, `DEFAULT_EPOCH` will be used.
+    unit : `astropy.time.Time`
+        If None, `DEFAULT_EPOCH` will be used.
+        Should be stored as `TIMEUNIT` in the same FITS header.
+
+    Returns
+    -------
+    time : astropy.units.Quantity
+        Duration since epoch
+    """
+    if epoch is None:
+        epoch = DEFAULT_EPOCH
+    return (time - epoch).to(unit)
+
+
+def time_to_fits_header(time, epoch=None, unit=u.s):
+    """Convert time to fits header format.
+
+    Times are stored as duration since an epoch in FITS.
+
+
+    Parameters
+    ----------
+    time : `~astropy.time.Time`
+        time to be converted
+    epoch : `astropy.time.Time`
+        epoch to use for the time. The corresponding keywords must
+        be stored in the same FITS header.
+        If None, `DEFAULT_EPOCH` will be used.
+    unit : `astropy.time.Time`
+        If None, `DEFAULT_EPOCH` will be used.
+        Should be stored as `TIMEUNIT` in the same FITS header.
+
+    Returns
+    -------
+    header_entry : tuple(float, string)
+        a float / comment tuple with the time and unit
+    """
+    if epoch is None:
+        epoch = DEFAULT_EPOCH
+    time = time_to_fits(time)
+    return time.to_value(unit), unit.to_string("fits")
 
 
 def time_ref_from_dict(meta, format="mjd", scale="tt"):
@@ -34,19 +96,21 @@ def time_ref_from_dict(meta, format="mjd", scale="tt"):
     return Time(mjd, format=format, scale=scale)
 
 
-def time_ref_to_dict(time, scale="tt"):
-    """TODO: document and test.
+def time_ref_to_dict(time=None, scale="tt"):
+    """Convert the epoch to the relevant FITS header keywords
 
     Parameters
     ----------
     time : `~astropy.time.Time`
-        Time object with ``format='MJD'``
+        The reference epoch for storing time in FITS.
 
     Returns
     -------
     meta : dict
         FITS time standard header info
     """
+    if time is None:
+        time = DEFAULT_EPOCH
     mjd = Time(time, scale=scale).mjd
     i = np.floor(mjd).astype(np.int64)
     f = mjd - i

--- a/gammapy/visualization/__init__.py
+++ b/gammapy/visualization/__init__.py
@@ -3,6 +3,7 @@ from .heatmap import annotate_heatmap, plot_heatmap
 from .panel import MapPanelPlotter
 from .utils import (
     plot_contour_line,
+    plot_map_rgb,
     plot_spectrum_datasets_off_regions,
     plot_theta_squared_table,
 )
@@ -14,6 +15,7 @@ __all__ = [
     "MapPanelPlotter",
     "plot_contour_line",
     "plot_heatmap",
+    "plot_map_rgb",
     "plot_spectrum_datasets_off_regions",
     "plot_theta_squared_table",
 ]

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -2,13 +2,16 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+import astropy.units as u
 from astropy.table import Table
 import matplotlib
 import matplotlib.pyplot as plt
 from packaging import version
-from gammapy.utils.testing import mpl_plot_check
+from gammapy.maps import Map, MapAxis, WcsNDMap
+from gammapy.utils.testing import mpl_plot_check, requires_data
 from gammapy.visualization import (
     plot_contour_line,
+    plot_map_rgb,
     plot_spectrum_datasets_off_regions,
     plot_theta_squared_table,
 )
@@ -83,3 +86,27 @@ def test_plot_theta2_distribution():
     # open a new figure to avoid
     plt.figure()
     plot_theta_squared_table(table=table)
+
+
+@requires_data()
+def test_plot_map_rgb():
+    map_ = Map.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
+
+    with pytest.raises(ValueError):
+        plot_map_rgb(map_)
+
+    with pytest.raises(ValueError):
+        plot_map_rgb(map_.sum_over_axes(keepdims=False))
+
+    axis = MapAxis([0, 1, 2, 3], node_type="edges")
+    map_allsky = WcsNDMap.create(binsz=10 * u.deg, axes=[axis])
+    with mpl_plot_check():
+        plot_map_rgb(map_allsky)
+
+    axis_rgb = MapAxis.from_energy_edges(
+        [0.1, 0.2, 0.5, 10], unit=u.TeV, name="energy", interp="log"
+    )
+    map_ = map_.resample_axis(axis_rgb)
+    kwargs = {"stretch": 0.5, "Q": 1, "minimum": 0.15}
+    with mpl_plot_check():
+        plot_map_rgb(map_, **kwargs)

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -278,5 +278,5 @@ def plot_theta_squared_table(table):
 
     ax1 = plt.subplot(2, 1, 2)
     ax1.errorbar(x, table["sqrt_ts"], xerr=xerr, linestyle="None")
-    ax1.set_xlabel(f"Theta  [{theta2_axis.unit}]")
+    ax1.set_xlabel(f"Theta [{theta2_axis.unit}]")
     ax1.set_ylabel("Significance")

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
     numpy>=1.20
-    scipy>=1.4,<1.10
+    scipy>=1.4,!=1.10
     astropy>=5.0
     regions>=0.5.0
     pyyaml>=5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ packages = find:
 python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    numpy>=1.20
+    numpy>=1.21
     scipy>=1.4,!=1.10
     astropy>=5.0
     regions>=0.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,16 @@ indexserver =
 setenv = MPLBACKEND=agg
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS GAMMAPY_DATA PKG_CONFIG_PATH
+passenv = 
+    HOME
+    WINDIR
+    LC_ALL
+    LC_CTYPE
+    CC
+    CI
+    TRAVIS
+    GAMMAPY_DATA
+    PKG_CONFIG_PATH
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 envlist =
     py{38,39,310}-test{,-alldeps,-devdeps}{,-cov}
-    py{38,39,310}-test-numpy{120,121,122,123}
+    py{38,39,310}-test-numpy{121,122,123}
     py{38,39,310}-test-astropy{50,lts}
     build_docs
     linkcheck
@@ -48,7 +48,6 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy120: with numpy 1.20.*
     numpy121: with numpy 1.21.*
     numpy122: with numpy 1.22.*
     numpy123: with numpy 1.23.*
@@ -59,15 +58,15 @@ description =
 deps =
 
     cov: coverage
-    numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*
     numpy122: numpy==1.22.*
     numpy123: numpy==1.23.*
 
     astropy50: astropy==5.0.*
     astropylts: astropy==5.0.*
+    astropylts: matplotlib==3.6.*
 
-    oldestdeps: numpy==1.20.*
+    oldestdeps: numpy==1.21.*
     oldestdeps: matplotlib==3.4.*
     oldestdeps: scipy==1.4.*
     oldestdeps: pyyaml==5.1.*


### PR DESCRIPTION
As we previously discussed, this enables to 
1. read the cat-sdc files. I have put the read method in utils now, because the file format is a bit annoying and might change in the future (we should encourage a "map" based format)
2. use adapt the evaluation for such model
3. enable plotting such models

It might be necessary to add some documentation in the future, maybe as a separate tutorial showing a full simulation with such models