### PR TITLE
correcting small typo in 1D spectral analysis energy dependant cut

### DIFF
--- a/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
@@ -220,7 +220,7 @@ dataset_maker = SpectrumDatasetMaker(
     containment_correction=False, selection=["counts", "exposure", "edisp"]
 )
 
-# tell the background maker to use the WobbleRegionsFinder, let us use 1 off
+# tell the background maker to use the WobbleRegionsFinder, let us use 3 off
 region_finder = WobbleRegionsFinder(n_off_regions=3)
 bkg_maker = ReflectedRegionsBackgroundMaker(region_finder=region_finder)
 


### PR DESCRIPTION
PR to correct a small typo in the 1D spectral analysis energy directional cut 