### PR TITLE
Raise error if the predicted event number is too large in event sampling

### DIFF
--- a/docs/development/intro.rst
+++ b/docs/development/intro.rst
@@ -106,12 +106,12 @@ Make small pull requests
 
 So as we'll explain in more detail below, the contribution cycle to Gammapy is roughly:
 
-1. Get the latest development version (``master`` branch) of Gammapy
+1. Get the latest development version (``main`` branch) of Gammapy
 2. Make fixes, changes and additions locally
 3. Make a pull request
 4. Someone else reviews the pull request, you iterate, others can chime in
 5. Someone else signs off on or merges your pull request
-6. You update to the latest ``master`` branch
+6. You update to the latest ``main`` branch
 
 Then you're done, and can start using the new version, or start a new pull request
 with further developments. It is possible and common to work on things in parallel
@@ -150,14 +150,14 @@ Get set up
 .. warning::
 
     The rest of this page isn't written yet. It's almost identical to
-    https://cta-observatory.github.io/ctapipe/getting_started/index.html so for
+    https://ctapipe.readthedocs.io/en/latest/developer-guide/getting-started.html so for
     now, see there. Also, we shouldn't duplicate content from
-    https://docs.astropy.org/en/latest/#developer-documentation but link
+    https://docs.astropy.org/en/latest/development/index.html but link
     there instead.
 
 The first steps are basically identical to
-https://cta-observatory.github.io/ctapipe/getting_started/index.html (until step
-4, excluding 5) and
+https://ctapipe.readthedocs.io/en/latest/developer-guide/getting-started.html (until 
+section *Setting up the development environment*) and
 http://astropy.readthedocs.io/en/latest/development/workflow/get_devel_version.html
 (up to *Create your own private workspace*). The following is a quick summary of
 commands to set up an environment for Gammapy development:
@@ -194,7 +194,7 @@ environment with the content present in `environment-dev.yml` see below:
     $ conda env update --file environment-dev.yml --prune
 
 
-When developing Gammapy you never want to work on the ``master`` branch, but
+When developing Gammapy you never want to work on the ``main`` branch, but
 always on a dedicated feature branch.
 
 .. code-block:: bash
@@ -287,7 +287,7 @@ The codestyle can be checked using the command:
 
     tox -e codestyle
 
-Which will run the tool `flak8` to check for code style issues.
+Which will run the tool `flake8` to check for code style issues.
 
 
 

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -254,6 +254,20 @@ to your code:
     from gammapy.utils import pbar
     pbar.SHOW_PROGRESS_BAR = True
 
+The progress bar is available within the following:
+
+* `~gammapy.analysis.Analysis.get_datasets` method
+
+* `~gammapy.data.DataStore.get_observations` method
+
+* The ``run()`` method from the ``estimator`` classes: `~gammapy.estimators.ASmoothMapEstimator`, `~gammapy.estimators.TSMapEstimator`, `~gammapy.estimators.LightCurveEstimator`
+
+* `~gammapy.modeling.Fit.stat_profile` and `~gammapy.modeling.Fit.stat_surface` methods
+
+* `~gammapy.scripts.download.progress_download` method
+
+* `~gammapy.utils.parallel.run_multiprocessing` method
+
 .. accordion-footer::
 
 .. accordion-header::

--- a/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
@@ -41,15 +41,15 @@ provided.
 The directional cut is typically an angular distance from the assumed
 source position, :math:`\\theta`. The
 `gamma-astro-data-format <https://gamma-astro-data-formats.readthedocs.io/en/latest/>`__
