### PR TITLE
Remove sampling value tests

### DIFF
--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -367,14 +367,17 @@ def test_mde_sample_background(dataset, models):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.sample_background(dataset=dataset)
 
-    assert len(events.table["ENERGY"]) == 15
-    assert_allclose(events.table["ENERGY"][0], 1.894698, rtol=1e-5)
+    assert len(events.table) == 15
+
+    assert_allclose(np.mean(events.table["ENERGY"]), 4.1, rtol=0.1)
     assert events.table["ENERGY"].unit == "TeV"
 
-    assert_allclose(events.table["RA"][0], 266.571824, rtol=1e-5)
+    assert np.all(events.table["RA"] < 269.95)
+    assert np.all(events.table["RA"] > 262.90)
     assert events.table["RA"].unit == "deg"
 
-    assert_allclose(events.table["DEC"][0], -27.979152, rtol=1e-5)
+    assert np.all(events.table["DEC"] < -25.43)
+    assert np.all(events.table["DEC"] > -32.43)
     assert events.table["DEC"].unit == "deg"
 
     assert events.table["DEC_TRUE"][0] == events.table["DEC"][0]

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -446,10 +446,16 @@ def test_event_det_coords(dataset, models):
     events = sampler.run(dataset=dataset, observation=obs)
 
     assert len(events.table) == 99
-    assert_allclose(events.table["DETX"][0], -1.15531813, rtol=1e-5)
+
+    # Check that det coordinates are within sqrt(2) * width of dataset
+    assert np.all(events.table["DETX"] < 3.53)
+    assert np.all(events.table["DETX"] > -3.53)
+
     assert events.table["DETX"].unit == "deg"
 
-    assert_allclose(events.table["DETY"][0], -1.3343611, rtol=1e-5)
+    assert np.all(events.table["DETY"] < 3.53)
+    assert np.all(events.table["DETY"] > -3.53)
+
     assert events.table["DETY"].unit == "deg"
 
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -486,15 +486,17 @@ def test_mde_run(dataset, models):
 
     events_bkg = sampler.run(dataset=dataset_bkg, observation=obs)
 
-    assert len(events.table) == 99
-    assert_allclose(events.table["ENERGY"][0], 4.406880, rtol=1e-5)
-    assert_allclose(events.table["RA"][0], 265.0677009, rtol=1e-5)
-    assert_allclose(events.table["DEC"][0], -30.2640157, rtol=1e-5)
+    #    assert len(events.table) == 99
+    assert_allclose(np.mean(events.table["ENERGY"]), 3.5, atol=1.0)
+    assert np.all(events.table["ENERGY"] > 1)
+
+    src_events = events.select_parameter("MC_ID", [0.5, 1.5])
+    assert_allclose(np.mean(src_events.table["RA"]), 266.40, atol=0.1)
+    assert_allclose(np.mean(src_events.table["DEC"]), -28.93, atol=0.1)
+    separation = src_events.radec.separation(models[0].spatial_model.position)
+    assert np.all(separation.to_value("deg") < 0.7)
 
     assert len(events_bkg.table) == 21
-    assert_allclose(events_bkg.table["ENERGY"][0], 1.5462581456, rtol=1e-5)
-    assert_allclose(events_bkg.table["RA"][0], 265.77338329, rtol=1e-5)
-    assert_allclose(events_bkg.table["DEC"][0], -30.701417442, rtol=1e-5)
     assert_allclose(events_bkg.table["MC_ID"][0], 0, rtol=1e-5)
 
     meta = events.table.meta


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies a number of tests in datasets/tests/test_simulate.py . Because the random generator is completely not stable from version to version of numpy, the tests that check a specific value of a sampled event quantities (e.g. energy or position) can fail. This PR modifies the failing tests to measure mean values or min and max values of the quantities. 

It should help solve #4709 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
