### PR TITLE
Documentation of `SpectrumDatasetMaker`, `NotImplementedError` methods and cleanup

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2745,6 +2745,7 @@ class MapDatasetOnOff(MapDataset):
         )
 
     def pad(self):
+        """Not implemented for MapDatasetOnOff."""
         raise NotImplementedError
 
     def slice_by_idx(self, slices, name=None):

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -292,11 +292,11 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
     tag = "SpectrumDatasetOnOff"
 
     def cutout(self, *args, **kwargs):
-        """Not supported for `SpectrumDataset`"""
+        """Not supported for `SpectrumDatasetOnOff`"""
         raise NotImplementedError("Method not supported on a spectrum dataset")
 
     def plot_residuals_spatial(self, *args, **kwargs):
-        """Not supported for `SpectrumDataset`"""
+        """Not supported for `SpectrumDatasetOnOff`"""
         raise NotImplementedError("Method not supported on a spectrum dataset")
 
     @classmethod

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -265,12 +265,15 @@ class SpectrumDataset(PlotMixin, MapDataset):
     tag = "SpectrumDataset"
 
     def cutout(self, *args, **kwargs):
+        """Not supported for `SpectrumDataset`"""
         raise NotImplementedError("Method not supported on a spectrum dataset")
 
     def plot_residuals_spatial(self, *args, **kwargs):
+        """Not supported for `SpectrumDataset`"""
         raise NotImplementedError("Method not supported on a spectrum dataset")
 
     def to_spectrum_dataset(self, *args, **kwargs):
+        """Not supported for `SpectrumDataset`"""
         raise NotImplementedError("Already a Spectrum Dataset. Method not supported")
 
 
@@ -289,9 +292,11 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
     tag = "SpectrumDatasetOnOff"
 
     def cutout(self, *args, **kwargs):
+        """Not supported for `SpectrumDataset`"""
         raise NotImplementedError("Method not supported on a spectrum dataset")
 
     def plot_residuals_spatial(self, *args, **kwargs):
+        """Not supported for `SpectrumDataset`"""
         raise NotImplementedError("Method not supported on a spectrum dataset")
 
     @classmethod

--- a/gammapy/makers/background/phase.py
+++ b/gammapy/makers/background/phase.py
@@ -13,8 +13,6 @@ __all__ = ["PhaseBackgroundMaker"]
 class PhaseBackgroundMaker(Maker):
     """Background estimation with on and off phases.
 
-    TODO: For a usage example see future notebook.
-
     Parameters
     ----------
     on_phase : `tuple` or list of tuples
@@ -97,18 +95,18 @@ class PhaseBackgroundMaker(Maker):
         )
 
     def run(self, dataset, observation):
-        """Run all steps.
+        """Make on off dataset.
 
         Parameters
         ----------
-        dataset : `SpectrumDataset`
+        dataset : `SpectrumDataset` or `MapDataset`
             Input dataset.
         observation : `Observation`
             Data store observation.
 
         Returns
         -------
-        dataset_on_off : `SpectrumDatasetOnOff`
+        dataset_on_off : `SpectrumDatasetOnOff` or `MapDatasetOnOff`
             On off dataset.
         """
         counts_off = self.make_counts_off(dataset, observation)

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -125,12 +125,6 @@ class MapDatasetMaker(Maker):
     def make_counts(geom, observation):
         """Make counts map.
 
-        **NOTE for 1D analysis:** if the `~gammapy.maps.Geom` is built from a
-        `~regions.CircleSkyRegion`, the latter will be directly used to extract
-        the counts. If instead the `~gammapy.maps.Geom` is built from a
-        `~regions.PointSkyRegion`, the size of the ON region is taken from
-        the `RAD_MAX_2D` table containing energy-dependent theta2 cuts.
-
         Parameters
         ----------
         geom : `~gammapy.maps.Geom`

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -113,7 +113,9 @@ class SpectrumDatasetMaker(MapDatasetMaker):
         counts : `~gammapy.maps.RegionNDMap`
             Counts map.
         """
-        return super().make_counts(geom, observation)
+        return super(SpectrumDatasetMaker, SpectrumDatasetMaker).make_counts(
+            geom, observation
+        )
 
     def run(self, dataset, observation):
         """Make spectrum dataset.
@@ -130,4 +132,4 @@ class SpectrumDatasetMaker(MapDatasetMaker):
         dataset : `~gammapy.spectrum.SpectrumDataset`
             Spectrum dataset.
         """
