### PR TITLE
Change covariance copy approach such as it is supported using ray

### DIFF
--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -136,7 +136,6 @@ def test_compute_ts_map(input_dataset):
     assert_allclose(energy_axis.edges.value, [0.1, 1])
 
 
-@pytest.mark.skip
 @requires_data()
 @requires_dependency("ray")
 def test_compute_ts_map_parallel_ray(input_dataset):

--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -686,7 +686,6 @@ def test_lightcurve_parallel_multiprocessing():
     )
 
 
-@pytest.mark.skip
 @requires_data()
 @requires_dependency("ray")
 def test_lightcurve_parallel_ray():

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -548,7 +548,6 @@ def test_flux_points_parallel_multiprocessing(fpe_pwl):
     parallel.N_PROCESSES = 1
 
 
-@pytest.mark.skip
 @requires_dependency("ray")
 def test_flux_points_parallel_ray(fpe_pwl):
     datasets, fpe = fpe_pwl

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -154,6 +154,13 @@ def makers_spectrum(exclusion_mask):
             "n_jobs": 2,
             "backend": "multiprocessing",
         },
+        {
+            "dataset": get_mapdataset(name="parallel_staking"),
+            "stack_datasets": True,
+            "cutout_width": None,
+            "n_jobs": 2,
+            "backend": "ray",
+        },
     ],
 )
 @requires_data()

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -17,7 +17,7 @@ from gammapy.makers import (
     WobbleRegionsFinder,
 )
 from gammapy.maps import MapAxis, RegionGeom, WcsGeom
-from gammapy.utils.testing import requires_data
+from gammapy.utils.testing import requires_data, requires_dependency
 
 
 @pytest.fixture(scope="session")
@@ -164,6 +164,7 @@ def makers_spectrum(exclusion_mask):
     ],
 )
 @requires_data()
+@requires_dependency("ray")
 def test_datasets_maker_map(pars, observations_cta, makers_map):
     makers = DatasetsMaker(
         makers_map,

--- a/gammapy/modeling/covariance.py
+++ b/gammapy/modeling/covariance.py
@@ -8,17 +8,6 @@ from .parameter import Parameters
 __all__ = ["Covariance"]
 
 
-def copy_covariance(func):
-    """Copy covariance decorator for model objects."""
-
-    def decorate(self, **kwargs):
-        result = func(self, **kwargs)
-        result.covariance = self.covariance.data.copy()
-        return result
-
-    return decorate
-
-
 class Covariance:
     """Parameter covariance class
 

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -11,7 +11,6 @@ import matplotlib.pyplot as plt
 import yaml
 from gammapy.maps import Map, RegionGeom
 from gammapy.modeling import Covariance, Parameter, Parameters
-from gammapy.modeling.covariance import copy_covariance
 from gammapy.utils.scripts import make_name, make_path
 
 __all__ = ["Model", "Models", "DatasetModels", "ModelBase"]
@@ -94,6 +93,9 @@ class ModelBase:
             setattr(self, par.name, par)
 
         self._covariance = Covariance(self.parameters)
+        covariance_data = kwargs.get("covariance_data", None)
+        if covariance_data is not None:
+            self.covariance = covariance_data
 
     def __getattribute__(self, name):
         value = object.__getattribute__(self, name)
@@ -163,7 +165,6 @@ class ModelBase:
             [getattr(self, name) for name in self.default_parameters.names]
         )
 
-    @copy_covariance
     def copy(self, **kwargs):
         """A deep copy."""
         return copy.deepcopy(self)
@@ -637,7 +638,6 @@ class DatasetModels(collections.abc.Sequence):
     def _ipython_key_completions_(self):
         return self.names
 
-    @copy_covariance
     def copy(self, copy_data=False):
         """A deep copy.
 

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -9,7 +9,6 @@ from astropy.nddata import NoOverlapError
 from astropy.time import Time
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling import Covariance, Parameters
-from gammapy.modeling.covariance import copy_covariance
 from gammapy.modeling.parameter import _get_parameters_str
 from gammapy.utils.fits import LazyFitsData
 from gammapy.utils.scripts import make_name, make_path
@@ -64,6 +63,7 @@ class SkyModel(ModelBase):
         name=None,
         apply_irf=None,
         datasets_names=None,
+        covariance_data=None,
     ):
         self.spatial_model = spatial_model
         self.spectral_model = spectral_model
@@ -84,7 +84,7 @@ class SkyModel(ModelBase):
                 "Spectral model used with SkyModel requires a norm type parameter."
             )
 
-        super().__init__()
+        super().__init__(covariance_data=covariance_data)
 
     @property
     def _models(self):
@@ -385,7 +385,6 @@ class SkyModel(ModelBase):
 
         return Map.from_geom(geom=geom, data=value.value, unit=value.unit)
 
