### PR TITLE
Display default model parameters (temporal and spatial) in docstrings

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -510,7 +510,7 @@ class PointSpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
-        Default is 0,0 deg
+        Default is "0 deg", "0 deg"
     frame : {"icrs", "galactic"}
         Center position coordinate frame
     """
@@ -589,7 +589,7 @@ class GaussianSpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
-        Default is 0,0 deg
+        Default is "0 deg", "0 deg"
     sigma : `~astropy.coordinates.Angle`
         Length of the major semiaxis of the Gaussian, in angular units.
         Default is 1 deg
@@ -718,7 +718,7 @@ class GeneralizedGaussianSpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
-        Default is 0,0 deg
+        Default is "0 deg", "0 deg"
     r_0 : `~astropy.coordinates.Angle`
         Length of the major semiaxis, in angular units.
         Default is 1 deg
@@ -845,7 +845,7 @@ class DiskSpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
-        Default is 0,0 deg
+        Default is "0 deg", "0 deg"
     r_0 : `~astropy.coordinates.Angle`
         :math:`a`: length of the major semiaxis, in angular units.
         Default is 1 deg
@@ -1017,7 +1017,7 @@ class ShellSpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
-        Default is 0,0 deg
+        Default is "0 deg", "0 deg"
     radius : `~astropy.coordinates.Angle`
         Inner radius, :math:`r_{in}`
         Default is 1 deg
@@ -1091,7 +1091,7 @@ class Shell2SpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
-        Default is 0,0 deg
+        Default is "0 deg", "0 deg"
     r_0 : `~astropy.coordinates.Angle`
         Outer radius, :math:`r_{out}`
         Default is 1 deg

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -510,6 +510,7 @@ class PointSpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
+        Default is 0,0 deg
     frame : {"icrs", "galactic"}
         Center position coordinate frame
     """
@@ -588,13 +589,17 @@ class GaussianSpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
+        Default is 0,0 deg
     sigma : `~astropy.coordinates.Angle`
         Length of the major semiaxis of the Gaussian, in angular units.
+        Default is 1 deg
     e : `float`
         Eccentricity of the Gaussian (:math:`0< e< 1`).
+        Default is 0
     phi : `~astropy.coordinates.Angle`
         Rotation angle :math:`\phi`: of the major semiaxis.
         Increases counter-clockwise from the North direction.
+        Default is 0 deg
     frame : {"icrs", "galactic"}
         Center position coordinate frame
     """
@@ -705,7 +710,7 @@ class GaussianSpatialModel(SpatialModel):
 
 
 class GeneralizedGaussianSpatialModel(SpatialModel):
-    r"""Two-dimensional Generealized Gaussian model.
+    r"""Two-dimensional Generalized Gaussian model.
 
     For more information see :ref:`generalized-gaussian-spatial-model`.
 
@@ -713,15 +718,20 @@ class GeneralizedGaussianSpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
+        Default is 0,0 deg
     r_0 : `~astropy.coordinates.Angle`
         Length of the major semiaxis, in angular units.
+        Default is 1 deg
     eta : `float`
         Shape parameter whitin (0, 1]. Special cases for disk: ->0, Gaussian: 0.5, Laplace:1
+        Default is 0.5
     e : `float`
         Eccentricity (:math:`0< e< 1`).
+        Default is 0
     phi : `~astropy.coordinates.Angle`
         Rotation angle :math:`\phi`: of the major semiaxis.
         Increases counter-clockwise from the North direction.
+        Default is 0 deg
     frame : {"icrs", "galactic"}
         Center position coordinate frame
     """
@@ -835,17 +845,22 @@ class DiskSpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
+        Default is 0,0 deg
     r_0 : `~astropy.coordinates.Angle`
         :math:`a`: length of the major semiaxis, in angular units.
+        Default is 1 deg
     e : `float`
         Eccentricity of the ellipse (:math:`0< e< 1`).
+        Default is 0
     phi : `~astropy.coordinates.Angle`
         Rotation angle :math:`\phi`: of the major semiaxis.
         Increases counter-clockwise from the North direction.
+        Default is 0 deg
     edge_width : float
         Width of the edge. The width is defined as the range within which
         the smooth edge of the model drops from 95% to 5% of its amplitude.
         It is given as fraction of r_0.
+        Default is 0.01
     frame : {"icrs", "galactic"}
         Center position coordinate frame
     """
@@ -1002,10 +1017,13 @@ class ShellSpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
+        Default is 0,0 deg
     radius : `~astropy.coordinates.Angle`
         Inner radius, :math:`r_{in}`
+        Default is 1 deg
     width : `~astropy.coordinates.Angle`
         Shell width
+        Default is 0.2 deg
     frame : {"icrs", "galactic"}
         Center position coordinate frame
 
@@ -1073,10 +1091,13 @@ class Shell2SpatialModel(SpatialModel):
     ----------
     lon_0, lat_0 : `~astropy.coordinates.Angle`
         Center position
+        Default is 0,0 deg
     r_0 : `~astropy.coordinates.Angle`
         Outer radius, :math:`r_{out}`
+        Default is 1 deg
     eta : float
-        Shell width relative to outer radius, r_0, should be within (0,1]
+        Shell width relative to outer radius, r_0, should be within (0,1)
+        Default is 0.2
     frame : {"icrs", "galactic"}
         Center position coordinate frame
 
@@ -1148,6 +1169,7 @@ class ConstantSpatialModel(SpatialModel):
     ----------
     value : `~astropy.units.Quantity`
         Value
+        Default is 1 sr-1
     """
 
     tag = ["ConstantSpatialModel", "const"]

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -260,10 +260,13 @@ class LinearTemporalModel(TemporalModel):
     ----------
     alpha : float
         Constant term of the baseline flux
