### PR TITLE
Update 4FGL catalog default  to DR4 

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1255,18 +1255,19 @@ class SourceCatalog4FGL(SourceCatalog):
     - https://arxiv.org/abs/1902.10045 (DR1)
     - https://arxiv.org/abs/2005.11208 (DR2)
     - https://arxiv.org/abs/2201.11184 (DR3)
+    - https://arxiv.org/abs/2307.12546 (DR4)
 
-    By default we use the file of the DR3 initial release
-    from https://fermi.gsfc.nasa.gov/ssc/data/access/lat/12yr_catalog/
+    By default we use the file of the DR4 initial release
+    from https://fermi.gsfc.nasa.gov/ssc/data/access/lat/14yr_catalog/
 
     One source is represented by `~gammapy.catalog.SourceCatalogObject4FGL`.
     """
 
     tag = "4fgl"
-    description = "LAT 8-year point source catalog"
+    description = "LAT 14-year point source catalog"
     source_object_class = SourceCatalogObject4FGL
 
-    def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v28.fit.gz"):
+    def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v32.fit"):
         filename = make_path(filename)
         table = Table.read(filename, hdu="LAT_Point_Source_Catalog")
         table_standardise_units_inplace(table)

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -375,9 +375,13 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
                 )
             elif morph_type in ["Map", "Ring", "2D Gaussian x2"]:
                 filename = de["Spatial_Filename"].strip()
-                path = make_path(
-                    "$GAMMAPY_DATA/catalogs/fermi/LAT_extended_sources_8years/Templates/"
-                )
+                if de["version"] < 28:
+                    path_extended = "$GAMMAPY_DATA/catalogs/fermi/LAT_extended_sources_8years/Templates/"
+                elif de["version"] < 32:
+                    path_extended = "$GAMMAPY_DATA/catalogs/fermi/LAT_extended_sources_12years/Templates/"
+                else:
+                    path_extended = "$GAMMAPY_DATA/catalogs/fermi/LAT_extended_sources_14years/Templates/"
+                path = make_path(path_extended)
                 with warnings.catch_warnings():  # ignore FITS units warnings
                     warnings.simplefilter("ignore", FITSFixedWarning)
                     model = TemplateSpatialModel.read(path / filename)
@@ -1291,6 +1295,9 @@ class SourceCatalog4FGL(SourceCatalog):
         )
 
         self.extended_sources_table = Table.read(filename, hdu="ExtendedSources")
+        self.extended_sources_table["version"] = int(
+            "".join(filter(str.isdigit, table.meta["VERSION"]))
+        )
         try:
             self.hist_table = Table.read(filename, hdu="Hist_Start")
             if "MJDREFI" not in self.hist_table.meta:

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -374,7 +374,7 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
                     lon_0=ra, lat_0=dec, r_0=r_0, e=e, phi=phi, frame="icrs"
                 )
             elif morph_type in ["Map", "Ring", "2D Gaussian x2"]:
-                filename = de["Spatial_Filename"].strip()
+                filename = de["Spatial_Filename"].strip() + ".gz"
                 if de["version"] < 28:
                     path_extended = "$GAMMAPY_DATA/catalogs/fermi/LAT_extended_sources_8years/Templates/"
                 elif de["version"] < 32:

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1271,7 +1271,7 @@ class SourceCatalog4FGL(SourceCatalog):
     description = "LAT 14-year point source catalog"
     source_object_class = SourceCatalogObject4FGL
 
-    def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v32.fit"):
+    def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v32.fit.gz"):
         filename = make_path(filename)
         table = Table.read(filename, hdu="LAT_Point_Source_Catalog")
         table_standardise_units_inplace(table)

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -135,8 +135,8 @@ SOURCES_3FHL = [
 
 
 @requires_data()
-def test_4FGL_DR3():
-    cat = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v28.fit.gz")
+def test_4FGL_DR4():
+    cat = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v32.fit.gz")
     source = cat["4FGL J0534.5+2200"]
     model = source.spectral_model()
     fp = source.flux_points
@@ -308,21 +308,21 @@ class TestFermi4FGLObject:
         assert table["flux_errn"].unit == "cm-2 s-1"
         assert_allclose(table["flux_errn"][0], 4.437058e-8, rtol=1e-3)
 
-    def test_lightcurve_dr2(self):
-        dr2 = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v27.fit.gz")
+    def test_lightcurve_dr4(self):
+        dr2 = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v32.fit.gz")
         source_dr2 = dr2[self.source_name]
         table = source_dr2.lightcurve(interval="1-year").to_table(
             format="lightcurve", sed_type="flux"
         )
 
         assert table["flux"].unit == "cm-2 s-1"
-        assert_allclose(table["flux"][0], 2.196788e-6, rtol=1e-3)
+        assert_allclose(table["flux"][0], 2.307773e-06, rtol=1e-3)
 
         assert table["flux_errp"].unit == "cm-2 s-1"
-        assert_allclose(table["flux_errp"][0], 2.312938e-8, rtol=1e-3)
+        assert_allclose(table["flux_errp"][0], 2.298336e-08, rtol=1e-3)
 
         assert table["flux_errn"].unit == "cm-2 s-1"
-        assert_allclose(table["flux_errn"][0], 2.312938e-8, rtol=1e-3)
+        assert_allclose(table["flux_errn"][0], 2.298336e-08, rtol=1e-3)
 
         with pytest.raises(ValueError):
             source_dr2.lightcurve(interval="2-month")

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -210,6 +210,7 @@ class TestFermi4FGLObject:
         assert_allclose(p["sigma"].value, 0.27)
 
         model = self.cat["4FGL J1443.0-6227e"].spatial_model()
+        assert self.cat["4FGL J1443.0-6227e"].data_extended["version"] == 20
         assert "TemplateSpatialModel" in model.tag
         assert model.frame == "fk5"
         assert model.normalize


### PR DESCRIPTION
Update 4FGL catalog default to DR4 and load the correct extended sources file based on the catalog version.
Requires https://github.com/gammapy/gammapy-data/pull/42