### PR TITLE
Backport #4753: Removes size 1 array to scalar conversion deprecation warnings from numpy 

### DIFF
--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -113,8 +113,8 @@ class PSFMap(IRFMap):
     def _psf_irf(self):
         geom = self.psf_map.geom
         npix_x, npix_y = geom.npix
-        axis_lon = MapAxis.from_edges(np.arange(npix_x + 1) - 0.5, name="lon_idx")
-        axis_lat = MapAxis.from_edges(np.arange(npix_y + 1) - 0.5, name="lat_idx")
+        axis_lon = MapAxis.from_edges(np.arange(npix_x[0] + 1) - 0.5, name="lon_idx")
+        axis_lat = MapAxis.from_edges(np.arange(npix_y[0] + 1) - 0.5, name="lat_idx")
         axes = MapAxes(
             [geom.axes[self.energy_name], geom.axes["rad"], axis_lat, axis_lon]
         )

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -842,7 +842,7 @@ class Map(abc.ABC):
             raise ValueError("Tuple length must equal number of non-spatial dimensions")
 
         # Only support scalar indices per axis
-        idx = tuple([int(_) for _ in idx])
+        idx = tuple([int(_.item()) for _ in np.array(idx)])
 
         geom = self.geom.to_image()
         data = self.data[idx[::-1]]

--- a/gammapy/maps/hpx/geom.py
+++ b/gammapy/maps/hpx/geom.py
@@ -1176,9 +1176,9 @@ class HpxGeom(Geom):
         hpx = self.to_image().to_nside(nside=nside_tiles)
         wcs_tiles = []
 
-        for pix in range(int(hpx.npix)):
+        for pix in range(int(hpx.npix[0])):
             skydir = hpx.pix_to_coord([pix])
-            vtx = hp.boundaries(nside=hpx.nside, pix=pix, nest=hpx.nest, step=1)
+            vtx = hp.boundaries(nside=hpx.nside.item(), pix=pix, nest=hpx.nest, step=1)
 
             lon, lat = hp.vec2ang(vtx.T, lonlat=True)
             boundaries = SkyCoord(lon * u.deg, lat * u.deg, frame=hpx.frame)
