### PR TITLE
Use correct type for alt/az pointing in event sampler, add observatory location info

### DIFF
--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -169,6 +169,12 @@ class Observation:
         events = self.obs_filter.filter_events(self._events)
         return events
 
+    @events.setter
+    def events(self, value):
+        if not isinstance(value, EventList):
+            raise TypeError(f"events must be an EventList instance, got: {type(value)}")
+        self._events = value
+
     @property
     def gti(self):
         """GTI of the observation as a `~gammapy.data.GTI`."""

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.io import fits
+from astropy.table import Table
 from astropy.time import Time
 from astropy.units import Quantity
 from gammapy.data import (
@@ -591,3 +592,31 @@ def test_observations_generator(data_store):
         assert obs.obs_id == obs_1[idx].obs_id
         assert isinstance(obs.events, EventList)
         assert isinstance(obs.psf, PSF3D)
+
+
+@requires_data()
+def test_event_setter():
+    irfs = load_irf_dict_from_file(
+        "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+    )
+    pointing = FixedPointingInfo(
+        fixed_icrs=SkyCoord(0 * u.deg, 0 * u.deg),
+    )
+    location = EarthLocation(lon="-70d18m58.84s", lat="-24d41m0.34s", height="2000m")
+    obs = Observation.create(
+        obs_id=1,
+        pointing=pointing,
+        livetime=20 * u.min,
+        irfs=irfs,
+        location=location,
+    )
+
+    assert obs.events is None
+
+    for invalid in (5, Table(), "foo"):
+        with pytest.raises(TypeError):
+            obs.events = invalid
+
+    events = EventList(Table())
+    obs.events = events
+    assert obs.events is events

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -509,8 +509,8 @@ class MapDatasetEventSampler:
         # this is not really correct but maybe OK for now
         coord_altaz = observation.pointing.get_altaz(dataset.gti.time_start, loc)
 
-        meta["ALT_PNT"] = str(coord_altaz.alt.deg[0])
-        meta["AZ_PNT"] = str(coord_altaz.az.deg[0])
+        meta["ALT_PNT"] = coord_altaz.alt.deg[0]
+        meta["AZ_PNT"] = coord_altaz.az.deg[0]
 
         # TO DO: these keywords should be taken from the IRF of the dataset
         meta["ORIGIN"] = "Gammapy"
@@ -520,7 +520,7 @@ class MapDatasetEventSampler:
         meta["TELLIST"] = ""
 
         meta["CREATED"] = ""
-        meta["OBS_MODE"] = ""
+        meta["OBS_MODE"] = "POINTING"
         meta["EV_CLASS"] = ""
 
         return meta

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -524,7 +524,7 @@ class MapDatasetEventSampler:
         meta["N_TELS"] = ""
         meta["TELLIST"] = ""
 
-        meta["CREATED"] = ""
+        meta["CREATED"] = Time.now().iso
         meta["OBS_MODE"] = "POINTING"
         meta["EV_CLASS"] = ""
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -14,6 +14,7 @@ from gammapy.modeling.models import (
     ConstantTemporalModel,
     PointSpatialModel,
 )
+from gammapy.utils.fits import earth_location_to_dict
 from gammapy.utils.random import get_random_state
 
 __all__ = ["MapDatasetEventSampler"]
@@ -495,16 +496,20 @@ class MapDatasetEventSampler:
         # Necessary for DataStore, but they should be ALT and AZ instead!
         telescope = observation.aeff.meta["TELESCOP"]
         instrument = observation.aeff.meta["INSTRUME"]
-        if telescope == "CTA":
-            if instrument == "Southern Array":
-                loc = observatory_locations["cta_south"]
-            elif instrument == "Northern Array":
-                loc = observatory_locations["cta_north"]
-            else:
-                loc = observatory_locations["cta_south"]
+        loc = observation.observatory_earth_location
+        if loc is None:
+            if telescope == "CTA":
+                if instrument == "Southern Array":
+                    loc = observatory_locations["cta_south"]
+                elif instrument == "Northern Array":
+                    loc = observatory_locations["cta_north"]
+                else:
+                    loc = observatory_locations["cta_south"]
 
-        else:
-            loc = observatory_locations[telescope.lower()]
+            else:
+                loc = observatory_locations[telescope.lower()]
+
+        meta.update(earth_location_to_dict(loc))
 
         # this is not really correct but maybe OK for now
         coord_altaz = observation.pointing.get_altaz(dataset.gti.time_start, loc)

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -582,7 +582,9 @@ def test_mde_run(dataset, models, tmp_path):
     path = tmp_path / "obs.fits.gz"
     obs.write(path)
     obs_back = Observation.read(path)
-    assert obs_back.observatory_earth_location == LOCATION
+    assert u.isclose(obs_back.observatory_earth_location.lon, LOCATION.lon)
+    assert u.isclose(obs_back.observatory_earth_location.lat, LOCATION.lat)
+    assert u.isclose(obs_back.observatory_earth_location.height, LOCATION.height)
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -479,7 +479,7 @@ def test_event_det_coords(dataset, models):
 
 
 @requires_data()
-def test_mde_run(dataset, models):
+def test_mde_run(dataset, models, tmp_path):
     irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
@@ -569,13 +569,19 @@ def test_mde_run(dataset, models):
     assert meta["MMN00000"] == "test-bkg"
     assert meta["MID00001"] == 1
     assert meta["NMCIDS"] == 2
-    assert_allclose(float(meta["ALT_PNT"]), float("-13.5345076464"), rtol=1e-7)
-    assert_allclose(float(meta["AZ_PNT"]), float("228.82981620065763"), rtol=1e-7)
+    assert_allclose(meta["ALT_PNT"], -13.5345076464, rtol=1e-7)
+    assert_allclose(meta["AZ_PNT"], 228.82981620065763, rtol=1e-7)
     assert meta["ORIGIN"] == "Gammapy"
     assert meta["TELESCOP"] == "CTA"
     assert meta["INSTRUME"] == "1DC"
     assert meta["N_TELS"] == ""
     assert meta["TELLIST"] == ""
+
+    # test writing out and reading back in works
+    obs.events = events
+    path = tmp_path / "obs.fits.gz"
+    obs.write(path)
+    obs_back = Observation.read(path)
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -582,6 +582,7 @@ def test_mde_run(dataset, models, tmp_path):
     path = tmp_path / "obs.fits.gz"
     obs.write(path)
     obs_back = Observation.read(path)
+    assert obs_back.observatory_earth_location == LOCATION
 
 
 @requires_data()


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes the data type of `{ALT,AZ}_PNT` filled by the event sampler, which was for some reason stored as string, not as float.

Additionally to the existing checks, the test now also writes the observation out and reads it back in.

For convenience, I added a setter for `Observatoin.events`, so that we can now do:
```
observation.events = sampler.run(observation)
```

I also noticed now that the observatory location info is not added, which I fixed as well here.
**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
