### PR TITLE
Add a Dependabot config to update GitHub workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**

I found that some GitHub action versions in the `.github/workflows/` directory were out-of-date. For example, the `cffconvert.yml` workflow uses `actions/checkout@v2`, not `v3`.

This PR introduces a Dependabot config that will automatically update the action versions used in GitHub workflows. This will happen on a monthly basis.

By merging this PR, action versions will be kept up-to-date automatically via PRs created by Dependabot. This will reduce maintenance burden.

<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->



**Dear reviewer**

This PR is ready for review and merging.

I've signed off on my commits. Please let me know if anything else is required. Thanks!

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
