### PR TITLE
Introduce a no-ray tox environment 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
         include:
           - os: ubuntu-latest
             python: '3.9'
-            tox_env: 'py39-test-alldeps_noray'
+            tox_env: 'py39-test-alldeps-cov'
             allowed_fail: false
           - os: ubuntu-latest
             python: '3.10'
-            tox_env: 'py310-test-alldeps-cov'
+            tox_env: 'py310-test-alldeps_noray'
             gammapy_data_path: /home/runner/work/gammapy/gammapy/gammapy-datasets/dev
             allowed_fail: false
           - os: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python: '3.9'
-            tox_env: 'py39-test-alldeps'
+            tox_env: 'py39-test-alldeps_noray'
             allowed_fail: false
           - os: ubuntu-latest
             python: '3.10'
@@ -36,7 +36,7 @@ jobs:
             allowed_fail: false
           - os: windows-latest
             python: '3.10'
-            tox_env: 'py310-test-alldeps'
+            tox_env: 'py310-test-alldeps_noray'
             gammapy_data_path:  D:\a\gammapy\gammapy\gammapy-datasets\dev
             allowed_fail: false
           - os: ubuntu-latest
@@ -49,7 +49,7 @@ jobs:
             allowed_fail: false
           - os: ubuntu-latest
             python: '3.9'
-            tox_env: 'py39-test-alldeps-astropylts-numpy121'
+            tox_env: 'py39-test-alldeps_noray-astropylts-numpy121'
             allowed_fail: false
           - os: ubuntu-latest
             python: '3.9'

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,13 @@ all =
     tqdm
     ipywidgets<8.0.5
     ray
+all_no_ray =
+    naima
+    sherpa; platform_system != "Windows"
+    healpy; platform_system != "Windows"
+    requests
+    tqdm
+    ipywidgets<8.0.5
 cov =
     naima
     sherpa; platform_system != "Windows"

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ changedir = .tmp/{envname}
 #
 description =
     run tests
+    alldeps_noray: with all optional dependencies but ray
     alldeps: with all optional dependencies
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
@@ -89,6 +90,7 @@ deps =
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
     test
+    alldeps_noray: all_no_ray
     alldeps: all
     cov: cov
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a set of dependencies without `ray` in the setup.cfg, as well as `alldeps_nroay` tox environment to allow for testing without ray installed. This is a temporary measure to limit CI fails due to inconsistencies between ray and the logging system. See issue #4691 .
 
The CI matrix workflow has been adapted accordingly. I have left ray on ubuntu with python 3.10 and coverage.
Opinion @QRemy , @adonath ?


**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
