### PR TITLE
Multidimensional geom support in SkyModel.integrate_geom and evaluate_geom

### DIFF
--- a/gammapy/maps/coord.py
+++ b/gammapy/maps/coord.py
@@ -76,7 +76,7 @@ class MapCoord:
         return len(self._data)
 
     @property
-    def axes_names(self):
+    def axis_names(self):
         """Names of axes."""
         return list(self._data.keys())
 

--- a/gammapy/maps/coord.py
+++ b/gammapy/maps/coord.py
@@ -76,6 +76,11 @@ class MapCoord:
         return len(self._data)
 
     @property
+    def axes_names(self):
+        """Names of axes."""
+        return list(self._data.keys())
+
+    @property
     def shape(self):
         """Coordinate array shape."""
         arrays = [_ for _ in self._data.values()]

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -349,7 +349,7 @@ class SkyModel(ModelBase):
         value = self.spectral_model(coords["energy_true"])
 
         if coords.ndim > 3:
-            additional_axes = set(coords._data.keys()) - set(
+            additional_axes = set(coords.axes_names) - set(
                 ["lon", "lat", "energy_true"]
             )
             for axis in additional_axes:

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -407,6 +407,8 @@ class SkyModel(ModelBase):
             integral = self.temporal_model.integral(gti.time_start, gti.time_stop)
             value = value * np.sum(integral)
 
+        value = value * np.ones(geom.data_shape)
+
         return Map.from_geom(geom=geom, data=value.value, unit=value.unit)
 
     def copy(self, name=None, copy_data=False, **kwargs):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -345,7 +345,15 @@ class SkyModel(ModelBase):
     def evaluate_geom(self, geom, gti=None):
         """Evaluate model on `~gammapy.maps.Geom`."""
         coords = geom.get_coord(sparse=True)
+
         value = self.spectral_model(coords["energy_true"])
+
+        if coords.ndim > 3:
+            additional_axes = set(coords._data.keys()) - set(
+                ["lon", "lat", "energy_true"]
+            )
+            for axis in additional_axes:
+                value = value * np.ones_like(coords[axis])
 
         if self.spatial_model:
             value = value * self.spatial_model.evaluate_geom(geom)
@@ -354,7 +362,7 @@ class SkyModel(ModelBase):
             integral = self.temporal_model.integral(gti.time_start, gti.time_stop)
             value = value * np.sum(integral)
 
-        return np.resize(value, geom.data_shape)
+        return value
 
     def integrate_geom(self, geom, gti=None, oversampling_factor=None):
         """Integrate model on `~gammapy.maps.Geom`.

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -354,7 +354,7 @@ class SkyModel(ModelBase):
             integral = self.temporal_model.integral(gti.time_start, gti.time_stop)
             value = value * np.sum(integral)
 
-        return value
+        return np.resize(value, geom.data_shape)
 
     def integrate_geom(self, geom, gti=None, oversampling_factor=None):
         """Integrate model on `~gammapy.maps.Geom`.

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -349,7 +349,7 @@ class SkyModel(ModelBase):
         value = self.spectral_model(coords["energy_true"])
 
         if coords.ndim > 3:
-            additional_axes = set(coords.axes_names) - set(
+            additional_axes = set(coords.axis_names) - set(
                 ["lon", "lat", "energy_true"]
             )
             for axis in additional_axes:

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -378,10 +378,14 @@ class SkyModel(ModelBase):
             Predicted flux map
         """
         energy = geom.axes["energy_true"].edges
+        shape = len(geom.data_shape) * [
+            1,
+        ]
+        shape[geom.axes.index_data("energy_true")] = -1
         value = self.spectral_model.integral(
             energy[:-1],
             energy[1:],
-        ).reshape((-1, 1, 1))
+        ).reshape(shape)
 
         if self.spatial_model:
             value = (

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -719,7 +719,7 @@ def test_integrate_geom():
     assert_allclose(integral / 1e-12, [[[5.299]], [[2.460]], [[1.142]]], rtol=1e-3)
 
 
-def test_integrate_nd_geom():
+def test_evaluate_integrate_nd_geom():
     model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1 * u.deg, frame="icrs")
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     sky_model = SkyModel(spectral_model=spectral_model, spatial_model=model)
@@ -738,6 +738,15 @@ def test_integrate_nd_geom():
     )
     region_geom = RegionGeom(
         region=region, axes=[other_axis, energy_axis], binsz_wcs="0.01deg"
+    )
+
+    evaluation = sky_model.evaluate_geom(wcs_geom)
+    assert evaluation.shape == (2, 3, 24, 20)
+    assert_allclose(evaluation[0], evaluation[1])
+    assert_allclose(
+        evaluation.value[0, :, 12, 10],
+        [2.278184e-07, 4.908198e-08, 1.057439e-08],
+        rtol=1e-6,
     )
 
     integral = sky_model.integrate_geom(wcs_geom).data

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -719,6 +719,41 @@ def test_integrate_geom():
     assert_allclose(integral / 1e-12, [[[5.299]], [[2.460]], [[1.142]]], rtol=1e-3)
 
 
+def test_integrate_nd_geom():
+    model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1 * u.deg, frame="icrs")
+    spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
+    sky_model = SkyModel(spectral_model=spectral_model, spatial_model=model)
+
+    center = SkyCoord("0d", "0d", frame="icrs")
+    radius = 0.3 * u.deg
+    region = CircleSkyRegion(center, radius)
+
+    energy_axis = MapAxis.from_energy_bounds(
+        "1 TeV", "10 TeV", nbin=3, name="energy_true"
+    )
+    other_axis = MapAxis.from_edges([0.0, 1.0, 2.0], name="other")
+
+    wcs_geom = WcsGeom.create(
+        width=[1, 1.2], binsz=0.05, skydir=center, axes=[energy_axis, other_axis]
+    )
+    region_geom = RegionGeom(
+        region=region, axes=[other_axis, energy_axis], binsz_wcs="0.01deg"
+    )
+
+    integral = sky_model.integrate_geom(wcs_geom).data
+    assert integral.shape == (2, 3, 24, 20)
+    assert_allclose(integral[0], integral[1])
+    assert_allclose(integral[0, :, 12, 10], [1.973745e-13, 9.161312e-14, 4.252304e-14])
+
+    integral = sky_model.integrate_geom(region_geom).data
+
+    assert integral.shape == (3, 2, 1, 1)
+    assert_allclose(integral[:, 0, :, :], integral[:, 1, :, :])
+    assert_allclose(
+        integral[:, 0] / 1e-12, [[[5.299]], [[2.460]], [[1.142]]], rtol=1e-3
+    )
+
+
 def test_compound_spectral_model(caplog):
     spatial_model = GaussianSpatialModel(
         lon_0="3 deg", lat_0="4 deg", sigma="3 deg", frame="galactic"


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces support for additional axes support in `SkyModel.integrate_geom` and `SkyModel.evaluate_geom`. One can pass a `WcsGeom` or `RegionGeom` with an axis which name is different from `energy_true` and the result will be a copy of the evaluation/integration over the additional axis bins.

This is implements part of the issue #4480 . The support for time dimension remains to be done.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
