### PR TITLE
Fix the case of none `counts_off` for the function `to_map_dataset`

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2292,10 +2292,7 @@ class MapDatasetOnOff(MapDataset):
         """
         name = make_name(name)
 
-        if self.counts_off is None:
-            background = self.counts * 0.0
-        else:
-            background = self.counts_off * self.alpha
+        background = self.counts_off * self.alpha if self.counts_off else None
 
         return MapDataset(
             counts=self.counts,

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2292,6 +2292,11 @@ class MapDatasetOnOff(MapDataset):
         """
         name = make_name(name)
 
+        if self.counts_off is None:
+            background = self.counts * 0.0
+        else:
+            background = self.counts_off * self.alpha
+
         return MapDataset(
             counts=self.counts,
             exposure=self.exposure,
@@ -2301,7 +2306,7 @@ class MapDatasetOnOff(MapDataset):
             gti=self.gti,
             mask_fit=self.mask_fit,
             mask_safe=self.mask_safe,
-            background=self.counts_off * self.alpha,
+            background=background,
             meta_table=self.meta_table,
         )
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1667,6 +1667,11 @@ def test_to_map_dataset():
     assert isinstance(dataset, MapDataset)
     assert dataset.counts == dataset_onoff.counts
 
+    dataset_onoff.counts_off = None
+    dataset2 = dataset_onoff.to_map_dataset(name="ds2")
+    assert dataset2.background.geom == dataset.background.geom
+    assert_allclose(dataset2.background.data.sum(), 0.0, rtol=1e-6)
+
 
 def test_downsample_onoff():
     axis = MapAxis.from_energy_bounds(1, 10, 4, unit="TeV")

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1669,8 +1669,7 @@ def test_to_map_dataset():
 
     dataset_onoff.counts_off = None
     dataset2 = dataset_onoff.to_map_dataset(name="ds2")
-    assert dataset2.background.geom == dataset.background.geom
-    assert_allclose(dataset2.background.data.sum(), 0.0, rtol=1e-6)
+    assert dataset2.background is None
 
 
 def test_downsample_onoff():

--- a/gammapy/makers/background/reflected.py
+++ b/gammapy/makers/background/reflected.py
@@ -562,7 +562,7 @@ class ReflectedRegionsBackgroundMaker(Maker):
         Returns
         -------
         dataset_on_off : `SpectrumDatasetOnOff`
-            On off dataset.
+            On-Off dataset.
         """
         counts_off, acceptance_off = self.make_counts_off(dataset, observation)
         acceptance = RegionNDMap.from_geom(geom=dataset.counts.geom, data=1)


### PR DESCRIPTION

**Description**
This pull request corrects the bug in the function `to_map_dataset` when the `counts_off` is None

It is associated to the Issue #4563 