### PR TITLE
Simple fix for reinitialising observation type

### DIFF
--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -519,7 +519,7 @@ class ReflectedRegionsBackgroundMaker(Maker):
 
         if geom.is_all_point_sky_regions and len(regions_off) > 0:
             regions_off = self._filter_regions_off_rad_max(
-                regions_off, energy_axis, geom, events, observation.rad_max
+                regions_off, energy_axis, geom, events, rad_max
             )
 
         if len(regions_off) == 0:
@@ -538,7 +538,7 @@ class ReflectedRegionsBackgroundMaker(Maker):
         if is_point_sky_region:
             counts_off = make_counts_off_rad_max(
                 geom_off=geom_off,
-                rad_max=observation.rad_max,
+                rad_max=rad_max,
                 events=events,
             )
         else:


### PR DESCRIPTION
This PR fixes the multiple loading of `rad_max` from `observation` in the reflected background file. As discussed in the coding sprint (related to #4680) 

This is the only occurrence I found in which something was loaded unnecessarily multiple times