### PR TITLE
Add a function to delete a time interval from GTI

### DIFF
--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -323,7 +323,7 @@ class GTI:
 
         Parameters
         ----------
-        time_interval : `astropy.time.Time`
+        time_interval : [`astropy.time.Time`, `astropy.time.Time`]
             Start and stop time for the selection.
 
         Returns

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -335,7 +335,7 @@ class GTI:
         interval_start.format = self.time_start.format
         interval_stop.format = self.time_stop.format
 
-        trim_table = self.table
+        trim_table = self.table.copy()
 
         trim_table["STOP"][
             (self.time_start < interval_start) & (self.time_stop > interval_start)

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -318,6 +318,35 @@ class GTI:
 
         return self.__class__(gti_within)
 
+    def delete_interval(self, time_interval):
+        """Select and crop GTIs in time interval.
+
+        Parameters
+        ----------
+        time_interval : `astropy.time.Time`
+            Start and stop time for the selection.
+
+        Returns
+        -------
+        gti : `GTI`
+            Copy of the GTI table with the bad time interval deleted.
+        """
+        interval_start, interval_stop = time_interval
+        interval_start.format = self.time_start.format
+        interval_stop.format = self.time_stop.format
+
+        trim_table = self.table
+
+        trim_table["STOP"][
+            (self.time_start < interval_start) & (self.time_stop > interval_start)
+        ] = interval_start
+        trim_table["START"][
+            (self.time_start < interval_stop) & (self.time_stop > interval_stop)
+        ] = interval_stop
+        mask = (self.time_stop > interval_stop) | (self.time_start < interval_start)
+
+        return self.__class__(trim_table[mask])
+
     def stack(self, other):
         """Stack with another GTI in place.
 

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -150,6 +150,8 @@ def test_gti_delete_intervals():
         ),
     )
     interval = Time(["2020-01-01 02:20:00.000", "2020-01-01 05:20:00.000"])
+    interval2 = Time(["2020-01-01 05:30:00.000", "2020-01-01 08:20:00.000"])
+    interval3 = Time(["2020-01-01 05:50:00.000", "2020-01-01 09:20:00.000"])
 
     gti_trim = gti.delete_interval(interval)
 
@@ -172,6 +174,30 @@ def test_gti_delete_intervals():
                 "2020-01-01 01:45:00.000",
                 "2020-01-01 02:20:00.000",
                 "2020-01-01 05:45:00.000",
+            ]
+        ),
+    )
+
+    gti_trim2 = gti_trim.delete_interval(interval2)
+    assert_time_allclose(
+        gti_trim2.table["STOP"],
+        Time(
+            [
+                "2020-01-01 01:45:00.000",
+                "2020-01-01 02:20:00.000",
+                "2020-01-01 05:30:00.000",
+            ]
+        ),
+    )
+
+    gti_trim3 = gti_trim2.delete_interval(interval3)
+    assert_time_allclose(
+        gti_trim3.table["STOP"],
+        Time(
+            [
+                "2020-01-01 01:45:00.000",
+                "2020-01-01 02:20:00.000",
+                "2020-01-01 05:30:00.000",
             ]
         ),
     )

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -130,6 +130,53 @@ def test_select_time(time_interval, expected_length, expected_times):
         assert_time_allclose(gti_selected.time_stop[-1], expected_times[1])
 
 
+def test_gti_delete_intervals():
+    gti = GTI.create(
+        Time(
+            [
+                "2020-01-01 01:00:00.000",
+                "2020-01-01 02:00:00.000",
+                "2020-01-01 03:00:00.000",
+                "2020-01-01 05:00:00.000",
+            ]
+        ),
+        Time(
+            [
+                "2020-01-01 01:45:00.000",
+                "2020-01-01 02:45:00.000",
+                "2020-01-01 03:45:00.000",
+                "2020-01-01 05:45:00.000",
+            ]
+        ),
+    )
+    interval = Time(["2020-01-01 02:20:00.000", "2020-01-01 05:20:00.000"])
+
+    gti_trim = gti.delete_interval(interval)
+
+    assert len(gti_trim.table) == 3
+
+    assert_time_allclose(
+        gti_trim.table["START"],
+        Time(
+            [
+                "2020-01-01 01:00:00.000",
+                "2020-01-01 02:00:00.000",
+                "2020-01-01 05:20:00.000",
+            ]
+        ),
+    )
+    assert_time_allclose(
+        gti_trim.table["STOP"],
+        Time(
+            [
+                "2020-01-01 01:45:00.000",
+                "2020-01-01 02:20:00.000",
+                "2020-01-01 05:45:00.000",
+            ]
+        ),
+    )
+
+
 def test_gti_stack():
     time_ref = Time("2010-01-01")
     gti1 = make_gti({"START": [0, 2] * u.s, "STOP": [1, 3] * u.s}, time_ref=time_ref)


### PR DESCRIPTION
As requested by the issue #4784 I added a function that removes a "bad time interval" from the GTIs with correlated test. A future addition will be a more complex handling of lists of "bad periods"