### PR TITLE
adding weights option to fill_events

### DIFF
--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1089,7 +1089,15 @@ class Map(abc.ABC):
         return output_map
 
     def fill_events(self, events, weights=None):
-        """Fill event coordinates (`~gammapy.data.EventList`)."""
+        """Fill event coordinates (`~gammapy.data.EventList`).
+
+        Parameters
+        ----------
+        events : `~gammapy.data.EventList`
+            Events to be fill in the map.
+        weights : `~numpy.ndarray`
+            Weights vector. Default is weight of one.
+        """
         self.fill_by_coord(events.map_coord(self.geom), weights=weights)
 
     def fill_by_coord(self, coords, weights=None):

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1096,8 +1096,8 @@ class Map(abc.ABC):
         events : `~gammapy.data.EventList`
             Events to be fill in the map.
         weights : `~numpy.ndarray`
-            Weights vector. Default is weight of one. The weights vector must be of the length
-            of the events column length.
+            Weights vector. Default is weight of one. The weights vector must be of the same length
+            as the events column length.
         """
         self.fill_by_coord(events.map_coord(self.geom), weights=weights)
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1088,9 +1088,9 @@ class Map(abc.ABC):
             output_map = output_map.resample(geom, preserve_counts=preserve_counts)
         return output_map
 
-    def fill_events(self, events):
+    def fill_events(self, events, weights=None):
         """Fill event coordinates (`~gammapy.data.EventList`)."""
-        self.fill_by_coord(events.map_coord(self.geom))
+        self.fill_by_coord(events.map_coord(self.geom), weights=weights)
 
     def fill_by_coord(self, coords, weights=None):
         """Fill pixels at ``coords`` with given ``weights``.

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1096,7 +1096,8 @@ class Map(abc.ABC):
         events : `~gammapy.data.EventList`
             Events to be fill in the map.
         weights : `~numpy.ndarray`
-            Weights vector. Default is weight of one.
+            Weights vector. Default is weight of one. The weights vector must be of the length
+            of the events column length.
         """
         self.fill_by_coord(events.map_coord(self.geom), weights=weights)
 

--- a/gammapy/maps/region/tests/test_ndmap.py
+++ b/gammapy/maps/region/tests/test_ndmap.py
@@ -245,7 +245,12 @@ def test_region_nd_map_fill_events(region_map):
     region_map = Map.from_geom(region_map.geom)
     region_map.fill_events(events)
 
+    weights = np.linspace(0, 1, len(events.time))
+    region_map2 = Map.from_geom(region_map.geom)
+    region_map2.fill_events(events, weights=weights)
+
     assert_allclose(region_map.data.sum(), 665)
+    assert_allclose(region_map2.data.sum(), 328.33487)
 
 
 @requires_data()
@@ -255,6 +260,11 @@ def test_region_nd_map_fill_events_point_sky_region(point_region_map):
     region_map = Map.from_geom(point_region_map.geom)
     region_map.fill_events(events)
 
+    assert_allclose(region_map.data.sum(), 0)
+
+    weights = np.linspace(0, 1, len(events.time))
+    region_map = Map.from_geom(point_region_map.geom)
+    region_map.fill_events(events, weights=weights)
     assert_allclose(region_map.data.sum(), 0)
 
 

--- a/gammapy/maps/tests/test_counts.py
+++ b/gammapy/maps/tests/test_counts.py
@@ -33,6 +33,11 @@ def test_map_fill_events_wcs(events):
     assert m.data.sum() == 1
     assert_allclose(m.data[0, 0, 0], 1)
 
+    weights = np.array([0.5, 1])
+    m = Map.create(npix=(2, 1), binsz=10, axes=[axis])
+    m.fill_events(events, weights=weights)
+    assert_allclose(m.data.sum(), 0.5)
+
 
 @requires_dependency("healpy")
 def test_map_fill_events_hpx(events):
@@ -47,6 +52,11 @@ def test_map_fill_events_hpx(events):
     m.fill_events(events)
     assert m.data[0, 4] == 1
     assert m.data[1, 4] == 1
+
+    weights = np.array([0.5, 1])
+    m = Map.from_geom(HpxGeom(1, axes=[axis]))
+    m.fill_events(events, weights=weights)
+    assert_allclose(m.data.sum(), 1.5)
 
 
 def test_map_fill_events_keyerror(events):


### PR DESCRIPTION
This pull request is related to #4457. 
I added a weights option to `Map.fill_events`. Since `Map.fill_events` uses `Map.fill_by_coord` which has a weights option, the implementation is straight forward. 