### PR TITLE
Fix interpolation values_scale in TemplateSpatialModel

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -22,7 +22,6 @@ from gammapy.modeling import Parameter
 from gammapy.modeling.covariance import copy_covariance
 from gammapy.utils.deprecation import deprecated
 from gammapy.utils.gauss import Gauss2DPDF
-from gammapy.utils.interpolation import interpolation_scale
 from gammapy.utils.regions import region_circle_to_ellipse, region_to_frame
 from gammapy.utils.scripts import make_path
 from .core import ModelBase
@@ -1215,20 +1214,7 @@ class TemplateSpatialModel(SpatialModel):
         if energy is not None:
             coord["energy_true"] = energy
 
-        # TODO: ideally all `interp_by_coord` should accept `values_scale` argument,
-        # remove this once done but for now we use this non api-breaking fix.
-        interp_kwargs = self._interp_kwargs.copy()
-
-        if "values_scale" in interp_kwargs:
-            values_scale = interp_kwargs.pop("values_scale")
-            scale = interpolation_scale(values_scale)
-            scaled_map = self.map.copy()
-            scaled_map.data = scale(scaled_map.data)
-            val = scaled_map.interp_by_coord(coord, **interp_kwargs)
-            val = scale.inverse(val)
-        else:
-            val = self.map.interp_by_coord(coord, **interp_kwargs)
-
+        val = self.map.interp_by_coord(coord, **self._interp_kwargs)
         val = np.clip(val, 0, a_max=None)
         return u.Quantity(val, self.map.unit, copy=False)
 

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -22,6 +22,7 @@ from gammapy.modeling import Parameter
 from gammapy.modeling.covariance import copy_covariance
 from gammapy.utils.deprecation import deprecated
 from gammapy.utils.gauss import Gauss2DPDF
+from gammapy.utils.interpolation import interpolation_scale
 from gammapy.utils.regions import region_circle_to_ellipse, region_to_frame
 from gammapy.utils.scripts import make_path
 from .core import ModelBase
@@ -1086,7 +1087,7 @@ class TemplateSpatialModel(SpatialModel):
         Normalize the input map so that it integrates to unity.
     interp_kwargs : dict
         Interpolation keyword arguments passed to `gammapy.maps.Map.interp_by_coord`.
-        Default arguments are {'method': 'linear', 'fill_value': 0}.
+        Default arguments are {'method': 'linear', 'fill_value': 0, "values_scale": "log"}.
     Filename : str
         Name of the map file
     copy_data : bool
@@ -1139,6 +1140,7 @@ class TemplateSpatialModel(SpatialModel):
         interp_kwargs = {} if interp_kwargs is None else interp_kwargs
         interp_kwargs.setdefault("method", "linear")
         interp_kwargs.setdefault("fill_value", 0)
+        interp_kwargs.setdefault("values_scale", "log")
 
         self._interp_kwargs = interp_kwargs
         self.filename = filename
@@ -1213,7 +1215,20 @@ class TemplateSpatialModel(SpatialModel):
         if energy is not None:
             coord["energy_true"] = energy
 
-        val = self.map.interp_by_coord(coord, **self._interp_kwargs)
+        # TODO: ideally all `interp_by_coord` should accept `values_scale` argument,
+        # remove this once done but for now we use this non api-breaking fix.
+        interp_kwargs = self._interp_kwargs.copy()
+
+        if "values_scale" in interp_kwargs:
+            values_scale = interp_kwargs.pop("values_scale")
+            scale = interpolation_scale(values_scale)
+            scaled_map = self.map.copy()
+            scaled_map.data = scale(scaled_map.data)
+            val = scaled_map.interp_by_coord(coord, **interp_kwargs)
+            val = scale.inverse(val)
+        else:
+            val = self.map.interp_by_coord(coord, **interp_kwargs)
+
         val = np.clip(val, 0, a_max=None)
         return u.Quantity(val, self.map.unit, copy=False)
 

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -427,7 +427,7 @@ class Test_Template_with_cube:
         val = model.evaluate(0 * u.deg, 0 * u.deg, 100 * u.GeV)
         assert val.unit == "cm-2 s-1 MeV-1 sr-1"
         assert val.shape == (1,)
-        assert_allclose(val.value, 1.396424e-12, rtol=1e-5)
+        assert_allclose(val.value, 1.395156e-12, rtol=1e-5)
 
     @staticmethod
     def test_evaluation_radius(diffuse_model):

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -323,7 +323,7 @@ def test_sky_diffuse_map(caplog):
     ]
 
     assert val.unit == "sr-1"
-    desired = [3269.178107, 0]
+    desired = [3265.6559, 0]
     assert_allclose(val.value, desired)
 
     res = model.evaluate_geom(model.map.geom)


### PR DESCRIPTION
This PR allows to change the `values_scale` in the interpolation of the `TemplateSpatialModel`. The default interp_kwargs is also set to `log` instead of `lin` to be consistent with  the `TemplateSpectralModel`.

The fix is done in the evaluate method of the `TemplateSpatialModel` to avoid API breaking changes but ideally  all `Map.interp_by_coord` methods  should accept the `values_scale` argument instead.