### PR TITLE
Clean up parallel code

### DIFF
--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -144,14 +144,14 @@ def test_compute_ts_map_parallel_ray(input_dataset):
     spectral_model = PowerLawSpectralModel(index=2)
     model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
 
-    parallel.MULTIPROCESSING_BACKEND = "ray"
-    parallel.N_PROCESSES = 2
+    parallel.BACKEND_DEFAULT = "ray"
+    parallel.N_JOBS_DEFAULT = 2
     ts_estimator = TSMapEstimator(model=model, threshold=1, selection_optional=[])
     assert ts_estimator.parallel_backend == "ray"
     assert ts_estimator.n_jobs == 2
 
-    parallel.MULTIPROCESSING_BACKEND = "multiprocessing"
-    parallel.N_PROCESSES = 1
+    parallel.BACKEND_DEFAULT = "multiprocessing"
+    parallel.N_JOBS_DEFAULT = 1
     assert ts_estimator.parallel_backend == "multiprocessing"
     assert ts_estimator.n_jobs == 1
 
@@ -169,8 +169,8 @@ def test_compute_ts_map_parallel_ray(input_dataset):
     assert_allclose(result["npred_excess"].data[0, 99, 99], 1026.874063, rtol=1e-2)
     assert_allclose(result["npred_excess_err"].data[0, 99, 99], 38.470995, rtol=1e-2)
 
-    parallel.MULTIPROCESSING_BACKEND = "multiprocessing"
-    parallel.N_PROCESSES = 1
+    parallel.BACKEND_DEFAULT = "multiprocessing"
+    parallel.N_JOBS_DEFAULT = 1
 
 
 @requires_data()
@@ -180,7 +180,7 @@ def test_compute_ts_map_parallel_multiprocessing(input_dataset):
     spectral_model = PowerLawSpectralModel(index=2)
     model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
 
-    parallel.MULTIPROCESSING_BACKEND = "multiprocessing"
+    parallel.BACKEND_DEFAULT = "multiprocessing"
     ts_estimator = TSMapEstimator(
         model=model, threshold=1, selection_optional=[], n_jobs=4
     )

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -93,7 +93,7 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         cube.
     n_jobs : int
         Number of processes used in parallel for the computation.
-        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES_DEFAULT` was modified.
+        Default is one, unless `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified.
     parallel_backend : {"multiprocessing", "ray"}
         Which backend to use for multiprocessing.
 
@@ -159,8 +159,8 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         selection_optional=None,
         energy_edges=None,
         sum_over_energy_groups=True,
-        n_jobs=parallel.N_JOBS_DEFAULT,
-        parallel_backend=parallel.BACKEND_DEFAULT,
+        n_jobs=None,
+        parallel_backend=None,
     ):
         if kernel_width is not None:
             kernel_width = Angle(kernel_width)
@@ -180,10 +180,6 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         self.n_sigma_ul = n_sigma_ul
         self.threshold = threshold
         self.rtol = rtol
-
-        if n_jobs is None:
-            n_jobs = parallel.N_JOBS_DEFAULT
-
         self.n_jobs = n_jobs
         self.parallel_backend = parallel_backend
         self.sum_over_energy_groups = sum_over_energy_groups

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -92,10 +92,11 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         Whether to sum over the energy groups or fit the norm on the full energy
         cube.
     n_jobs : int
-        Number of processes used in parallel for the computation.
-        Default is one, unless `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified.
+        Number of processes used in parallel for the computation. Default is one,
+        unless `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified. The number
+        of jobs limited to the number of physical CPUs.
     parallel_backend : {"multiprocessing", "ray"}
-        Which backend to use for multiprocessing.
+        Which backend to use for multiprocessing. Defaults to `~gammapy.utils.parallel.BACKEND_DEFAULT`.
 
     Notes
     -----

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -93,7 +93,9 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         cube.
     n_jobs : int
         Number of processes used in parallel for the computation.
-        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES` was modified.
+        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES_DEFAULT` was modified.
+    parallel_backend : {"multiprocessing", "ray"}
+        Which backend to use for multiprocessing.
 
     Notes
     -----
