### PR TITLE
Improve map axis test (x-axis format)

### DIFF
--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -777,8 +777,8 @@ def test_time_map_axis_format_plot_xaxis(time_intervals):
             ax.plot(axis.center, np.ones_like(axis.center))
 
     ax1 = axis.format_plot_xaxis(ax=ax)
-    assert ax1.axes.axes.get_xlabel().split()[0]=="Time"
-    assert ax1.axes.axes.get_xlabel().split()[1]=="[iso]"
+    assert ax1.axes.axes.get_xlabel().split()[0] == "Time"
+    assert ax1.axes.axes.get_xlabel().split()[1] == "[iso]"
 
 
 def test_single_valued_axis():

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -759,7 +759,8 @@ def test_map_axis_format_plot_xaxis():
             ax.plot(axis.center, np.ones_like(axis.center))
 
     ax1 = axis.format_plot_xaxis(ax=ax)
-    assert ax1.xaxis.label.properties()["text"] == "True Energy [TeV]"
+    assert ax1.xaxis.units == u.Unit("TeV")
+    assert " ".join(ax1.axes.axes.get_xlabel().split()[:2]) == "True Energy"
 
 
 def test_time_map_axis_format_plot_xaxis(time_intervals):
@@ -776,7 +777,8 @@ def test_time_map_axis_format_plot_xaxis(time_intervals):
             ax.plot(axis.center, np.ones_like(axis.center))
 
     ax1 = axis.format_plot_xaxis(ax=ax)
-    assert ax1.xaxis.label.properties()["text"] == "Time [iso]"
+    assert ax1.axes.axes.get_xlabel().split()[0]=="Time"
+    assert ax1.axes.axes.get_xlabel().split()[1]=="[iso]"
 
 
 def test_single_valued_axis():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request improves the tests `test_map_axis_format_plot_xaxis`  and `test_time_map_axis_format_plot_xaxis` following PR #4429. The former is required to merge PR #4428 since the previous version would fail because of the string representation of the axis units in latex_inline. 

I created a separate PR if it should be backported.

**Dear reviewer**
This PR is ready for review.
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
