### PR TITLE
Sample time for phase template models

### DIFF
--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -1120,7 +1120,7 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
         """Sample arrival times of events.
 
         To fully cover the phase range, t_delta is the minimum between the input
-        and 5 percent of the period at 0.5*(t_min + t_max).
+        and product of the period at 0.5*(t_min + t_max) and the table bin size.
 
         Parameters
         ----------
@@ -1151,7 +1151,8 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
         )
         period = 1 / frequency
 
-        # Take minimum time delta between user input and 5% of the period
-        t_delta = np.minimum(0.05 * period, t_delta)
+        # Take minimum time delta between user input and the period divied by the number of raows in the model table
+        # this assumes that phase values are evenly spaced.
+        t_delta = np.minimum(period / len(self.table), t_delta)
 
         return super().sample_time(n_events, t_min, t_max, t_delta, random_state)

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -1115,3 +1115,43 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
         ax = m.plot(ax=ax, **kwargs)
         ax.set_ylabel("Norm / A.U.")
         return ax
+
+    def sample_time(self, n_events, t_min, t_max, t_delta="1 s", random_state=0):
+        """Sample arrival times of events.
+
+        To fully cover the phase range, t_delta is the minimum between the input
+        and 5 percent of the period at 0.5*(t_min + t_max).
+
+        Parameters
+        ----------
+        n_events : int
+            Number of events to sample.
+        t_min : `~astropy.time.Time`
+            Start time of the sampling.
+        t_max : `~astropy.time.Time`
+            Stop time of the sampling.
+        t_delta : `~astropy.units.Quantity`
+            Time step used for sampling of the temporal model.
+        random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
+            Defines random number generator initialisation.
+            Passed to `~gammapy.utils.random.get_random_state`.
+
+        Returns
+        -------
+        time : `~astropy.units.Quantity`
+            Array with times of the sampled events.
+        """
+        t_delta = u.Quantity(t_delta)
+
+        # Determine period at the mid time
+        t_mid = Time(t_min, scale=self.scale) + 0.5 * (t_max - t_min)
+        delta_t = (t_mid - self.reference_time).to(u.d)
+        frequency = self.f0.quantity + delta_t * (
+            self.f1.quantity + delta_t * self.f2.quantity / 2
+        )
+        period = 1 / frequency
+
+        # Take minimum time delta between user input and 5% of the period
+        t_delta = np.minimum(0.05 * period, t_delta)
+
+        return super().sample_time(n_events, t_min, t_max, t_delta, random_state)

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -428,7 +428,7 @@ def test_phase_curve_model(tmp_path):
     assert_allclose(integral, 0.225, rtol=1e-5)
 
 
-def test_phase_curve_model_spale_time():
+def test_phase_curve_model_sample_time():
     phase = np.linspace(0.0, 1, 51)
     norm = 1 * (phase < 0.5)
     table = Table(data={"PHASE": phase, "NORM": norm})

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -32,6 +32,13 @@ def light_curve():
     return LightCurveTemplateTemporalModel.read(path)
 
 
+@pytest.fixture()
+def phase_curve_table():
+    phase = np.linspace(0.0, 1, 101)
+    norm = phase * (phase < 0.5) + (1 - phase) * (phase >= 0.5)
+    return Table(data={"PHASE": phase, "NORM": norm})
+
+
 @requires_data()
 def test_light_curve_str(light_curve):
     ss = str(light_curve)
@@ -419,6 +426,38 @@ def test_phase_curve_model(tmp_path):
     # 1.25 phase
     integral = phase_model.integral(t_ref, t_ref + 62.5 * u.ms)
     assert_allclose(integral, 0.225, rtol=1e-5)
+
+
+def test_phase_curve_model_spale_time():
+    phase = np.linspace(0.0, 1, 51)
+    norm = 1 * (phase < 0.5)
+    table = Table(data={"PHASE": phase, "NORM": norm})
+
+    t_ref = Time("2020-06-01", scale="utc")
+    phase_model = TemplatePhaseCurveTemporalModel(
+        table=table,
+        f0="50 Hz",
+        phi_ref=0.0,
+        f1="0 s-2",
+        f2="0 s-3",
+        t_ref=t_ref.mjd * u.d,
+        scale="utc",
+    )
+
+    tmin = Time("2023-06-01", scale="tt")
+    tmax = tmin + 0.5 * u.h
+
+    times = phase_model.sample_time(10, tmin, tmax)
+    phases, _ = phase_model._time_to_phase(
+        times,
+        phase_model.reference_time,
+        phase_model.phi_ref.quantity,
+        phase_model.f0.quantity,
+        phase_model.f1.quantity,
+        phase_model.f2.quantity,
+    )
+
+    assert np.all(phases <= 0.5)
 
 
 @requires_data()


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a `sample_time` method for `TemplatePhaseCurveTemporalModel`. This method determines
the best `t_delta` to use and then call the parent `sample_time` method. This has the advantage of providing correct phase 
distributions independently of the user input. 
This might be important when dealing with the `MapDatasetEventSampler` because you can provide a sample `t_delta` for all models. Computing down to the milliseconds for e.g. background models is useless. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
