### PR TITLE
Test SpatialModel.from_position()

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -407,7 +407,7 @@ class SpatialModel(ModelBase):
     @classmethod
     def from_position(cls, position, **kwargs):
         """Define the position of the model using a sky coord
-
+           The model will be created in the frame of the sky coord
         Parameters
         ----------
         position : `~astropy.coordinates.SkyCoord`


### PR DESCRIPTION
In v1.0.1, `GaussianSpatialModel.from_position` gives an error `SkyModel` creation 

```
155 def evaluate_geom(self, geom):
    156     """Evaluate model on `~gammapy.maps.Geom`
    157 
    158     Parameters
   (...)
    165 
    166     """
--> 167     coords = geom.get_coord(frame=self.frame, sparse=True)
    169     if self.is_energy_dependent:
    170         return self(coords.lon, coords.lat, energy=coords["energy_true"])

TypeError: unhashable type: 'ICRS'
```

The issue was fixed (unintentionally) in #4282 - the frame argument should be `position.frame.name` rather than `position.frame`

The function was also untested.

This PR adds a test. I intended to fix it, but the issue does not exist on the main branch. Should I rebase on the `1.0.x` branch @adonath @registerrier ?