### PR TITLE
Fix the FluxProfileEstimator to take into account models

### DIFF
--- a/gammapy/estimators/points/profile.py
+++ b/gammapy/estimators/points/profile.py
@@ -134,7 +134,7 @@ class FluxProfileEstimator(FluxPointsEstimator):
             Profile flux points.
         """
 
-        datasets_copy = Datasets(datasets=datasets)
+        datasets = Datasets(datasets=datasets)
         datasets_copy = datasets.copy()
         for dataset in datasets_copy:
             dataset.background = dataset.npred()

--- a/gammapy/estimators/points/profile.py
+++ b/gammapy/estimators/points/profile.py
@@ -133,12 +133,15 @@ class FluxProfileEstimator(FluxPointsEstimator):
         profile : `~gammapy.estimators.FluxPoints`
             Profile flux points.
         """
-        datasets = Datasets(datasets=datasets)
+
+        datasets_copy = Datasets(datasets=datasets)
+        datasets_copy = datasets.copy()
+        for dataset in datasets_copy:
+            dataset.background = dataset.npred()
 
         maps = []
-
         for region in self.regions:
-            datasets_to_fit = datasets.to_spectrum_datasets(region=region)
+            datasets_to_fit = datasets_copy.to_spectrum_datasets(region=region)
             datasets_to_fit.models = SkyModel(self.spectrum, name="test-source")
             fp = super().run(datasets_to_fit)
             maps.append(fp)

--- a/gammapy/estimators/points/tests/test_profile.py
+++ b/gammapy/estimators/points/tests/test_profile.py
@@ -5,10 +5,10 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
-from test_sed import simulate_map_dataset
 from gammapy.data import GTI
 from gammapy.datasets import MapDatasetOnOff
 from gammapy.estimators import FluxPoints, FluxProfileEstimator
+from gammapy.estimators.points.tests.test_sed import simulate_map_dataset
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.utils.regions import (

--- a/gammapy/estimators/points/tests/test_profile.py
+++ b/gammapy/estimators/points/tests/test_profile.py
@@ -187,7 +187,7 @@ def test_regions_init():
         FluxProfileEstimator(regions=[region])
 
 
-def test_profile_with_model():
+def test_profile_with_model_or_mask():
     dataset = simulate_map_dataset(name="test-map-pwl")
 
     geom = dataset.counts.geom
@@ -211,3 +211,8 @@ def test_profile_with_model():
     result = prof_maker.run(dataset)
     imp_prof = result.to_table(sed_type="flux", format="profile")
     assert_allclose(imp_prof[7]["npred_excess"], [[112.95312]], rtol=1e-3)
+
+    dataset.mask_fit = ~geom.region_mask([regions[7]])
+    result = prof_maker.run(dataset)
+    imp_prof = result.to_table(sed_type="flux", format="profile")
+    assert_allclose(imp_prof[7]["npred_excess"], [[0]], rtol=1e-3)

--- a/gammapy/estimators/points/tests/test_profile.py
+++ b/gammapy/estimators/points/tests/test_profile.py
@@ -15,6 +15,7 @@ from gammapy.utils.regions import (
     make_concentric_annulus_sky_regions,
     make_orthogonal_rectangle_sky_regions,
 )
+from gammapy.utils.testing import requires_data
 
 
 def get_simple_dataset_on_off():
@@ -187,6 +188,7 @@ def test_regions_init():
         FluxProfileEstimator(regions=[region])
 
 
+@requires_data()
 def test_profile_with_model_or_mask():
     dataset = simulate_map_dataset(name="test-map-pwl")
 


### PR DESCRIPTION
This PR fixes the FluxProfileEstimator such as the models attached to the dataset are taken into account.
Resolves #4650