### PR TITLE
Add `SpectralModel.spectral_index_error`

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -524,8 +524,9 @@ class SpectralModel(ModelBase):
         ----------
         energy : `~astropy.units.Quantity`
             Energy at which to estimate the index
-        epsilon : float
+        epsilon : float, optional
             Fractional energy increment to use for determining the spectral index.
+            default = 1e-5
 
         Returns
         -------
@@ -543,8 +544,9 @@ class SpectralModel(ModelBase):
         ----------
         energy : `~astropy.units.Quantity`
             Energy at which to estimate the index
-        epsilon : float
-            Fractional energy increment to use for determining the spectral index.
+        epsilon : float, optional
+            Fractional energy increment to use for determining the spectral index
+            default = 1e-5
 
         Returns
         -------

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -536,6 +536,25 @@ class SpectralModel(ModelBase):
         f2 = self(energy * (1 + epsilon))
         return np.log(f1 / f2) / np.log(1 + epsilon)
 
+    def spectral_index_error(self, energy, epsilon=1e-5):
+        """Evaluate the error on spectral index at the given energy
+
+        Parameters
+        ----------
+        energy : `~astropy.units.Quantity`
+            Energy at which to estimate the index
+        epsilon : float
+            Fractional energy increment to use for determining the spectral index.
+
+        Returns
+        -------
+        index, index_error : tuple of float
+            Estimated spectral index and its error
+        """
+        return self._propagate_error(
+            epsilon=epsilon, fct=self.spectral_index, energy=energy
+        )
+
     def inverse(self, value, energy_min=0.1 * u.TeV, energy_max=100 * u.TeV):
         """Return energy for a given function value of the spectral model.
 

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -953,6 +953,25 @@ class TestSpectralModelErrorPropagation:
         assert_allclose(out.data, [4.119e-11, 8.157e-12], rtol=1e-3)
 
 
+def test_logpar_index_error():
+    model = LogParabolaSpectralModel(
+        amplitude=3.81e-11 / u.cm**2 / u.s / u.TeV,
+        reference=1 * u.TeV,
+        alpha=2.19,
+        beta=0.226,
+    )
+
+    model.covariance = [
+        [1.25682098e-23, 0.00000000e00, 4.54479026e-13, -1.16956188e-13],
+        [0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00],
+        [4.54479026e-13, 0.00000000e00, 6.89373848e-02, -3.31016543e-02],
+        [-1.16956188e-13, 0.00000000e00, -3.31016543e-02, 1.94907439e-02],
+    ]
+
+    out = model.spectral_index_error(energy=3 * u.TeV)
+    assert_allclose(out, [2.6865, 0.132558], rtol=1e-3)
+
+
 def test_dnde_error_ecpl_model():
     # Regression test for ECPL model
     # https://github.com/gammapy/gammapy/issues/2007

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -960,16 +960,9 @@ def test_logpar_index_error():
         alpha=2.19,
         beta=0.226,
     )
-
-    model.covariance = [
-        [1.25682098e-23, 0.00000000e00, 4.54479026e-13, -1.16956188e-13],
-        [0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00],
-        [4.54479026e-13, 0.00000000e00, 6.89373848e-02, -3.31016543e-02],
-        [-1.16956188e-13, 0.00000000e00, -3.31016543e-02, 1.94907439e-02],
-    ]
-
-    out = model.spectral_index_error(energy=3 * u.TeV)
-    assert_allclose(out, [2.6865, 0.132558], rtol=1e-3)
+    model.alpha.error = 0.4
+    out = model.spectral_index_error(energy=1.0 * u.TeV)
+    assert_allclose(out, [2.19, 0.4], rtol=1e-3)
 
 
 def test_dnde_error_ecpl_model():


### PR DESCRIPTION
Signed-off-by: Atreyee Sinha <asinha@ucm.es>

As brought up by @chaimain on the slack help channel today, error propagation on the index at the particular energy was not implement earlier... 