### PR TITLE
Correct IO for FOVALIGN in gammapy.irf

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -97,6 +97,8 @@ class Background3D(BackgroundIRF):
         Data array.
     unit : str or `~astropy.units.Unit`
         Data unit usually ``s^-1 MeV^-1 sr^-1``
+    fov_alignment: `~gammapy.irf.FoVAlignment`
+        The orientation of the field of view coordinate system.
     meta : dict
         Meta data
 

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -484,6 +484,9 @@ class IRF(metaclass=abc.ABCMeta):
 
             table.meta.update(spec["mandatory_keywords"])
 
+            if "FOVALIGN" in table.meta:
+                table.meta["FOVALIGN"] = self.fov_alignment.value
+
             if self.is_pointlike:
                 table.meta["HDUCLAS3"] = "POINT-LIKE"
             else:

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -2,9 +2,9 @@
 import logging
 from astropy.io import fits
 from gammapy.data.hdu_index_table import HDUIndexTable
+from gammapy.utils.deprecation import deprecated
 from gammapy.utils.fits import HDULocation
 from gammapy.utils.scripts import make_path
-from gammapy.utils.deprecation import deprecated
 
 __all__ = ["load_cta_irfs", "load_irf_dict_from_file"]
 
@@ -44,6 +44,7 @@ IRF_DL3_HDU_SPECIFICATION = {
             "HDUCLAS2": "BKG",
             "HDUCLAS3": "FULL-ENCLOSURE",  # added here to have HDUCLASN in order
             "HDUCLAS4": "BKG_3D",
+            "FOVALIGN": "RADEC",
         },
     },
     "bkg_2d": {

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -80,6 +80,7 @@ def test_to_table():
     hdu = aeff.to_table_hdu()
     assert_equal(hdu.data["ENERG_LO"][0], aeff.axes["energy_true"].edges[:-1].value)
     assert hdu.header["TUNIT1"] == aeff.axes["energy_true"].unit
+    assert "FOVALIGN" not in hdu.header
 
 
 def test_to_table_is_pointlike():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects #4360 . It adds a `FOVALIGN` in the mandatory keywords for the `Background3D` since the latter is required by gadf. A mechanism is added to properly export it to the `Table.meta` when serializing the IRF.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
