### PR TITLE
Change master by main in howto dev docs and update broken links to ctapipe and astropy docs

### DIFF
--- a/docs/development/intro.rst
+++ b/docs/development/intro.rst
@@ -106,12 +106,12 @@ Make small pull requests
 
 So as we'll explain in more detail below, the contribution cycle to Gammapy is roughly:
 
-1. Get the latest development version (``master`` branch) of Gammapy
+1. Get the latest development version (``main`` branch) of Gammapy
 2. Make fixes, changes and additions locally
 3. Make a pull request
 4. Someone else reviews the pull request, you iterate, others can chime in
 5. Someone else signs off on or merges your pull request
-6. You update to the latest ``master`` branch
+6. You update to the latest ``main`` branch
 
 Then you're done, and can start using the new version, or start a new pull request
 with further developments. It is possible and common to work on things in parallel
@@ -194,7 +194,7 @@ environment with the content present in `environment-dev.yml` see below:
     $ conda env update --file environment-dev.yml --prune
 
 
-When developing Gammapy you never want to work on the ``master`` branch, but
+When developing Gammapy you never want to work on the ``main`` branch, but
 always on a dedicated feature branch.
 
 .. code-block:: bash

--- a/docs/development/intro.rst
+++ b/docs/development/intro.rst
@@ -150,13 +150,13 @@ Get set up
 .. warning::
 
     The rest of this page isn't written yet. It's almost identical to
-    https://cta-observatory.github.io/ctapipe/getting_started/index.html so for
+    https://ctapipe.readthedocs.io/en/latest/developer-guide/getting-started.html so for
     now, see there. Also, we shouldn't duplicate content from
-    https://docs.astropy.org/en/latest/#developer-documentation but link
+    https://docs.astropy.org/en/latest/development/index.html but link
     there instead.
 
 The first steps are basically identical to
-https://cta-observatory.github.io/ctapipe/getting_started/index.html (until step
+https://ctapipe.readthedocs.io/en/latest/developer-guide/getting-started.html (until step
 4, excluding 5) and
 http://astropy.readthedocs.io/en/latest/development/workflow/get_devel_version.html
 (up to *Create your own private workspace*). The following is a quick summary of

--- a/docs/development/intro.rst
+++ b/docs/development/intro.rst
@@ -287,7 +287,7 @@ The codestyle can be checked using the command:
 
     tox -e codestyle
 
-Which will run the tool `flak8` to check for code style issues.
+Which will run the tool `flake8` to check for code style issues.
 
 
 

--- a/docs/development/intro.rst
+++ b/docs/development/intro.rst
@@ -156,8 +156,8 @@ Get set up
     there instead.
 
 The first steps are basically identical to
-https://ctapipe.readthedocs.io/en/latest/developer-guide/getting-started.html (until step
-4, excluding 5) and
+https://ctapipe.readthedocs.io/en/latest/developer-guide/getting-started.html (until 
+section *Setting up the development environment*) and
 http://astropy.readthedocs.io/en/latest/development/workflow/get_devel_version.html
 (up to *Create your own private workspace*). The following is a quick summary of
 commands to set up an environment for Gammapy development:


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request:
 - changes the naming from master to main branch in *How to contribute to Gammapy* in the docs.
 - update broken links to ctapipe (they change from GH pages to RTD) and astropy development set-up documentation on the same page.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

Regarding the reference to ctapipe guidelines for development. The Gammapy docs were referring to some steps that I think are no longer explicitly mentioned in the ctapipe dev guide.

Besides, while building the docs locally I was getting a lot of formatting warnings. 

I kept it simple to help me set up everything to start contributing to Gammapy. 