### PR TITLE
Adapt `PiecewiseNormSpatialModel` to wrap the longitude

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1311,7 +1311,8 @@ class PiecewiseNormSpatialModel(SpatialModel):
 
     def __init__(self, coords, norms=None, interp="lin", **kwargs):
         self._coords = coords
-        self._coords["lon"] = Angle(self._coords.lon).wrap_at(180 * u.deg)
+        self._wrap_angle = (coords.lon.max() - coords.lon.min()) / 2
+        self._coords["lon"] = Angle(coords.lon).wrap_at(self._wrap_angle)
         self._interp = interp
 
         if norms is None:
@@ -1357,6 +1358,7 @@ class PiecewiseNormSpatialModel(SpatialModel):
         coords = [value.value for value in self.coords._data.values()]
         # TODO: apply axes scaling in this loop
         coords = list(zip(*coords))
+        lon = Angle(lon).wrap_at(self._wrap_angle)
         # by default rely on CloughTocher2DInterpolator
         # (Piecewise cubic, C1 smooth, curvature-minimizing interpolant)
         interpolated = griddata(coords, v_nodes, (lon, lat), method="cubic")
@@ -1377,7 +1379,7 @@ class PiecewiseNormSpatialModel(SpatialModel):
 
         """
         coords = geom.get_coord(frame=self.frame, sparse=True)
-        return self(Angle(coords.lon).wrap_at(180 * u.deg), coords.lat)
+        return self(coords.lon, coords.lat)
 
     def to_dict(self, full_output=False):
         data = super().to_dict(full_output=full_output)

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1311,6 +1311,7 @@ class PiecewiseNormSpatialModel(SpatialModel):
 
     def __init__(self, coords, norms=None, interp="lin", **kwargs):
         self._coords = coords
+        self._coords["lon"] = Angle(self._coords.lon).wrap_at(180 * u.deg)
         self._interp = interp
 
         if norms is None:
@@ -1376,7 +1377,7 @@ class PiecewiseNormSpatialModel(SpatialModel):
 
         """
         coords = geom.get_coord(frame=self.frame, sparse=True)
-        return self(coords.lon, coords.lat)
+        return self(Angle(coords.lon).wrap_at(180 * u.deg), coords.lat)
 
     def to_dict(self, full_output=False):
         data = super().to_dict(full_output=full_output)

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1310,7 +1310,8 @@ class PiecewiseNormSpatialModel(SpatialModel):
     tag = ["PiecewiseNormSpatialModel", "piecewise-norm"]
 
     def __init__(self, coords, norms=None, interp="lin", **kwargs):
-        self._coords = coords
+        self._coords = coords.copy()
+        self._coords["lon"] = Angle(coords.lon).wrap_at(0 * u.deg)
         self._wrap_angle = (coords.lon.max() - coords.lon.min()) / 2
         self._coords["lon"] = Angle(coords.lon).wrap_at(self._wrap_angle)
         self._interp = interp

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -545,7 +545,7 @@ def test_templatemap_clip():
 
 
 def test_piecewise_spatial_model_gc():
-    geom = WcsGeom.create(skydir=(0, 2.3), npix=(2, 2), binsz=0.3, frame="galactic")
+    geom = WcsGeom.create(skydir=(0, 0), npix=(2, 2), binsz=0.3, frame="galactic")
     coords = MapCoord.create(geom.footprint)
     coords["lon"] *= u.deg
     coords["lat"] *= u.deg

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -578,38 +578,35 @@ def test_piecewise_spatial_model_gc():
     )
 
 
-def test_piecewise_spatial_model_anticenter():
-    geom = WcsGeom.create(skydir=(180, 2.3), npix=(2, 2), binsz=0.3, frame="galactic")
-    coords = MapCoord.create(geom.footprint)
-    coords["lon"] *= u.deg
-    coords["lat"] *= u.deg
+def test_piecewise_spatial_model():
 
-    model = PiecewiseNormSpatialModel(coords, frame="galactic")
+    for lon in range(-360, 360):
+        geom = WcsGeom.create(
+            skydir=(lon, 2.3), npix=(2, 2), binsz=0.3, frame="galactic"
+        )
+        coords = MapCoord.create(geom.footprint)
+        coords["lon"] *= u.deg
+        coords["lat"] *= u.deg
 
-    assert_allclose(model(*geom.to_image().center_coord), 1.0)
+        model = PiecewiseNormSpatialModel(coords, frame="galactic")
 
-    norms = np.arange(coords.shape[0])
+        assert_allclose(model(*geom.to_image().center_coord), 1.0)
 
-    model = PiecewiseNormSpatialModel(coords, norms, frame="galactic")
+        norms = np.arange(coords.shape[0])
 