-specifications offer two different ways to store this information: \* if
-the same :math:`\\theta` cut is applied at all energies and offsets, `a
-`RAD_MAX`
-keyword <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max>`__
-is added to the header of the data units containing IRF components. This
-should be used to define the size of the ON and OFF regions; \* in case
-an energy- (and offset-) dependent :math:`\\theta` cut is applied, its
-values are stored in additional `FITS` data unit, named
-``RAD_MAX_2D` <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max-2d>`__.
+specifications offer two different ways to store this information:
+
+* if the same :math:`\\theta` cut is applied at all energies and offsets, a
+  `RAD_MAX <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max>`__
+  keyword is added to the header of the data units containing IRF components. This
+  should be used to define the size of the ON and OFF regions;
+* in case an energy-dependent (and offset-dependent) :math:`\\theta` cut is applied, its
+  values are stored in additional `FITS` data unit, named
+  `RAD_MAX_2D <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max-2d>`__.
 
 `Gammapy` provides a class to automatically read these values,
 `~gammapy.irf.RadMax2D`, for both cases (fixed or energy-dependent
@@ -176,7 +176,7 @@ plt.show()
 # --------------------
 #
 # To use the `RAD_MAX_2D` values to define the sizes of the ON and OFF
-# regions **it is necessary to specify the ON region as
+# regions it is necessary to specify the ON region as
 # a `~regions.PointSkyRegion`:
 #
 

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -159,8 +159,8 @@ class Analysis:
         """
         Produce reduced datasets.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
         """
         datasets_settings = self.config.datasets

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -156,7 +156,13 @@ class Analysis:
             log.debug(obs)
 
     def get_datasets(self):
-        """Produce reduced datasets."""
+        """
+        Produce reduced datasets.
+
+        Note
+        ----
+        The progress bar can be displayed for this function.
+        """
         datasets_settings = self.config.datasets
         if not self.observations or len(self.observations) == 0:
             raise RuntimeError("No observations have been selected.")

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -347,8 +347,8 @@ class DataStore:
     ):
         """Generate a `~gammapy.data.Observations`.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -347,6 +347,10 @@ class DataStore:
     ):
         """Generate a `~gammapy.data.Observations`.
 
+        Note
+        ----
+        The progress bar can be displayed for this function.
+
         Parameters
         ----------
         obs_id : list

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -4,8 +4,7 @@ import copy
 import logging
 import numpy as np
 from astropy import units as u
-from astropy.coordinates import AltAz, Angle, SkyCoord
-from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates import AltAz, Angle, SkyCoord, angular_separation
 from astropy.io import fits
 from astropy.table import Table
 from astropy.table import vstack as vstack_tables

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -29,7 +29,7 @@ class PointingMode(Enum):
     """
     Describes the behavior of the pointing during the observation.
 
-    See :ref:`gadf:obs-mode`.
+    See :ref:`gadf:iact-events-obs-mode`.
 
     For ground-based instruments, the most common options will be:
     * POINTING: The telescope observes a fixed position in the ICRS frame

--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -2,7 +2,7 @@
 import logging
 import numpy as np
 import astropy.units as u
-from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates import angular_separation
 from astropy.utils import lazyproperty
 from regions import CircleSkyRegion
 import matplotlib.pyplot as plt

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -170,12 +170,12 @@ class MapDatasetEventSampler:
         npred = self._evaluate_timevar_source(dataset, model=model)
         data = npred.data[np.isfinite(npred.data)]
 
-        if np.sum(data) > 1e6:
-            raise TypeError(
+        try:
+            n_events = self.random_state.poisson(np.sum(data))
+        except ValueError:
+            raise ValueError(
                 f"The number of predicted events for the model {model.name} is too large. No event sampling will be performed for this model!"
             )
-
-        n_events = self.random_state.poisson(np.sum(data))
 
         coords = npred.sample_coord(n_events=n_events, random_state=self.random_state)
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -169,6 +169,12 @@ class MapDatasetEventSampler:
 
         npred = self._evaluate_timevar_source(dataset, model=model)
         data = npred.data[np.isfinite(npred.data)]
+
+        if np.sum(data) > 1e6:
+            raise TypeError(
+                f"The number of predicted events for the model {model.name} is too large. No event sampling will be performed for this model!"
+            )
+
         n_events = self.random_state.poisson(np.sum(data))
 
         coords = npred.sample_coord(n_events=n_events, random_state=self.random_state)

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -250,11 +250,6 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_sky_model):
         rtol=1e-6,
     )
 
-    dataset.models[0].temporal_model.map.data *= 1e3
-    evaluator = dataset.evaluators["test-source"]
-    with pytest.raises(TypeError):
-        sampler._sample_coord_time_energy(dataset, evaluator.model)
-
 
 @requires_data()
 def test_fail_sample_coord_time_energy(

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -250,11 +250,6 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_sky_model):
         rtol=1e-6,
     )
 
-    dataset.models[0].temporal_model.map.data *= 1e3
-    evaluator = dataset.evaluators["test-source"]
-    with pytest.raises(TypeError):
-        sampler._sample_coord_time_energy(dataset, evaluator.model)
-
 
 @requires_data()
 def test_sample_coord_time_energy_random_seed(

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -250,6 +250,11 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_sky_model):
         rtol=1e-6,
     )
 
+    dataset.models[0].temporal_model.map.data *= 1e3
+    evaluator = dataset.evaluators["test-source"]
+    with pytest.raises(TypeError):
+        sampler._sample_coord_time_energy(dataset, evaluator.model)
+
 
 @requires_data()
 def test_fail_sample_coord_time_energy(

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -250,6 +250,11 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_sky_model):
         rtol=1e-6,
     )
 
+    dataset.models[0].temporal_model.map.data *= 1e3
+    evaluator = dataset.evaluators["test-source"]
+    with pytest.raises(TypeError):
+        sampler._sample_coord_time_energy(dataset, evaluator.model)
+
 
 @requires_data()
 def test_sample_coord_time_energy_random_seed(

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -252,6 +252,24 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_sky_model):
 
 
 @requires_data()
+def test_fail_sample_coord_time_energy(
+    dataset, models, energy_dependent_temporal_sky_model
+):
+    new_dataset = dataset.copy("my-dataset")
+    new_dataset.gti = GTI.create(
+        start=0 * u.s, stop=2.5 * u.s, reference_time=Time("2000-01-01").tt
+    )
+
+    new_dataset.models = energy_dependent_temporal_sky_model
+    new_dataset.models[0].temporal_model.map.data *= 1e20
+    evaluator = new_dataset.evaluators["test-source"]
+
+    sampler = MapDatasetEventSampler(random_state=0, oversample_energy_factor=1)
+    with pytest.raises(ValueError):
+        sampler._sample_coord_time_energy(new_dataset, evaluator.model)
+
+
+@requires_data()
 def test_sample_coord_time_energy_random_seed(
     dataset, energy_dependent_temporal_sky_model
 ):

--- a/gammapy/estimators/map/asmooth.py
+++ b/gammapy/estimators/map/asmooth.py
@@ -154,8 +154,8 @@ class ASmoothMapEstimator(Estimator):
     def run(self, dataset):
         """Run adaptive smoothing on input MapDataset.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters

