### PR TITLE
Allow to load observations with only IRFs defined

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -329,9 +329,10 @@ class DataStore:
 
         # TODO: right now, gammapy doesn't support using the pointing table of GADF
         # so we always pass the events location here to be read into a FixedPointingInfo
-        pointing_location = copy(kwargs["events"])
-        pointing_location.hdu_class = "pointing"
-        kwargs["pointing"] = pointing_location
+        if "events" in kwargs:
+            pointing_location = copy(kwargs["events"])
+            pointing_location.hdu_class = "pointing"
+            kwargs["pointing"] = pointing_location
 
         return Observation(**kwargs)
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -259,7 +259,7 @@ class DataStore:
         else:
             return s
 
-    def obs(self, obs_id, required_irf="full-enclosure", has_only_irf=False):
+    def obs(self, obs_id, required_irf="full-enclosure", require_events=True):
         """Access a given `~gammapy.data.Observation`.
 
         Parameters
@@ -281,6 +281,8 @@ class DataStore:
 
             * `"full-enclosure"` : includes `["events", "gti", "aeff", "edisp", "psf", "bkg"]`
             * `"point-like"` : includes `["events", "gti", "aeff", "edisp"]`
+        require_events : bool
+            Require events and gti table or not.
 
         Returns
         -------
@@ -303,10 +305,10 @@ class DataStore:
                 f"{difference} is not a valid hdu key. Choose from: {ALL_IRFS}"
             )
 
-        if has_only_irf:
-            required_hdus = required_irf
-        else:
+        if require_events:
             required_hdus = {"events", "gti"}.union(required_irf)
+        else:
+            required_hdus = required_irf
 
         missing_hdus = []
         for hdu in ALL_HDUS:
@@ -338,7 +340,7 @@ class DataStore:
         obs_id=None,
         skip_missing=False,
         required_irf="full-enclosure",
-        has_only_irf=False,
+        require_events=True,
     ):
         """Generate a `~gammapy.data.Observations`.
 
@@ -370,6 +372,9 @@ class DataStore:
             * `"all-optional"` : no HDUs are required, only warnings will be emitted
               for missing HDUs among all possibilities.
 
+        require_events : bool
+            Require events and gti table or not.
+
         Returns
         -------
         observations : `~gammapy.data.Observations`
@@ -383,7 +388,7 @@ class DataStore:
 
         for _ in obs_id:
             try:
-                obs = self.obs(_, required_irf, has_only_irf)
+                obs = self.obs(_, required_irf, require_events)
             except ValueError as err:
                 if skip_missing:
                     log.warning(f"Skipping missing obs_id: {_!r}")

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -259,7 +259,7 @@ class DataStore:
         else:
             return s
 
-    def obs(self, obs_id, required_irf="full-enclosure"):
+    def obs(self, obs_id, required_irf="full-enclosure", has_only_irf=False):
         """Access a given `~gammapy.data.Observation`.
 
         Parameters
@@ -303,7 +303,10 @@ class DataStore:
                 f"{difference} is not a valid hdu key. Choose from: {ALL_IRFS}"
             )
 
-        required_hdus = {"events", "gti"}.union(required_irf)
+        if has_only_irf:
+            required_hdus = required_irf
+        else:
+            required_hdus = {"events", "gti"}.union(required_irf)
 
         missing_hdus = []
         for hdu in ALL_HDUS:
@@ -331,7 +334,11 @@ class DataStore:
         return Observation(**kwargs)
 
     def get_observations(
-        self, obs_id=None, skip_missing=False, required_irf="full-enclosure"
+        self,
+        obs_id=None,
+        skip_missing=False,
+        required_irf="full-enclosure",
+        has_only_irf=False,
     ):
         """Generate a `~gammapy.data.Observations`.
 
@@ -376,7 +383,7 @@ class DataStore:
 
         for _ in obs_id:
             try:
-                obs = self.obs(_, required_irf)
+                obs = self.obs(_, required_irf, has_only_irf)
             except ValueError as err:
                 if skip_missing:
                     log.warning(f"Skipping missing obs_id: {_!r}")

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -322,7 +322,7 @@ def test_data_store_no_events():
     )
 
     observations = data_store.get_observations(
-        required_irfs=["aeff", "psf", "edisp"], require_events=False
+        required_irf=["aeff", "psf", "edisp"], require_events=False
     )
     assert len(observations) == 3
     for obs in observations:

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -308,3 +308,23 @@ def test_data_store_required_irf_pointlike_variable_rad_max():
     obs = store.get_observations([5029747, 5029748], required_irf="point-like")
     assert len(obs) == 2
     assert obs[0].rad_max.quantity is not None
+
+
+@requires_data()
+def test_data_store_no_events():
+    """Check behavior of the "point-like" option for data_store"""
+
+    data_path = "$GAMMAPY_DATA/hawc/crab_events_pass4/"
+    hdu_filename = "hdu-index-table-GP-no-events.fits.gz"
+    obs_filename = "obs-index-table-GP-no-events.fits.gz"
+    data_store = DataStore.from_dir(
+        data_path, hdu_table_filename=hdu_filename, obs_table_filename=obs_filename
+    )
+
+    observations = data_store.get_observations(
+        required_irfs=["aeff", "psf", "edisp"], require_events=False
+    )
+    assert len(observations) == 3
+    for obs in observations:
+        assert not obs.events
+        assert not obs.gti


### PR DESCRIPTION
Add a "has_only_irf" option in DataStore.get_obervation in order to be able to load observations without events defined (useful with HAWC data)