### PR TITLE
Computation of total observation time map

### DIFF
--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -41,8 +41,8 @@ or also select observations based on other information available using the `~gam
 
 .. accordion-header::
     :id: collapseHowToThree
-    :title: Check IRFs
-    :link: ../tutorials/data/cta.html#irfs
+    :title: Make observation duration maps
+    :link: ../tutorials/api/makers.html#observation-duration-and-effective-livetime
 
 Gammapy offers a number of methods to explore the content of the various IRFs
 contained in an observation. This is usually done thanks to their ``peek()``

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -373,3 +373,14 @@ using a dummy phase column.
     events_new.write("events.fits.gz", gti=obs.gti, overwrite=True)
 
 .. accordion-footer::
+
+.. accordion-header::
+    :id: collapseHowTo_ObservationMaps
+    :title: Make observation duration maps
+    :link: ../tutorials/api/makers.html#observation-duration-and-effective-livetime
+   
+Compute the absolute and acceptance corrected observation duration in the field of view
+
+.. accordion-footer::
+
+

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -363,7 +363,7 @@ print("No. of observations: ", len(observations))
 energy_min = 100 * u.GeV
 energy_max = 10.0 * u.TeV
 
-# define a offset cut (the camera field of view)
+# Define an offset cut (the camera field of view)
 offset_max = 2.5 * u.deg
 
 # define the geom

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -366,7 +366,7 @@ energy_max = 10.0 * u.TeV
 # Define an offset cut (the camera field of view)
 offset_max = 2.5 * u.deg
 
-# define the geom
+# Define the geom
 source_pos = SkyCoord(228.32, -59.08, unit="deg")
 energy_axis_true = MapAxis.from_energy_bounds(
     energy_min, energy_max, nbin=2, name="energy_true"

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -396,6 +396,7 @@ for obs in observations:
 ax.set_title("Total observation time")
 plt.show()
 
+######################################################################
 # As the acceptance of IACT cameras vary within the field of
 # view, it can also be interesting to plot the on-axis equivalent
 # number of hours.
@@ -418,6 +419,7 @@ for ax in axs:
         )
 plt.show()
 
+######################################################################
 # To get the value of the observation time at a particular position,
 # use `get_by_coord`
 

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -396,9 +396,9 @@ for obs in observations:
 ax.set_title("Total observation time")
 plt.show()
 
-# However, since the acceptance of IACT cameras vary within the field of
-# view, what is often interesting is not simply the total number of
-# hours a source was observed, but the on-axis equivalent number of hours.
+# As the acceptance of IACT cameras vary within the field of
+# view, it can also be interesting to plot the on-axis equivalent 
+# number of hours.
 #
 
 effective_livetime = make_effective_livetime_map(

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -350,7 +350,7 @@ plt.show()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # It can often be useful to know the total number of hours spent
 # in the given field of view (without correcting for the acceptance
-# variation in the field of view. This can be computed using `make_observation_time_map`
+# variation). This can be computed using `make_observation_time_map`
 # as shown below
 #
 

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -20,6 +20,7 @@ Setup
 
 import numpy as np
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
 import matplotlib.pyplot as plt
 from IPython.display import display
@@ -33,6 +34,7 @@ from gammapy.makers import (
     SafeMaskMaker,
     SpectrumDatasetMaker,
 )
+from gammapy.makers.utils import make_effective_livetime_map, make_observation_time_map
 from gammapy.maps import MapAxis, RegionGeom, WcsGeom
 
 ######################################################################
@@ -342,3 +344,93 @@ for observation in observations:
 print(datasets)
 
 plt.show()
+
+######################################################################
+# Observation duration and effective livetime
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# It can often be useful to know the total number of hours spent
+# in the given field of view (without correcting for the acceptance
+# variation in the field of view. This can be computed using `make_observation_time_map`
+# as shown below
+#
+
+# Get the observations
+obs_id = data_store.obs_table["OBS_ID"][data_store.obs_table["OBJECT"] == "MSH 15-5-02"]
+observations = data_store.get_observations(obs_id)
+print("No. of observations: ", len(observations))
+
+# Define an energy range
+energy_min = 100 * u.GeV
+energy_max = 10.0 * u.TeV
+
+# define a offset cut (the camera field of view)
+offset_max = 2.5 * u.deg
+
+# define the geom
+source_pos = SkyCoord(228.32, -59.08, unit="deg")
+energy_axis_true = MapAxis.from_energy_bounds(
+    energy_min, energy_max, nbin=2, name="energy_true"
+)
+geom = WcsGeom.create(
+    skydir=source_pos,
+    binsz=0.02,
+    width=(6, 6),
+    frame="icrs",
+    proj="CAR",
+    axes=[energy_axis_true],
+)
+
+total_obstime = make_observation_time_map(observations, geom, offset_max=offset_max)
+
+
+plt.figure(figsize=(5, 5))
+ax = total_obstime.plot(add_cbar=True)
+# Add the pointing position on top
+for obs in observations:
+    ax.plot(
+        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax.wcs)[0],
+        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax.wcs)[1],
+        "+",
+        color="black",
+    )
+ax.set_title("Total observation time")
+plt.show()
+
+# However, since the acceptance of IACT cameras vary within the field of
+# view, what is often interesting is not simply the total number of
+# hours a source was observed, but the on-axis equivalent number of hours.
+#
+
+effective_livetime = make_effective_livetime_map(
+    observations, geom, offset_max=offset_max
+)
+
+
+axs = effective_livetime.plot_grid(add_cbar=True)
+# Add the pointing position on top
+for ax in axs:
+    for obs in observations:
+        ax.plot(
+            obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax.wcs)[0],
+            obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax.wcs)[1],
+            "+",
+            color="black",
+        )
+plt.show()
+
+# To get the value of the observation time at a particular position,
+# use `get_by_coord`
+
+obs_time_src = total_obstime.get_by_coord(source_pos)
+effective_times_src = effective_livetime.get_by_coord(
+    (source_pos, energy_axis_true.center)
+)
+
+print(f"Time spent on position {source_pos}")
+print(f"Total observation time: {obs_time_src}* {total_obstime.unit}")
+print(
+    f"Effective livetime at {energy_axis_true.center[0]}: {effective_times_src[0]} * {effective_livetime.unit}"
+)
+print(
+    f"Effective livetime at {energy_axis_true.center[1]}: {effective_times_src[1]} * {effective_livetime.unit}"
+)

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -397,7 +397,7 @@ ax.set_title("Total observation time")
 plt.show()
 
 # As the acceptance of IACT cameras vary within the field of
-# view, it can also be interesting to plot the on-axis equivalent 
+# view, it can also be interesting to plot the on-axis equivalent
 # number of hours.
 #
 

--- a/examples/tutorials/data/hess.py
+++ b/examples/tutorials/data/hess.py
@@ -38,7 +38,6 @@ release 1.
 
 """
 
-import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 
@@ -46,9 +45,8 @@ from astropy.coordinates import SkyCoord
 import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import DataStore
-from gammapy.makers import MapDatasetMaker
 from gammapy.makers.utils import make_theta_squared_table
-from gammapy.maps import Map, MapAxis, WcsGeom
+from gammapy.maps import MapAxis, WcsGeom
 
 ######################################################################
 # Check setup
@@ -131,121 +129,6 @@ theta2_table = make_theta_squared_table(
 plt.figure(figsize=(10, 5))
 plot_theta_squared_table(theta2_table)
 plt.show()
-
-######################################################################
-# Observation duration map
-# It can often be useful to plot the total number of hours spent
-# in the given field of view (without correcting for the acceptance
-# variation in the field of view. We calculate the same
-# for the MSH 1552 runs here.
-#
-
-
-def create_obstime_map(observations, geom, offset_max=2.5 * u.deg):
-    stacked = Map.from_geom(geom, unit=u.h)
-    for obs in observations:
-        coords = geom.get_coord(sparse=True)
-        offset = coords.skycoord.separation(obs.get_pointing_icrs(obs.tmid))
-        mask = offset < offset_max
-        c1 = coords.apply_mask(mask)
-        weights = np.ones(c1.shape) * obs.observation_live_time_duration
-        stacked.fill_by_coord(coords=c1, weights=weights)
-    return stacked
-
-
-######################################################################
-# On-axis equivalent livetime
-# ---------------------------
-#
-# Since the acceptance of the H.E.S.S. camera varies within the field of
-# view, what is often interesting is not the simply the total number of
-# hours a source was observed, but the on-axis equivalent number of hours.
-#
-
-
-def create_effective_livetime(observations, geom):
-    livetime = Map.from_geom(geom, unit=u.hr)
-    for obs in observations:
-        geom_obs = geom.cutout(
-            position=obs.get_pointing_icrs(obs.tmid), width=2.0 * offset_max
-        )
-        exposure = MapDatasetMaker.make_exposure(geom=geom_obs, observation=obs)
-        on_axis = obs.aeff.evaluate(
-            offset=0.0 * u.deg, energy_true=geom.axes["energy_true"].center
-        )
-        on_axis = on_axis.reshape((on_axis.shape[0], 1, 1))
-        lv_obs = exposure / on_axis
-        livetime.stack(lv_obs)
-    return livetime
-
-
-# Now, we plot the total and the effective livetime for the MSH 1552 runs here
-
-# Get the observations
-obs_id = data_store.obs_table["OBS_ID"][data_store.obs_table["OBJECT"] == "MSH 15-5-02"]
-observations = data_store.get_observations(obs_id)
-print("No. of observations: ", len(observations))
-
-# Define an energy range
-energy_min = 100 * u.GeV
-energy_max = 10.0 * u.TeV
-
-# define a offset cut
-offset_max = 2.5 * u.deg
-
-# define the geom
-source_pos = SkyCoord(228.32, -59.08, unit="deg")
-energy_axis_true = MapAxis.from_energy_bounds(
-    energy_min, energy_max, nbin=1, name="energy_true"
-)
-geom_livetime = WcsGeom.create(
-    skydir=source_pos,
-    binsz=0.02,
-    width=(6, 6),
-    frame="icrs",
-    proj="CAR",
-    axes=[energy_axis_true],
-)
-
-geom_obs = WcsGeom.create(
-    skydir=source_pos,
-    binsz=0.02,
-    width=(6, 6),
-    frame="icrs",
-    proj="CAR",
-)
-
-
-effective_livetime = create_effective_livetime(observations, geom_livetime)
-total_obstime = create_obstime_map(observations, geom_obs)
-
-# Plot
-fig, (ax1, ax2) = plt.subplots(
-    figsize=(11, 5), subplot_kw={"projection": geom_obs.wcs}, ncols=2
-)
-total_obstime.plot(ax=ax1, add_cbar=True)
-# Add the pointing position on top
-for obs in observations:
-    ax1.plot(
-        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax1.wcs)[0],
-        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax1.wcs)[1],
-        "+",
-        color="black",
-    )
-ax1.set_title("Total observation time")
-
-effective_livetime.plot(ax=ax2, add_cbar=True)
-# Add the pointing position on top
-for obs in observations:
-    ax2.plot(
-        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax2.wcs)[0],
-        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax2.wcs)[1],
-        "+",
-        color="black",
-    )
-ax2.set_title("Effective livetime")
-plt.show()
-
 
 ######################################################################
 # Exercises

--- a/examples/tutorials/data/hess.py
+++ b/examples/tutorials/data/hess.py
@@ -38,6 +38,7 @@ release 1.
 
 """
 
+import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 
@@ -132,14 +133,53 @@ plot_theta_squared_table(theta2_table)
 plt.show()
 
 ######################################################################
+# Observation duration map
+# It can often be useful to plot the total number of hours spent
+# in the given field of view (without correcting for the acceptance
+# variation in the field of view. We calculate the same
+# for the MSH 1552 runs here.
+#
+
+
+def create_obstime_map(observations, geom, offset_max=2.5 * u.deg):
+    stacked = Map.from_geom(geom, unit=u.h)
+    for obs in observations:
+        coords = geom.get_coord(sparse=True)
+        offset = coords.skycoord.separation(obs.get_pointing_icrs(obs.tmid))
+        mask = offset < offset_max
+        c1 = coords.apply_mask(mask)
+        weights = np.ones(c1.shape) * obs.observation_live_time_duration
+        stacked.fill_by_coord(coords=c1, weights=weights)
+    return stacked
+
+
+######################################################################
 # On-axis equivalent livetime
 # ---------------------------
 #
 # Since the acceptance of the H.E.S.S. camera varies within the field of
 # view, what is often interesting is not the simply the total number of
 # hours a source was observed, but the on-axis equivalent number of hours.
-# We calculated the same for the MSH 1552 runs here.
 #
+
+
+def create_effective_livetime(observations, geom):
+    livetime = Map.from_geom(geom, unit=u.hr)
+    for obs in observations:
+        geom_obs = geom.cutout(
+            position=obs.get_pointing_icrs(obs.tmid), width=2.0 * offset_max
+        )
+        exposure = MapDatasetMaker.make_exposure(geom=geom_obs, observation=obs)
+        on_axis = obs.aeff.evaluate(
+            offset=0.0 * u.deg, energy_true=geom.axes["energy_true"].center
+        )
+        on_axis = on_axis.reshape((on_axis.shape[0], 1, 1))
+        lv_obs = exposure / on_axis
+        livetime.stack(lv_obs)
+    return livetime
+
+
+# Now, we plot the total and the effective livetime for the MSH 1552 runs here
 
 # Get the observations
 obs_id = data_store.obs_table["OBS_ID"][data_store.obs_table["OBJECT"] == "MSH 15-5-02"]
@@ -158,7 +198,7 @@ source_pos = SkyCoord(228.32, -59.08, unit="deg")
 energy_axis_true = MapAxis.from_energy_bounds(
     energy_min, energy_max, nbin=1, name="energy_true"
 )
-geom = WcsGeom.create(
+geom_livetime = WcsGeom.create(
     skydir=source_pos,
     binsz=0.02,
     width=(6, 6),
@@ -167,33 +207,45 @@ geom = WcsGeom.create(
     axes=[energy_axis_true],
 )
 
-# compute
-livetime = Map.from_geom(geom, unit=u.hr)
-for obs in observations:
-    geom_obs = geom.cutout(
-        position=obs.get_pointing_icrs(obs.tmid), width=2.0 * offset_max
-    )
-    exposure = MapDatasetMaker.make_exposure(geom=geom_obs, observation=obs)
-    on_axis = obs.aeff.evaluate(
-        offset=0.0 * u.deg, energy_true=geom.axes["energy_true"].center
-    )
-    on_axis = on_axis.reshape((on_axis.shape[0], 1, 1))
-    lv_obs = exposure / on_axis
-    livetime.stack(lv_obs)
+geom_obs = WcsGeom.create(
+    skydir=source_pos,
+    binsz=0.02,
+    width=(6, 6),
+    frame="icrs",
+    proj="CAR",
+)
+
+
+effective_livetime = create_effective_livetime(observations, geom_livetime)
+total_obstime = create_obstime_map(observations, geom_obs)
 
 # Plot
-ax = livetime.plot(add_cbar=True)
-plt.show()
-
+fig, (ax1, ax2) = plt.subplots(
+    figsize=(11, 5), subplot_kw={"projection": geom_obs.wcs}, ncols=2
+)
+total_obstime.plot(ax=ax1, add_cbar=True)
 # Add the pointing position on top
 for obs in observations:
-    ax.plot(
-        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax.wcs)[0],
-        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax.wcs)[1],
+    ax1.plot(
+        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax1.wcs)[0],
+        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax1.wcs)[1],
         "+",
         color="black",
     )
+ax1.set_title("Total observation time")
+
+effective_livetime.plot(ax=ax2, add_cbar=True)
+# Add the pointing position on top
+for obs in observations:
+    ax2.plot(
+        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax2.wcs)[0],
+        obs.get_pointing_icrs(obs.tmid).to_pixel(wcs=ax2.wcs)[1],
+        "+",
+        color="black",
+    )
+ax2.set_title("Effective livetime")
 plt.show()
+
 
 ######################################################################
 # Exercises

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -475,6 +475,7 @@ class TestTheta2Table:
         assert_allclose(theta2_table["alpha"], alpha_two_obs)
 
 
+@requires_data()
 def test_get_camera_fov(observations):
     with pytest.raises(ValueError):
         get_camera_fov(observations)
@@ -489,6 +490,7 @@ def test_get_camera_fov(observations):
         get_camera_fov(obs_no_aeff)
 
 
+@requires_data()
 def test_make_observation_time_map():
     ds = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
     obs_id = ds.obs_table["OBS_ID"][ds.obs_table["OBJECT"] == "MSH 15-5-02"][:3]
@@ -507,6 +509,7 @@ def test_make_observation_time_map():
     assert obs_time.unit == u.hr
 
 
+@requires_data()
 def test_make_effective_livetime_map():
     ds = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
     obs_id = ds.obs_table["OBS_ID"][ds.obs_table["OBJECT"] == "MSH 15-5-02"][:3]

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -17,7 +17,7 @@ from gammapy.irf import (
 from gammapy.makers import WobbleRegionsFinder
 from gammapy.makers.utils import (
     _map_spectrum_weight,
-    get_camera_fov,
+    guess_instrument_fov,
     make_counts_off_rad_max,
     make_counts_rad_max,
     make_edisp_kernel_map,
@@ -476,18 +476,18 @@ class TestTheta2Table:
 
 
 @requires_data()
-def test_get_camera_fov(observations):
+def test_guess_instrument_fov(observations):
     with pytest.raises(ValueError):
-        get_camera_fov(observations)
+        guess_instrument_fov(observations)
 
     ds = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
     obs_hess = ds.obs(23523)
 
-    assert_allclose(get_camera_fov(obs_hess), 2.5 * u.deg)
+    assert_allclose(guess_instrument_fov(obs_hess), 2.5 * u.deg)
 
     obs_no_aeff = obs_hess.copy(in_memory=True, aeff=None)
     with pytest.raises(ValueError):
-        get_camera_fov(obs_no_aeff)
+        guess_instrument_fov(obs_no_aeff)
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -17,11 +17,14 @@ from gammapy.irf import (
 from gammapy.makers import WobbleRegionsFinder
 from gammapy.makers.utils import (
     _map_spectrum_weight,
+    get_camera_fov,
     make_counts_off_rad_max,
     make_counts_rad_max,
     make_edisp_kernel_map,
+    make_effective_livetime_map,
     make_map_background_irf,
     make_map_exposure_true_energy,
+    make_observation_time_map,
     make_theta_squared_table,
 )
 from gammapy.maps import HpxGeom, MapAxis, RegionGeom, WcsGeom, WcsNDMap
@@ -344,7 +347,6 @@ def test_make_edisp_kernel_map():
 
 @requires_data()
 def test_make_counts_rad_max(observations):
-
     pos = SkyCoord(083.6331144560900, +22.0144871383400, unit="deg", frame="icrs")
     on_region = PointSkyRegion(pos)
     energy_axis = MapAxis.from_energy_bounds(
@@ -358,7 +360,6 @@ def test_make_counts_rad_max(observations):
 
 @requires_data()
 def test_make_counts_off_rad_max(observations):
-
     pos = SkyCoord(83.6331, +22.0145, unit="deg", frame="icrs")
     on_region = PointSkyRegion(pos)
     energy_axis = MapAxis.from_energy_bounds(
@@ -472,3 +473,57 @@ class TestTheta2Table:
         assert_allclose(theta2_table_two_obs["acceptance"], acceptance_two_obs)
         assert_allclose(theta2_table_two_obs["acceptance_off"], acceptance_off_two_obs)
         assert_allclose(theta2_table["alpha"], alpha_two_obs)
+
+
+def test_get_camera_fov(observations):
+    with pytest.raises(ValueError):
+        get_camera_fov(observations)
+
+    ds = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
+    obs_hess = ds.obs(23523)
+
+    assert_allclose(get_camera_fov(obs_hess), 2.5 * u.deg)
+
+    obs_no_aeff = obs_hess.copy(in_memory=True, aeff=None)
+    with pytest.raises(ValueError):
+        get_camera_fov(obs_no_aeff)
+
+
+def test_make_observation_time_map():
+    ds = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
+    obs_id = ds.obs_table["OBS_ID"][ds.obs_table["OBJECT"] == "MSH 15-5-02"][:3]
+    observations = ds.get_observations(obs_id)
+    source_pos = SkyCoord(228.32, -59.08, unit="deg")
+    geom = WcsGeom.create(
+        skydir=source_pos,
+        binsz=0.02,
+        width=(6, 6),
+        frame="icrs",
+        proj="CAR",
+    )
+    obs_time = make_observation_time_map(observations, geom, offset_max=2.5 * u.deg)
+    obs_time_center = obs_time.get_by_coord(source_pos)
+    assert_allclose(obs_time_center, 1.2847, rtol=1e-3)
+    assert obs_time.unit == u.hr
+
+
+def test_make_effective_livetime_map():
+    ds = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
+    obs_id = ds.obs_table["OBS_ID"][ds.obs_table["OBJECT"] == "MSH 15-5-02"][:3]
+    observations = ds.get_observations(obs_id)
+    source_pos = SkyCoord(228.32, -59.08, unit="deg")
+    energy_axis_true = MapAxis.from_energy_bounds(
+        10 * u.GeV, 1 * u.TeV, nbin=2, name="energy_true"
+    )
+    geom = WcsGeom.create(
+        skydir=source_pos,
+        binsz=0.02,
+        width=(6, 6),
+        frame="icrs",
+        proj="CAR",
+        axes=[energy_axis_true],
+    )
+    obs_time = make_effective_livetime_map(observations, geom, offset_max=2.5 * u.deg)
+    obs_time_center = obs_time.get_by_coord((source_pos, energy_axis_true.center))
+    assert_allclose(obs_time_center, [0, 1.2847], rtol=1e-3)
+    assert obs_time.unit == u.hr

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -584,7 +584,7 @@ def make_effective_livetime_map(observations, geom, offset_max=None):
     geom : `~gammapy.maps.Geom`
             Reference geom.
     offset_max : `~astropy.units.quantity.Quantity`
-        The maximum offset FoV
+        The maximum offset FoV.
 
     Returns
     -------

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -629,7 +629,7 @@ def get_camera_fov(obs):
     Returns
     -------
     offset_max : `~astropy.units.quantity.Quantity`
-        The maximum offset of the aeff irf
+        The maximum offset of the effective area IRF.
     """
 
     if "aeff" not in obs.available_irfs:

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -551,7 +551,7 @@ def make_observation_time_map(observations, geom, offset_max=None):
     geom : `~gammapy.maps.Geom`
             Reference geom.
     offset_max : `~astropy.units.quantity.Quantity`
-        The maximum offset FoV. If None, will be guessed from the irfs
+        The maximum offset FoV. If None, it will be taken from the IRFs
 
     Returns
     -------


### PR DESCRIPTION
Added a computation of the total observation time map in the H.E.S.S. tutorial.
I was asked this recently in context of H.E.S.S. proposal submission. I am not sure why the total time is more interesting than the effective (acceptance corrected) lifetime, but I thought it would be good to add this in a tutorial since it's not trivial.
I don't think this needs to move into the `MapDataset` meta in the future...