### PR TITLE
Set a default Xmax for plot_offset2_distribution

### DIFF
--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -552,9 +552,11 @@ class EventList:
             center = self._plot_center
 
         offset2 = center.separation(self.radec) ** 2
+        max2 = np.percentile(offset2, q=98)
 
         kwargs.setdefault("histtype", "step")
         kwargs.setdefault("bins", 30)
+        kwargs.setdefault("range", (0.0, max2.value))
 
         with quantity_support():
             ax.hist(offset2, **kwargs)

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -489,7 +489,9 @@ class EventList:
 
         return ax
 
-    def plot_offset2_distribution(self, ax=None, center=None, **kwargs):
+    def plot_offset2_distribution(
+        self, ax=None, center=None, max_percentile=98, **kwargs
+    ):
         """Plot offset^2 distribution of the events.
 
         The distribution shown in this plot is for this quantity::
@@ -513,6 +515,8 @@ class EventList:
         center : `astropy.coordinates.SkyCoord`
             Center position for the offset^2 distribution.
             Default is the observation pointing position.
+        max_percentile : float
+            Define the percentile of the offset^2 distribution used to define the maximum offset^2 value.
         **kwargs :
             Extra keyword arguments are passed to `~matplotlib.pyplot.hist`.
 
@@ -552,7 +556,7 @@ class EventList:
             center = self._plot_center
 
         offset2 = center.separation(self.radec) ** 2
-        max2 = np.percentile(offset2, q=98)
+        max2 = np.percentile(offset2, q=max_percentile)
 
         kwargs.setdefault("histtype", "step")
         kwargs.setdefault("bins", 30)


### PR DESCRIPTION
**Description**

This pull request fixes the fact that the event.peek shows an Offset distribution with only 1 bin:

![Capture d’écran du 2023-04-18 17-19-27](https://user-images.githubusercontent.com/16781593/232826981-797bd328-88c4-4cc7-90d2-f24992711a02.png)

This is due to badly reconstructed events at very large offset.

**Dear reviewer**
In this PR, I set a default xmax to the histogram (98% quantile). 

The issue of the latex rendering will be fixed in the PR #4428 .
