### PR TITLE
Fixing ImportError due to circular import in visualization.utils

### DIFF
--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -71,12 +71,3 @@ def test_plot_map_rgb():
     kwargs = {"stretch": 0.5, "Q": 1, "minimum": 0.15}
     with mpl_plot_check():
         plot_map_rgb(map_, **kwargs)
-
-
-def test_circular_import():
-    try:
-        from gammapy.visualization import plot_map_rgb
-
-        plot_map_rgb.__name__
-    except ImportError:
-        pytest.fail()

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -71,3 +71,12 @@ def test_plot_map_rgb():
     kwargs = {"stretch": 0.5, "Q": 1, "minimum": 0.15}
     with mpl_plot_check():
         plot_map_rgb(map_, **kwargs)
+
+
+def test_circular_import():
+    try:
+        from gammapy.visualization import plot_map_rgb
+
+        plot_map_rgb.__name__
+    except ImportError:
+        pytest.fail()

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -2,7 +2,6 @@ import numpy as np
 from scipy.interpolate import CubicSpline
 from astropy.visualization import make_lupton_rgb
 import matplotlib.pyplot as plt
-from gammapy.maps.axes import UNIT_STRING_FORMAT
 
 __all__ = [
     "plot_contour_line",
@@ -128,6 +127,7 @@ def plot_theta_squared_table(table):
         Required columns: theta2_min, theta2_max, counts, counts_off and alpha
     """
     from gammapy.maps import MapAxis
+    from gammapy.maps.axes import UNIT_STRING_FORMAT
     from gammapy.maps.utils import edges_from_lo_hi
 
     theta2_edges = edges_from_lo_hi(


### PR DESCRIPTION
This PR is related to #4582. 
I move the import of `UNIT_STRING_FORMAT` from `gammapy.maps.axes` inside `plot_theta_squared_table` to avoid the circular import issue.