-        return super().run(dataset, observation)
+        return super(SpectrumDatasetMaker, self).run(dataset, observation)

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -91,3 +91,43 @@ class SpectrumDatasetMaker(MapDatasetMaker):
             exposure.quantity *= containment.reshape(geom.data_shape)
 
         return exposure
+
+    @staticmethod
+    def make_counts(geom, observation):
+        """Make counts map.
+
+        If the `~gammapy.maps.Geom` is built from a `~regions.CircleSkyRegion`,
+        the latter will be directly used to extract the counts.
+        If instead the `~gammapy.maps.Geom` is built from a `~regions.PointSkyRegion`,
+        the size of the ON region is taken from the `RAD_MAX_2D` table containing energy-dependent theta2 cuts.
+
+        Parameters
+        ----------
+        geom : `~gammapy.maps.Geom`
+            Reference map geom.
+        observation : `~gammapy.data.Observation`
+            Observation container.
+
+        Returns
+        -------
+        counts : `~gammapy.maps.RegionNDMap`
+            Counts map.
+        """
+        return super().make_counts(geom, observation)
+
+    def run(self, dataset, observation):
+        """Make spectrum dataset.
+
+        Parameters
+        ----------
+        dataset : `~gammapy.spectrum.SpectrumDataset`
+            Reference dataset.
+        observation : `~gammapy.data.Observation`
+            Observation.
+
+        Returns
+        -------
+        dataset : `~gammapy.spectrum.SpectrumDataset`
+            Spectrum dataset.
+        """
+        return super().run(dataset, observation)

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -96,9 +96,9 @@ class SpectrumDatasetMaker(MapDatasetMaker):
     def make_counts(geom, observation):
         """Make counts map.
 
-        If the `~gammapy.maps.Geom` is built from a `~regions.CircleSkyRegion`,
+        If the `~gammapy.maps.RegionGeom` is built from a `~regions.CircleSkyRegion`,
         the latter will be directly used to extract the counts.
-        If instead the `~gammapy.maps.Geom` is built from a `~regions.PointSkyRegion`,
+        If instead the `~gammapy.maps.RegionGeom` is built from a `~regions.PointSkyRegion`,
         the size of the ON region is taken from the `RAD_MAX_2D` table containing energy-dependent theta2 cuts.
 
         Parameters

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2473,6 +2473,7 @@ class TimeMapAxis:
         return id(self)
 
     def is_aligned(self, other, atol=2e-2):
+        """Not supported for time axis."""
         raise NotImplementedError
 
     @property
@@ -2607,9 +2608,11 @@ class TimeMapAxis:
         return str_.expandtabs(tabsize=2)
 
     def upsample(self):
+        """Not supported for time axis."""
         raise NotImplementedError
 
     def downsample(self):
+        """Not supported for time axis."""
         raise NotImplementedError
 
     def _init_copy(self, **kwargs):
@@ -3196,22 +3199,22 @@ class LabelMapAxis:
 
     # TODO: could create sub-labels here using dashes like "label-1-a", etc.
     def upsample(self, *args, **kwargs):
-        """Upsample axis"""
+        """Not supported for label axis."""
         raise NotImplementedError("Upsampling a LabelMapAxis is not supported")
 
     # TODO: could merge labels here like "label-1-label2", etc.
     def downsample(self, *args, **kwargs):
-        """Downsample axis"""
+        """Not supported for label axis."""
         raise NotImplementedError("Downsampling a LabelMapAxis is not supported")
 
     # TODO: could merge labels here like "label-1-label2", etc.
     def resample(self, *args, **kwargs):
-        """Resample axis"""
+        """Not supported for label axis."""
         raise NotImplementedError("Resampling a LabelMapAxis is not supported")
 
     # TODO: could create new labels here like "label-10-a"
     def pad(self, *args, **kwargs):
-        """Resample axis"""
+        """Not supported for label axis."""
         raise NotImplementedError("Padding a LabelMapAxis is not supported")
 
     def copy(self):


### PR DESCRIPTION
This PR fix issue #4711. I redefine methods that are inherited from the parent class, write a new docstring and call-return the parent methods. This way, the behaviour is not changed, but the docstring is more specific to the child class. If I miss some places in the code where it should be done, let me know, and it can be added to this PR.

In addition:

- I added docstring on methods that are raising `NotImplementedError`. 

- I cleaned up the `PhaseBackgroundMaker` so that the docstring are in agreements with gammapy standard. 