### PR TITLE
Adding more documentation on datasets docstring

### DIFF
--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -18,7 +18,8 @@ __all__ = ["Dataset", "Datasets"]
 
 class Dataset(abc.ABC):
     """Dataset abstract base class.
-    For more information see the :ref:`datasets`.
+
+    For more information see :ref:`datasets`.
 
     TODO: add tutorial how to create your own dataset types.
 

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -18,6 +18,7 @@ __all__ = ["Dataset", "Datasets"]
 
 class Dataset(abc.ABC):
     """Dataset abstract base class.
+    For more information see the :ref:`datasets`.
 
     TODO: add tutorial how to create your own dataset types.
 
@@ -109,7 +110,7 @@ class Dataset(abc.ABC):
 
 
 class Datasets(collections.abc.MutableSequence):
-    """Dataset collection.
+    """Container class that holds a list of datasets.
 
     Parameters
     ----------

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -18,7 +18,8 @@ __all__ = ["FluxPointsDataset"]
 class FluxPointsDataset(Dataset):
     """Bundle a set of flux points with a parametric model,
     to compute fit statistic function using chi2 statistics.
-    For more information see the :ref:`datasets`.
+
+    For more information see :ref:`datasets`.
 
     Parameters
     ----------

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -18,6 +18,7 @@ __all__ = ["FluxPointsDataset"]
 class FluxPointsDataset(Dataset):
     """Bundle a set of flux points with a parametric model,
     to compute fit statistic function using chi2 statistics.
+    For more information see the :ref:`datasets`.
 
     Parameters
     ----------

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -102,8 +102,9 @@ def create_map_dataset_geoms(
 class MapDataset(Dataset):
     """
     Bundle together binned counts, background, IRFs, models and compute a likelihood.
-    For more information see the :ref:`datasets`.
-     Uses Cash statistics by default.
+    It uses the Cash statistics by default.
+
+    For more information see :ref:`datasets`.
 
     Parameters
     ----------
@@ -1940,9 +1941,9 @@ class MapDataset(Dataset):
 
 
 class MapDatasetOnOff(MapDataset):
-    """Map dataset for on-off likelihood fitting.
-    For more information see the :ref:`datasets`.
-    Uses wstat statistics.
+    """Map dataset for on-off likelihood fitting. It uses wstat statistics by default.
+
+    For more information see :ref:`datasets`.
 
     Parameters
     ----------

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -102,6 +102,7 @@ def create_map_dataset_geoms(
 class MapDataset(Dataset):
     """
     Bundle together binned counts, background, IRFs, models and compute a likelihood.
+    For more information see the :ref:`datasets`.
      Uses Cash statistics by default.
 
     Parameters
@@ -1939,7 +1940,9 @@ class MapDataset(Dataset):
 
 
 class MapDatasetOnOff(MapDataset):
-    """Map dataset for on-off likelihood fitting. Uses wstat statistics.
+    """Map dataset for on-off likelihood fitting.
+    For more information see the :ref:`datasets`.
+    Uses wstat statistics.
 
     Parameters
     ----------

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -252,6 +252,10 @@ class PlotMixin:
 
 
 class SpectrumDataset(PlotMixin, MapDataset):
+    """
+    For more information see the :ref:`datasets`.
+    """
+
     stat_type = "cash"
     tag = "SpectrumDataset"
 
@@ -266,6 +270,10 @@ class SpectrumDataset(PlotMixin, MapDataset):
 
 
 class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
+    """
+    For more information see the :ref:`datasets`.
+    """
+
     stat_type = "wstat"
     tag = "SpectrumDatasetOnOff"
 

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -253,7 +253,10 @@ class PlotMixin:
 
 class SpectrumDataset(PlotMixin, MapDataset):
     """
-    For more information see the :ref:`datasets`.
+    Bundle together binned counts, background, IRFs, models and compute a likelihood into 1D spectrum.
+    It uses the Cash statistics by default.
+
+    For more information see :ref:`datasets`.
     """
 
     stat_type = "cash"
@@ -271,7 +274,9 @@ class SpectrumDataset(PlotMixin, MapDataset):
 
 class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
     """
-    For more information see the :ref:`datasets`.
+    Spectrum dataset for on-off likelihood fitting. It uses the wstat statistics by default.
+
+    For more information see :ref:`datasets`.
     """
 
     stat_type = "wstat"


### PR DESCRIPTION
Pull request that add a link to the user-guide/datasets in each concerned dataset docstring. 

I also added a docstring for `SpectrumDataset` and `SpectrumDatasetOnOff` because there were none. 