### PR TITLE
Fixed offset calculation in Background2D.to_3d

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -255,7 +255,9 @@ class Background2D(BackgroundIRF):
 
         axes = MapAxes([self.axes["energy"], fov_lon, fov_lat])
         coords = axes.get_coord()
-        offset = angular_separation(0*u.rad, 0*u.rad, coords["fov_lon"], coords["fov_lat"])
+        offset = angular_separation(
+            0 * u.rad, 0 * u.rad, coords["fov_lon"], coords["fov_lat"]
+        )```
         data = self.evaluate(offset=offset, energy=coords["energy"])
 
         return Background3D(

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -2,6 +2,7 @@
 import logging
 import numpy as np
 import astropy.units as u
+from astropy.coordinates import angular_separation
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
@@ -254,7 +255,7 @@ class Background2D(BackgroundIRF):
 
         axes = MapAxes([self.axes["energy"], fov_lon, fov_lat])
         coords = axes.get_coord()
-        offset = np.sqrt(coords["fov_lat"] ** 2 + coords["fov_lon"] ** 2)
+        offset = angular_separation(0, 0, coords["fov_lon"], coords["fov_lat"])
         data = self.evaluate(offset=offset, energy=coords["energy"])
 
         return Background3D(

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -255,7 +255,7 @@ class Background2D(BackgroundIRF):
 
         axes = MapAxes([self.axes["energy"], fov_lon, fov_lat])
         coords = axes.get_coord()
-        offset = angular_separation(0, 0, coords["fov_lon"], coords["fov_lat"])
+        offset = angular_separation(0*u.rad, 0*u.rad, coords["fov_lon"], coords["fov_lat"])
         data = self.evaluate(offset=offset, energy=coords["energy"])
 
         return Background3D(

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -257,7 +257,7 @@ class Background2D(BackgroundIRF):
         coords = axes.get_coord()
         offset = angular_separation(
             0 * u.rad, 0 * u.rad, coords["fov_lon"], coords["fov_lat"]
-        )```
+        )
         data = self.evaluate(offset=offset, energy=coords["energy"])
 
         return Background3D(


### PR DESCRIPTION
I tried to fix the bug presented in issue #4724 by @maxnoe 

Background2D.to_3d was using cartesian offset instead of angular separation. Implemented using `astropy.coordinates.angular_separation `