-    @copy_covariance
     def copy(self, name=None, copy_data=False, **kwargs):
         """Copy sky model
 
@@ -419,6 +418,7 @@ class SkyModel(ModelBase):
         kwargs.setdefault("temporal_model", temporal_model)
         kwargs.setdefault("apply_irf", self.apply_irf.copy())
         kwargs.setdefault("datasets_names", self.datasets_names)
+        kwargs.setdefault("covariance_data", self.covariance.data.copy())
 
         return self.__class__(**kwargs)
 
@@ -602,7 +602,13 @@ class FoVBackgroundModel(ModelBase):
 
     tag = ["FoVBackgroundModel", "fov-bkg"]
 
-    def __init__(self, spectral_model=None, dataset_name=None, spatial_model=None):
+    def __init__(
+        self,
+        spectral_model=None,
+        dataset_name=None,
+        spatial_model=None,
+        covariance_data=None,
+    ):
         if dataset_name is None:
             raise ValueError("Dataset name a is required argument")
 
@@ -616,7 +622,7 @@ class FoVBackgroundModel(ModelBase):
 
         self._spatial_model = spatial_model
         self._spectral_model = spectral_model
-        super().__init__()
+        super().__init__(covariance_data=covariance_data)
 
     @staticmethod
     def contributes(*args, **kwargs):
@@ -682,7 +688,6 @@ class FoVBackgroundModel(ModelBase):
         else:
             return value
 
-    @copy_covariance
     def copy(self, name=None, copy_data=False, **kwargs):
         """Copy FoVBackgroundModel
 
@@ -702,6 +707,7 @@ class FoVBackgroundModel(ModelBase):
         """
         kwargs.setdefault("spectral_model", self.spectral_model.copy())
         kwargs.setdefault("dataset_name", self.datasets_names[0])
+        kwargs.setdefault("covariance_data", self.covariance.data.copy())
         return self.__class__(**kwargs)
 
     def to_dict(self, full_output=False):
@@ -803,6 +809,7 @@ class TemplateNPredModel(ModelBase):
         datasets_names=None,
         copy_data=True,
         spatial_model=None,
+        covariance_data=None,
     ):
         if isinstance(map, Map):
             axis = map.geom.axes["energy"]
@@ -835,9 +842,8 @@ class TemplateNPredModel(ModelBase):
                     "Currently background models can only be assigned to one dataset."
                 )
         self.datasets_names = datasets_names
-        super().__init__()
+        super().__init__(covariance_data=covariance_data)
 
-    @copy_covariance
     def copy(self, name=None, copy_data=False, **kwargs):
         """Copy template npred model.
 
@@ -860,6 +866,7 @@ class TemplateNPredModel(ModelBase):
         kwargs.setdefault("spectral_model", self.spectral_model.copy())
         kwargs.setdefault("filename", self.filename)
         kwargs.setdefault("datasets_names", self.datasets_names)
+        kwargs.setdefault("covariance_data", self.covariance.data.copy())
         return self.__class__(name=name, copy_data=copy_data, **kwargs)
 
     @property

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -20,7 +20,6 @@ from regions import (
 import matplotlib.pyplot as plt
 from gammapy.maps import Map, MapCoord, WcsGeom
 from gammapy.modeling import Parameter, Parameters
-from gammapy.modeling.covariance import copy_covariance
 from gammapy.utils.deprecation import deprecated
 from gammapy.utils.gauss import Gauss2DPDF
 from gammapy.utils.interpolation import interpolation_scale
@@ -1108,6 +1107,7 @@ class TemplateSpatialModel(SpatialModel):
         interp_kwargs=None,
         filename=None,
         copy_data=True,
+        covariance_data=None,
     ):
         if (map.data < 0).any():
             log.warning("Map has negative values. Check and fix this!")
@@ -1147,9 +1147,8 @@ class TemplateSpatialModel(SpatialModel):
 
         self._interp_kwargs = interp_kwargs
         self.filename = filename
-        super().__init__()
+        super().__init__(covariance_data=covariance_data)
 
-    @copy_covariance
     def copy(self, copy_data=False, **kwargs):
         """Copy model
 
@@ -1170,6 +1169,7 @@ class TemplateSpatialModel(SpatialModel):
         kwargs.setdefault("normalize", self.normalize)
         kwargs.setdefault("interp_kwargs", self._interp_kwargs)
         kwargs.setdefault("filename", self.filename)
+        kwargs.setdefault("covariance_data", self.covariance.data.copy())
         return self.__class__(copy_data=copy_data, **kwargs)
 
     @property

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,13 @@ all =
     tqdm
     ipywidgets<8.0.5
     ray
+cov =
+    naima
+    sherpa; platform_system != "Windows"
+    healpy; platform_system != "Windows"
+    requests
+    tqdm
+    ipywidgets<8.0.5
 test =
     pytest-astropy
     pytest-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -90,6 +90,7 @@ deps =
 extras =
     test
     alldeps: all
+    cov: cov
 
 commands =
     pip freeze


### PR DESCRIPTION
Currently the covariance copy involves to set a copy of the covariance data on the copy of the models but this is not possible with ray as the  covariance data of the models copy in shared memory is immutable.
This PR resolves this by passing the covariance_data on the model init so it can be set directly when the model copy is created.

Follow up of #4406. I will rebase after it is merged.