### PR TITLE
Rename append method of MapAxis and LabelMapAxis to concatenate

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3181,19 +3181,19 @@ class LabelMapAxis:
         return axis_stacked
 
     def concatenate(self, axis):
-        """Append another label map axis to this label map axis.
+        """Concatenate this `LabelMapAxis` with another one into a new one.
 
         Names must agree between the axes. labels must be unique.
 
         Parameters
         ----------
         axis : `LabelMapAxis`
-            Axis to append.
+            Axis to concatenate with.
 
         Returns
         -------
         axis : `LabelMapAxis`
-            Appended axis
+            Concatenation of the two axis.
         """
         if not isinstance(axis, LabelMapAxis):
             raise TypeError(

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3183,7 +3183,7 @@ class LabelMapAxis:
         return axis_stacked
 
     def concatenate(self, axis):
-        """Concatenate this `LabelMapAxis` with another one into a new one.
+        """Concatenate another `LabelMapAxis` to this `LabelMapAxis` into a new `LabelMapAxis` object.
 
         Names must agree between the axes. labels must be unique.
 

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -105,6 +105,8 @@ class MapAxis:
         String specifying the data units.
     """
 
+    append = deprecated_attribute("append", "1.1", alternative="concatenate")
+
     # TODO: Cache an interpolation object?
     def __init__(self, nodes, interp="lin", name="", node_type="edges", unit=""):
 
@@ -643,8 +645,8 @@ class MapAxis:
 
         return cls(edges, node_type="edges", **kwargs)
 
-    def append(self, axis):
-        """Append another map axis to this axis
+    def concatenate(self, axis):
+        """Concatenate another `MapAxis` to this `MapAxis` into a new `MapAxis` object.
 
         Name, interp type and node type must agree between the axes. If the node
         type is "edges", the edges must be contiguous and non-overlapping.
@@ -652,12 +654,12 @@ class MapAxis:
         Parameters
         ----------
         axis : `MapAxis`
-            Axis to append.
+            Axis to concatenate with.
 
         Returns
         -------
         axis : `MapAxis`
-            Appended axis
+            Concatenation of the two axis.
         """
         if self.node_type != axis.node_type:
             raise ValueError(
@@ -727,7 +729,7 @@ class MapAxis:
         ax_stacked = axes[0]
 
         for ax in axes[1:]:
-            ax_stacked = ax_stacked.append(ax)
+            ax_stacked = ax_stacked.concatenate(ax)
 
         return ax_stacked
 

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -11,6 +11,7 @@ from astropy.table import Column, Table, hstack
 from astropy.time import Time
 from astropy.utils import lazyproperty
 import matplotlib.pyplot as plt
+from gammapy.utils.deprecation import deprecated_attribute
 from gammapy.utils.interpolation import interpolation_scale
 from gammapy.utils.time import time_ref_from_dict, time_ref_to_dict
 from .utils import INVALID_INDEX, edges_from_lo_hi
@@ -2834,6 +2835,8 @@ class LabelMapAxis:
 
     """
 
+    append = deprecated_attribute("append", "1.1", alternative="concatenate")
+
     node_type = "label"
 
     def __init__(self, labels, name=""):
@@ -3173,11 +3176,11 @@ class LabelMapAxis:
         axis_stacked = axes[0]
 
         for ax in axes[1:]:
-            axis_stacked = axis_stacked.append(ax)
+            axis_stacked = axis_stacked.concatenate(ax)
 
         return axis_stacked
 
-    def append(self, axis):
+    def concatenate(self, axis):
         """Append another label map axis to this label map axis.
 
         Names must agree between the axes. labels must be unique.

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -819,12 +819,12 @@ def test_label_map_axis_append():
     label2 = LabelMapAxis(["cc", "dd"], name="letters")
     label3 = LabelMapAxis(["ee", "ff"], name="other_letters")
 
-    label_append12 = label1.append(label2)
+    label_append12 = label1.concatenate(label2)
 
     assert_equal(label_append12.center, np.array(["aa", "bb", "cc", "dd"], dtype="<U2"))
     assert label_append12.name == "letters"
     with pytest.raises(ValueError):
-        label2.append(label3)
+        label2.concatenate(label3)
 
 
 def test_label_map_axis_from_stack():

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -388,6 +388,19 @@ def test_map_axis_plot_helpers():
     assert_allclose(axis.edges, axis.as_plot_edges)
 
 
+def test_map_axis_concatenate():
+    axis_1 = MapAxis.from_bounds(0, 10, 10, name="axis")
+    axis_2 = MapAxis.from_bounds(10, 20, 10, name="axis")
+    axis_2_other_name = MapAxis.from_bounds(10, 20, 10, name="other_axis")
+
+    axis_12 = axis_1.concatenate(axis_2)
+
+    assert_equal(axis_12.edges, np.linspace(0, 20, 20))
+
+    with pytest.raises(ValueError):
+        axis_1.concatenate(axis_2_other_name)
+
+
 def test_time_axis(time_intervals):
     axis = TimeMapAxis(
         time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"]

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -395,7 +395,7 @@ def test_map_axis_concatenate():
 
     axis_12 = axis_1.concatenate(axis_2)
 
-    assert_equal(axis_12.edges, np.linspace(0, 20, 20))
+    assert_equal(axis_12.edges, np.linspace(0, 20, 21))
 
     with pytest.raises(ValueError):
         axis_1.concatenate(axis_2_other_name)

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -826,7 +826,7 @@ def test_single_valued_axis():
     _ = MapAxis.from_table(table, format="gadf-dl3", column_prefix="THETA")
 
 
-def test_label_map_axis_append():
+def test_label_map_axis_concatenate():
 
     label1 = LabelMapAxis(["aa", "bb"], name="letters")
     label2 = LabelMapAxis(["cc", "dd"], name="letters")


### PR DESCRIPTION
This pull request is related to issue #4443. 

I renamed the `append` method of `MapAxis` and `LabelMapAxis` to `concatenate` .