### PR TITLE
Fermi 2nd and 3rd Pulsar Catalog

### DIFF
--- a/gammapy/catalog/__init__.py
+++ b/gammapy/catalog/__init__.py
@@ -4,10 +4,12 @@ from gammapy.utils.registry import Registry
 from .core import SourceCatalog, SourceCatalogObject
 from .fermi import (
     SourceCatalog2FHL,
+    SourceCatalog2PC,
     SourceCatalog3FGL,
     SourceCatalog3FHL,
     SourceCatalog4FGL,
     SourceCatalogObject2FHL,
+    SourceCatalogObject2PC,
     SourceCatalogObject3FGL,
     SourceCatalogObject3FHL,
     SourceCatalogObject4FGL,

--- a/gammapy/catalog/__init__.py
+++ b/gammapy/catalog/__init__.py
@@ -7,11 +7,13 @@ from .fermi import (
     SourceCatalog2PC,
     SourceCatalog3FGL,
     SourceCatalog3FHL,
+    SourceCatalog3PC,
     SourceCatalog4FGL,
     SourceCatalogObject2FHL,
     SourceCatalogObject2PC,
     SourceCatalogObject3FGL,
     SourceCatalogObject3FHL,
+    SourceCatalogObject3PC,
     SourceCatalogObject4FGL,
 )
 from .gammacat import SourceCatalogGammaCat, SourceCatalogObjectGammaCat

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -56,7 +56,9 @@ class SourceCatalogObject:
         self.data = Bunch(**data)
         if data_extended:
             self.data_extended = Bunch(**data_extended)
-        if data_spectral:
+        if data_spectral is None:
+            self.data_spectral = None
+        else:
             self.data_spectral = Bunch(**data_spectral)
 
     def _repr_html_(self):
@@ -321,6 +323,8 @@ def _skycoord_from_table(table):
         lon, lat, frame = "RA", "DEC", "icrs"
     elif {"ra", "dec"}.issubset(keys):
         lon, lat, frame = "ra", "dec", "icrs"
+    elif {"RAJD", "DECJD"}.issubset(keys):
+        lon, lat, frame = "RAJD", "DECJD", "icrs"
     else:
         raise KeyError("No column GLON / GLAT or RA / DEC or RAJ2000 / DEJ2000 found.")
 

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -284,13 +284,13 @@ class SourceCatalog(abc.ABC):
 
     @lazyproperty
     def _lookup_spectral_source_idx(self):
-        names = [_.strip() for _ in self.spectral_table["PSR_Name"]]
+        names = [_.strip() for _ in self.spectral_table[self._source_name_key]]
         idx = range(len(names))
         return dict(zip(names, idx))
 
     @lazyproperty
     def _lookup_extended_source_idx(self):
-        names = [_.strip() for _ in self.extended_sources_table["Source_Name"]]
+        names = [_.strip() for _ in self.extended_sources_table[self._source_name_key]]
         idx = range(len(names))
         return dict(zip(names, idx))
 

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -260,8 +260,10 @@ class SourceCatalog(abc.ABC):
         else:
             name_extended = None
 
-        if self._source_name_key in data:
+        if self._source_name_key in data and self._source_name_key == "PSR_Name":
             name_spectral = data[self._source_name_key].strip()
+        elif self._source_name_key in data and self._source_name_key == "PSRJ":
+            name_spectral = f"PSR{data[self._source_name_key].strip()}"
         elif "Source_name" in data:
             name_spectral = data["Source_name"].strip()
         else:
@@ -284,7 +286,11 @@ class SourceCatalog(abc.ABC):
 
     @lazyproperty
     def _lookup_spectral_source_idx(self):
-        names = [_.strip() for _ in self.spectral_table[self._source_name_key]]
+        if self._source_name_key == "PSRJ":
+            source_name_key = "NickName"
+        else:
+            source_name_key = self._source_name_key
+        names = [_.strip() for _ in self.spectral_table[source_name_key]]
         idx = range(len(names))
         return dict(zip(names, idx))
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -43,6 +43,80 @@ def compute_flux_points_ul(quantity, quantity_errp):
     return 2 * quantity_errp + quantity
 
 
+class SourceCatalogObjectFermiPCBase(SourceCatalogObject, abc.ABC):
+    """Base class for Fermi-LAT Pulsar catalogs."""
+
+    def _auxiliary_filename(self):
+        return make_path(
+            "$GAMMAPY_DATA/catalogs/fermi/2PC_auxiliary/PSR"
+            + self.name
+            + "_2PC_data.fits"
+        )
+
+    def __str__(self):
+        return self.info()
+
+    def info(self, info="all"):
+
+        if info == "all":
+            info = "basic,more,position,pulsar,spectral,lightcurve"
+
+        ss = ""
+        ops = info.split(",")
+        if "basic" in ops:
+            ss += self._info_basic()
+        if "more" in ops:
+            ss += self._info_more()
+        if "pulsar" in ops:
+            ss += self._info_pulsar()
+        if "position" in ops:
+            ss += self._info_position()
+        if "spectral" in ops:
+            ss += self._info_spectral_fit()
+            ss += self._info_spectral_points()
+        if "lightcurve" in ops:
+            ss += self._info_lightcurve()
+        return ss
+
+    def _info_basic(self):
+        ss = "\n*** Basic info ***\n\n"
+        ss += "Catalog row index (zero-based) : {}\n".format(self.row_index)
+        ss += "{:<20s} : {}\n".format("Source name", self.name)
+        return ss
+
+    def _info_more(self):
+        pass
+
+    def _info_pulsar(self):
+        pass
+
+    def _info_position(self):
+        d = self.data
+        ss = "\n*** Position info ***\n\n"
+        ss += "{:<20s} : {:.3f}\n".format("RA", d["RAJ2000"])
+        ss += "{:<20s} : {:.3f}\n".format("DEC", d["DEJ2000"])
+        ss += "{:<20s} : {:.3f}\n".format("GLON", d["GLON"])
+        ss += "{:<20s} : {:.3f}\n".format("GLAT", d["GLAT"])
+        return ss
+
+    def _info_spectral_fit(self):
+        pass
+
+    def _info_spectral_points(self):
+        pass
+
+    def _info_lightcurve(self):
+        pass
+
+    def spatial_model(self):
+        d = self.data
+        ra = d["RAJ2000"]
+        dec = d["DEJ2000"]
+
+        model = PointSpatialModel(lon_0=ra, lat_0=dec, frame="icrs")
+        return model
+
+
 class SourceCatalogObjectFermiBase(SourceCatalogObject, abc.ABC):
     """Base class for Fermi-LAT catalogs."""
 
@@ -1212,7 +1286,7 @@ class SourceCatalogObject3FHL(SourceCatalogObjectFermiBase):
         return model
 
 
-class SourceCatalogObject2PC:
+class SourceCatalogObject2PC(SourceCatalogObjectFermiPCBase):
     pass
 
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1627,8 +1627,8 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
                 "expfactor": d["PLEC_ExpfactorS_bfr"],
             }
             errs = {
-                "amplitdue": d["Unc_PL_Prefactor_bfr"],
-                "index_1": d["Unc_PL_Photon_Index_bfr"],
+                "amplitude": d["Unc_PLEC_Flux_Density_bfr"],
+                "index_1": d["Unc_PLEC_IndexS_bfr"],
                 "index_2": d["Unc_PLEC_Exp_Index_bfr"],
                 "expfactor": d["Unc_PLEC_ExpfactorS_bfr"],
             }

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1675,20 +1675,20 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         table["e_ref"] = np.sqrt(table["e_min"] * table["e_max"])
 
         fgl_cols = ["Flux_Band", "Unc_Flux_Band", "Sqrt_TS_Band", "nuFnu_Band"]
