### PR TITLE
Add function to determine pivot energy for any spectral model

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -215,7 +215,8 @@ class SpectralModel(ModelBase):
 
     @property
     def pivot_energy(self):
-        """The pivot or decorrelation energy for a given spectral model calculated numerically.
+        """The pivot or decorrelation energy, for a given spectral model calculated numerically.
+        It is defined as the energy at which the correlation between the spectral parameters is minimized.
 
         Returns
         -------
@@ -236,13 +237,17 @@ class SpectralModel(ModelBase):
 
         std = np.std(min_func(x=np.linspace(bounds[0], bounds[1], 100)))
         if std < 1e-5:
-            log.warning("No minimum was found.")
+            log.warning(
+                "The relative error on the flux does not depend on energy. No pivot energy found."
+            )
             return np.nan * x_unit
 
         minimizer = scipy.optimize.minimize_scalar(min_func, bounds=bounds)
 
         if not minimizer.success:
-            log.warning("The minimizer was not successful.")
+            log.warning(
+                "No minima found in the relative error on the flux. Pivot energy computation failed."
+            )
             return np.nan * x_unit
         else:
             return np.exp(minimizer.x) * x_unit

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -215,12 +215,12 @@ class SpectralModel(ModelBase):
 
     @property
     def pivot_energy(self):
-        """The decorrelation energy for a given spectral model calculated numerically.
+        """The pivot or decorrelation energy for a given spectral model calculated numerically.
 
         Returns
         -------
         pivot energy : `~astropy.units.Quantity`
-            The energy at which the statistical error is smallest.
+            The energy at which the statistical error in the computed flux is smallest.
             If no minimum is found, NaN will be returned.
         """
 
@@ -849,7 +849,7 @@ class PowerLawSpectralModel(SpectralModel):
 
     @property
     def pivot_energy(self):
-        r"""The decorrelation energy is defined as:
+        r"""The pivot or decorrelation energy is defined as:
 
         .. math::
 
@@ -947,7 +947,7 @@ class PowerLawNormSpectralModel(SpectralModel):
 
     @property
     def pivot_energy(self):
-        r"""The decorrelation energy is defined as:
+        r"""The pivot or decorrelation energy is defined as:
 
         .. math::
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -228,15 +228,7 @@ class SpectralModel(ModelBase):
         """
         dnde, dnde_error = self.evaluate_error(energy)
 
-        y_lo = dnde - dnde_error
-        y_hi = dnde + dnde_error
-
-        log_y_lo = np.log10(y_lo[y_lo > 0].value)
-        log_y_hi = np.log10(y_hi[y_lo > 0].value)
-
-        energy = energy[y_lo > 0]
-
-        return energy[np.argmin(log_y_hi - log_y_lo)]
+        return energy[np.argmin(dnde_error / dnde)]
 
     def integral(self, energy_min, energy_max, **kwargs):
         r"""Integrate spectral model numerically if no analytical solution defined.

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -214,21 +214,23 @@ class SpectralModel(ModelBase):
         return self._propagate_error(epsilon=epsilon, fct=self, energy=energy)
 
     def pivot_energy(self, energy):
-        """Return the pivot energy for a given spectral model.
-        The pivot energy is the narrowest point of the butterfly.
+        """The decorrelation energy for a given spectral model calculated numerically.
 
         Parameters
         ----------
         energy : `~astropy.units.Quantity`
-            The energy to evaluate the spectral model and error.
+            Array of energies to evaluate the spectral model and error.
 
+        Returns
+        -------
+        pivot energy : `~astropy.units.Quantity`
+            The energy at which the statistical error is smallest.
         """
         dnde, dnde_error = self.evaluate_error(energy)
 
         y_lo = dnde - dnde_error
         y_hi = dnde + dnde_error
 
