### PR TITLE
Regenerate name to avoid starting with underscore

### DIFF
--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -4,8 +4,7 @@ import copy
 import logging
 import numpy as np
 from astropy import units as u
-from astropy.coordinates import AltAz, Angle, SkyCoord
-from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates import AltAz, Angle, SkyCoord, angular_separation
 from astropy.io import fits
 from astropy.table import Table
 from astropy.table import vstack as vstack_tables

--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -2,7 +2,7 @@
 import logging
 import numpy as np
 import astropy.units as u
-from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates import angular_separation
 from astropy.utils import lazyproperty
 from regions import CircleSkyRegion
 import matplotlib.pyplot as plt

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -7,8 +7,7 @@ import scipy.integrate
 import scipy.special
 from scipy.interpolate import griddata
 import astropy.units as u
-from astropy.coordinates import Angle, SkyCoord
-from astropy.coordinates.angle_utilities import angular_separation, position_angle
+from astropy.coordinates import Angle, SkyCoord, angular_separation, position_angle
 from astropy.utils import lazyproperty
 from regions import (
     CircleAnnulusSkyRegion,

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -4,8 +4,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from astropy.coordinates import SkyCoord
-from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates import SkyCoord, angular_separation
 from astropy.time import Time
 from regions import CircleSkyRegion
 from gammapy.data.gti import GTI

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -82,6 +82,8 @@ def make_name(name=None):
     """Make a dataset name"""
     if name is None:
         name = urlsafe_b64encode(codecs.decode(uuid4().hex, "hex")).decode()[:8]
+        while name[0] == "_":
+            name = urlsafe_b64encode(codecs.decode(uuid4().hex, "hex")).decode()[:8]
 
     if not isinstance(name, str):
         raise ValueError(


### PR DESCRIPTION
Prevent a random fail in the CI when auto-generated name start with underscore :
FAILED ..\..\.tox\py310-test-alldeps_noray\lib\site-packages\gammapy\visualization\tests\test_datasets.py::test_plot_spectrum_datasets_off_regions - matplotlib._api.deprecation.MatplotlibDeprecationWarning: An artist whose label starts with an underscore was passed to legend(); such artists will no longer be ignored in the future.  To suppress this warning, explicitly filter out such artists, e.g. with `[art for art in artists if not art.get_label().startswith('_')]`.

This should fix the break seen in #4759.