### PR TITLE
Deduce pointing mode from arguments in FixedPointingInfo

### DIFF
--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -6,7 +6,9 @@ import numpy as np
 import scipy.interpolate
 import astropy.units as u
 from astropy.coordinates import (
+    ICRS,
     AltAz,
+    BaseCoordinateFrame,
     CartesianRepresentation,
     SkyCoord,
     UnitSphericalRepresentation,
@@ -23,6 +25,28 @@ from gammapy.utils.time import time_ref_from_dict, time_ref_to_dict, time_to_fit
 log = logging.getLogger(__name__)
 
 __all__ = ["FixedPointingInfo", "PointingInfo", "PointingMode"]
+
+
+def _check_coord_frame(coord_or_frame, expected_frame, name):
+    """Check if a skycoord or frame is given in expected_frame"""
+    is_coord = isinstance(coord_or_frame, SkyCoord)
+    is_frame = isinstance(coord_or_frame, BaseCoordinateFrame)
+
+    if not (is_frame or is_coord):
+        raise TypeError(
+            f"{name} must be a 'astropy.coordinates.SkyCoord'"
+            "or {expected_frame} instance"
+        )
+
+    if is_coord:
+        frame = coord_or_frame.frame
+    else:
+        frame = coord_or_frame
+
+    if not isinstance(frame, expected_frame):
+        raise ValueError(
+            f"{name} is in wrong frame, expected {expected_frame}, got {frame}"
+        )
 
 
 class PointingMode(Enum):
@@ -74,7 +98,7 @@ class FixedPointingInfo:
         Passing this is deprecated, provide ``mode`` and ``fixed_icrs`` or ``fixed_altaz``
         instead or use `FixedPointingInfo.from_fits_header` instead.
     mode : `PointingMode`
-        How the telescope was pointing during the observation
+        How the telescope was pointing during the observation.
     fixed_icrs : SkyCoord in ICRS frame
         Mandatory if mode is `PointingMode.POINTING`, the ICRS coordinates that are fixed
         for the duration of the observation.
@@ -88,7 +112,7 @@ class FixedPointingInfo:
     >>> from astropy.coordinates import SkyCoord
     >>> import astropy.units as u
     >>> fixed_icrs = SkyCoord(83.633 * u.deg, 22.014 * u.deg, frame="icrs")
-    >>> pointing_info = FixedPointingInfo(mode=PointingMode.POINTING, fixed_icrs=fixed_icrs)
+    >>> pointing_info = FixedPointingInfo(fixed_icrs=fixed_icrs)
     >>> print(pointing_info)
     FixedPointingInfo:
     <BLANKLINE>
@@ -100,6 +124,7 @@ class FixedPointingInfo:
     def __init__(
         self,
         meta=None,
+        *,
         mode=None,
         fixed_icrs=None,
         fixed_altaz=None,
@@ -125,19 +150,24 @@ class FixedPointingInfo:
             self.__dict__.update(self.from_fits_header(meta).__dict__)
             return
 
-        if not isinstance(mode, PointingMode):
-            raise TypeError(f"mode must be an instance of PointingMode, got {mode!r}")
+        if mode is not None:
+            warnings.warn(
+                "Passing mode is deprecated and the argument will be removed in Gammapy 1.3."
+                " pointing mode is deduced from whether fixed_icrs or fixed_altaz is given",
+                GammapyDeprecationWarning,
+            )
 
-        self._mode = mode
         self._location = location
         self._time_start = time_start
         self._time_stop = time_stop
         self._time_ref = time_ref
         self._legacy_altaz = legacy_altaz or AltAz(np.nan * u.deg, np.nan * u.deg)
 
-        if mode is PointingMode.POINTING:
-            if fixed_icrs is None:
-                raise ValueError("fixed_icrs is mandatory for PointingMode.POINTING")
+        if fixed_icrs is not None and fixed_altaz is not None:
+            raise ValueError("fixed_icrs and fixed_altaz are mutually exclusive")
+
+        if fixed_icrs is not None:
+            _check_coord_frame(fixed_icrs, ICRS, "fixed_icrs")
 
             if np.isnan(fixed_icrs.ra.value) or np.isnan(fixed_icrs.dec.value):
                 warnings.warn(
@@ -145,20 +175,15 @@ class FixedPointingInfo:
                     GammapyDeprecationWarning,
                 )
 
+            self._mode = PointingMode.POINTING
             self._fixed_icrs = fixed_icrs
             self._fixed_altaz = None
 
-        elif mode is PointingMode.DRIFT:
-            if fixed_altaz is None:
-                raise ValueError("pointing_altaz is required for PointingMode.DRIFT")
-
-            if fixed_icrs is not None:
-                raise ValueError("fixed_icrs is excluded for PointingMode.DRIFT")
-
-            self._fixed_altaz = fixed_altaz
-            self._fixed_icrs = None
         else:
-            raise ValueError(f"Unsupported pointing mode for FixedPointingInfo: {mode}")
+            _check_coord_frame(fixed_altaz, AltAz, "fixed_altaz")
+            self._mode = PointingMode.DRIFT
+            self._fixed_icrs = None
+            self._fixed_altaz = fixed_altaz
 
     @classmethod
     def from_fits_header(cls, header):
@@ -229,7 +254,6 @@ class FixedPointingInfo:
                 time_stop = time_ref + u.Quantity(time_stop, time_unit)
 
         return cls(
-            mode=mode,
             location=location,
             fixed_icrs=fixed_icrs,
             fixed_altaz=pointing_altaz,

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -232,7 +232,6 @@ def test_observations_select_time_time_intervals_list(data_store):
 def test_observation_cta_1dc():
     ontime = 5.0 * u.hr
     pointing = FixedPointingInfo(
-        mode=PointingMode.POINTING,
         fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
     )
     irfs = load_irf_dict_from_file(
@@ -264,7 +263,6 @@ def test_observation_cta_1dc():
 @requires_data()
 def test_observation_create_radmax():
     pointing = FixedPointingInfo(
-        mode=PointingMode.POINTING,
         fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
     )
     obs = Observation.read("$GAMMAPY_DATA/joint-crab/dl3/magic/run_05029748_DL3.fits")

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -6,13 +6,8 @@ import astropy.units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
-from gammapy.data import (
-    DataStore,
-    Observation,
-    ObservationFilter,
-    Observations,
-)
-from gammapy.data.pointing import FixedPointingInfo, PointingMode
+from gammapy.data import DataStore, Observation, ObservationFilter, Observations
+from gammapy.data.pointing import FixedPointingInfo
 from gammapy.data.utils import get_irfs_features
 from gammapy.irf import PSF3D, load_irf_dict_from_file
 from gammapy.utils.cluster import hierarchical_clustering

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -21,7 +21,6 @@ def test_fixed_pointing_icrs():
     fixed_icrs = SkyCoord(ra=83.28 * u.deg, dec=21.78 * u.deg)
 
     pointing = FixedPointingInfo(
-        mode=PointingMode.POINTING,
         fixed_icrs=fixed_icrs,
         location=location,
     )
@@ -61,7 +60,6 @@ def test_fixed_pointing_info_altaz():
     location = observatory_locations["cta_south"]
     fixed_altaz = SkyCoord(alt=70 * u.deg, az=0 * u.deg, frame=AltAz())
     pointing = FixedPointingInfo(
-        mode=PointingMode.DRIFT,
         fixed_altaz=fixed_altaz,
     )
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -8,7 +8,7 @@ from astropy.io import fits
 from astropy.table import Table
 from astropy.time import Time
 from gammapy.data import GTI, DataStore, Observation
-from gammapy.data.pointing import FixedPointingInfo, PointingMode
+from gammapy.data.pointing import FixedPointingInfo
 from gammapy.datasets import MapDataset, MapDatasetEventSampler
 from gammapy.datasets.tests.test_map import get_map_dataset
 from gammapy.irf import load_irf_dict_from_file

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -337,7 +337,6 @@ def test_mde_sample_weak_src(dataset, models):
     )
     livetime = 10.0 * u.hr
     pointing = FixedPointingInfo(
-        mode=PointingMode.POINTING,
         fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
     )
     obs = Observation.create(
@@ -430,7 +429,6 @@ def test_event_det_coords(dataset, models):
     )
     livetime = 1.0 * u.hr
     pointing = FixedPointingInfo(
-        mode=PointingMode.POINTING,
         fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
     )
     obs = Observation.create(
@@ -466,7 +464,6 @@ def test_mde_run(dataset, models):
     )
     livetime = 1.0 * u.hr
     pointing = FixedPointingInfo(
-        mode=PointingMode.POINTING,
         fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
     )
     obs = Observation.create(
@@ -567,7 +564,6 @@ def test_irf_alpha_config(dataset, models):
     )
     livetime = 1.0 * u.hr
     pointing = FixedPointingInfo(
-        mode=PointingMode.POINTING,
         fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
     )
     obs = Observation.create(
@@ -591,7 +587,6 @@ def test_mde_run_switchoff(dataset, models):
     )
     livetime = 1.0 * u.hr
     pointing = FixedPointingInfo(
-        mode=PointingMode.POINTING,
         fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
     )
     obs = Observation.create(
@@ -631,7 +626,6 @@ def test_events_datastore(tmp_path, dataset, models):
     )
     livetime = 10.0 * u.hr
     pointing = FixedPointingInfo(
-        mode=PointingMode.POINTING,
         fixed_icrs=SkyCoord(0, 0, unit="deg", frame="galactic").icrs,
     )
     obs = Observation.create(
@@ -662,7 +656,7 @@ def test_MC_ID(model_alternative):
     )
     livetime = 0.1 * u.hr
     skydir = SkyCoord(0, 0, unit="deg", frame="galactic")
-    pointing = FixedPointingInfo(mode=PointingMode.POINTING, fixed_icrs=skydir.icrs)
+    pointing = FixedPointingInfo(fixed_icrs=skydir.icrs)
     obs = Observation.create(
         obs_id=1001,
         pointing=pointing,
@@ -719,7 +713,7 @@ def test_MC_ID_NMCID(model_alternative):
     )
     livetime = 0.1 * u.hr
     skydir = SkyCoord(0, 0, unit="deg", frame="galactic")
-    pointing = FixedPointingInfo(mode=PointingMode.POINTING, fixed_icrs=skydir.icrs)
+    pointing = FixedPointingInfo(fixed_icrs=skydir.icrs)
     obs = Observation.create(
         obs_id=1001,
         pointing=pointing,

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -103,7 +103,7 @@ def simulate_map_dataset(random_state=0, name=None):
     )
 
     skydir = SkyCoord("0 deg", "0 deg", frame="galactic")
-    pointing = FixedPointingInfo(mode=PointingMode.POINTING, fixed_icrs=skydir.icrs)
+    pointing = FixedPointingInfo(fixed_icrs=skydir.icrs)
     energy_edges = np.logspace(-1, 2, 15) * u.TeV
     energy_axis = MapAxis.from_edges(edges=energy_edges, name="energy", interp="log")
 

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -6,7 +6,7 @@ from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.table import Table
 from gammapy.data import Observation
-from gammapy.data.pointing import FixedPointingInfo, PointingMode
+from gammapy.data.pointing import FixedPointingInfo
 from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
 from gammapy.datasets.spectrum import SpectrumDataset
 from gammapy.estimators import FluxPoints, FluxPointsEstimator

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -15,7 +15,6 @@ from gammapy.data import (
     HDUIndexTable,
     Observation,
     ObservationTable,
-    PointingMode,
 )
 from gammapy.datasets import MapDataset
 from gammapy.datasets.map import RAD_AXIS_DEFAULT

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -347,9 +347,7 @@ def test_interpolate_map_dataset():
         bkg=bkg_map,
         events=events,
         obs_filter=None,
-        pointing=FixedPointingInfo(
-            mode=PointingMode.POINTING, fixed_icrs=SkyCoord(0 * u.deg, 0 * u.deg)
-        ),
+        pointing=FixedPointingInfo(fixed_icrs=SkyCoord(0 * u.deg, 0 * u.deg)),
     )
 
     # define analysis geometry

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -127,7 +127,6 @@ def fixed_pointing_info_aligned():
     fixed_icrs = SkyCoord(0 * u.deg, 0 * u.deg, frame="icrs")
 
     return FixedPointingInfo(
-        mode=PointingMode.POINTING,
         fixed_icrs=fixed_icrs,
         location=location,
         time_start=time_start,
@@ -407,7 +406,6 @@ class TestTheta2Table:
                 reference_time=Time("2010-01-01", scale="tt"),
             )
             pointing = FixedPointingInfo(
-                mode=PointingMode.POINTING,
                 fixed_icrs=SkyCoord(0 * u.deg, sign * 0.5 * u.deg),
             )
 

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -7,14 +7,7 @@ from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.table import Table
 from astropy.time import Time
 from regions import PointSkyRegion
-from gammapy.data import (
-    GTI,
-    DataStore,
-    EventList,
-    FixedPointingInfo,
-    Observation,
-    PointingMode,
-)
+from gammapy.data import GTI, DataStore, EventList, FixedPointingInfo, Observation
 from gammapy.irf import (
     Background2D,
     Background3D,


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

Checking up on #4694, I realized that the mode argument of the `FixedPointingInfo` is actually redundant and can be deduced from the given arguments.

So here, I deprecate the mode argument and implement the deduction from whether fixed_icrs and fixed_altaz are given.

I also realized that we didn't actually validate the given pointing directions, so this is now also done.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
