### PR TITLE
Fix typo in SpatialModel.plot_interactive()

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -20,6 +20,7 @@ import matplotlib.pyplot as plt
 from gammapy.maps import Map, WcsGeom
 from gammapy.modeling import Parameter
 from gammapy.modeling.covariance import copy_covariance
+from gammapy.utils.deprecation import deprecated
 from gammapy.utils.gauss import Gauss2DPDF
 from gammapy.utils.regions import region_circle_to_ellipse, region_to_frame
 from gammapy.utils.scripts import make_path
@@ -301,7 +302,31 @@ class SpatialModel(ModelBase):
             )
         return m.plot(ax=ax, **kwargs)
 
+    @deprecated("v1.1", alternative="plot_interactive")
     def plot_interative(self, ax=None, geom=None, **kwargs):
+        """Plot spatial model.
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axis
+        geom : `~gammapy.maps.WcsGeom`, optional
+            Geom to use for plotting.
+        **kwargs : dict
+            Keyword arguments passed to `~gammapy.maps.WcsMap.plot()`
+
+        Returns
+        -------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axis
+        """
+
+        m = self._get_plot_map(geom)
+        if m.geom.is_image:
+            raise TypeError("Use .plot() for 2D Maps")
+        m.plot_interactive(ax=ax, **kwargs)
+
+    def plot_interactive(self, ax=None, geom=None, **kwargs):
         """Plot spatial model.
 
         Parameters
@@ -1246,7 +1271,13 @@ class TemplateSpatialModel(SpatialModel):
             geom = self.map.geom
         super().plot(ax=ax, geom=geom, **kwargs)
 
+    @deprecated("v1.1", alternative="plot_interactive")
     def plot_interative(self, ax=None, geom=None, **kwargs):
         if geom is None:
             geom = self.map.geom
-        super().plot_interative(ax=ax, geom=geom, **kwargs)
+        super().plot_interactive(ax=ax, geom=geom, **kwargs)
+
+    def plot_interactive(self, ax=None, geom=None, **kwargs):
+        if geom is None:
+            geom = self.map.geom
+        super().plot_interactive(ax=ax, geom=geom, **kwargs)

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -302,7 +302,7 @@ class SpatialModel(ModelBase):
             )
         return m.plot(ax=ax, **kwargs)
 
-    @deprecated("v1.1", alternative="plot_interactive")
+    @deprecated("v1.0.1", alternative="plot_interactive")
     def plot_interative(self, ax=None, geom=None, **kwargs):
         """Plot spatial model.
 
@@ -1271,7 +1271,7 @@ class TemplateSpatialModel(SpatialModel):
             geom = self.map.geom
         super().plot(ax=ax, geom=geom, **kwargs)
 
-    @deprecated("v1.1", alternative="plot_interactive")
+    @deprecated("v1.0.1", alternative="plot_interactive")
     def plot_interative(self, ax=None, geom=None, **kwargs):
         if geom is None:
             geom = self.map.geom

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -336,7 +336,7 @@ def test_sky_diffuse_map(caplog):
     assert isinstance(model.to_region(), RectangleSkyRegion)
 
     with pytest.raises(TypeError):
-        model.plot_interative()
+        model.plot_interactive()
 
     with pytest.raises(TypeError):
         model.plot_grid()


### PR DESCRIPTION
Correct a typo in the name of some plot_interactive methods definition.