### PR TITLE
force color and linewidth in the plotting of the fit of `plot_distribution`

### DIFF
--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -313,7 +313,7 @@ def plot_distribution(
             xmin, xmax = kwargs_hist.get("range", (np.min(d), np.max(d)))
             x = np.linspace(xmin, xmax, 1000)
 
-            axe.plot(x, func(x, *pars), label="Fit")
+            axe.plot(x, func(x, *pars), label="Fit", lw=2, color="black")
 
         axe.set(**kwargs_axes)
         axe.legend()


### PR DESCRIPTION
This PR follows #4408. 
It is a small fix that force the color and the linewidth of the plotting of the fit to black and 2 respectively. 
I put the option that were used in the ring background tutorial (https://docs.gammapy.org/dev/tutorials/analysis-2d/ring_background.html). 
