### PR TITLE
Fix Parameter init if scale is not one

### DIFF
--- a/gammapy/modeling/models/tests/data/examples.yaml
+++ b/gammapy/modeling/models/tests/data/examples.yaml
@@ -30,14 +30,14 @@ components:
     type: PointSpatialModel
     parameters:
     - name: lon_0
-      value: -50.
+      value: -0.5
       scale: 0.01
       unit: deg
       min: -180.0
       max: 180.0
       frozen: true
     - name: lat_0
-      value: -0.05
+      value: -0.0005
       scale: 0.01
       unit: deg
       min: -90.0
@@ -68,7 +68,7 @@ components:
       max: .nan
       frozen: true
     - name: lambda_
-      value: 0.06
+      value: 0.006
       scale: 0.1
       unit: TeV-1
       min: .nan

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -134,7 +134,7 @@ class Parameter:
             self.value = val.value
             self.unit = val.unit
         else:
-            self.factor = value
+            self.value = float(value)
             self.unit = unit
 
         self.scan_min = scan_min

--- a/gammapy/modeling/tests/test_iminuit.py
+++ b/gammapy/modeling/tests/test_iminuit.py
@@ -10,8 +10,8 @@ pytest.importorskip("iminuit")
 
 class MyModel(ModelBase):
     x = Parameter("x", 2.1, error=0.2)
-    y = Parameter("y", 3.1, scale=1e5, error=3e4)
-    z = Parameter("z", 4.1, scale=1e-5, error=4e-6)
+    y = Parameter("y", 3.1e5, scale=1e5, error=3e4)
+    z = Parameter("z", 4.1e-5, scale=1e-5, error=4e-6)
     name = "test"
     datasets_names = ["test"]
 

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -38,7 +38,7 @@ def test_parameter_outside_limit(caplog):
 
 def test_parameter_scale():
     # Basic check how scale is used for value, min, max
-    par = Parameter("spam", 42, "deg", 10, 400, 500)
+    par = Parameter("spam", 420, "deg", 10, 400, 500)
 
     assert par.value == 420
     assert par.min == 400
@@ -52,7 +52,7 @@ def test_parameter_scale():
 
 
 def test_parameter_quantity():
-    par = Parameter("spam", 42, "deg", 10)
+    par = Parameter("spam", 420, "deg", 10)
 
     quantity = par.quantity
     assert quantity.unit == "deg"

--- a/gammapy/modeling/tests/test_scipy.py
+++ b/gammapy/modeling/tests/test_scipy.py
@@ -28,8 +28,8 @@ class MyDataset:
 @pytest.fixture()
 def pars():
     x = Parameter("x", 2.1)
-    y = Parameter("y", 3.1, scale=1e5)
-    z = Parameter("z", 4.1, scale=1e-5)
+    y = Parameter("y", 3.1e5, scale=1e5)
+    z = Parameter("z", 4.1e-5, scale=1e-5)
     return Parameters([x, y, z])
 
 

--- a/gammapy/modeling/tests/test_sherpa.py
+++ b/gammapy/modeling/tests/test_sherpa.py
@@ -25,8 +25,8 @@ class MyDataset:
 @pytest.fixture()
 def pars():
     x = Parameter("x", 2.1)
-    y = Parameter("y", 3.1, scale=1e5)
-    z = Parameter("z", 4.1, scale=1e-5)
+    y = Parameter("y", 3.1e5, scale=1e5)
+    z = Parameter("z", 4.1e-5, scale=1e-5)
     return Parameters([x, y, z])
 
 


### PR DESCRIPTION
The parameter init set the value to the factor which is incorrect if the given scale is not one. This PR fix this bug and correct the associated tests.