@@ -1188,7 +1188,7 @@ class HpxGeom(Geom):
             width = boundaries.separation(boundaries[:, np.newaxis]).max()
 
             wcs_tile_geom = WcsGeom.create(
-                skydir=(float(skydir[0]), float(skydir[1])),
+                skydir=(float(skydir[0].item()), float(skydir[1].item())),
                 width=width + margin,
                 binsz=binsz,
                 frame=hpx.frame,
@@ -1275,7 +1275,7 @@ class HpxGeom(Geom):
                 if idx is not None and idx_img != idx:
                     continue
 
-                npix = int(self._npix[idx_img])
+                npix = int(self._npix[idx_img].item())
                 if idx is None:
                     s_img = (slice(0, npix),) + idx_img
                 else:

--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -94,11 +94,12 @@ class HpxNDMap(HpxMap):
 
         hpx_ref = HpxGeom(nside=nside_superpix, nest=nest, frame=geom_wcs.frame)
 
-        idx = np.arange(map_hpx.geom.to_image().npix)
+        idx = np.arange(map_hpx.geom.to_image().npix.item())
         indices = get_superpixels(idx, map_hpx.geom.nside, nside_superpix, nest=nest)
 
         for wcs_tile in wcs_tiles:
-            hpx_idx = int(hpx_ref.coord_to_idx(wcs_tile.geom.center_skydir)[0])
+            hpx_idx = hpx_ref.coord_to_idx(wcs_tile.geom.center_skydir)[0]
+            hpx_idx = int(hpx_idx.item())
             mask = indices == hpx_idx
             map_hpx.data[mask] = wcs_tile.interp_by_coord(coords[mask])
 
@@ -343,7 +344,12 @@ class HpxNDMap(HpxMap):
         geom : `~HpxNDMap`
             Healpix map with new nside.
         """
-        factor = nside / self.geom.nside
+        if len(self.geom.nside) > 1:
+            raise NotImplementedError(
+                "to_nside() is not supported for an irregular map."
+            )
+
+        factor = nside / self.geom.nside.item()
 
         if factor > 1:
             return self.upsample(factor=int(factor), preserve_counts=preserve_counts)
@@ -460,7 +466,10 @@ class HpxNDMap(HpxMap):
         """
         import healpy as hp
 
-        nside = self.geom.nside
+        if len(self.geom.nside) > 1:
+            raise NotImplementedError("smooth is not supported for an irregular map.")
+
+        nside = self.geom.nside.item()
         lmax = int(3 * nside - 1)  # maximum l of the power spectrum
         ipix = self.geom._ipix
 
@@ -652,7 +661,12 @@ class HpxNDMap(HpxMap):
         """
         import healpy as hp
 
-        nside = self.geom.nside
+        if len(self.geom.nside) > 1:
+            raise NotImplementedError(
+                "convolve_full() is not supported for an irregular map."
+            )
+
+        nside = self.geom.nside.item()
         lmax = int(3 * nside - 1)  # maximum l of the power spectrum
         nest = self.geom.nest
         allsky = self.geom.is_allsky
@@ -970,7 +984,9 @@ class HpxNDMap(HpxMap):
 
         wcs_lonlat = wcs.center_coord[:2]
         idx = self.geom.get_idx()
-        vtx = hp.boundaries(self.geom.nside, idx[0], nest=self.geom.nest, step=step)
+        vtx = hp.boundaries(
+            self.geom.nside.item(), idx[0], nest=self.geom.nest, step=step
+        )
         theta, phi = hp.vec2ang(np.rollaxis(vtx, 2))
         theta = theta.reshape((4 * step, -1)).T
         phi = phi.reshape((4 * step, -1)).T

--- a/gammapy/maps/hpx/utils.py
+++ b/gammapy/maps/hpx/utils.py
@@ -334,14 +334,14 @@ class HpxToWcsMapping:
 
         # FIXME: Calculation of WCS pixel centers should be moved into a
         # method of WcsGeom
-        pix_crds = np.dstack(np.meshgrid(np.arange(npix[0]), np.arange(npix[1])))
+        pix_crds = np.dstack(np.meshgrid(np.arange(npix[0][0]), np.arange(npix[1][0])))
         pix_crds = pix_crds.swapaxes(0, 1).reshape((-1, 2))
         sky_crds = wcs.wcs.wcs_pix2world(pix_crds, 0)
         sky_crds *= np.radians(1.0)
         sky_crds[0:, 1] = (np.pi / 2) - sky_crds[0:, 1]
 
         mask = ~np.any(np.isnan(sky_crds), axis=1)
-        ipix = -1 * np.ones((len(hpx.nside), int(npix[0] * npix[1])), int)
+        ipix = -1 * np.ones((len(hpx.nside), int(npix[0][0] * npix[1][0])), int)
         m = mask[None, :] * np.ones_like(ipix, dtype=bool)
 
         ipix[m] = hp.ang2pix(

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -202,7 +202,7 @@ class RegionGeom(Geom):
     @property
     def npix(self):
         """Number of spatial pixels"""
-        return (1, 1)
+        return ([1], [1])
 
     def contains(self, coords):
         """Check if a given map coordinate is contained in the region.

--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -181,7 +181,7 @@ class WcsGeom(Geom):
         slices = overlap_slices(
             large_array_shape=geom.data_shape[-2:],
             small_array_shape=self.data_shape[-2:],
-            position=position[::-1],
+            position=[_[0] for _ in position[::-1]],
             mode=mode,
         )
         return {
@@ -440,8 +440,8 @@ class WcsGeom(Geom):
         width = _check_width(width) * u.deg
         npix = tuple(np.round(width / geom.pixel_scales).astype(int))
         xref, yref = geom.to_image().coord_to_pix(skydir)
-        xref = int(np.floor(-xref + npix[0] / 2.0)) + geom.wcs.wcs.crpix[0]
-        yref = int(np.floor(-yref + npix[1] / 2.0)) + geom.wcs.wcs.crpix[1]
+        xref = int(np.floor(-xref[0] + npix[0] / 2.0)) + geom.wcs.wcs.crpix[0]
+        yref = int(np.floor(-yref[0] + npix[1] / 2.0)) + geom.wcs.wcs.crpix[1]
         return cls.create(
             skydir=tuple(geom.wcs.wcs.crval),
             npix=npix,

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -303,8 +303,8 @@ class WcsNDMap(WcsMap):
         if self.geom.is_regular:
             slices = [slice(None)] * len(self.geom.axes)
             slices += [
-                slice(crop_width[1], int(self.geom.npix[1] - crop_width[1])),
-                slice(crop_width[0], int(self.geom.npix[0] - crop_width[0])),
+                slice(crop_width[1], int(self.geom.npix[1][0] - crop_width[1])),
+                slice(crop_width[0], int(self.geom.npix[0][0] - crop_width[0])),
             ]
             data = self.data[tuple(slices)]
             map_out = self._init_copy(geom=geom, data=data)
@@ -509,10 +509,10 @@ class WcsNDMap(WcsMap):
         _, ymin = self.geom.to_image().coord_to_pix({"lon": 0, "lat": -90})
         _, ymax = self.geom.to_image().coord_to_pix({"lon": 0, "lat": 90})
 
-        ax.set_xlim(xmin, xmax)
-        ax.set_ylim(ymin, ymax)
+        ax.set_xlim(xmin[0], xmax[0])
+        ax.set_ylim(ymin[0], ymax[0])
 
-        ax.text(0, ymax, self.geom.frame + " coords")
+        ax.text(0, ymax[0], self.geom.frame + " coords")
 
         # Grid and ticks
         glon_spacing, glat_spacing = 45, 15

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -153,8 +153,8 @@ class ModelBase:
 
         for par in self.parameters:
             pars = Parameters([par])
-            variance = self._covariance.get_subcovariance(pars)
-            par.error = np.sqrt(variance)
+            variance = self._covariance.get_subcovariance(pars).data
+            par.error = np.sqrt(variance[0][0])
 
     @property
     def parameters(self):


### PR DESCRIPTION

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request backports #4753 : Removes size 1 array to scalar conversion deprecation warnings from numpy

(cherry picked from commit 463b9677f0e3f1f6e7df189d703fe1933b5064c7)


**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
