### PR TITLE
Correct RegionGeom.get_coord() sparse argument

### DIFF
--- a/examples/tutorials/analysis-3d/event_sampling_nrg_depend_models.py
+++ b/examples/tutorials/analysis-3d/event_sampling_nrg_depend_models.py
@@ -136,7 +136,7 @@ m = RegionNDMap.create(
 )
 
 # to compute the spectra as a function of time we extract the coordinates of the geometry
-coords = m.geom.get_coord()
+coords = m.geom.get_coord(sparse=True)
 
 # We reshape the indices and amplitudes array to perform broadcasting
 indices = indices.reshape(coords["time"].shape)

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -127,7 +127,7 @@ class MapDatasetEventSampler:
             unit=flux_inte.unit,
         )
 
-        mapcoord = flux_pred.geom.get_coord()
+        mapcoord = flux_pred.geom.get_coord(sparse=True)
         mapcoord["energy_true"] = energy_true.center[:, None, None, None]
 
         flux_values = flux_pred.interp_by_coord(mapcoord) * flux_pred.unit

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -300,7 +300,6 @@ class RegionGeom(Geom):
         axis_name : str
             If mode = "edges", the edges will be returned for this axis only.
 
-
         Returns
         -------
         coord : `~MapCoord`
@@ -315,7 +314,12 @@ class RegionGeom(Geom):
         if frame is None:
             frame = self.frame
 
-        return MapCoord.create(coords, frame=self.frame).to_frame(frame)
+        coords = MapCoord.create(coords, frame=self.frame).to_frame(frame)
+
+        if not sparse:
+            coords = coords.broadcasted
+
+        return coords
 
     def _pad_spatial(self, pad_width):
         raise NotImplementedError("Spatial padding of `RegionGeom` not supported")

--- a/gammapy/maps/region/tests/test_geom.py
+++ b/gammapy/maps/region/tests/test_geom.py
@@ -124,6 +124,7 @@ def test_get_coord(region, energy_axis, test_axis):
     assert coords["lon"].shape == (2, 3, 1, 1)
     assert coords["test"].shape == (2, 3, 1, 1)
     assert coords["energy"].shape == (2, 3, 1, 1)
+    assert_allclose(coords["test"].value[:, 2, 0, 0].squeeze(), [1, 2], rtol=1e-5)
 
 
 def test_get_idx(region, energy_axis, test_axis):

--- a/gammapy/maps/region/tests/test_geom.py
+++ b/gammapy/maps/region/tests/test_geom.py
@@ -118,8 +118,12 @@ def test_get_coord(region, energy_axis, test_axis):
     assert_allclose(
         coords["energy"].value[0, :, 0, 0], [1.467799, 3.162278, 6.812921], rtol=1e-5
     )
-
     assert_allclose(coords["test"].value[:, 0, 0, 0].squeeze(), [1, 2], rtol=1e-5)
+
+    coords = geom.get_coord(sparse=False)
+    assert coords["lon"].shape == (2, 3, 1, 1)
+    assert coords["test"].shape == (2, 3, 1, 1)
+    assert coords["energy"].shape == (2, 3, 1, 1)
 
 
 def test_get_idx(region, energy_axis, test_axis):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request solves #4542 . When `sparse=False`, `RegionGeam.get_coord()` returns a broadcasted `MapCoord`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