@@ -157,8 +159,8 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         selection_optional=None,
         energy_edges=None,
         sum_over_energy_groups=True,
-        n_jobs=None,
-        parallel_backend=None,
+        n_jobs=parallel.N_JOBS_DEFAULT,
+        parallel_backend=parallel.BACKEND_DEFAULT,
     ):
         if kernel_width is not None:
             kernel_width = Angle(kernel_width)
@@ -178,6 +180,9 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         self.n_sigma_ul = n_sigma_ul
         self.threshold = threshold
         self.rtol = rtol
+
+        if n_jobs is None:
+            n_jobs = parallel.N_JOBS_DEFAULT
 
         self.n_jobs = n_jobs
         self.parallel_backend = parallel_backend

--- a/gammapy/estimators/points/lightcurve.py
+++ b/gammapy/estimators/points/lightcurve.py
@@ -70,7 +70,9 @@ class LightCurveEstimator(FluxPointsEstimator):
         Re-optimize other free model parameters. Default is False.
     n_jobs : int
         Number of processes used in parallel for the computation.
-        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES` was modified.
+        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES_DEFAULT` was modified.
+    parallel_backend : {"multiprocessing", "ray"}
+        Which backend to use for multiprocessing.
 
     Examples
     --------

--- a/gammapy/estimators/points/lightcurve.py
+++ b/gammapy/estimators/points/lightcurve.py
@@ -70,7 +70,7 @@ class LightCurveEstimator(FluxPointsEstimator):
         Re-optimize other free model parameters. Default is False.
     n_jobs : int
         Number of processes used in parallel for the computation.
-        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES_DEFAULT` was modified.
+        Default is one, unless `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified.
     parallel_backend : {"multiprocessing", "ray"}
         Which backend to use for multiprocessing.
 

--- a/gammapy/estimators/points/lightcurve.py
+++ b/gammapy/estimators/points/lightcurve.py
@@ -69,10 +69,11 @@ class LightCurveEstimator(FluxPointsEstimator):
     reoptimize : bool
         Re-optimize other free model parameters. Default is False.
     n_jobs : int
-        Number of processes used in parallel for the computation.
-        Default is one, unless `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified.
+        Number of processes used in parallel for the computation. Default is one,
+        unless `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified. The number
+        of jobs is limited to the number of physical CPUs.
     parallel_backend : {"multiprocessing", "ray"}
-        Which backend to use for multiprocessing.
+        Which backend to use for multiprocessing. Defaults to `~gammapy.utils.parallel.BACKEND_DEFAULT`.
 
     Examples
     --------

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -69,7 +69,9 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
         grid.
     n_jobs : int
         Number of processes used in parallel for the computation.
-        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES` was modified.
+        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES_DEFAULT` was modified.
+    parallel_backend : {"multiprocessing", "ray"}
+        Which backend to use for multiprocessing.
     """
 
     tag = "FluxPointsEstimator"
@@ -78,8 +80,8 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
         self,
         energy_edges=[1, 10] * u.TeV,
         sum_over_energy_groups=False,
-        n_jobs=None,
-        parallel_backend=None,
+        n_jobs=parallel.N_JOBS_DEFAULT,
+        parallel_backend=parallel.BACKEND_DEFAULT,
         **kwargs,
     ):
         self.energy_edges = energy_edges

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -68,8 +68,9 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
         Whether to sum over the energy groups or fit the norm on the full energy
         grid.
     n_jobs : int
-        Number of processes used in parallel for the computation.
-        Default is one, unless `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified.
+        Number of processes used in parallel for the computation. Default is one, unless
+        `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified. The number of jobs is
+        limited to the number of physical CPUs.
     parallel_backend : {"multiprocessing", "ray"}
         Which backend to use for multiprocessing.
     """

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -69,7 +69,7 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
         grid.
     n_jobs : int
         Number of processes used in parallel for the computation.
