### PR TITLE
Add Zhao profile

### DIFF
--- a/gammapy/astro/darkmatter/__init__.py
+++ b/gammapy/astro/darkmatter/__init__.py
@@ -1,5 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Dark matter spatial and spectral models."""
+from .profiles import (
+    BurkertProfile,
+    DMProfile,
+    EinastoProfile,
+    IsothermalProfile,
+    MooreProfile,
+    NFWProfile,
+    ZhaoProfile,
+)
 from .spectra import DarkMatterAnnihilationSpectralModel, PrimaryFlux
 from .utils import JFactory
 
@@ -7,4 +16,11 @@ __all__ = [
     "DarkMatterAnnihilationSpectralModel",
     "JFactory",
     "PrimaryFlux",
+    "BurkertProfile",
+    "DMProfile",
+    "EinastoProfile",
+    "IsothermalProfile",
+    "MooreProfile",
+    "NFWProfile",
+    "ZhaoProfile",
 ]

--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -21,7 +21,7 @@ class DMProfile(abc.ABC):
     """DMProfile model base class."""
 
     LOCAL_DENSITY = 0.3 * u.GeV / (u.cm**3)
-    """Local dark matter density as given in refenrece 2"""
+    """Local dark matter density as given in reference 2"""
     DISTANCE_GC = 8.33 * u.kpc
     """Distance to the Galactic Center as given in reference 2"""
 
@@ -91,9 +91,10 @@ class DMProfile(abc.ABC):
 class ZhaoProfile(DMProfile):
     r"""Zhao Profile.
     This is taken from equation 1 from Zhao (1996). It is a generalization of the NFW profile. The volume density is parametrized with
-    a double power-law. Scale radii smaller than the scale radiu are described with a slope of :math:`-\gamma` and scale radii larger than the scale radius are described with a slope of :math:`-\beta`. :math:`\alpha` is a measure for the width of the transition region.
+    a double power-law. Scale radii smaller than the scale radius are described with a slope of :math:`-\gamma` and scale radii larger than the scale radius are described with a slope of :math:`-\beta`. :math:`\alpha` is a measure for the width of the transition region.
+
     .. math::
-        \rho(r) = \rho_s \left(\frac{r_s}{r}\right)^\gamma \left(1 + \left(\frac{r}{r_s}\right)^\frac{1}{\alpha} \right)^{(\gamma - \beta) * \alpha}
+        \rho(r) = \rho_s \left(\frac{r_s}{r}\right)^\gamma \left(1 + \left(\frac{r}{r_s}\right)^\frac{1}{\alpha} \right)^{(\gamma - \beta) \alpha}
 
     Parameters
     ----------

--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -91,7 +91,7 @@ class DMProfile(abc.ABC):
 class ZhaoProfile(DMProfile):
     r"""Zaho Profile.
     .. math::
-        \rho(r) = \rho_s \frac{r_s}{r}^\gamma \left(1 + \frac{r}{r_s}^\alpha \right)^{\frac{\beta - \gamma}{\alpha}}
+        \rho(r) = \rho_s \left(\frac{r_s}{r}\right)^\gamma \left(1 + \left(\frac{r}{r_s}\right)^\alpha \right)^{\frac{\gamma - \beta}{\alpha}}
 
     Parameters
     ----------
@@ -121,7 +121,9 @@ class ZhaoProfile(DMProfile):
     Default scale radius as given in reference 2 (same as for NFW profile)
     """
 
-    def __init__(self, r_s=None, alpha=None, beta=None, gamma=None, rho_s=1 * u.Unit("GeV / cm3")):
+    def __init__(
+        self, r_s=None, alpha=None, beta=None, gamma=None, rho_s=1 * u.Unit("GeV / cm3")
+    ):
         r_s = self.DEFAULT_SCALE_RADIUS if r_s is None else r_s
         alpha = self.DEFAULT_ALPHA if alpha is None else alpha
         beta = self.DEFAULT_BETA if beta is None else beta
@@ -140,6 +142,7 @@ class ZhaoProfile(DMProfile):
     def evaluate(radius, r_s, alpha, beta, gamma, rho_s):
         rr = radius / r_s
         return rho_s / (rr**gamma * (1 + rr**alpha) ** ((beta - gamma) / alpha))