-        flux, fluxe, sig, nuFnu = [fp_data[col] for col in fgl_cols]
+        flux, flux_err, sig, nuFnu = [fp_data[col] for col in fgl_cols]
 
         table["flux"] = flux
-        table["flux_errn"] = np.abs(fluxe[:, 0])
-        table["flux_errp"] = fluxe[:, 1]
+        table["flux_errn"] = np.abs(flux_err[:, 0])
+        table["flux_errp"] = flux_err[:, 1]
 
         table["e2dnde"] = nuFnu
-        table["e2dnde_errn"] = np.abs(nuFnu * fluxe[:, 0] / flux)
-        table["e2dnde_errp"] = nuFnu * fluxe[:, 1] / flux
+        table["e2dnde_errn"] = np.abs(nuFnu * flux_err[:, 0] / flux)
+        table["e2dnde_errp"] = nuFnu * flux_err[:, 1] / flux
 
-        is_ul = np.isnan(fluxe[:, 0]) | (sig < 2)
+        is_ul = np.isnan(flux_err[:, 0]) | (sig < 2)
         table["is_ul"] = is_ul
 
-        table["flux_ul"] = np.nan * fluxe.unit
+        table["flux_ul"] = np.nan * flux_err.unit
         flux_ul = compute_flux_points_ul(table["flux"], table["flux_errp"])
         table["flux_ul"][is_ul] = flux_ul[is_ul]
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -26,10 +26,12 @@ __all__ = [
     "SourceCatalog3FGL",
     "SourceCatalog3FHL",
     "SourceCatalog4FGL",
+    "SourceCatalog2PC",
     "SourceCatalogObject2FHL",
     "SourceCatalogObject3FGL",
     "SourceCatalogObject3FHL",
     "SourceCatalogObject4FGL",
+    "SourceCatalogObject2PC",
 ]
 
 
@@ -1210,6 +1212,10 @@ class SourceCatalogObject3FHL(SourceCatalogObjectFermiBase):
         return model
 
 
