### PR TITLE
Catch invalid conversion warning in pix_tuple_to_idx

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -47,8 +47,8 @@ def pix_tuple_to_idx(pix):
         else:
             with np.errstate(invalid="ignore"):
                 p_idx = np.rint(p).astype(int)
-                p_idx[~np.isfinite(p)] = INVALID_INDEX.int
-                idx += [p_idx]
+            p_idx[~np.isfinite(p)] = INVALID_INDEX.int
+            idx += [p_idx]
 
     return tuple(idx)
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -45,9 +45,10 @@ def pix_tuple_to_idx(pix):
         if np.issubdtype(p.dtype, np.integer):
             idx += [p]
         else:
-            p_idx = np.rint(p).astype(int)
-            p_idx[~np.isfinite(p)] = INVALID_INDEX.int
-            idx += [p_idx]
+            with np.errstate(invalid="ignore"):
+                p_idx = np.rint(p).astype(int)
+                p_idx[~np.isfinite(p)] = INVALID_INDEX.int
+                idx += [p_idx]
 
     return tuple(idx)
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a method to catch invalid rounding warnings from numpy that are now raised systematically since numpy 1.24. They occur mostly in `gammapy.maps.geom.pix_tuple_to_idx`.  (See for instance outputs in v1.0.1 tutorials). 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
