### PR TITLE
Adapt default offset for plotting point like IRFs

### DIFF
--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -52,6 +52,14 @@ class EnergyDispersion2D(IRF):
     required_axes = ["energy_true", "migra", "offset"]
     default_unit = u.one
 
+    @property
+    def _default_offset(self):
+        if self.axes["offset"].nbin == 1:
+            default_offset = self.axes["offset"].center
+        else:
+            default_offset = [1.0] * u.deg
+        return default_offset
+
     def _mask_out_bounds(self, invalid):
         return (
             invalid[self.axes.index("energy_true")] & invalid[self.axes.index("migra")]
@@ -182,7 +190,7 @@ class EnergyDispersion2D(IRF):
         ax = plt.gca() if ax is None else ax
 
         if offset is None:
-            offset = Angle([1], "deg")
+            offset = self._default_offset
         else:
             offset = np.atleast_1d(Angle(offset))
 
@@ -232,7 +240,7 @@ class EnergyDispersion2D(IRF):
         ax = plt.gca() if ax is None else ax
 
         if offset is None:
-            offset = Angle(1, "deg")
+            offset = self._default_offset
 
         energy_true = self.axes["energy_true"]
         migra = self.axes["migra"]
@@ -266,7 +274,7 @@ class EnergyDispersion2D(IRF):
         fig, axes = plt.subplots(nrows=1, ncols=3, figsize=figsize)
         self.plot_bias(ax=axes[0])
         self.plot_migration(ax=axes[1])
-        edisp = self.to_edisp_kernel(offset="1 deg")
+        edisp = self.to_edisp_kernel(offset=self._default_offset[0])
         edisp.plot_matrix(ax=axes[2])
 
         plt.tight_layout()

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -184,10 +184,12 @@ class EffectiveAreaTable2D(IRF):
             Size of the figure.
 
         """
-        fig, axes = plt.subplots(nrows=1, ncols=3, figsize=figsize)
-        self.plot(ax=axes[2])
+        ncols = 2 if self.is_pointlike else 3
+        fig, axes = plt.subplots(nrows=1, ncols=ncols, figsize=figsize)
+        self.plot(ax=axes[ncols - 1])
         self.plot_energy_dependence(ax=axes[0])
-        self.plot_offset_dependence(ax=axes[1])
+        if self.is_pointlike is False:
+            self.plot_offset_dependence(ax=axes[1])
         plt.tight_layout()
 
     @classmethod


### PR DESCRIPTION
The plot for `edisp.peek()` looks bad for point like IRFs (eg: https://github.com/gammapy/gammapy-recipes/blob/2ee2588268dccc266cebafca32979f410068e68a/recipes/pulsar_phase/pulsar_phase_computation.ipynb)

This is because of the choice of the default angle. This PR corrects it. The plot now looks like

<img width="1002" alt="Screenshot 2023-03-14 at 19 03 32" src="https://user-images.githubusercontent.com/32677370/225097073-590beabc-0d6a-4024-b1f3-025e289815a4.png">

@registerrier : I dont know if we can't still put it in 1.0.1. 