### PR TITLE
Fix zero length shape after  WcsGeom.cutout()

### DIFF
--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -877,10 +877,9 @@ class WcsGeom(Geom):
 
         binsz = self.pixel_scales
         width_npix = np.clip((width / binsz).to_value(""), 1, None)
-        width = width_npix * binsz
 
         if odd_npix:
-            width = round_up_to_odd(width_npix)
+            width_npix = round_up_to_odd(width_npix)
 
         dummy_data = np.empty(self.to_image().data_shape, dtype=bool)
         c2d = Cutout2D(
@@ -888,7 +887,7 @@ class WcsGeom(Geom):
             wcs=self.wcs,
             position=position,
             # Cutout2D takes size with order (lat, lon)
-            size=width[::-1],
+            size=width_npix[::-1],
             mode=mode,
         )
         return self._init_copy(wcs=c2d.wcs, npix=c2d.shape[::-1])

--- a/gammapy/maps/wcs/tests/test_geom.py
+++ b/gammapy/maps/wcs/tests/test_geom.py
@@ -622,8 +622,9 @@ def test_wcs_geom_to_even_npix():
     assert geom_even.data_shape == (4, 4)
 
 
-def test_wcs_geom_no_zero_shape_cut(skydir):
+def test_wcs_geom_no_zero_shape_cut():
     geom = WcsGeom.create(skydir=(0, 2.5), binsz=(360, 5), width=(360, 180))
+    skydir = SkyCoord(110.0, 75.0, unit="deg", frame="icrs")
 
     geom_cut = geom.cutout(skydir, width=5)
 

--- a/gammapy/maps/wcs/tests/test_geom.py
+++ b/gammapy/maps/wcs/tests/test_geom.py
@@ -622,7 +622,7 @@ def test_wcs_geom_to_even_npix():
     assert geom_even.data_shape == (4, 4)
 
 
-def test_wcs_geom_1pix_cut(skydit):
+def test_wcs_geom_no_zero_shape_cut(skydir):
     geom = WcsGeom.create(skydir=(0, 2.5), binsz=(360, 5), width=(360, 180))
 
     geom_cut = geom.cutout(skydir, width=5)

--- a/gammapy/maps/wcs/tests/test_geom.py
+++ b/gammapy/maps/wcs/tests/test_geom.py
@@ -620,3 +620,12 @@ def test_wcs_geom_to_even_npix():
     geom_even = geom.to_even_npix()
 
     assert geom_even.data_shape == (4, 4)
+
+
+def test_wcs_geom_1pix_cut(skydit):
+    geom = WcsGeom.create(skydir=(0, 2.5), binsz=(360, 5), width=(360, 180))
+
+    geom_cut = geom.cutout(skydir, width=5)
+
+    assert geom_cut.data_shape != (1, 0)
+    assert geom_cut.data_shape == (1, 1)


### PR DESCRIPTION
This fix a bug where WcsGeom.cutout() creates a geom with zero length shape.
In the test case added the problem appears when the width passed to `astropy.nddata.Cutout2D` is in degrees but not if it is in pixels.