--- a/gammapy/estimators/map/asmooth.py
+++ b/gammapy/estimators/map/asmooth.py
@@ -154,6 +154,10 @@ class ASmoothMapEstimator(Estimator):
     def run(self, dataset):
         """Run adaptive smoothing on input MapDataset.
 
+        Note
+        ----
+        The progress bar can be displayed for this function.
+
         Parameters
         ----------
         dataset : `~gammapy.datasets.MapDataset` or `~gammapy.datasets.MapDatasetOnOff`

--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -1072,6 +1072,7 @@ class FluxMaps:
         flux_maps : `FluxMaps`
             Sliced flux maps object.
         """
+
         data = {}
 
         for key, item in self._data.items():
@@ -1083,6 +1084,70 @@ class FluxMaps:
             meta=self.meta.copy(),
             gti=self.gti,
         )
+
+    def slice_by_coord(self, slices):
+        """Slice flux maps by coordinate values
+
+        Parameters
+        ----------
+        slices : dict
+            Dict of axes names and `astropy.Quantity` or `astropy.Time` or `slice` object pairs.
+            Contains one element for each non-spatial dimension. For integer indexing the
+            corresponding axes is dropped from the map. Axes not specified in the
+            dict are kept unchanged.
+
+
+        Returns
+        -------
+        flux_maps : `FluxMaps`
+            Sliced flux maps object.
+        """
+
+        idx_intervals = []
+
+        for key, interval in zip(slices.keys(), slices.values()):
+            imin = self.geom.axes[key].coord_to_idx(interval.start)
+            imax = self.geom.axes[key].coord_to_idx(interval.stop)
+
+            idx_intervals.append(slice(imin, imax))
+
+        return self.slice_by_idx(dict(zip(slices.keys(), idx_intervals)))
+
+    def slice_by_time(self, time_min, time_max):
+        """Slice flux maps by coordinate values along the time axis
+
+        Parameters
+        ----------
+        time_min, time_max : `~astropy.time.Time`
+            Time bounds used to slice the flux map
+
+        Returns
+        -------
+        flux_maps : `FluxMaps`
+            Sliced flux maps object.
+        """
+
+        time_slice = slice(time_min, time_max)
+
+        return self.slice_by_coord({"time": time_slice})
+
+    def slice_by_energy(self, energy_min, energy_max):
+        """Slice flux maps by coordinate values along the energy axis
+
+        Parameters
+        ----------
+        energy_min, energy_max : `~astropy.units.Quantity`
+            Energy bounds used to slice the flux map
+
+        Returns
+        -------
+        flux_maps : `FluxMaps`
+            Sliced flux maps object.
+        """
+
+        energy_slice = slice(energy_min, energy_max)
+
+        return self.slice_by_coord({"energy": energy_slice})
 
     # TODO: should we allow this?
     def __getitem__(self, item):

