### PR TITLE
Fix points scaling in TemplateNDSpectralModel

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1723,11 +1723,6 @@ class TemplateNDSpectralModel(SpectralModel):
             filename = str(make_path(filename))
         self.filename = filename
 
-        points_scale = [
-            "lin",
-            "lin",
-            "log",
-        ]
         parameters = []
         has_energy = False
         for axis in map.geom.axes:
@@ -1742,7 +1737,6 @@ class TemplateNDSpectralModel(SpectralModel):
                     max=axis.bounds[-1],
                     interp=axis.interp,
                 )
-                points_scale.append(axis.interp)
                 parameters.append(parameter)
             else:
                 has_energy |= True
@@ -1753,7 +1747,6 @@ class TemplateNDSpectralModel(SpectralModel):
 
         interp_kwargs = interp_kwargs or {}
         interp_kwargs.setdefault("values_scale", "log")
-        interp_kwargs.setdefault("points_scale", points_scale)
         self._interp_kwargs = interp_kwargs
         super().__init__()
 

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -1160,7 +1160,7 @@ def test_template_ND_EBL(tmpdir):
     template = TemplateNDSpectralModel(region_map)
     assert len(template.parameters) == 1
     assert_allclose(template.parameters["redshift"].value, 1.001, rtol=1e-3)
-    expected = [9.950501e-01, 4.953951e-01, 1.588062e-06]
+    expected = [1.132092e00, 4.967878e-01, 1.596544e-06]
     assert_allclose(template([1, 100, 1000] * u.GeV), expected, rtol=1e-3)
     template.parameters["redshift"].value = 0.1
     template.filename = str(tmpdir / "template_ND_ebl_franceschini.fits")


### PR DESCRIPTION
Remove `points_scale` from the `interp_kwargs` because the transform is already applied by axis.coord_to_pix.