### PR TITLE
Introduce WcsNDMap.cutout_and_mask_region

### DIFF
--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -399,7 +399,6 @@ class RegionGeom(Geom):
         return wcs_geom
 
     def to_binsz_wcs(self, binsz):
-
         """Change the bin size of the underlying WCS geometry.
 
         Parameters

--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -15,6 +15,7 @@ from astropy.wcs.utils import (
     proj_plane_pixel_scales,
     wcs_to_celestial_frame,
 )
+from regions import RectangleSkyRegion
 from gammapy.utils.array import round_up_to_even, round_up_to_odd
 from ..axes import MapAxes
 from ..coord import MapCoord, skycoord_to_lonlat
@@ -35,7 +36,6 @@ def cast_to_shape(param, shape, dtype):
         param = [param[0].copy(), param[0].copy()]
 
     for i, p in enumerate(param):
-
         if p.size > 1 and p.shape != shape:
             raise ValueError
 
@@ -409,9 +409,17 @@ class WcsGeom(Geom):
 
     @property
     def footprint(self):
-        """Footprint of the geometry"""
+        """Footprint of the geometry as (`SkyCoord`)"""
         coords = self.wcs.calc_footprint()
         return SkyCoord(coords, frame=self.frame, unit="deg")
+
+    @property
+    def footprint_rectangle_sky_region(self):
+        """Footprint of the geometry as (`RectangleSkyRegion`)"""
+        width, height = self.width
+        return RectangleSkyRegion(
+            center=self.center_skydir, width=width[0], height=height[0]
+        )
 
     @classmethod
     def from_aligned(cls, geom, skydir, width):
@@ -494,7 +502,6 @@ class WcsGeom(Geom):
         return cls(wcs, npix, cdelt=cdelt, axes=axes)
 
     def _make_bands_cols(self):
-
         cols = []
         if not self.is_regular:
             cols += [

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -595,7 +595,7 @@ class WcsNDMap(WcsMap):
             # Casting needed as interp_by_coord transforms boolean
             data = data.astype(self.data.dtype)
         else:
-            cutout, mask = self.cutout_and_mask_region(region=region, weights=weights)
+            cutout, mask = self.cutout_and_mask_region(region=region)
 
             if weights is not None:
                 weights_cutout = weights.cutout(

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -8,7 +8,7 @@ import astropy.units as u
 from astropy.convolution import Tophat2DKernel
 from astropy.io import fits
 from astropy.nddata import block_reduce
-from regions import PixCoord, PointPixelRegion, PointSkyRegion, SkyRegion
+from regions import PixCoord, PointPixelRegion, SkyRegion
 import matplotlib.pyplot as plt
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
 from gammapy.utils.units import unit_from_fits_image_hdu
@@ -543,7 +543,7 @@ class WcsNDMap(WcsMap):
         if region is None:
             region = self.geom.footprint_rectangle_sky_region
 
-        geom = RegionGeom(region=region, wcs=self.geom.wcs)
+        geom = RegionGeom.from_regions(regions=region, wcs=self.geom.wcs)
         cutout = self.cutout(position=geom.center_skydir, width=geom.width)
 
         mask = cutout.geom.to_image().region_mask([region])
@@ -586,7 +586,7 @@ class WcsNDMap(WcsMap):
             regions=region, axes=self.geom.axes, wcs=self.geom.wcs
         )
 
-        if isinstance(region, PointSkyRegion):
+        if geom.is_all_point_sky_regions:
             coords = geom.get_coord()
             data = self.interp_by_coord(coords=coords, method=method)
 

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -522,7 +522,7 @@ class WcsNDMap(WcsMap):
         lat.grid(alpha=0.2, linestyle="solid", color="w")
         return ax
 
-    def cutout_and_mask_region(self, region):
+    def cutout_and_mask_region(self, region=None):
         """Compute cutout and mask for a given region of the map.
 
         The function will estimate the minimal size of the cutout, which encloses


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a little refactoring to expose a step in `to_region_nd_map()`. The method is called `.cutout_and_mask_region()` and it return a cutout if the map, corresponding to the size of the region along with a mask, that defines the region. I refactored the existing `.to_region_nd_map()` method to use it. So testing is already done however I could maybe add one more unit test.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