-        # Add here to get rid of any negative fluxes
         log_y_lo = np.log10(y_lo[y_lo > 0].value)
         log_y_hi = np.log10(y_hi[y_lo > 0].value)
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -213,6 +213,29 @@ class SpectralModel(ModelBase):
         """
         return self._propagate_error(epsilon=epsilon, fct=self, energy=energy)
 
+    def pivot_energy(self, energy):
+        """Return the pivot energy for a given spectral model.
+        The pivot energy is the narrowest point of the butterfly.
+
+        Parameters
+        ----------
+        energy : `~astropy.units.Quantity`
+            The energy to evaluate the spectral model and error.
+
+        """
+        dnde, dnde_error = self.evaluate_error(energy)
+
+        y_lo = dnde - dnde_error
+        y_hi = dnde + dnde_error
+
+        # Add here to get rid of any negative fluxes
+        log_y_lo = np.log10(y_lo[y_lo > 0].value)
+        log_y_hi = np.log10(y_hi[y_lo > 0].value)
+
+        energy = energy[y_lo > 0]
+
+        return energy[np.argmin(log_y_hi - log_y_lo)]
+
     def integral(self, energy_min, energy_max, **kwargs):
         r"""Integrate spectral model numerically if no analytical solution defined.
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -218,8 +218,8 @@ class SpectralModel(ModelBase):
 
         Parameters
         ----------
-        energy : `~astropy.units.Quantity`
-            Array of energies to evaluate the spectral model and error.
+        energy_bounds : `~astropy.units.Quantity`
+            Energy bounds to evaluate the spectral model and error.
 
         Returns
         -------

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -236,11 +236,13 @@ class SpectralModel(ModelBase):
 
         std = np.std(min_func(x=np.linspace(bounds[0], bounds[1], 100)))
         if std < 1e-5:
+            log.warning("No minimum was found.")
             return np.nan * x_unit
 
         minimizer = scipy.optimize.minimize_scalar(min_func, bounds=bounds)
 
         if not minimizer.success:
+            log.warning("The minimizer was not successful.")
             return np.nan * x_unit
         else:
             return np.exp(minimizer.x) * x_unit

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -213,7 +213,7 @@ class SpectralModel(ModelBase):
         """
         return self._propagate_error(epsilon=epsilon, fct=self, energy=energy)
 
-    def pivot_energy(self, energy):
+    def pivot_energy(self, energy_bounds, nbins=1000):
         """The decorrelation energy for a given spectral model calculated numerically.
 
         Parameters
