### PR TITLE
Add tutorial for the use of HAWC data

### DIFF
--- a/examples/tutorials/data/hawc.py
+++ b/examples/tutorials/data/hawc.py
@@ -182,6 +182,9 @@ safemask_maker = SafeMaskMaker(methods=["aeff-max"], aeff_percent=10)
 
 ######################################################################
 # Create empty Mapdataset
+# The keyword reco_psf=True is needed because the HAWC PSF is
+# derived in reconstructed energy.
+
 dataset_empty = MapDataset.create(
     geom, energy_axis_true=energy_axis_true, name="fHit " + str(fHit), reco_psf=True
 )

--- a/examples/tutorials/data/hawc.py
+++ b/examples/tutorials/data/hawc.py
@@ -38,16 +38,16 @@ This is how to access data and IRFs from the HAWC Crab event data release.
 
 """
 
+import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 import matplotlib.pyplot as plt
-import numpy as np
 from IPython.display import display
-from gammapy.datasets import MapDataset
-from gammapy.makers import MapDatasetMaker, SafeMaskMaker
 from gammapy.data import DataStore, HDUIndexTable, ObservationTable
-from gammapy.maps import Map, MapAxis, WcsGeom
+from gammapy.datasets import MapDataset
 from gammapy.estimators import ExcessMapEstimator
+from gammapy.makers import MapDatasetMaker, SafeMaskMaker
+from gammapy.maps import Map, MapAxis, WcsGeom
 
 ######################################################################
 # Check setup
@@ -60,7 +60,7 @@ check_tutorials_setup()
 ######################################################################
 # Chose which estimator we will use
 
-which = 'NN'
+which = "NN"
 
 
 ######################################################################
@@ -85,21 +85,21 @@ which = 'NN'
 # Load the tables
 
 data_path = "$GAMMAPY_DATA/hawc/crab_events_pass4/"
-hdu_filename = 'hdu-index-table-' + which + "-Crab.fits.gz"
-obs_filename = 'obs-index-table-' + which + "-Crab.fits.gz"
+hdu_filename = "hdu-index-table-" + which + "-Crab.fits.gz"
+obs_filename = "obs-index-table-" + which + "-Crab.fits.gz"
 
 # there is only one observation table
-obs_table = ObservationTable.read(data_path+obs_filename)
+obs_table = ObservationTable.read(data_path + obs_filename)
 
 # we read the hdu index table of fHit bin number 6
 fHit = 6
-hdu_table = HDUIndexTable.read(data_path+hdu_filename, hdu=fHit)
+hdu_table = HDUIndexTable.read(data_path + hdu_filename, hdu=fHit)
 
 
 ######################################################################
 # From the tables, we can create a Datastore
 
-data_store = DataStore( hdu_table=hdu_table, obs_table=obs_table)
+data_store = DataStore(hdu_table=hdu_table, obs_table=obs_table)
 
 data_store.info()
 
@@ -148,35 +148,43 @@ obs.aeff.reduce_over_axes().plot(add_cbar=True)
 # First we define the geometry and axes
 
 # create the energy reco axis
-energy_axis = MapAxis.from_edges([1.00,1.78,3.16,5.62,10.0,17.8,31.6,56.2,100,177,316] * u.TeV,
-        name="energy",
-        interp="log")
+# Note that this axis is the one used to create the background model map. If
+# different edges are used, the MapDatasetMaker will interpolate between
+# them, which might lead to unexpected behavior.
+energy_axis = MapAxis.from_edges(
+    [1.00, 1.78, 3.16, 5.62, 10.0, 17.8, 31.6, 56.2, 100, 177, 316] * u.TeV,
+    name="energy",
+    interp="log",
+)
 
 
 # and energy true axis
-energy_axis_true = MapAxis.from_energy_bounds(1e-3, 1e4, nbin=140, unit="TeV", name="energy_true")
+energy_axis_true = MapAxis.from_energy_bounds(
+    1e-3, 1e4, nbin=140, unit="TeV", name="energy_true"
+)
 
 
 # create a geometry around the Crab location
-geom = WcsGeom.create(skydir=SkyCoord(ra=83.63,dec=22.01, unit='deg', frame="icrs"),
-                     width=6*u.deg,
-                     axes=[energy_axis],
-                     binsz=0.05)
+geom = WcsGeom.create(
+    skydir=SkyCoord(ra=83.63, dec=22.01, unit="deg", frame="icrs"),
+    width=6 * u.deg,
+    axes=[energy_axis],
+    binsz=0.05,
+)
 
 
 ######################################################################
 # Define the makers we will use
 
-maker = MapDatasetMaker(selection = ["counts", "background", "exposure", "edisp", "psf"])
-safemask_maker = SafeMaskMaker(methods=['aeff-max'], aeff_percent=10)
+maker = MapDatasetMaker(selection=["counts", "background", "exposure", "edisp", "psf"])
+safemask_maker = SafeMaskMaker(methods=["aeff-max"], aeff_percent=10)
 
 
 ######################################################################
 # Create empty Mapdataset
-dataset_empty = MapDataset.create(geom,
-                                  energy_axis_true= energy_axis_true,
-                                  name ='fHit ' + str(fHit),
-                                  reco_psf=True )
+dataset_empty = MapDataset.create(
+    geom, energy_axis_true=energy_axis_true, name="fHit " + str(fHit), reco_psf=True
+)
 # run the map dataset maker
 dataset = maker.run(dataset_empty, obs)
 
@@ -196,14 +204,12 @@ dataset = safemask_maker.run(dataset)
 # with the event list. For convenience, the HAWC data release already
 # included this quantity as a map
 
-transit_map = Map.read(data_path + 'irfs/TransitsMap_Crab.fits.gz')
+transit_map = Map.read(data_path + "irfs/TransitsMap_Crab.fits.gz")
 transit_number = transit_map.get_by_coord(geom.center_skydir)
 
 # Correct the quantities
-dataset.background.data*=transit_number
-dataset.exposure.data*=transit_number
-
-
+dataset.background.data *= transit_number
+dataset.exposure.data *= transit_number
 
 
 ######################################################################
@@ -218,22 +224,27 @@ dataset.exposure.data*=transit_number
 dataset.peek()
 
 
-
 ######################################################################
 # And make significance maps to check that the Crab is visible
 
-excess_estimator = ExcessMapEstimator(correlation_radius='0.2 deg', selection_optional = [], energy_edges=energy_axis.edges)
+excess_estimator = ExcessMapEstimator(
+    correlation_radius="0.2 deg", selection_optional=[], energy_edges=energy_axis.edges
+)
 excess = excess_estimator.run(dataset)
 
-(dataset.mask*excess['sqrt_ts']).plot_grid(add_cbar=True, cmap='coolwarm', vmin=-5, vmax=5)
+(dataset.mask * excess["sqrt_ts"]).plot_grid(
+    add_cbar=True, cmap="coolwarm", vmin=-5, vmax=5
+)
 plt.show()
 
 ######################################################################
 # Combining all energies
-excess_estimator_integrated = ExcessMapEstimator(correlation_radius='0.2 deg', selection_optional = [])
+excess_estimator_integrated = ExcessMapEstimator(
+    correlation_radius="0.2 deg", selection_optional=[]
+)
 excess_integrated = excess_estimator_integrated.run(dataset)
 
-excess_integrated['sqrt_ts'].plot(add_cbar=True)
+excess_integrated["sqrt_ts"].plot(add_cbar=True)
 plt.show()
 
 

--- a/examples/tutorials/data/hawc.py
+++ b/examples/tutorials/data/hawc.py
@@ -1,0 +1,257 @@
+"""
+HAWC with Gammapy
+=====================
+Explore HAWC event lists and IRFs and perform the data reduction steps.
+
+`HAWC <https://www.hawc-observatory.org/>`__ is an array of
+water Cherenkov detectors located in Mexico that detects gamma-rays
+in the range between hundreds of GeV and hundreds of TeV.
+Gammapy recently added support of HAWC high level data analysis,
+after export to the current `open data level 3
+format <https://gamma-astro-data-formats.readthedocs.io/>`__.
+
+The HAWC data is largely private. However, in 2022, a small
+sub-set of HAWC Pass4 event lists from the Crab nebula region
+was publicly `released <https://data.hawc-observatory.org/datasets/crab_events_pass4/index.php>`__.
+This dataset is 1 GB in size, so only a subset will be used here as an example.
+
+This notebook is a quick introduction to HAWC data analysis with Gammapy.
+It briefly describes the HAWC data and how to access it, and then uses a
+subset of it to produce a MapDataset, to show how the data reduction is performed.
+
+The HAWC data release contains events where energy is estimated using
+two different algorithms, referred to as "NN" and "GP" (see this `paper <https://iopscience.iop.org/article/10.3847/1538-4357/ab2f7d>`__
+for a detailed description). These two event classes are not independent, meaning that
+events are repeated between the NN and GP datasets. So these data should never
+be analyzed jointly, and one of the two estimators needs to be chosen before
+proceeding.
+
+Once the data has been reduced to a MapDataset, there are no differences
+in the way that HAWC data is handled with respect to data from any other
+observatory, such as H.E.S.S. or CTA.
+
+
+HAWC data access and reduction
+------------------------------
+
+This is how to access data and IRFs from the HAWC Crab event data release.
+
+"""
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+import matplotlib.pyplot as plt
+import numpy as np
+from IPython.display import display
+from gammapy.datasets import MapDataset
+from gammapy.makers import MapDatasetMaker, SafeMaskMaker
+from gammapy.data import DataStore, HDUIndexTable, ObservationTable
+from gammapy.maps import Map, MapAxis, WcsGeom
+from gammapy.estimators import ExcessMapEstimator
+
+######################################################################
+# Check setup
+# -----------
+from gammapy.utils.check import check_tutorials_setup
+from gammapy.visualization import plot_theta_squared_table
+
+check_tutorials_setup()
+
+######################################################################
+# Chose which estimator we will use
+
+which = 'NN'
+
+
+######################################################################
+# A useful way to organize the relevant files are the index tables. The
+# observation index table contains information on each particular observation,
+# such as the run ID. The HDU index table has a row per
+# relevant file (i.e., events, effective area, psf…) and contains the path
+# to said file.
+# The HAWC data is divided into different event types, classified using
+# the fraction of the array that was triggered by an event, a quantity
+# usually referred to as "fHit". These event types are fully independent,
+# meaning that an event will have a unique event type identifier, which
+# is usually a number indicating which fHit bin the event corresponds to.
+# For this reason, a single HAWC observation has several HDU index tables
+# associated to it, one per event type. In each table, there will be
+# paths to a distinct event list file and IRFs.
+# In the HAWC event data release, all the HDU tables are saved into
+# the same FITS file, and can be accesses through the choice of the hdu index.
+
+
+######################################################################
+# Load the tables
+
+data_path = "$GAMMAPY_DATA/hawc/crab_events_pass4/"
+hdu_filename = 'hdu-index-table-' + which + "-Crab.fits.gz"
+obs_filename = 'obs-index-table-' + which + "-Crab.fits.gz"
+
+# there is only one observation table
+obs_table = ObservationTable.read(data_path+obs_filename)
+
+# we read the hdu index table of fHit bin number 6
+fHit = 6
+hdu_table = HDUIndexTable.read(data_path+hdu_filename, hdu=fHit)
+
+
+######################################################################
+# From the tables, we can create a Datastore
+
+data_store = DataStore( hdu_table=hdu_table, obs_table=obs_table)
+
+data_store.info()
+
+
+######################################################################
+# There is only one observation
+
+obs = data_store.get_observations()[0]
+
+######################################################################
+# Select and peek events
+
+obs.events.peek()
+
+
+######################################################################
+# Peek the energy dispersion
+
+obs.edisp.peek()
+
+######################################################################
+# Peek the psf
+obs.psf.peek()
+
+######################################################################
+# Peek the background for one transit
+plt.figure()
+obs.bkg.reduce_over_axes().plot(add_cbar=True)
+
+######################################################################
+# Peek the effective exposure for one transit
+plt.figure()
+obs.aeff.reduce_over_axes().plot(add_cbar=True)
+
+
+######################################################################
+# Data reduction into a MapDataset
+# --------------------------------
+#
+# We will now produce a MapDataset using the data from one of the
+# fHit bins. In order to use all bins, one just needs to repeat this
+# process inside of a for loop that modifies the variable fHit.
+
+
+######################################################################
+# First we define the geometry and axes
+
+# create the energy reco axis
+energy_axis = MapAxis.from_edges([1.00,1.78,3.16,5.62,10.0,17.8,31.6,56.2,100,177,316] * u.TeV,
+        name="energy",
+        interp="log")
+
+
+# and energy true axis
+energy_axis_true = MapAxis.from_energy_bounds(1e-3, 1e4, nbin=140, unit="TeV", name="energy_true")
+
+
+# create a geometry around the Crab location
+geom = WcsGeom.create(skydir=SkyCoord(ra=83.63,dec=22.01, unit='deg', frame="icrs"),
+                     width=6*u.deg,
+                     axes=[energy_axis],
+                     binsz=0.05)
+
+
+######################################################################
+# Define the makers we will use
+
+maker = MapDatasetMaker(selection = ["counts", "background", "exposure", "edisp", "psf"])
+safemask_maker = SafeMaskMaker(methods=['aeff-max'], aeff_percent=10)
+
+
+######################################################################
+# Create empty Mapdataset
+dataset_empty = MapDataset.create(geom,
+                                  energy_axis_true= energy_axis_true,
+                                  name ='fHit ' + str(fHit),
+                                  reco_psf=True )
+# run the map dataset maker
+dataset = maker.run(dataset_empty, obs)
+
+# The livetime info is used by the SafeMask maker to retrieve the
+# effective area from the exposure. The HAWC effective area is computed
+# for one source transit above 45º zenith, which is around 6h
+# Note that since the effective area condition used here is relative to
+# the maximum, this value does not actually impact the result
+dataset.exposure.meta["livetime"] = "6 h"
+dataset = safemask_maker.run(dataset)
+
+
+######################################################################
+# Now we have a dataset that has background and exposure quantities for
+# one single transit, but our dataset might comprise more. The number
+# of transits can be derived using the good time intervals (GTI) stored
+# with the event list. For convenience, the HAWC data release already
+# included this quantity as a map
+
+transit_map = Map.read(data_path + 'irfs/TransitsMap_Crab.fits.gz')
+transit_number = transit_map.get_by_coord(geom.center_skydir)
+
+# Correct the quantities
+dataset.background.data*=transit_number
+dataset.exposure.data*=transit_number
+
+
+
+
+######################################################################
+# Check the dataset we produced
+# -----------------------------
+#
+# We will now check the contents of the dataset
+
+
+######################################################################
+# We can use the .peek() method to quickly get a glimpse of the contents
+dataset.peek()
+
+
+
+######################################################################
+# And make significance maps to check that the Crab is visible
+
+excess_estimator = ExcessMapEstimator(correlation_radius='0.2 deg', selection_optional = [], energy_edges=energy_axis.edges)
+excess = excess_estimator.run(dataset)
+
+(dataset.mask*excess['sqrt_ts']).plot_grid(add_cbar=True, cmap='coolwarm', vmin=-5, vmax=5)
+plt.show()
+
+######################################################################
+# Combining all energies
+excess_estimator_integrated = ExcessMapEstimator(correlation_radius='0.2 deg', selection_optional = [])
+excess_integrated = excess_estimator_integrated.run(dataset)
+
+excess_integrated['sqrt_ts'].plot(add_cbar=True)
+plt.show()
+
+
+######################################################################
+# Exercises
+# ---------
+#
+# -  Repeat the process for a different fHit bin
+# -  Repeat the process for all the fHit bins provided in the data
+#    release and fit a model to the result.
+#
+
+
+######################################################################
+# Next steps
+# ----------
+#
+# Now you know how to access and work with HAWC data. All other
+# tutorials and documentation concerning 3D analysis and MapDatasets
+# can be used from this step.
+#

--- a/examples/tutorials/data/hess.py
+++ b/examples/tutorials/data/hess.py
@@ -74,7 +74,7 @@ data_store = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
 data_store.info()
 
 ######################################################################
-# Preview an excerpt from the observtaion table
+# Preview an excerpt from the observation table
 
 display(data_store.obs_table[:2][["OBS_ID", "DATE-OBS", "RA_PNT", "DEC_PNT", "OBJECT"]])
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -51,6 +51,7 @@ def create_map_dataset_geoms(
     migra_axis=None,
     rad_axis=None,
     binsz_irf=None,
+    reco_psf=False
 ):
     """Create map geometries for a `MapDataset`
 
