### PR TITLE
Separate units in pcolormesh

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -201,6 +201,8 @@ class Background3D(BackgroundIRF):
             else:
                 ax = axes.flat[i]
             bkg = self.evaluate(energy=ee)
+            bkg_unit = bkg.unit
+            bkg = bkg.value
             with quantity_support():
                 caxes = ax.pcolormesh(X, Y, bkg.squeeze(), **kwargs)
 
@@ -208,7 +210,7 @@ class Background3D(BackgroundIRF):
             self.axes["fov_lon"].format_plot_yaxis(ax)
             ax.set_title(str(ee))
             if add_cbar:
-                label = f"Background [{bkg.unit.to_string(UNIT_STRING_FORMAT)}]"
+                label = f"Background [{bkg_unit.to_string(UNIT_STRING_FORMAT)}]"
                 cbar = ax.figure.colorbar(caxes, ax=ax, label=label, fraction=cfraction)
                 cbar.formatter.set_powerlimits((0, 0))
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request solves #4754 by applying `pcolormesh` on the values rather than the quantity object.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
