### PR TITLE
Obs filter live time

### DIFF
--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -50,7 +50,7 @@ class ObservationFilter:
 
     @property
     def livetime_fraction(self):
-        """Fraction of the livetime resulting from event_filters."""
+        """Fraction of the livetime kept when applying the event_filters."""
         return self._check_filter_phase(self.event_filters)
 
     def filter_events(self, events):

--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -47,7 +47,11 @@ class ObservationFilter:
     def __init__(self, time_filter=None, event_filters=None):
         self.time_filter = time_filter
         self.event_filters = event_filters or []
-        self.phase_range = self._check_filter_phase(event_filters)
+
+    @property
+    def livetime_fraction(self):
+        """Fraction of the livetime resulting from event_filters."""
+        return self._check_filter_phase(self.event_filters)
 
     def filter_events(self, events):
         """Apply filters to an event list.

--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -47,6 +47,7 @@ class ObservationFilter:
     def __init__(self, time_filter=None, event_filters=None):
         self.time_filter = time_filter
         self.event_filters = event_filters or []
+        self.phase_range = self._check_filter_phase(event_filters)
 
     def filter_events(self, events):
         """Apply filters to an event list.
@@ -97,3 +98,14 @@ class ObservationFilter:
     def copy(self):
         """Copy the `ObservationFilter` object."""
         return copy.deepcopy(self)
+
+    @staticmethod
+    def _check_filter_phase(event_filter):
+        if not event_filter:
+            return 1
+        for f in event_filter:
+            if f.get("opts").get("parameter") == "PHASE":
+                band = f.get("opts").get("band")
+                return band[1] - band[0]
+            else:
+                return 1

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -277,7 +277,7 @@ class Observation:
         return (
             self.observation_time_duration
             * (1 - self.observation_dead_time_fraction)
-            * self.obs_filter.phase_range
+            * self.obs_filter.livetime_fraction
         )
 
     @property

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -305,6 +305,8 @@ class Observation:
                     if f.get("opts").get("parameter") == "PHASE":
                         band = f.get("opts").get("band")
                         return band[1] - band[0]
+                    else:
+                        return 1
             else:
                 return 1
         else:

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -299,18 +299,18 @@ class Observation:
     @staticmethod
     def _check_obs_filter_phase(obs_filter):
         """Static method that check for phase filter in the obs_filter in order to correct the live time duration."""
-        if obs_filter is not None:
-            if len(obs_filter.event_filters) != 0:
+        if obs_filter is None:
+            return 1
+        else:
+            if len(obs_filter.event_filters) == 0:
+                return 1
+            else:
                 for f in obs_filter.event_filters:
                     if f.get("opts").get("parameter") == "PHASE":
                         band = f.get("opts").get("band")
                         return band[1] - band[0]
                     else:
                         return 1
-            else:
-                return 1
-        else:
-            return 1
 
     @lazyproperty
     def obs_info(self):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -277,7 +277,7 @@ class Observation:
         return (
             self.observation_time_duration
             * (1 - self.observation_dead_time_fraction)
-            * self._check_obs_filter_phase(self.obs_filter)
+            * self.obs_filter.phase_range
         )
 
     @property
