### PR TITLE
Remove is_ul column in FluxPointsEstimator if no upper limit is defined

### DIFF
--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -9,7 +9,7 @@ from astropy.time import Time
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from gammapy.maps import MapAxis, Maps, RegionNDMap, TimeMapAxis
-from gammapy.maps.axes import flat_if_equal, UNIT_STRING_FORMAT
+from gammapy.maps.axes import UNIT_STRING_FORMAT, flat_if_equal
 from gammapy.modeling.models import TemplateSpectralModel
 from gammapy.modeling.models.spectral import scale_plot_flux
 from gammapy.modeling.scipy import stat_profile_ul_scipy
@@ -370,6 +370,8 @@ class FluxPoints(FluxMaps):
                 table["stat_scan"] = self.stat_scan.data[idx]
 
             table["is_ul"] = self.is_ul.data[idx]
+            if not self.has_ul:
+                table.remove_columns("is_ul")
 
         elif format == "lightcurve":
             time_axis = self.geom.axes["time"]

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -338,6 +338,7 @@ def test_flux_points_plot_no_error_bar():
         _ = flux_points.plot(sed_type="dnde")
 
 
+@requires_data()
 def test_fp_no_is_ul():
     path = make_path("$GAMMAPY_DATA/tests/spectrum/flux_points/flux_points.fits")
     table = Table.read(path)
@@ -347,5 +348,4 @@ def test_fp_no_is_ul():
     fp = FluxPoints.from_table(table)
 
     if not fp.has_ul:
-        with pytest.raises(AttributeError):
-            table.is_ul
+        assert "is_ul" not in table.colnames

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -6,9 +6,8 @@ import astropy.units as u
 from astropy.table import Table
 import matplotlib.pyplot as plt
 from gammapy.catalog.fermi import SourceCatalog3FGL, SourceCatalog4FGL
-from gammapy.estimators import FluxPoints, FluxPointsEstimator
+from gammapy.estimators import FluxPoints
 from gammapy.estimators.map.core import DEFAULT_UNIT
-from gammapy.estimators.points.tests.test_sed import simulate_map_dataset
 from gammapy.modeling.models import PowerLawSpectralModel, SpectralModel
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import (
@@ -340,19 +339,13 @@ def test_flux_points_plot_no_error_bar():
 
 
 def test_fp_no_is_ul():
-    dataset_1 = simulate_map_dataset(random_state=0, name="dataset_1")
+    path = make_path("$GAMMAPY_DATA/tests/spectrum/flux_points/flux_points.fits")
+    table = Table.read(path)
+    table.remove_column("is_ul")
+    table.remove_column("flux_ul")
 
-    energy_edges = [0.1, 1, 10, 100] * u.TeV
+    fp = FluxPoints.from_table(table)
 
-    fpe = FluxPointsEstimator(
-        energy_edges=energy_edges,
-        norm_n_values=3,
-        source="source",
-    )
-
-    FluxPoints = fpe.run(datasets=dataset_1)
-    table = FluxPoints.to_table()
-
-    if not FluxPoints.has_ul:
+    if not fp.has_ul:
         with pytest.raises(AttributeError):
             table.is_ul

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -346,6 +346,5 @@ def test_fp_no_is_ul():
     table.remove_column("flux_ul")
 
     fp = FluxPoints.from_table(table)
-
-    if not fp.has_ul:
-        assert "is_ul" not in table.colnames
+    fp_table = fp.to_table()
+    assert "is_ul" not in fp_table.colnames

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -6,8 +6,9 @@ import astropy.units as u
 from astropy.table import Table
 import matplotlib.pyplot as plt
 from gammapy.catalog.fermi import SourceCatalog3FGL, SourceCatalog4FGL
-from gammapy.estimators import FluxPoints
+from gammapy.estimators import FluxPoints, FluxPointsEstimator
 from gammapy.estimators.map.core import DEFAULT_UNIT
+from gammapy.estimators.points.tests.test_sed import simulate_map_dataset
 from gammapy.modeling.models import PowerLawSpectralModel, SpectralModel
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import (
@@ -336,3 +337,22 @@ def test_flux_points_plot_no_error_bar():
     flux_points = FluxPoints.from_table(table)
     with mpl_plot_check():
         _ = flux_points.plot(sed_type="dnde")
+
+
+def test_fp_no_is_ul():
+    dataset_1 = simulate_map_dataset(random_state=0, name="dataset_1")
+
+    energy_edges = [0.1, 1, 10, 100] * u.TeV
+
+    fpe = FluxPointsEstimator(
+        energy_edges=energy_edges,
+        norm_n_values=3,
+        source="source",
+    )
+
+    FluxPoints = fpe.run(datasets=dataset_1)
+    table = FluxPoints.to_table()
+
+    if not FluxPoints.has_ul:
+        with pytest.raises(AttributeError):
+            table.is_ul


### PR DESCRIPTION
**Description**
The default for `selection_optional` in `FluxPointsEstimator` is `None`. This means that the `is_ul` column shows all `False`. This current behaviour seems non-intuitive because it is not `False`, rather it has not been calculated. 

This PR proposes an alternative, such that if `has_ul` is `False`, then the `is_ul` column will be removed, as to avoid confusion for the user.