### PR TITLE
Fixing overwrite func in plot_distribution

### DIFF
--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -301,11 +301,11 @@ def plot_distribution(
 
             if func == "norm":
 
-                def func(x, mu, sigma):
+                def func_to_fit(x, mu, sigma):
                     return norm.pdf(x, mu, sigma)
 
                 pars, cov, infodict, message, _ = curve_fit(
-                    func, centers, n, **kwargs_fit
+                    func_to_fit, centers, n, **kwargs_fit
                 )
 
                 mu, sig = pars[0], pars[1]
@@ -319,8 +319,10 @@ def plot_distribution(
                 kwargs_plot_fit["label"] = label_norm
 
             else:
+                func_to_fit = func
+
                 pars, cov, infodict, message, _ = curve_fit(
-                    func, centers, n, **kwargs_fit
+                    func_to_fit, centers, n, **kwargs_fit
                 )
 
             axis_edges = (
@@ -339,7 +341,7 @@ def plot_distribution(
             xmin, xmax = kwargs_hist.get("range", (np.min(d), np.max(d)))
             x = np.linspace(xmin, xmax, 1000)
 
-            axe.plot(x, func(x, *pars), lw=2, color="black", **kwargs_plot_fit)
+            axe.plot(x, func_to_fit(x, *pars), lw=2, color="black", **kwargs_plot_fit)
 
         axe.set(**kwargs_axes)
         axe.legend()


### PR DESCRIPTION
This PR is a very small fix for `plot_distribution`. 

Because `func` was overwritten, in case of map with more than one non-spatial bins, the code had not the same behaviour for the first bin and for the other. See pictures, where the second bin does not have the fit information. 
<img width="595" alt="Capture d’écran 2023-09-28 à 16 35 50" src="https://github.com/gammapy/gammapy/assets/108189156/a5739acb-3ccd-4046-983d-88a0fc91a9b2">

I fix that by not overwritting `func` and putting the actual function to fit in `func_to_fit`.