### PR TITLE
Npred plot function in tutorials

### DIFF
--- a/examples/tutorials/analysis-3d/analysis_3d.py
+++ b/examples/tutorials/analysis-3d/analysis_3d.py
@@ -333,6 +333,13 @@ plt.show()
 
 
 ######################################################################
+# Here we can plot the number of predicted counts for each model and
+# for the background in our dataset by using the
+# `~gammapy.visualization.plot_npred_signal` function.
+#
+
+
+######################################################################
 # Joint analysis
 # --------------
 #

--- a/examples/tutorials/analysis-3d/cta_data_analysis.py
+++ b/examples/tutorials/analysis-3d/cta_data_analysis.py
@@ -314,6 +314,32 @@ print(result)
 
 
 ######################################################################
+# Here we can plot the predicted number of counts for each model and
+# for the background in the dataset. This is especially useful when
+# studying complex field with a lot a sources. There is a function
+# in the visualization sub-package of gammapy that does this automatically.
+#
+# First we need to stack our datasets.
+
+
+stacked_dataset = datasets.stack_reduce(name="stacked")
+stacked_dataset.models = model
+
+print(stacked_dataset)
+
+
+######################################################################
+# Import the function from `~gammapy.visualization`
+#
+
+
+from gammapy.visualization import plot_npred_signal
+
+plot_npred_signal(stacked_dataset)
+plt.show()
+
+
+######################################################################
 # Spectral points
 # ~~~~~~~~~~~~~~~
 #
@@ -322,14 +348,9 @@ print(result)
 # profile to compute the flux and flux error.
 #
 
-# Flux points are computed on stacked observation
-stacked_dataset = datasets.stack_reduce(name="stacked")
 
-print(stacked_dataset)
-
+# Flux points are computed on stacked datasets
 energy_edges = MapAxis.from_energy_bounds("1 TeV", "30 TeV", nbin=5).edges
-
-stacked_dataset.models = model
 
 fpe = FluxPointsEstimator(energy_edges=energy_edges, source="source-gc")
 flux_points = fpe.run(datasets=[stacked_dataset])

--- a/examples/tutorials/analysis-3d/cta_data_analysis.py
+++ b/examples/tutorials/analysis-3d/cta_data_analysis.py
@@ -53,7 +53,7 @@ from gammapy.modeling.models import (
     PowerLawSpectralModel,
     SkyModel,
 )
-from gammapy.visualization import plot_spectrum_datasets_off_regions
+from gammapy.visualization import plot_npred_signal, plot_spectrum_datasets_off_regions
 
 logging.basicConfig()
 log = logging.getLogger("gammapy.spectrum")
@@ -329,11 +329,9 @@ print(stacked_dataset)
 
 
 ######################################################################
-# Import the function from `~gammapy.visualization`
+# Call `plot_npred_signal` to plot the predicted counts.
 #
 
-
-from gammapy.visualization import plot_npred_signal
 
 plot_npred_signal(stacked_dataset)
 plt.show()

--- a/examples/tutorials/starting/analysis_2.py
+++ b/examples/tutorials/starting/analysis_2.py
@@ -92,6 +92,7 @@ from gammapy.modeling.models import (
     SkyModel,
 )
 from gammapy.utils.check import check_tutorials_setup
+from gammapy.visualization import plot_npred_signal
 
 ######################################################################
 # Check setup
@@ -318,6 +319,16 @@ print(result)
 #
 
 print(stacked.models.to_parameters_table())
+
+
+######################################################################
+# Here we can plot the number of predicted counts for each model and
+# for the background in our dataset. In order to do this, we can use
+# the `~gammapy.visualization.plot_npred_signal` function.
+#
+
+plot_npred_signal(stacked)
+plt.show()
 
 
 ######################################################################


### PR DESCRIPTION
This PR follows #4409. 

It aims to add the `plot_npred_signal` function in tutorials. 

For now I added it in the `Basic image exploration and fitting` tutorial (https://docs.gammapy.org/dev/tutorials/analysis-3d/cta_data_analysis.html). 

It could be added in another tutorial, maybe in the `3D details analysis` tutorial (https://docs.gammapy.org/dev/tutorials/analysis-3d/analysis_3d.html). 

What do you think ?