### PR TITLE
Add a faster reprojection method  : reproject_by_image

### DIFF
--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1129,7 +1129,7 @@ class Map(abc.ABC):
 
         output_map = Map.from_geom(geom.to_cube(self.geom.axes))
         maps = parallel.run_multiprocessing(
-            self._reproject_slice,
+            self._reproject_image,
             zip(
                 self.iter_by_image(),
                 repeat(geom),

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1116,7 +1116,7 @@ class Map(abc.ABC):
             if the map is an integral quantity (e.g. counts) and false if
             the map is a differential quantity (e.g. intensity)
         precision_factor : int
-           Minimal factor between the bin size of the output map and the oversampled base map.
+             Minimal factor between the bin size of the output map and the oversampled base map.
            Used only for the oversampling method.
 
         Returns

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1105,6 +1105,8 @@ class Map(abc.ABC):
     ):
         """Reproject each image of a ND map to input 2d geometry.
 
+           For large maps this method is faster than `reproject_to_geom`.
+
         Parameters
         ----------
         geom : `~gammapy.maps.Geom`

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 import matplotlib.pyplot as plt
+import gammapy.utils.parallel as parallel
 from gammapy.utils.deprecation import deprecated
 from gammapy.utils.random import InverseCDFSampler, get_random_state
 from gammapy.utils.scripts import make_path
@@ -1140,10 +1141,11 @@ class Map(abc.ABC):
                 repeat(preserve_counts),
                 repeat(precision_factor),
             ),
-            backend=self.parallel_backend,
-            pool_kwargs=dict(processes=self.n_jobs),
+            # backend=self.parallel_backend,
+            # pool_kwargs=dict(processes=self.n_jobs),
             task_name="Reprojection",
         )
+        # TODO: uncomment after parallel support is added on maps
         return Map.from_stack(maps, axis=axis)
 
     @staticmethod

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1105,19 +1105,19 @@ class Map(abc.ABC):
     ):
         """Reproject each image of a ND map to input 2d geometry.
 
-       For large maps this method is faster than `reproject_to_geom`.
+        For large maps this method is faster than `reproject_to_geom`.
 
         Parameters
         ----------
         geom : `~gammapy.maps.Geom`
             Target slice geometry (2d)
         preserve_counts : bool
-            Preserve the integral over each bin.  This should be true
-            if the map is an integral quantity (e.g. counts) and false if
-            the map is a differential quantity (e.g. intensity)
+            Preserve the integral over each bin.  This should be True
+            if the map is an integral quantity (e.g. counts) and False if
+            the map is a differential quantity (e.g. intensity).
         precision_factor : int
-             Minimal factor between the bin size of the output map and the oversampled base map.
-           Used only for the oversampling method.
+            Minimal factor between the bin size of the output map and the oversampled base map.
+            Used only for the oversampling method.
 
         Returns
         -------

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1105,7 +1105,7 @@ class Map(abc.ABC):
     ):
         """Reproject each image of a ND map to input 2d geometry.
 
-           For large maps this method is faster than `reproject_to_geom`.
+       For large maps this method is faster than `reproject_to_geom`.
 
         Parameters
         ----------

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1136,11 +1136,8 @@ class Map(abc.ABC):
                 repeat(preserve_counts),
                 repeat(precision_factor),
             ),
-            # backend=self.parallel_backend,
-            # pool_kwargs=dict(processes=self.n_jobs),
             task_name="Reprojection",
         )
-        # TODO: uncomment after parallel support is added on maps
         for idx in np.ndindex(self.geom.shape_axes):
             output_map.data[idx[0]] = maps[idx[0]].data
         return output_map

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1097,13 +1097,13 @@ class Map(abc.ABC):
             output_map = output_map.resample(geom, preserve_counts=preserve_counts)
         return output_map
 
-    def reproject_by_slice(
+    def reproject_by_image(
         self,
         geom,
         preserve_counts=False,
         precision_factor=10,
     ):
-        """Reproject each slice of a 3d map to input 2d geometry.
+        """Reproject each image of a ND map to input 2d geometry.
 
         Parameters
         ----------
@@ -1124,9 +1124,6 @@ class Map(abc.ABC):
         """
         if not geom.is_image:
             raise TypeError("This method is only valid for 2d geom")
-        if len(self.geom.axes) != 1:
-            raise TypeError("This method is only valid for 3d map")
-            # TODO: could this work with more axes ? with iter_by_image maybe
 
         output_map = Map.from_geom(geom.to_cube(self.geom.axes))
         maps = parallel.run_multiprocessing(
@@ -1147,7 +1144,7 @@ class Map(abc.ABC):
         return output_map
 
     @staticmethod
-    def _reproject_slice(image, geom, preserve_counts, precision_factor):
+    def _reproject_image(image, geom, preserve_counts, precision_factor):
         return image.reproject_to_geom(
             geom, precision_factor=precision_factor, preserve_counts=preserve_counts
         )

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -717,7 +717,7 @@ def test_map_reproject_wcs_to_wcs_with_axes():
             assert_allclose(np.nanmean(data[data > 0]), ref)
 
 
-def test_map_reproject_by_slice():
+def test_map_reproject_by_image():
     axis = MapAxis.from_bounds(
         1.0, 10.0, 3, interp="log", name="energy_true", node_type="center"
     )
@@ -731,7 +731,7 @@ def test_map_reproject_by_slice():
 
     m = HpxNDMap(geom_hpx_wrong)
     with pytest.raises(TypeError):
-        m.reproject_by_slice(geom_wcs)
+        m.reproject_by_image(geom_wcs)
 
     data = np.arange(3 * 768).reshape(geom_hpx.data_shape)
     m = HpxNDMap(geom_hpx, data=data)
@@ -739,9 +739,9 @@ def test_map_reproject_by_slice():
         skydir=(0, 0), npix=(11, 11), binsz=10, axes=[axis], frame="galactic"
     )
     with pytest.raises(TypeError):
-        m.reproject_by_slice(geom_wcs_wrong)
+        m.reproject_by_image(geom_wcs_wrong)
 
-    m_r = m.reproject_by_slice(geom_wcs)
+    m_r = m.reproject_by_image(geom_wcs)
     actual = m_r.get_by_coord(
         {"lon": 0, "lat": 0, "energy_true": [1.0, 3.16227766, 10.0]}
     )

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -730,8 +730,8 @@ def test_map_reproject_by_image():
     geom_hpx_wrong = HpxGeom.create(binsz=10, frame="galactic", axes=[axis, axis2])
 
     m = HpxNDMap(geom_hpx_wrong)
-    with pytest.raises(TypeError):
-        m.reproject_by_image(geom_wcs)
+    m.reproject_by_image(geom_wcs)
+    assert len(m.geom.axes) == 2
 
     data = np.arange(3 * 768).reshape(geom_hpx.data_shape)
     m = HpxNDMap(geom_hpx, data=data)


### PR DESCRIPTION
This PR adds a method `reproject_by_slice` that reprojects each slice of a 3d map independently  in parallel. Even without the parallelisation the loop over the slices  is more efficient and consumes less memory than using directly  `reproject_to_geom`.