-        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES_DEFAULT` was modified.
+        Default is one, unless `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified.
     parallel_backend : {"multiprocessing", "ray"}
         Which backend to use for multiprocessing.
     """
@@ -80,8 +80,8 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
         self,
         energy_edges=[1, 10] * u.TeV,
         sum_over_energy_groups=False,
-        n_jobs=parallel.N_JOBS_DEFAULT,
-        parallel_backend=parallel.BACKEND_DEFAULT,
+        n_jobs=None,
+        parallel_backend=None,
         **kwargs,
     ):
         self.energy_edges = energy_edges

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -5,7 +5,6 @@ from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.table import Table
-import gammapy.utils.parallel as parallel
 from gammapy.data import Observation
 from gammapy.data.pointing import FixedPointingInfo, PointingMode
 from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
@@ -535,17 +534,13 @@ def test_flux_points_parallel_multiprocessing(fpe_pwl):
     fpe.selection_optional = ["all"]
     fpe.n_jobs = 2
     assert fpe.n_jobs == 2
+
     fp = fpe.run(datasets)
     assert_allclose(
         fp.flux_ul.data,
         [[[2.629819e-12]], [[9.319243e-13]], [[9.004449e-14]]],
         rtol=1e-3,
     )
-
-    fpe.n_jobs = None
-    parallel.N_PROCESSES = 2
-    assert fpe.n_jobs == 2
-    parallel.N_PROCESSES = 1
 
 
 @requires_dependency("ray")

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -22,6 +22,7 @@ from gammapy.modeling.models import (
     PowerLawSpectralModel,
     SkyModel,
 )
+from gammapy.utils import parallel
 from gammapy.utils.testing import requires_data, requires_dependency
 
 
@@ -541,6 +542,25 @@ def test_flux_points_parallel_multiprocessing(fpe_pwl):
         [[[2.629819e-12]], [[9.319243e-13]], [[9.004449e-14]]],
         rtol=1e-3,
     )
+
+
+def test_global_n_jobs_default_handling():
+    fpe = FluxPointsEstimator(energy_edges=[1, 3, 10] * u.TeV)
+
+    assert fpe.n_jobs == 1
+
+    parallel.N_JOBS_DEFAULT = 2
+    assert fpe.n_jobs == 2
+
+    fpe.n_jobs = 5
+    assert fpe.n_jobs == 5
+
+    fpe.n_jobs = None
+    assert fpe.n_jobs == 2
+    assert fpe._n_jobs is None
+
+    parallel.N_JOBS_DEFAULT = 1
+    assert fpe.n_jobs == 1
 
 
 @requires_dependency("ray")

--- a/gammapy/makers/reduce.py
+++ b/gammapy/makers/reduce.py
@@ -66,6 +66,10 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
             else:
                 self.cutout_width = 2 * self.offset_max
 
+        # backwards compatibility
+        if n_jobs is None:
+            n_jobs = parallel.N_JOBS_DEFAULT
+
         self.n_jobs = n_jobs
         self.parallel_backend = parallel_backend
         self.stack_datasets = stack_datasets

--- a/gammapy/makers/reduce.py
+++ b/gammapy/makers/reduce.py
@@ -1,5 +1,4 @@
 import logging
-import numpy as np
 from astropy.coordinates import Angle
 import gammapy.utils.parallel as parallel
 from gammapy.datasets import Datasets, MapDataset, MapDatasetOnOff, SpectrumDataset
@@ -192,12 +191,8 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
 
         if self.stack_datasets:
             return Datasets([self._dataset])
-        else:
-            # have to sort datasets because of async
-            obs_ids = [d.meta_table["OBS_ID"][0] for d in self._datasets]
-            ordered = []
-            for obs in observations:
-                ind = np.where(np.array(obs_ids) == obs.obs_id)[0][0]
-                ordered.append(self._datasets[ind])
-            self._datasets = ordered
-            return Datasets(self._datasets)
+
+        lookup = {
+            d.meta_table["OBS_ID"][0]: idx for d, idx in enumerate(self._datasets)
+        }
+        return Datasets([self._datasets[lookup[obs.obs_id]] for obs in observations])

--- a/gammapy/makers/reduce.py
+++ b/gammapy/makers/reduce.py
@@ -193,6 +193,6 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
             return Datasets([self._dataset])
 
         lookup = {
-            d.meta_table["OBS_ID"][0]: idx for d, idx in enumerate(self._datasets)
+            d.meta_table["OBS_ID"][0]: idx for idx, d in enumerate(self._datasets)
         }
         return Datasets([self._datasets[lookup[obs.obs_id]] for obs in observations])

--- a/gammapy/makers/reduce.py
+++ b/gammapy/makers/reduce.py
@@ -25,7 +25,7 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
         If True stack into the reference dataset (see `run` method arguments).
     n_jobs : int
         Number of processes to run in parallel.
-        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES` was modified.
+        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES_DEFAULT` was modified.
     cutout_mode : {'trim', 'partial', 'strict'}
         Used only to cutout the reference `MapDataset` around each processed observation.
         Mode is an option for Cutout2D, for details see `~astropy.nddata.utils.Cutout2D`.
@@ -35,6 +35,8 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
         If only one value is passed, a square region is extracted.
         If None it returns an error, except if the list of makers includes a `SafeMaskMaker`
         with the offset-max method defined. In that case it is set to two times `offset_max`.
+    parallel_backend : {'multiprocessing', 'ray'}
+        Which backend to use for multiprocessing.
     """
 
     tag = "DatasetsMaker"
