### PR TITLE
Always use FixedPointingInfo from events header in DataStore

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -322,11 +322,11 @@ class DataStore:
                 f"Required HDUs {missing_hdus} not found in observation {obs_id}"
             )
 
-        # if we didn't find the pointing hdu, extract FixedPointingInfo from events
-        if "pointing" not in kwargs:
-            pointing_location = copy(kwargs["events"])
-            pointing_location.hdu_class = "pointing"
-            kwargs["pointing"] = pointing_location
+        # TODO: right now, gammapy doesn't support using the pointing table of GADF
+        # so we always pass the events location here to be read into a FixedPointingInfo
+        pointing_location = copy(kwargs["events"])
+        pointing_location.hdu_class = "pointing"
+        kwargs["pointing"] = pointing_location
 
         return Observation(**kwargs)
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**


This pull request fixes the  behavior of the data store for files that do contain the `POINTING` table.
Gammapy doesn't support using the pointing table currently, so the code in the data store that didn't read the `FixedPointingInfo` from the events header in case the `POINTING` table is there does not make sense currently.

To be changed once Gammapy actually uses the pointing table.

