### PR TITLE
Exposing NormSpectralModels

### DIFF
--- a/examples/models/spectral/plot_exp_cutoff_powerlaw_norm_spectral.py
+++ b/examples/models/spectral/plot_exp_cutoff_powerlaw_norm_spectral.py
@@ -1,0 +1,46 @@
+r"""
+.. _exp-cutoff-powerlaw-norm-spectral-model:
+
+Exponential cutoff power law norm spectral model
+========================
+
+This model parametrises a cutoff power law spectral correction with a norm parameter.
+
+"""
+
+# %%
+# Example plot
+# ------------
+# Here is an example plot of the model:
+
+from astropy import units as u
+import matplotlib.pyplot as plt
+from gammapy.modeling.models import (
+    ExpCutoffPowerLawNormSpectralModel,
+    ExpCutoffPowerLawSpectralModel,
+    Models,
+    SkyModel,
+)
+
+energy_bounds = [0.1, 100] * u.TeV
+
+model = ExpCutoffPowerLawSpectralModel()
+norm = ExpCutoffPowerLawNormSpectralModel(
+    norm=2,
+    reference=1 * u.TeV,
+)
+ecpl_norm = model * norm
+model.plot(energy_bounds, label="Cutoff PowerLaw")
+ecpl_norm.plot(energy_bounds, label="Cutoff PowerLaw with a norm correction")
+plt.legend(loc="best")
+plt.grid(which="both")
+
+# %%
+# YAML representation
+# -------------------
+# Here is an example YAML file using the model:
+
+model = SkyModel(spectral_model=ecpl_norm, name="exp-cutoff-power-law-norm-model")
+models = Models([model])
+
+print(models.to_yaml())

--- a/examples/models/spectral/plot_logparabola_norm_spectral.py
+++ b/examples/models/spectral/plot_logparabola_norm_spectral.py
@@ -1,0 +1,46 @@
+r"""
+.. _logparabola-spectral-norm-model:
+
+Log parabola spectral norm model
+===========================
+
+This model parametrises a log parabola spectral correction with a norm parameter.
+
+"""
+
+# %%
+# Example plot
+# ------------
+# Here is an example plot of the model:
+
+from astropy import units as u
+import matplotlib.pyplot as plt
+from gammapy.modeling.models import (
+    LogParabolaNormSpectralModel,
+    LogParabolaSpectralModel,
+    Models,
+    SkyModel,
+)
+
+energy_bounds = [0.1, 100] * u.TeV
+
+model = LogParabolaSpectralModel()
+norm = LogParabolaNormSpectralModel(
+    norm=1.5,
+    reference=1 * u.TeV,
+)
+lp_norm = model * norm
+model.plot(energy_bounds, label="LogParabola")
+lp_norm.plot(energy_bounds, label="LogParabola with a norm correction")
+plt.legend(loc="best")
+plt.grid(which="both")
+
+# %%
+# YAML representation
+# -------------------
+# Here is an example YAML file using the model:
+
+model = SkyModel(spectral_model=lp_norm, name="log-parabola-norm-model")
+models = Models([model])
+
+print(models.to_yaml())

--- a/examples/models/spectral/plot_powerlaw_norm_spectral.py
+++ b/examples/models/spectral/plot_powerlaw_norm_spectral.py
@@ -1,0 +1,46 @@
+r"""
+.. _powerlaw-spectral-norm-model:
+
+Power law norm spectral model
+========================
+
+This model parametrises a power law spectral correction with a norm and tilt parameter.
+
+"""
+
+# %%
+# Example plot
+# ------------
+# Here is an example plot of the model:
+
+from astropy import units as u
+import matplotlib.pyplot as plt
+from gammapy.modeling.models import (
+    Models,
+    PowerLawNormSpectralModel,
+    PowerLawSpectralModel,
+    SkyModel,
+)
+
+energy_bounds = [0.1, 100] * u.TeV
+
+model = PowerLawSpectralModel()
+norm = PowerLawNormSpectralModel(
+    norm=5,
+    reference=1 * u.TeV,
+)
+pwl_norm = model * norm
+model.plot(energy_bounds, label="PowerLaw")
+pwl_norm.plot(energy_bounds, label="PowerLaw with a norm correction")
+plt.legend(loc="best")
+plt.grid(which="both")
+
+# %%
+# YAML representation
+# -------------------
+# Here is an example YAML file using the model:
+
+model = SkyModel(spectral_model=pwl_norm, name="power-law-norm-model")
+models = Models([model])
+
+print(models.to_yaml())


### PR DESCRIPTION
This PR is to fix issue [#4515](https://github.com/gammapy/gammapy/issues/4515)
I have implemented three new scripts to expose the `NormSpectralModels` in the Model Gallery

**Dear reviewer**
I have been thinking about this a bit, although this solves issue #4515, I would like some further discussion. Do we really want to expose them in this manner?
For example, we wouldn't typically add the `PowerLawNormSpectralModel` to a `PowerLawSpectralModel`. One very obvious use case is adding the `ExpCutoffPowerLawNormSpectralModel` to a `PowerLawSpectralModel`. Or creating a `TemplateSpectralModel` and then applying the `NormSpectralModel`. 
Therefore, I think it is a good idea to discuss further the use cases of these `NormSpectralModels`, and therefore the best way to expose them in the model gallery.