### PR TITLE
fixing 4fgl and broken power law equations in docs

### DIFF
--- a/examples/models/spectral/plot_broken_powerlaw.py
+++ b/examples/models/spectral/plot_broken_powerlaw.py
@@ -9,7 +9,7 @@ This model parametrises a broken power law spectrum.
 It is defined by the following equation:
 
 .. math::
-    \phi(E) = phi_0 \cdot \begin{cases}
+    \phi(E) = \phi_0 \cdot \begin{cases}
                           \left( \frac{E}{E_{break}} \right)^{-\Gamma1} & \text{if } E < E_{break} \\
                           \left( \frac{E}{E_{break}} \right)^{-\Gamma2} & \text{otherwise}
                          \end{cases}

--- a/examples/models/spectral/plot_super_exp_cutoff_powerlaw_4fgl.py
+++ b/examples/models/spectral/plot_super_exp_cutoff_powerlaw_4fgl.py
@@ -10,7 +10,7 @@ It is defined by the following equation:
 
 .. math::
 
-\phi(E) = \begin{cases} \phi_0 \cdot \left(\frac{E}{E_0}\right)^{\frac{a}{\Gamma_2} -\Gamma_1} \cdot \exp \left( \frac{a}{\Gamma_2^2}\left( 1 - \left(\frac{E}{E_0}\right)^{\Gamma_2} \right) \right) \\ \phi_0 \cdot \left(\frac{E}{E_0}\right)^{ -\Gamma_1 - \frac{a}{2} \ln \frac{E}{E_0} - \frac{a \Gamma_2}{6} \ln^2 \frac{E}{E_0} - \frac{a \Gamma_2^2}{24} \ln^3 \frac{E}{E_0}} & \text{for } \left| \Gamma_2 \ln \frac{E}{E_0} \right| < 10^{-2} \end{cases}
+    \phi(E) = \begin{cases} \phi_0 \cdot \left(\frac{E}{E_0}\right)^{\frac{a}{\Gamma_2} -\Gamma_1} \cdot \exp \left( \frac{a}{\Gamma_2^2}\left( 1 - \left(\frac{E}{E_0}\right)^{\Gamma_2} \right) \right) \\ \phi_0 \cdot \left(\frac{E}{E_0}\right)^{ -\Gamma_1 - \frac{a}{2} \ln \frac{E}{E_0} - \frac{a \Gamma_2}{6} \ln^2 \frac{E}{E_0} - \frac{a \Gamma_2^2}{24} \ln^3 \frac{E}{E_0}} & \text{for } \left| \Gamma_2 \ln \frac{E}{E_0} \right| < 10^{-2} \end{cases}
 
 See Equation (2) and (3) in https://arxiv.org/pdf/2201.11184.pdf
 """


### PR DESCRIPTION
Signed-off-by: Maxime Regeard <regeard@apc.in2p3.fr>

Pull request related to #4320.

Fixing 4fgl equation by adding an indent before the equation.
Fixing broken power law equation by adding "\" before "phi_0".