### PR TITLE
Add stack option to npred_signal()

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -502,7 +502,8 @@ class MapDataset(Dataset):
             evaluators = {name: self.evaluators[name] for name in model_name}
 
         npred_list = []
-        for evaluator_name, evaluator in zip(evaluators.keys(), evaluators.values()):
+        labels = []
+        for evaluator_name, evaluator in evaluators.items():
             if evaluator.needs_update:
                 evaluator.update(
                     self.exposure,
@@ -519,12 +520,12 @@ class MapDataset(Dataset):
                 else:
                     npred_geom = Map.from_geom(self._geom, dtype=float)
                     npred_geom.stack(npred)
-                    label = LabelMapAxis(labels=[evaluator_name], name="models")
-                    npred_geom = npred_geom.to_cube([label])
+                    labels.append(evaluator_name)
                     npred_list.append(npred_geom)
 
         if npred_list != []:
-            npred_total = Map.from_stack(npred_list, axis_name="models")
+            label_axis = LabelMapAxis(labels=labels, name="models")
+            npred_total = Map.from_stack(npred_list, axis=label_axis)
 
         return npred_total
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -512,14 +512,17 @@ class MapDataset(Dataset):
 
             if evaluator.contributes:
                 npred = evaluator.compute_npred()
-                label = LabelMapAxis(labels=[evaluator_name], name="models")
-                npred = npred.to_cube([label])
-                npred_list.append(npred)
+                if stack:
+                    npred_total.stack(npred)
+                else:
+                    npred_geom = Map.from_geom(self._geom, dtype=float)
+                    npred_geom.stack(npred)
+                    label = LabelMapAxis(labels=[evaluator_name], name="models")
+                    npred_geom = npred_geom.to_cube([label])
+                    npred_list.append(npred_geom)
 
         if npred_list != []:
             npred_total = Map.from_stack(npred_list, axis_name="models")
-            if stack:
-                npred_total = npred_total.sum_over_axes(axes_names=["models"])
 
         return npred_total
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -515,11 +515,12 @@ class MapDataset(Dataset):
                 npred = npred.to_cube([label])
                 npred_list.append(npred)
 
-        npred_total = Map.from_stack(npred_list, axis_name="models")
-        if stack:
-            npred_total = npred_total.sum_over_axes(axes_names=["models"])
+        if npred_list != []:
+            npred_total = Map.from_stack(npred_list, axis_name="models")
+            if stack:
+                npred_total = npred_total.sum_over_axes(axes_names=["models"])
 
-        return npred_total
+            return npred_total
 
     @classmethod
     def from_geoms(

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -486,7 +486,7 @@ class MapDataset(Dataset):
 
         Parameters
         ----------
-        model_name: list of str
+        model_names: list of str
             List of name of  SkyModel for which to compute the npred.
             If none, all the SkyModel predicted counts are computed
         stack: bool

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -18,6 +18,7 @@ from gammapy.stats import (
     get_wstat_mu_bkg,
     wstat,
 )
+from gammapy.utils.deprecation import deprecated_renamed_argument
 from gammapy.utils.fits import HDULocation, LazyFitsData
 from gammapy.utils.random import get_random_state
 from gammapy.utils.scripts import make_name, make_path
@@ -475,7 +476,8 @@ class MapDataset(Dataset):
             self._background_parameters_cached = values
         return changed
 
-    def npred_signal(self, model_name=None, stack=True):
+    @deprecated_renamed_argument("model_name", "model_names", "1.1")
+    def npred_signal(self, model_names=None, stack=True):
         """Model predicted signal counts.
 
         If a list of model name is passed, predicted counts from these components are returned.
@@ -498,8 +500,8 @@ class MapDataset(Dataset):
         npred_total = Map.from_geom(self._geom, dtype=float)
 
         evaluators = self.evaluators
-        if model_name is not None:
-            evaluators = {name: self.evaluators[name] for name in model_name}
+        if model_names is not None:
+            evaluators = {name: self.evaluators[name] for name in model_names}
 
         npred_list = []
         labels = []

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -493,13 +493,14 @@ class MapDataset(Dataset):
         npred_sig: `gammapy.maps.Map`
             Map of the predicted signal counts
         """
+        npred_total = Map.from_geom(self._geom, dtype=float)
 
         evaluators = self.evaluators
         if model_name is not None:
             evaluators = {name: self.evaluators[name] for name in model_name}
 
         npred_list = []
-        for evaluator in evaluators.values():
+        for evaluator_name, evaluator in zip(evaluators.keys(), evaluators.values()):
             if evaluator.needs_update:
                 evaluator.update(
                     self.exposure,
@@ -511,7 +512,7 @@ class MapDataset(Dataset):
 
             if evaluator.contributes:
                 npred = evaluator.compute_npred()
-                label = LabelMapAxis(labels=[evaluator.keys()[0]], name="models")
+                label = LabelMapAxis(labels=[evaluator_name], name="models")
                 npred = npred.to_cube([label])
                 npred_list.append(npred)
 
@@ -520,7 +521,7 @@ class MapDataset(Dataset):
             if stack:
                 npred_total = npred_total.sum_over_axes(axes_names=["models"])
 
-            return npred_total
+        return npred_total
 
     @classmethod
     def from_geoms(

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -501,6 +501,8 @@ class MapDataset(Dataset):
 
         evaluators = self.evaluators
         if model_names is not None:
+            if isinstance(model_names, str):
+                model_names = [model_names]
             evaluators = {name: self.evaluators[name] for name in model_names}
 
         npred_list = []

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -478,15 +478,17 @@ class MapDataset(Dataset):
     def npred_signal(self, model_name=None, stack=True):
         """Model predicted signal counts.
 
-        If a model name is passed, predicted counts from that component are returned.
-        Else, the total signal counts are returned.
+        If a list of model name is passed, predicted counts from these components are returned.
+        If stack is set to True, a map of the sum of all the predicted counts is returned.
+        If stack is set to False, a map with an additional axis representing the models is returned.
 
         Parameters
         ----------
         model_name: list of str
-            Name of  SkyModel for which to compute the npred for.
-            If none, the sum of all components (minus the background model)
-            is returned
+            List of name of  SkyModel for which to compute the npred.
+            If none, all the SkyModel predicted counts are computed
+        stack: bool
+            Whether to stack the npred maps upon each other.
 
         Returns
         -------

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -956,7 +956,7 @@ def test_npred(sky_model, geom, geom_etrue):
     dataset.models = [bkg, sky_model, model1]
 
     assert_allclose(
-        dataset.npred_signal(model_name=[model1.name]).data.sum(), 150.7487, rtol=1e-3
+        dataset.npred_signal(model_names=[model1.name]).data.sum(), 150.7487, rtol=1e-3
     )
     assert dataset._background_cached is None
     assert_allclose(dataset.npred_background().data.sum(), 4000.0, rtol=1e-3)
@@ -973,7 +973,7 @@ def test_npred(sky_model, geom, geom_etrue):
         KeyError,
         match="m2",
     ):
-        dataset.npred_signal(model_name=["m2"])
+        dataset.npred_signal(model_names=["m2"])
 
 
 def test_stack_npred():

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -956,7 +956,7 @@ def test_npred(sky_model, geom, geom_etrue):
     dataset.models = [bkg, sky_model, model1]
 
     assert_allclose(
-        dataset.npred_signal(model_name=model1.name).data.sum(), 150.7487, rtol=1e-3
+        dataset.npred_signal(model_name=[model1.name]).data.sum(), 150.7487, rtol=1e-3
     )
     assert dataset._background_cached is None
     assert_allclose(dataset.npred_background().data.sum(), 4000.0, rtol=1e-3)
@@ -973,7 +973,7 @@ def test_npred(sky_model, geom, geom_etrue):
         KeyError,
         match="m2",
     ):
-        dataset.npred_signal(model_name="m2")
+        dataset.npred_signal(model_name=["m2"])
 
 
 def test_stack_npred():

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -126,7 +126,7 @@ def test_npred_models():
     npred_sig = spectrum_dataset.npred_signal()
     assert_allclose(npred_sig.data.sum(), 64.8)
 
-    npred_sig_model1 = spectrum_dataset.npred_signal(model_name=[model_1.name])
+    npred_sig_model1 = spectrum_dataset.npred_signal(model_names=[model_1.name])
     assert_allclose(npred_sig_model1.data.sum(), 32.4)
 
 

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
 from astropy.table import Table
 from astropy.time import Time
@@ -9,7 +9,7 @@ from gammapy.data import GTI
 from gammapy.datasets import Datasets, SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.irf import EDispKernelMap, EffectiveAreaTable2D
 from gammapy.makers.utils import make_map_exposure_true_energy
-from gammapy.maps import MapAxis, RegionGeom, RegionNDMap, WcsGeom
+from gammapy.maps import LabelMapAxis, MapAxis, RegionGeom, RegionNDMap, WcsGeom
 from gammapy.modeling import Fit
 from gammapy.modeling.models import (
     ConstantSpectralModel,
@@ -128,6 +128,30 @@ def test_npred_models():
 
     npred_sig_model1 = spectrum_dataset.npred_signal(model_names=[model_1.name])
     assert_allclose(npred_sig_model1.data.sum(), 32.4)
+
+    assert_allclose(
+        spectrum_dataset.npred_signal(
+            model_names=[model_1.name, model_2.name]
+        ).data.sum(),
+        64.8,
+    )
+
+    npred_model1_not_stack = spectrum_dataset.npred_signal(
+        model_names=[model_1.name], stack=False
+    )
+    assert_allclose(npred_model1_not_stack.geom.data_shape, (1, 3, 1, 1))
+    assert_allclose(npred_model1_not_stack.data.sum(), 32.4)
+    assert isinstance(npred_model1_not_stack.geom.axes[-1], LabelMapAxis)
+    assert npred_model1_not_stack.geom.axes[-1].name == "models"
+    assert_equal(npred_model1_not_stack.geom.axes[-1].center, [model_1.name])
+
+    npred_all_models_not_stack = spectrum_dataset.npred_signal(
+        model_names=[model_1.name, model_2.name], stack=False
+    )
+    assert_allclose(npred_all_models_not_stack.geom.data_shape, (2, 3, 1, 1))
+    assert_allclose(
+        npred_all_models_not_stack.sum_over_axes(["models"]).data.sum(), 64.8
+    )
 
 
 def test_npred_spatial_model(spectrum_dataset):

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -126,7 +126,7 @@ def test_npred_models():
     npred_sig = spectrum_dataset.npred_signal()
     assert_allclose(npred_sig.data.sum(), 64.8)
 
-    npred_sig_model1 = spectrum_dataset.npred_signal(model_name=model_1.name)
+    npred_sig_model1 = spectrum_dataset.npred_signal(model_name=[model_1.name])
     assert_allclose(npred_sig_model1.data.sum(), 32.4)
 
 

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -151,7 +151,7 @@ class FluxEstimator(ParameterEstimator):
 
         for dataset in datasets:
             name = datasets.models[self.source].name
-            npred_signal = dataset.npred_signal(model_name=name)
+            npred_signal = dataset.npred_signal(model_name=[name])
             npred = Map.from_geom(dataset.counts.geom)
             npred.stack(npred_signal)
             npred_excess.append(npred.data[dataset.mask].sum())

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -151,7 +151,7 @@ class FluxEstimator(ParameterEstimator):
 
         for dataset in datasets:
             name = datasets.models[self.source].name
-            npred_signal = dataset.npred_signal(model_name=[name])
+            npred_signal = dataset.npred_signal(model_names=[name])
             npred = Map.from_geom(dataset.counts.geom)
             npred.stack(npred_signal)
             npred_excess.append(npred.data[dataset.mask].sum())


### PR DESCRIPTION
This pull request is related to PR #4409.

It aims to introduce several features to the `npred_signal()`methods. 

- First, it adds the possibility to input a list of model name instead of only one. 

- Secondly, it adds a new parameter `stack` which is True by default to keep the former behaviour in the calls of `npred_signal` in the other place of the code. 

If stack is True, the npred maps are stack one onto the others. If stack is False, I first create a new map with the geometry of the Dataset and stack the npred map on this new map. This is the simplest and fastest way I found to make all the npred maps have the same geometry (in order to do a from_stack over those maps). Then I create a `LabelMapAxis` named "models" with the label set to the name of the model. I "append" this axis to the geometry, and repeat.
Once all the npred have been computed, I do a `from_stack` of all the npred maps over the `LabelMapAxis`. 