@@ -43,23 +45,27 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
         self,
         makers,
         stack_datasets=True,
-        n_jobs=None,
+        n_jobs=parallel.N_JOBS_DEFAULT,
         cutout_mode="trim",
         cutout_width=None,
-        parallel_backend=None,
+        parallel_backend=parallel.BACKEND_DEFAULT,
     ):
         self.log = logging.getLogger(__name__)
         self.makers = makers
         self.cutout_mode = cutout_mode
+
         if cutout_width is not None:
             cutout_width = Angle(cutout_width)
+
         self.cutout_width = cutout_width
         self._apply_cutout = True
+
         if self.cutout_width is None:
             if self.offset_max is None:
                 self._apply_cutout = False
             else:
                 self.cutout_width = 2 * self.offset_max
+
         self.n_jobs = n_jobs
         self.parallel_backend = parallel_backend
         self.stack_datasets = stack_datasets
@@ -101,15 +107,18 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
             )
         else:
             dataset_obs = dataset.copy()
+
         if dataset.models is not None:
             models = dataset.models.copy()
             models.reassign(dataset.name, dataset_obs.name)
             dataset_obs.models = models
 
         log.info(f"Computing dataset for observation {observation.obs_id}")
+
         for maker in self.makers:
             log.info(f"Running {maker.tag}")
             dataset_obs = maker.run(dataset=dataset_obs, observation=observation)
+
         return dataset_obs
 
     def callback(self, dataset):
@@ -160,6 +169,7 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
             datasets = len(observations) * [dataset]
 
         n_jobs = min(self.n_jobs, len(observations))
+
         parallel.run_multiprocessing(
             self.make_dataset,
             zip(datasets, observations),
@@ -172,6 +182,7 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
             ),
             task_name="Data reduction",
         )
+
         if self._error:
             raise RuntimeError("Execution of a sub-process failed")
 

--- a/gammapy/makers/reduce.py
+++ b/gammapy/makers/reduce.py
@@ -24,7 +24,7 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
         If True stack into the reference dataset (see `run` method arguments).
     n_jobs : int
         Number of processes to run in parallel.