@@ -295,22 +295,6 @@ class Observation:
         which in turn is used in the exposure and flux computation.
         """
         return 1 - self.obs_info["DEADC"]
-
-    @staticmethod
-    def _check_obs_filter_phase(obs_filter):
-        """Static method that check for phase filter in the obs_filter in order to correct the live time duration."""
-        if obs_filter is None:
-            return 1
-        else:
-            if len(obs_filter.event_filters) == 0:
-                return 1
-            else:
-                for f in obs_filter.event_filters:
-                    if f.get("opts").get("parameter") == "PHASE":
-                        band = f.get("opts").get("band")
-                        return band[1] - band[0]
-                    else:
-                        return 1
 
     @lazyproperty
     def obs_info(self):

--- a/gammapy/data/tests/test_filters.py
+++ b/gammapy/data/tests/test_filters.py
@@ -7,7 +7,7 @@ from astropy.time import Time
 from astropy.units import Quantity
 from gammapy.data import GTI, DataStore, EventList, ObservationFilter
 from gammapy.utils.regions import SphericalCircleSkyRegion
-from gammapy.utils.testing import assert_time_allclose, requires_data
+from gammapy.utils.testing import assert_allclose, assert_time_allclose, requires_data
 
 
 def test_event_filter_types():
@@ -78,3 +78,31 @@ def test_filter_gti(observation):
     assert isinstance(filtered_gti, GTI)
     assert_time_allclose(filtered_gti.time_start, time_filter[0])
     assert_time_allclose(filtered_gti.time_stop, time_filter[1])
+
+
+@pytest.mark.parametrize(
+    "pars",
+    [
+        {
+            "p_in": [
+                {"type": "custom", "opts": dict(parameter="PHASE", band=(0.2, 0.8))}
+            ],
+            "p_out": 0.6,
+        },
+        {
+            "p_in": [
+                {
+                    "type": "custom",
+                    "opts": dict(parameter="ENERGY", band=(0.1, 1) * u.TeV),
+                }
+            ],
+            "p_out": 1,
+        },
+        {
+            "p_in": [],
+            "p_out": 1,
+        },
+    ],
+)
+def test_check_filter_phase(pars):
+    assert_allclose(ObservationFilter._check_filter_phase(pars["p_in"]), pars["p_out"])

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -501,3 +501,33 @@ def test_filter_live_time_phase(data_store):
     live_time_filter = observation.observation_live_time_duration
 
     assert_allclose(live_time_filter, default_obs_live_time * (0.8 - 0.2))
+
+
+@pytest.mark.parametrize(
+    "pars",
+    [
+        {
+            "p_in": ObservationFilter(
+                event_filters=[
+                    {"type": "custom", "opts": dict(parameter="PHASE", band=(0.2, 0.8))}
+                ]
+            ),
+            "p_out": 0.6,
+        },
+        {
+            "p_in": ObservationFilter(
+                event_filters=[
+                    {
+                        "type": "custom",
+                        "opts": dict(parameter="ENERGY", band=(0.1, 1) * u.TeV),
+                    }
+                ]
+            ),
+            "p_out": 1,
+        },
+        {"p_in": ObservationFilter(), "p_out": 1},
+        {"p_in": None, "p_out": 1},
+    ],
+)
+def test_check_obs_filter_phase(pars):
+    assert_allclose(Observation._check_obs_filter_phase(pars["p_in"]), pars["p_out"])

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -501,33 +501,3 @@ def test_filter_live_time_phase(data_store):
     live_time_filter = observation.observation_live_time_duration
 
     assert_allclose(live_time_filter, default_obs_live_time * (0.8 - 0.2))
-
-
-@pytest.mark.parametrize(
-    "pars",
-    [
-        {
-            "p_in": ObservationFilter(
-                event_filters=[
-                    {"type": "custom", "opts": dict(parameter="PHASE", band=(0.2, 0.8))}
-                ]
-            ),
-            "p_out": 0.6,
-        },
-        {
-            "p_in": ObservationFilter(
-                event_filters=[
-                    {
-                        "type": "custom",
-                        "opts": dict(parameter="ENERGY", band=(0.1, 1) * u.TeV),
-                    }
-                ]
-            ),
-            "p_out": 1,
-        },
-        {"p_in": ObservationFilter(), "p_out": 1},
-        {"p_in": None, "p_out": 1},
-    ],
-)
-def test_check_obs_filter_phase(pars):
-    assert_allclose(Observation._check_obs_filter_phase(pars["p_in"]), pars["p_out"])

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -6,7 +6,7 @@ import astropy.units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
-from gammapy.data import DataStore, Observation
+from gammapy.data import DataStore, Observation, ObservationFilter
 from gammapy.data.pointing import FixedPointingInfo, PointingMode
 from gammapy.data.utils import get_irfs_features
 from gammapy.irf import PSF3D, load_irf_dict_from_file
@@ -487,3 +487,17 @@ def test_observations_clustering(data_store):
     assert len(obs_clusters["group_1"]) == 3
     assert len(obs_clusters["group_2"]) == 1
     assert obs_clusters["group_2"][0].obs_id == 23523
+
+
+@requires_data()
+def test_filter_live_time_phase(data_store):
+    observation = data_store.obs(20136)
+    phase_filter = {"type": "custom", "opts": dict(parameter="PHASE", band=(0.2, 0.8))}
+
+    default_obs_live_time = observation.observation_live_time_duration
+
+    obs_filter = ObservationFilter(event_filters=[phase_filter])
+    observation.obs_filter = obs_filter
+    live_time_filter = observation.observation_live_time_duration
+
+    assert_allclose(live_time_filter, default_obs_live_time * (0.8 - 0.2))


### PR DESCRIPTION
This pull request is related to issue #4387. 

I added a staticmethod which check if the `ObservationFilter`applied is on the phase. If it's the case it returns the range of phase that has been filtered (i.e. phase range is [0.2, 0.8], it returns 0.6). If no phase filtering has been applied to `ObservationFilter`, it just return 1. 
And then this method is called when computing `observation_live_time_duration`.

I also added a test that check the observation livetime durationn, and especially check that the livetime is corrected when filtering on phase. 
I also added a test for the staticmethod. 