### PR TITLE
Allow to set psf max radius in evaluator

### DIFF
--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 from gammapy.maps import HpxNDMap, Map, RegionNDMap, WcsNDMap
 from gammapy.modeling.models import PointSpatialModel, TemplateNPredModel
 
+PSF_MAX_RADIUS = None
 PSF_CONTAINMENT = 0.999
 CUTOUT_MARGIN = 0.1 * u.deg
 
@@ -192,6 +193,7 @@ class MapEvaluator:
                     position=self.model.position,
                     geom=geom_psf,
                     containment=PSF_CONTAINMENT,
+                    max_radius=PSF_MAX_RADIUS,
                 )
 
         if self.evaluation_mode == "local":


### PR DESCRIPTION
Currently the psf max radius in the evaluator is derived as the max 0.999 containment radius but this can lead to aberrantly  high values if the psf is not well-defined everywhere or noisy (I noticed that for HAWC psf where it can go from <1deg in one bin in energy and >10deg in the next). This will affect seriously the performance increasing the psf convolution time.

This PR allow to set a PSF_MAX_RADIUS variable in evaluator in order to limit the size of the kernel. If the user set the mask_safe  such as the psf is well-defined they can evaluate the max radius only in the mask_safe.