### PR TITLE
Support Astropy 5.3

### DIFF
--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -23,6 +23,7 @@ from gammapy.utils.gauss import Gauss2DPDF
 from gammapy.utils.testing import (
     assert_quantity_allclose,
     assert_time_allclose,
+    modify_unit_order_astropy_5_3,
     requires_data,
 )
 
@@ -163,7 +164,7 @@ class TestFermi4FGLObject:
     def test_str(self, ref):
         actual = str(self.cat[ref["idx"]])
         expected = open(get_pkg_data_filename(ref["str_ref_file"])).read()
-        assert actual == expected
+        assert actual == modify_unit_order_astropy_5_3(expected)
 
     @pytest.mark.parametrize("ref", SOURCES_4FGL, ids=lambda _: _["name"])
     def test_spectral_model(self, ref):
@@ -350,7 +351,7 @@ class TestFermi3FGLObject:
     def test_str(self, ref):
         actual = str(self.cat[ref["idx"]])
         expected = open(get_pkg_data_filename(ref["str_ref_file"])).read()
-        assert actual == expected
+        assert actual == modify_unit_order_astropy_5_3(expected)
 
     @pytest.mark.parametrize("ref", SOURCES_3FGL, ids=lambda _: _["name"])
     def test_spectral_model(self, ref):
@@ -484,7 +485,7 @@ class TestFermi2FHLObject:
     def test_str(self, ref):
         actual = str(self.cat[ref["idx"]])
         expected = open(get_pkg_data_filename(ref["str_ref_file"])).read()
-        assert actual == expected
+        assert actual == modify_unit_order_astropy_5_3(expected)
 
     def test_spectral_model(self):
         model = self.source.spectral_model()
@@ -568,7 +569,7 @@ class TestFermi3FHLObject:
     def test_str(self):
         actual = str(self.cat["3FHL J2301.9+5855e"])  # an extended source
         expected = open(get_pkg_data_filename("data/3fhl_j2301.9+5855e.txt")).read()
-        assert actual == expected
+        assert actual == modify_unit_order_astropy_5_3(expected)
 
     def test_position(self):
         position = self.source.position

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -5,7 +5,11 @@ from astropy import units as u
 from astropy.utils.data import get_pkg_data_filename
 from gammapy.catalog import SourceCatalogGammaCat
 from gammapy.utils.gauss import Gauss2DPDF
-from gammapy.utils.testing import assert_quantity_allclose, requires_data
+from gammapy.utils.testing import (
+    assert_quantity_allclose,
+    modify_unit_order_astropy_5_3,
+    requires_data,
+)
 
 SOURCES = [
     {
@@ -90,7 +94,7 @@ class TestSourceCatalogObjectGammaCat:
     def test_str(self, gammacat, ref):
         actual = str(gammacat[ref["name"]])
         expected = open(get_pkg_data_filename(ref["str_ref_file"])).read()
-        assert actual == expected
+        assert actual == modify_unit_order_astropy_5_3(expected)
 
     @pytest.mark.parametrize("ref", SOURCES, ids=lambda _: _["name"])
     def test_spectral_model(self, gammacat, ref):

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -12,7 +12,11 @@ from gammapy.modeling.models import (
     PowerLawSpectralModel,
 )
 from gammapy.utils.gauss import Gauss2DPDF
-from gammapy.utils.testing import assert_quantity_allclose, requires_data
+from gammapy.utils.testing import (
+    assert_quantity_allclose,
+    modify_unit_order_astropy_5_3,
+    requires_data,
+)
 
 SOURCES = [
     {"idx": 33, "name": "HESS J1713-397", "str_ref_file": "data/hess_j1713-397.txt"},
@@ -100,7 +104,7 @@ class TestSourceCatalogObjectHGPS:
     def test_str(cat, ref):
         actual = str(cat[ref["idx"]])
         expected = open(get_pkg_data_filename(ref["str_ref_file"])).read()
-        assert actual == expected
+        assert actual == modify_unit_order_astropy_5_3(expected)
 
     @staticmethod
     def test_position(source):

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -15,7 +15,7 @@ from gammapy.maps import (
     WcsGeom,
     WcsNDMap,
 )
-from gammapy.utils.testing import mpl_plot_check
+from gammapy.utils.testing import modify_unit_order_astropy_5_3, mpl_plot_check
 
 pytest.importorskip("healpy")
 
@@ -244,7 +244,7 @@ def test_map_properties():
     assert isinstance(m.unit, u.CompositeUnit)
     assert m._unit == u.one
     m._unit = u.Unit("cm-2 s-1")
-    assert m.unit.to_string() == "1 / (cm2 s)"
+    assert m.unit.to_string() == modify_unit_order_astropy_5_3("1 / (cm2 s)")
 
     assert isinstance(m.meta, dict)
     m.meta = {"spam": 42}
@@ -285,7 +285,6 @@ map_arithmetics_args = [("wcs"), ("hpx")]
 
 @pytest.mark.parametrize(("map_type"), map_arithmetics_args)
 def test_map_arithmetics(map_type):
-
     m1 = Map.create(binsz=0.1, width=1.0, map_type=map_type, skydir=(0, 0), unit="m2")
 
     m2 = Map.create(binsz=0.1, width=1.0, map_type=map_type, skydir=(0, 0), unit="m2")

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-ASTROPY_LT_5_3 = not minversion(astropy, "5.3.dev")
+ASTROPY_LT_5_3 = minversion(astropy, "5.3.dev")
 
 # Cache for `requires_dependency`
 _requires_dependency_cache = {}
@@ -253,7 +253,7 @@ UNIT_REPLACEMENTS_ASTROPY_5_3 = {
 
 def modify_unit_order_astropy_5_3(expected_str):
     """Modify unit order for tests with astropy >= 5.3"""
-    if not ASTROPY_LT_5_3:
+    if ASTROPY_LT_5_3:
         for old, new in UNIT_REPLACEMENTS_ASTROPY_5_3.items():
             expected_str = expected_str.replace(old, new)
 

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -3,9 +3,11 @@
 import os
 import sys
 from numpy.testing import assert_allclose
+import astropy
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
+from astropy.utils.introspection import minversion
 import matplotlib.pyplot as plt
 
 __all__ = [
@@ -17,6 +19,9 @@ __all__ = [
     "requires_data",
     "requires_dependency",
 ]
+
+
+ASTROPY_LT_5_3 = not minversion(astropy, "5.3.dev")
 
 # Cache for `requires_dependency`
 _requires_dependency_cache = {}
@@ -237,3 +242,19 @@ class Checker:
         for check in checks:
             method = getattr(self, self.CHECKS[check])
             yield from method()
+
+
+UNIT_REPLACEMENTS_ASTROPY_5_3 = {
+    "cm2 s TeV": "TeV s cm2",
+    "1 / (cm2 s)": "1 / (s cm2)",
+    "erg / (cm2 s)": "erg / (s cm2)",
+}
+
+
+def modify_unit_order_astropy_5_3(expected_str):
+    """Modify unit order for tests with astropy >= 5.3"""
+    if not ASTROPY_LT_5_3:
+        for old, new in UNIT_REPLACEMENTS_ASTROPY_5_3.items():
+            expected_str = expected_str.replace(old, new)
+
+    return expected_str


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies out tests to support Astropy 5.3, where the default unit order changed when printing. For this it introduces a `modify_unit_order_astropy_5_3` helper method, which will remain until we support older version than 5.3. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
