### PR TITLE
Fix plot spectrum function

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -411,7 +411,7 @@ class Background2D(BackgroundIRF):
         energy_axis = self.axes["energy"]
 
         bkg = self.integral(offset=offset_axis.bounds[1], axis_name="offset")
-        bkg = bkg.to(u.Unit("s-1")/energy_axis.unit)
+        bkg = bkg.to(u.Unit("s-1") / energy_axis.unit)
 
         with quantity_support():
             ax.plot(energy_axis.center, bkg, label="integrated spectrum", **kwargs)

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -411,7 +411,7 @@ class Background2D(BackgroundIRF):
         energy_axis = self.axes["energy"]
 
         bkg = self.integral(offset=offset_axis.bounds[1], axis_name="offset")
-        bkg = bkg.to(u.Unit("s-1 MeV-1"))
+        bkg = bkg.to(u.Unit("s-1")/energy_axis.unit)
 
         with quantity_support():
             ax.plot(energy_axis.center, bkg, label="integrated spectrum", **kwargs)

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -412,7 +412,7 @@ class Background2D(BackgroundIRF):
 
         bkg = self.integral(offset=offset_axis.bounds[1], axis_name="offset")
         bkg = bkg.to(u.Unit("s-1 MeV-1"))
-        
+
         with quantity_support():
             ax.plot(energy_axis.center, bkg, label="integrated spectrum", **kwargs)
 

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -411,7 +411,8 @@ class Background2D(BackgroundIRF):
         energy_axis = self.axes["energy"]
 
         bkg = self.integral(offset=offset_axis.bounds[1], axis_name="offset")
-
+        bkg = bkg.to(u.Unit("s-1 MeV-1"))
+        
         with quantity_support():
             ax.plot(energy_axis.center, bkg, label="integrated spectrum", **kwargs)
 

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -339,7 +339,7 @@ class IRF(metaclass=abc.ABCMeta):
 
         values = self.quantity * axis.bin_width.reshape(shape)
 
-        if axis_name == "rad":
+        if axis_name in ["rad", "offset"]:
             # take Jacobian into account
             values = 2 * np.pi * axis.center.reshape(shape) * values
 

--- a/gammapy/irf/tests/test_core.py
+++ b/gammapy/irf/tests/test_core.py
@@ -76,8 +76,8 @@ def test_cum_sum():
 
     data = np.full((10, 1), 1)
 
-    irf = MyCustomIRF(axes=[energy_axis, offset_axis], data=data, unit=1 / u.deg**2)
+    irf = MyCustomIRF(axes=[energy_axis, offset_axis], data=data, unit="")
     cumsum = irf.cumsum(axis_name="offset")
 
-    assert cumsum.unit == u.Unit("")
+    assert cumsum.unit == u.Unit("deg^2")
     assert cumsum.data[0, 0] == 2.5**2 * np.pi

--- a/gammapy/irf/tests/test_core.py
+++ b/gammapy/irf/tests/test_core.py
@@ -68,3 +68,16 @@ def test_slice_by_idx():
         str(exc_info.value)
         == "Integer indexing not supported, got {'energy': 3, 'offset': 7}"
     )
+
+
+def test_cum_sum():
+    energy_axis = MapAxis.from_energy_bounds(10, 100, 10, unit="TeV", name="energy")
+    offset_axis = MapAxis.from_bounds(0, 2.5, 1, unit="deg", name="offset")
+
+    data = np.full((10, 1), 1)
+
+    irf = MyCustomIRF(axes=[energy_axis, offset_axis], data=data, unit=1 / u.deg**2)
+    cumsum = irf.cumsum(axis_name="offset")
+
+    assert cumsum.unit == u.Unit("")
+    assert cumsum.data[0, 0] == 2.5**2 * np.pi


### PR DESCRIPTION
Actual behavior:
The function `plot_spectrum() ` https://github.com/gammapy/gammapy/blob/4f7f73e493df78ceee59c9884e0ad4750e1fa97c/gammapy/irf/background.py#L398 calculates the integrated background rate and the output is in units of `deg / (MeV s sr)`.

Expected behavior: 
Calculate integrated background rate in units of `1 / (MeV s)`.

Fix:
- Change `cumsum()` function so that the Jacobian is applied when integrating over the offset axis. -> integrated background rate  is calculated in units of `deg^2 / (MeV s sr)`.
- Change `plot_spectrum()`: convert unit of the integrated bg rate to  `1 / (MeV s)`.