+class SourceCatalogObject2PC:
+    pass
+
+
 class SourceCatalog3FGL(SourceCatalog):
     """Fermi-LAT 3FGL source catalog.
 
@@ -1384,3 +1390,36 @@ class SourceCatalog3FHL(SourceCatalog):
         self.extended_sources_table = Table.read(filename, hdu="ExtendedSources")
         self.rois = Table.read(filename, hdu="ROIs")
         self.energy_bounds_table = Table.read(filename, hdu="EnergyBounds")
+
+
+class SourceCatalog2PC(SourceCatalog):
+    """Fermi-LAT 2nd pulsar catalog.
+
+    - https://ui.adsabs.harvard.edu/abs/2013ApJS..208...17A
+    - https://fermi.gsfc.nasa.gov/ssc/data/access/lat/2nd_PSR_catalog/
+
+    One source is represented by `~gammapy.catalog.SourceCatalogObject2PC`.
+    """
+
+    tag = "2PC"
+    description = "LAT 2nd pulsar catalog"
+    source_object_class = SourceCatalogObject2PC
+
+    def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/2PC_catalog_v04.fits"):
+        filename = make_path(filename)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", u.UnitsWarning)
+            table_psr = Table.read(filename, hdu="PULSAR_CATALOG")
+            table_spectral = Table.read(filename, hdu="SPECTRAL")
+            table_off_peak = Table.read(filename, hdu="OFF_PEAK")
+
+        table_standardise_units_inplace(table_psr)
+        table_standardise_units_inplace(table_spectral)
+        table_standardise_units_inplace(table_off_peak)
+
+        source_name_key = "PSR_Name"
+        super().__init__(table=table_psr, source_name_key=source_name_key)
+
+        self.spectral_table = table_spectral
+        self.off_peak_table = table_off_peak

--- a/gammapy/catalog/tests/data/2pc_j0034-0534.txt
+++ b/gammapy/catalog/tests/data/2pc_j0034-0534.txt
@@ -1,0 +1,75 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 3
+Source name          : J0034-0534
+
+*** Other info ***
+
+Binary               : Y
+
+*** Pulsar info ***
+
+Period               : 1.880 ms
+P_Dot                : 4.980e-21
+E_Dot                : 1.720e+34 erg / s
+Type                 : MSP
+
+*** Position info ***
+
+RA                   : 8.591 deg
+DEC                  : -5.577 deg
+GLON                 : 111.492 deg
+GLAT                 : -68.069 deg
+
+*** Spectral info ***
+
+On peak              : N
+TS DC                : 563
+TS cutoff            : 45
+TS b free            : 0
+
+    * PLSuperExpCutoff b = 1 *
+
+    Amplitude            : 8.691e-12 1 / (MeV s cm2) +- 1.208e-12 1 / (MeV s cm2)
+    Index 1              : 1.436 +- 0.169
+    Index 2              : 1.000
+    Reference            : 755.700 MeV
+    Ecut                 : 1831.000 MeV +- 416.700 MeV
+
+    * PLSuperExpCutoff b free *
+
+    Amplitude            : 0.000e+00 1 / (MeV s cm2) +- 0.000e+00 1 / (MeV s cm2)
+    Index 1              : -- +- --
+    Index 2              : -- +- --
+    Reference            : 0.000 MeV
+    Ecut                 : 0.000 MeV +- 0.000 MeV
+
+    * PowerLaw *
+
+    Amplitude            : 2.435e-12 1 / (MeV s cm2) +- 1.520e-13 1 / (MeV s cm2)
+    Index                : 2.219 +- 0.049
+    Reference            : 1000.000 MeV
+
+*** Spectral points ***
+
+e_min   e_max  e_ref        flux           flux_err         e2dnde      e2dnde_err  is_ul     flux_ul        e2dnde_ul
+ GeV     GeV    GeV   ph / (GeV s cm2) ph / (GeV s cm2) erg / (s cm2) erg / (s cm2)       ph / (GeV s cm2) erg / (s cm2)
+------ ------- ------ ---------------- ---------------- ------------- ------------- ----- ---------------- -------------
+ 0.100   0.178  0.128        1.747e-07        0.000e+00     4.586e-12     0.000e+00  True        1.747e-07     4.586e-12
+ 0.178   0.316  0.228        5.343e-08        1.041e-08     4.436e-12     8.638e-13 False              nan           nan
+ 0.316   0.562  0.405        1.886e-08        2.588e-09     4.950e-12     6.794e-13 False              nan           nan
+ 0.562   1.000  0.720        5.558e-09        6.914e-10     4.614e-12     5.740e-13 False              nan           nan
+ 1.000   1.778  1.280        1.927e-09        2.320e-10     5.059e-12     6.090e-13 False              nan           nan
+ 1.778   3.162  2.276        5.261e-10        7.922e-11     4.368e-12     6.576e-13 False              nan           nan
+ 3.162   5.623  4.048        8.004e-11        2.215e-11     2.101e-12     5.816e-13 False              nan           nan
+ 5.623  10.000  7.199        1.634e-11        0.000e+00     1.356e-12     0.000e+00  True        1.634e-11     1.356e-12
+10.000  17.783 12.801        3.678e-12        0.000e+00     9.655e-13     0.000e+00  True        3.678e-12     9.655e-13
+17.783  31.623 22.764        1.158e-12        0.000e+00     9.616e-13     0.000e+00  True        1.158e-12     9.616e-13
+31.623  56.234 40.482        6.298e-13        0.000e+00     1.653e-12     0.000e+00  True        6.298e-13     1.653e-12
+56.234 100.000 71.988        9.865e-13        0.000e+00     8.190e-12     0.000e+00  True        9.865e-13     8.190e-12
+
+*** Phasogram info ***
+
+Number of peaks      : 2
+Peak separation      : 0.285

--- a/gammapy/catalog/tests/data/2pc_j0034-0534.txt
+++ b/gammapy/catalog/tests/data/2pc_j0034-0534.txt
@@ -53,7 +53,7 @@ TS b free            : 0
 
 *** Spectral points ***
 
-e_min   e_max  e_ref        flux           flux_err         e2dnde      e2dnde_err  is_ul     flux_ul        e2dnde_ul
+e_min   e_max  e_ref        flux           flux_err         e2dnde      e2dnde_err  is_ul     flux_ul        e2dnde_ul  
  GeV     GeV    GeV   ph / (GeV s cm2) ph / (GeV s cm2) erg / (s cm2) erg / (s cm2)       ph / (GeV s cm2) erg / (s cm2)
 ------ ------- ------ ---------------- ---------------- ------------- ------------- ----- ---------------- -------------
  0.100   0.178  0.128        1.747e-07        0.000e+00     4.586e-12     0.000e+00  True        1.747e-07     4.586e-12

--- a/gammapy/catalog/tests/data/2pc_j1112-6103.txt
+++ b/gammapy/catalog/tests/data/2pc_j1112-6103.txt
@@ -1,0 +1,69 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 38
+Source name          : J1112-6103
+
+*** Other info ***
+
+Binary               : N
+
+*** Pulsar info ***
+
+Period               : 64.970 ms
+P_Dot                : 3.150e-14
+E_Dot                : 4.540e+36 erg / s
+Type                 : YRL
+
+*** Position info ***
+
+RA                   : 168.062 deg
+DEC                  : -61.059 deg
+GLON                 : 291.221 deg
+GLAT                 : -0.463 deg
+
+*** Spectral info ***
+
+On peak              : N
+TS DC                : 58
+TS cutoff            : 6
+TS b free            : 0
+
+    * PLSuperExpCutoff b = 1 *
+
+    Amplitude            : 3.555e-12 1 / (MeV s cm2) +- 1.157e-12 1 / (MeV s cm2)
+    Index 1              : 1.557 +- 0.281
+    Index 2              : 1.000
+    Reference            : 1000.000 MeV
+    Ecut                 : 5889.000 MeV +- 3235.000 MeV
+
+    * PLSuperExpCutoff b free *
+
+    Amplitude            : 0.000e+00 1 / (MeV s cm2) +- 0.000e+00 1 / (MeV s cm2)
+    Index 1              : -- +- --
+    Index 2              : -- +- --
+    Reference            : 0.000 MeV
+    Ecut                 : 0.000 MeV +- 0.000 MeV
+
+    * PowerLaw *
+
+    Amplitude            : 2.554e-12 1 / (MeV s cm2) +- 6.340e-13 1 / (MeV s cm2)
+    Index                : 2.070 +- 0.105
+    Reference            : 1000.000 MeV
+
+*** Spectral points ***
+
+e_min   e_max  e_ref        flux           flux_err         e2dnde      e2dnde_err  is_ul     flux_ul        e2dnde_ul
+ GeV     GeV    GeV   ph / (GeV s cm2) ph / (GeV s cm2) erg / (s cm2) erg / (s cm2)       ph / (GeV s cm2) erg / (s cm2)
+------ ------- ------ ---------------- ---------------- ------------- ------------- ----- ---------------- -------------
+ 0.100   0.316  0.152        2.641e-07        0.000e+00     9.769e-12     0.000e+00  True        2.641e-07     9.769e-12
+ 0.316   1.000  0.481        2.015e-08        9.124e-09     7.452e-12     3.375e-12 False              nan           nan
+ 1.000   3.162  1.520        1.999e-09        4.012e-10     7.396e-12     1.484e-12 False              nan           nan
+ 3.162  10.000  4.805        8.503e-11        3.112e-11     3.145e-12     1.151e-12 False              nan           nan
+10.000  31.623 15.195        1.433e-11        0.000e+00     5.302e-12     0.000e+00  True        1.433e-11     5.302e-12
+31.623 100.000 48.052        1.453e-12        0.000e+00     5.373e-12     0.000e+00  True        1.453e-12     5.373e-12
+
+*** Phasogram info ***
+
+Number of peaks      : 2
+Peak separation      : 0.457

--- a/gammapy/catalog/tests/data/2pc_j1112-6103.txt
+++ b/gammapy/catalog/tests/data/2pc_j1112-6103.txt
@@ -53,7 +53,7 @@ TS b free            : 0
 
 *** Spectral points ***
 
-e_min   e_max  e_ref        flux           flux_err         e2dnde      e2dnde_err  is_ul     flux_ul        e2dnde_ul
+e_min   e_max  e_ref        flux           flux_err         e2dnde      e2dnde_err  is_ul     flux_ul        e2dnde_ul  
  GeV     GeV    GeV   ph / (GeV s cm2) ph / (GeV s cm2) erg / (s cm2) erg / (s cm2)       ph / (GeV s cm2) erg / (s cm2)
 ------ ------- ------ ---------------- ---------------- ------------- ------------- ----- ---------------- -------------
  0.100   0.316  0.152        2.641e-07        0.000e+00     9.769e-12     0.000e+00  True        2.641e-07     9.769e-12

--- a/gammapy/catalog/tests/data/3pc_j0834-4159.txt
+++ b/gammapy/catalog/tests/data/3pc_j0834-4159.txt
@@ -1,0 +1,30 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 51
+Source name          : J0834-4159
+
+*** Pulsar info ***
+
+Period               : 0.121
+P_Dot                : 4.281e-15
+E_Dot                : 9.511e+34
+
+*** Position info ***
+
+RA                   : 128.574 deg
+DEC                  : -41.993 deg
+GLON                 : 260.886 deg
+GLAT                 : -1.036 deg
+
+*** Spectral info ***
+
+No spectral info available.
+
+*** Spectral points ***
+
+No spectral points available.
+
+*** Phasogram info ***
+
+No phasogram info available.

--- a/gammapy/catalog/tests/data/3pc_j0835-4510.txt
+++ b/gammapy/catalog/tests/data/3pc_j0835-4510.txt
@@ -42,7 +42,7 @@ Spectrum Type        : PLSuperExpCutoff4
 *** Spectral points ***
 
   e_min       e_max      e_ref        flux     flux_errn   flux_errp      e2dnde     e2dnde_errn   e2dnde_errp  is_ul   flux_ul     e2dnde_ul   sqrt_ts
-   MeV         MeV        MeV     1 / (s cm2) 1 / (s cm2) 1 / (s cm2) MeV / (s cm2) MeV / (s cm2) MeV / (s cm2)       1 / (s cm2) MeV / (s cm2)
+   MeV         MeV        MeV     1 / (s cm2) 1 / (s cm2) 1 / (s cm2) MeV / (s cm2) MeV / (s cm2) MeV / (s cm2)       1 / (s cm2) MeV / (s cm2)        
 ---------- ----------- ---------- ----------- ----------- ----------- ------------- ------------- ------------- ----- ----------- ------------- -------
     50.000     100.000     70.711   5.392e-06   3.093e-07   3.093e-07     5.543e-04     3.179e-05     3.179e-05 False         nan           nan   6.801
    100.000     300.000    173.205   5.596e-06   4.955e-07   4.955e-07     8.878e-04     7.861e-05     7.861e-05 False         nan           nan  35.488

--- a/gammapy/catalog/tests/data/3pc_j0835-4510.txt
+++ b/gammapy/catalog/tests/data/3pc_j0835-4510.txt
@@ -1,0 +1,61 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 52
+Source name          : J0835-4510
+
+*** Pulsar info ***
+
+Period               : 0.089
+P_Dot                : 1.223e-13
+E_Dot                : 6.764e+36
+
+*** Position info ***
+
+RA                   : 128.836 deg
+DEC                  : -45.176 deg
+GLON                 : 263.552 deg
+GLAT                 : -2.787 deg
+
+*** Spectral info ***
+
+TS                   : 443007
+Significance (DC)    : 666
+Spectrum Type        : PLSuperExpCutoff4
+
+    * PLSuperExpCutoff4FGLDR3 b = 2/3 *
+
+    Amplitude            : 5.290e-10 1 / (MeV s cm2) +- 1.665e-12 1 / (MeV s cm2)
+    Index 1              : 2.153 +- 0.002
+    Index 2              : 0.667
+    Reference            : 1760.385 MeV
+    Expfactor            : 0.517 +- 0.003
+
+    * PLSuperExpCutoff b free *
+
+    Amplitude            : 5.327e-10 1 / (MeV s cm2) +- 1.649e-12 1 / (MeV s cm2)
+    Index 1              : 2.196 +- 0.004
+    Index 2              : 0.493 +- 0.011
+    Reference            : 1760.385 MeV
+    Expfactor            : 0.549 +- 0.004
+
+*** Spectral points ***
+
+  e_min       e_max      e_ref        flux     flux_errn   flux_errp      e2dnde     e2dnde_errn   e2dnde_errp  is_ul   flux_ul     e2dnde_ul   sqrt_ts
+   MeV         MeV        MeV     1 / (s cm2) 1 / (s cm2) 1 / (s cm2) MeV / (s cm2) MeV / (s cm2) MeV / (s cm2)       1 / (s cm2) MeV / (s cm2)
+---------- ----------- ---------- ----------- ----------- ----------- ------------- ------------- ------------- ----- ----------- ------------- -------
+    50.000     100.000     70.711   5.392e-06   3.093e-07   3.093e-07     5.543e-04     3.179e-05     3.179e-05 False         nan           nan   6.801
+   100.000     300.000    173.205   5.596e-06   4.955e-07   4.955e-07     8.878e-04     7.861e-05     7.861e-05 False         nan           nan  35.488
+   300.000    1000.000    547.723   3.387e-06   2.368e-08   2.368e-08     1.503e-03     1.050e-05     1.050e-05 False         nan           nan 202.272
+  1000.000    3000.000   1732.051   1.087e-06   4.350e-09   4.350e-09     1.600e-03     6.407e-06     6.407e-06 False         nan           nan 405.607
+  3000.000   10000.000   5477.226   2.264e-07   1.099e-09   1.099e-09     8.652e-04     4.201e-06     4.201e-06 False         nan           nan 441.811
+ 10000.000   30000.000  17320.508   1.171e-08   1.586e-10   1.586e-10     1.425e-04     1.930e-06     1.930e-06 False         nan           nan 188.212
+ 30000.000  100000.000  54772.256   2.162e-10   2.102e-11   2.102e-11     7.046e-06     6.849e-07     6.849e-07 False         nan           nan  26.673
+100000.000 1000000.000 316227.766   4.480e-16   4.480e-16   3.641e-12     2.591e-11     2.591e-11     2.106e-07  True   7.283e-12     4.212e-07   0.000
+
+*** Phasogram info ***
+
+Number of peaks      : 4.000
+Ph1 (peak one)       : 0.133
+Ph2 (peak two)       : 0.565
+Peak separation      : 0.432

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -34,7 +34,7 @@ SOURCES_2PC = [
     dict(
         idx=3,
         name="J0034-0534",
-        str_ref_file="data/2pc_J0034-0534.txt",
+        str_ref_file="data/2pc_j0034-0534.txt",
         spec_type=SuperExpCutoffPowerLaw3FGLSpectralModel,
         dnde=u.Quantity(8.69100018e-12, "cm-2 s-1 MeV-1"),
         dnde_err=u.Quantity(1.20799995e-12, "cm-2 s-1 MeV-1"),
@@ -42,7 +42,7 @@ SOURCES_2PC = [
     dict(
         idx=38,
         name="J1112-6103",
-        str_ref_file="data/2pc_J1112-6103.txt",
+        str_ref_file="data/2pc_j1112-6103.txt",
         spec_type=PowerLawSpectralModel,
         dnde=u.Quantity(2.55399998e-12, "cm-2 s-1 MeV-1"),
         dnde_err=u.Quantity(6.34000014e-13, "cm-2 s-1 MeV-1"),
@@ -53,7 +53,7 @@ SOURCES_3PC_NONE = [
     dict(
         idx=51,
         name="J0834-4159",
-        str_ref_file="data/3pc_J0834-4159.txt",
+        str_ref_file="data/3pc_j0834-4159.txt",
         spec_type=None,
     ),
 ]
@@ -62,7 +62,7 @@ SOURCES_3PC = [
     dict(
         idx=52,
         name="J0835-4510",
-        str_ref_file="data/3pc_J0835-4510.txt",
+        str_ref_file="data/3pc_j0835-4510.txt",
         spec_type=SuperExpCutoffPowerLaw4FGLDR3SpectralModel,
         dnde=u.Quantity(5.32697275e-10, "cm-2 s-1 MeV-1"),
         dnde_err=u.Quantity(1.64905329e-12, "cm-2 s-1 MeV-1"),

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -7,8 +7,10 @@ from astropy.time import Time
 from astropy.utils.data import get_pkg_data_filename
 from gammapy.catalog import (
     SourceCatalog2FHL,
+    SourceCatalog2PC,
     SourceCatalog3FGL,
     SourceCatalog3FHL,
+    SourceCatalog3PC,
     SourceCatalog4FGL,
 )
 from gammapy.modeling.models import (
@@ -17,6 +19,7 @@ from gammapy.modeling.models import (
     PowerLaw2SpectralModel,
     PowerLawSpectralModel,
     SuperExpCutoffPowerLaw3FGLSpectralModel,
+    SuperExpCutoffPowerLaw4FGLDR3SpectralModel,
     SuperExpCutoffPowerLaw4FGLSpectralModel,
 )
 from gammapy.utils.gauss import Gauss2DPDF
@@ -26,6 +29,45 @@ from gammapy.utils.testing import (
     modify_unit_order_astropy_5_3,
     requires_data,
 )
+
+SOURCES_2PC = [
+    dict(
+        idx=3,
+        name="J0034-0534",
+        str_ref_file="data/2pc_J0034-0534.txt",
+        spec_type=SuperExpCutoffPowerLaw3FGLSpectralModel,
+        dnde=u.Quantity(8.69100018e-12, "cm-2 s-1 MeV-1"),
+        dnde_err=u.Quantity(1.20799995e-12, "cm-2 s-1 MeV-1"),
+    ),
+    dict(
+        idx=38,
+        name="J1112-6103",
+        str_ref_file="data/2pc_J1112-6103.txt",
+        spec_type=PowerLawSpectralModel,
+        dnde=u.Quantity(2.55399998e-12, "cm-2 s-1 MeV-1"),
+        dnde_err=u.Quantity(6.34000014e-13, "cm-2 s-1 MeV-1"),
+    ),
+]
+
+SOURCES_3PC_NONE = [
+    dict(
+        idx=51,
+        name="J0834-4159",
+        str_ref_file="data/3pc_J0834-4159.txt",
+        spec_type=None,
+    ),
+]
+
+SOURCES_3PC = [
+    dict(
+        idx=52,
+        name="J0835-4510",
+        str_ref_file="data/3pc_J0835-4510.txt",
+        spec_type=SuperExpCutoffPowerLaw4FGLDR3SpectralModel,
+        dnde=u.Quantity(5.32697275e-10, "cm-2 s-1 MeV-1"),
+        dnde_err=u.Quantity(1.64905329e-12, "cm-2 s-1 MeV-1"),
+    ),
+]
 
 SOURCES_4FGL = [
     dict(
@@ -630,6 +672,204 @@ class TestFermi3FHLObject:
 
 
 @requires_data()
+class TestFermi2PCObject:
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog2PC()
+        # Use J0835-4510 (Vela pulsar) as a test source
+        cls.source_name = "J0835-4510"
+        cls.source = cls.cat[cls.source_name]
+
+    def test_name(self):
+        assert self.source.name == self.source_name
+
+    def test_row_index(self):
+        assert self.source.row_index == 26
+
+    @pytest.mark.parametrize("ref", SOURCES_2PC, ids=lambda _: _["name"])
+    def test_str(self, ref):
+        # TODO: fix the test
+        actual = str(self.cat[ref["idx"]])
+
+        with open(get_pkg_data_filename(ref["str_ref_file"])) as fh:
+            expected = fh.read()
+
+        assert actual == modify_unit_order_astropy_5_3(expected)
+
+    def test_position(self):
+        position = self.source.position
+        assert_allclose(position.ra.deg, 128.83580017, atol=1e-3)
+        assert_allclose(position.dec.deg, -45.17630005, atol=1e-3)
+
+    def test_data(self):
+        assert_allclose(self.source.data["Period"], 89.36 * u.ms)
+
+    @pytest.mark.parametrize("ref", SOURCES_2PC, ids=lambda _: _["name"])
+    def test_spectral_model(self, ref):
+        model = self.cat[ref["idx"]].spectral_model()
+
+        e_ref = model.reference.quantity
+        dnde, dnde_err = model.evaluate_error(e_ref)
+        assert isinstance(model, ref["spec_type"])
+        assert_quantity_allclose(dnde, ref["dnde"], rtol=1e-4)
+        assert_quantity_allclose(dnde_err, ref["dnde_err"], rtol=1e-4)
+
+    def test_spatial_model(self):
+        model = self.source.spatial_model()
+        assert "PointSpatialModel" in model.tag
+        assert model.frame == "icrs"
+        p = model.parameters
+        assert_allclose(p["lon_0"].value, 128.83580017)
+        assert_allclose(p["lat_0"].value, -45.17630005)
+
+    @pytest.mark.parametrize("ref", SOURCES_2PC, ids=lambda _: _["name"])
+    def test_sky_model(self, ref):
+        self.cat[ref["idx"]].sky_model
+
+    def test_flux_points(self):
+        flux_points = self.source.flux_points
+
+        assert flux_points.norm.geom.axes["energy"].nbin == 12
+        assert flux_points.norm_ul
+
+        desired = [
+            3.72509152e-09,
+            2.66778077e-09,
+            1.89817530e-09,
+            1.23380980e-09,
+            7.13620134e-10,
+            3.64504041e-10,
+            1.47285787e-10,
+            4.66089223e-11,
+            9.73255716e-12,
+            1.48225895e-12,
+            1.20599140e-13,
+            3.89632873e-14,
+        ]
+        assert_allclose(flux_points.flux.data.flat, desired, rtol=1e-5)
+
+    def test_flux_points_ul(self):
+        flux_points = self.source.flux_points
+
+        desired = [
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            3.896328e-14,
+        ]
+        assert_allclose(flux_points.flux_ul.data.flat, desired, rtol=1e-5)
+
+    def test_lightcurve(self):
+        # TODO: add lightcurve test when lightcurve is introduce to the class.
+        pass
+
+
+@requires_data()
+class TestFermi3PCObject:
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog3PC()
+        # Use J0835-4510 (Vela pulsar) as a test source
+        cls.source_name = "J0835-4510"
+        cls.source = cls.cat[cls.source_name]
+
+    def test_name(self):
+        assert self.source.name == self.source_name
+
+    def test_row_index(self):
+        assert self.source.row_index == 52
+
+    @pytest.mark.parametrize(
+        "ref", [SOURCES_3PC[0], SOURCES_3PC_NONE[0]], ids=lambda _: _["name"]
+    )
+    def test_str(self, ref):
+        # TODO: fix the test
+        actual = str(self.cat[ref["idx"]])
+
+        with open(get_pkg_data_filename(ref["str_ref_file"])) as fh:
+            expected = fh.read()
+
+        assert actual == modify_unit_order_astropy_5_3(expected)
+
+    def test_position(self):
+        position = self.source.position
+        assert_allclose(position.ra.deg, 128.83580017, atol=1e-3)
+        assert_allclose(position.dec.deg, -45.17630005, atol=1e-3)
+
+    def test_data(self):
+        assert_allclose(self.source.data["P0"], 0.08937108859019084)
+
+    @pytest.mark.parametrize("ref", SOURCES_3PC, ids=lambda _: _["name"])
+    def test_spectral_model(self, ref):
+        model = self.cat[ref["idx"]].spectral_model()
+
+        e_ref = model.reference.quantity
+        dnde, dnde_err = model.evaluate_error(e_ref)
+        assert isinstance(model, ref["spec_type"])
+        assert_quantity_allclose(dnde, ref["dnde"], rtol=1e-4)
+        assert_quantity_allclose(dnde_err, ref["dnde_err"], rtol=1e-4)
+
+    @pytest.mark.parametrize("ref", SOURCES_3PC_NONE, ids=lambda _: _["name"])
+    def test_spectral_model_none(self, ref):
+        model = self.cat[ref["idx"]].spectral_model()
+        assert model is None
+
+    def test_spatial_model(self):
+        model = self.source.spatial_model()
+        assert "PointSpatialModel" in model.tag
+        assert model.frame == "icrs"
+        p = model.parameters
+        assert_allclose(p["lon_0"].value, 128.83588121)
+        assert_allclose(p["lat_0"].value, -45.17635419)
+
+    @pytest.mark.parametrize("ref", SOURCES_3PC, ids=lambda _: _["name"])
+    def test_sky_model(self, ref):
+        self.cat[ref["idx"]].sky_model
+
+    @pytest.mark.parametrize("ref", SOURCES_3PC, ids=lambda _: _["name"])
+    def test_flux_points(self, ref):
+        flux_points = self.cat[ref["idx"]].flux_points
+
+        assert flux_points.norm.geom.axes["energy"].nbin == 8
+        assert flux_points.norm_ul
+
+        desired = [
+            5.431500e-06,
+            5.635604e-06,
+            3.341596e-06,
+            1.058516e-06,
+            2.264139e-07,
+            1.421599e-08,
+            6.306778e-10,
+            3.165719e-12,
+        ]
+        assert_allclose(flux_points.flux.data.flat, desired, rtol=1e-5)
+
+    @pytest.mark.parametrize("ref", SOURCES_3PC_NONE, ids=lambda _: _["name"])
+    def test_flux_points_none(self, ref):
+        flux_points = self.cat[ref["idx"]].flux_points
+        assert flux_points is None
+
+    def test_flux_points_ul(self):
+        flux_points = self.source.flux_points
+
+        desired = [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 5.146455e-08]
+        assert_allclose(flux_points.flux_ul.data.flat, desired, rtol=1e-5)
+
+    def test_lightcurve(self):
+        # TODO: add lightcurve test when lightcurve is introduce to the class.
+        pass
+
+
+@requires_data()
 class TestSourceCatalog3FGL:
     @classmethod
     def setup_class(cls):
@@ -676,6 +916,46 @@ class TestSourceCatalog3FHL:
 
     def test_to_models(self):
         mask = self.cat.table["GLAT"].quantity > 80 * u.deg
+        subcat = self.cat[mask]
+        models = subcat.to_models()
+        assert len(models) == 17
+
+
+@requires_data()
+class TestSourceCatalog2PC:
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog2PC()
+
+    def test_main_table(self):
+        assert len(self.cat.table) == 117
+
+    def test_spectral_table(self):
+        table = self.cat.spectral_table
+        assert len(table) == 117
+
+    def test_to_models(self):
+        mask = self.cat.table["GLAT"].quantity > 30 * u.deg
+        subcat = self.cat[mask]
+        models = subcat.to_models()
+        assert len(models) == 2
+
+
+@requires_data()
+class TestSourceCatalog3PC:
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog3PC()
+
+    def test_main_table(self):
+        assert len(self.cat.table) == 294
+
+    def test_spectral_table(self):
+        table = self.cat.spectral_table
+        assert len(table) == 305
+
+    def test_to_models(self):
+        mask = self.cat.table["Gb"] > 30
         subcat = self.cat[mask]
         models = subcat.to_models()
         assert len(models) == 17

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -688,7 +688,6 @@ class TestFermi2PCObject:
 
     @pytest.mark.parametrize("ref", SOURCES_2PC, ids=lambda _: _["name"])
     def test_str(self, ref):
-        # TODO: fix the test
         actual = str(self.cat[ref["idx"]])
 
         with open(get_pkg_data_filename(ref["str_ref_file"])) as fh:
@@ -791,7 +790,6 @@ class TestFermi3PCObject:
         "ref", [SOURCES_3PC[0], SOURCES_3PC_NONE[0]], ids=lambda _: _["name"]
     )
     def test_str(self, ref):
-        # TODO: fix the test
         actual = str(self.cat[ref["idx"]])
 
         with open(get_pkg_data_filename(ref["str_ref_file"])) as fh:


### PR DESCRIPTION
This pull request introduce the 2PC Fermi-LAT catalog to `gammapy.catalog` sub-package. 

The catalog fits file consist of 2 main HDUs:

- One is for the actual pulsar catalog. It gathers intrinsic information on the pulsars, such as the position, the period, derivative of the period, etc.
- The other one is for the spectral parameters of the pulsars. 

Therefore, I had to modify a little bit the core class `SourceCatalog` and `SourceCatalogObject` to account for the spectral parameters to be in another HDU (as with the `extended_source_table`). 

I still need to make the `SourceCatalogObject` class for this catalog. 