### PR TITLE
Add a function to combine excess maps

### DIFF
--- a/gammapy/estimators/core.py
+++ b/gammapy/estimators/core.py
@@ -50,6 +50,9 @@ class Estimator(abc.ABC):
         """Energy axis."""
         if self.energy_edges is None:
             energy_axis = dataset.counts.geom.axes["energy"].squash()
+            if getattr(self, "sum_over_energy_groups", False):
+                energy_edges = [energy_axis.edges[0], energy_axis.edges[1]]
+                energy_axis = MapAxis.from_energy_edges(energy_edges)
         else:
             energy_axis = MapAxis.from_energy_edges(self.energy_edges)
 

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -129,6 +129,11 @@ class ExcessMapEstimator(Estimator):
     spectral_model : `~gammapy.modeling.models.SpectralModel`
         Spectral model used for the computation of the flux map.
         If None, a Power Law of index 2 is assumed (default).
+    sum_over_energy_groups : bool
+        Only used if energy_edges is None.
+        If False apply the estimator in each energy bin of the parent dataset.
+        If True apply the estimator in only one bin defined by the energy edges of the parent dataset.
+        Default is False.
 
     Examples
     --------
@@ -169,6 +174,7 @@ class ExcessMapEstimator(Estimator):
         gamma_min_sensitivity=10,
         bkg_syst_fraction_sensitivity=0.05,
         apply_threshold_sensitivity=False,
+        sum_over_energy_groups=False,
     ):
         self.correlation_radius = correlation_radius
         self.n_sigma = n_sigma
@@ -179,6 +185,7 @@ class ExcessMapEstimator(Estimator):
         self.apply_threshold_sensitivity = apply_threshold_sensitivity
         self.selection_optional = selection_optional
         self.energy_edges = energy_edges
+        self.sum_over_energy_groups = sum_over_energy_groups
         self.correlate_off = correlate_off
 
         if spectral_model is None:

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -8,13 +8,12 @@ from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.maps import Map
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.stats import CashCountsStatistic, WStatCountsStatistic
+from gammapy.stats.utils import ts_to_sigma
 from ..core import Estimator
 from ..utils import estimate_exposure_reco_energy
 from .core import FluxMaps
 
-__all__ = [
-    "ExcessMapEstimator",
-]
+__all__ = ["ExcessMapEstimator", "get_joint_excess_maps"]
 
 log = logging.getLogger(__name__)
 
