### PR TITLE
Match energy binning per decade to pyirf's

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -583,7 +583,7 @@ class MapAxis:
             )
 
         if per_decade:
-            nbin = np.ceil(np.log10(energy_max / energy_min).value * nbin)
+            nbin = np.floor(np.log10(energy_max / energy_min).value * nbin)
 
         if name is None:
             name = "energy"

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -583,7 +583,10 @@ class MapAxis:
             )
 
         if per_decade:
-            nbin = np.floor(np.log10(energy_max / energy_min).value * nbin)
+            bin_per_decade = nbin
+            nbin = np.floor(np.log10(energy_max / energy_min).value * bin_per_decade)
+            if np.log10(energy_max / energy_min).value % (1 / bin_per_decade) != 0:
+                energy_max = energy_min * 10 ** (nbin / bin_per_decade)
 
         if name is None:
             name = "energy"

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -592,7 +592,9 @@ class MapAxis:
                 nbin = np.ceil(np.log10(energy_max / energy_min).value * nbin)
             else:
                 bin_per_decade = nbin
-                nbin = np.floor(np.log10(energy_max / energy_min).value * bin_per_decade)
+                nbin = np.floor(
+                    np.log10(energy_max / energy_min).value * bin_per_decade
+                )
                 if np.log10(energy_max / energy_min).value % (1 / bin_per_decade) != 0:
                     energy_max = energy_min * 10 ** (nbin / bin_per_decade)
 

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -546,6 +546,7 @@ class MapAxis:
         per_decade=False,
         name=None,
         node_type="edges",
+        strict_bounds=True,
     ):
         """Make an energy axis.
 
@@ -564,6 +565,10 @@ class MapAxis:
             Whether `nbin` is given per decade.
         name : str
             Name of the energy axis, either 'energy' or 'energy_true'
+        strict_bounds : bool
+            Whether to strictly end the binning at the max energy when
+            `per_decade=True`. If True, the number of bins per decade
+            might be slightly adjusted.
 
         Returns
         -------
@@ -583,10 +588,13 @@ class MapAxis:
             )
 
         if per_decade:
-            bin_per_decade = nbin
-            nbin = np.floor(np.log10(energy_max / energy_min).value * bin_per_decade)
-            if np.log10(energy_max / energy_min).value % (1 / bin_per_decade) != 0:
-                energy_max = energy_min * 10 ** (nbin / bin_per_decade)
+            if strict_bounds:
+                nbin = np.ceil(np.log10(energy_max / energy_min).value * nbin)
+            else:
+                bin_per_decade = nbin
+                nbin = np.floor(np.log10(energy_max / energy_min).value * bin_per_decade)
+                if np.log10(energy_max / energy_min).value % (1 / bin_per_decade) != 0:
+                    energy_max = energy_min * 10 ** (nbin / bin_per_decade)
 
         if name is None:
             name = "energy"

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -28,7 +28,6 @@ MAP_AXIS_NODE_TYPES = [
     ([0.25, 0.75, 1.0, 2.0], "sqrt", "center"),
 ]
 
-
 nodes_array = np.array([0.25, 0.75, 1.0, 2.0])
 
 MAP_AXIS_NODE_TYPE_UNIT = [
@@ -880,3 +879,12 @@ def test_label_map_axis_squash():
 
     assert squash_label.nbin == 1
     assert_equal(squash_label.center, np.array(["a...c"]))
+
+
+def test_energy_bin_per_decade_not_strict_bounds():
+    nbin = 5
+    axis = MapAxis.from_energy_bounds(
+        "0.03 TeV", "333 TeV", nbin=nbin, per_decade=True, strict_bounds=False
+    )
+
+    assert_allclose(axis.edges[0:-nbin] * 10.0, axis.edges[nbin:], rtol=1e-5, atol=0)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request has the purpose of matching what pyirf does when making an energy binning per decade, i.e. to make sure that when using the same energy limits and number of bins per decade, the resulting bins are exactly the same in both pyirf and gammapy.
Before these changes, the value of energy_max was always included as the last edge, even when it didn't match the bins-per-decade requirement, so the edges were shifted and the actual number of bins per decade was a fraction higher. Now, energy_max is not forced to be an edge and the last edge is recalculated.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This PR is ready for review.
