### PR TITLE
gammapy.maps cleanup: move Map.apply_edisp to gammapy.datasets

### DIFF
--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -8,6 +8,7 @@ from regions import CircleSkyRegion
 import matplotlib.pyplot as plt
 from gammapy.maps import HpxNDMap, Map, RegionNDMap, WcsNDMap
 from gammapy.modeling.models import PointSpatialModel, TemplateNPredModel
+from .utils import apply_edisp
 
 PSF_CONTAINMENT = 0.999
 CUTOUT_MARGIN = 0.1 * u.deg
@@ -348,7 +349,7 @@ class MapEvaluator:
         npred_reco : `~gammapy.maps.Map`
             Predicted counts in reco energy bins
         """
-        return npred.apply_edisp(self.edisp)
+        return apply_edisp(npred, self.edisp)
 
     @lazyproperty
     def _compute_npred(self):

--- a/gammapy/datasets/tests/test_utils.py
+++ b/gammapy/datasets/tests/test_utils.py
@@ -1,0 +1,36 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from gammapy.irf import EDispKernel
+from gammapy.maps import Map, MapAxis
+
+
+@pytest.fixture
+def region_map_true():
+    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=6, name="energy_true")
+    m = Map.create(
+        region="icrs;circle(83.63, 21.51, 1)",
+        map_type="region",
+        axes=[axis],
+        unit="1/TeV",
+    )
+    m.data = np.arange(m.data.size, dtype=float).reshape(m.geom.data_shape)
+    return m
+
+
+def test_apply_edisp(region_map_true):
+    e_true = region_map_true.geom.axes[0]
+    e_reco = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
+
+    edisp = EDispKernel.from_diagonal_response(
+        energy_axis_true=e_true, energy_axis=e_reco
+    )
+
+    m = region_map_true.apply_edisp(edisp)
+    assert m.geom.data_shape == (3, 1, 1)
+
+    e_reco = m.geom.axes[0].edges
+    assert e_reco.unit == "TeV"
+    assert m.geom.axes[0].name == "energy"
+    assert_allclose(e_reco[[0, -1]].value, [1, 10])

--- a/gammapy/datasets/tests/test_utils.py
+++ b/gammapy/datasets/tests/test_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from gammapy.irf import EDispKernel
 from gammapy.maps import Map, MapAxis
+from ..utils import apply_edisp
 
 
 @pytest.fixture
@@ -27,7 +28,7 @@ def test_apply_edisp(region_map_true):
         energy_axis_true=e_true, energy_axis=e_reco
     )
 
-    m = region_map_true.apply_edisp(edisp)
+    m = apply_edisp(region_map_true, edisp)
     assert m.geom.data_shape == (3, 1, 1)
 
     e_reco = m.geom.axes[0].edges

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -8,6 +8,7 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 import matplotlib.pyplot as plt
+from gammapy.utils.deprecation import deprecated
 from gammapy.utils.random import InverseCDFSampler, get_random_state
 from gammapy.utils.scripts import make_path
 from gammapy.utils.units import energy_unit_format
@@ -1382,6 +1383,7 @@ class Map(abc.ABC):
 
         return self._init_copy(**kwargs)
 
+    @deprecated("v1.1", alternative="gammapy.datasets.apply_edisp")
     def apply_edisp(self, edisp):
         """Apply energy dispersion to map. Requires energy axis.
 

--- a/gammapy/maps/region/tests/test_ndmap.py
+++ b/gammapy/maps/region/tests/test_ndmap.py
@@ -259,8 +259,8 @@ def test_region_nd_map_fill_events_point_sky_region(point_region_map):
 
 
 def test_apply_edisp(point_region_map):
-    e_true = point_region_map.geom.axes[0]
-    e_reco = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
+    e_true = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3, name="energy_true")
+    e_reco = point_region_map.geom.axes[0]
 
     edisp = EDispKernel.from_diagonal_response(
         energy_axis_true=e_true, energy_axis=e_reco

--- a/gammapy/maps/region/tests/test_ndmap.py
+++ b/gammapy/maps/region/tests/test_ndmap.py
@@ -16,6 +16,7 @@ from gammapy.maps import (
     RegionNDMap,
     TimeMapAxis,
 )
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.testing import mpl_plot_check, requires_data
 
 
@@ -50,19 +51,6 @@ def point_region_map():
     axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=6, name="energy")
     m = Map.create(
         region="icrs;point(83.63, 21.51)",
-        map_type="region",
-        axes=[axis],
-        unit="1/TeV",
-    )
-    m.data = np.arange(m.data.size, dtype=float).reshape(m.geom.data_shape)
-    return m
-
-
-@pytest.fixture
-def region_map_true():
-    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=6, name="energy_true")
-    m = Map.create(
-        region="icrs;circle(83.63, 21.51, 1)",
         map_type="region",
         axes=[axis],
         unit="1/TeV",
@@ -270,21 +258,16 @@ def test_region_nd_map_fill_events_point_sky_region(point_region_map):
     assert_allclose(region_map.data.sum(), 0)
 
 
-def test_apply_edisp(region_map_true):
-    e_true = region_map_true.geom.axes[0]
+def test_apply_edisp(point_region_map):
+    e_true = point_region_map.geom.axes[0]
     e_reco = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
 
     edisp = EDispKernel.from_diagonal_response(
         energy_axis_true=e_true, energy_axis=e_reco
     )
 
-    m = region_map_true.apply_edisp(edisp)
-    assert m.geom.data_shape == (3, 1, 1)
-
-    e_reco = m.geom.axes[0].edges
-    assert e_reco.unit == "TeV"
-    assert m.geom.axes[0].name == "energy"
-    assert_allclose(e_reco[[0, -1]].value, [1, 10])
+    with pytest.raises(GammapyDeprecationWarning):
+        point_region_map.apply_edisp(edisp)
 
 
 def test_region_nd_map_resample_axis():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request proposes a small clean-up of the `gammapy.maps` sub-package. 
As this package could become more independent of gammapy, we should avoid dependencies to other parts of gammapy, in particular to `gammapy.irf`.
Here, we deprecate `Map.apply_edisp` and move it to a stand-alone function in `gammapy.datasets.utils.py`.

A further change will require making `Map.convolve` take a `Map` directly rather than a `gammapy.irf.PSFKernel`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