@@ -84,7 +85,11 @@ def create_map_dataset_geoms(
     geom_image = geom.to_image()
     geom_exposure = geom_image.to_cube([energy_axis_true])
     geom_irf = geom_image.to_binsz(binsz=binsz_irf)
-    geom_psf = geom_irf.to_cube([rad_axis, energy_axis_true])
+
+    if reco_psf:
+        geom_psf = geom_irf.to_cube([rad_axis,geom.axes["energy"]])
+    else:
+        geom_psf = geom_irf.to_cube([rad_axis, energy_axis_true])
 
     if migra_axis:
         geom_edisp = geom_irf.to_cube([migra_axis, energy_axis_true])
@@ -588,6 +593,7 @@ class MapDataset(Dataset):
         reference_time="2000-01-01",
         name=None,
         meta_table=None,
+        reco_psf=False,
         **kwargs,
     ):
         """Create a MapDataset object with zero filled maps.
@@ -643,6 +649,7 @@ class MapDataset(Dataset):
             rad_axis=rad_axis,
             migra_axis=migra_axis,
             binsz_irf=binsz_irf,
+            reco_psf=reco_psf
         )
 
         kwargs.update(geoms)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -618,6 +618,8 @@ class MapDataset(Dataset):
         meta_table : `~astropy.table.Table`
             Table listing information on observations used to create the dataset.
             One line per observation for stacked datasets.
+        reco_psf : bool
+            Use reconstructed energy for the PSF geometry. Default is False
 
         Returns
         -------

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -68,6 +68,8 @@ def create_map_dataset_geoms(
         Rad axis for the psf map
     binsz_irf : float
         IRF Map pixel size in degrees.
+    reco_psf : bool
+        Use reconstructed energy for the PSF geometry. Default is False
 
     Returns
     -------

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -18,6 +18,7 @@ from gammapy.irf import (
     EnergyDependentMultiGaussPSF,
     EnergyDispersion2D,
     PSFMap,
+    RecoPSFMap
 )
 from gammapy.makers.utils import make_map_exposure_true_energy, make_psf_map
 from gammapy.maps import HpxGeom, Map, MapAxis, RegionGeom, WcsGeom, WcsNDMap
@@ -1873,3 +1874,7 @@ def test_peek(images):
 
     with mpl_plot_check():
         dataset.peek()
+
+def test_create_psf_reco(geom):
+    dat = MapDataset.create(geom, reco_psf=True)
+    assert isinstance(dat.psf, RecoPSFMap)

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -532,7 +532,8 @@ class PSFMap(IRFMap):
         self.plot_psf_vs_rad(ax=ax1)
 
         axes[2].set_title("Exposure")
-        self.exposure_map.reduce_over_axes().plot(ax=axes[2], add_cbar=True)
+        if self.exposure_map is not None:
+            self.exposure_map.reduce_over_axes().plot(ax=axes[2], add_cbar=True)
 
         axes[3].set_title("Containment radius at 1 TeV")
         kwargs = {self.energy_name: 1 * u.TeV}


### PR DESCRIPTION
This pull request adds a tutorial showing how to open and use the HAWC data from the public data release.

The tutorial goes slightly beyond the usual "data" tutorial by showing the data reduction because there are some subtleties that are different for HAWC.


It also adds/fixes some things that I encountered along the way, namely:

- a typo in the HESS tutorial
- the ability to `.peek()` a PSFMap when no exposure map is set
- the ability to `.create()` an empty `MapDataset` where the psf is a `RecoPSFMap`
