### PR TITLE
Typo in my name in the release notes file v1.0.1

### DIFF
--- a/docs/release-notes/v1.0.1.rst
+++ b/docs/release-notes/v1.0.1.rst
@@ -33,7 +33,7 @@ Contributors
 - Bruno Khelifi
 - Maximilian Linhoff
 - Lars Mohrmann
-- Maxime Régeard
+- Maxime Regeard
 - Quentin Remy
 - Atreyee Sinha
 - Régis Terrier


### PR DESCRIPTION
PR that correct a typo in my name in the v1.0.1 release notes.