### PR TITLE
Fix the stacking of `DatasetsMaker`

### DIFF
--- a/gammapy/makers/reduce.py
+++ b/gammapy/makers/reduce.py
@@ -125,6 +125,8 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
 
     def callback(self, dataset):
         if self.stack_datasets:
+            # print(self._dataset)
+            # print(dataset)
             if isinstance(self._dataset, MapDataset) and isinstance(
                 dataset, MapDatasetOnOff
             ):

--- a/gammapy/makers/reduce.py
+++ b/gammapy/makers/reduce.py
@@ -124,16 +124,18 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
         return dataset_obs
 
     def callback(self, dataset):
-        if self.stack_datasets:
-            # print(self._dataset)
-            # print(dataset)
-            if isinstance(self._dataset, MapDataset) and isinstance(
-                dataset, MapDatasetOnOff
-            ):
-                dataset = dataset.to_map_dataset(name=dataset.name)
-            self._dataset.stack(dataset)
-        else:
-            self._datasets.append(dataset)
+        try:
+            if self.stack_datasets:
+                if isinstance(self._dataset, MapDataset) and isinstance(
+                    dataset, MapDatasetOnOff
+                ):
+                    dataset = dataset.to_map_dataset(name=dataset.name)
+                self._dataset.stack(dataset)
+            else:
+                self._datasets.append(dataset)
+        except Exception as err:
+            self._error = True
+            log.error(err)
 
     def error_callback(self, dataset):
         # parallel run could cause a memory error with non-explicit message.

--- a/gammapy/makers/reduce.py
+++ b/gammapy/makers/reduce.py
@@ -21,7 +21,8 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
     makers : list of `Maker` objects
         Makers
     stack_datasets : bool