--- a/gammapy/estimators/map/tests/test_core.py
+++ b/gammapy/estimators/map/tests/test_core.py
@@ -456,3 +456,34 @@ def test_flux_map_iter_by_axis():
     assert_allclose(split_maps[0].gti.time_stop.value, 51545.3340, rtol=1e-3)
 
     assert split_maps[0].reference_model == ref_map.reference_model
+
+
+def test_slice_by_coord():
+    axis1 = MapAxis.from_energy_edges((0.1, 1.0, 10.0), unit="TeV")
+    axis2 = TimeMapAxis.from_time_bounds(
+        Time(51544, format="mjd"), Time(51548, format="mjd"), 3
+    )
+    geom = RegionGeom.create("galactic;circle(0, 0, 0.1)", axes=[axis1, axis2])
+
+    maps = Maps.from_geom(
+        geom=geom, names=["norm", "norm_err", "norm_errn", "norm_errp", "norm_ul"]
+    )
+    val = np.ones(geom.data_shape)
+
+    maps["norm"].data = val
+    maps["norm_err"].data = 0.1 * val
+    maps["norm_errn"].data = 0.2 * val
+    maps["norm_errp"].data = 0.15 * val
+    maps["norm_ul"].data = 2.0 * val
+
+    start = u.Quantity([1, 2, 3], "day")
+    stop = u.Quantity([1.5, 2.5, 3.9], "day")
+    gti = GTI.create(start, stop)
+    ref_map = FluxMaps(maps, gti=gti, reference_model=PowerLawSpectralModel())
+
+    sliced_map = ref_map.slice_by_coord(
+        {"time": slice(Time(51544, format="mjd"), Time(51546, format="mjd"))}
+    )
+    assert sliced_map.available_quantities == ref_map.available_quantities
+    assert_allclose(sliced_map.gti.time_stop.value, 51545.3340, rtol=1e-3)
+    assert sliced_map.reference_model == ref_map.reference_model

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -457,8 +457,8 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         Requires a MapDataset with counts, exposure and background_model
         properly set to run.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -457,6 +457,10 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         Requires a MapDataset with counts, exposure and background_model
         properly set to run.
 
+        Note
+        ----
+        The progress bar can be displayed for this function.
+
         Parameters
         ----------
         dataset : `~gammapy.datasets.MapDataset`

--- a/gammapy/estimators/points/lightcurve.py
+++ b/gammapy/estimators/points/lightcurve.py
@@ -98,8 +98,8 @@ class LightCurveEstimator(FluxPointsEstimator):
 
         Normalize integral and energy flux between emin and emax.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters

--- a/gammapy/estimators/points/lightcurve.py
+++ b/gammapy/estimators/points/lightcurve.py
@@ -98,6 +98,10 @@ class LightCurveEstimator(FluxPointsEstimator):
 
         Normalize integral and energy flux between emin and emax.
 
+        Note
+        ----
+        The progress bar can be displayed for this function.
+
         Parameters
         ----------
         datasets : list of `~gammapy.datasets.SpectrumDataset` or `~gammapy.datasets.MapDataset`

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -201,6 +201,8 @@ class Background3D(BackgroundIRF):
             else:
                 ax = axes.flat[i]
             bkg = self.evaluate(energy=ee)
+            bkg_unit = bkg.unit
+            bkg = bkg.value
             with quantity_support():
                 caxes = ax.pcolormesh(X, Y, bkg.squeeze(), **kwargs)
 
@@ -208,7 +210,7 @@ class Background3D(BackgroundIRF):
             self.axes["fov_lon"].format_plot_yaxis(ax)
             ax.set_title(str(ee))
             if add_cbar:
