### PR TITLE
fix vmin vmax to (0, 1) when plotting mask

### DIFF
--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -10,6 +10,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.nddata import block_reduce
 from regions import PixCoord, PointPixelRegion, PointSkyRegion, SkyRegion
+import matplotlib.colors as mpcolors
 import matplotlib.pyplot as plt
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
 from gammapy.utils.units import unit_from_fits_image_hdu
@@ -21,6 +22,9 @@ from .geom import WcsGeom
 __all__ = ["WcsNDMap"]
 
 log = logging.getLogger(__name__)
+
+
+C_MAP_MASK = mpcolors.ListedColormap(["black", "white"], name="mask")
 
 
 class WcsNDMap(WcsMap):
@@ -409,6 +413,7 @@ class WcsNDMap(WcsMap):
         if self.is_mask:
             kwargs.setdefault("vmin", 0)
             kwargs.setdefault("vmax", 1)
+            kwargs["cmap"] = C_MAP_MASK
 
         if mask.any():
             min_cut, max_cut = kwargs.pop("vmin", None), kwargs.pop("vmax", None)

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -406,6 +406,10 @@ class WcsNDMap(WcsMap):
 
         mask = np.isfinite(data)
 
+        if self.is_mask:
+            kwargs.setdefault("vmin", 0)
+            kwargs.setdefault("vmax", 1)
+
         if mask.any():
             min_cut, max_cut = kwargs.pop("vmin", None), kwargs.pop("vmax", None)
             norm = simple_norm(data[mask], stretch, min_cut=min_cut, max_cut=max_cut)

--- a/gammapy/maps/wcs/tests/test_ndmap.py
+++ b/gammapy/maps/wcs/tests/test_ndmap.py
@@ -970,3 +970,19 @@ def test_to_region_nd_map_histogram_advanced():
     assert_allclose(
         hist.data[:, :, 2, 0, 0], [[24189, 13587, 9212], [24053, 13410, 9186]]
     )
+
+
+def test_plot_mask():
+    axis = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=2)
+    geom = WcsGeom.create(
+        binsz=0.02,
+        width=(2, 2),
+        frame="icrs",
+        axes=[axis],
+    )
+
+    mask = Map.from_geom(geom=geom, dtype=bool)
+    mask.data[1] |= True
+
+    with mpl_plot_check():
+        mask.plot_grid()


### PR DESCRIPTION
This PR is related to issue #4830. 

It set vmin and vmax to (0, 1) resp. when plotting mask. This simple fix transform the example shown in the issue to this :
<img width="986" alt="Capture d’écran 2023-10-19 à 15 15 33" src="https://github.com/gammapy/gammapy/assets/108189156/2a0febbc-89ca-413b-9263-211275376ced">