-        Default is one, unless `~gammapy.utils.parallel.N_PROCESSES_DEFAULT` was modified.
+        Default is one, unless `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified.
     cutout_mode : {'trim', 'partial', 'strict'}
         Used only to cutout the reference `MapDataset` around each processed observation.
         Mode is an option for Cutout2D, for details see `~astropy.nddata.utils.Cutout2D`.
@@ -44,10 +44,10 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
         self,
         makers,
         stack_datasets=True,
-        n_jobs=parallel.N_JOBS_DEFAULT,
+        n_jobs=None,
         cutout_mode="trim",
         cutout_width=None,
-        parallel_backend=parallel.BACKEND_DEFAULT,
+        parallel_backend=None,
     ):
         self.log = logging.getLogger(__name__)
         self.makers = makers
@@ -64,10 +64,6 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
                 self._apply_cutout = False
             else:
                 self.cutout_width = 2 * self.offset_max
-
-        # backwards compatibility
-        if n_jobs is None:
-            n_jobs = parallel.N_JOBS_DEFAULT
 
         self.n_jobs = n_jobs
         self.parallel_backend = parallel_backend

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -83,6 +83,11 @@ class ParallelMixin:
     @n_jobs.setter
     def n_jobs(self, value):
         """Number of jobs setter (int)"""
+        if not isinstance(value, (int, type(None))):
+            raise ValueError(
+                f"Invalid type: {value!r}, and integer or None is expected."
+            )
+
         self._n_jobs = value
 
     @property

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -141,12 +141,17 @@ def run_multiprocessing(
     if pool_kwargs is None:
         pool_kwargs = {}
 
-    processes = pool_kwargs.get("processes", None)
+    processes = pool_kwargs.get("processes", N_JOBS_DEFAULT)
 
     multiprocessing = PARALLEL_BACKEND_MODULES[backend]
 
     if backend == ParallelBackendEnum.multiprocessing:
-        processes = min(processes, multiprocessing.cpu_count())
+        cpu_count = multiprocessing.cpu_count()
+
+        if processes > cpu_count:
+            log.info(f"Limiting number of processes from {processes} to {cpu_count}")
+            processes = cpu_count
+
         if multiprocessing.current_process().name != "MainProcess":
             # subprocesses cannot have childs
             processes = 1

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -1,143 +1,202 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Multiprocessing and multithreading setup"""
+import importlib
 import logging
-import os
+import multiprocessing
+from enum import Enum
 from gammapy.utils.pbar import progress_bar
 
 log = logging.getLogger(__name__)
 
 
-MULTIPROCESSING_BACKEND = "multiprocessing"
-N_PROCESSES = 1
-N_THREADS = 1
+class ParallelBackendEnum(Enum):
+    """Enum for parallel backend"""
+
+    multiprocessing = "multiprocessing"
+    ray = "ray"
 
 
-def warning_prototype(module="ray"):
+class PoolMethodEnum(Enum):
+    """Enum for pool method"""
+
+    starmap = "starmap"
+    apply_async = "apply_async"
+
+
+BACKEND_DEFAULT = ParallelBackendEnum.multiprocessing
+N_JOBS_DEFAULT = 1
+
+
+def get_multiprocessing_ray():
+    """Get multiprocessing module for ray backend"""
+    import ray.util.multiprocessing as multiprocessing
+
     log.warning(
-        f"gammapy supports for parallelisation with {module} is still a prototype and is not fully functional."
+        "Gammapy support for parallelisation with ray is still a prototype and is not fully functional."
     )
+    return multiprocessing
 
 
 def is_ray_initialized():
+    """Check if ray is initialized"""
     try:
         from ray import is_initialized
 
         return is_initialized()
-    except (ModuleNotFoundError):
+    except ModuleNotFoundError:
+        return False
+
+
+def is_ray_available():
+    """Check if ray is available"""
+    try:
+        importlib.import_module("ray")
+        return True
+    except ModuleNotFoundError:
         return False
 
 
 class ParallelMixin:
+    """Mixin class to handle parallel processing"""
+
     @property
     def n_jobs(self):
-        if self._n_jobs is None:
-            return N_PROCESSES
-        else:
-            return self._n_jobs
+        """Number of jobs (int)"""
+        return self._n_jobs
 
     @n_jobs.setter
     def n_jobs(self, value):
-        self._n_jobs = value
+        """Number of jobs setter (int)"""
+        self._n_jobs = int(value)
 
     @property
     def parallel_backend(self):
-        if self._parallel_backend is None:
-            return MULTIPROCESSING_BACKEND
-        else:
-            return self._parallel_backend
+        """Parallel backend (str)"""
+        return self._parallel_backend
 
     @parallel_backend.setter
     def parallel_backend(self, value):
+        """Parallel backend setter (str)"""
+        value = ParallelBackendEnum(value)
+
+        if value == ParallelBackendEnum.ray and not is_ray_available():
+            log.warning("Ray is not installed, falling back to multiprocessing backend")
+            value = ParallelBackendEnum.multiprocessing
+
         self._parallel_backend = value
-
-
-def get_multiprocessing(backend=None):
-    """import multiprocessing module for a given backend"""
-
-    if backend is None:
-        backend = MULTIPROCESSING_BACKEND
-    if backend == "multiprocessing":
-        import multiprocessing
-
-        return multiprocessing
-    elif backend == "ray":
-        import ray.util.multiprocessing as multiprocessing
-
-        warning_prototype(module=backend)
-        return multiprocessing
-    else:
-        raise ValueError("Invalid multiprocessing backend")
 
 
 def run_multiprocessing(
     func,
     inputs,
-    backend=None,
+    backend=BACKEND_DEFAULT,
     pool_kwargs=None,
     method="starmap",
     method_kwargs=None,
     task_name="",
 ):
-    """Run function in a loop or in Parallel"""
+    """Run function in a loop or in Parallel
 
-    if method not in ["starmap", "apply_async"]:
-        raise ValueError("Invalid multiprocessing method")
-
-    multiprocessing = get_multiprocessing(backend)
+    Parameters
+    ----------
+    func : function
+        Function to run
+    inputs : list
+        List of arguments to pass to the function
+    backend : {'multiprocessing', 'ray'}
+        Backend to use.
+    pool_kwargs : dict
+        Keyword arguments passed to the pool
+    method : {'starmap', 'apply_async'}
+        Pool method to use.
+    method_kwargs : dict
+        Keyword arguments passed to the method
+    task_name : str
+        Name of the task to display in the progress bar
+    """
     if method_kwargs is None:
         method_kwargs = {}
+
     if pool_kwargs is None:
         pool_kwargs = {}
-    pool_kwargs.setdefault("processes", N_PROCESSES)
-    if backend == "ray":
-        from ray import is_initialized
 
-        if is_initialized():
-            address = "auto"
-        else:
-            address = None
-        pool_kwargs.setdefault("ray_address", address)
+    processes = pool_kwargs.get("processes", N_JOBS_DEFAULT)
 
-    processes = pool_kwargs["processes"]
-    if backend == "multiprocessing":
-        processes = max(processes, os.cpu_count())
+    multiprocessing = PARALLEL_BACKEND_MODULES[backend]
+
+    if backend == ParallelBackendEnum.multiprocessing:
         if multiprocessing.current_process().name != "MainProcess":
             # subprocesses cannot have childs
             processes = 1
     # TODO: check for ray
 
+    if processes == 1:
+        return run_loop(
+            func=func, inputs=inputs, method_kwargs=method_kwargs, task_name=task_name
+        )
+
+    if backend == ParallelBackendEnum.ray:
+        address = "auto" if is_ray_initialized() else None
+        pool_kwargs.setdefault("ray_address", address)
+
     log.info(f"Using {processes} processes to compute {task_name}")
 
-    if processes == 1:
-        return run_loop(func, inputs, method_kwargs, task_name)
-    else:
-        with multiprocessing.Pool(**pool_kwargs) as pool:
-            return run_pool(pool, func, inputs, method, method_kwargs, task_name)
+    with multiprocessing.Pool(**pool_kwargs) as pool:
+        pool_func = POOL_METHODS[PoolMethodEnum(method)]
+        results = pool_func(
+            pool=pool,
+            func=func,
+            inputs=inputs,
+            method_kwargs=method_kwargs,
+            task_name=task_name,
+        )
+
+    return results
 
 
 def run_loop(func, inputs, method_kwargs=None, task_name=""):
     """Loop over inputs an run function"""
-
     results = []
+
+    callback = method_kwargs.get("callback", None)
+
     for arguments in progress_bar(inputs, desc=task_name):
-        output = func(*arguments)
-        if "callback" in method_kwargs:
-            results.append(method_kwargs["callback"](output))
-        else:
-            results.append(output)
+        result = func(*arguments)
+
+        if callback is not None:
+            result = callback(result)
+
+        results.append(result)
+
     return results
 
 
-def run_pool(pool, func, inputs, method="starmap", method_kwargs=None, task_name=""):
-    """Run function in Parallel"""
+def run_pool_star_map(pool, func, inputs, method_kwargs=None, task_name=""):
+    """Run function in parallel"""
+    return pool.starmap(func, progress_bar(inputs, desc=task_name), **method_kwargs)
 
-    if method == "starmap":
-        return pool.starmap(func, progress_bar(inputs, desc=task_name), **method_kwargs)
-    elif method == "apply_async":
-        results = []
-        for arguments in progress_bar(inputs, desc=task_name):
-            result = pool.apply_async(func, arguments, **method_kwargs)
-            results.append(result)
-        # wait async run is done
-        [result.wait() for result in results]
-        return results
+
+def run_pool_async(pool, func, inputs, method_kwargs=None, task_name=""):
+    """Run function in parallel async"""
+    results = []
+
+    for arguments in progress_bar(inputs, desc=task_name):
+        result = pool.apply_async(func, arguments, **method_kwargs)
+        results.append(result)
+
+    # wait async run is done
+    [result.wait() for result in results]
+    return results
+
+
+POOL_METHODS = {
+    PoolMethodEnum.starmap: run_pool_star_map,
+    PoolMethodEnum.apply_async: run_pool_async,
+}
+
+PARALLEL_BACKEND_MODULES = {
+    ParallelBackendEnum.multiprocessing: multiprocessing,
+}
+
+if is_ray_available():
+    PARALLEL_BACKEND_MODULES[ParallelBackendEnum.ray] = get_multiprocessing_ray()

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -79,6 +79,9 @@ class ParallelMixin:
     @n_jobs.setter
     def n_jobs(self, value):
         """Number of jobs setter (int)"""
+        if value is None:
+            value = N_JOBS_DEFAULT
+
         self._n_jobs = int(value)
 
     @property
@@ -89,7 +92,7 @@ class ParallelMixin:
     @parallel_backend.setter
     def parallel_backend(self, value):
         """Parallel backend setter (str)"""
-        self._parallel_backend = ParallelBackendEnum.from_str(value)
+        self._parallel_backend = ParallelBackendEnum.from_str(value).value
 
 
 def run_multiprocessing(

--- a/gammapy/utils/tests/test_parallel.py
+++ b/gammapy/utils/tests/test_parallel.py
@@ -4,15 +4,25 @@ import gammapy.utils.parallel as parallel
 from gammapy.utils.testing import requires_dependency
 
 
+def test_parallel_mixin():
+    p = parallel.ParallelMixin()
+
+    with pytest.raises():
+        p.parallel_backend = "wrong_name"
+
+    with pytest.raises():
+        p.n_jobs = "5 jobs"
+
+
 def test_get_multiprocessing():
-    parallel.MULTIPROCESSING_BACKEND = "multiprocessing"
+    parallel.BACKEND_DEFAULT = "multiprocessing"
     multiprocessing = parallel.get_multiprocessing()
     assert multiprocessing.__name__ == "multiprocessing"
 
 
 @requires_dependency("ray")
 def test_get_multiprocessing_ray():
-    parallel.MULTIPROCESSING_BACKEND = "ray"
+    parallel.BACKEND_DEFAULT = "ray"
     multiprocessing = parallel.get_multiprocessing()
     assert multiprocessing.__name__ == "ray.util.multiprocessing"
 

--- a/gammapy/utils/tests/test_parallel.py
+++ b/gammapy/utils/tests/test_parallel.py
@@ -30,3 +30,41 @@ def test_run_multiprocessing_wrong_method():
         parallel.run_multiprocessing(
             func, [True, True], method="wrong_name", pool_kwargs=dict(processes=2)
         )
+
+
+@pytest.mark.parametrize("method", ["starmap", "apply_async"])
+def test_run_multiprocessing_simple(method):
+    1 / 0
+
+    def square(x):
+        return x**2
+
+    N = 10
+    inputs = range(N + 1)
+
+    result = parallel.run_multiprocessing(
+        func=square,
+        inputs=inputs,
+        methode=method,
+        pool_kwargs=dict(processes=2),
+    )
+    assert sum(result) == N * (N + 1) * (2 * N + 1) / 6
+
+
+@requires_dependency("ray")
+@pytest.mark.parametrize("method", ["starmap", "apply_async"])
+def test_run_multiprocessing_simple_ray(method):
+    def square(x):
+        return x**2
+
+    N = 10
+    inputs = range(N + 1)
+
+    result = parallel.run_multiprocessing(
+        func=square,
+        inputs=inputs,
+        methode=method,
+        pool_kwargs=dict(processes=2),
+        parallel_backend="ray",
+    )
+    assert sum(result) == N * (N + 1) * (2 * N + 1) / 6

--- a/gammapy/utils/tests/test_parallel.py
+++ b/gammapy/utils/tests/test_parallel.py
@@ -7,23 +7,26 @@ from gammapy.utils.testing import requires_dependency
 def test_parallel_mixin():
     p = parallel.ParallelMixin()
 
-    with pytest.raises():
+    with pytest.raises(ValueError):
         p.parallel_backend = "wrong_name"
 
-    with pytest.raises():
+    with pytest.raises(ValueError):
         p.n_jobs = "5 jobs"
 
 
-def test_get_multiprocessing():
-    parallel.BACKEND_DEFAULT = "multiprocessing"
+def test_change_n_process_default():
+    parallel.N_JOBS_DEFAULT = 5
+
     multiprocessing = parallel.get_multiprocessing()
     assert multiprocessing.__name__ == "multiprocessing"
 
 
 @requires_dependency("ray")
 def test_get_multiprocessing_ray():
-    parallel.BACKEND_DEFAULT = "ray"
-    multiprocessing = parallel.get_multiprocessing()
+    assert parallel.is_ray_available()
+    assert not parallel.is_ray_initialized()
+
+    multiprocessing = parallel.get_multiprocessing_ray()
     assert multiprocessing.__name__ == "ray.util.multiprocessing"
 
 

--- a/gammapy/utils/tests/test_parallel.py
+++ b/gammapy/utils/tests/test_parallel.py
@@ -17,7 +17,6 @@ def test_parallel_mixin():
 @requires_dependency("ray")
 def test_get_multiprocessing_ray():
     assert parallel.is_ray_available()
-    assert not parallel.is_ray_initialized()
 
     multiprocessing = parallel.get_multiprocessing_ray()
     assert multiprocessing.__name__ == "ray.util.multiprocessing"

--- a/gammapy/utils/tests/test_parallel.py
+++ b/gammapy/utils/tests/test_parallel.py
@@ -14,13 +14,6 @@ def test_parallel_mixin():
         p.n_jobs = "5 jobs"
 
 
-def test_change_n_process_default():
-    parallel.N_JOBS_DEFAULT = 5
-
-    multiprocessing = parallel.get_multiprocessing()
-    assert multiprocessing.__name__ == "multiprocessing"
-
-
 @requires_dependency("ray")
 def test_get_multiprocessing_ray():
     assert parallel.is_ray_available()


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request cleans up some of the parallel code:
- Introduce a `MultiprocessingBackenEnum` to avoid the hard-coded strings
- Introduce a `PoolMethodEnum`
- Include `DEFAULT` in the module level variable names
- Add and extend docstrings where missing
- Introduce internal registries `PARALLEL_BACKEND_MODULES` and `POOL_METHODS`
- Fix a bug where the line https://github.com/gammapy/gammapy/blob/main/gammapy/utils/parallel.py#L103 would always trigger the multiprocessing. I'm not sure what the intended behavior was @QRemy, for now I just removed the line. It is in any case unclear whether the number of processes should be equal to the number of CPUs...

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