-                label = f"Background [{bkg.unit.to_string(UNIT_STRING_FORMAT)}]"
+                label = f"Background [{bkg_unit.to_string(UNIT_STRING_FORMAT)}]"
                 cbar = ax.figure.colorbar(caxes, ax=ax, label=label, fraction=cfraction)
                 cbar.formatter.set_powerlimits((0, 0))
 

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3240,8 +3240,8 @@ class LabelMapAxis:
     def from_stack(cls, axes):
         """Create a label map axis by merging a list of axis.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         axes : list of `LabelMapAxis`
             A list of map axis to be merged.
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -358,8 +358,8 @@ class Fit:
         The method used is to vary one parameter, keeping all others fixed.
         So this is taking a "slice" or "scan" of the fit statistic.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters
@@ -416,8 +416,8 @@ class Fit:
 
         See also: `Fit.stat_contour`
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -358,6 +358,10 @@ class Fit:
         The method used is to vary one parameter, keeping all others fixed.
         So this is taking a "slice" or "scan" of the fit statistic.
 
+        Note
+        ----
+        The progress bar can be displayed for this function.
+
         Parameters
         ----------
         datasets : `Datasets` or list of `Dataset`
@@ -411,6 +415,10 @@ class Fit:
         Caveat: This method can be very computationally intensive and slow
 
         See also: `Fit.stat_contour`
+
+        Note
+        ----
+        The progress bar can be displayed for this function.
 
         Parameters
         ----------

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -7,8 +7,7 @@ import scipy.integrate
 import scipy.special
 from scipy.interpolate import griddata
 import astropy.units as u
-from astropy.coordinates import Angle, SkyCoord
-from astropy.coordinates.angle_utilities import angular_separation, position_angle
+from astropy.coordinates import Angle, SkyCoord, angular_separation, position_angle
 from astropy.utils import lazyproperty
 from regions import (
     CircleAnnulusSkyRegion,

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -467,6 +467,7 @@ class SpatialModel(ModelBase):
     def from_position(cls, position, **kwargs):
         """Define the position of the model using a sky coord
            The model will be created in the frame of the sky coord
+
         Parameters
         ----------
         position : `~astropy.coordinates.SkyCoord`

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -672,6 +672,7 @@ class ConstantSpectralModel(SpectralModel):
     ----------
     const : `~astropy.units.Quantity`
         :math:`k`
