### PR TITLE
introducing union support in ObservationFilter

### DIFF
--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import copy
 import logging
+import numpy as np
 from astropy.table import unique, vstack
+import pandas as pd
 
 __all__ = ["ObservationFilter"]
 
@@ -24,8 +26,10 @@ class ObservationFilter:
           class that corresponds to the filter type
           (see `~gammapy.data.ObservationFilter.EVENT_FILTER_TYPES`)
 
-        The filtered event list will be an intersection of all filters. A union
-        of filters is not supported yet.
+    event_filter_method: str
+        The filterring method to use on the event_filters. Either "intersect" or "union". Default is "intersect".
+        If "intersect", the filtered event list will be the intersection of all the event filters.
+        If "union", the filtered event list will be the union of all the event fileters, under uniquness condition.
 
     Examples
     --------
@@ -45,10 +49,12 @@ class ObservationFilter:
 
     EVENT_FILTER_TYPES = dict(sky_region="select_region", custom="select_parameter")
 
-    def __init__(self, time_filter=None, event_filters=None, event_logic="and"):
+    def __init__(
+        self, time_filter=None, event_filters=None, event_filter_method="intersect"
+    ):
         self.time_filter = time_filter
-        self.event_filters = event_filters or []
-        self.event_logic = event_logic
+        self.event_filters = self._check_overlap_phase(event_filters) or []
+        self.event_filter_method = event_filter_method
 
     @property
     def livetime_fraction(self):
@@ -72,7 +78,7 @@ class ObservationFilter:
 
         filtered_events = self._filter_by_time(events)
 
-        if self.event_logic == "and":
+        if self.event_filter_method == "intersect":
 
             for f in self.event_filters:
                 method_str = self.EVENT_FILTER_TYPES[f["type"]]
@@ -80,7 +86,7 @@ class ObservationFilter:
 
             return filtered_events
 
-        elif self.event_logic == "or":
+        elif self.event_filter_method == "union":
 
             filtered_events = []
             for f in self.event_filters:
@@ -92,6 +98,11 @@ class ObservationFilter:
             )
             tot_filtered_events = EventList(table)
             return tot_filtered_events
+
+        else:
+            raise ValueError(
+                "event_filter_method has to be either 'intersect' or 'union'."
+            )
 
     def filter_gti(self, gti):
         """Apply filters to a GTI table.
@@ -131,3 +142,22 @@ class ObservationFilter:
                 fraction += band[1] - band[0]
 
         return 1 if fraction == 0 else fraction
+
+    @staticmethod
+    def _check_overlap_phase(event_filter):
+        bands = []
+        for f in event_filter:
+            if f.get("opts").get("parameter") == "PHASE":
+                bands.append(f.get("opts").get("band"))
+
+        intervals = pd.arrays.IntervalArray.from_tuples(bands)
+        interval_matrix = []
+        for b in bands:
+            interval_matrix.append(intervals.overlaps(pd.Interval(b[0], b[1])))
+
+        interval_matrix = np.array(interval_matrix)
+        overlap_array = interval_matrix[~np.eye(interval_matrix.shape[0], dtype=bool)]
+        if True in overlap_array:
+            raise ValueError(
+                "Overlapping bands in event_filters that apply to pulsar phase are not allowed."
+            )

--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -53,7 +53,8 @@ class ObservationFilter:
         self, time_filter=None, event_filters=None, event_filter_method="intersect"
     ):
         self.time_filter = time_filter
-        self.event_filters = self._check_overlap_phase(event_filters) or []
+        self.event_filters = event_filters or []
+        self._check_overlap_phase(self.event_filters)
         self.event_filter_method = event_filter_method
 
     @property
@@ -150,14 +151,17 @@ class ObservationFilter:
             if f.get("opts").get("parameter") == "PHASE":
                 bands.append(f.get("opts").get("band"))
 
-        intervals = pd.arrays.IntervalArray.from_tuples(bands)
-        interval_matrix = []
-        for b in bands:
-            interval_matrix.append(intervals.overlaps(pd.Interval(b[0], b[1])))
+        if len(bands) > 1:
+            intervals = pd.arrays.IntervalArray.from_tuples(bands)
+            interval_matrix = []
+            for b in bands:
+                interval_matrix.append(intervals.overlaps(pd.Interval(b[0], b[1])))
 
-        interval_matrix = np.array(interval_matrix)
-        overlap_array = interval_matrix[~np.eye(interval_matrix.shape[0], dtype=bool)]
-        if True in overlap_array:
-            raise ValueError(
-                "Overlapping bands in event_filters that apply to pulsar phase are not allowed."
-            )
+            interval_matrix = np.array(interval_matrix)
+            overlap_array = interval_matrix[
+                ~np.eye(interval_matrix.shape[0], dtype=bool)
+            ]
+            if True in overlap_array:
+                raise ValueError(
+                    "Overlapping bands in event_filters that apply to pulsar phase are not allowed."
+                )

--- a/gammapy/data/tests/test_filters.py
+++ b/gammapy/data/tests/test_filters.py
@@ -102,6 +102,13 @@ def test_filter_gti(observation):
             "p_in": [],
             "p_out": 1,
         },
+        {
+            "p_in": [
+                {"type": "custom", "opts": dict(parameter="PHASE", band=(0.2, 0.4))},
+                {"type": "custom", "opts": dict(parameter="PHASE", band=(0.6, 0.8))},
+            ],
+            "p_out": 0.4,
+        },
     ],
 )
 def test_check_filter_phase(pars):


### PR DESCRIPTION
This pull request introduce "union" filtering in `ObservationFilter`, as mentioned in #4511. 

First of all, I introduce a new input parameter to the class, `event_filter_method`, which can take either the value `'intersect'`or `'union'`. By default it is set to `'intersect'` to stick to the former behaviour. 

Then I modified the `filter_events` method to be able to do "union filtering". For that, I take the event filtered by each filter one by one, `vstack`their table, sort the table by `'TIME'`, apply `unique` to table and then put this in a new `EventList` which is retuned.

I also modified the `_check_filter_phase` (that check for "phase filter" and apply the livetime correction if needed) so that it can support multiple filtering. 

Finally, I also added a staticmethod `_check_overlap_phase`, which check if there are overlap in the define `band`of "phase filter". This is mandatory to avoid having livetime that are not corresponding to the really fraction of livetime that is kept. 