+        Default is 1
     beta : `~astropy.units.Quantity`
         Time variation coefficient of the flux
+        Default is 0
     t_ref : `~astropy.units.Quantity`
-        The reference time in mjd. Frozen per default, at 2000-01-01.
+        The reference time in mjd.
+        Frozen per default, at 2000-01-01.
     """
 
     tag = ["LinearTemporalModel", "linear"]
@@ -312,8 +315,10 @@ class ExpDecayTemporalModel(TemporalModel):
     ----------
     t0 : `~astropy.units.Quantity`
         Decay time scale
+        Default is 1 day
     t_ref : `~astropy.units.Quantity`
-        The reference time in mjd. Frozen per default, at 2000-01-01 .
+        The reference time in mjd.
+        Frozen per default, at 2000-01-01.
     """
 
     tag = ["ExpDecayTemporalModel", "exp-decay"]
@@ -358,8 +363,10 @@ class GaussianTemporalModel(TemporalModel):
     ----------
     t_ref : `~astropy.units.Quantity`
         The reference time in mjd at the peak.
+        Default is 2000-01-01
     sigma : `~astropy.units.Quantity`
         Width of the gaussian profile.
+        Default is 1 day
     """
 
     tag = ["GaussianTemporalModel", "gauss"]
@@ -408,12 +415,16 @@ class GeneralizedGaussianTemporalModel(TemporalModel):
     ----------
     t_ref : `~astropy.units.Quantity`
         The time of the pulse's maximum intensity.
+        Default is 2000-01-01
     t_rise : `~astropy.units.Quantity`
         Rise time constant.
+        Default is 1 day
     t_decay : `~astropy.units.Quantity`
         Decay time constant.
+        Default is 1 day
     eta : `~astropy.units.Quantity`
         Inverse pulse sharpness -> higher values implies a more peaked pulse
+        Default is 1/2
 
     """
 
@@ -782,10 +793,13 @@ class PowerLawTemporalModel(TemporalModel):
     ----------
     alpha : float
         Decay time power
+        Default is 1
     t_ref: `~astropy.units.Quantity`
-        The reference time in mjd. Frozen by default, at 2000-01-01.
+        The reference time in mjd.
+        Frozen by default, at 2000-01-01.
     t0: `~astropy.units.Quantity`
-        The scaling time in mjd. Fixed by default, at 1 day.
+        The scaling time in mjd.
+        Fixed by default, at 1 day.
     """
 
     tag = ["PowerLawTemporalModel", "powerlaw"]
@@ -838,10 +852,13 @@ class SineTemporalModel(TemporalModel):
     ----------
     amp : float
         Amplitude of the sinusoidal function
+        Default is 1
     t_ref: `~astropy.units.Quantity`
         The reference time in mjd.
+        Default is 2000-01-01
     omega: `~astropy.units.Quantity`
         Pulsation of the signal.
+        Default is 1 rad/day
     """
 
     tag = ["SineTemporalModel", "sinus"]
@@ -909,14 +926,19 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
         The name of the file containing the phase curve
     t_ref : `~astropy.units.Quantity`
         The reference time in mjd
+        Default is 48442.5 mjd
     phi_ref : `~astropy.units.Quantity`
-        The phase at reference time. Default is 0.
+        The phase at reference time.
+        Default is 0.
     f0 : `~astropy.units.Quantity`
         The frequency at t_ref in s-1
+        Default is 29.946923 s-1
     f1 : `~astropy.units.Quantity`
-        The frequency derivative at t_ref in s-2. Default is 0 s-2.
+        The frequency derivative at t_ref in s-2.
+        Default is 0 s-2.
     f2 : `~astropy.units.Quantity`
-        The frequency second derivative at t_ref in s-3. Default is 0 s-3.
+        The frequency second derivative at t_ref in s-3.
+        Default is 0 s-3.
     """
 
     tag = ["TemplatePhaseCurveTemporalModel", "template-phase"]

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -929,16 +929,16 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
         Default is 48442.5 mjd
     phi_ref : `~astropy.units.Quantity`
         The phase at reference time.
-        Default is 0.
+        Default is 0
     f0 : `~astropy.units.Quantity`
         The frequency at t_ref in s-1
         Default is 29.946923 s-1
     f1 : `~astropy.units.Quantity`
         The frequency derivative at t_ref in s-2.
-        Default is 0 s-2.
+        Default is 0 s-2
     f2 : `~astropy.units.Quantity`
         The frequency second derivative at t_ref in s-3.
-        Default is 0 s-3.
+        Default is 0 s-3
     """
 
     tag = ["TemplatePhaseCurveTemporalModel", "template-phase"]
@@ -1003,7 +1003,8 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
         t_ref : `~astropy.units.Quantity`
             The reference time in mjd.
         phi_ref : `~astropy.units.Quantity`
-            The phase at reference time. Default is 0.
+            The phase at reference time.
+            Default is 0
         f0 : `~astropy.units.Quantity`
             The frequency at t_ref in s-1
         f1 : `~astropy.units.Quantity`


### PR DESCRIPTION
Resolves issue [#4763](https://github.com/gammapy/gammapy/issues/4763)