### PR TITLE
Integral sensitivity in FluxPointsEstimator

### DIFF
--- a/examples/tutorials/analysis-1d/cta_sensitivity.py
+++ b/examples/tutorials/analysis-1d/cta_sensitivity.py
@@ -209,16 +209,12 @@ plt.show()
 #
 # It is often useful to obtain the integral sensitivity above a certain
 # threshold. In this case, it is simplest to use a dataset with one energy bin
-# while setting the high energy edge to a very large value
+# while setting the high energy edge to a very large value.
+# Here, we simply squash the previously created dataset into one with a single
+# energy
 #
 
-energy_axis1 = MapAxis.from_energy_bounds("0.03 TeV", "300 TeV", nbin=1)
-geom = RegionGeom.create("icrs;circle(0, 0.5, 0.1)", axes=[energy_axis1])
-empty_dataset1 = SpectrumDataset.create(geom=geom, energy_axis_true=energy_axis_true)
-dataset1 = spectrum_maker.run(empty_dataset1, obs)
-dataset_on_off1 = SpectrumDatasetOnOff.from_spectrum_dataset(
-    dataset=dataset1, acceptance=1, acceptance_off=5
-)
+dataset_on_off1 = dataset_on_off.to_image()
 sensitivity_estimator = SensitivityEstimator(
     gamma_min=5, n_sigma=3, bkg_syst_fraction=0.10
 )
@@ -232,7 +228,7 @@ flux_points = FluxPoints.from_table(
     sensitivity_table, sed_type="e2dnde", reference_model=sensitivity_estimator.spectrum
 )
 print(
-    f"Integral sensitivity in {livetime:.2f} above {energy_axis1.edges[0]:.2e} "
+    f"Integral sensitivity in {livetime:.2f} above {energy_axis.edges[0]:.2e} "
     f"is {np.squeeze(flux_points.flux.quantity):.2e}"
 )
 

--- a/examples/tutorials/analysis-1d/cta_sensitivity.py
+++ b/examples/tutorials/analysis-1d/cta_sensitivity.py
@@ -39,7 +39,7 @@ import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import Observation, observatory_locations
 from gammapy.datasets import SpectrumDataset, SpectrumDatasetOnOff
-from gammapy.estimators import SensitivityEstimator
+from gammapy.estimators import FluxPoints, SensitivityEstimator
 from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import SpectrumDatasetMaker
 from gammapy.maps import MapAxis, RegionGeom
@@ -83,8 +83,9 @@ irfs = load_irf_dict_from_file(
 )
 location = observatory_locations["cta_south"]
 pointing = SkyCoord("0 deg", "0 deg")
+livetime = 5.0 * u.h
 obs = Observation.create(
-    pointing=pointing, irfs=irfs, livetime="5 h", location=location
+    pointing=pointing, irfs=irfs, livetime=livetime, location=location
 )
 
 spectrum_maker = SpectrumDatasetMaker(selection=["exposure", "edisp", "background"])
