### PR TITLE
Fix get_overlap_fraction for different energies

### DIFF
--- a/gammapy/irf/edisp/map.py
+++ b/gammapy/irf/edisp/map.py
@@ -17,7 +17,7 @@ def get_overlap_fraction(energy_axis, energy_axis_true):
 
     xmin = np.fmin(a_max, b_max)
     xmax = np.fmax(a_min, b_min)
-    return np.clip(xmin - xmax, 0, np.inf) / (b_max - b_min)
+    return (np.clip(xmin - xmax, 0, np.inf) / (b_max - b_min)).to("")
 
 
 class EDispMap(IRFMap):

--- a/gammapy/irf/edisp/tests/test_kernel.py
+++ b/gammapy/irf/edisp/tests/test_kernel.py
@@ -35,6 +35,12 @@ class TestEDispKernel:
 
         assert_equal(edisp.pdf_matrix, expected)
 
+        # Test with different energy units
+        energy_axis = MapAxis.from_energy_edges([2000, 4000, 6000] * u.GeV)
+        edisp = EDispKernel.from_diagonal_response(energy_axis_true, energy_axis)
+        assert edisp.pdf_matrix.shape == (4, 2)
+        assert_allclose(edisp.pdf_matrix, expected, atol=1e-5)
+
         # Test square matrix
         edisp = EDispKernel.from_diagonal_response(energy_axis_true)
         assert_allclose(edisp.axes["energy"].edges, edisp.axes["energy_true"].edges)

--- a/gammapy/irf/edisp/tests/test_map.py
+++ b/gammapy/irf/edisp/tests/test_map.py
@@ -224,7 +224,7 @@ def test_edisp_kernel_map_stack():
     assert_allclose(exposure, 3.0)
 
 
-def test__incorrect_edisp_kernel_map_stack():
+def test_incorrect_edisp_kernel_map_stack():
     energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=5)
 
     energy_axis_true = MapAxis.from_energy_bounds(


### PR DESCRIPTION
This PR resolves issue [#4702](https://github.com/gammapy/gammapy/issues/4702)
Namely, it allows different units for the `energy_true_axis` and `energy_axis` to be defined and still achieve the correct result. 

I added to the `test_kernel.py` to test this behaviour.

(Side note: I just fixed a typo in another test function too)