### PR TITLE
Improve performance of  1d analyses

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2063,7 +2063,8 @@ class MapDatasetOnOff(MapDataset):
         with np.errstate(invalid="ignore", divide="ignore"):
             data = self.acceptance.quantity / self.acceptance_off.quantity
         data = np.nan_to_num(data)
-        return Map.from_geom(self._geom, data=data.value, unit=data.unit)
+
+        return Map.from_geom(self._geom, data=data.to_value(""), unit="")
 
     def npred_background(self):
         """Predicted background counts estimated from the marginalized likelihood estimate.

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2061,10 +2061,9 @@ class MapDatasetOnOff(MapDataset):
             Alpha map
         """
         with np.errstate(invalid="ignore", divide="ignore"):
-            alpha = self.acceptance / self.acceptance_off
-
-        alpha.data = np.nan_to_num(alpha.data)
-        return alpha
+            data = self.acceptance.quantity / self.acceptance_off.quantity
+        data = np.nan_to_num(data)
+        return Map.from_geom(self._geom, data=data.value, unit=data.unit)
 
     def npred_background(self):
         """Predicted background counts estimated from the marginalized likelihood estimate.

--- a/gammapy/datasets/utils.py
+++ b/gammapy/datasets/utils.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
+from gammapy.maps import Map
 
 
 def apply_edisp(input_map, edisp):
@@ -30,7 +31,7 @@ def apply_edisp(input_map, edisp):
         energy_axis = input_map.geom.axes["energy_true"].copy(name="energy")
 
     geom = input_map.geom.to_image().to_cube(axes=[energy_axis])
-    return input_map._init_copy(geom=geom, data=data)
+    return Map.from_geom(geom=geom, data=data, unit=input_map.unit)
 
 
 def get_figure(fig, width, height):

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -887,7 +887,8 @@ class MapAxis:
 
         for arg in argnames:
             value = getattr(self, "_" + arg)
-            kwargs.setdefault(arg, copy.deepcopy(value))
+            if arg not in kwargs:
+                kwargs[arg] = copy.deepcopy(value)
 
         return self.__class__(**kwargs)
 
@@ -2565,7 +2566,8 @@ class TimeMapAxis:
 
         for arg in argnames:
             value = getattr(self, "_" + arg)
-            kwargs.setdefault(arg, copy.deepcopy(value))
+            if arg not in kwargs:
+                kwargs[arg] = copy.deepcopy(value)
 
         return self.__class__(**kwargs)
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -63,7 +63,8 @@ class Map(abc.ABC):
 
         for arg in argnames:
             value = getattr(self, "_" + arg)
-            kwargs.setdefault(arg, copy.deepcopy(value))
+            if arg not in kwargs:
+                kwargs[arg] = copy.deepcopy(value)
 
         return self.from_geom(**kwargs)
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1409,7 +1409,7 @@ class Map(abc.ABC):
             energy_axis = self.geom.axes["energy_true"].copy(name="energy")
 
         geom = self.geom.to_image().to_cube(axes=[energy_axis])
-        return self._init_copy(geom=geom, data=data)
+        return Map.from_geom(geom=geom, data=data, unit=self.unit)
 
     def mask_nearest_position(self, position):
         """Given a sky coordinate return nearest valid position in the mask

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1410,7 +1410,7 @@ class Map(abc.ABC):
             energy_axis = self.geom.axes["energy_true"].copy(name="energy")
 
         geom = self.geom.to_image().to_cube(axes=[energy_axis])
-        return Map.from_geom(geom=geom, data=data, unit=self.unit)
+        return self.__class__(geom=geom, data=data, unit=self.unit)
 
     def mask_nearest_position(self, position):
         """Given a sky coordinate return nearest valid position in the mask

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -585,7 +585,8 @@ class Geom(abc.ABC):
 
         for arg in argnames:
             value = getattr(self, "_" + arg)
-            kwargs.setdefault(arg, copy.deepcopy(value))
+            if arg not in kwargs:
+                kwargs[arg] = copy.deepcopy(value)
 
         return self.__class__(**kwargs)
 

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -462,7 +462,7 @@ class RegionGeom(Geom):
             RegionGeom with the added axes.
         """
         axes = copy.deepcopy(self.axes) + axes
-        return self._init_copy(axes=axes)
+        return self._init_copy(region=self.region, wcs=self.wcs, axes=axes)
 
     def to_image(self):
         """Remove non-spatial axes to create a 2D region.
@@ -472,7 +472,7 @@ class RegionGeom(Geom):
         region : `~RegionGeom`
             RegionGeom without any non-spatial axes.
         """
-        return self._init_copy(axes=None)
+        return self._init_copy(region=self.region, wcs=self.wcs, axes=None)
 
     def upsample(self, factor, axis_name=None):
         """Upsample a non-spatial dimension of the region by a given factor.
@@ -483,7 +483,7 @@ class RegionGeom(Geom):
             RegionGeom with the upsampled axis.
         """
         axes = self.axes.upsample(factor=factor, axis_name=axis_name)
-        return self._init_copy(axes=axes)
+        return self._init_copy(region=self.region, wcs=self.wcs, axes=axes)
 
     def downsample(self, factor, axis_name):
         """Downsample a non-spatial dimension of the region by a given factor.
@@ -494,7 +494,7 @@ class RegionGeom(Geom):
             RegionGeom with the downsampled axis.
         """
         axes = self.axes.downsample(factor=factor, axis_name=axis_name)
-        return self._init_copy(axes=axes)
+        return self._init_copy(region=self.region, wcs=self.wcs, axes=axes)
 
     def pix_to_coord(self, pix):
         lon = np.where(


### PR DESCRIPTION
Looking into the 1d analyses benchmarks it seems that
- a lot of time is spent in copy
- the alpha property of the MapDatasetOnOff could be cached
