### PR TITLE
Fix MapDatasetEventSampler.sample_source

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -107,7 +107,7 @@ class MapDatasetEventSampler:
             name="time",
         )
 
-        temp_eval = model.temporal_model(
+        temp_eval = model.temporal_model.evaluate(
             time_axis_eval.time_mid, energy=energy_new.center
         )
 
@@ -246,7 +246,7 @@ class MapDatasetEventSampler:
                 temporal_model = evaluator.model.temporal_model
 
             if temporal_model.is_energy_dependent:
-                table = self._sample_coord_time_energy(dataset, evaluator)
+                table = self._sample_coord_time_energy(dataset, evaluator.model)
             else:
                 flux = evaluator.compute_flux()
                 npred = evaluator.apply_exposure(flux)

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -314,6 +314,23 @@ def test_mde_sample_sources(dataset, models):
 
 
 @requires_data()
+def test_sample_sources_energy_dependent(dataset, energy_dependent_temporal_sky_model):
+    dataset.models = energy_dependent_temporal_sky_model
+
+    sampler = MapDatasetEventSampler(random_state=0)
+    events = sampler.sample_sources(dataset=dataset)
+
+    assert len(events.table["ENERGY_TRUE"]) == 1268
+    assert_allclose(events.table["ENERGY_TRUE"][0], 6.456526, rtol=1e-5)
+
+    assert_allclose(events.table["RA_TRUE"][0], 266.404988, rtol=1e-5)
+
+    assert_allclose(events.table["DEC_TRUE"][0], -28.936178, rtol=1e-5)
+
+    assert_allclose(events.table["TIME"][0], 95.464699, rtol=1e-5)
+
+
+@requires_data()
 def test_mde_sample_weak_src(dataset, models):
     irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"


### PR DESCRIPTION
These PR fix a bug in `MapDatasetEventSampler.sample_source` when an energy-dependent temporal model is sampled.