### PR TITLE
Use interpolation for dark matter mass

### DIFF
--- a/examples/tutorials/api/astro_dark_matter.py
+++ b/examples/tutorials/api/astro_dark_matter.py
@@ -154,8 +154,9 @@ for mDM, ax in zip(mDMs, axes):
     ax.set_ylabel("dN/dE")
 
     for channel in ["tau", "mu", "b", "Z"]:
+        fluxes = PrimaryFlux(mDM=mDM, channel=channel)
         fluxes.channel = channel
-        fluxes.table_model.plot(
+        fluxes.plot(
             energy_bounds=[mDM / 100, mDM],
             ax=ax,
             label=channel,

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -35,7 +35,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
     mDM : `~astropy.units.Quantity`
         Dark matter mass
     channel: str
-        Annihilation channel
+        Annihilation channel. List available channels with `~gammapy.spectrum.PrimaryFlux.allowed_channels`.
 
     References
     ----------

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -2,9 +2,7 @@
 """Dark matter spectra."""
 import numpy as np
 import astropy.units as u
-from astropy.coordinates import SkyCoord
 from astropy.table import Table
-from regions import CircleSkyRegion
 from gammapy.maps import MapAxis, RegionNDMap
 from gammapy.modeling import Parameter
 from gammapy.modeling.models import (
@@ -102,18 +100,15 @@ class PrimaryFlux(TemplateNDSpectralModel):
         masses = np.unique(self.table["mDM"])
         log10x = np.unique(self.table["Log[10,x]"])
 
-        coord = SkyCoord(0, 0, unit="deg", frame="galactic")
-        region = CircleSkyRegion(coord, radius=1 * u.deg)
-
         mass_axis = MapAxis.from_nodes(masses, name="mass", interp="log", unit="GeV")
         log10x_axis = MapAxis.from_nodes(log10x, name="energy_true")
 
         channel_name = self.channel_registry[self.channel]
-        regionMap = RegionNDMap.create(
-            region, axes=[log10x_axis, mass_axis], data=self.table[channel_name]
+        region_map = RegionNDMap.create(
+            region=None, axes=[log10x_axis, mass_axis], data=self.table[channel_name]
         )
 
-        super().__init__(regionMap)
+        super().__init__(region_map)
         self.mDM = mDM
         self.mass.frozen = True
 

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -31,7 +31,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
     Parameters
     ----------
     mDM : `~astropy.units.Quantity`
-        Dark matter mass
+        Dark matter particle mass as rest mass energy
     channel: str
         Annihilation channel. List available channels with `~gammapy.spectrum.PrimaryFlux.allowed_channels`.
 
@@ -119,8 +119,19 @@ class PrimaryFlux(TemplateNDSpectralModel):
 
     @mDM.setter
     def mDM(self, mDM):
-        _mDM = u.Quantity(mDM).to("GeV")
-        self.mass.value = _mDM.to_value("GeV")
+        unit = self.mass.unit
+        _mDM = u.Quantity(mDM).to(unit)
+        _mDM_val = _mDM.to_value(unit)
+
+        min_mass = u.Quantity(self.mass.min, unit)
+        max_mass = u.Quantity(self.mass.max, unit)
+
+        if _mDM_val < self.mass.min or _mDM_val > self.mass.max:
+            raise ValueError(
+                f"The mass {_mDM} is out of the bounds of the model. Please choose a mass between {min_mass} < `mDM` < {max_mass}"
+            )
+
+        self.mass.value = _mDM_val
 
     @property
     def allowed_channels(self):

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -13,7 +13,7 @@ def test_primary_flux():
         PrimaryFlux(channel="Spam", mDM=1 * u.TeV)
 
     primflux = PrimaryFlux(channel="W", mDM=1 * u.TeV)
-    actual = primflux.table_model(500 * u.GeV)
+    actual = primflux(500 * u.GeV)
     desired = 9.328234e-05 / u.GeV
     assert_quantity_allclose(actual, desired)
 

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -18,6 +18,16 @@ def test_primary_flux():
     assert_quantity_allclose(actual, desired)
 
 
+@pytest.mark.parametrize(
+    "mass, expected_flux", [(1.6, 0.00024956), (11, 0.00501605), (75, 0.02027279)]
+)
+@requires_data()
+def test_primary_flux_interpolation(mass, expected_flux):
+    primflux = PrimaryFlux(channel="W", mDM=mass * u.TeV)
+    actual = primflux(500 * u.GeV)
+    assert_quantity_allclose(actual, expected_flux / u.GeV, rtol=1e-5)
+
+
 @requires_data()
 def test_dm_annihilation_spectral_model(tmpdir):
     channel = "b"

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1886,14 +1886,15 @@ class TemplateNDSpectralModel(SpectralModel):
         has_energy = False
         for axis in map.geom.axes:
             if axis.name not in ["energy_true", "energy"]:
+                unit = axis.unit
                 center = (axis.bounds[1] + axis.bounds[0]) / 2
                 parameter = Parameter(
                     name=axis.name,
-                    value=center,
-                    unit=axis.unit,
+                    value=center.to_value(unit),
+                    unit=unit,
                     scale_method="scale10",
-                    min=axis.bounds[0],
-                    max=axis.bounds[-1],
+                    min=axis.bounds[0].to_value(unit),
+                    max=axis.bounds[-1].to_value(unit),
                     interp=axis.interp,
                 )
                 parameters.append(parameter)


### PR DESCRIPTION
Fixes #4781 

The `PrimaryFlux` is now based on `TemplateNDSpectralModel`. My upper limit plot looks better now haha :shipit: 

Before:
<img width="810" alt="272549014-0be46766-b6d0-48dc-9372-8acc16eb342d" src="https://github.com/gammapy/gammapy/assets/44728015/0218fb88-e47e-4c8a-9351-6554ae1c9f6d">


After:
<img width="671" alt="Screenshot 2023-10-06 at 16 39 19" src="https://github.com/gammapy/gammapy/assets/44728015/dec54ff7-786e-48d1-8036-55bcb39b9f2f">
