### PR TITLE
Remove Observation.from_caldb() in notebook

### DIFF
--- a/examples/tutorials/analysis-3d/simulate_3d.py
+++ b/examples/tutorials/analysis-3d/simulate_3d.py
@@ -82,10 +82,7 @@ from gammapy.modeling.models import (
 
 
 ######################################################################
-# We will simulate using the CTA-1DC IRFs shipped with gammapy. Note that
-# for dedictaed CTA simulations, you can simply use
-# ``Observation.from_caldb()` <>`__ without having to externally load
-# the IRFs
+# We will simulate using the CTA-1DC IRFs shipped with gammapy
 #
 
 # Loading IRFs


### PR DESCRIPTION
I think we removed `Observation.from_caldb()` at some(?) point, but forgot to remove the statement in the tutorial which is a bit confusing for users