### PR TITLE
Change default index for  NormSpectralModel

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -3,6 +3,7 @@
 import logging
 import operator
 import os
+import warnings
 from pathlib import Path
 import numpy as np
 import scipy.optimize
@@ -16,6 +17,7 @@ import matplotlib.pyplot as plt
 from gammapy.maps import MapAxis, RegionNDMap
 from gammapy.maps.axes import UNIT_STRING_FORMAT
 from gammapy.modeling import Parameter, Parameters
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.integrate import trapz_loglog
 from gammapy.utils.interpolation import (
     ScaledRegularGridInterpolator,
@@ -1326,11 +1328,34 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
     """
     tag = ["ExpCutoffPowerLawNormSpectralModel", "ecpl-norm"]
 
-    index = Parameter("index", 0)
+    index = Parameter("index", 1.5)
     norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
     reference = Parameter("reference", "1 TeV", frozen=True)
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
     alpha = Parameter("alpha", "1.0", frozen=True)
+
+    def __init__(
+        self, index=None, norm=None, reference=None, lambda_=None, alpha=None, **kwargs
+    ):
+
+        if not index:
+            warnings.warn(
+                "The default index value changed from 1.5 to 0 since v1.0.1",
+                GammapyDeprecationWarning,
+            )
+
+        if norm is not None:
+            kwargs.update({"norm": norm})
+        if index is not None:
+            kwargs.update({"index": index})
+        if reference is not None:
+            kwargs.update({"reference": reference})
+        if lambda_ is not None:
+            kwargs.update({"lambda_": lambda_})
+        if alpha is not None:
+            kwargs.update({"alpha": alpha})
+
+        super().__init__(**kwargs)
 
     @staticmethod
     def evaluate(energy, index, norm, reference, lambda_, alpha):
@@ -1594,15 +1619,42 @@ class LogParabolaNormSpectralModel(SpectralModel):
     beta : `~astropy.units.Quantity`
         :math:`\beta`
 
-    See Also
+    See also
     --------
     LogParabolaSpectralModel
     """
+
     tag = ["LogParabolaNormSpectralModel", "lp-norm"]
+
     norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 0)
     beta = Parameter("beta", 0)
+
+    def __init__(self, norm=None, reference=None, alpha=None, beta=None, **kwargs):
+
+        if not alpha:
+            warnings.warn(
+                "The default alpha value changed from 2 to 0 since v1.0.1",
+                GammapyDeprecationWarning,
+            )
+
+        if not beta:
+            warnings.warn(
+                "The default beta value changed from 1 to 0 since v1.0.1",
+                GammapyDeprecationWarning,
+            )
+
+        if norm is not None:
+            kwargs.update({"norm": norm})
+        if beta is not None:
+            kwargs.update({"beta": beta})
+        if reference is not None:
+            kwargs.update({"reference": reference})
+        if alpha is not None:
+            kwargs.update({"alpha": alpha})
+
+        super().__init__(**kwargs)
 
     @classmethod
     def from_log10(cls, norm, reference, alpha, beta):

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1340,7 +1340,7 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
 
         if index is None:
             warnings.warn(
-                "The default index value changed from 1.5 to 0 since v1.0.1",
+                "The default index value changed from 1.5 to 0 since v1.2",
                 GammapyDeprecationWarning,
             )
 
@@ -1635,13 +1635,13 @@ class LogParabolaNormSpectralModel(SpectralModel):
 
         if alpha is None:
             warnings.warn(
-                "The default alpha value changed from 2 to 0 since v1.0.1",
+                "The default alpha value changed from 2 to 0 since v1.2",
                 GammapyDeprecationWarning,
             )
 
         if beta is None:
             warnings.warn(
-                "The default beta value changed from 1 to 0 since v1.0.1",
+                "The default beta value changed from 1 to 0 since v1.2",
                 GammapyDeprecationWarning,
             )
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1326,7 +1326,7 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
     """
     tag = ["ExpCutoffPowerLawNormSpectralModel", "ecpl-norm"]
 
-    index = Parameter("index", 1.5)
+    index = Parameter("index", 0)
     norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
     reference = Parameter("reference", "1 TeV", frozen=True)
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
@@ -1601,8 +1601,8 @@ class LogParabolaNormSpectralModel(SpectralModel):
     tag = ["LogParabolaNormSpectralModel", "lp-norm"]
     norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
     reference = Parameter("reference", "10 TeV", frozen=True)
-    alpha = Parameter("alpha", 2)
-    beta = Parameter("beta", 1)
+    alpha = Parameter("alpha", 0)
+    beta = Parameter("beta", 0)
 
     @classmethod
     def from_log10(cls, norm, reference, alpha, beta):

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1338,7 +1338,7 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
         self, index=None, norm=None, reference=None, lambda_=None, alpha=None, **kwargs
     ):
 
-        if not index:
+        if index is None:
             warnings.warn(
                 "The default index value changed from 1.5 to 0 since v1.0.1",
                 GammapyDeprecationWarning,
@@ -1633,13 +1633,13 @@ class LogParabolaNormSpectralModel(SpectralModel):
 
     def __init__(self, norm=None, reference=None, alpha=None, beta=None, **kwargs):
 
-        if not alpha:
+        if alpha is None:
             warnings.warn(
                 "The default alpha value changed from 2 to 0 since v1.0.1",
                 GammapyDeprecationWarning,
             )
 
-        if not beta:
+        if beta is None:
             warnings.warn(
                 "The default beta value changed from 1 to 0 since v1.0.1",
                 GammapyDeprecationWarning,

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -25,6 +25,7 @@ from gammapy.modeling.models import (
     SkyModel,
     TemplateNPredModel,
 )
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.scripts import read_yaml, write_yaml
 from gammapy.utils.testing import requires_data
 
@@ -315,13 +316,15 @@ def make_all_models():
     yield Model.create("PowerLawNormSpectralModel", "spectral")
     yield Model.create("PowerLaw2SpectralModel", "spectral")
     yield Model.create("ExpCutoffPowerLawSpectralModel", "spectral")
-    yield Model.create("ExpCutoffPowerLawNormSpectralModel", "spectral")
+    with pytest.warns(GammapyDeprecationWarning):
+        yield Model.create("ExpCutoffPowerLawNormSpectralModel", "spectral")
     yield Model.create("ExpCutoffPowerLaw3FGLSpectralModel", "spectral")
     yield Model.create("SuperExpCutoffPowerLaw3FGLSpectralModel", "spectral")
     yield Model.create("SuperExpCutoffPowerLaw4FGLDR3SpectralModel", "spectral")
     yield Model.create("SuperExpCutoffPowerLaw4FGLSpectralModel", "spectral")
     yield Model.create("LogParabolaSpectralModel", "spectral")
-    yield Model.create("LogParabolaNormSpectralModel", "spectral")
+    with pytest.warns(GammapyDeprecationWarning):
+        yield Model.create("LogParabolaNormSpectralModel", "spectral")
     yield Model.create(
         "TemplateSpectralModel", "spectral", energy=[1, 2] * u.cm, values=[3, 4] * u.cm
     )  # TODO: add unit validation?


### PR DESCRIPTION
This PR change to 0 the default index value of the `ExpCutoffPowerLawNormSpectralModel ` and `LogParabolaNormSpectralModel`  such as it match the default tilt value of the `PiecewiseNormSpectralModel`.
Do we need/have a deprecation message for that ?