+        Default is 1e-12 cm-2 s-1 TeV-1
     """
 
     tag = ["ConstantSpectralModel", "const"]
@@ -755,10 +756,13 @@ class PowerLawSpectralModel(SpectralModel):
     ----------
     index : `~astropy.units.Quantity`
         :math:`\Gamma`
+        Default is 2.0
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1e-12 cm-2 s-1 TeV-1
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+        Default is 1 TeV
 
     See Also
     --------
@@ -883,10 +887,13 @@ class PowerLawNormSpectralModel(SpectralModel):
     ----------
     tilt : `~astropy.units.Quantity`
         :math:`\Gamma`
+        Default is 0
     norm : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+        Default is 1 TeV
 
     See Also
     --------
@@ -983,12 +990,16 @@ class PowerLaw2SpectralModel(SpectralModel):
     ----------
     index : `~astropy.units.Quantity`
         Spectral index :math:`\Gamma`
+        Default is 2
     amplitude : `~astropy.units.Quantity`
-        Integral flux :math:`F_0`.
+        Integral flux :math:`F_0`
+        Default is 1e-12 cm-2 s-1
     emin : `~astropy.units.Quantity`
-        Lower energy limit :math:`E_{0, min}`.
+        Lower energy limit :math:`E_{0, min}`
+        Default is 0.1 TeV
     emax : `~astropy.units.Quantity`
-        Upper energy limit :math:`E_{0, max}`.
+        Upper energy limit :math:`E_{0, max}`
+        Default is 100 TeV
 
     See Also
     --------
@@ -1069,12 +1080,16 @@ class BrokenPowerLawSpectralModel(SpectralModel):
     ----------
     index1 : `~astropy.units.Quantity`
         :math:`\Gamma1`
+        Default is 2
     index2 : `~astropy.units.Quantity`
         :math:`\Gamma2`
+        Default is 2
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1e-12 cm-2 s-1 TeV-1
     ebreak : `~astropy.units.Quantity`
         :math:`E_{break}`
+        Default is 1 TeV
 
     See Also
     --------
@@ -1113,16 +1128,22 @@ class SmoothBrokenPowerLawSpectralModel(SpectralModel):
     ----------
     index1 : `~astropy.units.Quantity`
         :math:`\Gamma1`
+        Default is 2
     index2 : `~astropy.units.Quantity`
         :math:`\Gamma2`
+        Default is 2
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1e-12 cm-2 s-1 TeV-1
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+        Default is 1 TeV
     ebreak : `~astropy.units.Quantity`
         :math:`E_{break}`
+        Default is 1 TeV
     beta : `~astropy.units.Quantity`
         :math:`\beta`
+        Default is 1
 
     See Also
     --------
@@ -1250,14 +1271,19 @@ class ExpCutoffPowerLawSpectralModel(SpectralModel):
     ----------
     index : `~astropy.units.Quantity`
         :math:`\Gamma`
+        Default is 1.5
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1e-12 cm-2 s-1 TeV-1
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+        Default is 1 TeV
     lambda_ : `~astropy.units.Quantity`
         :math:`\lambda`
+        Default is 0.1 TeV-1
     alpha : `~astropy.units.Quantity`
         :math:`\alpha`
+        Default is 1
 
     See Also
     --------
@@ -1313,14 +1339,19 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
     ----------
     index : `~astropy.units.Quantity`
         :math:`\Gamma`
+        Default is 1.5
     norm : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+        Default is 1 TeV
     lambda_ : `~astropy.units.Quantity`
         :math:`\lambda`
+        Default is 0.1 TeV-1
     alpha : `~astropy.units.Quantity`
         :math:`\alpha`
+        Default is 1
 
     See Also
     --------
@@ -1375,12 +1406,16 @@ class ExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
     ----------
     index : `~astropy.units.Quantity`
         :math:`\Gamma`
+        Default is 1.5
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1e-12 cm-2 s-1 TeV-1
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+        Default is 1 TeV
     ecut : `~astropy.units.Quantity`
         :math:`E_{C}`
+        Default is 10 TeV
     """
 
     tag = ["ExpCutoffPowerLaw3FGLSpectralModel", "ecpl-3fgl"]
@@ -1418,14 +1453,19 @@ class SuperExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
     ----------
     index_1 : `~astropy.units.Quantity`
         :math:`\Gamma_1`
+        Default is 1.5
     index_2 : `~astropy.units.Quantity`
         :math:`\Gamma_2`
+        Default is 2
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1e-12 cm-2 s-1 TeV-1
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+        Default is 1 TeV
     ecut : `~astropy.units.Quantity`
         :math:`E_{C}`
+        Default is 10 TeV
     """
 
     tag = ["SuperExpCutoffPowerLaw3FGLSpectralModel", "secpl-3fgl"]
@@ -1458,15 +1498,20 @@ class SuperExpCutoffPowerLaw4FGLSpectralModel(SpectralModel):
     ----------
     index_1 : `~astropy.units.Quantity`
         :math:`\Gamma_1`
+        Default is 1.5
     index_2 : `~astropy.units.Quantity`
         :math:`\Gamma_2`
+        Default is 2
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1e-12 cm-2 s-1 TeV-1
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+        Default is 1 TeV
     expfactor : `~astropy.units.Quantity`
         :math:`a`, given as dimensionless value but
         internally assumes unit of :math: `[E_0]` power :math:`-\Gamma_2`
+        Default is 1e-2
     """
 
     tag = ["SuperExpCutoffPowerLaw4FGLSpectralModel", "secpl-4fgl"]
@@ -1503,14 +1548,19 @@ class SuperExpCutoffPowerLaw4FGLDR3SpectralModel(SpectralModel):
     ----------
     index_1 : `~astropy.units.Quantity`
         :math:`\Gamma_1`
+        Default is 1.5
     index_2 : `~astropy.units.Quantity`
         :math:`\Gamma_2`
+        Default is 2
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1e-12 cm-2 s-1 TeV-1
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+        Default is 1 TeV
     expfactor : `~astropy.units.Quantity`
         :math:`a`, given as dimensionless value