@@ -226,6 +226,9 @@ class SpectralModel(ModelBase):
         pivot energy : `~astropy.units.Quantity`
             The energy at which the statistical error is smallest.
         """
+        energy_min, energy_max = energy_bounds
+        energy = np.geomspace(energy_min, energy_max, nbins)
+
         dnde, dnde_error = self.evaluate_error(energy)
 
         return energy[np.argmin(dnde_error / dnde)]

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -617,11 +617,23 @@ def test_pwl_pivot_energy():
     assert_quantity_allclose(pwl.pivot_energy, np.nan * u.TeV, rtol=1e-5)
 
     pwl.covariance = [
-        [0.0318377**2, 6.56889442e-14, 0],
-        [6.56889442e-14, 0, 0],
+        [0.08**2, 6.56889e-14, 0],
+        [6.56889e-14, (5.5e-12) ** 2, 0],
         [0, 0, 0],
     ]
-    assert_quantity_allclose(pwl.pivot_energy, 3.3540034 * u.TeV, rtol=1e-5)
+    assert_quantity_allclose(pwl.pivot_energy, 1.2112653 * u.TeV, rtol=1e-5)
+
+    ecpl = ExpCutoffPowerLawSpectralModel(
+        amplitude="5.35510540e-11 cm-2 s-1 TeV-1", lambda_=0.001 * (1 / u.TeV), index=2
+    )
+    ecpl.covariance = [
+        [0.08**2, 6.56889e-14, 0, 0, 0],
+        [6.56889e-14, (5.5e-12) ** 2, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+    ]
+    assert_quantity_allclose(pwl.pivot_energy, ecpl.pivot_energy, rtol=1e-5)
 
 
 def test_num_pivot_energy():

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -635,9 +635,9 @@ def test_num_pivot_energy():
     lp.alpha.error = "0.1126"
     lp.beta.error = "0.0670"
 
-    energy = np.geomspace(0.1, 1000, 1000) * u.GeV
+    energy_bounds = [0.1, 1000] * u.GeV
 
-    assert_quantity_allclose(lp.pivot_energy(energy), 17.307655 * u.GeV)
+    assert_quantity_allclose(lp.pivot_energy(energy_bounds), 17.307655 * u.GeV)
 
 
 def test_template_spectral_model_evaluate_tiny():

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -614,14 +614,14 @@ def test_ecpl_integrate():
 
 def test_pwl_pivot_energy():
     pwl = PowerLawSpectralModel(amplitude="5.35510540e-11 cm-2 s-1 TeV-1")
-    assert_quantity_allclose(pwl.pivot_energy, np.nan * u.TeV)
+    assert_quantity_allclose(pwl.pivot_energy, np.nan * u.TeV, rtol=1e-5)
 
     pwl.covariance = [
         [0.0318377**2, 6.56889442e-14, 0],
         [6.56889442e-14, 0, 0],
         [0, 0, 0],
     ]
-    assert_quantity_allclose(pwl.pivot_energy, 3.3540034 * u.TeV)
+    assert_quantity_allclose(pwl.pivot_energy, 3.3540034 * u.TeV, rtol=1e-5)
 
 
 def test_num_pivot_energy():
@@ -632,11 +632,11 @@ def test_num_pivot_energy():
         beta="0.2217",
     )
     lp.amplitude.error = "2.8804e-12 cm-2 s-1 GeV-1"
-    assert_quantity_allclose(lp.pivot_energy, np.nan * u.GeV)
+    assert_quantity_allclose(lp.pivot_energy, np.nan * u.GeV, rtol=1e-5)
 
     lp.alpha.error = "0.1126"
     lp.beta.error = "0.0670"
-    assert_quantity_allclose(lp.pivot_energy, 17.337042 * u.GeV)
+    assert_quantity_allclose(lp.pivot_energy, 17.337042 * u.GeV, rtol=1e-5)
 
 
 def test_template_spectral_model_evaluate_tiny():

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -624,6 +624,22 @@ def test_pwl_pivot_energy():
     assert_quantity_allclose(pwl.pivot_energy, 3.3540034240210987 * u.TeV)
 
 
+def test_num_pivot_energy():
+    lp = LogParabolaSpectralModel(
+        amplitude="5.82442e-11 cm-2 s-1 GeV-1",
+        reference="17.337 GeV",
+        alpha="1.9134",
+        beta="0.2217",
+    )
+    lp.amplitude.error = "2.8804e-12 cm-2 s-1 GeV-1"
+    lp.alpha.error = "0.1126"
+    lp.beta.error = "0.0670"
+
+    energy = np.geomspace(0.1, 1000, 1000) * u.GeV
+
+    assert_quantity_allclose(lp.pivot_energy(energy), 17.307655 * u.GeV)
+
+
 def test_template_spectral_model_evaluate_tiny():
     energy = np.array([1.00000000e06, 1.25892541e06, 1.58489319e06, 1.99526231e06])
     values = np.array([4.39150790e-38, 1.96639562e-38, 8.80497507e-39, 3.94262401e-39])

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -635,9 +635,7 @@ def test_num_pivot_energy():
     lp.alpha.error = "0.1126"
     lp.beta.error = "0.0670"
 
-    energy_bounds = [0.1, 1000] * u.GeV
-
-    assert_quantity_allclose(lp.pivot_energy(energy_bounds), 17.307655 * u.GeV)
+    assert_quantity_allclose(lp.pivot_energy, 17.337913 * u.GeV)
 
 
 def test_template_spectral_model_evaluate_tiny():

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -617,23 +617,11 @@ def test_pwl_pivot_energy():
     assert_quantity_allclose(pwl.pivot_energy, np.nan * u.TeV, rtol=1e-5)
 
     pwl.covariance = [
-        [0.08**2, 6.56889e-14, 0],
-        [6.56889e-14, (5.5e-12) ** 2, 0],
+        [0.0318377**2, 6.56889442e-14, 0],
+        [6.56889442e-14, 0, 0],
         [0, 0, 0],
     ]
-    assert_quantity_allclose(pwl.pivot_energy, 1.2112653 * u.TeV, rtol=1e-5)
-
-    ecpl = ExpCutoffPowerLawSpectralModel(
-        amplitude="5.35510540e-11 cm-2 s-1 TeV-1", lambda_=0.001 * (1 / u.TeV), index=2
-    )
-    ecpl.covariance = [
-        [0.08**2, 6.56889e-14, 0, 0, 0],
-        [6.56889e-14, (5.5e-12) ** 2, 0, 0, 0],
-        [0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0],
-    ]
-    assert_quantity_allclose(pwl.pivot_energy, ecpl.pivot_energy, rtol=1e-5)
+    assert_quantity_allclose(pwl.pivot_energy, 3.3540034 * u.TeV, rtol=1e-5)
 
 
 def test_num_pivot_energy():

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -621,7 +621,7 @@ def test_pwl_pivot_energy():
         [0, 0, 0],
     ]
 
-    assert_quantity_allclose(pwl.pivot_energy, 3.3540034240210987 * u.TeV)
+    assert_quantity_allclose(pwl.pivot_energy(), 3.3540034 * u.TeV)
 
 
 def test_num_pivot_energy():
@@ -635,7 +635,7 @@ def test_num_pivot_energy():
     lp.alpha.error = "0.1126"
     lp.beta.error = "0.0670"
 
-    assert_quantity_allclose(lp.pivot_energy, 17.337913 * u.GeV)
+    assert_quantity_allclose(lp.pivot_energy(), 17.33698 * u.GeV)
 
 
 def test_template_spectral_model_evaluate_tiny():

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -614,14 +614,14 @@ def test_ecpl_integrate():
 
 def test_pwl_pivot_energy():
     pwl = PowerLawSpectralModel(amplitude="5.35510540e-11 cm-2 s-1 TeV-1")
+    assert_quantity_allclose(pwl.pivot_energy, np.nan * u.TeV)
 
     pwl.covariance = [
         [0.0318377**2, 6.56889442e-14, 0],
         [6.56889442e-14, 0, 0],
         [0, 0, 0],
     ]
-
-    assert_quantity_allclose(pwl.pivot_energy(), 3.3540034 * u.TeV)
+    assert_quantity_allclose(pwl.pivot_energy, 3.3540034 * u.TeV)
 
 
 def test_num_pivot_energy():
@@ -632,10 +632,11 @@ def test_num_pivot_energy():
         beta="0.2217",
     )
     lp.amplitude.error = "2.8804e-12 cm-2 s-1 GeV-1"
+    assert_quantity_allclose(lp.pivot_energy, np.nan * u.GeV)
+
     lp.alpha.error = "0.1126"
     lp.beta.error = "0.0670"
-
-    assert_quantity_allclose(lp.pivot_energy(), 17.33698 * u.GeV)
+    assert_quantity_allclose(lp.pivot_energy, 17.337042 * u.GeV)
 
 
 def test_template_spectral_model_evaluate_tiny():


### PR DESCRIPTION
**Description**
This PR is addressing the feature request from issue [#4016.](https://github.com/gammapy/gammapy/issues/4016) 
I have added a `pivot_energy` function to the `SpectralModel` class that finds the energy at which the error butterfly is minimum. This function is then 'overridden' in the `PowerLawSpectralModel` where there is an analytical equation available.

Please note: this must be performed in log space (as I understand) because the butterfly minimum occurs in the log space plot. 

**Dear reviewer**
I am certainly open to suggestions/feedback on this issue. 
