### PR TITLE
Add 'norm' option to `plot_distribution`

### DIFF
--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -94,20 +94,23 @@ def test_plot_distribution():
         return norm.pdf(x, mu, sigma)
 
     with mpl_plot_check():
-        res, axes = plot_distribution(
+        axes, res = plot_distribution(
             wcs_map=map_, func=fit_func, kwargs_hist={"bins": 40}
         )
 
         assert axes.shape == (1,)
-        assert res[0].get("info_dict").get("nfev") == 19
+        assert "info_dict" in res[0]
+        assert ["fvec", "nfev", "fjac", "ipvt", "qtf"] == list(
+            (res[0].get("info_dict").keys())
+        )
         assert res[0].get("param") is not None
         assert res[0].get("covar") is not None
 
-        res, axes = plot_distribution(map_empty)
+        axes, res = plot_distribution(map_empty)
 
         assert res == []
         assert axes.shape == (4, 3)
 
-        res, axes = plot_distribution(
+        axes, res = plot_distribution(
             wcs_map=map_, func="norm", kwargs_hist={"bins": 40}
         )

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -107,3 +107,7 @@ def test_plot_distribution():
 
         assert res == []
         assert axes.shape == (4, 3)
+
+        res, axes = plot_distribution(
+            wcs_map=map_, func="norm", kwargs_hist={"bins": 40}
+        )

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -218,6 +218,9 @@ def plot_distribution(
 
     Returns
     -------
+    axes : `~numpy.ndarray` of `~matplotlib.pyplot.Axes`
+        Array of Axes.
+
     result_list : list of dict
         List of dictionnary that contains the results of `scipy.optimize.curve_fit`. The number of elements in the list
         correspond to the dimension of the non-spatial axis of the map.
@@ -228,9 +231,6 @@ def plot_distribution(
             * `covar` : the covariance matrix for the fitted parameters `param`
             * `info_dict` : the `infodict` return of `scipy.optimize.curve_fit`
 
-    axes : `~numpy.ndarray` of `~matplotlib.pyplot.Axes`
-        Array of Axes.
-
     Examples
     --------
     >>> from gammapy.datasets import MapDataset
@@ -239,10 +239,10 @@ def plot_distribution(
     >>> from gammapy.visualization import plot_distribution
     >>> dataset = MapDataset.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
     >>> tsmap_est = TSMapEstimator().run(dataset)
-    >>> res, ax = plot_distribution(tsmap_est.sqrt_ts, func="norm", kwargs_hist={'bins': 75, 'range': (-10, 10), 'density': True})
+    >>> axs, res = plot_distribution(tsmap_est.sqrt_ts, func="norm", kwargs_hist={'bins': 75, 'range': (-10, 10), 'density': True})
     >>> # Equivalently, one can do the following:
     >>> func = lambda x, mu, sig : norm.pdf(x, loc=mu, scale=sig)
-    >>> res, ax = plot_distribution(tsmap_est.sqrt_ts, func=func, kwargs_hist={'bins': 75, 'range': (-10, 10), 'density': True})
+    >>> axs, res = plot_distribution(tsmap_est.sqrt_ts, func=func, kwargs_hist={'bins': 75, 'range': (-10, 10), 'density': True})
     """
 
     from gammapy.maps import WcsNDMap  # import here to avoid circular import
@@ -345,4 +345,4 @@ def plot_distribution(
         axe.set(**kwargs_axes)
         axe.legend()
 
-    return result_list, axes
+    return axes, result_list

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -220,7 +220,6 @@ def plot_distribution(
     -------
     axes : `~numpy.ndarray` of `~matplotlib.pyplot.Axes`
         Array of Axes.
-
     result_list : list of dict
         List of dictionnary that contains the results of `scipy.optimize.curve_fit`. The number of elements in the list
         correspond to the dimension of the non-spatial axis of the map.

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -205,8 +205,8 @@ def plot_distribution(
         Axis object to plot on. If a list of Axis is provided it has to be the same length as the length of _map.data.
     ncols : int
         Number of columns to plot if a "plot grid" was to be done.
-    func : function object
-        The function to pass to `scipy.optimize.curve_fit` or "norm". Default is None.
+    func : function object or str
+        The function to used to fit a map data histogram or "norm". Default is None.
         If None, no fit will be done. If "norm" is given, `scipy.stats.norm.pdf`
         will be passed to `scipy.optimize.curve_fit`.
     kwargs_hist : dict
@@ -310,13 +310,13 @@ def plot_distribution(
                 )
 
                 mu, sig = pars[0], pars[1]
-                err_mu, err_sig = cov[0][0] ** 2, cov[1][1] ** 2
+                err_mu, err_sig = np.sqrt(cov[0][0]), np.sqrt(cov[1][1])
 
                 label_norm = (
-                    r"$\mu$ = {:.2f} ± {:.2E}, $\sigma$ = {:.2f} ± {:.2E}".format(
+                    r"$\mu$ = {:.2f} ± {:.2E}\n$\sigma$ = {:.2f} ± {:.2E}".format(
                         mu, err_mu, sig, err_sig
                     )
-                )
+                ).replace(r"\n", "\n")
                 kwargs_plot_fit["label"] = label_norm
 
             else:

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -206,8 +206,8 @@ def plot_distribution(
     ncols : int
         Number of columns to plot if a "plot grid" was to be done.
     func : function object or str
-        The function to used to fit a map data histogram or "norm". Default is None.
-        If None, no fit will be done. If "norm" is given, `scipy.stats.norm.pdf`
+        The function used to fit a map data histogram or "norm". Default is None.
+        If None, no fit will be performed. If "norm" is given, `scipy.stats.norm.pdf`
         will be passed to `scipy.optimize.curve_fit`.
     kwargs_hist : dict
         Keyword arguments to pass to `matplotlib.pyplot.hist`.


### PR DESCRIPTION
This PR introduce a 'norm' option to `plot_distribution` to directly fit a normal distribution, as mentioned in #4665. 