### PR TITLE
Adapt tutorials to include PowerLawNormSpectralModel in the FoVBackgroundMaker

### DIFF
--- a/docs/user-guide/makers/fov.rst
+++ b/docs/user-guide/makers/fov.rst
@@ -19,7 +19,8 @@ Gammapy provides the `~gammapy.makers.FoVBackgroundMaker`. The latter creates a
 and a `~gammapy.modeling.models.NormSpectralModel` which allows to renormalize the background cube, and
 possibly to change its spectral distribution. By default, only the `norm` parameter of a
 `~gammapy.modeling.models.PowerLawNormSpectralModel` is left free. Here we show the addition of a `~gammapy.modeling.models.PowerLawNormSpectralModel`
-in which the `norm` and `tilt` parameters are unfrozen as an example.
+in which the `norm` and `tilt` parameters are unfrozen as an example. It is also possible to implement other normed
+models, such as the `~gammapy.modeling.models.PiecewiseNormSpectralModel`.
 
 .. testcode::
 

--- a/docs/user-guide/makers/fov.rst
+++ b/docs/user-guide/makers/fov.rst
@@ -18,14 +18,15 @@ Gammapy provides the `~gammapy.makers.FoVBackgroundMaker`. The latter creates a
 `~gammapy.modeling.models.FoVBackgroundModel` which combines the `background` predicted number of counts
 and a `~gammapy.modeling.models.NormSpectralModel` which allows to renormalize the background cube, and
 possibly to change its spectral distribution. By default, only the `norm` parameter of a
-`~gammapy.modeling.models.PowerLawNormSpectralModel` is left free. If needed the spectral parameters
-can be unfrozen.
+`~gammapy.modeling.models.PowerLawNormSpectralModel` is left free. Here we show the addition of a `~gammapy.modeling.models.PowerLawNormSpectralModel`
+in which the `norm` and `tilt` parameters are unfrozen as an example.
 
 .. testcode::
 
 	from gammapy.makers import MapDatasetMaker, FoVBackgroundMaker, SafeMaskMaker
 	from gammapy.datasets import MapDataset
 	from gammapy.data import DataStore
+	from gammapy.modeling.models import PowerLawNormSpectralModel
 	from gammapy.maps import MapAxis, WcsGeom, Map
 	from regions import CircleSkyRegion
 	from astropy import units as u
@@ -48,7 +49,14 @@ can be unfrozen.
 	circle = CircleSkyRegion(center=geom.center_skydir, radius=0.2 * u.deg)
 	exclusion_mask = geom.region_mask([circle], inside=False)
 
-	fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
+	spectral_model = PowerLawNormSpectralModel()
+	spectral_model.norm.frozen = False
+	spectral_model.tilt.frozen = False
+	fov_bkg_maker = FoVBackgroundMaker(
+		method="fit",
+		exclusion_mask=exclusion_mask,
+		spectral_model=spectral_model
+	)
 
 	for obs in observations:
 		dataset = maker.run(stacked, obs)

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -127,7 +127,7 @@ plt.show()
 # includes the pixel, while a value of `False` or `0` excludes a
 # pixels from the analysis. To compute safe data range masks according to
 # certain criteria, Gammapy provides a `~gammapy.makers.SafeMaskMaker` class. The
-# different criteria are given by the `methods`\ argument, available
+# different criteria are given by the `methods` argument, available
 # options are :
 #
 # -  aeff-default, uses the energy ranged specified in the DL3 data files,
@@ -188,7 +188,7 @@ plt.show()
 # is incorrect and that some spectral corrections are necessary. This is
 # made possible thanks to the `~gammapy.makers.FoVBackgroundMaker`. This
 # technique is recommended in most 3D data reductions. For more details
-# and usage, see `fov_background <../../user-guide/makers/fov.rst>`__.
+# and usage, see the :doc:`FoV background </user-guide/makers/fov>`.
 #
 # Here we are going to use a `~gammapy.makers.FoVBackgroundMaker` that
 # will rescale the background model to the data excluding the region where
@@ -204,7 +204,7 @@ dataset = fov_bkg_maker.run(dataset)
 
 
 ######################################################################
-# Other backgrounds production methods are available as listed below.
+# Other backgrounds production methods available are listed below.
 #
 # Ring background
 # ~~~~~~~~~~~~~~~
@@ -219,7 +219,7 @@ dataset = fov_bkg_maker.run(dataset)
 # fitting.
 #
 # For more details and usage, see
-# `ring_background <../../user-guide/makers/ring.rst>`__.
+# :doc:`Ring background </user-guide/makers/ring>`
 #
 # Reflected regions background
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -234,7 +234,7 @@ dataset = fov_bkg_maker.run(dataset)
 # This method is only used for 1D spectral analysis.
 #
 # For more details and usage, see
-# `reflected_background <../../user-guide/makers/reflected.rst>`__.
+# the :doc:`Reflected background </user-guide/makers/ring>`
 #
 # Data reduction loop
 # -------------------


### PR DESCRIPTION
This is to include a spectral model (`PowerLawNormSpectralModel`) in which both the tilt and norm are unfrozen, and fit for the `FoVBackgroundMaker`. This partly resolves task number 5 in #4788 

I also noticed some broken links so fixed those.