### PR TITLE
Backport PR #4593 on branch v1.0.x (Make geom_exposure optional in MapDatasetOnOff.from_geoms)

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2145,7 +2145,7 @@ class MapDatasetOnOff(MapDataset):
     def from_geoms(
         cls,
         geom,
-        geom_exposure,
+        geom_exposure=None,
         geom_psf=None,
         geom_edisp=None,
         reference_time="2000-01-01",

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1873,3 +1873,27 @@ def test_peek(images):
 
     with mpl_plot_check():
         dataset.peek()
+
+
+def test_to_masked():
+    axis = MapAxis.from_energy_bounds(1, 10, 2, unit="TeV")
+    geom = WcsGeom.create(npix=(10, 10), binsz=0.05, axes=[axis])
+    counts = Map.from_geom(geom, data=1)
+    mask = Map.from_geom(geom, data=True, dtype=bool)
+    mask.data[0][5:8] = False
+    dataset = MapDataset(counts=counts, mask_safe=mask)
+    d1 = dataset.to_masked()
+    assert_allclose(d1.counts.data.sum(), 170)
+
+    acceptance = Map.from_geom(geom, data=1)
+    acceptance_off = Map.from_geom(geom, data=0.1)
+    counts_off = counts
+    datasetonoff = MapDatasetOnOff(
+        counts=counts,
+        acceptance=acceptance,
+        mask_safe=mask,
+        acceptance_off=acceptance_off,
+        counts_off=counts_off,
+    )
+    d1 = datasetonoff.to_masked()
+    assert_allclose(d1.counts.data.sum(), 170)


### PR DESCRIPTION
Make geom_exposure optional in MapDatasetOnOff.from_geoms

(cherry picked from commit 9f510bda5802e8df571479a9b33df94337d456ba)

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request ...

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
