### PR TITLE
Add function to plot error of SpatialModels

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -360,7 +360,7 @@ class SpatialModel(ModelBase):
         Parameters
         ----------
         ax : `~matplotlib.axes.Axes`, optional
-            Axis
+            Axes to plot the position error on.
         **kwargs : dict
             Keyword arguments passed to `~gammapy.maps.WcsMap.plot()`
 
@@ -388,39 +388,46 @@ class SpatialModel(ModelBase):
 
         return ax
 
-    def plot_extension_error(self, ax=None):
+    def plot_extension_error(self, ax=None, **kwargs):
         pass
 
-    def plot_error(self, ax, selection_optional="position", **kwargs):
+    def plot_error(
+        self, ax=None, which="position", kwargs_position=None, kwargs_extension=None
+    ):
         """Plot the errors of the spatial model.
 
         Parameters
         ----------
         ax : `~matplotlib.axes.Axes`, optional
-            Axis
-        selection_optional: list of str
+            Axes to plot the errors on.
+        which: list of str
             Which errors to plot.
             Available options are:
                 * "all": all the optional steps are plotted
                 * "position": plot the position error of the spatial model.
                 * "extension": plot the extension error of the spatial model.
-        **kwargs : dict
-            Keyword arguments passed to `~gammapy.maps.WcsMap.plot()`
+        kwargs_position : dict
+            Keyword arguments passed to `~SpatialModel.plot_position_error`
+        kwargs_extension : dict
+            Keyword arguments passed to `~SpatialModel.plot_extension_error`
 
         Returns
         -------
         ax : `~matplotlib.axes.Axes`, optional
             Axis
         """
-        if "all" in selection_optional:
-            self.plot_position_error(ax, **kwargs)
-            self.plot_extension_error(ax, **kwargs)
+        kwargs_position = kwargs_position or {}
+        kwargs_extension = kwargs_extension or {}
 
-        if "position" in selection_optional:
-            self.plot_position_error(ax, **kwargs)
+        if "all" in which:
+            self.plot_position_error(ax, **kwargs_position)
+            self.plot_extension_error(ax, **kwargs_extension)
 
-        if "extension" in selection_optional:
-            self.plot_extension_error(ax, **kwargs)
+        if "position" in which:
+            self.plot_position_error(ax, **kwargs_position)
+
+        if "extension" in which:
+            self.plot_extension_error(ax, **kwargs_extension)
 
     def plot_grid(self, geom=None, **kwargs):
         """Plot spatial model energy slices in a grid.
@@ -653,18 +660,18 @@ class GaussianSpatialModel(SpatialModel):
         Parameters
         ----------
         ax : `~matplotlib.axes.Axes`, optional
-                Axis
+            Axes to plot the extension error on.
         x_sigma : float
             Number of :math:`\sigma
             Default is :math:`1.5\sigma` which corresponds to about 68%
             containment for a 2D symmetric Gaussian.
         **kwargs : dict
-                Keyword arguments passed to `~gammapy.maps.WcsMap.plot()`
+            Keyword arguments passed to `~gammapy.maps.WcsMap.plot()`
 
         Returns
         -------
         ax : `~matplotlib.axes.Axes`, optional
-                Axis
+            Axis
         """
         ax = plt.gca() if ax is None else ax
 
@@ -786,6 +793,23 @@ class GeneralizedGaussianSpatialModel(SpatialModel):
         return self.to_region(x_r_0=scale)
 
     def plot_extension_error(self, ax=None, x_r_0=1, **kwargs):
+        r"""Plot model error at a given number of :math:`r_0`.
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axes to plot the extension error on.
+        x_r_0 : float
+            Number of :math:`r_0`
+            Default is :math:`1`
+        **kwargs : dict
+            Keyword arguments passed to `~gammapy.maps.WcsMap.plot()`
+
+        Returns
+        -------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axis
+        """
 
         ax = plt.gca() if ax is None else ax
 
@@ -958,6 +982,20 @@ class DiskSpatialModel(SpatialModel):
         return cls.from_position(region.center, **kwargs)
 
     def plot_extension_error(self, ax=None, **kwargs):
+        r"""Plot model error.
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axes to plot the extension error on.
+        **kwargs : dict
+            Keyword arguments passed to `~gammapy.maps.WcsMap.plot()`
+
+        Returns
+        -------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axis
+        """
 
         ax = plt.gca() if ax is None else ax
 

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -469,13 +469,19 @@ def test_spatial_model_plot():
         model.plot_error(ax=ax, which="all")
 
 
-def test_spatial_model_plot_error():
-    model = GaussianSpatialModel(
-        lon="0d", lat="0d", sigma=0.2 * u.deg, frame="galactic"
-    )
+models_test = [
+    (GaussianSpatialModel, "sigma"),
+    (GeneralizedGaussianSpatialModel, "r_0"),
+    (DiskSpatialModel, "r_0"),
+]
+
+
+@pytest.mark.parametrize(("model_class", "extension_param"), models_test)
+def test_spatial_model_plot_error(model_class, extension_param):
+    model = model_class(lon="0d", lat="0d", sigma=0.2 * u.deg, frame="galactic")
     model.lat_0.error = 0.04
     model.lon_0.error = 0.02
-    model.sigma.error = 0.04
+    model.parameters[extension_param].error = 0.04
     model.e.error = 0.002
 
     empty_map = Map.create(
@@ -484,6 +490,8 @@ def test_spatial_model_plot_error():
     with mpl_plot_check():
         ax = empty_map.plot()
         model.plot_error(ax=ax, which="all")
+        model.plot_error(ax=ax, which="position")
+        model.plot_error(ax=ax, which="extension")
 
 
 def test_integrate_region_geom():

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -466,7 +466,24 @@ def test_spatial_model_plot():
         ax = model.plot()
 
     with mpl_plot_check():
-        model.plot_error(ax=ax)
+        model.plot_error(ax=ax, selection_optional="all")
+
+
+def test_spatial_model_plot_error():
+    model = GaussianSpatialModel(
+        lon="0d", lat="0d", sigma=0.2 * u.deg, frame="galactic"
+    )
+    model.lat_0.error = 0.04
+    model.lon_0.error = 0.02
+    model.sigma.error = 0.04
+    model.e.error = 0.002
+
+    empty_map = Map.create(
+        skydir=model.position, frame=model.frame, width=1, binsz=0.02
+    )
+    with mpl_plot_check():
+        ax = empty_map.plot()
+        model.plot_error(ax=ax, selection_optional="all")
 
 
 def test_integrate_region_geom():

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -466,7 +466,7 @@ def test_spatial_model_plot():
         ax = model.plot()
 
     with mpl_plot_check():
-        model.plot_error(ax=ax, selection_optional="all")
+        model.plot_error(ax=ax, which="all")
 
 
 def test_spatial_model_plot_error():
@@ -483,7 +483,7 @@ def test_spatial_model_plot_error():
     )
     with mpl_plot_check():
         ax = empty_map.plot()
-        model.plot_error(ax=ax, selection_optional="all")
+        model.plot_error(ax=ax, which="all")
 
 
 def test_integrate_region_geom():


### PR DESCRIPTION
**Description**
This PR aims to resolve [#4651](https://github.com/gammapy/gammapy/issues/4651). 
I have changed the `plot_error` function to be `plot_position_error`, and added a new `plot_error` function which allows the user to plot either/both the position and extension errors for each `SpatialModel`. 
For any `SpatialModel` which has no extension error define it will just default to the base class and `pass`.

I adapted the test, and added a new one for this PR.

**Dear reviewer**
It might be nice to show the use of this somewhere too