+        Default is 1e-2
     """
 
     tag = ["SuperExpCutoffPowerLaw4FGLDR3SpectralModel", "secpl-4fgl-dr3"]
@@ -1553,12 +1603,16 @@ class LogParabolaSpectralModel(SpectralModel):
     ----------
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1e-12 cm-2 s-1 TeV-1
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+        Default is 10 TeV
     alpha : `~astropy.units.Quantity`
         :math:`\alpha`
+        Default is 2
     beta : `~astropy.units.Quantity`
         :math:`\beta`
+        Default is 1
 
     See Also
     --------
@@ -1612,14 +1666,18 @@ class LogParabolaNormSpectralModel(SpectralModel):
     ----------
     norm : `~astropy.units.Quantity`
         :math:`\phi_0`
+        Default is 1
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+        Default is 10 TeV
     alpha : `~astropy.units.Quantity`
         :math:`\alpha`
+        Default is 0
     beta : `~astropy.units.Quantity`
         :math:`\beta`
+        Default is 0
 
-    See also
+    See Also
     --------
     LogParabolaSpectralModel
     """
@@ -1904,6 +1962,7 @@ class ScaleSpectralModel(SpectralModel):
         Spectral model to wrap.
     norm : float
         Multiplicative norm factor for the model value.
+        Default is 1
     """
 
     tag = ["ScaleSpectralModel", "scale"]
@@ -1936,8 +1995,10 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
         Model value
     redshift : float
         Redshift of the absorption model
+        Default is 0.1
     alpha_norm: float
         Norm of the EBL model
+        Default is 1
     interp_kwargs : dict
         Interpolation option passed to `ScaledRegularGridInterpolator`.
         By default the models are extrapolated outside the range. To prevent
@@ -2306,10 +2367,13 @@ class GaussianSpectralModel(SpectralModel):
     ----------
     amplitude : `~astropy.units.Quantity`
         :math:`N_0`
+        Default is 1e-12 cm-2 s-1
     mean : `~astropy.units.Quantity`
         :math:`\bar{E}`
+        Default is 1 TeV
     sigma : `~astropy.units.Quantity`
         :math:`\sigma`
+        Default is 2 TeV
     """
 
     tag = ["GaussianSpectralModel", "gauss"]

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -3,6 +3,7 @@
 import logging
 import operator
 import os
+import warnings
 from pathlib import Path
 import numpy as np
 import scipy.optimize
