### PR TITLE
Update the `_evaluate_timevar_source` function in `MapDatasetEventSampler`

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -128,6 +128,7 @@ class MapDatasetEventSampler:
         pred = (
             (
                 region_exposure.quantity[:, None, :, :]
+                / time_axis.nbin
                 * flux_pred.interp_by_coord(mapcoord)
                 * flux_pred.unit
             )

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -118,7 +118,7 @@ class MapDatasetEventSampler:
 
         flux_diff = (
             evaluator.model.temporal_model.evaluate(
-                time_axis_eval.time_mid, energy=energy_new.center, method=self.method
+                time_axis_eval.time_mid, energy=energy_new.center
             )
             * evaluator.model.spectral_model.parameters[0].quantity
         )

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -74,7 +74,7 @@ class MapDatasetEventSampler:
 
         Returns
         -------
-        npred : `~RegionNDMap`
+        npred : `~gammapy.maps.RegionNDMap`
             Npred map.
         """
         energy = MapAxis.from_edges(
@@ -87,20 +87,25 @@ class MapDatasetEventSampler:
         if not time_axis:
             tstart = dataset.gti.time_start
             tstop = dataset.gti.time_stop
+            min_timebin = np.min(
+                evaluator.model.temporal_model.map.geom.axes["time"].bin_width
+            )
             # how do we choose the number of bins?
             time_axis = TimeMapAxis.from_time_bounds(
-                time_min=tstart, time_max=tstop, nbin=10
+                time_min=tstart,
+                time_max=tstop,
+                nbin=((tstop - tstart) / min_timebin).to(""),
             )
 
         flux = (
             evaluator.model.temporal_model.evaluate(
                 time_axis.time_mid, energy=energy.center
             )
-            * evaluator.model.spectral_model.parameters[0].unit
+            * evaluator.model.spectral_model.parameters[0].quantity
         )
 
         pred = (
-            (region_exposure.data[:, 0, 0, None] * dataset.exposure.unit * flux)
+            (region_exposure.data[:, 0, 0, None] * flux)
             * np.diff(energy.edges)[:, None]
         ).to("")
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -131,6 +131,7 @@ class MapDatasetEventSampler:
                 / time_axis.nbin
                 * flux_pred.interp_by_coord(mapcoord)
                 * flux_pred.unit
+                * self.oversample_energy_factor
             )
         ).to("")
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -30,11 +30,16 @@ class MapDatasetEventSampler:
     oversample_energy_factor: {int}
         Defines an oversampling factor for the energies; it is used only when sampling
         an energy-dependent time-varying source.
+    t_delta : `~astropy.units.Quantity`
+        Time interval used to sample the time-dependent source.
     """
 
-    def __init__(self, random_state="random-seed", oversample_energy_factor=10):
+    def __init__(
+        self, random_state="random-seed", oversample_energy_factor=10, t_delta=0.5 * u.s
+    ):
         self.random_state = get_random_state(random_state)
         self.oversample_energy_factor = oversample_energy_factor
+        self.t_delta = t_delta
 
     def _make_table(self, coords, time_ref):
         """Create a table for sampled events.
@@ -69,7 +74,6 @@ class MapDatasetEventSampler:
         self,
         dataset,
         model,
-        t_delta=0.5 * u.s,
     ):
         """Calculate Npred for a given `dataset.model` by evaluating
         it on a region geometry.
@@ -94,7 +98,7 @@ class MapDatasetEventSampler:
 
         tstart = dataset.gti.time_start
         tstop = dataset.gti.time_stop
-        nbin = int(((tstop - tstart) / t_delta).to(""))
+        nbin = int(((tstop - tstart) / self.t_delta).to(""))
         time_axis_eval = TimeMapAxis.from_time_bounds(
             time_min=tstart,
             time_max=tstop,
@@ -208,6 +212,7 @@ class MapDatasetEventSampler:
             t_min=time_start,
             t_max=time_stop,
             random_state=self.random_state,
+            t_delta=self.t_delta,
         )
 
         table = self._make_table(coords, time_ref)

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -207,8 +207,7 @@ class MapDatasetEventSampler:
             else:
                 temporal_model = evaluator.model.temporal_model
 
-            #            if hasattr(temporal_model, "is_energy_dependent"):
-            if temporal_model == "TemplateTemporalModel":
+            if hasattr(temporal_model, "is_energy_dependent"):
                 table = self._sample_coord_time_energy(dataset, evaluator)
             else:
                 flux = evaluator.compute_flux()

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -35,12 +35,9 @@ class MapDatasetEventSampler:
         performed. It is used only when sampling an energy-dependent time-varying source.
     """
 
-    def __init__(
-        self, random_state="random-seed", oversample_energy_factor=10, method="linear"
-    ):
+    def __init__(self, random_state="random-seed", oversample_energy_factor=10):
         self.random_state = get_random_state(random_state)
         self.oversample_energy_factor = oversample_energy_factor
-        self.method = method
 
     def _make_table(self, coords, time_ref):
         """Create a table for sampled events.

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -30,11 +30,17 @@ class MapDatasetEventSampler:
     oversample_energy_factor: {int}
         Defines an oversampling factor for the energies; it is used only when sampling
         an energy-dependent time-varying source.
+    method : {"linear", "nearest"}
+        Method to interpolate data values. By default linear interpolation is
+        performed. It is used only when sampling an energy-dependent time-varying source.
     """
 
-    def __init__(self, random_state="random-seed", oversample_energy_factor=10):
+    def __init__(
+        self, random_state="random-seed", oversample_energy_factor=10, method="linear"
+    ):
         self.random_state = get_random_state(random_state)
         self.oversample_energy_factor = oversample_energy_factor
+        self.method = method
 
     def _make_table(self, coords, time_ref):
         """Create a table for sampled events.
@@ -66,7 +72,11 @@ class MapDatasetEventSampler:
         return table
 
     def _evaluate_timevar_source(
-        self, dataset, evaluator, time_axis=None, t_delta=0.5 * u.s
+        self,
+        dataset,
+        evaluator,
+        time_axis=None,
+        t_delta=0.5 * u.s,
     ):
         """Calculate Npred for a given `dataset.model` by evaluating
         it on a region geometry.
@@ -108,7 +118,7 @@ class MapDatasetEventSampler:
 
         flux_diff = (
             evaluator.model.temporal_model.evaluate(
-                time_axis_eval.time_mid, energy=energy_new.center
+                time_axis_eval.time_mid, energy=energy_new.center, method=self.method
             )
             * evaluator.model.spectral_model.parameters[0].quantity
         )

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -95,20 +95,15 @@ class MapDatasetEventSampler:
         position = model.spatial_model.position
         region_exposure = dataset.exposure.to_region_nd_map(position)
 
-        time_min = dataset.gti.time_start[0]
-        time_max = dataset.gti.time_stop[-1]
-
-        nbin = int(((time_max - time_min) / self.t_delta).to(""))
-        time_axis_eval = TimeMapAxis.from_time_bounds(
-            time_min=time_min,
-            time_max=time_max,
-            nbin=nbin,
+        time_axis_eval = TimeMapAxis.from_gti_bounds(
+            gti=dataset.gti, t_delta=self.t_delta
         )
 
+        time_min, time_max = time_axis_eval.time_bounds
         time_axis = MapAxis.from_bounds(
             time_min.mjd * u.d,
             time_max.mjd * u.d,
-            nbin=nbin,
+            nbin=time_axis_eval.nbin,
             name="time",
         )
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -30,9 +30,6 @@ class MapDatasetEventSampler:
     oversample_energy_factor: {int}
         Defines an oversampling factor for the energies; it is used only when sampling
         an energy-dependent time-varying source.
-    method : {"linear", "nearest"}
-        Method to interpolate data values. By default linear interpolation is
-        performed. It is used only when sampling an energy-dependent time-varying source.
     """
 
     def __init__(self, random_state="random-seed", oversample_energy_factor=10):

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -27,10 +27,14 @@ class MapDatasetEventSampler:
     random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
         Defines random number generator initialisation.
         Passed to `~gammapy.utils.random.get_random_state`.
+    oversample_energy_factor: {int}
+        Defines an oversampling factor for the energies; it is used only when sampling
+        an energy-dependent time-varying source.
     """
 
-    def __init__(self, random_state="random-seed"):
+    def __init__(self, random_state="random-seed", oversample_energy_factor=10):
         self.random_state = get_random_state(random_state)
+        self.oversample_energy_factor = oversample_energy_factor
 
     def _make_table(self, coords, time_ref):
         """Create a table for sampled events.
@@ -82,7 +86,7 @@ class MapDatasetEventSampler:
             Npred map.
         """
         energy_true = dataset.edisp.edisp_map.geom.axes["energy_true"]
-        energy_new = energy_true.upsample(10)
+        energy_new = energy_true.upsample(self.oversample_energy_factor)
         target = evaluator.model.spatial_model.position
         region_exposure = dataset.exposure.to_region_nd_map(target)
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -7,7 +7,11 @@ from astropy.table import Table
 import gammapy
 from gammapy.data import EventList, observatory_locations
 from gammapy.maps import MapAxis, MapCoord, TimeMapAxis
-from gammapy.modeling.models import ConstantTemporalModel, PointSpatialModel
+from gammapy.modeling.models import (
+    ConstantSpectralModel,
+    ConstantTemporalModel,
+    PointSpatialModel,
+)
 from gammapy.utils.random import get_random_state
 
 __all__ = ["MapDatasetEventSampler"]
@@ -124,6 +128,10 @@ class MapDatasetEventSampler:
             )
 
         else:
+            if not isinstance(evaluator.model.spectral_model, ConstantSpectralModel):
+                raise TypeError(
+                    f"Event sampler expects ConstantSpectralModel for a time varying source. Got {evaluator.model.spectral_model} instead."
+                )
             raise NotImplementedError("The functionality is not yet implemented")
 
         return
@@ -192,9 +200,7 @@ class MapDatasetEventSampler:
             else:
                 temporal_model = evaluator.model.temporal_model
 
-            if (
-                temporal_model == "TemplateTemporalModel"
-            ):  # check the condition when the format model is defined
+            if temporal_model.is_energy_dependent is True:
                 table = self._sample_coord_time_energy(dataset, evaluator)
             else:
                 flux = evaluator.compute_flux()

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -168,8 +168,8 @@ def test_evaluate_timevar_source(enedip_temporal_model, dataset):
 
     assert_allclose(np.shape(npred.data), (3, 1999, 1, 1))
 
-    assert_allclose(npred.data[:, 10, 0, 0], [0.002483, 0.011042, 0.032185], rtol=2e-4)
-    assert_allclose(npred.data[:, 50, 0, 0], [0.002483, 0.011042, 0.032185], rtol=2e-4)
+    assert_allclose(npred.data[:, 10, 0, 0], [0.024827, 0.110424, 0.321845], rtol=2e-4)
+    assert_allclose(npred.data[:, 50, 0, 0], [0.024827, 0.110424, 0.321845], rtol=2e-4)
 
     filename = "$GAMMAPY_DATA/gravitational_waves/GW_example_DC_map_file.fits.gz"
     temporal_model = LightCurveTemplateTemporalModel.read(filename, format="map")
@@ -182,7 +182,7 @@ def test_evaluate_timevar_source(enedip_temporal_model, dataset):
 
     assert_allclose(
         npred.data[:, 1000, 0, 0] / 1e-13,
-        [0.003934, 0.003484, 0.00119],
+        [0.039339, 0.034838, 0.011899],
         rtol=2e-4,
     )
 
@@ -207,11 +207,11 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
-    assert_allclose(len(events), 93)
+    assert_allclose(len(events), 918)
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [929.329725, 5.342327, 266.404988, -28.936178],
+        [11.460277, 7.687285, 266.404988, -28.936178],
         rtol=1e-6,
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -168,8 +168,8 @@ def test_evaluate_timevar_source(enedip_temporal_model, dataset):
 
     assert_allclose(np.shape(npred.data), (3, 1999, 1, 1))
 
-    assert_allclose(npred.data[:, 10, 0, 0], [4.962884, 22.073776, 64.336892])
-    assert_allclose(npred.data[:, 50, 0, 0], [4.962884, 22.073776, 64.336892])
+    assert_allclose(npred.data[:, 10, 0, 0], [0.002483, 0.011042, 0.032185], rtol=2e-4)
+    assert_allclose(npred.data[:, 50, 0, 0], [0.002483, 0.011042, 0.032185], rtol=2e-4)
 
     filename = "$GAMMAPY_DATA/gravitational_waves/GW_example_DC_map_file.fits.gz"
     temporal_model = LightCurveTemplateTemporalModel.read(filename, format="map")
@@ -182,8 +182,8 @@ def test_evaluate_timevar_source(enedip_temporal_model, dataset):
 
     assert_allclose(
         npred.data[:, 1000, 0, 0] / 1e-13,
-        [7.86377, 6.964184, 2.378613],
-        rtol=1e-6,
+        [0.003934, 0.003484, 0.00119],
+        rtol=2e-4,
     )
 
 
@@ -207,11 +207,11 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
-    assert_allclose(len(events), 182714)
+    assert_allclose(len(events), 93)
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [928.9002723991871, 6.464528406763099, 266.4049882865447, -28.936177761791473],
+        [929.329725, 5.342327, 266.404988, -28.936178],
         rtol=1e-6,
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -118,7 +118,7 @@ def enedip_temporal_model(models):
     time_min = np.arange(0, 1000, 10) * u.s
     time_max = np.arange(10, 1010, 10) * u.s
     edges = np.append(time_min, time_max[-1])
-    time_axis = MapAxis.from_edges(edges=edges, name="time", interp="log")
+    time_axis = MapAxis.from_edges(edges=edges, name="time", interp="lin")
 
     data = np.ones((nbin, len(time_min))) * 1e-12 * u.cm**-2 * u.s**-1 * u.TeV**-1
     m = RegionNDMap.create(
@@ -182,7 +182,7 @@ def test_evaluate_timevar_source(enedip_temporal_model, dataset):
 
     assert_allclose(
         npred.data[:, 1000, 0, 0] / 1e-13,
-        [0.039339, 0.034838, 0.011899],
+        [0.038113, 0.033879, 0.010938],
         rtol=2e-4,
     )
 
@@ -211,7 +211,7 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [11.460277, 7.687285, 266.404988, -28.936178],
+        [568.238666, 7.687285, 266.404988, -28.936178],
         rtol=1e-6,
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -218,8 +218,6 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
 
     assert_allclose(len(events), 1089)
 
-    sort_by_time = np.argsort(events["TIME"])
-    events = events[sort_by_time]
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
         [0.277014, 7.509978, 266.404988, -28.936178],
@@ -234,8 +232,6 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
 
     assert_allclose(len(events), 1090)
 
-    sort_by_time = np.argsort(events["TIME"])
-    events = events[sort_by_time]
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
         [2.421369, 1.121694, 266.404988, -28.936178],
@@ -250,9 +246,6 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
     assert_allclose(len(events), 1089)
-
-    sort_by_time = np.argsort(events["TIME"])
-    events = events[sort_by_time]
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
         [0.277014, 7.509978, 266.404988, -28.936178],

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -221,7 +221,7 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [568.238666, 7.687285, 266.404988, -28.936178],
+        [990.950021, 7.687285, 266.404988, -28.936178],
         rtol=1e-6,
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -226,7 +226,7 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_model):
     sampler = MapDatasetEventSampler(random_state=1)
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
-    assert_allclose(len(events), 1089)
+    assert len(events) == 1089
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
@@ -243,7 +243,7 @@ def test_sample_coord_time_energy_random_seed(dataset, energy_dependent_temporal
     sampler = MapDatasetEventSampler(random_state=2)
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
-    assert_allclose(len(events), 1090)
+    assert len(events) == 1090
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
@@ -261,7 +261,7 @@ def test_sample_coord_time_energy_unit(dataset, energy_dependent_temporal_model)
     sampler = MapDatasetEventSampler(random_state=1)
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
-    assert_allclose(len(events), 1089)
+    assert len(events) == 1089
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
         [404.470523, 2.095024, 266.404988, -28.936178],

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -164,7 +164,7 @@ def test_evaluate_timevar_source(energy_dependent_temporal_sky_model, dataset):
     evaluator = dataset.evaluators["test-source"]
 
     sampler = MapDatasetEventSampler(random_state=0)
-    npred = sampler._evaluate_timevar_source(dataset, evaluator)
+    npred = sampler._evaluate_timevar_source(dataset, evaluator.model)
 
     assert_allclose(np.shape(npred.data), (3, 1999, 1, 1))
 
@@ -178,7 +178,7 @@ def test_evaluate_timevar_source(energy_dependent_temporal_sky_model, dataset):
     evaluator = dataset.evaluators["test-source"]
 
     sampler = MapDatasetEventSampler(random_state=0)
-    npred = sampler._evaluate_timevar_source(dataset, evaluator)
+    npred = sampler._evaluate_timevar_source(dataset, evaluator.model)
 
     assert_allclose(
         npred.data[:, 1000, 0, 0] / 1e-13,
@@ -201,7 +201,7 @@ def test_sample_coord_time_energy_no_spatial(
     evaluator = dataset.evaluators["test-source"]
 
     with pytest.raises(TypeError):
-        sampler._sample_coord_time_energy(dataset, evaluator)
+        sampler._sample_coord_time_energy(dataset, evaluator.model)
 
 
 @requires_data()
@@ -218,7 +218,7 @@ def test_sample_coord_time_energy_gaussian(
     evaluator = dataset.evaluators["test-source"]
 
     with pytest.raises(TypeError):
-        sampler._sample_coord_time_energy(dataset, evaluator)
+        sampler._sample_coord_time_energy(dataset, evaluator.model)
 
 
 @requires_data()
@@ -231,7 +231,7 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_sky_model):
     dataset.models = energy_dependent_temporal_sky_model
     evaluator = dataset.evaluators["test-source"]
 
-    events = sampler._sample_coord_time_energy(dataset, evaluator)
+    events = sampler._sample_coord_time_energy(dataset, evaluator.model)
 
     assert len(events) == 1089
 
@@ -252,7 +252,7 @@ def test_sample_coord_time_energy_random_seed(
     dataset.models = energy_dependent_temporal_sky_model
     evaluator = dataset.evaluators["test-source"]
 
-    events = sampler._sample_coord_time_energy(dataset, evaluator)
+    events = sampler._sample_coord_time_energy(dataset, evaluator.model)
 
     assert len(events) == 1090
 
@@ -272,7 +272,7 @@ def test_sample_coord_time_energy_unit(dataset, energy_dependent_temporal_sky_mo
     dataset.models = energy_dependent_temporal_sky_model
     evaluator = dataset.evaluators["test-source"]
 
-    events = sampler._sample_coord_time_energy(dataset, evaluator)
+    events = sampler._sample_coord_time_energy(dataset, evaluator.model)
 
     assert len(events) == 1089
     assert_allclose(

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -168,8 +168,8 @@ def test_evaluate_timevar_source(enedip_temporal_model, dataset):
 
     assert_allclose(np.shape(npred.data), (3, 1999, 1, 1))
 
-    assert_allclose(npred.data[:, 10, 0, 0], [4.95923152, 22.05753141, 64.28954516])
-    assert_allclose(npred.data[:, 50, 0, 0], [4.95923152, 22.05753141, 64.28954516])
+    assert_allclose(npred.data[:, 10, 0, 0], [4.962884, 22.073776, 64.336892])
+    assert_allclose(npred.data[:, 50, 0, 0], [4.962884, 22.073776, 64.336892])
 
     filename = "$GAMMAPY_DATA/gravitational_waves/GW_example_DC_map_file.fits.gz"
     temporal_model = LightCurveTemplateTemporalModel.read(filename, format="map")
@@ -182,7 +182,7 @@ def test_evaluate_timevar_source(enedip_temporal_model, dataset):
 
     assert_allclose(
         npred.data[:, 1000, 0, 0] / 1e-13,
-        [7.87070535, 6.97078021, 2.38271383],
+        [7.86377, 6.964184, 2.378613],
         rtol=1e-6,
     )
 
@@ -207,11 +207,11 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
-    assert_allclose(len(events), 182580)
+    assert_allclose(len(events), 182714)
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [846.8268346739933, 5.350864113060689, 266.4049882865447, -28.936177761791473],
+        [928.9002723991871, 6.464528406763099, 266.4049882865447, -28.936177761791473],
         rtol=1e-6,
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -167,49 +167,10 @@ def test_evaluate_timevar_source(enedip_temporal_model, dataset):
     npred = sampler._evaluate_timevar_source(dataset, evaluator)
 
     assert_allclose(
-        npred.data[0],
-        [
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-        ],
+        npred.data[:, 10, 0, 0], [2.25974055e-10, 6.58630784e-10, 5.08061231e-11]
     )
     assert_allclose(
-        npred.data[1],
-        [
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-        ],
-    )
-    assert_allclose(
-        npred.data[2],
-        [
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-        ],
+        npred.data[:, 50, 0, 0], [6.58630784e-10, 5.08061231e-11, 2.25974055e-10]
     )
 
     filename = "$GAMMAPY_DATA/gravitational_waves/GW_example_DC_map_file.fits.gz"
@@ -221,54 +182,13 @@ def test_evaluate_timevar_source(enedip_temporal_model, dataset):
     npred = sampler._evaluate_timevar_source(dataset, evaluator)
 
     assert_allclose(
-        npred.data[0],
-        [
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-            50.806123,
-        ],
-    )
-    assert_allclose(
-        npred.data[1],
-        [
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-            225.97405,
-        ],
-    )
-    assert_allclose(
-        npred.data[2],
-        [
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-            658.63078,
-        ],
+        npred.data[:, 10, 0, 0],
+        [0.0, 0.0, 0.0],
     )
 
 
 @requires_data()
-def test_sample_coord_time_energy(dataset, models):
+def test_sample_coord_time_energy(dataset, models, enedip_temporal_model):
     models[0].spatial_model = None
     models[0].spectral_model = ConstantSpectralModel(amplitude="1 cm-2 s-1 TeV-1")
     dataset.models = models
@@ -280,11 +200,10 @@ def test_sample_coord_time_energy(dataset, models):
     models[0].spatial_model = PointSpatialModel(
         lon_0="0 deg", lat_0="0 deg", frame="galactic"
     )
-    dataset.models = models
+    dataset.models = enedip_temporal_model
     evaluator = dataset.evaluators["test-source"]
     sampler = MapDatasetEventSampler(random_state=0)
-    with pytest.raises(NotImplementedError):
-        sampler._sample_coord_time_energy(dataset, evaluator)
+    sampler._sample_coord_time_energy(dataset, evaluator)
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -218,9 +218,11 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
 
     assert_allclose(len(events), 1089)
 
+    sort_by_time = np.argsort(events["TIME"])
+    events = events[sort_by_time]
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [938.237406, 2.095024, 266.404988, -28.936178],
+        [0.277014, 7.509978, 266.404988, -28.936178],
         rtol=1e-6,
     )
 
@@ -232,9 +234,11 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
 
     assert_allclose(len(events), 1090)
 
+    sort_by_time = np.argsort(events["TIME"])
+    events = events[sort_by_time]
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [970.98951, 8.334667, 266.404988, -28.936178],
+        [2.421369, 1.121694, 266.404988, -28.936178],
         rtol=1e-6,
     )
 
@@ -247,9 +251,11 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
 
     assert_allclose(len(events), 1089)
 
+    sort_by_time = np.argsort(events["TIME"])
+    events = events[sort_by_time]
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [938.237406, 2.095024, 266.404988, -28.936178],
+        [0.277014, 7.509978, 266.404988, -28.936178],
         rtol=1e-6,
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -121,7 +121,7 @@ def enedip_temporal_model(models):
     m = RegionNDMap.create(
         region=PointSkyRegion(center=models[0].spatial_model.position),
         axes=[energy_axis, time_axis],
-        data=1e-12,
+        data=1.2e-12,
         unit="cm-2 s-1 TeV-1",
     )
 
@@ -167,8 +167,8 @@ def test_evaluate_timevar_source(enedip_temporal_model, dataset):
 
     assert_allclose(np.shape(npred.data), (3, 1999, 1, 1))
 
-    assert_allclose(npred.data[:, 10, 0, 0], [0.024827, 0.110424, 0.321845], rtol=2e-4)
-    assert_allclose(npred.data[:, 50, 0, 0], [0.024827, 0.110424, 0.321845], rtol=2e-4)
+    assert_allclose(npred.data[:, 10, 0, 0], [0.029792, 0.132509, 0.386214], rtol=2e-4)
+    assert_allclose(npred.data[:, 50, 0, 0], [0.029792, 0.132509, 0.386214], rtol=2e-4)
 
     filename = "$GAMMAPY_DATA/gravitational_waves/GW_example_DC_map_file.fits.gz"
     temporal_model = LightCurveTemplateTemporalModel.read(filename, format="map")
@@ -216,11 +216,11 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
     sampler = MapDatasetEventSampler(random_state=1)
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
-    assert_allclose(len(events), 907)
+    assert_allclose(len(events), 1089)
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [870.710645, 1.024155, 266.404988, -28.936178],
+        [938.237406, 2.095024, 266.404988, -28.936178],
         rtol=1e-6,
     )
 
@@ -230,11 +230,11 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
     sampler = MapDatasetEventSampler(random_state=2)
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
-    assert_allclose(len(events), 908)
+    assert_allclose(len(events), 1090)
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [252.864558, 5.251921, 266.404988, -28.936178],
+        [970.98951, 8.334667, 266.404988, -28.936178],
         rtol=1e-6,
     )
 
@@ -245,11 +245,11 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
     sampler = MapDatasetEventSampler(random_state=1)
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
-    assert_allclose(len(events), 907)
+    assert_allclose(len(events), 1089)
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [870.710645, 1.024155, 266.404988, -28.936178],
+        [938.237406, 2.095024, 266.404988, -28.936178],
         rtol=1e-6,
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -199,6 +199,16 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
     with pytest.raises(TypeError):
         sampler._sample_coord_time_energy(dataset, evaluator)
 
+    enedip_temporal_model.spatial_model = GaussianSpatialModel()
+    enedip_temporal_model.spectral_model = ConstantSpectralModel(
+        const="1 cm-2 s-1 TeV-1"
+    )
+    dataset.models = enedip_temporal_model
+    evaluator = dataset.evaluators["test-source"]
+    sampler = MapDatasetEventSampler(random_state=0)
+    with pytest.raises(TypeError):
+        sampler._sample_coord_time_energy(dataset, evaluator)
+
     enedip_temporal_model.spatial_model = PointSpatialModel(
         lon_0="0 deg", lat_0="0 deg", frame="galactic"
     )

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -213,14 +213,43 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
     )
     dataset.models = enedip_temporal_model
     evaluator = dataset.evaluators["test-source"]
-    sampler = MapDatasetEventSampler(random_state=0)
+    sampler = MapDatasetEventSampler(random_state=1)
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
-    assert_allclose(len(events), 918)
+    assert_allclose(len(events), 907)
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [760.334713, 7.687285, 266.404988, -28.936178],
+        [870.710645, 1.024155, 266.404988, -28.936178],
+        rtol=1e-6,
+    )
+
+    enedip_temporal_model.temporal_model.map._unit == ""
+    dataset.models = enedip_temporal_model
+    evaluator = dataset.evaluators["test-source"]
+    sampler = MapDatasetEventSampler(random_state=2)
+    events = sampler._sample_coord_time_energy(dataset, evaluator)
+
+    assert_allclose(len(events), 908)
+
+    assert_allclose(
+        [events[0][0], events[0][1], events[0][2], events[0][3]],
+        [252.864558, 5.251921, 266.404988, -28.936178],
+        rtol=1e-6,
+    )
+
+    enedip_temporal_model.temporal_model.map._unit == "cm-2 s-1 TeV-1"
+    enedip_temporal_model.spectral_model.parameters[0].unit = ""
+    dataset.models = enedip_temporal_model
+    evaluator = dataset.evaluators["test-source"]
+    sampler = MapDatasetEventSampler(random_state=1)
+    events = sampler._sample_coord_time_energy(dataset, evaluator)
+
+    assert_allclose(len(events), 907)
+
+    assert_allclose(
+        [events[0][0], events[0][1], events[0][2], events[0][3]],
+        [870.710645, 1.024155, 266.404988, -28.936178],
         rtol=1e-6,
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -237,7 +237,7 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_sky_model):
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [404.470523, 2.095024, 266.404988, -28.936178],
+        [798.667621, 2.095024, 266.404988, -28.936178],
         rtol=1e-6,
     )
 
@@ -258,7 +258,7 @@ def test_sample_coord_time_energy_random_seed(
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [767.387708, 8.334667, 266.404988, -28.936178],
+        [725.866948, 8.334667, 266.404988, -28.936178],
         rtol=1e-6,
     )
 
@@ -277,7 +277,7 @@ def test_sample_coord_time_energy_unit(dataset, energy_dependent_temporal_sky_mo
     assert len(events) == 1089
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [404.470523, 2.095024, 266.404988, -28.936178],
+        [798.667621, 2.095024, 266.404988, -28.936178],
         rtol=1e-6,
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -218,12 +218,14 @@ def test_sample_coord_time_energy_gaussian(dataset, energy_dependent_temporal_mo
 
 @requires_data()
 def test_sample_coord_time_energy(dataset, energy_dependent_temporal_model):
+    sampler = MapDatasetEventSampler(random_state=1)
+
     energy_dependent_temporal_model.spatial_model = PointSpatialModel(
         lon_0="0 deg", lat_0="0 deg", frame="galactic"
     )
     dataset.models = energy_dependent_temporal_model
     evaluator = dataset.evaluators["test-source"]
-    sampler = MapDatasetEventSampler(random_state=1)
+
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
     assert len(events) == 1089
@@ -237,10 +239,12 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_model):
 
 @requires_data()
 def test_sample_coord_time_energy_random_seed(dataset, energy_dependent_temporal_model):
+    sampler = MapDatasetEventSampler(random_state=2)
+
     energy_dependent_temporal_model.temporal_model.map._unit == ""
     dataset.models = energy_dependent_temporal_model
     evaluator = dataset.evaluators["test-source"]
-    sampler = MapDatasetEventSampler(random_state=2)
+
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
     assert len(events) == 1090
@@ -254,11 +258,13 @@ def test_sample_coord_time_energy_random_seed(dataset, energy_dependent_temporal
 
 @requires_data()
 def test_sample_coord_time_energy_unit(dataset, energy_dependent_temporal_model):
+    sampler = MapDatasetEventSampler(random_state=1)
+
     energy_dependent_temporal_model.temporal_model.map._unit == "cm-2 s-1 TeV-1"
     energy_dependent_temporal_model.spectral_model.parameters[0].unit = ""
     dataset.models = energy_dependent_temporal_model
     evaluator = dataset.evaluators["test-source"]
-    sampler = MapDatasetEventSampler(random_state=1)
+
     events = sampler._sample_coord_time_energy(dataset, evaluator)
 
     assert len(events) == 1089

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -203,13 +203,15 @@ def test_sample_coord_time_energy_no_spatial(dataset, energy_dependent_temporal_
 
 @requires_data()
 def test_sample_coord_time_energy_gaussian(dataset, energy_dependent_temporal_model):
+    sampler = MapDatasetEventSampler(random_state=0)
+
     energy_dependent_temporal_model.spatial_model = GaussianSpatialModel()
     energy_dependent_temporal_model.spectral_model = ConstantSpectralModel(
         const="1 cm-2 s-1 TeV-1"
     )
     dataset.models = energy_dependent_temporal_model
     evaluator = dataset.evaluators["test-source"]
-    sampler = MapDatasetEventSampler(random_state=0)
+
     with pytest.raises(TypeError):
         sampler._sample_coord_time_energy(dataset, evaluator)
 
@@ -232,6 +234,9 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_model):
         rtol=1e-6,
     )
 
+
+@requires_data()
+def test_sample_coord_time_energy_random_seed(dataset, energy_dependent_temporal_model):
     energy_dependent_temporal_model.temporal_model.map._unit == ""
     dataset.models = energy_dependent_temporal_model
     evaluator = dataset.evaluators["test-source"]
@@ -246,6 +251,9 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_model):
         rtol=1e-6,
     )
 
+
+@requires_data()
+def test_sample_coord_time_energy_unit(dataset, energy_dependent_temporal_model):
     energy_dependent_temporal_model.temporal_model.map._unit == "cm-2 s-1 TeV-1"
     energy_dependent_temporal_model.spectral_model.parameters[0].unit = ""
     dataset.models = energy_dependent_temporal_model

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -211,6 +211,7 @@ def test_evaluate_timevar_source(dataset, models):
 @requires_data()
 def test_sample_coord_time_energy(dataset, models):
     models[0].spatial_model = None
+    models[0].spectral_model = ConstantSpectralModel(amplitude="1 cm-2 s-1 TeV-1")
     dataset.models = models
     evaluator = dataset.evaluators["test-source"]
     sampler = MapDatasetEventSampler(random_state=0)

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -115,17 +115,16 @@ def enedip_temporal_model(models):
         energy_min=1 * u.TeV, energy_max=10 * u.TeV, nbin=nbin, name="energy"
     )
 
-    time_min = np.arange(0, 1000, 10) * u.s
-    time_max = np.arange(10, 1010, 10) * u.s
-    edges = np.append(time_min, time_max[-1])
+    edges = np.linspace(0, 1000, 101) * u.s
     time_axis = MapAxis.from_edges(edges=edges, name="time", interp="lin")
 
-    data = np.ones((nbin, len(time_min))) * 1e-12 * u.cm**-2 * u.s**-1 * u.TeV**-1
     m = RegionNDMap.create(
         region=PointSkyRegion(center=models[0].spatial_model.position),
         axes=[energy_axis, time_axis],
-        data=np.array(data),
+        data=1e-12,
+        unit="cm-2 s-1 TeV-1",
     )
+
     t_ref = Time(51544.00074287037, format="mjd", scale="tt")
     temporal_model = LightCurveTemplateTemporalModel(m, t_ref=t_ref)
     models[0].temporal_model = temporal_model
@@ -221,7 +220,7 @@ def test_sample_coord_time_energy(dataset, enedip_temporal_model):
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [990.950021, 7.687285, 266.404988, -28.936178],
+        [760.334713, 7.687285, 266.404988, -28.936178],
         rtol=1e-6,
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -298,7 +298,7 @@ def test_mde_sample_sources(dataset, models):
     assert_allclose(events.table["DEC_TRUE"][0], -28.748145, rtol=1e-5)
     assert events.table["DEC_TRUE"].unit == "deg"
 
-    assert_allclose(events.table["TIME"][0], 119.7494479, rtol=1e-5)
+    assert_allclose(events.table["TIME"][0], 120.37471, rtol=1e-5)
     assert events.table["TIME"].unit == "s"
 
     assert_allclose(events.table["MC_ID"][0], 1, rtol=1e-5)

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -212,7 +212,7 @@ def test_evaluate_timevar_source(enedip_temporal_model, dataset):
         ],
     )
 
-    filename = "$GAMMAPY_DATA/..."
+    filename = "$GAMMAPY_DATA/gravitational_waves/GW_example_DC_map_file.fits.gz"
     temporal_model = LightCurveTemplateTemporalModel.read(filename, format="map")
     dataset.models[0].temporal_model = temporal_model
     evaluator = dataset.evaluators["test-source"]

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -4,7 +4,7 @@ import numpy as np
 from gammapy.datasets import Datasets
 from gammapy.estimators.parameter import ParameterEstimator
 from gammapy.maps import Map, MapAxis
-from gammapy.modeling import Parameter, Parameters
+from gammapy.modeling import Parameter
 from gammapy.modeling.models import ScaleSpectralModel
 
 log = logging.getLogger(__name__)
@@ -121,7 +121,8 @@ class FluxEstimator(ParameterEstimator):
 
         scale_model = ScaleSpectralModel(ref_model)
 
-        norms = Parameters([p for p in ref_model.parameters if p.is_norm])
+        norms = ref_model.parameters.norm_parameters
+
         if len(norms) == 0 or len(norms.free_parameters) > 1:
             raise ValueError(
                 f"{self.tag} requires one and only one free 'norm' or 'amplitude' parameter"

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -109,7 +109,6 @@ class MapAxis:
 
     # TODO: Cache an interpolation object?
     def __init__(self, nodes, interp="lin", name="", node_type="edges", unit=""):
-
         if not isinstance(name, str):
             raise TypeError(f"Name must be a string, got: {type(name)!r}")
 
@@ -2766,6 +2765,35 @@ class TimeMapAxis:
             edges_max=tmax.to("s"),
             reference_time=gti.time_ref,
             name=name,
+        )
+
+    @classmethod
+    def from_gti_bounds(cls, gti, t_delta, name="time"):
+        """Create a time axis from an input GTI.
+
+        Parameters
+        ----------
+        gti : `GTI`
+            GTI table
+        t_delta : `~astropy.units.Quantity`
+            Time binning
+        name : str
+            Axis name
+
+        Returns
+        -------
+        axis : `TimeMapAxis`
+            Time map axis.
+
+        """
+        time_min = gti.time_start[0]
+        time_max = gti.time_stop[-1]
+
+        nbin = int(((time_max - time_min) / t_delta).to(""))
+        return TimeMapAxis.from_time_bounds(
+            time_min=time_min,
+            time_max=time_max,
+            nbin=nbin,
         )
 
     @classmethod

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -115,7 +115,19 @@ class SkyModel(ModelBase):
             ref_unit = ref_unit / u.sr
 
         if self.temporal_model:
-            obt_unit = obt_unit * u.Quantity(self.temporal_model(time)).unit
+            if u.Quantity(self.temporal_model(time)).unit.is_equivalent(
+                self.spectral_model(axis.center).unit
+            ):
+                obt_unit = (
+                    (
+                        self.temporal_model(time)
+                        * self.spatial_model.evaluate_geom(geom).unit
+                    )
+                    .to(obt_unit.to_string())
+                    .unit
+                )
+            else:
+                obt_unit = obt_unit * u.Quantity(self.temporal_model(time)).unit
 
         if not obt_unit.is_equivalent(ref_unit):
             raise ValueError(

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -441,6 +441,10 @@ class LightCurveTemplateTemporalModel(TemporalModel):
     The model does linear interpolation for times between the given ``(time, energy, norm)``
     values.
 
+    When the temporal model is energy-dependent, the default interpolation scheme is
+    linear with a log scale for the values. The interpolation method and scale values
+    can be changed with the ``method`` and ``values_scale`` arguments.
+
     For more information see :ref:`LightCurve-temporal-model`.
 
     Examples
@@ -650,11 +654,11 @@ class LightCurveTemplateTemporalModel(TemporalModel):
 
     def evaluate(self, time, t_ref=None, energy=None):
         """Evaluate the model at given coordinates.
-        time: ~astropy.Time; array of times where the model is
-            evaluate;
-        t_ref: ~astropy.Time; reference time. Default is None;
-        energy: ~astropy.Quantity; array of energies where the
-            model is evaluate;
+        time: ~astropy.time.Time;
+            array of times where the model is evaluated;
+        t_ref: ~astropy.time.Time; reference time. Default is None;
+        energy: ~astropy.units.Quantity; array of energies where the
+            model is evaluated;
         """
 
         if t_ref is None:

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -637,8 +637,17 @@ class LightCurveTemplateTemporalModel(TemporalModel):
         else:
             raise ValueError("Not a valid format, choose from ['map', 'table']")
 
-    def evaluate(self, time, t_ref=None, energy=None):
-        """Evaluate the model at given coordinates."""
+    def evaluate(self, time, t_ref=None, energy=None, method="linear"):
+        """Evaluate the model at given coordinates.
+        time: ~astropy.Time; array of times where the model is
+            evaluate;
+        t_ref: ~astropy.Time; reference time. Default is None;
+        energy: ~astropy.Quantity; array of energies where the
+            model is evaluate;
+        method : {"linear", "nearest"}
+            Method to interpolate data values. By default linear
+            interpolation is performed.
+        """
 
         if t_ref is None:
             t_ref = self.reference_time
@@ -648,7 +657,7 @@ class LightCurveTemplateTemporalModel(TemporalModel):
             if energy is None:
                 energy = self.map.geom.axes["energy"].center
             coords["energy"] = energy.reshape(-1, 1)
-        val = self.map.interp_by_coord(coords)
+        val = self.map.interp_by_coord(coords, method=method)
         val = np.clip(val, 0, a_max=None)
         return u.Quantity(val, self.map.unit, copy=False)
 

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -654,11 +654,12 @@ class LightCurveTemplateTemporalModel(TemporalModel):
 
     def evaluate(self, time, t_ref=None, energy=None):
         """Evaluate the model at given coordinates.
-        time: ~astropy.time.Time;
+        time: `~astropy.time.Time`
             array of times where the model is evaluated;
-        t_ref: ~astropy.time.Time; reference time. Default is None;
-        energy: ~astropy.units.Quantity; array of energies where the
-            model is evaluated;
+        t_ref: `~astropy.time.Time`
+            reference time. Default is None;
+        energy: `~astropy.units.Quantity`
+            array of energies where the model is evaluated;
         """
 
         if t_ref is None:

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -40,7 +40,6 @@ def models():
 
 @requires_data()
 def test_dict_to_skymodels(models):
-
     assert len(models) == 5
 
     model0 = models[0]
@@ -108,12 +107,14 @@ def test_dict_to_skymodels(models):
 
 
 @requires_data()
-def test_sky_models_io(tmp_path, models):
+def test_sky_models_io(tmpdir, models):
     # TODO: maybe change to a test case where we create a model programmatically?
     models.covariance = np.eye(len(models.parameters))
-    models.write(tmp_path / "tmp.yaml", full_output=True, overwrite_templates=False)
-    models = Models.read(tmp_path / "tmp.yaml")
+    models.write(tmpdir / "tmp.yaml", full_output=True, overwrite_templates=False)
+    models = Models.read(tmpdir / "tmp.yaml")
+
     assert models._covar_file == "tmp_covariance.dat"
+
     assert_allclose(models.covariance.data, np.eye(len(models.parameters)))
     assert_allclose(models.parameters["lat_0"].min, -90.0)
 
@@ -124,7 +125,6 @@ def test_sky_models_io(tmp_path, models):
 
 @requires_data()
 def test_sky_models_io_auto_write(tmp_path, models):
-
     models_new = models.copy()
     fsource2 = str(tmp_path / "source2_test.fits")
     fbkg_iem = str(tmp_path / "cube_iem_test.fits")
@@ -157,22 +157,14 @@ def test_sky_models_io_auto_write(tmp_path, models):
 def test_piecewise_norm_spectral_model_init():
     with pytest.raises(ValueError):
         PiecewiseNormSpectralModel(
-            energy=[
-                1,
-            ]
-            * u.TeV,
+            energy=[1] * u.TeV,
             norms=[1, 5],
         )
 
     with pytest.raises(ValueError):
         PiecewiseNormSpectralModel(
-            energy=[
-                1,
-            ]
-            * u.TeV,
-            norms=[
-                1,
-            ],
+            energy=[1] * u.TeV,
+            norms=[1],
         )
 
 
@@ -436,7 +428,6 @@ def test_link_label(models):
 
 
 def test_to_dict_not_default():
-
     model = PowerLawSpectralModel()
     model.index.min = -1
     model.index.max = -5
@@ -459,7 +450,6 @@ def test_to_dict_not_default():
 
 
 def test_to_dict_unfreeze_parameters_frozen_by_default():
-
     model = PowerLawSpectralModel()
 
     mdict = model.to_dict(full_output=False)

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -54,7 +54,7 @@ def test_energy_dependent_lightcurve(tmp_path):
 
     t = Time(55555.6157407407, format="mjd")
     val = mod.evaluate(t, energy=[0.3, 2] * u.TeV)
-    assert_allclose(val.data, [[2.389591e-21], [4.399548e-23]], rtol=1e-5)
+    assert_allclose(val.data, [[2.278068e-21], [4.280503e-23]], rtol=1e-5)
 
     t = Time([55555, 55556, 55557], format="mjd")
     val = mod.evaluate(t)

--- a/gammapy/modeling/models/tests/test_utils.py
+++ b/gammapy/modeling/models/tests/test_utils.py
@@ -15,7 +15,7 @@ def test__template_model_from_cta_sdc(tmp_path):
     assert isinstance(mod, LightCurveTemplateTemporalModel)
     t = Time(55555.6157407407, format="mjd")
     val = mod.evaluate(t, energy=[0.3, 2] * u.TeV)
-    assert_allclose(val.data, [[2.39329809e-21], [4.40027593e-23]], rtol=1e-5)
+    assert_allclose(val.data, [[2.281216e-21], [4.281390e-23]], rtol=1e-5)
 
     filename = make_path(tmp_path / "test.fits")
     mod.write(filename=filename, format="map", overwrite=True)

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -547,6 +547,11 @@ class Parameters(collections.abc.Sequence):
         return copy.deepcopy(self)
 
     @property
+    def norm_parameters(self):
+        """List of norm parameters"""
+        return self.__class__([par for par in self._parameters if par.is_norm])
+
+    @property
     def free_parameters(self):
         """List of free parameters"""
         return self.__class__([par for par in self._parameters if not par.frozen])


### PR DESCRIPTION
This PR re-implements the `_evaluate_timevar_source` function in `MapDatasetEventSampler`. The function evaluates a energy-dependent temporal model over a given time and energy range, assuming the a point-like morphology, and returns a npred.
The PR is still in draft. @AtreyeeS @adonath @registerrier @QRemy do you have any comment or advice?