### PR TITLE
Fix MapEvaluator for regions

### DIFF
--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -229,9 +229,9 @@ class MapEvaluator:
 
         res_scale = res_scale.to_value("deg") if res_scale is not None else 0
 
-        if geom.is_region or geom.is_hpx:
-            geom = geom.to_wcs_geom()
         if res_scale != 0:
+            if geom.is_region or geom.is_hpx:
+                geom = geom.to_wcs_geom()
             factor = int(np.ceil(np.max(geom.pixel_scales.deg) / res_scale))
             self._spatial_oversampling_factor = factor
 


### PR DESCRIPTION
Fix a fails in MapEvaluator with regions because of update_spatial_oversampling_factor