@@ -16,6 +17,7 @@ import matplotlib.pyplot as plt
 from gammapy.maps import MapAxis, RegionNDMap
 from gammapy.maps.axes import UNIT_STRING_FORMAT
 from gammapy.modeling import Parameter, Parameters
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.integrate import trapz_loglog
 from gammapy.utils.interpolation import (
     ScaledRegularGridInterpolator,
@@ -1332,6 +1334,29 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
     alpha = Parameter("alpha", "1.0", frozen=True)
 
+    def __init__(
+        self, index=None, norm=None, reference=None, lambda_=None, alpha=None, **kwargs
+    ):
+
+        if index is None:
+            warnings.warn(
+                "The default index value changed from 1.5 to 0 since v1.2",
+                GammapyDeprecationWarning,
+            )
+
+        if norm is not None:
+            kwargs.update({"norm": norm})
+        if index is not None:
+            kwargs.update({"index": index})
+        if reference is not None:
+            kwargs.update({"reference": reference})
+        if lambda_ is not None:
+            kwargs.update({"lambda_": lambda_})
+        if alpha is not None:
+            kwargs.update({"alpha": alpha})
+
+        super().__init__(**kwargs)
+
     @staticmethod
     def evaluate(energy, index, norm, reference, lambda_, alpha):
         """Evaluate the model (static function)."""
@@ -1594,15 +1619,42 @@ class LogParabolaNormSpectralModel(SpectralModel):
     beta : `~astropy.units.Quantity`
         :math:`\beta`
 
-    See Also
+    See also
     --------
     LogParabolaSpectralModel
     """
+
     tag = ["LogParabolaNormSpectralModel", "lp-norm"]
+
     norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
     reference = Parameter("reference", "10 TeV", frozen=True)
-    alpha = Parameter("alpha", 2)
-    beta = Parameter("beta", 1)
+    alpha = Parameter("alpha", 0)
+    beta = Parameter("beta", 0)
+
+    def __init__(self, norm=None, reference=None, alpha=None, beta=None, **kwargs):
+
+        if alpha is None:
+            warnings.warn(
+                "The default alpha value changed from 2 to 0 since v1.2",
+                GammapyDeprecationWarning,
+            )
+
+        if beta is None:
+            warnings.warn(
+                "The default beta value changed from 1 to 0 since v1.2",
+                GammapyDeprecationWarning,
+            )
+
+        if norm is not None:
+            kwargs.update({"norm": norm})
+        if beta is not None:
+            kwargs.update({"beta": beta})
+        if reference is not None:
+            kwargs.update({"reference": reference})
+        if alpha is not None:
+            kwargs.update({"alpha": alpha})
+
+        super().__init__(**kwargs)
 
     @classmethod
     def from_log10(cls, norm, reference, alpha, beta):

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -4,8 +4,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from astropy.coordinates import SkyCoord
-from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates import SkyCoord, angular_separation
 from astropy.time import Time
 from regions import CircleSkyRegion
 from gammapy.data.gti import GTI

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -25,6 +25,7 @@ from gammapy.modeling.models import (
     SkyModel,
     TemplateNPredModel,
 )
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.scripts import read_yaml, write_yaml
 from gammapy.utils.testing import requires_data
 
@@ -315,13 +316,15 @@ def make_all_models():
     yield Model.create("PowerLawNormSpectralModel", "spectral")
     yield Model.create("PowerLaw2SpectralModel", "spectral")
     yield Model.create("ExpCutoffPowerLawSpectralModel", "spectral")
-    yield Model.create("ExpCutoffPowerLawNormSpectralModel", "spectral")
+    with pytest.warns(GammapyDeprecationWarning):
+        yield Model.create("ExpCutoffPowerLawNormSpectralModel", "spectral")
     yield Model.create("ExpCutoffPowerLaw3FGLSpectralModel", "spectral")
     yield Model.create("SuperExpCutoffPowerLaw3FGLSpectralModel", "spectral")
     yield Model.create("SuperExpCutoffPowerLaw4FGLDR3SpectralModel", "spectral")
     yield Model.create("SuperExpCutoffPowerLaw4FGLSpectralModel", "spectral")
     yield Model.create("LogParabolaSpectralModel", "spectral")
-    yield Model.create("LogParabolaNormSpectralModel", "spectral")
+    with pytest.warns(GammapyDeprecationWarning):
+        yield Model.create("LogParabolaNormSpectralModel", "spectral")
     yield Model.create(
         "TemplateSpectralModel", "spectral", energy=[1, 2] * u.cm, values=[3, 4] * u.cm
     )  # TODO: add unit validation?

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -64,6 +64,11 @@ class DownloadIndex:
 
 
 def progress_download(source, destination):
+    """
+    Note
+    ----
+    The progress bar can be displayed for this function.
+    """
     import requests
     from tqdm import tqdm
 

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -65,8 +65,8 @@ class DownloadIndex:
 
 def progress_download(source, destination):
     """
-    Note
-    ----
+    Notes
+    -----
     The progress bar can be displayed for this function.
     """
     import requests

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -115,8 +115,8 @@ def run_multiprocessing(
 ):
     """Run function in a loop or in Parallel
 
-    Note
-    ----
+    Notes
+    -----
     The progress bar can be displayed for this function.
 
     Parameters

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -115,6 +115,10 @@ def run_multiprocessing(
 ):
     """Run function in a loop or in Parallel
 
+    Note
+    ----
+    The progress bar can be displayed for this function.
+
     Parameters
     ----------
     func : function

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -82,6 +82,8 @@ def make_name(name=None):
     """Make a dataset name"""
     if name is None:
         name = urlsafe_b64encode(codecs.decode(uuid4().hex, "hex")).decode()[:8]
+        while name[0] == "_":
+            name = urlsafe_b64encode(codecs.decode(uuid4().hex, "hex")).decode()[:8]
 
     if not isinstance(name, str):
         raise ValueError(


### PR DESCRIPTION
For a set of DC energy-dependent temporal models, the number of predicted events at some energies and time intervals may be very large (>>1e6). The reason is due to the creation methods of such models. 
The event sampling of them does not work since `MapDatasetEventSampler` raises a `ValueError` that is not very clear for the user (`Error: lam value is too large`) and does not help much in finding the issue. 
This PR introduces a clearer way to determine which model cannot be properly sampled and why.