+
 
 class NFWProfile(DMProfile):
     r"""NFW Profile.

--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -93,7 +93,7 @@ class ZhaoProfile(DMProfile):
     This is taken from equation 1 from Zhao (1996). It is a generalization of the NFW profile. The volume density is parametrized with
     a double power-law. Scale radii smaller than the scale radiu are described with a slope of :math:`-\gamma` and scale radii larger than the scale radius are described with a slope of :math:`-\beta`. :math:`\alpha` is a measure for the width of the transition region.
     .. math::
-        \rho(r) = \rho_s \left(\frac{r_s}{r}\right)^\gamma \left(1 + \left(\frac{r}{r_s}\right)^\alpha \right)^{\frac{\gamma - \beta}{\alpha}}
+        \rho(r) = \rho_s \left(\frac{r_s}{r}\right)^\gamma \left(1 + \left(\frac{r}{r_s}\right)^\frac{1}{\alpha} \right)^{(\gamma - \beta) * \alpha}
 
     Parameters
     ----------
@@ -111,7 +111,7 @@ class ZhaoProfile(DMProfile):
     References
     ----------
     * `1996MNRAS.278..488Z <https://ui.adsabs.harvard.edu/abs/1996MNRAS.278..488Z>`_
-    * `2011JCAP...03..051 <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051>`_
+    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 24.42 * u.kpc
@@ -143,7 +143,9 @@ class ZhaoProfile(DMProfile):
     @staticmethod
     def evaluate(radius, r_s, alpha, beta, gamma, rho_s):
         rr = radius / r_s
-        return rho_s / (rr**gamma * (1 + rr**alpha) ** ((beta - gamma) / alpha))
+        return rho_s / (
+            rr**gamma * (1 + rr ** (1 / alpha)) ** ((beta - gamma) * alpha)
+        )
 
 
 class NFWProfile(DMProfile):
@@ -162,7 +164,7 @@ class NFWProfile(DMProfile):
     References
     ----------
     * `1997ApJ...490..493 <https://ui.adsabs.harvard.edu/abs/1997ApJ...490..493N>`_
-    * `2011JCAP...03..051 <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051>`_
+    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 24.42 * u.kpc
@@ -200,7 +202,7 @@ class EinastoProfile(DMProfile):
     References
     ----------
     * `1965TrAlm...5...87E <https://ui.adsabs.harvard.edu/abs/1965TrAlm...5...87E>`_
-    * `2011JCAP...03..051 <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051>`_
+    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 28.44 * u.kpc
@@ -240,7 +242,7 @@ class IsothermalProfile(DMProfile):
     References
     ----------
     * `1991MNRAS.249..523B <https://ui.adsabs.harvard.edu/abs/1991MNRAS.249..523B>`_
-    * `2011JCAP...03..051 <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051>`_
+    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 4.38 * u.kpc
@@ -272,7 +274,7 @@ class BurkertProfile(DMProfile):
     References
     ----------
     * `1995ApJ...447L..25B <https://ui.adsabs.harvard.edu/abs/1995ApJ...447L..25B>`_
-    * `2011JCAP...03..051 <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051>`_
+    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 12.67 * u.kpc
@@ -306,7 +308,7 @@ class MooreProfile(DMProfile):
     References
     ----------
     * `2004MNRAS.353..624D <https://ui.adsabs.harvard.edu/abs/2004MNRAS.353..624D>`_
-    * `2011JCAP...03..051 <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051>`_
+    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 30.28 * u.kpc

--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -89,7 +89,9 @@ class DMProfile(abc.ABC):
 
 
 class ZhaoProfile(DMProfile):
-    r"""Zaho Profile.
+    r"""Zhao Profile.
+    This is taken from equation 1 from Zhao (1996). It is a generalization of the NFW profile. The volume density is parametrized with
+    a double power-law. Scale radii smaller than the scale radiu are described with a slope of :math:`-\gamma` and scale radii larger than the scale radius are described with a slope of :math:`-\beta`. :math:`\alpha` is a measure for the width of the transition region.
     .. math::
         \rho(r) = \rho_s \left(\frac{r_s}{r}\right)^\gamma \left(1 + \left(\frac{r}{r_s}\right)^\alpha \right)^{\frac{\gamma - \beta}{\alpha}}
 

--- a/gammapy/astro/darkmatter/tests/test_profiles.py
+++ b/gammapy/astro/darkmatter/tests/test_profiles.py
@@ -4,6 +4,7 @@ from gammapy.astro.darkmatter import profiles
 from gammapy.utils.testing import assert_quantity_allclose
 
 dm_profiles = [
+    profiles.ZhaoProfile,
     profiles.NFWProfile,
     profiles.EinastoProfile,
     profiles.IsothermalProfile,


### PR DESCRIPTION
**Description**
Adding the Zhao profile to the available dark matter profiles.

reference: https://ui.adsabs.harvard.edu/abs/1996MNRAS.278..488Z/abstract