### PR TITLE
Deprecate Fit.minuit member

### DIFF
--- a/examples/tutorials/api/fitting.py
+++ b/examples/tutorials/api/fitting.py
@@ -196,7 +196,7 @@ print(result_minuit)
 # to check the convergence
 #
 
-print(fit.minuit)
+print(result_minuit.minuit)
 
 
 ######################################################################

--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -223,8 +223,8 @@ def test_lightcurve_estimator_fit_options():
 
     assert_allclose(estimator.fit.optimize_opts["tol"], 0.2)
 
-    estimator.fit.run(datasets=datasets)
-    assert_allclose(estimator.fit.minuit.tol, 0.2)
+    result = estimator.fit.run(datasets=datasets)
+    assert_allclose(result.minuit.tol, 0.2)
 
 
 @requires_data()

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -393,7 +393,6 @@ def test_flux_points_estimator_no_norm_scan(fpe_pwl, tmpdir):
     fp = fpe.run(datasets)
 
     assert_allclose(fpe.fit.optimize_opts["tol"], 0.2)
-    assert_allclose(fpe.fit.minuit.tol, 0.2)
 
     assert fp.sed_type_init == "likelihood"
     assert "stat_scan" not in fp._data

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -270,7 +270,7 @@ class Fit:
 
         kwargs = self.covariance_opts.copy()
 
-        if optimize_result is not None:
+        if optimize_result is not None and optimize_result.backend == "minuit":
             kwargs["minuit"] = optimize_result.minuit
 
         backend = kwargs.pop("backend", self.backend)

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -642,6 +642,11 @@ class FitResult:
 
         self._covariance_result = covariance_result
 
+    @property
+    def minuit(self):
+        """Minuit object"""
+        return self.optimize_result.minuit
+
     # TODO: is the convenience access needed?
     @property
     def parameters(self):

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -221,6 +221,7 @@ class Fit:
         )
 
         if backend == "minuit":
+            self._minuit = optimizer
             kwargs["method"] = "migrad"
 
         trace = Table(info.pop("trace"))

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -258,7 +258,7 @@ class Fit:
             Datasets to optimize.
         optimize_result : `OptimizeResult`
             Optimization result. Can be optionally used to pass the state of the IMinuit object
-            to the convariance estimatiomn. This might save computation time in certain cases.
+            to the covariance estimation. This might save computation time in certain cases.
 
         Returns
         -------

--- a/gammapy/modeling/iminuit.py
+++ b/gammapy/modeling/iminuit.py
@@ -91,7 +91,7 @@ def optimize_iminuit(parameters, function, store_trace=False, **kwargs):
 
 
 def covariance_iminuit(parameters, function, **kwargs):
-    minuit = kwargs["minuit"]
+    minuit = kwargs.get("minuit")
 
     if minuit is None:
         minuit, _ = setup_iminuit(

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -90,6 +90,7 @@ def test_run(backend):
     result = fit.run([dataset])
     pars = dataset.models.parameters
 
+    assert fit._minuit is not None
     assert result.success
     assert result.optimize_result.method == "migrad"
     assert result.covariance_result.method == "hesse"


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request deprecates the `Fit.minuit` member and moves it to the `OptimizeResult` instead. The motivation is to get rid of the stateful dependency of the `Fit` object, which is likely the reason for the remaining test fails in #4406. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
