### PR TITLE
Optional meta_table creation in MapDatasetMaker

### DIFF
--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -95,6 +95,7 @@ class MapSelectionEnum(str, Enum):
     background = "background"
     psf = "psf"
     edisp = "edisp"
+    meta_table = "meta_table"
 
 
 class GammapyBaseConfig(BaseModel):

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -99,7 +99,14 @@ class MapDatasetMaker(Maker):
     """
 
     tag = "MapDatasetMaker"
-    available_selection = ["counts", "exposure", "background", "psf", "edisp"]
+    available_selection = [
+        "counts",
+        "exposure",
+        "background",
+        "psf",
+        "edisp",
+        "meta_table",
+    ]
 
     def __init__(
         self,
@@ -378,7 +385,8 @@ class MapDatasetMaker(Maker):
             Map dataset.
         """
         kwargs = {"gti": observation.gti}
-        kwargs["meta_table"] = self.make_meta_table(observation)
+        if "meta_table" in self.selection:
+            kwargs["meta_table"] = self.make_meta_table(observation)
 
         mask_safe = Map.from_geom(dataset.counts.geom, dtype=bool)
         mask_safe.data[...] = True

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -28,7 +28,7 @@ class MapDatasetMaker(Maker):
     ----------
     selection : list
         List of str, selecting which maps to make.
-        Available: 'counts', 'exposure', 'background', 'psf', 'edisp'
+        Available: 'counts', 'exposure', 'background', 'psf', 'edisp', 'meta_table'
         By default, all maps are made.
     background_oversampling : int
         Background evaluation oversampling factor in energy.

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -17,7 +17,7 @@ from gammapy.data import (
 )
 from gammapy.datasets import MapDataset
 from gammapy.datasets.map import RAD_AXIS_DEFAULT
-from gammapy.irf import EDispKernelMap, EDispMap, PSFMap, Background2D
+from gammapy.irf import Background2D, EDispKernelMap, EDispMap, PSFMap
 from gammapy.makers import FoVBackgroundMaker, MapDatasetMaker, SafeMaskMaker
 from gammapy.maps import HpxGeom, Map, MapAxis, WcsGeom
 from gammapy.utils.testing import requires_data, requires_dependency
@@ -237,6 +237,18 @@ def test_make_meta_table(observations):
     assert_allclose(map_dataset_meta_table["DEC_PNT"], -29.6075)
     assert_allclose(map_dataset_meta_table["OBS_ID"], 110380)
     assert map_dataset_meta_table["OBS_MODE"] == "POINTING"
+
+
+@requires_data()
+def test_make_map_meta(observations):
+    dataset = MapDataset.create(geom((0.1, 1, 10)))
+    maker_obs = MapDatasetMaker(selection=["meta_table"])
+    map_dataset = maker_obs.run(dataset, observation=observations[0])
+
+    assert_allclose(map_dataset.meta_table["RA_PNT"], 267.68121338)
+    assert_allclose(map_dataset.meta_table["DEC_PNT"], -29.6075)
+    assert_allclose(map_dataset.meta_table["OBS_ID"], 110380)
+    assert map_dataset.meta_table["OBS_MODE"] == "POINTING"
 
 
 @requires_data()


### PR DESCRIPTION
This PR add meta_table  in to the list of available_selection for the MapDatasetMaker so it can run even if the observations meta_table are not well-defined.