### PR TITLE
Use pip to install ray

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -47,7 +47,6 @@ dependencies:
   - pandas
   - reproject
   - sherpa
-  - ray-default
   # dev dependencies
   - black
   - codespell
@@ -79,4 +78,5 @@ dependencies:
   - memray
   - pip:
       - pytest-sphinx
+      - ray
       - PyGithub


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies the `environment-dev.yaml` to use `pip` instead of `conda` to install `ray`. 
This is the recommended approach in the ray documentation:
https://docs.ray.io/en/latest/ray-overview/installation.html#installing-from-conda-forge


**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
