### PR TITLE
Add parallel options support in Map classes 

### DIFF
--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -41,13 +41,22 @@ class HpxNDMap(HpxMap):
         The map unit
     """
 
-    def __init__(self, geom, data=None, dtype="float32", meta=None, unit=""):
+    def __init__(
+        self,
+        geom,
+        data=None,
+        dtype="float32",
+        meta=None,
+        unit="",
+        parallel_backend=None,
+        n_jobs=None,
+    ):
         data_shape = geom.data_shape
 
         if data is None:
             data = self._make_default_data(geom, data_shape, dtype)
 
-        super().__init__(geom, data, meta, unit)
+        super().__init__(geom, data, meta, unit, parallel_backend, n_jobs)
 
     @staticmethod
     def _make_default_data(geom, shape_np, dtype):

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -41,13 +41,24 @@ class RegionNDMap(Map):
         The map unit
     """
 
-    def __init__(self, geom, data=None, dtype="float32", meta=None, unit=""):
+    def __init__(
+        self,
+        geom,
+        data=None,
+        dtype="float32",
+        meta=None,
+        unit="",
+        parallel_backend=None,
+        n_jobs=None,
+    ):
         if data is None:
             data = np.zeros(geom.data_shape, dtype=dtype)
 
         if meta is None:
             meta = {}
 
+        self.parallel_backend = parallel_backend
+        self.n_jobs = n_jobs
         self._geom = geom
         self.data = data
         self.meta = meta

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -44,7 +44,16 @@ class WcsNDMap(WcsMap):
         The map unit
     """
 
-    def __init__(self, geom, data=None, dtype="float32", meta=None, unit=""):
+    def __init__(
+        self,
+        geom,
+        data=None,
+        dtype="float32",
+        meta=None,
+        unit="",
+        parallel_backend=None,
+        n_jobs=None,
+    ):
         # TODO: Figure out how to mask pixels for integer data types
 
         data_shape = geom.data_shape
@@ -52,7 +61,7 @@ class WcsNDMap(WcsMap):
         if data is None:
             data = self._make_default_data(geom, data_shape, dtype)
 
-        super().__init__(geom, data, meta, unit)
+        super().__init__(geom, data, meta, unit, parallel_backend, n_jobs)
 
     @staticmethod
     def _make_default_data(geom, shape_np, dtype):


### PR DESCRIPTION
Add parallel options support to Map classes.
Required for #4664
In future this could also be useful to convolution with multiple kernels of a PSFMap in parallel.  