### PR TITLE
Fix plotting for Energy Dependent TemplateSpatialModel

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -275,10 +275,13 @@ class SpatialModel(ModelBase):
             )
 
         if geom is None:
-            width = 2 * max(self.evaluation_radius, 0.1 * u.deg)
-            geom = WcsGeom.create(
-                skydir=self.position, frame=self.frame, width=width, binsz=0.02
-            )
+            if isinstance(self, TemplateSpatialModel):
+                geom = self.map.geom
+            else:
+                width = 2 * max(self.evaluation_radius, 0.1 * u.deg)
+                geom = WcsGeom.create(
+                    skydir=self.position, frame=self.frame, width=width, binsz=0.02
+                )
         data = self.evaluate_geom(geom)
         return Map.from_geom(geom, data=data.value, unit=data.unit)
 
@@ -458,9 +461,9 @@ class SpatialModel(ModelBase):
             Axis
         """
 
-        if (geom is None) or geom.is_image:
-            raise TypeError("Use .plot() for 2D Maps")
         m = self._get_plot_map(geom)
+        if (m.geom is None) or m.geom.is_image:
+            raise TypeError("Use .plot() for 2D Maps")
         m.plot_grid(**kwargs)
 
     @classmethod

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -387,6 +387,12 @@ def test_sky_diffuse_map_3d():
     with pytest.raises(TypeError):
         model.plot()
 
+    with mpl_plot_check():
+        model.plot_grid()
+
+    with mpl_plot_check():
+        model.plot_interactive()
+
 
 def test_sky_diffuse_map_normalize():
     # define model map with a constant value of 1
@@ -605,7 +611,6 @@ def test_piecewise_spatial_model_gc():
 
 
 def test_piecewise_spatial_model():
-
     for lon in range(-360, 360):
         geom = WcsGeom.create(
             skydir=(lon, 2.3), npix=(2, 2), binsz=0.3, frame="galactic"


### PR DESCRIPTION
A simple edit to get the map geom for Template Spatial Models for plotting.

Side question: Should Spatial Models be strict about the `energy_true` axis name, specially for Template Maps? The templates usually have an `energy` axis, rather than `energy_true`.