@@ -76,6 +75,45 @@ def convolved_map_dataset_counts_statistics(dataset, kernel, mask, correlate_off
         npred = dataset.npred() * mask
         background_conv = npred.convolve(kernel_data)
         return CashCountsStatistic(n_on_conv.data, background_conv.data)
+
+
+def get_joint_excess_maps(estimator, datasets):
+    """Computes correlated excess and significance for a set of datasets.
+    The significance computation assumes that the model contains
+    one degree of freedom per valid bin in energy in each dataset.
+
+    Parameters
+    ----------
+    estimator : `~gammapy.estimator.ExcessMapEstimator`
+        Excess Map Estimator
+    dataset : `~gammapy.datasets.Datasets`
+        Datasets
+
+    """
+
+    geom = datasets[0].counts.geom.to_image()
+    for dataset in datasets[1:]:
+        if dataset.counts.geom.to_image() != geom:
+            raise ValueError
+
+    ts_sum = Map.from_geom(geom)
+    npred_excess_sum = Map.from_geom(geom)
+    significance = Map.from_geom(geom)
+
+    dof = 0
+    for dataset in datasets:
+        results = estimator.run(dataset)
+
+        dof += np.sum(results["ts"].data > 0, axis=0)
+        ts = results["ts"].reduce_over_axes()
+
+        npred_excess = results["npred_excess"].reduce_over_axes()
+
+        ts_sum += ts
+        npred_excess_sum += npred_excess
+
+    significance.data = ts_to_sigma(ts_sum.data, dof) * np.sign(npred_excess_sum.data)
+    return dict(ts=ts_sum, npred_excess=npred_excess_sum, significance=significance)
 
 
 class ExcessMapEstimator(Estimator):

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -7,7 +7,7 @@ from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.estimators import ExcessMapEstimator
 from gammapy.estimators.utils import (
     estimate_exposure_reco_energy,
-    get_joint_significance_maps,
+    get_combined_significance_maps,
 )
 from gammapy.irf import PSFMap
 from gammapy.maps import Map, MapAxis, WcsGeom
@@ -405,7 +405,7 @@ def test_joint_excess_map(simple_dataset):
     assert_allclose(result["npred_excess"].data.sum(), 2 * 19733.602, rtol=1e-3)
     assert_allclose(result["sqrt_ts"].data[0, 10, 10], 5.960441, rtol=1e-3)
 
-    result = get_joint_significance_maps(estimator, [simple_dataset, simple_dataset])
+    result = get_combined_significance_maps(estimator, [simple_dataset, simple_dataset])
 
     assert_allclose(result["npred_excess"].data.sum(), 2 * 19733.602, rtol=1e-3)
     assert_allclose(result["significance"].data[10, 10], 5.618187, rtol=1e-3)

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -409,3 +409,6 @@ def test_joint_excess_map(simple_dataset):
 
     assert_allclose(result["npred_excess"].data.sum(), 2 * 19733.602, rtol=1e-3)
     assert_allclose(result["significance"].data[10, 10], 5.618187, rtol=1e-3)
+    assert_allclose(
+        result["df"].data, 2 * (~np.isnan(result["significance"].data)), rtol=1e-3
+    )

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -5,7 +5,10 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.estimators import ExcessMapEstimator
-from gammapy.estimators.utils import estimate_exposure_reco_energy
+from gammapy.estimators.utils import (
+    estimate_exposure_reco_energy,
+    get_joint_significance_maps,
+)
 from gammapy.irf import PSFMap
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling.models import (
@@ -372,3 +375,37 @@ def test_incorrect_selection():
 def test_significance_map_estimator_incorrect_dataset():
     with pytest.raises(ValueError):
         ExcessMapEstimator("bad")
+
+
+def test_joint_excess_map(simple_dataset):
+    simple_dataset.exposure += 1e10 * u.cm**2 * u.s
+    axis = simple_dataset.exposure.geom.axes[0]
+    simple_dataset.psf = PSFMap.from_gauss(axis, sigma="0.05 deg")
+
+    model = SkyModel(
+        PowerLawSpectralModel(amplitude="1e-9 cm-2 s-1 TeV-1"),
+        GaussianSpatialModel(
+            lat_0=0.0 * u.deg, lon_0=0.0 * u.deg, sigma=0.1 * u.deg, frame="icrs"
+        ),
+        name="sky_model",
+    )
+
+    simple_dataset.models = [model]
+    simple_dataset.npred()
+
+    stacked_dataset = simple_dataset.copy(name="copy")
+    stacked_dataset.counts *= 2
+    stacked_dataset.exposure *= 2
+    stacked_dataset.background *= 2
+    stacked_dataset.models = [model]
+    estimator = ExcessMapEstimator(0.1 * u.deg, sum_over_energy_groups=True)
+    assert estimator.sum_over_energy_groups
+
+    result = estimator.run(stacked_dataset)
+    assert_allclose(result["npred_excess"].data.sum(), 2 * 19733.602, rtol=1e-3)
+    assert_allclose(result["sqrt_ts"].data[0, 10, 10], 5.960441, rtol=1e-3)
+
+    result = get_joint_significance_maps(estimator, [simple_dataset, simple_dataset])
+
+    assert_allclose(result["npred_excess"].data.sum(), 2 * 19733.602, rtol=1e-3)
+    assert_allclose(result["significance"].data[10, 10], 5.618187, rtol=1e-3)

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -6,7 +6,7 @@ import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
 from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.estimators import TSMapEstimator
-from gammapy.estimators.utils import get_joint_significance_maps
+from gammapy.estimators.utils import get_combined_significance_maps
 from gammapy.irf import EDispKernelMap, PSFMap
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling.models import (
@@ -384,7 +384,7 @@ def test_joint_ts_map(fake_dataset):
     assert_allclose(result["npred_excess"].data.sum(), 1140.364071, rtol=1e-3)
     assert_allclose(result["sqrt_ts"].data[0, 10, 10], 1.360219, rtol=1e-3)
 
-    result = get_joint_significance_maps(estimator, [fake_dataset, fake_dataset])
+    result = get_combined_significance_maps(estimator, [fake_dataset, fake_dataset])
 
     assert_allclose(result["npred_excess"].data.sum(), 2 * 1140.364071, rtol=1e-3)
     assert_allclose(result["significance"].data[10, 10], 1.414529, rtol=1e-3)

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -6,6 +6,7 @@ import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
 from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.estimators import TSMapEstimator
+from gammapy.estimators.utils import get_joint_significance_maps
 from gammapy.irf import EDispKernelMap, PSFMap
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling.models import (
@@ -362,3 +363,28 @@ def test_with_TemplateSpatialModel():
 
     result = estimator.run(dataset)
     assert_allclose(result["sqrt_ts"].data[0, 12, 16], 22.932, rtol=1e-3)
+
+
+def test_joint_ts_map(fake_dataset):
+
+    model = fake_dataset.models["source"]
+    fake_dataset.models = [model]
+
+    stacked_dataset = fake_dataset.copy(name="copy")
+    stacked_dataset.counts *= 2
+    stacked_dataset.exposure *= 2
+    stacked_dataset.background *= 2
+    stacked_dataset.models = [model]
+    estimator = TSMapEstimator(
+        model=model, threshold=1, selection_optional=[], sum_over_energy_groups=True
+    )
+    assert estimator.sum_over_energy_groups
+
+    result = estimator.run(fake_dataset)
+    assert_allclose(result["npred_excess"].data.sum(), 1140.364071, rtol=1e-3)
+    assert_allclose(result["sqrt_ts"].data[0, 10, 10], 1.360219, rtol=1e-3)
+
+    result = get_joint_significance_maps(estimator, [fake_dataset, fake_dataset])
+
+    assert_allclose(result["npred_excess"].data.sum(), 2 * 1140.364071, rtol=1e-3)
+    assert_allclose(result["significance"].data[10, 10], 1.414529, rtol=1e-3)

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -388,3 +388,6 @@ def test_joint_ts_map(fake_dataset):
 
     assert_allclose(result["npred_excess"].data.sum(), 2 * 1140.364071, rtol=1e-3)
     assert_allclose(result["significance"].data[10, 10], 1.414529, rtol=1e-3)
+    assert_allclose(
+        result["df"].data, 2 * (~np.isnan(result["significance"].data)), rtol=1e-3
+    )

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -706,17 +706,25 @@ def get_joint_significance_maps(
 
     Parameters
     ----------
-    estimator : `~gammapy.estimator.ExcessMapEstimator`
-        Excess Map Estimator
+    estimator : `~gammapy.estimator.ExcessMapEstimator` or `~gammapy.estimator.TSMapEstimator`
+        Excess Map Estimator or TS Map Estimator
     dataset : `~gammapy.datasets.Datasets`
-        Datasets
+        Datasets containing only `~gammapy.maps.MapDataset`.
     energy_edges : list of `~astropy.units.Quantity`, optional
         Edges of the target maps energy bins. The resulting bin edges won't be exactly equal to the input ones,
         but rather the closest values to the energy axis edges of the parent dataset.
         Default is None: apply the estimator in each energy bin of the parent dataset.
         For further explanation see :ref:`estimators`.
     sum_over_energy_groups : bool
-        Whether to sum over the energy groups or not. Default is True.
+        Whether to sum over the energy groups or not. Default is True
+
+    Returns
+    -------
+    results : dict
+        Dictionary with keys :
+        - "significance" : joint significance map.
+        - "npred_excess" : summed excess map.
+        - "estimator_results" : dictionary containing the estimator results for each dataset.
 
     """
     from .map.excess import ExcessMapEstimator
@@ -749,8 +757,7 @@ def get_joint_significance_maps(
     significance = Map.from_geom(geom)
     significance.data = ts_to_sigma(ts_sum.data, dof) * np.sign(ts_sum_sign)
     return dict(
-        ts=ts_sum,
-        npred_excess=npred_excess_sum,
         significance=significance,
+        npred_excess=npred_excess_sum,
         estimator_results=results,
     )

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -17,7 +17,7 @@ from gammapy.stats.utils import ts_to_sigma
 from .map.core import FluxMaps
 
 __all__ = [
-    "get_joint_significance_maps",
+    "get_combined_significance_maps",
     "estimate_exposure_reco_energy",
     "find_peaks",
     "find_peaks_in_flux_map",
@@ -690,7 +690,7 @@ def get_rebinned_axis(fluxpoint, axis_name="energy", method=None, **kwargs):
     return axis_new
 
 
-def get_joint_significance_maps(estimator, datasets):
+def get_combined_significance_maps(estimator, datasets):
     """Computes excess and significance for a set of datasets.
     The significance computation assumes that the model contains
     one degree of freedom per valid bin in energy in each dataset.

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -693,7 +693,7 @@ def get_rebinned_axis(fluxpoint, axis_name="energy", method=None, **kwargs):
 def get_combined_significance_maps(estimator, datasets):
     """Computes excess and significance for a set of datasets.
     The significance computation assumes that the model contains
-    one degree of freedom per valid bin in energy in each dataset.
+    one degree of freedom per valid energy bin in each dataset.
     This method implemented here is valid under the assumption
     that the TS in each independent bin follows a Chi2 distribution,
     then the sum of the TS also follows a Chi2 distribution (with the sum of degree of freedom).

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -17,7 +17,7 @@ from gammapy.stats.utils import ts_to_sigma
 from .map.core import FluxMaps
 
 __all__ = [
-    "get_joint_excess_maps",
+    "get_joint_significance_maps",
     "estimate_exposure_reco_energy",
     "find_peaks",
     "find_peaks_in_flux_map",
@@ -690,7 +690,7 @@ def get_rebinned_axis(fluxpoint, axis_name="energy", method=None, **kwargs):
     return axis_new
 
 
-def get_joint_excess_maps(
+def get_joint_significance_maps(
     estimator, datasets, energy_edges=None, sum_over_energy_groups=True
 ):
     """Computes correlated excess and significance for a set of datasets.

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -735,11 +735,6 @@ def get_joint_significance_maps(
     dof = 0
     results = dict()
     for kd, d in enumerate(datasets):
-        if energy_edges is None:
-            energy_edges = d.counts.geom.axes[0].edges
-        if sum_over_energy_groups:
-            energy_edges = [energy_edges[0], energy_edges[-1]]
-
         result = estimator.run(d)
         results[d.anme] = result
 

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -690,10 +690,8 @@ def get_rebinned_axis(fluxpoint, axis_name="energy", method=None, **kwargs):
     return axis_new
 
 
-def get_joint_significance_maps(
-    estimator, datasets, energy_edges=None, sum_over_energy_groups=True
-):
-    """Computes correlated excess and significance for a set of datasets.
+def get_joint_significance_maps(estimator, datasets):
+    """Computes excess and significance for a set of datasets.
     The significance computation assumes that the model contains
     one degree of freedom per valid bin in energy in each dataset.
     This method implemented here is valid under the assumption
@@ -710,13 +708,6 @@ def get_joint_significance_maps(
         Excess Map Estimator or TS Map Estimator
     dataset : `~gammapy.datasets.Datasets`
         Datasets containing only `~gammapy.maps.MapDataset`.
-    energy_edges : list of `~astropy.units.Quantity`, optional
-        Edges of the target maps energy bins. The resulting bin edges won't be exactly equal to the input ones,
-        but rather the closest values to the energy axis edges of the parent dataset.
-        Default is None: apply the estimator in each energy bin of the parent dataset.
-        For further explanation see :ref:`estimators`.
-    sum_over_energy_groups : bool
-        Whether to sum over the energy groups or not. Default is True
 
     Returns
     -------
@@ -744,15 +735,15 @@ def get_joint_significance_maps(
     results = dict()
     for kd, d in enumerate(datasets):
         result = estimator.run(d)
-        results[d.anme] = result
+        results[d.name] = result
 
         dof += np.sum(result["ts"].data > 0, axis=0)  # one dof (norm) per valid bin
-        ts = result["ts"].reduce_over_axes()
 
-        npred_excess = result["npred_excess"].reduce_over_axes()
-
-        ts_sum += ts
-        ts_sum_sign += ts * np.sign(npred_excess)
+        ts_sum += result["ts"].reduce_over_axes()
+        ts_sum_sign += (
+            result["ts"] * np.sign(result["npred_excess"])
+        ).reduce_over_axes()
+        npred_excess_sum += result["npred_excess"].reduce_over_axes()
 
     significance = Map.from_geom(geom)
     significance.data = ts_to_sigma(ts_sum.data, dof) * np.sign(ts_sum_sign)

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -737,7 +737,7 @@ def get_joint_excess_maps(
     for kd, d in enumerate(datasets):
         if energy_edges is None:
             energy_edges = d.counts.geom.axes[0].edges
-        if sum_over_energy_groups == True:
+        if sum_over_energy_groups:
             energy_edges = [energy_edges[0], energy_edges[-1]]
 
         result = estimator.run(d)

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -15,8 +15,6 @@ from gammapy.modeling.models import (
 from gammapy.stats import compute_flux_doubling, compute_fpp, compute_fvar
 from gammapy.stats.utils import ts_to_sigma
 from .map.core import FluxMaps
-from .map.excess import ExcessMapEstimator
-from .map.ts import TSMapEstimator
 
 __all__ = [
     "get_joint_excess_maps",
@@ -721,6 +719,8 @@ def get_joint_excess_maps(
         Whether to sum over the energy groups or not. Default is True.
 
     """
+    from .map.excess import ExcessMapEstimator
+    from .map.ts import TSMapEstimator
 
     if not isinstance(estimator, (ExcessMapEstimator, TSMapEstimator)):
         raise TypeError(


### PR DESCRIPTION
Computes correlated excess and significance for a set of datasets.
The significance computation assumes that the model contains
 one degree of freedom per valid bin in energy in each dataset.
 
 To add an estimate for the flux #4414 is needed.
