### PR TITLE
Add squash method to LabelMapAxis

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3196,15 +3196,20 @@ class LabelMapAxis:
 
         return LabelMapAxis(merged_labels, self.name)
 
-    def squash(self):
+    def squash(self, label=[""]):
         """Create a new axis object by squashing the axis into one bin.
 
-        The label of the new axis is given as "squash_" + the name of the axis.
+        Parameters
+        ----------
+        label : list of str
+            The label of the new axis. If label is not given, the label will be set to "first_label...last_label"
+            of the axis.
 
         Returns
         -------
         axis : `~MapAxis`
             Sliced axis object.
         """
-
-        return LabelMapAxis(labels=["squash_" + self._name], name=self._name)
+        if label == [""]:
+            label = [self.center[0] + "..." + self.center[-1]]
+        return LabelMapAxis(labels=label, name=self._name)

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3195,3 +3195,15 @@ class LabelMapAxis:
         merged_labels = np.append(self.center, axis.center)
 
         return LabelMapAxis(merged_labels, self.name)
+
+    def squash(self):
+        """Create a new axis object by squashing the axis into one bin.
+        The label of the new axis is given as "squash_" + the name of the axis.
+
+        Returns
+        -------
+        axis : `~MapAxis`
+            Sliced axis object.
+        """
+
+        return LabelMapAxis(labels=["squash_" + self._name], name=self._name)

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3196,20 +3196,16 @@ class LabelMapAxis:
 
         return LabelMapAxis(merged_labels, self.name)
 
-    def squash(self, label=[""]):
+    def squash(self):
         """Create a new axis object by squashing the axis into one bin.
 
-        Parameters
-        ----------
-        label : list of str
-            The label of the new axis. If label is not given, the label will be set to "first_label...last_label"
-            of the axis.
+        The label of the new axis is given as "first-label...last-label".
 
         Returns
         -------
         axis : `~MapAxis`
             Sliced axis object.
         """
-        if label == [""]:
-            label = [self.center[0] + "..." + self.center[-1]]
-        return LabelMapAxis(labels=label, name=self._name)
+        return LabelMapAxis(
+            labels=[self.center[0] + "..." + self.center[-1]], name=self._name
+        )

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3198,6 +3198,7 @@ class LabelMapAxis:
 
     def squash(self):
         """Create a new axis object by squashing the axis into one bin.
+
         The label of the new axis is given as "squash_" + the name of the axis.
 
         Returns

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -822,8 +822,6 @@ def test_label_map_axis_squash():
 
     label = LabelMapAxis(["a", "b", "c"], name="Letters")
     squash_label = label.squash()
-    squash_label_2 = label.squash(label=["my_label"])
 
     assert squash_label.nbin == 1
     assert_equal(squash_label.center, np.array(["a...c"]))
-    assert_equal(squash_label_2.center, np.array(["my_label"]))

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -814,9 +814,7 @@ def test_label_map_axis_from_stack():
 
     label_stack = LabelMapAxis.from_stack([label1, label2, label3])
 
-    assert_equal(
-        label_stack.center, np.array(["a", "b", "c", "d", "e", "f"], dtype="<U2")
-    )
+    assert_equal(label_stack.center, np.array(["a", "b", "c", "d", "e", "f"]))
     assert label_stack.name == "letters"
 
 
@@ -824,6 +822,8 @@ def test_label_map_axis_squash():
 
     label = LabelMapAxis(["a", "b", "c"], name="Letters")
     squash_label = label.squash()
+    squash_label_2 = label.squash(label=["my_label"])
 
     assert squash_label.nbin == 1
-    assert_equal(squash_label.center, np.array(["squash_Letters"], dtype="<U14"))
+    assert_equal(squash_label.center, np.array(["a...c"]))
+    assert_equal(squash_label_2.center, np.array(["my_label"]))

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -818,3 +818,12 @@ def test_label_map_axis_from_stack():
         label_stack.center, np.array(["a", "b", "c", "d", "e", "f"], dtype="<U2")
     )
     assert label_stack.name == "letters"
+
+
+def test_label_map_axis_squash():
+
+    label = LabelMapAxis(["a", "b", "c"], name="Letters")
+    squash_label = label.squash()
+
+    assert squash_label.nbin == 1
+    assert_equal(squash_label.center, np.array(["squash_Letters"], dtype="<U14"))


### PR DESCRIPTION
This PR is related to PR #4409. 

I added a squash method the `LabelMapAxis`in order to be able to use `sum_over_axes` on a `LabelMapAxis`. 

For the label of the squashed axis, I currently put 'squash_' + the name of the axis. But if anyone has a better, more explicit proposition for this, let me know. 