### PR TITLE
Introduce a function to compute the point-to-point fractional variance

### DIFF
--- a/gammapy/estimators/tests/test_utils.py
+++ b/gammapy/estimators/tests/test_utils.py
@@ -181,4 +181,3 @@ def test_compute_lightcurve_fpp():
 
     assert_allclose(ffpp, [[[0.99373035]], [[0.53551551]]])
     assert_allclose(ffpp_err, [[[0.07930673]], [[0.07397653]]])
-

--- a/gammapy/estimators/tests/test_utils.py
+++ b/gammapy/estimators/tests/test_utils.py
@@ -9,6 +9,7 @@ from astropy.time import Time
 from gammapy.datasets import MapDataset
 from gammapy.estimators import ExcessMapEstimator, FluxPoints
 from gammapy.estimators.utils import (
+    compute_lightcurve_dtime,
     compute_lightcurve_fpp,
     compute_lightcurve_fvar,
     find_peaks,
@@ -181,3 +182,15 @@ def test_compute_lightcurve_fpp():
 
     assert_allclose(ffpp, [[[0.99373035]], [[0.53551551]]])
     assert_allclose(ffpp_err, [[[0.07930673]], [[0.07397653]]])
+
+
+def test_compute_lightcurve_dtime():
+
+    lightcurve = lc()
+
+    dtime = compute_lightcurve_dtime(lightcurve)
+    ddtime = dtime["doubling_time"].quantity
+    ddtime_err = dtime["dtime_err"].quantity
+
+    assert_allclose(ddtime, [[[245305.49]], [[481572.59]]] * u.s)
+    assert_allclose(ddtime_err, [[[45999.766]], [[11935.665]]] * u.s)

--- a/gammapy/estimators/tests/test_utils.py
+++ b/gammapy/estimators/tests/test_utils.py
@@ -2,18 +2,18 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.table import Column, Table
-from astropy.time import Time
-from gammapy.estimators import FluxPoints
 import astropy.units as u
 from astropy.coordinates import SkyCoord
+from astropy.table import Column, Table
+from astropy.time import Time
 from gammapy.datasets import MapDataset
-from gammapy.estimators import ExcessMapEstimator
+from gammapy.estimators import ExcessMapEstimator, FluxPoints
 from gammapy.estimators.utils import (
+    compute_lightcurve_fpp,
+    compute_lightcurve_fvar,
     find_peaks,
     find_peaks_in_flux_map,
     resample_energy_edges,
-    compute_lightcurve_fvar,
 )
 from gammapy.maps import Map, MapAxis
 from gammapy.utils.testing import requires_data
@@ -169,3 +169,15 @@ def test_compute_lightcurve_fvar():
 
     assert_allclose(ffvar, [[[0.698212]], [[0.37150576]]])
     assert_allclose(ffvar_err, [[[0.0795621]], [[0.074706]]])
+
+
+def test_compute_lightcurve_fpp():
+
+    lightcurve = lc()
+
+    fpp = compute_lightcurve_fpp(lightcurve)
+    ffpp = fpp["fpp"].quantity
+    ffpp_err = fpp["fpp_err"].quantity
+
+    assert_allclose(ffpp, [[[0.99373035]], [[0.53551551]]])
+    assert_allclose(ffpp_err, [[[0.07930673]], [[0.07397653]]])

--- a/gammapy/estimators/tests/test_utils.py
+++ b/gammapy/estimators/tests/test_utils.py
@@ -9,7 +9,6 @@ from astropy.time import Time
 from gammapy.datasets import MapDataset
 from gammapy.estimators import ExcessMapEstimator, FluxPoints
 from gammapy.estimators.utils import (
-    compute_lightcurve_dtime,
     compute_lightcurve_fpp,
     compute_lightcurve_fvar,
     find_peaks,
@@ -183,14 +182,3 @@ def test_compute_lightcurve_fpp():
     assert_allclose(ffpp, [[[0.99373035]], [[0.53551551]]])
     assert_allclose(ffpp_err, [[[0.07930673]], [[0.07397653]]])
 
-
-def test_compute_lightcurve_dtime():
-
-    lightcurve = lc()
-
-    dtime = compute_lightcurve_dtime(lightcurve)
-    ddtime = dtime["doubling_time"].quantity
-    ddtime_err = dtime["dtime_err"].quantity
-
-    assert_allclose(ddtime, [[[245305.49]], [[481572.59]]] * u.s)
-    assert_allclose(ddtime_err, [[[45999.766]], [[11935.665]]] * u.s)

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -357,7 +357,7 @@ def compute_lightcurve_fpp(lightcurve, flux_quantity="flux"):
 
     Parameters
     ----------
-    lightcurve : '~gammapy.estimators.FluxPoints'
+    lightcurve : `~gammapy.estimators.FluxPoints`
         the lightcurve object
     flux_quantity : str
         flux quantity to use for calculation. Should be 'dnde', 'flux', 'e2dnde' or 'eflux'. Default is 'flux'.

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -382,9 +382,7 @@ def compute_lightcurve_fpp(lightcurve, flux_quantity="flux"):
     table = Table(
         [energies[:-1], energies[1:], fpp, fpp_err, significance],
         names=("min_energy", "max_energy", "fpp", "fpp_err", "significance"),
-        meta=lightcurve.meta,
+        meta=dict(quantity=flux_quantity),
     )
-
-    table.meta["flux_quantity"] = flux_quantity
 
     return table

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -386,4 +386,3 @@ def compute_lightcurve_fpp(lightcurve, flux_quantity="flux"):
     )
 
     return table
-

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -12,7 +12,7 @@ from gammapy.modeling.models import (
     PowerLawSpectralModel,
     SkyModel,
 )
-from gammapy.stats import compute_dtime, compute_fpp, compute_fvar
+from gammapy.stats import compute_fpp, compute_fvar
 from .map.core import FluxMaps
 
 __all__ = [
@@ -21,7 +21,6 @@ __all__ = [
     "resample_energy_edges",
     "compute_lightcurve_fvar",
     "compute_lightcurve_fpp",
-    "compute_lightcurve_dtime",
     "find_peaks_in_flux_map",
 ]
 
@@ -388,54 +387,3 @@ def compute_lightcurve_fpp(lightcurve, flux_quantity="flux"):
 
     return table
 
-
-def compute_lightcurve_dtime(lightcurve, flux_quantity="flux"):
-    r"""Compute the doubling time of the input lightcurve.
-
-    Internally calls the `~gammapy.stats.compute_dtime` function
-
-
-    Parameters
-    ----------
-    lightcurve : '~gammapy.estimators.FluxPoints'
-        the lightcurve object
-    flux_quantity : str
-        flux quantity to use for calculation. Should be 'dnde', 'flux', 'e2dnde' or 'eflux'. Default is 'flux'.
-        Useful in case of custom lightcurves computed outside gammapy
-
-    Returns
-    -------
-    table : `~astropy.table.Table`
-        Table of doubling times and associated error for each energy bin of the lightcurve.
-    """
-
-    flux = getattr(lightcurve, flux_quantity)
-    flux_err = getattr(lightcurve, flux_quantity + "_err")
-    time = lightcurve.geom.axes["time"].center
-
-    time_id = flux.geom.axes.index_data("time")
-
-    dtime, dtime_err = compute_dtime(flux.data, flux_err.data, time, axis=time_id)
-
-    energies = lightcurve.geom.axes["energy"].edges
-    table = Table(
-        [
-            energies[:-1],
-            energies[1:],
-            dtime.T[0],
-            dtime_err.T[0],
-            np.abs(dtime.T[1]),
-            dtime_err.T[1],
-        ],
-        names=(
-            "min_energy",
-            "max_energy",
-            "doubling_time",
-            "dtime_err",
-            "halving_time",
-            "htime_err",
-        ),
-        meta=lightcurve.meta,
-    )
-
-    return table

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -419,8 +419,22 @@ def compute_lightcurve_dtime(lightcurve, flux_quantity="flux"):
 
     energies = lightcurve.geom.axes["energy"].edges
     table = Table(
-        [energies[:-1], energies[1:], dtime, dtime_err],
-        names=("min_energy", "max_energy", "dtime", "dtime_err"),
+        [
+            energies[:-1],
+            energies[1:],
+            dtime.T[0],
+            dtime_err.T[0],
+            np.abs(dtime.T[1]),
+            dtime_err.T[1],
+        ],
+        names=(
+            "min_energy",
+            "max_energy",
+            "doubling_time",
+            "dtime_err",
+            "halving_time",
+            "htime_err",
+        ),
         meta=lightcurve.meta,
     )
 

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -385,4 +385,6 @@ def compute_lightcurve_fpp(lightcurve, flux_quantity="flux"):
         meta=lightcurve.meta,
     )
 
+    table.meta["flux_quantity"] = flux_quantity
+
     return table

--- a/gammapy/stats/__init__.py
+++ b/gammapy/stats/__init__.py
@@ -2,16 +2,12 @@
 """Statistics."""
 from .counts_statistic import CashCountsStatistic, WStatCountsStatistic
 from .fit_statistics import cash, cstat, get_wstat_gof_terms, get_wstat_mu_bkg, wstat
-from .variability import (
-    compute_fvar,
-    compute_chisq,
-)
-
 from .fit_statistics_cython import (
     cash_sum_cython,
     f_cash_root_cython,
     norm_bounds_cython,
 )
+from .variability import compute_chisq, compute_dtime, compute_fpp, compute_fvar
 
 __all__ = [
     "cash",
@@ -25,5 +21,7 @@ __all__ = [
     "wstat",
     "WStatCountsStatistic",
     "compute_fvar",
+    "compute_fpp",
+    "compute_dtime",
     "compute_chisq",
 ]

--- a/gammapy/stats/__init__.py
+++ b/gammapy/stats/__init__.py
@@ -7,7 +7,7 @@ from .fit_statistics_cython import (
     f_cash_root_cython,
     norm_bounds_cython,
 )
-from .variability import compute_chisq, compute_dtime, compute_fpp, compute_fvar
+from .variability import compute_chisq, compute_fpp, compute_fvar
 
 __all__ = [
     "cash",
@@ -22,6 +22,5 @@ __all__ = [
     "WStatCountsStatistic",
     "compute_fvar",
     "compute_fpp",
-    "compute_dtime",
     "compute_chisq",
 ]

--- a/gammapy/stats/tests/test_variability.py
+++ b/gammapy/stats/tests/test_variability.py
@@ -79,12 +79,18 @@ def test_lightcurve_fpp():
     flux = np.array([[1e-11, 4e-12], [3e-11, np.nan], [1e-11, 1e-12]])
     flux_err = np.array([[0.1e-11, 0.4e-12], [0.3e-11, np.nan], [0.1e-11, 0.1e-12]])
 
-    time_id = 0
-
-    fpp, fpp_err = compute_fpp(flux, flux_err, axis=time_id)
+    fpp, fpp_err = compute_fpp(flux, flux_err)
 
     assert_allclose(fpp, [1.19448734, 0.11661904])
     assert_allclose(fpp_err, [0.06648574, 0.10099505])
+
+    flux_1d = np.array([1e-11, 3e-11, 1e-11])
+    flux_err_1d = np.array([0.1e-11, 0.3e-11, 0.1e-11])
+
+    fpp_1d, fpp_err_1d = compute_fpp(flux_1d, flux_err_1d)
+
+    assert_allclose(fpp_1d, [1.19448734])
+    assert_allclose(fpp_err_1d, [0.06648574])
 
 
 def test_lightcurve_chisq(lc_table):

--- a/gammapy/stats/tests/test_variability.py
+++ b/gammapy/stats/tests/test_variability.py
@@ -2,10 +2,16 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+import astropy.units as u
 from astropy.table import Column, Table
 from astropy.time import Time
 from gammapy.estimators import FluxPoints
-from gammapy.stats.variability import compute_chisq, compute_fpp, compute_fvar
+from gammapy.stats.variability import (
+    compute_chisq,
+    compute_dtime,
+    compute_fpp,
+    compute_fvar,
+)
 from gammapy.utils.testing import assert_quantity_allclose
 
 
@@ -85,6 +91,45 @@ def test_lightcurve_fpp():
 
     assert_allclose(fpp, [1.19448734, 0.11661904])
     assert_allclose(fpp_err, [0.06648574, 0.10099505])
+
+
+def test_lightcurve_dtime():
+
+    flux = np.array(
+        [
+            [1e-11, 4e-12],
+            [3e-11, np.nan],
+            [1e-11, 1e-12],
+            [0.8e-11, 0.8e-12],
+            [1e-11, 1e-12],
+        ]
+    )
+    flux_err = np.array(
+        [
+            [0.1e-11, 0.4e-12],
+            [0.3e-11, np.nan],
+            [0.1e-11, 0.1e-12],
+            [0.08e-11, 0.8e-12],
+            [0.1e-11, 0.1e-12],
+        ]
+    )
+    time = (
+        np.array(
+            [6.31157019e08, 6.31160619e08, 6.31164219e08, 6.31171419e08, 6.31178419e08]
+        )
+        * u.s
+    )
+    time_id = 0
+
+    dtime, dtime_err = compute_dtime(flux, flux_err, time, axis=time_id)
+
+    assert_allclose(
+        dtime,
+        [[2271.34711286, -2271.34711286], [21743.98603654, -22365.24278044]] * u.s,
+    )
+    assert_allclose(
+        dtime_err, [[425.92375713, 425.92375713], [242.80234065, 249.73955038]] * u.s
+    )
 
 
 def test_lightcurve_chisq(lc_table):

--- a/gammapy/stats/tests/test_variability.py
+++ b/gammapy/stats/tests/test_variability.py
@@ -2,15 +2,10 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-import astropy.units as u
 from astropy.table import Column, Table
 from astropy.time import Time
 from gammapy.estimators import FluxPoints
-from gammapy.stats.variability import (
-    compute_chisq,
-    compute_fpp,
-    compute_fvar,
-)
+from gammapy.stats.variability import compute_chisq, compute_fpp, compute_fvar
 from gammapy.utils.testing import assert_quantity_allclose
 
 

--- a/gammapy/stats/tests/test_variability.py
+++ b/gammapy/stats/tests/test_variability.py
@@ -8,7 +8,6 @@ from astropy.time import Time
 from gammapy.estimators import FluxPoints
 from gammapy.stats.variability import (
     compute_chisq,
-    compute_dtime,
     compute_fpp,
     compute_fvar,
 )
@@ -91,45 +90,6 @@ def test_lightcurve_fpp():
 
     assert_allclose(fpp, [1.19448734, 0.11661904])
     assert_allclose(fpp_err, [0.06648574, 0.10099505])
-
-
-def test_lightcurve_dtime():
-
-    flux = np.array(
-        [
-            [1e-11, 4e-12],
-            [3e-11, np.nan],
-            [1e-11, 1e-12],
-            [0.8e-11, 0.8e-12],
-            [1e-11, 1e-12],
-        ]
-    )
-    flux_err = np.array(
-        [
-            [0.1e-11, 0.4e-12],
-            [0.3e-11, np.nan],
-            [0.1e-11, 0.1e-12],
-            [0.08e-11, 0.8e-12],
-            [0.1e-11, 0.1e-12],
-        ]
-    )
-    time = (
-        np.array(
-            [6.31157019e08, 6.31160619e08, 6.31164219e08, 6.31171419e08, 6.31178419e08]
-        )
-        * u.s
-    )
-    time_id = 0
-
-    dtime, dtime_err = compute_dtime(flux, flux_err, time, axis=time_id)
-
-    assert_allclose(
-        dtime,
-        [[2271.34711286, -2271.34711286], [21743.98603654, -22365.24278044]] * u.s,
-    )
-    assert_allclose(
-        dtime_err, [[425.92375713, 425.92375713], [242.80234065, 249.73955038]] * u.s
-    )
 
 
 def test_lightcurve_chisq(lc_table):

--- a/gammapy/stats/tests/test_variability.py
+++ b/gammapy/stats/tests/test_variability.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 from astropy.table import Column, Table
 from astropy.time import Time
 from gammapy.estimators import FluxPoints
-from gammapy.stats.variability import compute_chisq, compute_fvar
+from gammapy.stats.variability import compute_chisq, compute_fpp, compute_fvar
 from gammapy.utils.testing import assert_quantity_allclose
 
 
@@ -72,6 +72,19 @@ def test_lightcurve_fvar():
 
     assert_allclose(fvar, [0.68322763, 0.84047606])
     assert_allclose(fvar_err, [0.06679978, 0.08285806])
+
+
+def test_lightcurve_fpp():
+
+    flux = np.array([[1e-11, 4e-12], [3e-11, np.nan], [1e-11, 1e-12]])
+    flux_err = np.array([[0.1e-11, 0.4e-12], [0.3e-11, np.nan], [0.1e-11, 0.1e-12]])
+
+    time_id = 0
+
+    fpp, fpp_err = compute_fpp(flux, flux_err, axis=time_id)
+
+    assert_allclose(fpp, [1.19448734, 0.11661904])
+    assert_allclose(fpp_err, [0.06648574, 0.10099505])
 
 
 def test_lightcurve_chisq(lc_table):

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -70,12 +70,12 @@ def compute_fpp(flux, flux_err, axis=0):
     from the lightcurve data.
 
     F_pp is a quantity strongly related to the fractional excess variance F_var
-    implemented in ~gammapy.stats.compute_fvar; F_pp probes the variability
+    implemented in `~gammapy.stats.compute_fvar`; F_pp probes the variability
     on a shorter timescale.
 
     For white noise, F_pp and F_var give the same value.
     However, for red noise, F_var will be larger
-    than F_pp, as the variations will be larger on longer timescales
+    than F_pp, as the variations will be larger on longer timescales.
 
     It is important to note that the errors on the flux must be Gaussian.
 

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 import scipy.stats as stats
-import astropy.units as u
 
 __all__ = [
     "compute_fvar",
@@ -70,14 +69,15 @@ def compute_fpp(flux, flux_err, axis=0):
     This method accesses the ``FLUX`` and ``FLUX_ERR`` columns
     from the lightcurve data.
 
-    F_pp is a quantity strongly related to F_var, probing the variability
-    in a shorter timescale.
+    F_pp is a quantity strongly related to the fractional excess variance F_var
+    implemented in ~gammapy.stats.compute_fvar; F_pp probes the variability
+    on a shorter timescale.
 
     For white noise, F_pp and F_var give the same value.
     However, for red noise, F_var will be larger
     than F_pp, as the variations will be larger on longer timescales
 
-    It is important to note that the errors on the flux must be gaussian.
+    It is important to note that the errors on the flux must be Gaussian.
 
     Parameters
     ----------
@@ -140,4 +140,3 @@ def compute_chisq(flux):
     yobs = flux.data
     chi2, pval = stats.chisquare(yobs, yexp)
     return chi2, pval
-

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -66,9 +66,6 @@ def compute_fvar(flux, flux_err, axis=0):
 def compute_fpp(flux, flux_err, axis=0):
     r"""Calculate the point-to-point excess variance.
 
-    This method accesses the ``FLUX`` and ``FLUX_ERR`` columns
-    from the lightcurve data.
-
     F_pp is a quantity strongly related to the fractional excess variance F_var
     implemented in `~gammapy.stats.compute_fvar`; F_pp probes the variability
     on a shorter timescale.
@@ -98,13 +95,13 @@ def compute_fpp(flux, flux_err, axis=0):
     ----------
     .. [Edelson2002] "X-Ray Spectral Variability and Rapid Variability
        of the Soft X-Ray Spectrum Seyfert 1 Galaxies
-       Arakelian 564 and Ton S180", Edelson et al. (2002)
+       Arakelian 564 and Ton S180", Edelson et al. (2002), equation 3,
        https://iopscience.iop.org/article/10.1086/323779
     """
 
     flux_mean = np.nanmean(flux, axis=axis)
     n_points = np.count_nonzero(~np.isnan(flux), axis=axis)
-    flux = np.atleast_2d(flux).swapaxes(0, axis).T
+    flux = flux.swapaxes(0, axis).T
 
     s_square = np.nansum((flux[..., 1:] - flux[..., :-1]) ** 2, axis=-1) / (
         n_points.T - 1

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -198,8 +198,16 @@ def compute_dtime(flux, flux_err, time, axis=0):
         (flux_err[..., 1:] * times_err_1) ** 2 + (flux_err[..., :-1] * times_err_2) ** 2
     )
 
-    imin = np.argmin(np.where(times > 0, times, 1e15 * u.s), axis=-1, keepdims=True)
-    imax = np.argmax(np.where(times < 0, times, -1e15 * u.s), axis=-1, keepdims=True)
+    imin = np.argmin(
+        np.where(np.logical_and(np.isfinite(times), times > 0), times, 1e15 * u.s),
+        axis=-1,
+        keepdims=True,
+    )
+    imax = np.argmax(
+        np.where(np.logical_and(np.isfinite(times), times < 0), times, -1e15 * u.s),
+        axis=-1,
+        keepdims=True,
+    )
     index = np.concatenate([imin, imax], axis=-1)
 
     dtime = np.take_along_axis(times, index, axis=-1)

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -1,9 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 import scipy.stats as stats
+import astropy.units as u
 
 __all__ = [
     "compute_fvar",
+    "compute_fpp",
+    "compute_dtime",
     "compute_chisq",
 ]
 
@@ -62,6 +65,62 @@ def compute_fvar(flux, flux_err, axis=0):
     return fvar, fvar_err
 
 
+def compute_fpp(flux, flux_err, axis=0):
+    r"""Calculate the point-to-point excess variance.
+
+    This method accesses the ``FLUX`` and ``FLUX_ERR`` columns
+    from the lightcurve data.
+
+    F_pp is a quantity strongly related to F_var, probing the variability
+    in a shorter timescale.
+
+    For white noise, F_pp and F_var give the same value.
+    However, for red noise, F_var will be larger
+    than F_pp, as the variations will be larger on longer timescales
+
+    It is important to note that the errors on the flux must be gaussian.
+
+    Parameters
+    ----------
+    flux : `~astropy.units.Quantity`
+        the measured fluxes
+    flux_err : `~astropy.units.Quantity`
+        the error on measured fluxes
+    axis : int, optional
+        Axis along which the excess variance is computed.
+        The default is to compute the value on axis 0.
+
+    Returns
+    -------
+    fpp, fpp_err : `~numpy.ndarray`
+        Point-to-point excess variance.
+
+    References
+    ----------
+    .. [Edelson2002] "X-Ray Spectral Variability and Rapid Variability
+       of the Soft X-Ray Spectrum Seyfert 1 Galaxies
+       Arakelian 564 and Ton S180", Edelson et al. (2002)
+       https://iopscience.iop.org/article/10.1086/323779
+    """
+
+    flux_mean = np.nanmean(flux, axis=axis)
+    n_points = np.count_nonzero(~np.isnan(flux), axis=axis)
+    flux = np.atleast_2d(flux).swapaxes(0, axis).T
+
+    s_square = np.nansum((flux[..., 1:] - flux[..., :-1]) ** 2, axis=-1) / (
+        n_points.T - 1
+    )
+    sig_square = np.nansum(flux_err**2, axis=axis) / n_points
+    fpp = np.sqrt(np.abs(s_square.T - sig_square)) / flux_mean
+
+    sigxserr_a = np.sqrt(2 / n_points) * sig_square / flux_mean**2
+    sigxserr_b = np.sqrt(sig_square / n_points) * (2 * fpp / flux_mean)
+    sigxserr = np.sqrt(sigxserr_a**2 + sigxserr_b**2)
+    fpp_err = sigxserr / (2 * fpp)
+
+    return fpp, fpp_err
+
+
 def compute_chisq(flux):
     r"""Calculate the chi-square test for `LightCurve`.
 
@@ -82,3 +141,68 @@ def compute_chisq(flux):
     yobs = flux.data
     chi2, pval = stats.chisquare(yobs, yexp)
     return chi2, pval
+
+
+def compute_dtime(flux, flux_err, time, axis=0):
+    r"""Calculate the characteristic doubling time for a series of measurements.
+
+    The characteristic doubling time  is estimated to obtain the
+    minimum variability timescale for the light curves in which
+    rapid variations are clearly evident: for example it is useful in AGN flaring episodes.
+
+    This quantity, especially for AGN flares, is often expressed
+    as the pair of doubling time and halving time, or the minimum characteristic time
+    for the rising and falling components respectively.
+
+    Parameters
+    ----------
+    flux : `~astropy.units.Quantity`
+        the measured fluxes
+    flux_err : `~astropy.units.Quantity`
+        the error on measured fluxes
+    time: `~astropy.units.Quantity`
+        the times at which the fluxes are measured
+    axis : int, optional
+        Axis along which the value is computed.
+        The default is to compute the value on axis 0.
+
+    Returns
+    -------
+    dtime, dtime_err : `~numpy.ndarray`
+        Characteristic doubling time, halving time and errors.
+
+    References
+    ----------
+    ..[Brown2013] "Locating the γ-ray emission region
+    of the flat spectrum radio quasar PKS 1510−089", Brown et al. (2013)
+    https://academic.oup.com/mnras/article/431/1/824/1054498
+    """
+
+    flux = np.atleast_2d(flux).swapaxes(0, axis).T
+    flux_err = np.atleast_2d(flux_err).swapaxes(0, axis).T
+
+    times = (time[1:] - time[:-1]) / np.log2(flux[..., 1:] / flux[..., :-1])
+    times_err_1 = (
+        (time[1:] - time[:-1])
+        * np.log(2)
+        / flux[..., 1:]
+        * np.log(flux[..., 1:] / flux[..., :-1]) ** 2
+    )
+    times_err_2 = (
+        (time[1:] - time[:-1])
+        * np.log(2)
+        / flux[..., :-1]
+        * np.log(flux[..., 1:] / flux[..., :-1]) ** 2
+    )
+    times_err = np.sqrt(
+        (flux_err[..., 1:] * times_err_1) ** 2 + (flux_err[..., :-1] * times_err_2) ** 2
+    )
+
+    imin = np.argmin(np.where(times > 0, times, 1e15 * u.s), axis=-1, keepdims=True)
+    imax = np.argmax(np.where(times < 0, times, -1e15 * u.s), axis=-1, keepdims=True)
+    index = np.concatenate([imin, imax], axis=-1)
+
+    dtime = np.take_along_axis(times, index, axis=-1)
+    dtime_err = np.take_along_axis(times_err, index, axis=-1)
+
+    return dtime, dtime_err


### PR DESCRIPTION
After the merging of pr #4501 I wrote a parallel script providing the computation for the point-to-point fractional variation, another estimator of temporal variability, very similar to the excess fractional variation but quite different in code implementation. 

This PR includes the code for the computation of the variable itself in `stats/variability.py`, as well as a wrapper in `estimators/utils.py`, each with its test.