### PR TITLE
Serialisation of MapAxes

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -13,7 +13,7 @@ from astropy.utils import lazyproperty
 import matplotlib.pyplot as plt
 from gammapy.utils.interpolation import interpolation_scale
 from gammapy.utils.time import time_ref_from_dict, time_ref_to_dict
-from .utils import INVALID_INDEX, edges_from_lo_hi
+from .utils import INVALID_INDEX, edges_from_lo_hi, guess_axis
 
 __all__ = ["MapAxes", "MapAxis", "TimeMapAxis", "LabelMapAxis"]
 
@@ -1960,17 +1960,6 @@ class MapAxes(Sequence):
         table = Table.read(hdu)
         return cls.from_table(table, format=format)
 
-    @staticmethod
-    def _guess_axis(table, format="gadf", idx=0):
-        try:
-            axis = LabelMapAxis.from_table(table, format=format, idx=idx)
-        except (KeyError, TypeError):
-            try:
-                axis = TimeMapAxis.from_table(table, format=format, idx=idx)
-            except (KeyError, ValueError, IndexError):
-                axis = MapAxis.from_table(table, format=format, idx=idx)
-        return axis
-
     @classmethod
     def from_table(cls, table, format="gadf"):
         """Create MapAxes from table
@@ -2012,7 +2001,7 @@ class MapAxes(Sequence):
                     log.info(
                         "Node type information not present in axis {idx+1}. Guessing axis type"
                     )
-                    axis = cls._guess_axis(table, format=format, idx=idx)
+                    axis = guess_axis(table, format=format, idx=idx)
                 elif node_type == "label":
                     axis = LabelMapAxis.from_table(table, format=format, idx=idx)
                 elif node_type == "intervals":

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1109,7 +1109,7 @@ class MapAxis:
 
             key_interp = f"INTERP{idx}"
             header[key_interp] = self.interp
-            key_node = f"NODE{idx}"
+            key_node = f"AXNODE{idx}"
             header[key_node] = self.node_type
 
         else:
@@ -1996,7 +1996,7 @@ class MapAxes(Sequence):
                 if axcols is None:
                     break
 
-                node_type = table.meta.get("NODE{}".format(idx + 1))
+                node_type = table.meta.get("AXNODE{}".format(idx + 1))
                 if node_type is None:
                     log.info(
                         "Node type information not present in axis {idx+1}. Guessing axis type"
@@ -2007,7 +2007,7 @@ class MapAxes(Sequence):
                 elif node_type == "intervals":
                     axis = TimeMapAxis.from_table(table, format=format, idx=idx)
                 elif node_type == "edges" or node_type == "center":
-                    axis = LabelMapAxis.from_table(table, format=format, idx=idx)
+                    axis = MapAxis.from_table(table, format=format, idx=idx)
                 else:
                     raise ValueError(f"Invalid node type for axis {idx + 1}")
                 axes.append(axis)
@@ -2812,7 +2812,7 @@ class TimeMapAxis:
             header[key] = f"{name}_MIN,{name}_MAX"
             key_interp = f"INTERP{idx}"
             header[key_interp] = self.interp
-            key_node = f"NODE{idx}"
+            key_node = f"AXNODE{idx}"
             header[key_node] = self.node_type
 
             ref_dict = time_ref_to_dict(self.reference_time)
@@ -3042,7 +3042,7 @@ class LabelMapAxis:
         if format == "gadf":
             key = f"AXCOLS{idx}"
             header[key] = self.name.upper()
-            key_node = f"NODE{idx}"
+            key_node = f"AXNODE{idx}"
             header[key_node] = self.node_type
         else:
             raise ValueError(f"Unknown format {format}")

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1998,8 +1998,8 @@ class MapAxes(Sequence):
 
                 node_type = table.meta.get("AXNODE{}".format(idx + 1))
                 if node_type is None:
-                    log.info(
-                        "Node type information not present in axis {idx+1}. Guessing axis type"
+                    log.warning(
+                        f"Node type information not present in axis {str(idx + 1)}. Guessing axis type"
                     )
                     axis = guess_axis(table, format=format, idx=idx)
                 elif node_type == "label":
@@ -2009,7 +2009,7 @@ class MapAxes(Sequence):
                 elif node_type == "edges" or node_type == "center":
                     axis = MapAxis.from_table(table, format=format, idx=idx)
                 else:
-                    raise ValueError(f"Invalid node type for axis {idx + 1}")
+                    raise ValueError(f"Invalid node type for axis {str(idx + 1)}")
                 axes.append(axis)
         elif format == "gadf-dl3":
             for column_prefix in IRF_DL3_AXES_SPECIFICATION:

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -829,11 +829,18 @@ def test_label_map_axis_squash():
 
 def test_axis_from_table():
     ax1 = LabelMapAxis(["a", "b", "c"], name="Letters")
-    ax2 = TimeMapAxis
-    ax3 = MapAxis
-    ax4 = MapAxis
+    ax2 = TimeMapAxis(
+        edges_min=[1, 10] * u.day,
+        edges_max=[2, 13] * u.day,
+        reference_time=Time("2020-03-19"),
+    )
+    ax3 = MapAxis.from_nodes([0, 1, 3, 7], name="ax3", interp="lin")
+    ax4 = MapAxis.from_edges([0, 1, 3, 7], name="ax4", interp="log")
 
     axes = MapAxes([ax1, ax2, ax3, ax4])
-    table = axes.to_table()
-    table.meta
+    table_hdu = axes.to_table_hdu()
+
+    assert table_hdu.header["AXNODE2"] == "intervals"
+    assert table_hdu.header["AXNODE4"] == "edges"
+
     # without node type info present

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -825,3 +825,15 @@ def test_label_map_axis_squash():
 
     assert squash_label.nbin == 1
     assert_equal(squash_label.center, np.array(["a...c"]))
+
+
+def test_axis_from_table():
+    ax1 = LabelMapAxis(["a", "b", "c"], name="Letters")
+    ax2 = TimeMapAxis
+    ax3 = MapAxis
+    ax4 = MapAxis
+
+    axes = MapAxes([ax1, ax2, ax3, ax4])
+    table = axes.to_table()
+    table.meta
+    # without node type info present

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -96,3 +96,17 @@ def edges_from_lo_hi(edges_lo, edges_hi):
     except AttributeError:
         edges = np.insert(edges, len(edges), edges_hi[-1])
     return edges
+
+
+def guess_axis(table, format="gadf", idx=0):
+    """Create Axis from a table"""
+    from gammapy.maps import LabelMapAxis, MapAxis, TimeMapAxis
+
+    try:
+        axis = LabelMapAxis.from_table(table, format=format, idx=idx)
+    except (KeyError, TypeError):
+        try:
+            axis = TimeMapAxis.from_table(table, format=format, idx=idx)
+        except (KeyError, ValueError, IndexError):
+            axis = MapAxis.from_table(table, format=format, idx=idx)
+    return axis


### PR DESCRIPTION
In the present version, `MapAxes.from_table_hdu()` tries to instantiate different axes, and keeps the one which does not fail https://github.com/gammapy/gammapy/blob/d98b5b2b547a87270ead6d13c99359fba8d2da94/gammapy/maps/axes.py#L1997

This is annoying, see: https://github.com/gammapy/gammapy/blob/18c2597f23816f465189f6dde4e6e75fd9e50fe6/gammapy/modeling/models/temporal.py#L595

This PR introduces a AXNODE keyword in the header, and the axis type is chosen accordingly. For older files, the guess work still remains.

In a broader context, we should decide on the `to_table` and `from_table` behaviour of the map classes in general, eg

1. The arguments in to and from table are not always the same (eg: `RegionNDMap`)
2. Support of the `ogip` format. (Its the default in `MapAxis.to_table`, why?)