### PR TITLE
Suppress some matplotlib outputs in tutorials

### DIFF
--- a/examples/tutorials/analysis-1d/cta_sensitivity.py
+++ b/examples/tutorials/analysis-1d/cta_sensitivity.py
@@ -179,7 +179,8 @@ ax.plot(
 ax.loglog()
 ax.set_xlabel(f"Energy [{t['e_ref'].unit.to_string(UNIT_STRING_FORMAT)}]")
 ax.set_ylabel(f"Sensitivity [{t['e2dnde'].unit.to_string(UNIT_STRING_FORMAT)}]")
-ax.legend();
+ax.legend()
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/analysis-1d/cta_sensitivity.py
+++ b/examples/tutorials/analysis-1d/cta_sensitivity.py
@@ -179,7 +179,7 @@ ax.plot(
 ax.loglog()
 ax.set_xlabel(f"Energy [{t['e_ref'].unit.to_string(UNIT_STRING_FORMAT)}]")
 ax.set_ylabel(f"Sensitivity [{t['e2dnde'].unit.to_string(UNIT_STRING_FORMAT)}]")
-ax.legend()
+ax.legend();
 
 
 ######################################################################

--- a/examples/tutorials/analysis-1d/extended_source_spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/extended_source_spectral_analysis.py
@@ -284,7 +284,7 @@ ax_sqrt_ts.plot(
 
 ax_sqrt_ts.set_title("Sqrt(TS)")
 ax_sqrt_ts.set_xlabel("Livetime [h]")
-ax_sqrt_ts.set_ylabel("Sqrt(TS)")
+ax_sqrt_ts.set_ylabel("Sqrt(TS)");
 
 
 ######################################################################

--- a/examples/tutorials/analysis-1d/extended_source_spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/extended_source_spectral_analysis.py
@@ -17,9 +17,9 @@ Context
 
 Many VHE sources in the Galaxy are extended. Studying them with a 1D
 spectral analysis is more complex than studying point sources. One often
-has to use complex (i.e. non circular) regions and more importantly, one
-has to take into account the fact that the instrument response is non
-uniform over the selectred region. A typical example is given by the
+has to use complex (i.e. non-circular) regions and more importantly, one
+has to take into account the fact that the instrument response is non-uniform
+over the selected region. A typical example is given by the
 supernova remnant RX J1713-3935 which is nearly 1 degree in diameter.
 See the `following
 article <https://ui.adsabs.harvard.edu/abs/2018A%26A...612A...6H/abstract>`__.
@@ -36,7 +36,7 @@ tutorial) that Gammapy uses specific
 datasets makers to first produce reduced spectral data and then to
 extract OFF measurements with reflected background techniques: the
 `~gammapy.makers.SpectrumDatasetMaker` and the
-`~gammapy.makers.ReflectedRegionsBackgroundMaker`. However if the flag
+`~gammapy.makers.ReflectedRegionsBackgroundMaker`. However, if the flag
 `use_region_center` is not set to `False`, the former simply
 computes the reduced IRFs at the center of the ON region (assumed to be
 circular).
@@ -47,12 +47,12 @@ average responses in the ON region, we can set
 `~gammapy.makers.SpectrumDatasetMaker`, in which case the values of
 the IRFs are averaged over the entire region.
 
-In summary we have to:
+In summary, we have to:
 
 -  Define an ON region (a `~regions.SkyRegion`) fully enclosing the
    source we want to study.
 -  Define a `~gammapy.maps.RegionGeom` with the ON region and the
-   required energy range (beware in particular, the true energy range).
+   required energy range (in particular, beware of the true energy range).
 -  Create the necessary makers :
 
    -  the spectrum dataset maker :
@@ -246,6 +246,7 @@ display(datasets.meta_table)
 #
 
 datasets[0].peek()
+plt.show()
 
 
 ######################################################################
@@ -284,7 +285,8 @@ ax_sqrt_ts.plot(
 
 ax_sqrt_ts.set_title("Sqrt(TS)")
 ax_sqrt_ts.set_xlabel("Livetime [h]")
-ax_sqrt_ts.set_ylabel("Sqrt(TS)");
+ax_sqrt_ts.set_ylabel("Sqrt(TS)")
+plt.show()
 
 
 ######################################################################
@@ -332,11 +334,11 @@ display(datasets.models.to_parameters_table())
 
 # First stack them all
 reduced = datasets.stack_reduce()
+
 # Assign the fitted model
 reduced.models = model
-# Plot the result
 
-plt.figure()
+# Plot the result
 ax_spectrum, ax_residuals = reduced.plot_fit()
 reduced.plot_masks(ax=ax_spectrum)
 plt.show()

--- a/examples/tutorials/analysis-1d/sed_fitting.py
+++ b/examples/tutorials/analysis-1d/sed_fitting.py
@@ -29,7 +29,7 @@ Proposed approach
 
 Here we will load, the spectral points from Fermi-LAT and TeV catalogs
 and fit them with various spectral models to find the best
-representation of the wide band spectrum.
+representation of the wide-band spectrum.
 
 The central class we’re going to use for this example analysis is:
 

--- a/examples/tutorials/analysis-1d/spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis.py
@@ -148,7 +148,7 @@ check_tutorials_setup()
 # (simulated events for now).
 #
 # We will access the events, effective area, energy dispersion, livetime
-# and PSF for containement correction.
+# and PSF for containment correction.
 #
 
 datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
@@ -195,7 +195,8 @@ geom = WcsGeom.create(
 )
 
 exclusion_mask = ~geom.region_mask([exclusion_region])
-exclusion_mask.plot();
+exclusion_mask.plot()
+plt.show()
 
 
 ######################################################################
@@ -240,7 +241,8 @@ print(datasets)
 plt.figure()
 ax = exclusion_mask.plot()
 on_region.to_pixel(ax.wcs).plot(ax=ax, edgecolor="k")
-plot_spectrum_datasets_off_regions(ax=ax, datasets=datasets);
+plot_spectrum_datasets_off_regions(ax=ax, datasets=datasets)
+plt.show()
 
 
 ######################################################################
@@ -256,7 +258,7 @@ info_table = datasets.info_table(cumulative=True)
 display(info_table)
 
 ######################################################################
-# And make the correpsonding plots
+# And make the corresponding plots
 
 fig, (ax_excess, ax_sqrt_ts) = plt.subplots(figsize=(10, 4), ncols=2, nrows=1)
 ax_excess.plot(
@@ -279,7 +281,8 @@ ax_sqrt_ts.plot(
 
 ax_sqrt_ts.set_title("Sqrt(TS)")
 ax_sqrt_ts.set_xlabel("Livetime [h]")
-ax_sqrt_ts.set_ylabel("Sqrt(TS)");
+ax_sqrt_ts.set_ylabel("Sqrt(TS)")
+plt.show()
 
 
 ######################################################################
@@ -359,10 +362,10 @@ display(result_joint.models.to_parameters_table())
 # `~SpectrumDataset.plot_fit()`
 #
 
-plt.figure()
 ax_spectrum, ax_residuals = datasets[0].plot_fit()
 ax_spectrum.set_ylim(0.1, 40)
-datasets[0].plot_masks(ax=ax_spectrum);
+datasets[0].plot_masks(ax=ax_spectrum)
+plt.show()
 
 
 ######################################################################
@@ -410,7 +413,8 @@ display(flux_points.to_table(sed_type="dnde", formatted=True))
 
 fig, ax = plt.subplots()
 flux_points.plot(ax=ax, sed_type="e2dnde", color="darkorange")
-flux_points.plot_ts_profiles(ax=ax, sed_type="e2dnde");
+flux_points.plot_ts_profiles(ax=ax, sed_type="e2dnde")
+plt.show()
 
 
 ######################################################################
@@ -419,7 +423,8 @@ flux_points.plot_ts_profiles(ax=ax, sed_type="e2dnde");
 #
 
 flux_points_dataset = FluxPointsDataset(data=flux_points, models=model_best_joint)
-flux_points_dataset.plot_fit();
+flux_points_dataset.plot_fit()
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/analysis-1d/spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis.py
@@ -195,7 +195,7 @@ geom = WcsGeom.create(
 )
 
 exclusion_mask = ~geom.region_mask([exclusion_region])
-exclusion_mask.plot()
+exclusion_mask.plot();
 
 
 ######################################################################
@@ -240,7 +240,7 @@ print(datasets)
 plt.figure()
 ax = exclusion_mask.plot()
 on_region.to_pixel(ax.wcs).plot(ax=ax, edgecolor="k")
-plot_spectrum_datasets_off_regions(ax=ax, datasets=datasets)
+plot_spectrum_datasets_off_regions(ax=ax, datasets=datasets);
 
 
 ######################################################################
@@ -279,7 +279,7 @@ ax_sqrt_ts.plot(
 
 ax_sqrt_ts.set_title("Sqrt(TS)")
 ax_sqrt_ts.set_xlabel("Livetime [h]")
-ax_sqrt_ts.set_ylabel("Sqrt(TS)")
+ax_sqrt_ts.set_ylabel("Sqrt(TS)");
 
 
 ######################################################################
@@ -362,7 +362,7 @@ display(result_joint.models.to_parameters_table())
 plt.figure()
 ax_spectrum, ax_residuals = datasets[0].plot_fit()
 ax_spectrum.set_ylim(0.1, 40)
-datasets[0].plot_masks(ax=ax_spectrum)
+datasets[0].plot_masks(ax=ax_spectrum);
 
 
 ######################################################################
@@ -410,7 +410,7 @@ display(flux_points.to_table(sed_type="dnde", formatted=True))
 
 fig, ax = plt.subplots()
 flux_points.plot(ax=ax, sed_type="e2dnde", color="darkorange")
-flux_points.plot_ts_profiles(ax=ax, sed_type="e2dnde")
+flux_points.plot_ts_profiles(ax=ax, sed_type="e2dnde");
 
 
 ######################################################################
@@ -419,7 +419,7 @@ flux_points.plot_ts_profiles(ax=ax, sed_type="e2dnde")
 #
 
 flux_points_dataset = FluxPointsDataset(data=flux_points, models=model_best_joint)
-flux_points_dataset.plot_fit()
+flux_points_dataset.plot_fit();
 
 
 ######################################################################

--- a/examples/tutorials/analysis-1d/spectral_analysis_hli.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_hli.py
@@ -90,7 +90,7 @@ check_tutorials_setup()
 #
 # For configuration of the analysis we use the
 # `YAML <https://en.wikipedia.org/wiki/YAML>`__ data format. YAML is a
-# machine readable serialisation format, that is also friendly for humans
+# machine-readable serialisation format, that is also friendly for humans
 # to read. In this tutorial we will write the configuration file just
 # using Python strings, but of course the file can be created and modified
 # with any text editor of your choice.
@@ -151,7 +151,7 @@ print(config)
 # degrees of the Crab nebula. Parameters can be set directly or as a
 # python dict.
 #
-# PS: do not forget to setup your environment variable *$GAMMAPY_DATA* to
+# PS: do not forget to set up your environment variable *$GAMMAPY_DATA* to
 # your local directory containing the H.E.S.S. DL3-DR1 as described in
 # :ref:`quickstart-setup`.
 #
@@ -396,7 +396,8 @@ ax_spectrum, ax_residuals = analysis.datasets[0].plot_fit()
 ax_spectrum.set_ylim(0.1, 200)
 ax_spectrum.set_xlim(0.2, 60)
 ax_residuals.set_xlim(0.2, 60)
-analysis.datasets[0].plot_masks(ax=ax_spectrum);
+analysis.datasets[0].plot_masks(ax=ax_spectrum)
+plt.show()
 
 
 ######################################################################
@@ -438,7 +439,8 @@ fig, ax_sed = plt.subplots()
 crab_fp.plot(ax=ax_sed, sed_type="e2dnde", color="darkorange")
 ax_sed.set_ylim(1.0e-12, 2.0e-10)
 ax_sed.set_xlim(0.5, 40)
-crab_fp.plot_ts_profiles(ax=ax_sed, sed_type="e2dnde");
+crab_fp.plot_ts_profiles(ax=ax_sed, sed_type="e2dnde")
+plt.show()
 
 
 ######################################################################
@@ -477,6 +479,6 @@ plt.show()
 # You can look at the same analysis without the high level interface in
 # :doc:`/tutorials/analysis-1d/spectral_analysis`
 #
-# As we can store the best model fit, you can overlaid the fit results of
-# both methods on an unique plot.
+# As we can store the best model fit, you can overlay the fit results of
+# both methods on a unique plot.
 #

--- a/examples/tutorials/analysis-1d/spectral_analysis_hli.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_hli.py
@@ -396,7 +396,7 @@ ax_spectrum, ax_residuals = analysis.datasets[0].plot_fit()
 ax_spectrum.set_ylim(0.1, 200)
 ax_spectrum.set_xlim(0.2, 60)
 ax_residuals.set_xlim(0.2, 60)
-analysis.datasets[0].plot_masks(ax=ax_spectrum)
+analysis.datasets[0].plot_masks(ax=ax_spectrum);
 
 
 ######################################################################
@@ -438,7 +438,7 @@ fig, ax_sed = plt.subplots()
 crab_fp.plot(ax=ax_sed, sed_type="e2dnde", color="darkorange")
 ax_sed.set_ylim(1.0e-12, 2.0e-10)
 ax_sed.set_xlim(0.5, 40)
-crab_fp.plot_ts_profiles(ax=ax_sed, sed_type="e2dnde")
+crab_fp.plot_ts_profiles(ax=ax_sed, sed_type="e2dnde");
 
 
 ######################################################################

--- a/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
@@ -20,7 +20,7 @@ Context
 -------
 
 As already explained in the :doc:`/tutorials/analysis-1d/spectral_analysis`
-tutorial, the background is estimated fromthe field of view of the observation.
+tutorial, the background is estimated from the field of view of the observation.
 In particular, the source and background events are counted within a circular 
 ON region enclosing the source. The background to be subtracted is then estimated
 from one or more OFF regions with an expected background rate similar to the one
@@ -167,7 +167,8 @@ print(rad_max)
 #
 
 fig, ax = plt.subplots()
-rad_max.plot_rad_max_vs_energy(ax=ax);
+rad_max.plot_rad_max_vs_energy(ax=ax)
+plt.show()
 
 
 ######################################################################
@@ -248,10 +249,10 @@ for observation in observations:
 # map:
 #
 
-plt.figure()
 ax = counts.plot(cmap="viridis")
 geom.plot_region(ax=ax, kwargs_point={"color": "k", "marker": "*"})
-plot_spectrum_datasets_off_regions(ax=ax, datasets=datasets);
+plot_spectrum_datasets_off_regions(ax=ax, datasets=datasets)
+plt.show()
 
 
 ######################################################################
@@ -311,7 +312,8 @@ display(datasets.models.to_parameters_table())
 # `~SpectrumDataset.plot_fit()`
 #
 ax_spectrum, ax_residuals = datasets[0].plot_fit()
-ax_spectrum.set_ylim(0.1, 120);
+ax_spectrum.set_ylim(0.1, 120)
+plt.show()
 
 
 ######################################################################
@@ -356,7 +358,8 @@ plt.show()
 #
 # A common way to check if a fit is biased is to simulate multiple datasets with
 # the obtained best fit model, and check the distribution of the fitted parameters.
-# Here, we show how to perform one such simulation assuming the measured off counts provide a good distribution of the background.
+# Here, we show how to perform one such simulation assuming the measured off counts
+# provide a good distribution of the background.
 #
 
 dataset_simulated = datasets.stack_reduce().copy(name="simulated_ds")
@@ -365,7 +368,6 @@ dataset_simulated.models = simulated_model
 dataset_simulated.fake(
     npred_background=dataset_simulated.counts_off * dataset_simulated.alpha
 )
-plt.figure()
 dataset_simulated.peek()
 plt.show()
 

--- a/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
@@ -167,7 +167,7 @@ print(rad_max)
 #
 
 fig, ax = plt.subplots()
-rad_max.plot_rad_max_vs_energy(ax=ax)
+rad_max.plot_rad_max_vs_energy(ax=ax);
 
 
 ######################################################################
@@ -251,7 +251,7 @@ for observation in observations:
 plt.figure()
 ax = counts.plot(cmap="viridis")
 geom.plot_region(ax=ax, kwargs_point={"color": "k", "marker": "*"})
-plot_spectrum_datasets_off_regions(ax=ax, datasets=datasets)
+plot_spectrum_datasets_off_regions(ax=ax, datasets=datasets);
 
 
 ######################################################################
@@ -311,7 +311,7 @@ display(datasets.models.to_parameters_table())
 # `~SpectrumDataset.plot_fit()`
 #
 ax_spectrum, ax_residuals = datasets[0].plot_fit()
-ax_spectrum.set_ylim(0.1, 120)
+ax_spectrum.set_ylim(0.1, 120);
 
 
 ######################################################################

--- a/examples/tutorials/analysis-1d/spectrum_simulation.py
+++ b/examples/tutorials/analysis-1d/spectrum_simulation.py
@@ -84,7 +84,7 @@ check_tutorials_setup()
 # the livetime, the offset, the assumed integration radius, the energy
 # range to perform the simulation for and the choice of spectral model. We
 # then use an in-memory observation which is convolved with the IRFs to
-# get the predicted number of counts. This is Poission fluctuated using
+# get the predicted number of counts. This is Poisson fluctuated using
 # the `fake()` to get the simulated counts for each observation.
 #
 
@@ -119,7 +119,7 @@ model = SkyModel(spectral_model=model_simu, name="source")
 
 ######################################################################
 # Load the IRFs
-# In this simulation, we use the CTA-1DC irfs shipped with gammapy.
+# In this simulation, we use the CTA-1DC IRFs shipped with Gammapy.
 irfs = load_irf_dict_from_file(
     "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
@@ -208,7 +208,8 @@ axes[0].set_xlabel("Counts")
 axes[1].hist(table["counts_off"])
 axes[1].set_xlabel("Counts Off")
 axes[2].hist(table["excess"])
-axes[2].set_xlabel("excess");
+axes[2].set_xlabel("excess")
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/analysis-1d/spectrum_simulation.py
+++ b/examples/tutorials/analysis-1d/spectrum_simulation.py
@@ -208,7 +208,7 @@ axes[0].set_xlabel("Counts")
 axes[1].hist(table["counts_off"])
 axes[1].set_xlabel("Counts Off")
 axes[2].hist(table["excess"])
-axes[2].set_xlabel("excess")
+axes[2].set_xlabel("excess");
 
 
 ######################################################################

--- a/examples/tutorials/analysis-2d/detect.py
+++ b/examples/tutorials/analysis-2d/detect.py
@@ -123,7 +123,8 @@ smooth = ASmoothMapEstimator(threshold=3, scales=scales, energy_edges=[10, 500] 
 images = smooth.run(dataset)
 
 plt.figure(figsize=(9, 5))
-images["flux"].plot(add_cbar=True, stretch="asinh");
+images["flux"].plot(add_cbar=True, stretch="asinh")
+plt.show()
 
 
 ######################################################################
@@ -176,7 +177,8 @@ ax1.set_title("Significance map")
 maps["flux"].plot(ax=ax2, add_cbar=True, stretch="sqrt", vmin=0)
 ax2.set_title("Flux map")
 maps["niter"].plot(ax=ax3, add_cbar=True)
-ax3.set_title("Iteration map");
+ax3.set_title("Iteration map")
+plt.show()
 
 ######################################################################
 # Source candidates

--- a/examples/tutorials/analysis-2d/detect.py
+++ b/examples/tutorials/analysis-2d/detect.py
@@ -123,7 +123,7 @@ smooth = ASmoothMapEstimator(threshold=3, scales=scales, energy_edges=[10, 500] 
 images = smooth.run(dataset)
 
 plt.figure(figsize=(9, 5))
-images["flux"].plot(add_cbar=True, stretch="asinh")
+images["flux"].plot(add_cbar=True, stretch="asinh");
 
 
 ######################################################################
@@ -176,7 +176,7 @@ ax1.set_title("Significance map")
 maps["flux"].plot(ax=ax2, add_cbar=True, stretch="sqrt", vmin=0)
 ax2.set_title("Flux map")
 maps["niter"].plot(ax=ax3, add_cbar=True)
-ax3.set_title("Iteration map")
+ax3.set_title("Iteration map");
 
 ######################################################################
 # Source candidates

--- a/examples/tutorials/analysis-2d/modeling_2D.py
+++ b/examples/tutorials/analysis-2d/modeling_2D.py
@@ -143,7 +143,7 @@ print(analysis.datasets["stacked"].exposure)
 # We can have a quick look of these maps in the following way:
 #
 
-analysis.datasets["stacked"].counts.reduce_over_axes().plot(vmax=10, add_cbar=True)
+analysis.datasets["stacked"].counts.reduce_over_axes().plot(vmax=10, add_cbar=True);
 
 
 ######################################################################

--- a/examples/tutorials/analysis-2d/modeling_2D.py
+++ b/examples/tutorials/analysis-2d/modeling_2D.py
@@ -7,7 +7,7 @@ Source modelling and fitting in stacked observations using the high level interf
 Prerequisites
 -------------
 
--  To understand how a generel modelling and fiiting works in gammapy,
+-  To understand how a general modelling and fitting works in gammapy,
    please refer to the :doc:`/tutorials/analysis-3d/analysis_3d` tutorial.
 
 Context
@@ -143,7 +143,8 @@ print(analysis.datasets["stacked"].exposure)
 # We can have a quick look of these maps in the following way:
 #
 
-analysis.datasets["stacked"].counts.reduce_over_axes().plot(vmax=10, add_cbar=True);
+analysis.datasets["stacked"].counts.reduce_over_axes().plot(vmax=10, add_cbar=True)
+plt.show()
 
 
 ######################################################################
@@ -204,4 +205,3 @@ analysis.run_fit()
 
 # To see the best fit values along with the errors
 display(analysis.models.to_parameters_table())
-plt.show()

--- a/examples/tutorials/analysis-2d/ring_background.py
+++ b/examples/tutorials/analysis-2d/ring_background.py
@@ -172,7 +172,7 @@ geom_image = geom.to_image().to_cube([energy_axis.squash()])
 # Make the exclusion mask
 regions = CircleSkyRegion(center=source_pos, radius=0.3 * u.deg)
 exclusion_mask = ~geom_image.region_mask([regions])
-exclusion_mask.sum_over_axes().plot()
+exclusion_mask.sum_over_axes().plot();
 
 
 ######################################################################
@@ -243,7 +243,7 @@ ax1.set_title("Significance map")
 significance_map.plot(ax=ax1, add_cbar=True)
 
 ax2.set_title("Excess map")
-excess_map.plot(ax=ax2, add_cbar=True)
+excess_map.plot(ax=ax2, add_cbar=True);
 
 
 ######################################################################

--- a/examples/tutorials/analysis-2d/ring_background.py
+++ b/examples/tutorials/analysis-2d/ring_background.py
@@ -150,7 +150,7 @@ analysis.get_datasets()
 # ------------------------------
 #
 # Since the ring background is extracted from real off events, we need to
-# use the wstat statistics in this case. For this, we will use the
+# use the Wstat statistics in this case. For this, we will use the
 # `MapDatasetOnOFF` and the `RingBackgroundMaker` classes.
 #
 
@@ -172,7 +172,8 @@ geom_image = geom.to_image().to_cube([energy_axis.squash()])
 # Make the exclusion mask
 regions = CircleSkyRegion(center=source_pos, radius=0.3 * u.deg)
 exclusion_mask = ~geom_image.region_mask([regions])
-exclusion_mask.sum_over_axes().plot();
+exclusion_mask.sum_over_axes().plot()
+plt.show()
 
 
 ######################################################################
@@ -243,11 +244,12 @@ ax1.set_title("Significance map")
 significance_map.plot(ax=ax1, add_cbar=True)
 
 ax2.set_title("Excess map")
-excess_map.plot(ax=ax2, add_cbar=True);
+excess_map.plot(ax=ax2, add_cbar=True)
+plt.show()
 
 
 ######################################################################
-# It is often important to look at the signficance distribution outside
+# It is often important to look at the significance distribution outside
 # the exclusion region to check that the background estimation is not
 # contaminated by gamma-ray events. This can be the case when exclusion
 # regions are not large enough. Typically, we expect the off distribution

--- a/examples/tutorials/analysis-3d/analysis_3d.py
+++ b/examples/tutorials/analysis-3d/analysis_3d.py
@@ -4,7 +4,7 @@
 
 Perform detailed 3D stacked and joint analysis.
 
-This tutorial does a 3D map based analsis on the galactic center, using
+This tutorial does a 3D map based analysis on the galactic center, using
 simulated observations from the CTA-1DC. We will use the high level
 interface for the data reduction, and then do a detailed modelling. This
 will be done in two different ways:
@@ -148,24 +148,28 @@ print(dataset_stacked)
 #
 
 dataset_stacked.counts.smooth(0.02 * u.deg).plot_interactive(add_cbar=True)
+plt.show()
 
 ######################################################################
 # And the background map
 #
 
 dataset_stacked.background.plot_interactive(add_cbar=True)
+plt.show()
 
 ######################################################################
 # We can quickly check the PSF
 #
 
 dataset_stacked.psf.peek()
+plt.show()
 
 ######################################################################
 # And the energy dispersion in the center of the map
 #
 
 dataset_stacked.edisp.peek()
+plt.show()
 
 ######################################################################
 # You can also get an excess image with a few lines of code:
@@ -173,7 +177,7 @@ dataset_stacked.edisp.peek()
 
 excess = dataset_stacked.excess.sum_over_axes()
 excess.smooth("0.06 deg").plot(stretch="sqrt", add_cbar=True)
-
+plt.show()
 
 ######################################################################
 # Modeling and fitting
@@ -259,6 +263,7 @@ display(models_stacked.to_parameters_table())
 # plot):
 #
 dataset_stacked.plot_residuals_spatial(method="diff/sqrt(model)", vmin=-1, vmax=1)
+plt.show()
 
 
 ######################################################################
@@ -271,6 +276,7 @@ dataset_stacked.plot_residuals(
     kwargs_spatial=dict(method="diff/sqrt(model)", vmin=-1, vmax=1),
     kwargs_spectral=dict(region=region),
 )
+plt.show()
 
 
 ######################################################################
@@ -294,6 +300,7 @@ result = estimator.run(dataset_stacked)
 result["sqrt_ts"].plot_grid(
     figsize=(12, 4), cmap="coolwarm", add_cbar=True, vmin=-5, vmax=5, ncols=2
 )
+plt.show()
 
 
 ######################################################################
@@ -322,6 +329,7 @@ ax.plot(
 )
 ax.legend(fontsize=17)
 ax.set_xlim(-5, 5)
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/analysis-3d/analysis_mwl.py
+++ b/examples/tutorials/analysis-3d/analysis_mwl.py
@@ -74,7 +74,7 @@ check_tutorials_setup()
 # ---------------------
 #
 # The datasets serialization produce YAML files listing the datasets and
-# models. In the following cells we show an example containning only the
+# models. In the following cells we show an example containing only the
 # Fermi-LAT dataset and the Crab model.
 #
 # Fermi-LAT-3FHL_datasets.yaml:

--- a/examples/tutorials/analysis-3d/cta_data_analysis.py
+++ b/examples/tutorials/analysis-3d/cta_data_analysis.py
@@ -163,7 +163,7 @@ ax2.set_title("Background map")
 dataset_image.background.plot(ax=ax2, vmax=5)
 
 ax3.set_title("Excess map")
-dataset_image.excess.smooth(3).plot(ax=ax3, vmax=2)
+dataset_image.excess.smooth(3).plot(ax=ax3, vmax=2);
 
 
 ######################################################################
@@ -219,7 +219,7 @@ ax.scatter(
     marker="o",
     s=200,
     lw=1.5,
-)
+);
 
 
 ######################################################################
@@ -245,7 +245,7 @@ on_region = CircleSkyRegion(center=target_position, radius=on_radius)
 
 exclusion_mask = ~geom.to_image().region_mask([on_region])
 plt.figure()
-exclusion_mask.plot()
+exclusion_mask.plot();
 
 ######################################################################
 # Configure spectral analysis
@@ -285,7 +285,7 @@ plt.figure(figsize=(8, 6))
 ax = dataset_image.counts.smooth("0.03 deg").plot(vmax=8)
 
 on_region.to_pixel(ax.wcs).plot(ax=ax, edgecolor="white")
-plot_spectrum_datasets_off_regions(datasets, ax=ax)
+plot_spectrum_datasets_off_regions(datasets, ax=ax);
 
 
 ######################################################################

--- a/examples/tutorials/analysis-3d/cta_data_analysis.py
+++ b/examples/tutorials/analysis-3d/cta_data_analysis.py
@@ -163,7 +163,8 @@ ax2.set_title("Background map")
 dataset_image.background.plot(ax=ax2, vmax=5)
 
 ax3.set_title("Excess map")
-dataset_image.excess.smooth(3).plot(ax=ax3, vmax=2);
+dataset_image.excess.smooth(3).plot(ax=ax3, vmax=2)
+plt.show()
 
 
 ######################################################################
@@ -219,7 +220,8 @@ ax.scatter(
     marker="o",
     s=200,
     lw=1.5,
-);
+)
+plt.show()
 
 
 ######################################################################
@@ -244,8 +246,8 @@ on_radius = 0.2 * u.deg
 on_region = CircleSkyRegion(center=target_position, radius=on_radius)
 
 exclusion_mask = ~geom.to_image().region_mask([on_region])
-plt.figure()
-exclusion_mask.plot();
+exclusion_mask.plot()
+plt.show()
 
 ######################################################################
 # Configure spectral analysis
@@ -285,7 +287,8 @@ plt.figure(figsize=(8, 6))
 ax = dataset_image.counts.smooth("0.03 deg").plot(vmax=8)
 
 on_region.to_pixel(ax.wcs).plot(ax=ax, edgecolor="white")
-plot_spectrum_datasets_off_regions(datasets, ax=ax);
+plot_spectrum_datasets_off_regions(datasets, ax=ax)
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/analysis-3d/event_sampling.py
+++ b/examples/tutorials/analysis-3d/event_sampling.py
@@ -35,7 +35,7 @@ output of the event-sampler will be a set of events having information
 about their true coordinates, true energies and times of arrival.
 
 To these events, IRF corrections (i.e. PSF and energy dispersion) can
-also further applied in order to obtain reconstructed coordinates and
+also further be applied in order to obtain reconstructed coordinates and
 energies of the sampled events.
 
 At the end of this process, you will obtain an event-list in FITS
@@ -163,11 +163,11 @@ observation = Observation.create(
 # Let’s generate the `~gammapy.datasets.Dataset` object (for more info
 # on `~gammapy.datasets.Dataset` objects, please checkout
 # :doc:`/tutorials/api/datasets` tutorial):
-# we define the energy axes (true and reconstruncted), the migration axis
+# we define the energy axes (true and reconstructed), the migration axis
 # and the geometry of the observation.
 #
 # *This is a crucial point for the correct configuration of the event
-# sampler. Indeed the spatial and energetic binning should be treaten
+# sampler. Indeed, the spatial and energetic binning should be treated
 # carefully and… the finer the better. For this reason, we suggest to
 # define the energy axes (true and reconstructed) by setting a minimum
 # binning of least 10-20 bins per decade for all the sources of interest.
@@ -291,6 +291,7 @@ print(f"Background events: {(events.table['MC_ID'] == 0).sum()}")
 #
 
 events.select_offset([0, 1] * u.deg).peek()
+plt.show()
 
 
 ######################################################################
@@ -323,8 +324,8 @@ hdu_all.writeto("./event_sampling/events_0001.fits", overwrite=True)
 
 counts = Map.from_geom(geom)
 counts.fill_events(events)
-plt.figure()
-counts.sum_over_axes().plot(add_cbar=True);
+counts.sum_over_axes().plot(add_cbar=True)
+plt.show()
 
 
 ######################################################################
@@ -383,7 +384,7 @@ expdecay_model = ExpDecayTemporalModel(t_ref=t_ref.mjd * u.d, t0=t0)
 # where we defined the time axis starting from the reference time
 # `t_ref` up to the requested exposure (`livetime`). The bin size of
 # the time-axis is quite arbitrary but, as above for spatial and energy
-# binnings, the finer the better.
+# binning, the finer the better.
 #
 
 
@@ -449,6 +450,7 @@ src_events = events.select_region(on_region)
 #
 
 src_events.peek()
+plt.show()
 
 
 ######################################################################
@@ -494,6 +496,7 @@ sampler = MapDatasetEventSampler(random_state=0)
 events = sampler.run(dataset, observation)
 
 events.select_offset([0, 1] * u.deg).peek()
+plt.show()
 
 
 ######################################################################
@@ -502,7 +505,7 @@ events.select_offset([0, 1] * u.deg).peek()
 #
 # In some user case, you may want to sample events from a number of
 # observations. In this section, we show how to simulate a set of event
-# lists. For simplicity we consider only one point-like source, observed
+# lists. For simplicity, we consider only one point-like source, observed
 # three times for 1 hr and assuming the same pointing position.
 #
 # Let’s firstly define the time start and the livetime of each
@@ -550,14 +553,13 @@ display(data_store.obs_table)
 
 
 ######################################################################
-# Then you can create the obervations from the data store and make your own
+# Then you can create the observations from the data store and make your own
 # analysis following the instructions in the
 # :doc:`/tutorials/starting/analysis_2` tutorial.
 #
 
 observations = data_store.get_observations()
 observations[0].peek()
-
 plt.show()
 
 

--- a/examples/tutorials/analysis-3d/event_sampling.py
+++ b/examples/tutorials/analysis-3d/event_sampling.py
@@ -324,7 +324,7 @@ hdu_all.writeto("./event_sampling/events_0001.fits", overwrite=True)
 counts = Map.from_geom(geom)
 counts.fill_events(events)
 plt.figure()
-counts.sum_over_axes().plot(add_cbar=True)
+counts.sum_over_axes().plot(add_cbar=True);
 
 
 ######################################################################

--- a/examples/tutorials/analysis-3d/flux_profiles.py
+++ b/examples/tutorials/analysis-3d/flux_profiles.py
@@ -13,8 +13,8 @@ instance the first analysis tutorial.
 Context
 -------
 
-A useful tool to study and compare the saptial distribution of flux in
-images and data cubes is the measurement of flxu profiles. Flux profiles
+A useful tool to study and compare the spatial distribution of flux in
+images and data cubes is the measurement of flux profiles. Flux profiles
 can show spatial correlations of gamma-ray data with e.g. gas maps or
 other type of gamma-ray data. Most commonly flux profiles are measured
 along some preferred coordinate axis, either radially distance from a
@@ -31,7 +31,7 @@ linear profiles it’s typically a rectangular shape.
 
 We will work on a pre-computed `~gammapy.datasets.MapDataset` of Fermi-LAT data, use
 `~regions.SkyRegion` to define the structure of the bins of the flux profile and
-run the actually profile extraction using the `~gammapy.estimators.FluxProfileEstimator`
+run the flux profile extraction using the `~gammapy.estimators.FluxProfileEstimator`
 
 """
 
@@ -79,7 +79,8 @@ dataset = MapDataset.read(
 # This is what the counts image we will work with looks like:
 #
 counts_image = dataset.counts.sum_over_axes()
-counts_image.smooth("0.1 deg").plot(stretch="sqrt");
+counts_image.smooth("0.1 deg").plot(stretch="sqrt")
+plt.show()
 
 
 ######################################################################
@@ -101,7 +102,7 @@ print(dataset.counts)
 # galactic longitude axis. For this there is a helper function
 # `~gammapy.utils.regions.make_orthogonal_rectangle_sky_regions`. The individual region bins
 # for the profile have a height of 3 deg and in total there are 31 bins.
-# The starts from lon = 10 deg tand goes to lon = 350 deg. In addition we
+# Its starts from lon = 10 deg and goes to lon = 350 deg. In addition, we
 # have to specify the `wcs` to take into account possible projections
 # effects on the region definition:
 #
@@ -120,10 +121,10 @@ regions = make_orthogonal_rectangle_sky_regions(
 # the counts image:
 #
 
-plt.figure()
 geom = RegionGeom.create(region=regions)
 ax = counts_image.smooth("0.1 deg").plot(stretch="sqrt")
-geom.plot_region(ax=ax, color="w");
+geom.plot_region(ax=ax, color="w")
+plt.show()
 
 
 ######################################################################
@@ -170,9 +171,9 @@ print(profile)
 #
 # Let us directly plot the result using `~gammapy.estimators.FluxPoints.plot`:
 #
-plt.figure()
 ax = profile.plot(sed_type="dnde")
 ax.set_yscale("linear")
+plt.show()
 
 
 ######################################################################
@@ -186,6 +187,7 @@ profile.sqrt_ts_threshold_ul = 2
 plt.figure()
 ax = profile.plot(sed_type="eflux")
 ax.set_yscale("linear")
+plt.show()
 
 
 ######################################################################
@@ -201,7 +203,8 @@ fig, ax = plt.subplots()
 for quantity in quantities:
     profile[quantity].plot(ax=ax, label=quantity.title())
 
-ax.set_ylabel("Counts");
+ax.set_ylabel("Counts")
+plt.show()
 
 
 ######################################################################
@@ -221,9 +224,9 @@ profile.write(
 
 profile_new = FluxPoints.read(filename="flux_profile_fermi.fits", format="profile")
 
-fig = plt.figure()
 ax = profile_new.plot()
 ax.set_yscale("linear")
+plt.show()
 
 
 ######################################################################
@@ -250,13 +253,13 @@ regions = make_concentric_annulus_sky_regions(
 ######################################################################
 # Again we first illustrate the regions:
 #
-plt.figure()
 geom = RegionGeom.create(region=regions)
 gc_image = counts_image.cutout(
     position=SkyCoord("0d", "0d", frame="galactic"), width=3 * u.deg
 )
 ax = gc_image.smooth("0.1 deg").plot(stretch="sqrt")
-geom.plot_region(ax=ax, color="w");
+geom.plot_region(ax=ax, color="w")
+plt.show()
 
 
 ######################################################################
@@ -279,8 +282,8 @@ profile = flux_profile_estimator.run(datasets=dataset)
 # We can directly plot the result:
 #
 
-plt.figure()
-profile.plot(axis_name="projected-distance", sed_type="flux");
+profile.plot(axis_name="projected-distance", sed_type="flux")
+plt.show()
 
 
 ######################################################################
@@ -289,6 +292,7 @@ profile.plot(axis_name="projected-distance", sed_type="flux");
 #
 
 profile_high = profile.slice_by_idx({"energy": slice(1, 2)})
+plt.show()
 
 
 ######################################################################
@@ -299,8 +303,6 @@ fig, ax = plt.subplots()
 profile_high.plot(ax=ax, sed_type="eflux", color="tab:orange")
 profile_high.plot_ts_profiles(ax=ax, sed_type="eflux")
 ax.set_yscale("linear")
-
-
 plt.show()
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/tutorials/analysis-3d/flux_profiles.py
+++ b/examples/tutorials/analysis-3d/flux_profiles.py
@@ -79,7 +79,7 @@ dataset = MapDataset.read(
 # This is what the counts image we will work with looks like:
 #
 counts_image = dataset.counts.sum_over_axes()
-counts_image.smooth("0.1 deg").plot(stretch="sqrt")
+counts_image.smooth("0.1 deg").plot(stretch="sqrt");
 
 
 ######################################################################
@@ -123,7 +123,7 @@ regions = make_orthogonal_rectangle_sky_regions(
 plt.figure()
 geom = RegionGeom.create(region=regions)
 ax = counts_image.smooth("0.1 deg").plot(stretch="sqrt")
-geom.plot_region(ax=ax, color="w")
+geom.plot_region(ax=ax, color="w");
 
 
 ######################################################################
@@ -201,7 +201,7 @@ fig, ax = plt.subplots()
 for quantity in quantities:
     profile[quantity].plot(ax=ax, label=quantity.title())
 
-ax.set_ylabel("Counts")
+ax.set_ylabel("Counts");
 
 
 ######################################################################
@@ -256,7 +256,7 @@ gc_image = counts_image.cutout(
     position=SkyCoord("0d", "0d", frame="galactic"), width=3 * u.deg
 )
 ax = gc_image.smooth("0.1 deg").plot(stretch="sqrt")
-geom.plot_region(ax=ax, color="w")
+geom.plot_region(ax=ax, color="w");
 
 
 ######################################################################
@@ -280,7 +280,7 @@ profile = flux_profile_estimator.run(datasets=dataset)
 #
 
 plt.figure()
-profile.plot(axis_name="projected-distance", sed_type="flux")
+profile.plot(axis_name="projected-distance", sed_type="flux");
 
 
 ######################################################################

--- a/examples/tutorials/analysis-3d/simulate_3d.py
+++ b/examples/tutorials/analysis-3d/simulate_3d.py
@@ -198,7 +198,7 @@ print(dataset.models)
 fit = Fit(optimize_opts={"print_level": 1})
 result = fit.run(datasets=[dataset])
 plt.figure()
-dataset.plot_residuals_spatial(method="diff/sqrt(model)", vmin=-0.5, vmax=0.5)
+dataset.plot_residuals_spatial(method="diff/sqrt(model)", vmin=-0.5, vmax=0.5);
 
 
 ######################################################################

--- a/examples/tutorials/analysis-3d/simulate_3d.py
+++ b/examples/tutorials/analysis-3d/simulate_3d.py
@@ -135,7 +135,7 @@ print(models)
 ######################################################################
 # Now, comes the main part of dataset simulation. We create an in-memory
 # observation and an empty dataset. We then predict the number of counts
-# for the given model, and Poission fluctuate it using `fake()` to make
+# for the given model, and Poisson fluctuate it using `fake()` to make
 # a simulated counts maps. Keep in mind that it is important to specify
 # the `selection` of the maps that you want to produce
 #
@@ -156,7 +156,7 @@ dataset = maker.run(empty, obs)
 dataset = maker_safe_mask.run(dataset, obs)
 print(dataset)
 
-# Add the model on the dataset and Poission fluctuate
+# Add the model on the dataset and Poisson fluctuate
 dataset.models = models
 dataset.fake()
 # Do a print on the dataset - there is now a counts maps
@@ -171,8 +171,8 @@ print(dataset)
 #
 
 # To plot, eg, counts:
-plt.figure()
 dataset.counts.smooth(0.05 * u.deg).plot_interactive(add_cbar=True, stretch="linear")
+plt.show()
 
 
 ######################################################################
@@ -197,8 +197,9 @@ print(dataset.models)
 # %%time
 fit = Fit(optimize_opts={"print_level": 1})
 result = fit.run(datasets=[dataset])
-plt.figure()
-dataset.plot_residuals_spatial(method="diff/sqrt(model)", vmin=-0.5, vmax=0.5);
+
+dataset.plot_residuals_spatial(method="diff/sqrt(model)", vmin=-0.5, vmax=0.5)
+plt.show()
 
 
 ######################################################################
@@ -218,5 +219,3 @@ print(
 #
 
 display(result.parameters.to_table())
-
-plt.show()

--- a/examples/tutorials/analysis-time/light_curve.py
+++ b/examples/tutorials/analysis-time/light_curve.py
@@ -19,7 +19,7 @@ bins.
 
 Cherenkov telescopes usually work with observing runs and distribute
 data according to this basic time interval. A typical use case is to
-look for variability of a source on various time binnings: observation
+look for variability of a source on various time bins: observation
 run-wise binning, nightly, weekly etc.
 
 **Objective: The Crab nebula is not known to be variable at TeV
@@ -219,6 +219,7 @@ fig, ax = plt.subplots(
 )
 lc_3d.sqrt_ts_threshold_ul = 5
 lc_3d.plot(ax=ax, axis_name="time")
+plt.show()
 
 table = lc_3d.to_table(format="lightcurve", sed_type="flux")
 display(table["time_min", "time_max", "e_min", "e_max", "flux", "flux_err"])
@@ -340,7 +341,8 @@ fig, ax = plt.subplots(
 )
 lc_1d.plot(ax=ax, marker="o", label="1D")
 lc_3d.plot(ax=ax, marker="o", label="3D")
-plt.legend();
+plt.legend()
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/analysis-time/light_curve.py
+++ b/examples/tutorials/analysis-time/light_curve.py
@@ -340,7 +340,7 @@ fig, ax = plt.subplots(
 )
 lc_1d.plot(ax=ax, marker="o", label="1D")
 lc_3d.plot(ax=ax, marker="o", label="3D")
-plt.legend()
+plt.legend();
 
 
 ######################################################################

--- a/examples/tutorials/analysis-time/light_curve_simulation.py
+++ b/examples/tutorials/analysis-time/light_curve_simulation.py
@@ -218,7 +218,7 @@ display(datasets.info_table())
 # extraction. Only a spectral model needs to be defined in this case.
 # Since the estimator returns the integrated flux separately for each time
 # bin, the temporal model need not be accounted for at this stage. We
-# extract the lightcurve in 3 energy binsç
+# extract the lightcurve in 3 energy bins.
 #
 
 # Define the model:
@@ -242,7 +242,8 @@ fig, ax = plt.subplots(
     figsize=(8, 6),
     gridspec_kw={"left": 0.16, "bottom": 0.2, "top": 0.98, "right": 0.98},
 )
-lc_1d.plot(ax=ax, marker="o", axis_name="time", sed_type="flux");
+lc_1d.plot(ax=ax, marker="o", axis_name="time", sed_type="flux")
+plt.show()
 
 
 ######################################################################
@@ -317,7 +318,8 @@ time_range = lc_1TeV_10TeV.geom.axes["time"].time_bounds
 temporal_model1.plot(ax=ax, time_range=time_range, label="Best fit model")
 
 ax.set_yscale("linear")
-ax.legend();
+ax.legend()
+plt.show()
 
 
 ######################################################################
@@ -355,7 +357,6 @@ result = fit.run(datasets=datasets)
 
 display(result.parameters.to_table())
 
-plt.show()
 ######################################################################
 # We see that the fitted parameters are consistent between fitting flux
 # points and datasets, and match well with the simulated ones

--- a/examples/tutorials/analysis-time/light_curve_simulation.py
+++ b/examples/tutorials/analysis-time/light_curve_simulation.py
@@ -242,7 +242,7 @@ fig, ax = plt.subplots(
     figsize=(8, 6),
     gridspec_kw={"left": 0.16, "bottom": 0.2, "top": 0.98, "right": 0.98},
 )
-lc_1d.plot(ax=ax, marker="o", axis_name="time", sed_type="flux")
+lc_1d.plot(ax=ax, marker="o", axis_name="time", sed_type="flux");
 
 
 ######################################################################
@@ -317,7 +317,7 @@ time_range = lc_1TeV_10TeV.geom.axes["time"].time_bounds
 temporal_model1.plot(ax=ax, time_range=time_range, label="Best fit model")
 
 ax.set_yscale("linear")
-ax.legend()
+ax.legend();
 
 
 ######################################################################

--- a/examples/tutorials/analysis-time/pulsar_analysis.py
+++ b/examples/tutorials/analysis-time/pulsar_analysis.py
@@ -206,7 +206,7 @@ ax.text(0.895, 5, "OFF", color="black", fontsize=17, ha="center")
 ax.set_xlabel("Phase")
 ax.set_ylabel("Counts")
 ax.set_xlim(0, 1)
-ax.set_title(f"Phasogram with angular cut of {on_radius}")
+ax.set_title(f"Phasogram with angular cut of {on_radius}");
 
 
 ######################################################################
@@ -302,7 +302,7 @@ counts.plot(ax=ax1, add_cbar=True)
 ax1.set_title("Counts")
 
 background.plot(ax=ax2, add_cbar=True)
-ax2.set_title("Background")
+ax2.set_title("Background");
 
 
 ######################################################################
@@ -324,7 +324,7 @@ npred_excess.plot(ax=ax1, add_cbar=True)
 ax1.set_title("Excess counts")
 
 sqrt_ts.plot(ax=ax2, add_cbar=True)
-ax2.set_title("Significance")
+ax2.set_title("Significance");
 
 
 ######################################################################

--- a/examples/tutorials/analysis-time/pulsar_analysis.py
+++ b/examples/tutorials/analysis-time/pulsar_analysis.py
@@ -74,7 +74,7 @@ data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps")
 
 
 ######################################################################
-# Define obsevation ID and print events:
+# Define observation ID and print events:
 
 
 id_obs_vela = [111630]
@@ -139,6 +139,7 @@ ax.set_xlim(0, 1)
 ax.set_xlabel("Phase")
 ax.set_ylabel("Counts")
 ax.set_title(f"Phasogram with angular cut of {on_radius}")
+plt.show()
 
 on_phase_range = (0.5, 0.6)
 off_phase_range = (0.7, 1)
@@ -206,7 +207,8 @@ ax.text(0.895, 5, "OFF", color="black", fontsize=17, ha="center")
 ax.set_xlabel("Phase")
 ax.set_ylabel("Counts")
 ax.set_xlim(0, 1)
-ax.set_title(f"Phasogram with angular cut of {on_radius}");
+ax.set_title(f"Phasogram with angular cut of {on_radius}")
+plt.show()
 
 
 ######################################################################
@@ -302,7 +304,9 @@ counts.plot(ax=ax1, add_cbar=True)
 ax1.set_title("Counts")
 
 background.plot(ax=ax2, add_cbar=True)
-ax2.set_title("Background");
+ax2.set_title("Background")
+
+plt.show()
 
 
 ######################################################################
@@ -324,7 +328,9 @@ npred_excess.plot(ax=ax1, add_cbar=True)
 ax1.set_title("Excess counts")
 
 sqrt_ts.plot(ax=ax2, add_cbar=True)
-ax2.set_title("Significance");
+ax2.set_title("Significance")
+
+plt.show()
 
 
 ######################################################################
@@ -340,7 +346,7 @@ ax2.set_title("Significance");
 #
 # Here to create the `~gammapy.datasets.SpectrumDatasetOnOff`, we are going to redo the whole data reduction.
 # However, note that one can use the `to_spectrum_dataset()` method of `~gammapy.datasets.MapDatasetOnOff`
-# (with the `containement_correction` parameter set to True) if such a `~gammapy.datasets.MapDatasetOnOff`
+# (with the `containment_correction` parameter set to True) if such a `~gammapy.datasets.MapDatasetOnOff`
 # has been created as shown above.
 
 e_true = MapAxis.from_energy_bounds(0.003, 10, 100, unit="TeV", name="energy_true")
@@ -372,6 +378,7 @@ for obs in obs_list_vela:
 # Now let’s take a look at the datasets we just created:
 
 spectrum_datasets[0].peek()
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/api/astro_dark_matter.py
+++ b/examples/tutorials/api/astro_dark_matter.py
@@ -63,7 +63,6 @@ check_tutorials_setup()
 
 profiles.DMProfile.__subclasses__()
 
-plt.figure()
 for profile in profiles.DMProfile.__subclasses__():
     p = profile()
     p.scale_to_local_density()
@@ -73,6 +72,7 @@ for profile in profiles.DMProfile.__subclasses__():
 plt.loglog()
 plt.axvline(8.5, linestyle="dashed", color="black", label="local density")
 plt.legend()
+plt.show()
 
 print("LOCAL_DENSITY:", profiles.DMProfile.LOCAL_DENSITY)
 print("DISTANCE_GC:", profiles.DMProfile.DISTANCE_GC)
@@ -116,6 +116,7 @@ pix_reg_rec = sky_reg_rec.to_pixel(wcs=geom.wcs)
 pix_reg_rec.plot(ax=ax, facecolor="none", edgecolor="orange", label="+/- 0.3 deg band")
 
 plt.legend()
+plt.show()
 
 # NOTE: https://arxiv.org/abs/1607.08142 quote 2.67e21
 total_jfact = (
@@ -163,6 +164,7 @@ for mDM, ax in zip(mDMs, axes):
 
 axes[0].legend()
 plt.subplots_adjust(hspace=0.9)
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/api/catalog.py
+++ b/examples/tutorials/api/catalog.py
@@ -8,12 +8,12 @@ Introduction
 ------------
 
 `~gammapy.catalog` provides convenient access to common gamma-ray
-source catalogs. This module is mostly independent from the rest of
-Gammapy. Typically you use it to compare new analyses against catalog
-results, e.g. overplot the spectral model, or compare the source
+source catalogs. This module is mostly independent of the rest of
+Gammapy. Typically, you use it to compare new analyses against catalog
+results, e.g. overplot the spectral model, or compare the source
 position.
 
-Moreover as creating a source model and flux points for a given catalog
+Moreover, as creating a source model and flux points for a given catalog
 from the FITS table is tedious, `~gammapy.catalog` has this already
 implemented. So you can create initial source models for your analyses.
 This is very common for Fermi-LAT, to start with a catalog model. For
@@ -41,7 +41,7 @@ In this tutorial we will show examples using the following catalogs:
 
 All catalog and source classes work the same, as long as some
 information is available. E.g. trying to access a lightcurve from a
-catalog and source that doesn’t have that information will return
+catalog and source that does not have that information will return
 `None`.
 
 Further information is available at `~gammapy.catalog`.
@@ -298,11 +298,11 @@ print(model.spatial_model)
 print(model.spectral_model)
 
 # %%
-plt.figure()
 energy_bounds = (100 * u.MeV, 100 * u.GeV)
 opts = dict(sed_type="e2dnde", yunits=u.Unit("TeV cm-2 s-1"))
 model.spectral_model.plot(energy_bounds, **opts)
-model.spectral_model.plot_error(energy_bounds, **opts);
+model.spectral_model.plot_error(energy_bounds, **opts)
+plt.show()
 
 
 ######################################################################
@@ -376,8 +376,8 @@ print(flux_points)
 display(flux_points.to_table(sed_type="flux"))
 
 # %%
-plt.figure()
-flux_points.plot(sed_type="e2dnde");
+flux_points.plot(sed_type="e2dnde")
+plt.show()
 
 
 ######################################################################
@@ -397,8 +397,8 @@ print(lightcurve)
 display(lightcurve.to_table(format="lightcurve", sed_type="flux"))
 
 # %%
-plt.figure()
-lightcurve.plot();
+lightcurve.plot()
+plt.show()
 
 
 ######################################################################
@@ -422,6 +422,3 @@ help(source.info)
 
 # %%
 print(source.info("associations"))
-
-# %%
-plt.show()

--- a/examples/tutorials/api/catalog.py
+++ b/examples/tutorials/api/catalog.py
@@ -302,7 +302,7 @@ plt.figure()
 energy_bounds = (100 * u.MeV, 100 * u.GeV)
 opts = dict(sed_type="e2dnde", yunits=u.Unit("TeV cm-2 s-1"))
 model.spectral_model.plot(energy_bounds, **opts)
-model.spectral_model.plot_error(energy_bounds, **opts)
+model.spectral_model.plot_error(energy_bounds, **opts);
 
 
 ######################################################################
@@ -377,7 +377,7 @@ display(flux_points.to_table(sed_type="flux"))
 
 # %%
 plt.figure()
-flux_points.plot(sed_type="e2dnde")
+flux_points.plot(sed_type="e2dnde");
 
 
 ######################################################################
@@ -398,7 +398,7 @@ display(lightcurve.to_table(format="lightcurve", sed_type="flux"))
 
 # %%
 plt.figure()
-lightcurve.plot()
+lightcurve.plot();
 
 
 ######################################################################

--- a/examples/tutorials/api/datasets.py
+++ b/examples/tutorials/api/datasets.py
@@ -166,7 +166,7 @@ dataset_cta.peek()
 #
 plt.figure()
 counts_image = dataset_cta.counts.sum_over_axes()
-counts_image.smooth("0.1 deg").plot()
+counts_image.smooth("0.1 deg").plot();
 
 
 ######################################################################
@@ -187,7 +187,7 @@ print(radius)
 
 plt.figure()
 edisp_kernel = dataset_cta.edisp.get_edisp_kernel()
-edisp_kernel.plot_matrix()
+edisp_kernel.plot_matrix();
 
 
 ######################################################################
@@ -226,7 +226,7 @@ print(dataset_cta)
 
 plt.figure()
 npred = dataset_cta.npred()
-npred.sum_over_axes().plot()
+npred.sum_over_axes().plot();
 
 
 ######################################################################
@@ -236,7 +236,7 @@ npred.sum_over_axes().plot()
 
 plt.figure()
 npred_source = dataset_cta.npred_signal(model_name="gc")
-npred_source.sum_over_axes().plot()
+npred_source.sum_over_axes().plot();
 
 
 ######################################################################
@@ -248,7 +248,7 @@ npred_source.sum_over_axes().plot()
 
 plt.figure()
 npred_background = dataset_cta.npred_background()
-npred_background.sum_over_axes().plot()
+npred_background.sum_over_axes().plot();
 
 
 ######################################################################
@@ -274,7 +274,7 @@ npred_background.sum_over_axes().plot()
 # eg: to see the safe data range
 
 # plt.figure()
-dataset_cta.mask_safe.plot_grid()
+dataset_cta.mask_safe.plot_grid();
 
 
 ######################################################################
@@ -290,7 +290,7 @@ geom = dataset_cta.counts.geom
 mask_space = geom.region_mask([region])
 mask_energy = geom.energy_mask(0.3 * u.TeV, 8 * u.TeV)
 dataset_cta.mask_fit = mask_space & mask_energy
-dataset_cta.mask_fit.plot_grid(vmin=0, vmax=1, add_cbar=True)
+dataset_cta.mask_fit.plot_grid(vmin=0, vmax=1, add_cbar=True);
 
 
 ######################################################################
@@ -314,7 +314,7 @@ e_min.plot(add_cbar=True)
 # To see the high energy threshold at each point
 
 plt.figure()
-e_max.plot(add_cbar=True)
+e_max.plot(add_cbar=True);
 
 
 ######################################################################
@@ -330,7 +330,7 @@ cutout = dataset_cta.cutout(
 )
 
 plt.figure()
-cutout.counts.sum_over_axes().plot()
+cutout.counts.sum_over_axes().plot();
 
 
 ######################################################################
@@ -340,7 +340,7 @@ cutout.counts.sum_over_axes().plot()
 sliced = dataset_cta.slice_by_energy(
     energy_min=1 * u.TeV, energy_max=5 * u.TeV, name="slice-energy"
 )
-sliced.counts.plot_grid()
+sliced.counts.plot_grid();
 
 
 ######################################################################
@@ -348,7 +348,7 @@ sliced.counts.plot_grid()
 # datasets such as `~gammapy.datasets.MapDataset.mask_fit`:
 #
 
-sliced.mask_fit.plot_grid()
+sliced.mask_fit.plot_grid();
 
 
 ######################################################################
@@ -362,7 +362,7 @@ sliced.mask_fit.plot_grid()
 
 plt.figure()
 downsampled = dataset_cta.downsample(factor=8)
-downsampled.counts.sum_over_axes().plot()
+downsampled.counts.sum_over_axes().plot();
 
 
 ######################################################################
@@ -372,7 +372,7 @@ downsampled.counts.sum_over_axes().plot()
 downsampled_energy = dataset_cta.downsample(
     factor=5, axis_name="energy", name="downsampled-energy"
 )
-downsampled_energy.counts.plot_grid()
+downsampled_energy.counts.plot_grid();
 
 
 ######################################################################
@@ -390,7 +390,7 @@ print(downsampled_energy, dataset_cta)
 
 energy_axis_new = MapAxis.from_energy_edges([0.1, 0.3, 1, 3, 10] * u.TeV)
 resampled = dataset_cta.resample_energy_axis(energy_axis=energy_axis_new)
-resampled.counts.plot_grid(ncols=2)
+resampled.counts.plot_grid(ncols=2);
 
 
 ######################################################################
@@ -400,7 +400,7 @@ resampled.counts.plot_grid(ncols=2)
 
 plt.figure()
 dataset_image = dataset_cta.to_image()
-dataset_image.counts.plot()
+dataset_image.counts.plot();
 
 
 ######################################################################
@@ -451,7 +451,7 @@ flux_points = FluxPoints.read(
 model = SkyModel(spectral_model=PowerLawSpectralModel(index=2.3))
 fp_dataset = FluxPointsDataset(data=flux_points, models=model)
 
-fp_dataset.plot_spectrum()
+fp_dataset.plot_spectrum();
 
 
 ######################################################################

--- a/examples/tutorials/api/datasets.py
+++ b/examples/tutorials/api/datasets.py
@@ -159,14 +159,15 @@ print(dataset_cta.info_dict())
 #
 
 dataset_cta.peek()
-
+plt.show()
 
 ######################################################################
 # And access individual maps like:
 #
 plt.figure()
 counts_image = dataset_cta.counts.sum_over_axes()
-counts_image.smooth("0.1 deg").plot();
+counts_image.smooth("0.1 deg").plot()
+plt.show()
 
 
 ######################################################################
@@ -185,9 +186,9 @@ print(radius)
 
 # %%
 
-plt.figure()
 edisp_kernel = dataset_cta.edisp.get_edisp_kernel()
-edisp_kernel.plot_matrix();
+edisp_kernel.plot_matrix()
+plt.show()
 
 
 ######################################################################
@@ -224,9 +225,9 @@ print(dataset_cta)
 # of the model:
 #
 
-plt.figure()
 npred = dataset_cta.npred()
-npred.sum_over_axes().plot();
+npred.sum_over_axes().plot()
+plt.show()
 
 
 ######################################################################
@@ -234,9 +235,9 @@ npred.sum_over_axes().plot();
 # use:
 #
 
-plt.figure()
 npred_source = dataset_cta.npred_signal(model_name="gc")
-npred_source.sum_over_axes().plot();
+npred_source.sum_over_axes().plot()
+plt.show()
 
 
 ######################################################################
@@ -246,9 +247,9 @@ npred_source.sum_over_axes().plot();
 # corrected background, one can use `~gammapy.datasets.MapDataset.npred_background`.
 #
 
-plt.figure()
 npred_background = dataset_cta.npred_background()
-npred_background.sum_over_axes().plot();
+npred_background.sum_over_axes().plot()
+plt.show()
 
 
 ######################################################################
@@ -268,20 +269,21 @@ npred_background.sum_over_axes().plot();
 #    applying masks, please refer to :ref:`masks-for-fitting`.
 #
 # Both the `~gammapy.datasets.MapDataset.mask_fit` and `~gammapy.datasets.MapDataset.mask_safe` must
-# have the same `~gammapy.maps.Map.geom` as the `~gammapy.datasets.MapDataset.counts` and `~gammapy.datasets.MapDataset.background` maps.
+# have the same `~gammapy.maps.Map.geom` as the `~gammapy.datasets.MapDataset.counts` and
+# `~gammapy.datasets.MapDataset.background` maps.
 #
 
 # eg: to see the safe data range
 
-# plt.figure()
-dataset_cta.mask_safe.plot_grid();
+dataset_cta.mask_safe.plot_grid()
+plt.show()
 
 
 ######################################################################
 # In addition it is possible to define a custom `~gammapy.datasets.MapDataset.mask_fit`:
 #
 
-# To apply a mask fit - in enegy and space
+# To apply a mask fit - in energy and space
 
 region = CircleSkyRegion(SkyCoord("0d", "0d", frame="galactic"), 1.5 * u.deg)
 
@@ -290,7 +292,8 @@ geom = dataset_cta.counts.geom
 mask_space = geom.region_mask([region])
 mask_energy = geom.energy_mask(0.3 * u.TeV, 8 * u.TeV)
 dataset_cta.mask_fit = mask_space & mask_energy
-dataset_cta.mask_fit.plot_grid(vmin=0, vmax=1, add_cbar=True);
+dataset_cta.mask_fit.plot_grid(vmin=0, vmax=1, add_cbar=True)
+plt.show()
 
 
 ######################################################################
@@ -308,13 +311,13 @@ e_min, e_max = dataset_cta.energy_range
 
 # To see the low energy threshold at each point
 
-plt.figure()
 e_min.plot(add_cbar=True)
+plt.show()
 
 # To see the high energy threshold at each point
 
-plt.figure()
-e_max.plot(add_cbar=True);
+e_max.plot(add_cbar=True)
+plt.show()
 
 
 ######################################################################
@@ -329,8 +332,8 @@ cutout = dataset_cta.cutout(
     name="cta-cutout",
 )
 
-plt.figure()
-cutout.counts.sum_over_axes().plot();
+cutout.counts.sum_over_axes().plot()
+plt.show()
 
 
 ######################################################################
@@ -340,7 +343,8 @@ cutout.counts.sum_over_axes().plot();
 sliced = dataset_cta.slice_by_energy(
     energy_min=1 * u.TeV, energy_max=5 * u.TeV, name="slice-energy"
 )
-sliced.counts.plot_grid();
+sliced.counts.plot_grid()
+plt.show()
 
 
 ######################################################################
@@ -348,7 +352,8 @@ sliced.counts.plot_grid();
 # datasets such as `~gammapy.datasets.MapDataset.mask_fit`:
 #
 
-sliced.mask_fit.plot_grid();
+sliced.mask_fit.plot_grid()
+plt.show()
 
 
 ######################################################################
@@ -362,22 +367,24 @@ sliced.mask_fit.plot_grid();
 
 plt.figure()
 downsampled = dataset_cta.downsample(factor=8)
-downsampled.counts.sum_over_axes().plot();
+downsampled.counts.sum_over_axes().plot()
+plt.show()
 
 
 ######################################################################
-# And the same downsampling process is possible along the energy axis:
+# And the same down-sampling process is possible along the energy axis:
 #
 
 downsampled_energy = dataset_cta.downsample(
     factor=5, axis_name="energy", name="downsampled-energy"
 )
-downsampled_energy.counts.plot_grid();
+downsampled_energy.counts.plot_grid()
+plt.show()
 
 
 ######################################################################
 # In the printout one can see that the actual number of counts is
-# preserved during the downsampling:
+# preserved during the down-sampling:
 #
 
 print(downsampled_energy, dataset_cta)
@@ -390,7 +397,8 @@ print(downsampled_energy, dataset_cta)
 
 energy_axis_new = MapAxis.from_energy_edges([0.1, 0.3, 1, 3, 10] * u.TeV)
 resampled = dataset_cta.resample_energy_axis(energy_axis=energy_axis_new)
-resampled.counts.plot_grid(ncols=2);
+resampled.counts.plot_grid(ncols=2)
+plt.show()
 
 
 ######################################################################
@@ -398,9 +406,9 @@ resampled.counts.plot_grid(ncols=2);
 # `~gammapy.datasets.MapDataset.to_image()` convenience method:
 #
 
-plt.figure()
 dataset_image = dataset_cta.to_image()
-dataset_image.counts.plot();
+dataset_image.counts.plot()
+plt.show()
 
 
 ######################################################################
@@ -409,7 +417,7 @@ dataset_image.counts.plot();
 #
 # `~gammapy.datasets.SpectrumDataset` inherits from a `~gammapy.datasets.MapDataset`, and is specially
 # adapted for 1D spectral analysis, and uses a `RegionGeom` instead of a
-# `WcsGeom`. A `~gammapy.datasets.MapDatset` can be converted to a `~gammapy.datasets.SpectrumDataset`,
+# `WcsGeom`. A `~gammapy.datasets.MapDataset` can be converted to a `~gammapy.datasets.SpectrumDataset`,
 # by summing the `counts` and `background` inside the `on_region`,
 # which can then be used for classical spectral analysis. Containment
 # correction is feasible only for circular regions.
@@ -423,6 +431,7 @@ spectrum_dataset = dataset_cta.to_spectrum_dataset(
 
 # For a quick look
 spectrum_dataset.peek()
+plt.show()
 
 
 ######################################################################
@@ -444,21 +453,21 @@ print(reg_dataset)
 # points, which can be then used in fitting.
 #
 
-plt.figure()
 flux_points = FluxPoints.read(
     "$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits"
 )
 model = SkyModel(spectral_model=PowerLawSpectralModel(index=2.3))
 fp_dataset = FluxPointsDataset(data=flux_points, models=model)
 
-fp_dataset.plot_spectrum();
+fp_dataset.plot_spectrum()
+plt.show()
 
 
 ######################################################################
 # The masks on `~gammapy.datasets.FluxPointsDataset` are `~numpy.ndarray` objects
 # and the data is a
-# `~gammapy.datasets.FluxPoints` object. The `~gammapy.datasets.FluxPointsDataset.mask_safe`, by default, masks the upper
-# limit points
+# `~gammapy.datasets.FluxPoints` object. The `~gammapy.datasets.FluxPointsDataset.mask_safe`,
+# by default, masks the upper limit points.
 #
 
 print(fp_dataset.mask_safe)  # Note: the mask here is simply a numpy array
@@ -507,7 +516,7 @@ print(datasets)
 
 ######################################################################
 # If all the datasets have the same type we can also print an info table,
-# collectiong all the information from the individual calls to
+# collecting all the information from the individual calls to
 # `~gammapy.datasets.Dataset.info_dict()`:
 #
 
@@ -576,8 +585,8 @@ print(stacked)
 #
 
 datasets_sliced = datasets.slice_by_energy(energy_min="1 TeV", energy_max="10 TeV")
+plt.show()
+
 print(datasets_sliced.energy_ranges)
 
 # %%
-
-plt.show()

--- a/examples/tutorials/api/fitting.py
+++ b/examples/tutorials/api/fitting.py
@@ -239,6 +239,7 @@ for ax, par in zip(axes, datasets.parameters.free_parameters):
     ax.set_xlabel(f"{par.name} [{par.unit}]")
     ax.set_ylabel("Delta TS")
     ax.set_title(f"{name}:\n {par.value:.1e} +- {par.error:.1e}")
+plt.show()
 
 
 ######################################################################
@@ -264,6 +265,7 @@ print(result_minuit.models.covariance)
 #
 
 result_minuit.models.covariance.plot_correlation()
+plt.show()
 
 # The covariance information is also propagated to the individual models
 # Therefore, one can also get the error on a specific parameter by directly
@@ -278,10 +280,10 @@ print(crab_model.spectral_model.alpha.error)
 # the envelope of the model taking into account parameter uncertainties.
 #
 
-plt.figure()
 energy_bounds = [1, 10] * u.TeV
 crab_spectrum.plot(energy_bounds=energy_bounds, energy_power=2)
 ax = crab_spectrum.plot_error(energy_bounds=energy_bounds, energy_power=2)
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -71,7 +71,7 @@ print(dataset_empty)
 
 ######################################################################
 # It is possible to compute the instrument response functions with
-# different spatial and energy binnings as compared to the counts and
+# different spatial and energy bins as compared to the counts and
 # background maps. For example, one can specify a true energy axis which
 # defines the energy binning of the IRFs:
 #
@@ -83,7 +83,7 @@ dataset_empty = MapDataset.create(geom=geom, energy_axis_true=energy_axis_true)
 
 
 ######################################################################
-# For the detail of the other options availables, you can always call the
+# For the detail of the other options available, you can always call the
 # help:
 #
 
@@ -103,8 +103,9 @@ obs = data_store.get_observations([23592])[0]
 maker = MapDatasetMaker()
 dataset = maker.run(dataset_empty, obs)
 print(dataset)
-plt.figure()
-dataset.counts.sum_over_axes().plot(stretch="sqrt", add_cbar=True);
+
+dataset.counts.sum_over_axes().plot(stretch="sqrt", add_cbar=True)
+plt.show()
 
 
 ######################################################################
@@ -113,7 +114,7 @@ dataset.counts.sum_over_axes().plot(stretch="sqrt", add_cbar=True);
 # The `~gammapy.makers.MapDatasetMaker` has a `selection` parameter, in case some of
 # the maps should not be computed. There is also a
 # `background_oversampling` parameter that defines the oversampling
-# factor in energy used to compute the bakcground (default is None).
+# factor in energy used to compute the background (default is None).
 #
 # Safe data range handling
 # ------------------------
@@ -156,8 +157,9 @@ safe_mask_maker = SafeMaskMaker(
 dataset = maker.run(dataset_empty, obs)
 dataset = safe_mask_maker.run(dataset, obs)
 print(dataset.mask_safe)
-plt.figure()
-dataset.mask_safe.sum_over_axes().plot();
+
+dataset.mask_safe.sum_over_axes().plot()
+plt.show()
 
 
 ######################################################################
@@ -210,7 +212,7 @@ dataset = fov_bkg_maker.run(dataset)
 # If the background model does not reproduce well the morphology, a
 # classical approach consists in applying local corrections by smoothing
 # the data with a ring kernel. This allows to build a set of OFF counts
-# taking into account the inperfect knowledge of the background. This is
+# taking into account the imperfect knowledge of the background. This is
 # implemented in the `~gammapy.makers.RingBackgroundMaker` which
 # transforms the Dataset in a `~gammapy.datasets.MapDatasetOnOff`. This technique is
 # mostly used for imaging, and should not be applied for 3D modeling and
@@ -239,7 +241,7 @@ dataset = fov_bkg_maker.run(dataset)
 #
 # The data reduction steps can be combined in a single loop to run a full
 # data reduction chain. For this the `MapDatasetMaker` is run first and
-# the output dataset is the passed on to the next maker step. Finally the
+# the output dataset is the passed on to the next maker step. Finally, the
 # dataset per observation is stacked into a larger map.
 #
 
@@ -280,11 +282,11 @@ print(stacked)
 # to zero, then data is added to the larger map dataset. To stack multiple
 # observations, the larger dataset must be created first.
 #
-# The data reduction loop shown above can be done throught the
+# The data reduction loop shown above can be done through the
 # `~gammapy.makers.DatasetsMaker` class that take as argument a list of makers. **Note
 # that the order of the makers list is important as it determines their
 # execution order.** Moreover the `stack_datasets` option offers the
-# possibily to stack or not the output datasets, and the `n_jobs` option
+# possibility to stack or not the output datasets, and the `n_jobs` option
 # allow to use multiple processes on run.
 #
 
@@ -299,7 +301,7 @@ print(datasets)
 # Spectrum dataset
 # ----------------
 #
-# The spectrum datasets represent 1D spectra along an energy axis whitin a
+# The spectrum datasets represent 1D spectra along an energy axis within a
 # given on region. The `~gammapy.datasets.SpectrumDataset` contains a counts spectrum, and
 # a background model. The `~gammapy.datasets.SpectrumDatasetOnOff` contains ON and OFF
 # count spectra, background is implicitly modeled via the OFF counts
@@ -307,7 +309,7 @@ print(datasets)
 #
 # The `~gammapy.datasets.SpectrumDatasetMaker` make spectrum dataset for a single
 # observation. In that case the irfs and background are computed at a
-# single fixed offset, which is recommend only for point-sources.
+# single fixed offset, which is recommended only for point-sources.
 #
 # Here is an example of data reduction loop to create
 # `~gammapy.datasets.SpectrumDatasetOnOff` datasets:

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -104,7 +104,7 @@ maker = MapDatasetMaker()
 dataset = maker.run(dataset_empty, obs)
 print(dataset)
 plt.figure()
-dataset.counts.sum_over_axes().plot(stretch="sqrt", add_cbar=True)
+dataset.counts.sum_over_axes().plot(stretch="sqrt", add_cbar=True);
 
 
 ######################################################################
@@ -157,7 +157,7 @@ dataset = maker.run(dataset_empty, obs)
 dataset = safe_mask_maker.run(dataset, obs)
 print(dataset.mask_safe)
 plt.figure()
-dataset.mask_safe.sum_over_axes().plot()
+dataset.mask_safe.sum_over_axes().plot();
 
 
 ######################################################################

--- a/examples/tutorials/api/maps.py
+++ b/examples/tutorials/api/maps.py
@@ -821,7 +821,7 @@ m_3fhl_gc = Map.read(filename)
 #
 
 plt.figure()
-m_3fhl_gc.plot()
+m_3fhl_gc.plot();
 
 
 ######################################################################
@@ -833,7 +833,7 @@ m_3fhl_gc.plot()
 
 plt.figure()
 smoothed = m_3fhl_gc.smooth(width=0.2 * u.deg, kernel="gauss")
-smoothed.plot(stretch="sqrt", add_cbar=True, vmax=4, cmap="inferno")
+smoothed.plot(stretch="sqrt", add_cbar=True, vmax=4, cmap="inferno");
 
 
 ######################################################################
@@ -847,7 +847,7 @@ plt.figure()
 rc_params = {"figure.figsize": (12, 5.4), "font.size": 12}
 with plt.rc_context(rc=rc_params):
     smoothed = m_3fhl_gc.smooth(width=0.2 * u.deg, kernel="gauss")
-    smoothed.plot(stretch="sqrt", add_cbar=True, vmax=4)
+    smoothed.plot(stretch="sqrt", add_cbar=True, vmax=4);
 
 
 ######################################################################

--- a/examples/tutorials/api/maps.py
+++ b/examples/tutorials/api/maps.py
@@ -149,8 +149,8 @@ print(m_gc.geom)
 # `~gammapy.maps.~Geom` object can be seen as a generalization of an
 # `astropy.wcs.WCS` object, providing the information on how the data
 # maps to physical coordinate systems. In some cases e.g. when creating
-# many maps with the same WCS geometry it can be advantegeous to first
-# create the map geometry independent of the map object itsself:
+# many maps with the same WCS geometry it can be advantageous to first
+# create the map geometry independent of the map object it-self:
 #
 
 wcs_geom = WcsGeom.create(binsz=0.02, width=(10, 5), skydir=(0, 0), frame="galactic")
@@ -272,9 +272,9 @@ print(energy_axis.center)
 # -------------------
 #
 # Gammapy `~gammapy.maps.Map` objects are serialized using the Flexible Image
-# Transport Format (FITS). Depending on the pixelisation scheme (HEALPix
+# Transport Format (FITS). Depending on the pixelization scheme (HEALPix
 # or WCS) and presence of non-spatial dimensions the actual convention to
-# write the FITS file is different. By default Gammpy uses a generic
+# write the FITS file is different. By default Gammapy uses a generic
 # convention named ``"gadf"``, which will support WCS and HEALPix formats as
 # well as an arbitrary number of non-spatial axes. The convention is
 # documented in detail on the `Gamma Astro Data
@@ -344,7 +344,7 @@ print(Map.from_hdulist(hdulist=hdulist))
 # Writing Maps
 # ~~~~~~~~~~~~
 #
-# Writing FITS files is mainoy exposure via the `Map.write()` method.
+# Writing FITS files on disk via the `Map.write()` method.
 # Here is a first example:
 #
 
@@ -657,7 +657,7 @@ counts.fill_events(events)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Maps support interpolation via the `~~gammapy.maps.Map.interp_by_coord` and
-# `~~gammapy.maps.Map.interp_by_pix` methods. Currently the following interpolation
+# `~~gammapy.maps.Map.interp_by_pix` methods. Currently, the following interpolation
 # methods are supported:
 #
 # -  ``"nearest"`` : Return value of nearest pixel (no interpolation).
@@ -756,7 +756,7 @@ iem_times_two = m_iem_10GeV * 2
 
 
 ######################################################################
-# The logic operators can also by applied on maps (the result is a map of
+# The logic operators can also be applied on maps (the result is a map of
 # boolean type):
 #
 
@@ -765,7 +765,7 @@ print(is_null)
 
 
 ######################################################################
-# Here we check that the result is `True` for all the well-defiend
+# Here we check that the result is `True` for all the well-defined
 # pixels (not `NaN`):
 #
 
@@ -778,7 +778,7 @@ print(np.all(is_null.data[~np.isnan(iem_minus_iem)]))
 #
 # The `WCSNDMap` objects features a `~gammapy.maps.Map.cutout()` method, which allows
 # you to cut out a smaller part of a larger map. This can be useful,
-# e.g. when working with allsky diffuse maps. Here is an example:
+# e.g. when working with all-sky diffuse maps. Here is an example:
 #
 
 position = SkyCoord(0, 0, frame="galactic", unit="deg")
@@ -802,7 +802,7 @@ m_iem_cutout = m_iem_gc.cutout(position=position, width=(4 * u.deg, 2 * u.deg))
 # of a map. This method returns figure, axes, and image objects that can
 # be used to further tweak/customize the image. The `~gammapy.maps.Map.plot` method should
 # be used with 2D maps, while 3D maps can be displayed with the
-# `~gammapy.maps.Map.plot_interative()` or `~gammapy.maps.Map.plot_grid()` methods.
+# `~gammapy.maps.Map.plot_interactive()` or `~gammapy.maps.Map.plot_grid()` methods.
 #
 # Image Plotting
 # ~~~~~~~~~~~~~~
@@ -820,8 +820,8 @@ m_3fhl_gc = Map.read(filename)
 # ``.plot()`` method:
 #
 
-plt.figure()
-m_3fhl_gc.plot();
+m_3fhl_gc.plot()
+plt.show()
 
 
 ######################################################################
@@ -831,9 +831,9 @@ m_3fhl_gc.plot();
 # `plt.imshow() <https://matplotlib.org/api/_as_gen/matplotlib.pyplot.imshow.html>`__:
 #
 
-plt.figure()
 smoothed = m_3fhl_gc.smooth(width=0.2 * u.deg, kernel="gauss")
-smoothed.plot(stretch="sqrt", add_cbar=True, vmax=4, cmap="inferno");
+smoothed.plot(stretch="sqrt", add_cbar=True, vmax=4, cmap="inferno")
+plt.show()
 
 
 ######################################################################
@@ -843,11 +843,11 @@ smoothed.plot(stretch="sqrt", add_cbar=True, vmax=4, cmap="inferno");
 # font size:
 #
 
-plt.figure()
 rc_params = {"figure.figsize": (12, 5.4), "font.size": 12}
 with plt.rc_context(rc=rc_params):
     smoothed = m_3fhl_gc.smooth(width=0.2 * u.deg, kernel="gauss")
-    smoothed.plot(stretch="sqrt", add_cbar=True, vmax=4);
+    smoothed.plot(stretch="sqrt", add_cbar=True, vmax=4)
+plt.show()
 
 
 ######################################################################
@@ -861,13 +861,13 @@ with plt.rc_context(rc=rc_params):
 # the data cube by calling `~gammapy.maps.Map.plot_interactive()`:
 #
 
-plt.figure()
 rc_params = {
     "figure.figsize": (12, 5.4),
     "font.size": 12,
     "axes.formatter.limits": (2, -2),
 }
 m_iem_gc.plot_interactive(add_cbar=True, stretch="sqrt", rc_params=rc_params)
+plt.show()
 
 
 ######################################################################
@@ -886,5 +886,4 @@ m_iem_gc.plot_interactive(add_cbar=True, stretch="sqrt", rc_params=rc_params)
 #
 
 counts_3d.plot_grid(ncols=4, figsize=(16, 12), vmin=0, vmax=100, stretch="log")
-
 plt.show()

--- a/examples/tutorials/api/mask_maps.py
+++ b/examples/tutorials/api/mask_maps.py
@@ -195,7 +195,7 @@ dataset.mask_fit &= mask_map
 # Let’s check the result and plot the full mask.
 #
 
-_ = dataset.mask_fit.plot_grid(ncols=5, vmin=0, vmax=1, figsize=(14, 3))
+dataset.mask_fit.plot_grid(ncols=5, vmin=0, vmax=1, figsize=(14, 3));
 
 
 ######################################################################
@@ -282,7 +282,7 @@ print(regions)
 # to define the exclusion mask we take the inverse
 mask_map = ~geom.region_mask(regions)
 plt.figure()
-mask_map.plot()
+mask_map.plot();
 
 
 ######################################################################
@@ -322,7 +322,7 @@ regions = [CircleSkyRegion(position, exclusion_radius) for position in positions
 
 mask_map_catalog = ~geom.region_mask(regions)
 plt.figure()
-mask_map_catalog.plot()
+mask_map_catalog.plot();
 
 
 ######################################################################
@@ -364,7 +364,7 @@ significance_mask = result["sqrt_ts"] < 5.0
 invalid_pixels = np.isnan(result["sqrt_ts"].data)
 significance_mask.data[invalid_pixels] = True
 plt.figure()
-significance_mask.plot()
+significance_mask.plot();
 
 
 ######################################################################
@@ -395,7 +395,7 @@ significance_mask.plot()
 
 mask = mask_map | mask_map_catalog
 plt.figure()
-mask.plot()
+mask.plot();
 
 
 ######################################################################
@@ -404,7 +404,7 @@ mask.plot()
 
 mask_map &= mask_map_catalog
 plt.figure()
-mask_map.plot()
+mask_map.plot();
 
 
 ######################################################################
@@ -413,7 +413,7 @@ mask_map.plot()
 
 significance_mask_inv = ~significance_mask
 plt.figure()
-significance_mask_inv.plot()
+significance_mask_inv.plot();
 
 
 ######################################################################
@@ -433,7 +433,7 @@ mask.plot()
 
 plt.figure()
 mask = significance_mask_inv.binary_dilate(width=0.2 * u.deg)
-mask.plot()
+mask.plot();
 
 
 ######################################################################

--- a/examples/tutorials/api/mask_maps.py
+++ b/examples/tutorials/api/mask_maps.py
@@ -175,7 +175,7 @@ print(f"Fit range : {dataset.energy_range}")
 # we use the same frame to define the box to ensure a correct alignment.
 # We can now create the map. We use the `WcsGeom.region_mask` method
 # putting all pixels outside the regions to False (because we only want to
-# consider pixels inside the region. For convenience we can directly pass
+# consider pixels inside the region. For convenience, we can directly pass
 # a ds9 region string to the method:
 #
 
@@ -195,7 +195,8 @@ dataset.mask_fit &= mask_map
 # Let’s check the result and plot the full mask.
 #
 
-dataset.mask_fit.plot_grid(ncols=5, vmin=0, vmax=1, figsize=(14, 3));
+dataset.mask_fit.plot_grid(ncols=5, vmin=0, vmax=1, figsize=(14, 3))
+plt.show()
 
 
 ######################################################################
@@ -231,7 +232,7 @@ mask_energy = Map.from_geom(dataset.counts.geom, data=mask_data)
 #
 # Masks are stored in `Map` objects. We must first define its geometry
 # and then we can determine which pixels to exclude. Here we consider a
-# region at the Galactic anticentre around the crab nebula.
+# region at the Galactic anti-centre around the crab nebula.
 #
 
 position = SkyCoord(83.633083, 22.0145, unit="deg", frame="icrs")
@@ -281,8 +282,8 @@ print(regions)
 
 # to define the exclusion mask we take the inverse
 mask_map = ~geom.region_mask(regions)
-plt.figure()
-mask_map.plot();
+mask_map.plot()
+plt.show()
 
 
 ######################################################################
@@ -321,8 +322,8 @@ regions = [CircleSkyRegion(position, exclusion_radius) for position in positions
 #
 
 mask_map_catalog = ~geom.region_mask(regions)
-plt.figure()
-mask_map_catalog.plot();
+mask_map_catalog.plot()
+plt.show()
 
 
 ######################################################################
@@ -363,8 +364,8 @@ significance_mask = result["sqrt_ts"] < 5.0
 
 invalid_pixels = np.isnan(result["sqrt_ts"].data)
 significance_mask.data[invalid_pixels] = True
-plt.figure()
-significance_mask.plot();
+significance_mask.plot()
+plt.show()
 
 
 ######################################################################
@@ -394,8 +395,8 @@ significance_mask.plot();
 #
 
 mask = mask_map | mask_map_catalog
-plt.figure()
-mask.plot();
+mask.plot()
+plt.show()
 
 
 ######################################################################
@@ -403,8 +404,8 @@ mask.plot();
 #
 
 mask_map &= mask_map_catalog
-plt.figure()
-mask_map.plot();
+mask_map.plot()
+plt.show()
 
 
 ######################################################################
@@ -412,8 +413,8 @@ mask_map.plot();
 #
 
 significance_mask_inv = ~significance_mask
-plt.figure()
-significance_mask_inv.plot();
+significance_mask_inv.plot()
+plt.show()
 
 
 ######################################################################
@@ -427,13 +428,13 @@ significance_mask_inv.plot();
 # `binary_dilate` methods, respectively.
 #
 
-plt.figure()
 mask = significance_mask_inv.binary_erode(width=0.2 * u.deg, kernel="disk")
 mask.plot()
+plt.show()
 
-plt.figure()
 mask = significance_mask_inv.binary_dilate(width=0.2 * u.deg)
-mask.plot();
+mask.plot()
+plt.show()
 
 
 ######################################################################
@@ -450,12 +451,12 @@ mask.plot();
 # get PSF 95% containment radius
 energy_true = dataset.exposure.geom.axes[0].center
 psf_r95 = dataset.psf.containment_radius(fraction=0.95, energy_true=energy_true)
+plt.show()
+
 # create mask_fit with margin based on PSF
 mask_fit = dataset.counts.geom.boundary_mask(psf_r95.max())
 dataset.mask_fit = mask_fit
-plt.figure()
 dataset.mask_fit.sum_over_axes().plot()
-
 plt.show()
 
 ######################################################################

--- a/examples/tutorials/api/model_management.py
+++ b/examples/tutorials/api/model_management.py
@@ -113,7 +113,9 @@ datasets[1].counts.sum_over_axes().smooth(0.05 * u.deg).plot(
     ax=ax2, stretch="sqrt", add_cbar=True
 )
 ax1.set_title("Fermi counts")
-ax2.set_title("CTA counts");
+ax2.set_title("CTA counts")
+plt.show()
+
 
 ######################################################################
 #
@@ -276,7 +278,7 @@ print(len(models_selected))
 ######################################################################
 # We now want to assign `models_3fhl` to the Fermi dataset, and
 # `models_selected` to both the CTA and Fermi datasets. For this, we
-# explicitlty mention the `datasets_names` to the former, and leave it
+# explicitly mention the `datasets_names` to the former, and leave it
 # `None` (default) for the latter.
 #
 

--- a/examples/tutorials/api/model_management.py
+++ b/examples/tutorials/api/model_management.py
@@ -113,7 +113,7 @@ datasets[1].counts.sum_over_axes().smooth(0.05 * u.deg).plot(
     ax=ax2, stretch="sqrt", add_cbar=True
 )
 ax1.set_title("Fermi counts")
-ax2.set_title("CTA counts")
+ax2.set_title("CTA counts");
 
 ######################################################################
 #

--- a/examples/tutorials/api/models.py
+++ b/examples/tutorials/api/models.py
@@ -134,7 +134,7 @@ print(energy)
 #
 
 plt.figure()
-pwl.plot(energy_bounds=[1, 100] * u.TeV)
+pwl.plot(energy_bounds=[1, 100] * u.TeV);
 
 
 ######################################################################
@@ -195,7 +195,7 @@ template = TemplateSpectralModel(energy, values)
 template.plot(energy_bounds=[0.2, 50] * u.TeV, label="template model")
 normed_template = template * pwl_norm
 normed_template.plot(energy_bounds=[0.2, 50] * u.TeV, label="normed_template model")
-plt.legend()
+plt.legend();
 
 
 ######################################################################
@@ -284,14 +284,14 @@ print(flux_per_omega)
 m = Map.create(skydir=(0, 0), width=(1, 1), binsz=0.02, frame="galactic")
 m.quantity = gauss.evaluate_geom(m.geom)
 plt.figure()
-m.plot(add_cbar=True)
+m.plot(add_cbar=True);
 
 
 ######################################################################
 # Again for convenience the model can be plotted directly:
 #
 plt.figure()
-gauss.plot(add_cbar=True)
+gauss.plot(add_cbar=True);
 
 
 ######################################################################
@@ -317,7 +317,7 @@ ax = gauss_elongated.plot(add_cbar=True)
 # add region illustration
 region = gauss_elongated.to_region()
 region_pix = region.to_pixel(ax.wcs)
-ax.add_artist(region_pix.as_artist(ec="w", fc="None"))
+ax.add_artist(region_pix.as_artist(ec="w", fc="None"));
 
 
 ######################################################################
@@ -382,7 +382,7 @@ gauss_temp(time)
 #
 
 time = Time([59233.0, 59250], format="mjd")
-gauss_temp.plot(time)
+gauss_temp.plot(time);
 
 
 ######################################################################
@@ -438,7 +438,7 @@ print(model.temporal_model)
 #
 
 plt.figure()
-model.spectral_model.plot(energy_bounds=[1, 10] * u.TeV)
+model.spectral_model.plot(energy_bounds=[1, 10] * u.TeV);
 
 
 ######################################################################
@@ -698,7 +698,7 @@ print(my_custom_model)
 print(my_custom_model.integral(1 * u.TeV, 10 * u.TeV))
 
 plt.figure()
-my_custom_model.plot(energy_bounds=[1, 10] * u.TeV)
+my_custom_model.plot(energy_bounds=[1, 10] * u.TeV);
 
 
 ######################################################################

--- a/examples/tutorials/api/models.py
+++ b/examples/tutorials/api/models.py
@@ -133,8 +133,8 @@ print(energy)
 # range:
 #
 
-plt.figure()
-pwl.plot(energy_bounds=[1, 100] * u.TeV);
+pwl.plot(energy_bounds=[1, 100] * u.TeV)
+plt.show()
 
 
 ######################################################################
@@ -188,14 +188,14 @@ print(pwl_norm(energy))
 
 from gammapy.modeling.models import TemplateSpectralModel
 
-plt.figure()
 energy = [0.3, 1, 3, 10, 30] * u.TeV
 values = [40, 30, 20, 10, 1] * u.Unit("TeV-1 s-1 cm-2")
 template = TemplateSpectralModel(energy, values)
 template.plot(energy_bounds=[0.2, 50] * u.TeV, label="template model")
 normed_template = template * pwl_norm
 normed_template.plot(energy_bounds=[0.2, 50] * u.TeV, label="normed_template model")
-plt.legend();
+plt.legend()
+plt.show()
 
 
 ######################################################################
@@ -283,20 +283,20 @@ print(flux_per_omega)
 
 m = Map.create(skydir=(0, 0), width=(1, 1), binsz=0.02, frame="galactic")
 m.quantity = gauss.evaluate_geom(m.geom)
-plt.figure()
-m.plot(add_cbar=True);
+m.plot(add_cbar=True)
+plt.show()
 
 
 ######################################################################
 # Again for convenience the model can be plotted directly:
 #
-plt.figure()
-gauss.plot(add_cbar=True);
+gauss.plot(add_cbar=True)
+plt.show()
 
 
 ######################################################################
 # All spatial models have an associated sky region to it e.g. to
-# illustrate the extend of the model on a sky image. The returned object
+# illustrate the extension of the model on a sky image. The returned object
 # is an `~regions.SkyRegion` object:
 #
 
@@ -317,7 +317,8 @@ ax = gauss_elongated.plot(add_cbar=True)
 # add region illustration
 region = gauss_elongated.to_region()
 region_pix = region.to_pixel(ax.wcs)
-ax.add_artist(region_pix.as_artist(ec="w", fc="None"));
+ax.add_artist(region_pix.as_artist(ec="w", fc="None"))
+plt.show()
 
 
 ######################################################################
@@ -382,7 +383,8 @@ gauss_temp(time)
 #
 
 time = Time([59233.0, 59250], format="mjd")
-gauss_temp.plot(time);
+gauss_temp.plot(time)
+plt.show()
 
 
 ######################################################################
@@ -437,8 +439,8 @@ print(model.temporal_model)
 # And can be used as you have seen already seen above:
 #
 
-plt.figure()
-model.spectral_model.plot(energy_bounds=[1, 10] * u.TeV);
+model.spectral_model.plot(energy_bounds=[1, 10] * u.TeV)
+plt.show()
 
 
 ######################################################################
@@ -508,7 +510,7 @@ display(model.parameters.to_table())
 
 ######################################################################
 # You can use the interactive boxes to choose model parameters by name,
-# type or other attrributes mentioned in the column names.
+# type or other attributes mentioned in the column names.
 #
 
 
@@ -576,7 +578,7 @@ print(models_yaml)
 # tag attribute) and sub-mobels (i.e ``spectral`` model and eventually
 # ``spatial`` model). Then the spatial and spectral models are defined by
 # their type and parameters. The ``parameters`` keys name/value/unit are
-# mandatory, while the keys min/max/frozen are optionnals (so you can
+# mandatory, while the keys min/max/frozen are optional (so you can
 # prepare shorter files).
 #
 # If you want to write this list of models to disk and read it back later
@@ -589,7 +591,7 @@ models_read = Models.read("models.yaml")
 
 
 ######################################################################
-# Additionally the models can exported and imported togeter with the data
+# Additionally the models can be exported and imported together with the data
 # using the ``Datasets.read()`` and ``Datasets.write()`` methods as shown
 # in the :doc:`/tutorials/analysis-3d/analysis_mwl`
 # notebook.
@@ -646,7 +648,7 @@ from gammapy.modeling.models import SpectralModel
 
 
 class MyCustomSpectralModel(SpectralModel):
-    """My custom spectral model, parametrising a power law plus a Gaussian spectral line.
+    """My custom spectral model, parametrizing a power law plus a Gaussian spectral line.
 
     Parameters
     ----------
@@ -684,7 +686,7 @@ class MyCustomSpectralModel(SpectralModel):
 
 ######################################################################
 # It is good practice to also implement a docstring for the model,
-# defining the parameters and also definig a ``.tag``, which specifies the
+# defining the parameters and also defining a ``.tag``, which specifies the
 # name of the model for serialisation. Also note that gammapy assumes that
 # all SpectralModel evaluate functions return a flux in unit of
 # `"cm-2 s-1 TeV-1"` (or equivalent dimensions).
@@ -697,14 +699,14 @@ print(my_custom_model)
 
 print(my_custom_model.integral(1 * u.TeV, 10 * u.TeV))
 
-plt.figure()
-my_custom_model.plot(energy_bounds=[1, 10] * u.TeV);
+my_custom_model.plot(energy_bounds=[1, 10] * u.TeV)
+plt.show()
 
 
 ######################################################################
 # As a next step we can also register the custom model in the
 # ``SPECTRAL_MODELS`` registry, so that it becomes available for
-# serilisation:
+# serialization:
 #
 
 SPECTRAL_MODEL_REGISTRY.append(MyCustomSpectralModel)

--- a/examples/tutorials/data/cta.py
+++ b/examples/tutorials/data/cta.py
@@ -278,7 +278,7 @@ irfs["psf"].peek()
 irfs["psf"].plot_containment_radius_vs_energy(
     offset=[1] * u.deg, fraction=[0.68, 0.8, 0.95]
 )
-
+plt.show()
 
 ######################################################################
 # Background
@@ -299,7 +299,6 @@ print(irfs["bkg"].evaluate(energy="3 TeV", fov_lon="1 deg", fov_lat="0 deg"))
 irfs["bkg"].plot_at_energy(
     ["100 GeV", "500 GeV", "1 TeV", "3 TeV", "10 TeV", "100 TeV"]
 )
-
 plt.show()
 
 ######################################################################

--- a/examples/tutorials/data/cta.py
+++ b/examples/tutorials/data/cta.py
@@ -50,7 +50,7 @@ observability and sensitivity, or how to analyse CTA data.
 Note that the FITS data and IRF format currently used by CTA is the one
 documented at https://gamma-astro-data-formats.readthedocs.io/, and is
 also used by H.E.S.S. and other imaging atmospheric Cherenkov telescopes
-(IACTs). So if you see other Gammapy tutorials using e.g. H.E.S.S.
+(IACTs). So if you see other Gammapy tutorials using e.g. H.E.S.S.
 example data, know that they also apply to CTA, all you have to do is to
 change the loaded data or IRFs to CTA.
 
@@ -200,7 +200,7 @@ display(events.table[:5])
 #
 
 events.peek()
-
+plt.show()
 
 ######################################################################
 # IRFs
@@ -253,6 +253,7 @@ aeff = EffectiveAreaTable2D.read(irf_filename, hdu="EFFECTIVE AREA")
 print(aeff)
 
 irfs["aeff"].peek()
+plt.show()
 
 # What is the on-axis effective area at 10 TeV?
 print(aeff.evaluate(energy_true="10 TeV", offset="0 deg").to("km2"))
@@ -264,6 +265,7 @@ print(aeff.evaluate(energy_true="10 TeV", offset="0 deg").to("km2"))
 #
 
 irfs["edisp"].peek()
+plt.show()
 
 
 ######################################################################
@@ -272,6 +274,7 @@ irfs["edisp"].peek()
 #
 
 irfs["psf"].peek()
+plt.show()
 
 # This is how for analysis you could slice out the PSF
 # at a given field of view offset
@@ -288,6 +291,7 @@ plt.show()
 #
 
 irfs["bkg"].peek()
+plt.show()
 
 print(irfs["bkg"].evaluate(energy="3 TeV", fov_lon="1 deg", fov_lat="0 deg"))
 
@@ -310,10 +314,10 @@ plt.show()
 # XML model file format. We are currently developing a YAML based format
 # that improves upon the XML format, to be easier to write and read, add
 # relevant information (units for physical quantities), and omit useless
-# information (e.g. parameter scales in addition to values).
+# information (e.g. parameter scales in addition to values).
 #
 # If you must or want to read the XML model files, you can use
-# e.g. `ElementTree <https://docs.python.org/3/library/xml.etree.elementtree.html>`__
+# e.g. `ElementTree <https://docs.python.org/3/library/xml.etree.elementtree.html>`__
 # from the Python standard library, or
 # `xmltodict <https://github.com/martinblech/xmltodict>`__ if you
 # `pip install xmltodict`. Here’s an example how to load the information

--- a/examples/tutorials/data/fermi_lat.py
+++ b/examples/tutorials/data/fermi_lat.py
@@ -157,9 +157,8 @@ counts.fill_events(events)
 
 print(counts.geom.axes[0])
 
-plt.figure()
 counts.sum_over_axes().smooth(2).plot(stretch="sqrt", vmax=30)
-
+plt.show()
 
 ######################################################################
 # Exposure
@@ -189,8 +188,8 @@ exposure_hpx = Map.read("$GAMMAPY_DATA/fermi_3fhl/fermi_3fhl_exposure_cube_hpx.f
 print(exposure_hpx.geom)
 print(exposure_hpx.geom.axes[0])
 
-plt.figure()
 exposure_hpx.plot()
+plt.show()
 
 ######################################################################
 # For exposure, we choose a geometry with node_type='center',
@@ -210,8 +209,8 @@ print(exposure.geom.axes[0])
 
 ######################################################################
 # Exposure is almost constant across the field of view
-plt.figure()
 exposure.slice_by_idx({"energy_true": 0}).plot(add_cbar=True)
+plt.show()
 
 ######################################################################
 # Exposure varies very little with energy at these high energies
@@ -253,8 +252,8 @@ diffuse_iem = SkyModel(
 ######################################################################
 # Let’s look at the map of first energy band of the cube:
 #
-plt.figure()
 template_diffuse.map.slice_by_idx({"energy_true": 0}).plot(add_cbar=True)
+plt.show()
 
 
 ######################################################################
@@ -262,10 +261,10 @@ template_diffuse.map.slice_by_idx({"energy_true": 0}).plot(add_cbar=True)
 #
 
 dnde = template_diffuse.map.to_region_nd_map(region=gc_pos)
-plt.figure()
 dnde.plot()
 plt.xlabel("Energy (GeV)")
 plt.ylabel("Flux (cm-2 s-1 MeV-1 sr-1)")
+plt.show()
 
 
 ######################################################################
@@ -287,9 +286,9 @@ diffuse_iso = create_fermi_isotropic_diffuse_model(
 ######################################################################
 # We can plot the model in the energy range between 50 GeV and 2000 GeV:
 #
-plt.figure()
 energy_bounds = [50, 2000] * u.GeV
 diffuse_iso.spectral_model.plot(energy_bounds, yunits=u.Unit("1 / (cm2 MeV s)"))
+plt.show()
 
 
 ######################################################################
@@ -316,6 +315,7 @@ print(psf)
 
 plt.figure(figsize=(8, 5))
 psf.plot_containment_radius_vs_energy()
+plt.show()
 
 
 ######################################################################
@@ -335,6 +335,7 @@ psf_mean.plot_psf_vs_rad(c="k", ls="--", energy_true=[500] * u.GeV)
 plt.xlim(1e-3, 0.3)
 plt.ylim(1e3, 1e6)
 plt.legend()
+plt.show()
 
 ######################################################################
 # This is whaty the corresponding PSF kernel looks like:
@@ -343,8 +344,8 @@ plt.legend()
 psf_kernel = psf.get_psf_kernel(
     position=geom.center_skydir, geom=geom, max_radius="1 deg"
 )
-plt.figure()
 psf_kernel.to_image().psf_kernel_map.plot(stretch="log", add_cbar=True)
+plt.show()
 
 
 ######################################################################
@@ -359,8 +360,8 @@ edisp = EDispKernelMap.from_diagonal_response(
     energy_axis_true=e_true, energy_axis=energy_axis
 )
 
-plt.figure()
 edisp.get_edisp_kernel().plot_matrix()
+plt.show()
 
 
 ######################################################################
@@ -404,10 +405,10 @@ print(models)
 
 residual = counts - dataset.npred()
 
-plt.figure()
 residual.sum_over_axes().smooth("0.1 deg").plot(
     cmap="coolwarm", vmin=-3, vmax=3, add_cbar=True
 )
+plt.show()
 
 ######################################################################
 # Serialisation
@@ -425,7 +426,7 @@ datasets_read = Datasets.read(
 )
 print(datasets_read)
 
-plt.show()
+
 ######################################################################
 # Exercises
 # ---------

--- a/examples/tutorials/data/hawc.py
+++ b/examples/tutorials/data/hawc.py
@@ -113,26 +113,31 @@ obs = data_store.get_observations()[0]
 # Select and peek events
 
 obs.events.peek()
+plt.show()
 
 
 ######################################################################
 # Peek the energy dispersion
 
 obs.edisp.peek()
+plt.show()
 
 ######################################################################
 # Peek the psf
 obs.psf.peek()
+plt.show()
 
 ######################################################################
 # Peek the background for one transit
 plt.figure()
 obs.bkg.reduce_over_axes().plot(add_cbar=True)
+plt.show()
 
 ######################################################################
 # Peek the effective exposure for one transit
 plt.figure()
 obs.aeff.reduce_over_axes().plot(add_cbar=True)
+plt.show()
 
 
 ######################################################################
@@ -225,6 +230,7 @@ dataset.exposure.data *= transit_number
 ######################################################################
 # We can use the .peek() method to quickly get a glimpse of the contents
 dataset.peek()
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/data/hess.py
+++ b/examples/tutorials/data/hess.py
@@ -40,6 +40,8 @@ release 1.
 
 import astropy.units as u
 from astropy.coordinates import SkyCoord
+
+# %matplotlib inline
 import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import DataStore
@@ -104,9 +106,8 @@ obs.psf.peek()
 
 ######################################################################
 # Peek the background rate
-plt.figure()
 obs.bkg.to_2d().plot()
-
+plt.show()
 
 ######################################################################
 # Theta squared event distribution
@@ -128,7 +129,7 @@ theta2_table = make_theta_squared_table(
 
 plt.figure(figsize=(10, 5))
 plot_theta_squared_table(theta2_table)
-
+plt.show()
 
 ######################################################################
 # On-axis equivalent livetime
@@ -181,8 +182,8 @@ for obs in observations:
     livetime.stack(lv_obs)
 
 # Plot
-plt.figure()
 ax = livetime.plot(add_cbar=True)
+plt.show()
 
 # Add the pointing position on top
 for obs in observations:
@@ -192,7 +193,6 @@ for obs in observations:
         "+",
         color="black",
     )
-
 plt.show()
 
 ######################################################################

--- a/examples/tutorials/starting/analysis_1.py
+++ b/examples/tutorials/starting/analysis_1.py
@@ -60,7 +60,7 @@ In summary, we have to:
    -  Model fitting
    -  Estimating flux points
 
-Finally we will compare the results against a reference model.
+Finally, we will compare the results against a reference model.
 
 """
 
@@ -70,9 +70,11 @@ Finally we will compare the results against a reference model.
 # -----
 #
 
-# %matplotlib inline
 from pathlib import Path
 from astropy import units as u
+
+# %matplotlib inline
+import matplotlib.pyplot as plt
 from gammapy.analysis import Analysis, AnalysisConfig
 
 ######################################################################
@@ -302,8 +304,8 @@ counts.smooth("0.05 deg").plot_interactive()
 #
 
 analysis.get_excess_map()
-analysis.excess_map["sqrt_ts"].plot(add_cbar=True);
-
+analysis.excess_map["sqrt_ts"].plot(add_cbar=True)
+plt.show()
 
 ######################################################################
 # Save dataset to disk
@@ -415,12 +417,12 @@ analysis.get_flux_points()
 fp = analysis.flux_points.data
 fp.sqrt_ts_threshold_ul = 5
 ax_sed, ax_residuals = analysis.flux_points.plot_fit()
-
+plt.show()
 
 ######################################################################
 # The flux points can be exported to a fits table following the format
 # defined
-# `here <https://gamma-astro-data-formats.readthedocs.io/en/latest/spectra/flux_points/index.html>`__
+# `here <https://gamma-astro-data-formats.readthedocs.io/en/latest/spectra/flux_points/index.html>`_
 #
 
 filename = path / "flux-points.fits"
@@ -433,7 +435,8 @@ analysis.flux_points.write(filename, overwrite=True)
 #
 
 analysis.get_excess_map()
-analysis.excess_map["sqrt_ts"].plot(add_cbar=True, cmap="RdBu", vmin=-5, vmax=5);
+analysis.excess_map["sqrt_ts"].plot(add_cbar=True, cmap="RdBu", vmin=-5, vmax=5)
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/starting/analysis_1.py
+++ b/examples/tutorials/starting/analysis_1.py
@@ -302,7 +302,7 @@ counts.smooth("0.05 deg").plot_interactive()
 #
 
 analysis.get_excess_map()
-analysis.excess_map["sqrt_ts"].plot(add_cbar=True)
+analysis.excess_map["sqrt_ts"].plot(add_cbar=True);
 
 
 ######################################################################
@@ -433,7 +433,7 @@ analysis.flux_points.write(filename, overwrite=True)
 #
 
 analysis.get_excess_map()
-analysis.excess_map["sqrt_ts"].plot(add_cbar=True, cmap="RdBu", vmin=-5, vmax=5)
+analysis.excess_map["sqrt_ts"].plot(add_cbar=True, cmap="RdBu", vmin=-5, vmax=5);
 
 
 ######################################################################

--- a/examples/tutorials/starting/analysis_2.py
+++ b/examples/tutorials/starting/analysis_2.py
@@ -78,6 +78,7 @@ from regions import CircleSkyRegion
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
+from IPython.display import display
 from gammapy.data import DataStore
 from gammapy.datasets import MapDataset
 from gammapy.estimators import FluxPointsEstimator
@@ -228,7 +229,8 @@ print(stacked)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 
-stacked.counts.sum_over_axes().smooth(0.05 * u.deg).plot(stretch="sqrt", add_cbar=True);
+stacked.counts.sum_over_axes().smooth(0.05 * u.deg).plot(stretch="sqrt", add_cbar=True)
+plt.show()
 
 
 ######################################################################
@@ -328,7 +330,8 @@ print(stacked.models.to_parameters_table())
 # energies:
 #
 
-stacked.plot_residuals_spatial(method="diff/sqrt(model)", vmin=-0.5, vmax=0.5);
+stacked.plot_residuals_spatial(method="diff/sqrt(model)", vmin=-0.5, vmax=0.5)
+plt.show()
 
 
 ######################################################################
@@ -341,7 +344,8 @@ region = CircleSkyRegion(center=SkyCoord("83.63 deg", "22.14 deg"), radius=0.5 *
 stacked.plot_residuals(
     kwargs_spatial=dict(method="diff/sqrt(model)", vmin=-0.5, vmax=0.5),
     kwargs_spectral=dict(region=region),
-);
+)
+plt.show()
 
 
 ######################################################################
@@ -353,7 +357,7 @@ residuals = stacked.residuals(method="diff")
 residuals.smooth("0.08 deg").plot_interactive(
     cmap="coolwarm", vmin=-0.2, vmax=0.2, stretch="linear", add_cbar=True
 )
-
+plt.show()
 
 ######################################################################
 # Plot the fitted spectrum
@@ -380,6 +384,7 @@ spec = sky_model.spectral_model
 energy_bounds = [1, 10] * u.TeV
 spec.plot(energy_bounds=energy_bounds, energy_power=2)
 ax = spec.plot_error(energy_bounds=energy_bounds, energy_power=2)
+plt.show()
 
 
 ######################################################################
@@ -401,4 +406,5 @@ fpe = FluxPointsEstimator(energy_edges=energy_edges, source="crab")
 flux_points = fpe.run(datasets=[stacked])
 
 ax = spec.plot_error(energy_bounds=energy_bounds, energy_power=2)
-flux_points.plot(ax=ax, energy_power=2);
+flux_points.plot(ax=ax, energy_power=2)
+plt.show()

--- a/examples/tutorials/starting/analysis_2.py
+++ b/examples/tutorials/starting/analysis_2.py
@@ -228,7 +228,7 @@ print(stacked)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 
-stacked.counts.sum_over_axes().smooth(0.05 * u.deg).plot(stretch="sqrt", add_cbar=True)
+stacked.counts.sum_over_axes().smooth(0.05 * u.deg).plot(stretch="sqrt", add_cbar=True);
 
 
 ######################################################################
@@ -328,7 +328,7 @@ print(stacked.models.to_parameters_table())
 # energies:
 #
 
-stacked.plot_residuals_spatial(method="diff/sqrt(model)", vmin=-0.5, vmax=0.5)
+stacked.plot_residuals_spatial(method="diff/sqrt(model)", vmin=-0.5, vmax=0.5);
 
 
 ######################################################################
@@ -341,7 +341,7 @@ region = CircleSkyRegion(center=SkyCoord("83.63 deg", "22.14 deg"), radius=0.5 *
 stacked.plot_residuals(
     kwargs_spatial=dict(method="diff/sqrt(model)", vmin=-0.5, vmax=0.5),
     kwargs_spectral=dict(region=region),
-)
+);
 
 
 ######################################################################
@@ -401,4 +401,4 @@ fpe = FluxPointsEstimator(energy_edges=energy_edges, source="crab")
 flux_points = fpe.run(datasets=[stacked])
 
 ax = spec.plot_error(energy_bounds=energy_bounds, energy_power=2)
-flux_points.plot(ax=ax, energy_power=2)
+flux_points.plot(ax=ax, energy_power=2);

--- a/examples/tutorials/starting/overview.py
+++ b/examples/tutorials/starting/overview.py
@@ -145,8 +145,8 @@ print(f"Total number of counts in the image: {gc_3fhl.data.sum():.0f}")
 # `astropy.visualization.wcsaxes <https://docs.astropy.org/en/stable/visualization/wcsaxes/>`__
 # and defines some defaults for nicer plots (e.g. the colormap ‘afmhot’):
 #
-plt.figure()
-gc_3fhl.plot(stretch="sqrt");
+gc_3fhl.plot(stretch="sqrt")
+plt.show()
 
 
 ######################################################################
@@ -154,9 +154,9 @@ gc_3fhl.plot(stretch="sqrt");
 # using a Gaussian kernel.
 #
 
-plt.figure()
 gc_3fhl_smoothed = gc_3fhl.smooth(kernel="gauss", width=0.2 * u.deg)
-gc_3fhl_smoothed.plot(stretch="sqrt");
+gc_3fhl_smoothed.plot(stretch="sqrt")
+plt.show()
 
 
 ######################################################################
@@ -167,11 +167,11 @@ gc_3fhl_smoothed.plot(stretch="sqrt");
 # cutout map:
 #
 
-plt.figure()
 # define center and size of the cutout region
 center = SkyCoord(0, 0, unit="deg", frame="galactic")
 gc_3fhl_cutout = gc_3fhl_smoothed.cutout(center, 9 * u.deg)
-gc_3fhl_cutout.plot(stretch="sqrt");
+gc_3fhl_cutout.plot(stretch="sqrt")
+plt.show()
 
 
 ######################################################################
@@ -393,8 +393,8 @@ print(crab_3fhl_spec)
 # 2000 GeV:
 #
 
-plt.figure()
 ax_crab_3fhl = crab_3fhl_spec.plot(energy_bounds=[10, 2000] * u.GeV, energy_power=0)
+plt.show()
 
 
 ######################################################################
@@ -464,10 +464,8 @@ print(crab_3fhl.flux_points.to_table(sed_type="dnde", formatted=True))
 # distribution:
 #
 
-plt.figure()
 ax = crab_3fhl_spec.plot(energy_bounds=[10, 2000] * u.GeV, sed_type="e2dnde")
 crab_3fhl.flux_points.plot(ax=ax, sed_type="e2dnde")
-
 plt.show()
 
 ######################################################################

--- a/examples/tutorials/starting/overview.py
+++ b/examples/tutorials/starting/overview.py
@@ -146,8 +146,7 @@ print(f"Total number of counts in the image: {gc_3fhl.data.sum():.0f}")
 # and defines some defaults for nicer plots (e.g. the colormap ‘afmhot’):
 #
 plt.figure()
-
-gc_3fhl.plot(stretch="sqrt")
+gc_3fhl.plot(stretch="sqrt");
 
 
 ######################################################################
@@ -157,8 +156,7 @@ gc_3fhl.plot(stretch="sqrt")
 
 plt.figure()
 gc_3fhl_smoothed = gc_3fhl.smooth(kernel="gauss", width=0.2 * u.deg)
-
-gc_3fhl_smoothed.plot(stretch="sqrt")
+gc_3fhl_smoothed.plot(stretch="sqrt");
 
 
 ######################################################################
@@ -173,8 +171,7 @@ plt.figure()
 # define center and size of the cutout region
 center = SkyCoord(0, 0, unit="deg", frame="galactic")
 gc_3fhl_cutout = gc_3fhl_smoothed.cutout(center, 9 * u.deg)
-
-gc_3fhl_cutout.plot(stretch="sqrt")
+gc_3fhl_cutout.plot(stretch="sqrt");
 
 
 ######################################################################


### PR DESCRIPTION

**Description**

This pull request is associated to the Issue #4327. It adds semicolons when necessary

**Dear reviewer**
During my commits, I have noticed that `black` automatically suppresses some semicolons. One might need to configure back if possible (a new issue?)
