### PR TITLE
Introduce a function to compute the doubling/halving time for a lightcurve

### DIFF
--- a/gammapy/estimators/tests/test_utils.py
+++ b/gammapy/estimators/tests/test_utils.py
@@ -9,6 +9,7 @@ from astropy.time import Time
 from gammapy.datasets import MapDataset
 from gammapy.estimators import ExcessMapEstimator, FluxPoints
 from gammapy.estimators.utils import (
+    compute_lightcurve_doublingtime,
     compute_lightcurve_fpp,
     compute_lightcurve_fvar,
     find_peaks,
@@ -181,3 +182,15 @@ def test_compute_lightcurve_fpp():
 
     assert_allclose(ffpp, [[[0.99373035]], [[0.53551551]]])
     assert_allclose(ffpp_err, [[[0.07930673]], [[0.07397653]]])
+
+
+def test_compute_lightcurve_doublingtime():
+
+    lightcurve = lc()
+
+    dtime = compute_lightcurve_doublingtime(lightcurve)
+    ddtime = dtime["doublingtime"].quantity
+    ddtime_err = dtime["doubling_err"].quantity
+
+    assert_allclose(ddtime, [[[245305.49]], [[481572.59]]] * u.s)
+    assert_allclose(ddtime_err, [[[45999.766]], [[11935.665]]] * u.s)

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -433,21 +433,19 @@ def compute_lightcurve_doublingtime(lightcurve, flux_quantity="flux"):
 
     axis = flux.geom.axes.index_data("time")
 
-    doubling, doubling_err, coord = compute_flux_doubling(
-        flux.data, flux_err.data, coords, axis=axis
-    )
+    doubling_dict = compute_flux_doubling(flux.data, flux_err.data, coords, axis=axis)
 
     energies = lightcurve.geom.axes["energy"].edges
     table = Table(
         [
             energies[:-1],
             energies[1:],
-            doubling.T[0],
-            doubling_err.T[0],
-            coord.T[0],
-            np.abs(doubling.T[1]),
-            doubling_err.T[1],
-            coord.T[1],
+            doubling_dict["doubling"],
+            doubling_dict["doubling_err"],
+            doubling_dict["doubling_coord"],
+            doubling_dict["halving"],
+            doubling_dict["halving_err"],
+            doubling_dict["halving_coord"],
         ],
         names=(
             "min_energy",

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -406,12 +406,12 @@ def compute_lightcurve_doublingtime(lightcurve, flux_quantity="flux"):
     Parameters
     ----------
     lightcurve : `~gammapy.estimators.FluxPoints`
-        the lightcurve object
+        The lightcurve object.
     axis_name : str
-        name of the axis over which to compute the flux doubling
+        Name of the axis over which to compute the flux doubling.
     flux_quantity : str
-        flux quantity to use for calculation. Should be 'dnde', 'flux', 'e2dnde' or 'eflux'. Default is 'flux'.
-        Useful in case of custom lightcurves computed outside gammapy
+        Flux quantity to use for calculation. Should be 'dnde', 'flux', 'e2dnde' or 'eflux'.
+        Default is 'flux'.
 
     Returns
     -------

--- a/gammapy/stats/__init__.py
+++ b/gammapy/stats/__init__.py
@@ -7,7 +7,7 @@ from .fit_statistics_cython import (
     f_cash_root_cython,
     norm_bounds_cython,
 )
-from .variability import compute_chisq, compute_fpp, compute_fvar
+from .variability import compute_chisq, compute_flux_doubling, compute_fpp, compute_fvar
 
 __all__ = [
     "cash",
@@ -22,5 +22,6 @@ __all__ = [
     "WStatCountsStatistic",
     "compute_fvar",
     "compute_fpp",
+    "compute_flux_doubling",
     "compute_chisq",
 ]

--- a/gammapy/stats/tests/test_variability.py
+++ b/gammapy/stats/tests/test_variability.py
@@ -140,8 +140,6 @@ def test_lightcurve_flux_doubling():
     dtime_err = dtime_dict["doubling_err"]
     assert_allclose(
         dtime,
-        [[2271.34711286, -2271.34711286], [21743.98603654, -22365.24278044]] * u.s,
+        [2271.34711286, 21743.98603654] * u.s,
     )
-    assert_allclose(
-        dtime_err, [[425.92375713, 425.92375713], [242.80234065, 249.73955038]] * u.s
-    )
+    assert_allclose(dtime_err, [425.92375713, 242.80234065] * u.s)

--- a/gammapy/stats/tests/test_variability.py
+++ b/gammapy/stats/tests/test_variability.py
@@ -2,10 +2,16 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+import astropy.units as u
 from astropy.table import Column, Table
 from astropy.time import Time
 from gammapy.estimators import FluxPoints
-from gammapy.stats.variability import compute_chisq, compute_fpp, compute_fvar
+from gammapy.stats.variability import (
+    compute_chisq,
+    compute_flux_doubling,
+    compute_fpp,
+    compute_fvar,
+)
 from gammapy.utils.testing import assert_quantity_allclose
 
 
@@ -98,3 +104,42 @@ def test_lightcurve_chisq(lc_table):
     chi2, pval = compute_chisq(flux)
     assert_quantity_allclose(chi2, 1e-11)
     assert_quantity_allclose(pval, 0.999997476867478)
+
+
+def test_lightcurve_flux_doubling():
+
+    flux = np.array(
+        [
+            [1e-11, 4e-12],
+            [3e-11, np.nan],
+            [1e-11, 1e-12],
+            [0.8e-11, 0.8e-12],
+            [1e-11, 1e-12],
+        ]
+    )
+    flux_err = np.array(
+        [
+            [0.1e-11, 0.4e-12],
+            [0.3e-11, np.nan],
+            [0.1e-11, 0.1e-12],
+            [0.08e-11, 0.8e-12],
+            [0.1e-11, 0.1e-12],
+        ]
+    )
+    time = (
+        np.array(
+            [6.31157019e08, 6.31160619e08, 6.31164219e08, 6.31171419e08, 6.31178419e08]
+        )
+        * u.s
+    )
+    time_id = 0
+
+    dtime, dtime_err, coord = compute_flux_doubling(flux, flux_err, time, axis=time_id)
+
+    assert_allclose(
+        dtime,
+        [[2271.34711286, -2271.34711286], [21743.98603654, -22365.24278044]] * u.s,
+    )
+    assert_allclose(
+        dtime_err, [[425.92375713, 425.92375713], [242.80234065, 249.73955038]] * u.s
+    )

--- a/gammapy/stats/tests/test_variability.py
+++ b/gammapy/stats/tests/test_variability.py
@@ -134,8 +134,10 @@ def test_lightcurve_flux_doubling():
     )
     time_id = 0
 
-    dtime, dtime_err, coord = compute_flux_doubling(flux, flux_err, time, axis=time_id)
+    dtime_dict = compute_flux_doubling(flux, flux_err, time, axis=time_id)
 
+    dtime = dtime_dict["doubling"]
+    dtime_err = dtime_dict["doubling_err"]
     assert_allclose(
         dtime,
         [[2271.34711286, -2271.34711286], [21743.98603654, -22365.24278044]] * u.s,

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -152,17 +152,17 @@ def compute_flux_doubling(flux, flux_err, coords, axis=0):
      .. math::
         doubling = min(\frac{t_(i+1)-t_i}{log_2{f_(i+1)/f_i}})
 
-    Where f_i and f_(i+1) are the fluxes measured at subsequent coordinates t_i and t_(i+1)
+    where f_i and f_(i+1) are the fluxes measured at subsequent coordinates t_i and t_(i+1).
     The error is obtained by propagating the relative errors on the flux measures.
 
     Parameters
     ----------
     flux : `~astropy.units.Quantity`
-        the measured fluxes
+        The measured fluxes.
     flux_err : `~astropy.units.Quantity`
-        the error on measured fluxes
+        The error on measured fluxes.
     coords: `~astropy.units.Quantity`
-        the coordinates at which the fluxes are measured
+        The coordinates at which the fluxes are measured.
     axis : int, optional
         Axis along which the value is computed.
 

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -168,8 +168,8 @@ def compute_flux_doubling(flux, flux_err, coords, axis=0):
 
     Returns
     -------
-    doubling, doubling_err, coord : `~numpy.ndarray`
-        Characteristic flux doubling, halving and errors,
+    doubling_dict: dict
+        A dictionary containing the characteristic flux doubling, halving and errors,
         with coordinates at which they were found.
     """
 
@@ -218,4 +218,13 @@ def compute_flux_doubling(flux, flux_err, coords, axis=0):
     doubling = np.take_along_axis(axes, index, axis=-1)
     doubling_err = np.take_along_axis(axes_err, index, axis=-1)
 
-    return doubling, doubling_err, coord
+    doubling_dict = {
+        "doubling": doubling.T[0],
+        "doubling_err": doubling_err.T[0],
+        "doubling_coord": coord.T[0],
+        "halving": np.abs(doubling.T[1]),
+        "halving_err": doubling_err.T[1],
+        "halving_coord": coord.T[1],
+    }
+
+    return doubling_dict


### PR DESCRIPTION
This pull request is a simple reopening of pull request #4727 after it was closed by mistake. It contains the same implementation as the previous PR: the flux doubling computation for simple numpy arrays and a wrapper for lightcurve objects, and associated tests.
