### PR TITLE
add from_region()

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -775,6 +775,28 @@ class DiskSpatialModel(SpatialModel):
             **kwargs,
         )
 
+    @classmethod
+    def from_region(cls, region, **kwargs):
+        """Create a `DiskSpatialModel from a ~regions.EllipseSkyRegion`
+
+        Parameters
+        ----------
+        region : `~regions.EllipseSkyRegion`
+            region to create model from
+
+        Returns
+        -------
+        spatial_model : `~gammapy.modeling.models.DiskSpatialModel`
+        """
+        frame = kwargs.pop("frame", region.center.frame)
+        model = cls.from_position(getattr(region.center, frame))
+        r0 = max(region.width, region.height)
+        model.r_0.quantity = r0 / 2.0
+        r1 = min(region.width, region.height)
+        model.e.value = np.sqrt(1.0 - np.power(r1 / r0, 2))
+        model.phi.quantity = 90 * u.deg + region.angle
+        return model
+
 
 class ShellSpatialModel(SpatialModel):
     r"""Shell model.

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -223,6 +223,21 @@ def test_sky_disk_edge():
     assert_allclose((value_edge_nwidth / value_center).to_value(""), 0.95)
 
 
+def test_disk_from_region():
+    region = EllipseSkyRegion(
+        center=SkyCoord(20, 17, unit="deg"),
+        height=0.3 * u.deg,
+        width=1.0 * u.deg,
+        angle=30 * u.deg,
+    )
+    disk = DiskSpatialModel.from_region(region, frame="galactic")
+    assert_allclose(disk.parameters["lon_0"].value, 2.315473, rtol=1e-2)
+    assert_allclose(disk.parameters["lat_0"].value, -0.791178, rtol=1e-2)
+    assert_allclose(disk.parameters["r_0"].value, 0.5, rtol=1e-2)
+    assert_allclose(disk.parameters["e"].value, 0.9539, rtol=1e-2)
+    assert_allclose(disk.parameters["phi"].quantity, 120 * u.deg)
+
+
 def test_sky_shell():
     width = 2 * u.deg
     rad = 2 * u.deg


### PR DESCRIPTION
Signed-off-by: Atreyee Sinha <asinha@ucm.es>

This PR adds a `DiskSpatialModel.from_region()` to create a model directly from an elliptical region. I am using this often these days, and felt having a convenience function can be useful for others as well...