### PR TITLE
Serialise gti table to flux points object

### DIFF
--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -187,7 +187,7 @@ class FluxPoints(FluxMaps):
         table = self.to_table(sed_type=sed_type, format=format)
 
         # TODO: rather ugly - better method?
-        if not ".fits" in filename.suffixes:
+        if ".fits" not in filename.suffixes:
             table.write(filename)
             return
 

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -7,6 +7,7 @@ from astropy.io import fits
 from astropy.io.registry import IORegistryError
 from astropy.table import Table, vstack
 from astropy.time import Time
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from gammapy.data import GTI
@@ -143,7 +144,7 @@ class FluxPoints(FluxMaps):
 
         try:
             gti = GTI.read(filename)
-        except TypeError:
+        except (TypeError, AstropyDeprecationWarning):
             gti = None
 
         return cls.from_table(

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -140,14 +140,13 @@ class FluxPoints(FluxMaps):
             table = Table.read(filename, **kwargs)
         except (IORegistryError, UnicodeDecodeError):
             with fits.open(filename) as hdulist:
-                hdu_names = [_.name for _ in hdulist]
-                if "FLUXPOINTS" in hdu_names:
+                if "FLUXPOINTS" in hdulist:
                     fp = hdulist["FLUXPOINTS"]
                 else:
                     fp = hdulist[""]  # to handle older files
                 table = Table.read(fp)
-                if "GTI" in hdu_names:
-                    gti = GTI.read(filename)
+                if "GTI" in hdulist:
+                    gti = GTI.from_table_hdu(hdulist["GTI"])
 
         return cls.from_table(
             table=table,
@@ -180,7 +179,7 @@ class FluxPoints(FluxMaps):
                 flux profiles. Basically a generalisation of the "gadf" format, but
                 currently there is no detailed documentation available.
         overwrite : bool
-            Overwrite existing file`.
+            Overwrite existing file.
         """
         filename = make_path(filename)
         if sed_type is None:
@@ -188,7 +187,7 @@ class FluxPoints(FluxMaps):
         table = self.to_table(sed_type=sed_type, format=format)
 
         # TODO: rather ugly - better method?
-        if str(filename).split(".")[-1] != "fits":
+        if not ".fits" in filename.suffixes:
             table.write(filename)
             return
 

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -211,7 +211,9 @@ class TestFluxPoints:
 
     def test_write_ecsv(self, tmp_path, flux_points):
         flux_points.write(
-            tmp_path / "flux_points.ecsv", sed_type=flux_points.sed_type_init
+            tmp_path / "flux_points.ecsv",
+            sed_type=flux_points.sed_type_init,
+            overwrite=True,
         )
         actual = FluxPoints.read(tmp_path / "flux_points.ecsv")
         actual._data.pop("is_ul", None)

--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -35,8 +35,9 @@ def lc():
             Column([True, True], "success"),
         ],
     )
+    gti = GTI.create("0h", "1h", "2010-01-01T00:00:00")
 
-    return FluxPoints.from_table(table=table, format="lightcurve")
+    return FluxPoints.from_table(table=table, format="lightcurve", gti=gti)
 
 
 @pytest.fixture(scope="session")
@@ -104,6 +105,7 @@ def test_lightcurve_read_write(tmp_path, lc, sed_type):
     lc.write(tmp_path / "tmp.fits", format="lightcurve", sed_type=sed_type)
 
     lc = FluxPoints.read(tmp_path / "tmp.fits", format="lightcurve")
+    assert_allclose(lc.gti.time_start[0].mjd, 55197.000766, rtol=1e-5)
 
     # Check if time-related info round-trips
     axis = lc.geom.axes["time"]

--- a/gammapy/estimators/points/tests/test_profile.py
+++ b/gammapy/estimators/points/tests/test_profile.py
@@ -172,6 +172,7 @@ def test_serialisation(tmpdir):
     assert_allclose(result.norm_err, profile.norm_err, rtol=1e-4)
     assert_allclose(result.npred, profile.npred)
     assert_allclose(result.ts, profile.ts)
+    assert_allclose(profile.gti.time_start[0].mjd, 55197.000766, rtol=1e-5)
 
     assert np.all(result.is_ul == profile.is_ul)
 


### PR DESCRIPTION
This is intended to address #4230 

There is a test fail here with the ecsv format that I am not sure how to handle.
I am serialising the gti table as an additional hdu, but that does not work for non-fits formats.

The issue, I guess, is that FluxPoints format is not very well specified in the GADF.
We can decide to serialise the GTI only if the output is a fits format (any quick way to check @adonath ?)
Or, we can write the GTI table separately and have a yaml file connecting the FluxPoints and the GTI.
Suggestions please @adonath @registerrier @bkhelifi 

