### PR TITLE
Fix section naming in docstring causing visualization problems

### DIFF
--- a/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
@@ -47,7 +47,7 @@ specifications offer two different ways to store this information:
   `RAD_MAX <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max>`__
   keyword is added to the header of the data units containing IRF components. This
   should be used to define the size of the ON and OFF regions;
-* in case an energy- (and offset-) dependent :math:`\\theta` cut is applied, its
+* in case an energy-dependent (and offset-dependent) :math:`\\theta` cut is applied, its
   values are stored in additional `FITS` data unit, named
   `RAD_MAX_2D <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max-2d>`__.
 

--- a/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_rad_max.py
@@ -41,15 +41,15 @@ provided.
 The directional cut is typically an angular distance from the assumed
 source position, :math:`\\theta`. The
 `gamma-astro-data-format <https://gamma-astro-data-formats.readthedocs.io/en/latest/>`__
-specifications offer two different ways to store this information: \* if
-the same :math:`\\theta` cut is applied at all energies and offsets, `a
-`RAD_MAX`
-keyword <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max>`__
-is added to the header of the data units containing IRF components. This
-should be used to define the size of the ON and OFF regions; \* in case
-an energy- (and offset-) dependent :math:`\\theta` cut is applied, its
-values are stored in additional `FITS` data unit, named
-``RAD_MAX_2D` <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max-2d>`__.
+specifications offer two different ways to store this information:
+
+* if the same :math:`\\theta` cut is applied at all energies and offsets, a
+  `RAD_MAX <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max>`__
+  keyword is added to the header of the data units containing IRF components. This
+  should be used to define the size of the ON and OFF regions;
+* in case an energy- (and offset-) dependent :math:`\\theta` cut is applied, its
+  values are stored in additional `FITS` data unit, named
+  `RAD_MAX_2D <https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/point_like/#rad-max-2d>`__.
 
 `Gammapy` provides a class to automatically read these values,
 `~gammapy.irf.RadMax2D`, for both cases (fixed or energy-dependent
@@ -176,7 +176,7 @@ plt.show()
 # --------------------
 #
 # To use the `RAD_MAX_2D` values to define the sizes of the ON and OFF
-# regions **it is necessary to specify the ON region as
+# regions it is necessary to specify the ON region as
 # a `~regions.PointSkyRegion`:
 #
 

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -159,8 +159,8 @@ class Analysis:
         """
         Produce reduced datasets.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
         """
         datasets_settings = self.config.datasets

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -347,8 +347,8 @@ class DataStore:
     ):
         """Generate a `~gammapy.data.Observations`.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -29,7 +29,7 @@ class PointingMode(Enum):
     """
     Describes the behavior of the pointing during the observation.
 
-    See :ref:`gadf:obs-mode`.
+    See :ref:`gadf:iact-events-obs-mode`.
 
     For ground-based instruments, the most common options will be:
     * POINTING: The telescope observes a fixed position in the ICRS frame

--- a/gammapy/estimators/map/asmooth.py
+++ b/gammapy/estimators/map/asmooth.py
@@ -154,8 +154,8 @@ class ASmoothMapEstimator(Estimator):
     def run(self, dataset):
         """Run adaptive smoothing on input MapDataset.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -457,8 +457,8 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         Requires a MapDataset with counts, exposure and background_model
         properly set to run.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters

--- a/gammapy/estimators/points/lightcurve.py
+++ b/gammapy/estimators/points/lightcurve.py
@@ -98,8 +98,8 @@ class LightCurveEstimator(FluxPointsEstimator):
 
         Normalize integral and energy flux between emin and emax.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3240,8 +3240,8 @@ class LabelMapAxis:
     def from_stack(cls, axes):
         """Create a label map axis by merging a list of axis.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         axes : list of `LabelMapAxis`
             A list of map axis to be merged.
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -358,8 +358,8 @@ class Fit:
         The method used is to vary one parameter, keeping all others fixed.
         So this is taking a "slice" or "scan" of the fit statistic.
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters
@@ -416,8 +416,8 @@ class Fit:
 
         See also: `Fit.stat_contour`
 
-        Note
-        ----
+        Notes
+        -----
         The progress bar can be displayed for this function.
 
         Parameters

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -468,6 +468,7 @@ class SpatialModel(ModelBase):
     def from_position(cls, position, **kwargs):
         """Define the position of the model using a sky coord
            The model will be created in the frame of the sky coord
+
         Parameters
         ----------
         position : `~astropy.coordinates.SkyCoord`


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes some docstring formatting issues that were causing warnings in docs deployment and some docs visualization problems (these sections were not being shown).

Also fixes a broken link to GADF docs related to the observation modes section.

Also improves the readability of a paragraph in [spectral calculation with energy-dependent directional cuts](https://docs.gammapy.org/1.1/tutorials/analysis-1d/spectral_analysis_rad_max.html).

Solves #4760 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
