### PR TITLE
add missing bracket in deprecated_rename_argument dev how to example

### DIFF
--- a/docs/development/dev_howto.rst
+++ b/docs/development/dev_howto.rst
@@ -602,7 +602,7 @@ It will replace the old argument with the new one in a call to the function and 
 
     from gammapy.utils.deprecation import deprecated_renamed_argument
 
-    @deprecated_renamed_argument(["a", "b", ["x", "y"], ["1.1", "1.1"])
+    @deprecated_renamed_argument(["a", "b"], ["x", "y"], ["1.1", "1.1"])
     def deprecated_argument_function(x, y):
         return x + y
 


### PR DESCRIPTION
This pull request correct for a missing bracket in the dev how to deprecated_rename_argument example. 