### PR TITLE
Corrected kwargs docstring of plot_grid()

### DIFF
--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1205,7 +1205,7 @@ class Map(abc.ABC):
         ncols : int
             Number of columns to plot
         **kwargs : dict
-            Keyword arguments passed to `Map.plot`.
+            Keyword arguments passed to `WcsNDMap.plot`.
 
         Returns
         -------


### PR DESCRIPTION
This pull request is related to issue #4518. 

I changed the kwargs docstring to `passed to WcsNDMap.plot` . 