-    assert not model.is_energy_dependent
+        model = PiecewiseNormSpatialModel(coords, norms, frame="galactic")
 
-    expected = np.array([[0, 3], [1, 2]])
-    assert_allclose(model(*geom.to_image().get_coord()), expected, atol=1e-5)
+        expected = np.array([[0, 3], [1, 2]])
+        assert_allclose(model(*geom.to_image().get_coord()), expected, atol=1e-5)
 
-    assert_allclose(model.evaluate_geom(geom.to_image()), expected, atol=1e-5)
+        assert_allclose(model.evaluate_geom(geom.to_image()), expected, atol=1e-5)
 
-    assert_allclose(model.evaluate_geom(geom), expected, atol=1e-5)
+        assert_allclose(model.evaluate_geom(geom), expected, atol=1e-5)
 
-    model_dict = model.to_dict()
-    new_model = PiecewiseNormSpatialModel.from_dict(model_dict)
+        model_dict = model.to_dict()
+        new_model = PiecewiseNormSpatialModel.from_dict(model_dict)
 
-    assert_allclose(new_model.evaluate_geom(geom.to_image()), expected, atol=1e-5)
-
-    assert_allclose(
-        model.evaluate(180.1 * u.deg, 2.3 * u.deg),
-        model.evaluate(-179.9 * u.deg, 2.3 * u.deg),
-    )
+        assert_allclose(new_model.evaluate_geom(geom.to_image()), expected, atol=1e-5)
 
 
 def test_piecewise_spatial_model_3d():

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -544,8 +544,8 @@ def test_templatemap_clip():
     assert_allclose(val, 0, rtol=0.0001)
 
 
-def test_piecewise_spatial_model():
-    geom = WcsGeom.create(skydir=(2.4, 2.3), npix=(2, 2), binsz=0.3, frame="galactic")
+def test_piecewise_spatial_model_gc():
+    geom = WcsGeom.create(skydir=(0, 2.3), npix=(2, 2), binsz=0.3, frame="galactic")
     coords = MapCoord.create(geom.footprint)
     coords["lon"] *= u.deg
     coords["lat"] *= u.deg
@@ -571,6 +571,45 @@ def test_piecewise_spatial_model():
     new_model = PiecewiseNormSpatialModel.from_dict(model_dict)
 
     assert_allclose(new_model.evaluate_geom(geom.to_image()), expected, atol=1e-5)
+
+    assert_allclose(
+        model.evaluate(-0.1 * u.deg, 2.3 * u.deg),
+        model.evaluate(359.9 * u.deg, 2.3 * u.deg),
+    )
+
+
+def test_piecewise_spatial_model_anticenter():
+    geom = WcsGeom.create(skydir=(180, 2.3), npix=(2, 2), binsz=0.3, frame="galactic")
+    coords = MapCoord.create(geom.footprint)
+    coords["lon"] *= u.deg
+    coords["lat"] *= u.deg
+
+    model = PiecewiseNormSpatialModel(coords, frame="galactic")
+
+    assert_allclose(model(*geom.to_image().center_coord), 1.0)
+
+    norms = np.arange(coords.shape[0])
+
+    model = PiecewiseNormSpatialModel(coords, norms, frame="galactic")
+
+    assert not model.is_energy_dependent
+
+    expected = np.array([[0, 3], [1, 2]])
+    assert_allclose(model(*geom.to_image().get_coord()), expected, atol=1e-5)
+
+    assert_allclose(model.evaluate_geom(geom.to_image()), expected, atol=1e-5)
+
+    assert_allclose(model.evaluate_geom(geom), expected, atol=1e-5)
+
+    model_dict = model.to_dict()
+    new_model = PiecewiseNormSpatialModel.from_dict(model_dict)
+
+    assert_allclose(new_model.evaluate_geom(geom.to_image()), expected, atol=1e-5)
+
+    assert_allclose(
+        model.evaluate(180.1 * u.deg, 2.3 * u.deg),
+        model.evaluate(-179.9 * u.deg, 2.3 * u.deg),
+    )
 
 
 def test_piecewise_spatial_model_3d():


### PR DESCRIPTION
**Description**
This PR is to fix [#4602](https://github.com/gammapy/gammapy/issues/4602)
Adapted so that the code 'wraps' the Galactic longitude at 180 deg, so there is no longer an issue at the Galactic Centre. 

**Dear reviewer**
Hoping for some feedback. 
I tried to change the test for the `PiecewiseNormSpatialModel` such that it is testing at the GC, however, the following line of code does not return the expected
`assert_allclose(model(*geom.to_image().get_coord()), expected, atol=1e-5)`

The other tests work fine. So any explanation on this would be good