-        If True stack into the reference dataset (see `run` method arguments).
+        If True, stack into the reference dataset (see `run` method arguments).
+        Default is True.
     n_jobs : int
         Number of processes to run in parallel.
         Default is one, unless `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified.
@@ -34,8 +35,10 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
         If only one value is passed, a square region is extracted.
         If None it returns an error, except if the list of makers includes a `SafeMaskMaker`
         with the offset-max method defined. In that case it is set to two times `offset_max`.
+        Default is None.
     parallel_backend : {'multiprocessing', 'ray'}
         Which backend to use for multiprocessing.
+        Default is None.
     """
 
     tag = "DatasetsMaker"

--- a/gammapy/makers/reduce.py
+++ b/gammapy/makers/reduce.py
@@ -124,19 +124,12 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
         return dataset_obs
 
     def callback(self, dataset):
-        try:
-            if self.stack_datasets:
-                if (
-                    type(self._dataset) is MapDataset
-                    and type(dataset) is MapDatasetOnOff
-                ):
-                    dataset = dataset.to_map_dataset(name=dataset.name)
-                self._dataset.stack(dataset)
-            else:
-                self._datasets.append(dataset)
-        except Exception as err:
-            self._error = True
-            log.error(err)
+        if self.stack_datasets:
+            if type(self._dataset) is MapDataset and type(dataset) is MapDatasetOnOff:
+                dataset = dataset.to_map_dataset(name=dataset.name)
+            self._dataset.stack(dataset)
+        else:
+            self._datasets.append(dataset)
 
     def error_callback(self, dataset):
         # parallel run could cause a memory error with non-explicit message.

--- a/gammapy/makers/reduce.py
+++ b/gammapy/makers/reduce.py
@@ -126,8 +126,9 @@ class DatasetsMaker(Maker, parallel.ParallelMixin):
     def callback(self, dataset):
         try:
             if self.stack_datasets:
-                if isinstance(self._dataset, MapDataset) and isinstance(
-                    dataset, MapDatasetOnOff
+                if (
+                    type(self._dataset) is MapDataset
+                    and type(dataset) is MapDatasetOnOff
                 ):
                     dataset = dataset.to_map_dataset(name=dataset.name)
                 self._dataset.stack(dataset)

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -121,7 +121,7 @@ def exclusion_mask():
     return ~geom.region_mask([exclusion_region])
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def full_exclusion_mask():
     exclusion_region = CircleSkyRegion(
         center=SkyCoord(183.604, -8.708, unit="deg", frame="galactic"),
@@ -156,7 +156,7 @@ def makers_spectrum(exclusion_mask):
     ]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def failure_makers_spectrum(full_exclusion_mask):
     return [
         SpectrumDatasetMaker(

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -339,10 +339,8 @@ def test_failure_datasets_maker_spectrum(
 
     counts = datasets[0].counts
     assert counts.unit == ""
-    assert_allclose(counts.data.sum(), 192, rtol=1e-5)
-    print(datasets[0].background)
-    print(datasets[1].background)
-    assert_allclose(datasets[0].background.data.sum(), 18.66666664, rtol=1e-5)
+    assert_allclose(counts.data.sum(), 0, rtol=1e-5)
+    assert_allclose(datasets[0].background.data.sum(), 0, rtol=1e-5)
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -20,13 +20,13 @@ from gammapy.maps import MapAxis, RegionGeom, WcsGeom
 from gammapy.utils.testing import requires_data, requires_dependency
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def observations_cta():
     data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps/")
     return data_store.get_observations()[:3]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def observations_cta_with_issue():
     data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps/")
     list = data_store.get_observations()[:2]
@@ -34,7 +34,7 @@ def observations_cta_with_issue():
     return list
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def observations_hess():
     datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
     obs_ids = [23523, 23526, 23559, 23592]

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -157,7 +157,7 @@ def makers_spectrum(exclusion_mask):
 
 
 @pytest.fixture()
-def failure_makers_spectrum(full_exclusion_mask):
+def makers_spectrum_large_region(full_exclusion_mask):
     return [
         SpectrumDatasetMaker(
             containment_correction=True, selection=["counts", "exposure", "edisp"]
@@ -332,10 +332,10 @@ def test_datasets_maker_spectrum(observations_hess, makers_spectrum, spectrum_da
 
 
 @requires_data()
-def test_failure_datasets_maker_spectrum(
-    observations_hess, failure_makers_spectrum, spectrum_dataset
+def test_datasets_maker_spectrum_large_region(
+    observations_hess, makers_spectrum_large_region, spectrum_dataset
 ):
-    makers = DatasetsMaker(failure_makers_spectrum, stack_datasets=True, n_jobs=4)
+    makers = DatasetsMaker(makers_spectrum_large_region, stack_datasets=True, n_jobs=4)
     datasets = makers.run(spectrum_dataset, observations_hess)
 
     counts = datasets[0].counts

--- a/gammapy/makers/tests/test_reduce.py
+++ b/gammapy/makers/tests/test_reduce.py
@@ -30,7 +30,8 @@ def observations_cta():
 def observations_cta_with_issue():
     data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps/")
     list = data_store.get_observations()[:2]
-    list.append(None)
+    empty_obs = Observation()
+    list.append(empty_obs)
     return list
 
 

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -210,13 +210,20 @@ def run_pool_star_map(pool, func, inputs, method_kwargs=None, task_name=""):
 def run_pool_async(pool, func, inputs, method_kwargs=None, task_name=""):
     """Run function in parallel async"""
     results = []
+    print("TOTO")
 
     for arguments in progress_bar(inputs, desc=task_name):
+        # try:
+        #     result = pool.apply_async(func, arguments, **method_kwargs)
+        #     results.append(result)
+        # except Exception as err:
+        #     print("PRINTING ERROR")
+        #     print(err)
         result = pool.apply_async(func, arguments, **method_kwargs)
         results.append(result)
-
     # wait async run is done
     [result.wait() for result in results]
+    print("\n END")
     return results
 
 

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -210,20 +210,12 @@ def run_pool_star_map(pool, func, inputs, method_kwargs=None, task_name=""):
 def run_pool_async(pool, func, inputs, method_kwargs=None, task_name=""):
     """Run function in parallel async"""
     results = []
-    print("TOTO")
 
     for arguments in progress_bar(inputs, desc=task_name):
-        # try:
-        #     result = pool.apply_async(func, arguments, **method_kwargs)
-        #     results.append(result)
-        # except Exception as err:
-        #     print("PRINTING ERROR")
-        #     print(err)
         result = pool.apply_async(func, arguments, **method_kwargs)
         results.append(result)
     # wait async run is done
     [result.wait() for result in results]
-    print("\n END")
     return results
 
 


### PR DESCRIPTION
**Description**
This pull request fixes the stacking when dealing with spectrum datasets. It permits to create a MapDataset only when the final dataset is a MapDataset.

This fix is associated to the issue #4563 .

At the same time, it precises the default values of arguments. And it adds also tests in case of failure modes