### PR TITLE
Introduce metadata base class

### DIFF
--- a/gammapy/utils/metadata.py
+++ b/gammapy/utils/metadata.py
@@ -1,0 +1,71 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Metadata base container for Gammapy."""
+import json
+from typing import Optional, Union
+from astropy.coordinates import Angle, EarthLocation, SkyCoord
+from astropy.time import Time
+from astropy.units import Quantity
+import yaml
+from pydantic import BaseModel
+from gammapy.version import version
+
+
+class MetaData(BaseModel):
+    """Base model for all metadata classes in Gammapy."""
+
+    class Config:
+        """Global config for all metadata."""
+
+        arbitrary_types_allowed = True
+        validate_all = True
+        validate_assignment = True
+        # allow additional entries
+        extra = "allow"
+
+        # provides a recipe to export arbitrary types to json
+        json_encoders = {
+            Angle: lambda v: f"{v.value} {v.unit}",
+            Quantity: lambda v: f"{v.value} {v.unit}",
+            Time: lambda v: f"{v.iso}",
+            EarthLocation: lambda v: f"lon : {v.lon.value} {v.lon.unit}, "
+            f"lat : {v.lat.value} {v.lat.unit}, "
+            f"height : {v.height.value} {v.height.unit}",
+            SkyCoord: lambda v: f"lon: {v.spherical.lon.value} {v.spherical.lon.unit}, "
+            f"lat: {v.spherical.lat.value} {v.spherical.lat.unit}, "
+            f"frame: {v.frame.name} ",
+        }
+
+    def to_header(self):
+        hdr_dict = {}
+        for key, item in self.dict().items():
+            hdr_dict[key.upper()] = item.__str__()
+        return hdr_dict
+
+    @classmethod
+    def from_header(cls, hdr):
+        kwargs = {}
+        for key in cls.__fields__.keys():
+            kwargs[key] = hdr.get(key.upper(), None)
+        return cls(**kwargs)
+
+    def to_yaml(self):
+        """Dumps metadata content to yaml."""
+        meta = json.loads(self.json())
+        return yaml.dump(
+            meta, sort_keys=False, indent=4, width=80, default_flow_style=False
+        )
+
+
+class CreatorMetaData(MetaData):
+    """Metadata containing information about the object creation."""
+
+    creator: Optional[str]
+    date: Optional[Union[str, Time]]
+    origin: Optional[str]
+
+    @classmethod
+    def from_default(cls):
+        """Creation metadata containing current time and Gammapy version."""
+        date = Time.now()
+        creator = f"Gammapy {version}"
+        return cls(creator=creator, date=date)

--- a/gammapy/utils/metadata.py
+++ b/gammapy/utils/metadata.py
@@ -6,8 +6,10 @@ from astropy.coordinates import Angle, EarthLocation, SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from gammapy.version import version
+
+__all__ = ["MetaData", "CreatorMetaData"]
 
 
 class MetaData(BaseModel):
@@ -19,8 +21,6 @@ class MetaData(BaseModel):
         arbitrary_types_allowed = True
         validate_all = True
         validate_assignment = True
-        # allow additional entries
-        extra = "allow"
 
         # provides a recipe to export arbitrary types to json
         json_encoders = {
@@ -62,6 +62,10 @@ class CreatorMetaData(MetaData):
     creator: Optional[str]
     date: Optional[Union[str, Time]]
     origin: Optional[str]
+
+    @validator("date")
+    def validate_time(cls, v):
+        return Time(v)
 
     @classmethod
     def from_default(cls):

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -1,8 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from typing import Optional
 import pytest
 from numpy.testing import assert_allclose
+from astropy.coordinates import SkyCoord
 from pydantic import ValidationError
-from gammapy.utils.metadata import CreatorMetaData
+from gammapy.utils.metadata import CreatorMetaData, MetaData
 
 
 def test_creator():
@@ -17,3 +19,19 @@ def test_creator():
 
     with pytest.raises(ValidationError):
         default.date = 3
+
+
+def test_subclass():
+    class TestMetaData(MetaData):
+        name: str
+        mode: Optional[SkyCoord]
+        creation: Optional[CreatorMetaData]
+
+    creator = CreatorMetaData.from_default()
+    test_meta = TestMetaData(name="test", creation=creator)
+
+    assert test_meta.name == "test"
+    assert test_meta.creation.creator.split()[0] == "Gammapy"
+
+    with pytest.raises(ValidationError):
+        test_meta.mode = "coord"

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -1,0 +1,19 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+from numpy.testing import assert_allclose
+from pydantic import ValidationError
+from gammapy.utils.metadata import CreatorMetaData
+
+
+def test_creator():
+    default = CreatorMetaData(date="2022-01-01", creator="gammapy", origin="CTA")
+
+    assert default.creator == "gammapy"
+    assert default.origin == "CTA"
+    assert_allclose(default.date.mjd, 59580)
+
+    default.creator = "other"
+    assert default.creator == "other"
+
+    with pytest.raises(ValidationError):
+        default.date = 3


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

Following PIG 25, this pull request introduces the base class for the `MetaData` in gammapy. 
It is based on the `BaseModel` of pydantic. 

For now, it uses pydantic v1.x API and syntax. This will have to be upgraded to v2. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
