### PR TITLE
Add MapDatasetOnOff type test and associated error for TSMapEstimator

### DIFF
--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import Angle
-from gammapy.datasets import MapDataset
+from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.estimators import TSMapEstimator
 from gammapy.irf import EDispKernelMap, PSFMap
 from gammapy.maps import Map, MapAxis, WcsGeom
@@ -275,3 +275,14 @@ def test_compute_ts_map_with_hole(fake_dataset):
     holes_dataset.exposure.data[...] = 0.0
     with pytest.raises(ValueError):
         kernel = ts_estimator.estimate_kernel(dataset=holes_dataset)
+
+
+def test_MapDatasetOnOff_error():
+    """Test raise error when applying TSMapEStimator to MapDatasetOnOff"""
+    axis = MapAxis.from_edges([1, 10] * u.TeV, name="energy")
+    geom = WcsGeom.create(width=1, axes=[axis])
+    dataset_on_off = MapDatasetOnOff.create(geom)
+
+    ts_estimator = TSMapEstimator()
+    with pytest.raises(TypeError):
+        ts_estimator.run(dataset=dataset_on_off)

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -8,7 +8,6 @@ import numpy as np
 import scipy.optimize
 from astropy.coordinates import Angle
 from astropy.utils import lazyproperty
-from gammapy.datasets import MapDatasetOnOff
 from gammapy.datasets.map import MapEvaluator
 from gammapy.datasets.utils import get_nearest_valid_exposure_position
 from gammapy.maps import Map, Maps
@@ -469,7 +468,7 @@ class TSMapEstimator(Estimator):
                 * flux_ul : upper limit map
 
         """
-        if isinstance(dataset, MapDatasetOnOff):
+        if dataset.stat_type != "cash":
             raise TypeError(f"{type(dataset)} is not a valid type for {self.__class__}")
         dataset_models = dataset.models
 

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -8,6 +8,7 @@ import numpy as np
 import scipy.optimize
 from astropy.coordinates import Angle
 from astropy.utils import lazyproperty
+from gammapy.datasets import MapDatasetOnOff
 from gammapy.datasets.map import MapEvaluator
 from gammapy.datasets.utils import get_nearest_valid_exposure_position
 from gammapy.maps import Map, Maps
@@ -468,6 +469,8 @@ class TSMapEstimator(Estimator):
                 * flux_ul : upper limit map
 
         """
+        if isinstance(dataset, MapDatasetOnOff):
+            raise TypeError(f"{type(dataset)} is not a valid type for {self.__class__}")
         dataset_models = dataset.models
 
         pad_width = self.estimate_pad_width(dataset=dataset)


### PR DESCRIPTION
Signed-off-by: Maxime Regeard <regeard@apc.in2p3.fr>

This pull request is associated with issue #4287.

I added a `TypeErrors`if the type of `dataset`in `TSMapEstimator.run`is `MapDatasetOnOff`. 

I also added a test for that.