@@ -156,7 +157,7 @@ is_s = t["criterion"] == "significance"
 
 fig, ax = plt.subplots()
 ax.plot(
-    t["energy"][is_s],
+    t["e_ref"][is_s],
     t["e2dnde"][is_s],
     "s-",
     color="red",
@@ -164,10 +165,10 @@ ax.plot(
 )
 
 is_g = t["criterion"] == "gamma"
-ax.plot(t["energy"][is_g], t["e2dnde"][is_g], "*-", color="blue", label="gamma")
+ax.plot(t["e_ref"][is_g], t["e2dnde"][is_g], "*-", color="blue", label="gamma")
 is_bkg_syst = t["criterion"] == "bkg"
 ax.plot(
-    t["energy"][is_bkg_syst],
+    t["e_ref"][is_bkg_syst],
     t["e2dnde"][is_bkg_syst],
     "v-",
     color="green",
@@ -175,7 +176,7 @@ ax.plot(
 )
 
 ax.loglog()
-ax.set_xlabel(f"Energy [{t['energy'].unit}]")
+ax.set_xlabel(f"Energy [{t['e_ref'].unit}]")
 ax.set_ylabel(f"Sensitivity [{t['e2dnde'].unit}]")
 ax.legend()
 
@@ -188,20 +189,52 @@ ax.legend()
 
 # Plot expected number of counts for signal and background
 fig, ax1 = plt.subplots()
-# ax1.plot( t["energy"], t["excess"],"o-", color="red", label="signal")
-ax1.plot(t["energy"], t["background"], "o-", color="black", label="blackground")
+# ax1.plot( t["e_ref"], t["excess"],"o-", color="red", label="signal")
+ax1.plot(t["e_ref"], t["background"], "o-", color="black", label="blackground")
 
 ax1.loglog()
-ax1.set_xlabel(f"Energy [{t['energy'].unit}]")
+ax1.set_xlabel(f"Energy [{t['e_ref'].unit}]")
 ax1.set_ylabel("Expected number of bkg counts")
 
 ax2 = ax1.twinx()
 ax2.set_ylabel(f"ON region radius [{on_radii.unit}]", color="red")
-ax2.semilogy(t["energy"], on_radii, color="red", label="PSF68")
+ax2.semilogy(t["e_ref"], on_radii, color="red", label="PSF68")
 ax2.tick_params(axis="y", labelcolor="red")
 ax2.set_ylim(0.01, 0.5)
 plt.show()
 
+######################################################################
+# Obtaining an integral flux sensitivity
+# --------------------------------------
+#
+# It is often useful to obtain the integral sensitivity above a certain
+# threshold. In this case, it is simplest to use a dataset with one energy bin
+# while setting the high energy edge to a very large value
+#
+
+energy_axis1 = MapAxis.from_energy_bounds("0.03 TeV", "300 TeV", nbin=1)
+geom = RegionGeom.create("icrs;circle(0, 0.5, 0.1)", axes=[energy_axis1])
+empty_dataset1 = SpectrumDataset.create(geom=geom, energy_axis_true=energy_axis_true)
+dataset1 = spectrum_maker.run(empty_dataset1, obs)
+dataset_on_off1 = SpectrumDatasetOnOff.from_spectrum_dataset(
+    dataset=dataset1, acceptance=1, acceptance_off=5
+)
+sensitivity_estimator = SensitivityEstimator(
+    gamma_min=5, n_sigma=3, bkg_syst_fraction=0.10
+)
+sensitivity_table = sensitivity_estimator.run(dataset_on_off1)
+print(sensitivity_table)
+
+# To get the integral flux, we convert to a `FluxPoints` object that does the conversion
+# internally
+
+flux_points = FluxPoints.from_table(
+    sensitivity_table, sed_type="e2dnde", reference_model=sensitivity_estimator.spectrum
+)
+print(
+    f"Integral sensitivity in {livetime:.2f} above {energy_axis1.edges[0]:.2e} "
+    f"is {np.squeeze(flux_points.flux.quantity):.2e}"
+)
 
 ######################################################################
 # Exercises

--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -10,7 +10,7 @@ __all__ = ["SensitivityEstimator"]
 
 
 class SensitivityEstimator(Estimator):
-    """Estimate differential sensitivity.
+    """Estimate sensitivity.
 
     This class allows to determine for each reconstructed energy bin the flux
     associated to the number of gamma-ray events for which the significance is
@@ -38,7 +38,12 @@ class SensitivityEstimator(Estimator):
     tag = "SensitivityEstimator"
 
     def __init__(
-        self, spectrum=None, n_sigma=5.0, gamma_min=10, bkg_syst_fraction=0.05
+        self,
+        spectrum=None,
+        n_sigma=5.0,
+        gamma_min=10,
+        bkg_syst_fraction=0.05,
+        integral=False,
     ):
 
         if spectrum is None:
@@ -140,7 +145,19 @@ class SensitivityEstimator(Estimator):
             [
                 Column(
                     data=energy,
-                    name="energy",
+                    name="e_ref",
+                    format="5g",
+                    description="Reconstructed Energy",
+                ),
+                Column(
+                    data=dataset._geom.axes["energy"].edges_min,
+                    name="e_min",
+                    format="5g",
+                    description="Reconstructed Energy",
+                ),
+                Column(
+                    data=dataset._geom.axes["energy"].edges_max,
+                    name="e_max",
                     format="5g",
                     description="Reconstructed Energy",
                 ),
@@ -151,19 +168,19 @@ class SensitivityEstimator(Estimator):
                     description="Energy squared times differential flux",
                 ),
                 Column(
-                    data=excess.data.squeeze(),
+                    data=np.atleast_1d(excess.data.squeeze()),
                     name="excess",
                     format="5g",
                     description="Number of excess counts in the bin",
                 ),
                 Column(
-                    data=dataset.background.data.squeeze(),
+                    data=np.atleast_1d(dataset.background.data.squeeze()),
                     name="background",
                     format="5g",
                     description="Number of background counts in the bin",
                 ),
                 Column(
-                    data=criterion,
+                    data=np.atleast_1d(criterion),
                     name="criterion",
                     description="Sensitivity-limiting criterion",
                 ),

--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import logging
 import numpy as np
 from astropy.table import Column, Table
 from gammapy.maps import Map
@@ -43,7 +44,6 @@ class SensitivityEstimator(Estimator):
         n_sigma=5.0,
         gamma_min=10,
         bkg_syst_fraction=0.05,
-        integral=False,
     ):
 
         if spectrum is None:
@@ -140,26 +140,35 @@ class SensitivityEstimator(Estimator):
         criterion = self._get_criterion(
             excess.data.squeeze(), dataset.background.data.squeeze()
         )
+        logging.warning(
+            "Table column name energy will be deprecated by e_ref since v1.2"
+        )
 
         return Table(
             [
                 Column(
                     data=energy,
-                    name="e_ref",
+                    name="energy",
                     format="5g",
                     description="Reconstructed Energy",
+                ),
+                Column(
+                    data=energy,
+                    name="e_ref",
+                    format="5g",
+                    description="Energy center",
                 ),
                 Column(
                     data=dataset._geom.axes["energy"].edges_min,
                     name="e_min",
                     format="5g",
-                    description="Reconstructed Energy",
+                    description="Energy edge low",
                 ),
                 Column(
                     data=dataset._geom.axes["energy"].edges_max,
                     name="e_max",
                     format="5g",
-                    description="Reconstructed Energy",
+                    description="Energy edge high",
                 ),
                 Column(
                     data=e2dnde,

--- a/gammapy/estimators/points/tests/test_sensitivity.py
+++ b/gammapy/estimators/points/tests/test_sensitivity.py
@@ -2,7 +2,7 @@
 import pytest
 from numpy.testing import assert_allclose
 from gammapy.datasets import SpectrumDataset, SpectrumDatasetOnOff
-from gammapy.estimators import SensitivityEstimator
+from gammapy.estimators import FluxPoints, SensitivityEstimator
 from gammapy.irf import EDispKernelMap
 from gammapy.maps import MapAxis, RegionNDMap
 
@@ -42,27 +42,55 @@ def test_cta_sensitivity_estimator(spectrum_dataset):
     table = sens.run(dataset_on_off)
 
     assert len(table) == 4
-    assert table.colnames == ["energy", "e2dnde", "excess", "background", "criterion"]
-    assert table["energy"].unit == "TeV"
+    assert table.colnames == [
+        "e_ref",
+        "e_min",
+        "e_max",
+        "e2dnde",
+        "excess",
+        "background",
+        "criterion",
+    ]
+    assert table["e_ref"].unit == "TeV"
     assert table["e2dnde"].unit == "erg / (cm2 s)"
 
     row = table[0]
-    assert_allclose(row["energy"], 1.33352, rtol=1e-3)
+    assert_allclose(row["e_ref"], 1.33352, rtol=1e-3)
     assert_allclose(row["e2dnde"], 2.74559e-08, rtol=1e-3)
     assert_allclose(row["excess"], 270000, rtol=1e-3)
     assert_allclose(row["background"], 3.6e06, rtol=1e-3)
     assert row["criterion"] == "bkg"
 
     row = table[1]
-    assert_allclose(row["energy"], 2.37137, rtol=1e-3)
+    assert_allclose(row["e_ref"], 2.37137, rtol=1e-3)
     assert_allclose(row["e2dnde"], 6.04795e-11, rtol=1e-3)
     assert_allclose(row["excess"], 334.454, rtol=1e-3)
     assert_allclose(row["background"], 3600, rtol=1e-3)
     assert row["criterion"] == "significance"
 
     row = table[3]
-    assert_allclose(row["energy"], 7.49894, rtol=1e-3)
+    assert_allclose(row["e_ref"], 7.49894, rtol=1e-3)
     assert_allclose(row["e2dnde"], 1.42959e-11, rtol=1e-3)
     assert_allclose(row["excess"], 25, rtol=1e-3)
     assert_allclose(row["background"], 3.6, rtol=1e-3)
     assert row["criterion"] == "gamma"
+
+
+def test_integral_estimation(spectrum_dataset):
+    dataset = spectrum_dataset.to_image()
+    geom = dataset.background.geom
+
+    dataset_on_off = SpectrumDatasetOnOff.from_spectrum_dataset(
+        dataset=dataset,
+        acceptance=RegionNDMap.from_geom(geom=geom, data=1),
+        acceptance_off=RegionNDMap.from_geom(geom=geom, data=5),
+    )
+
+    sens = SensitivityEstimator(gamma_min=25, bkg_syst_fraction=0.075)
+    table = sens.run(dataset_on_off)
+    flux_points = FluxPoints.from_table(
+        table, sed_type="e2dnde", reference_model=sens.spectrum
+    )
+
+    assert_allclose(table["excess"].data.squeeze(), 270540, rtol=1e-3)
+    assert_allclose(flux_points.flux.data.squeeze(), 7.52e-9, rtol=1e-3)

--- a/gammapy/estimators/points/tests/test_sensitivity.py
+++ b/gammapy/estimators/points/tests/test_sensitivity.py
@@ -29,7 +29,7 @@ def spectrum_dataset():
     )
 
 
-def test_cta_sensitivity_estimator(spectrum_dataset):
+def test_cta_sensitivity_estimator(spectrum_dataset, caplog):
     geom = spectrum_dataset.background.geom
 
     dataset_on_off = SpectrumDatasetOnOff.from_spectrum_dataset(
@@ -41,8 +41,15 @@ def test_cta_sensitivity_estimator(spectrum_dataset):
     sens = SensitivityEstimator(gamma_min=25, bkg_syst_fraction=0.075)
     table = sens.run(dataset_on_off)
 
+    warning_message = (
+        "Table column name energy will be " "deprecated by e_ref since v1.2"
+    )
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert warning_message in [_.message for _ in caplog.records]
+
     assert len(table) == 4
     assert table.colnames == [
+        "energy",
         "e_ref",
         "e_min",
         "e_max",
@@ -76,7 +83,7 @@ def test_cta_sensitivity_estimator(spectrum_dataset):
     assert row["criterion"] == "gamma"
 
 
-def test_integral_estimation(spectrum_dataset):
+def test_integral_estimation(spectrum_dataset, caplog):
     dataset = spectrum_dataset.to_image()
     geom = dataset.background.geom
 
@@ -91,6 +98,10 @@ def test_integral_estimation(spectrum_dataset):
     flux_points = FluxPoints.from_table(
         table, sed_type="e2dnde", reference_model=sens.spectrum
     )
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert "Table column name energy will be deprecated by e_ref since v1.2" in [
+        _.message for _ in caplog.records
+    ]
 
     assert_allclose(table["excess"].data.squeeze(), 270540, rtol=1e-3)
     assert_allclose(flux_points.flux.data.squeeze(), 7.52e-9, rtol=1e-3)


### PR DESCRIPTION
The PR address #4329

The issue is how to keep backwards compatibility while renaming `energy` to `e_min` in the `Table` column.
One option might be to have both columns in the table, but that is rather ugly.


