### PR TITLE
Patch plot npred

### DIFF
--- a/gammapy/visualization/datasets.py
+++ b/gammapy/visualization/datasets.py
@@ -153,7 +153,7 @@ def plot_npred_signal(
         ax = plt.gca()
 
     npred_not_stack.plot(ax=ax, axis_name="energy", **kwargs)
-    if len(dataset.models) > 1:
+    if npred_not_stack.geom.axes["models"].bins > 1:
         npred_stack.plot(ax=ax, label="stacked models")
     npred_background.plot(ax=ax, label="background", **kwargs)
 

--- a/gammapy/visualization/datasets.py
+++ b/gammapy/visualization/datasets.py
@@ -146,7 +146,6 @@ def plot_npred_signal(
     npred_not_stack = dataset.npred_signal(
         model_names=model_names, stack=False
     ).to_region_nd_map(region)
-    npred_stack = npred_not_stack.sum_over_axes(["models"])
     npred_background = dataset.npred_background().to_region_nd_map(region)
 
     if ax is None:
@@ -154,6 +153,7 @@ def plot_npred_signal(
 
     npred_not_stack.plot(ax=ax, axis_name="energy", **kwargs)
     if npred_not_stack.geom.axes["models"].bins > 1:
+        npred_stack = npred_not_stack.sum_over_axes(["models"])
         npred_stack.plot(ax=ax, label="stacked models")
     npred_background.plot(ax=ax, label="background", **kwargs)
 


### PR DESCRIPTION
I changes the way the if statement works in `plot_npred_signal`. 
Before I was looking at the length of `dataset.models` but often it contains the background model, however the background model is plotted separately  from the "source models". So instead I have to look at the number of bins in the `LabelMapAxis` that contains the model names. 

I also move the stacking of the models to create the npred_stack inside the if statement. 