### PR TITLE
Add checksum argument to gammapy products write functions

### DIFF
--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import collections
 import copy
-import logging
 import html
+import logging
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import AltAz, Angle, SkyCoord, angular_separation
@@ -130,7 +130,7 @@ class EventList:
 
         return fits.BinTableHDU(self.table, name="EVENTS")
 
-    def write(self, filename, gti=None, overwrite=False, format="gadf"):
+    def write(self, filename, gti=None, overwrite=False, format="gadf", checksum=False):
         """Write the event list to a FITS file.
 
         If a GTI object is provided, it is saved into
@@ -148,6 +148,9 @@ class EventList:
         format : str, optional
             FITS format convention.  By default files will be written
             to the gamma-astro-data-formats (GADF) format.
+        checksum : bool
+            When True adds both DATASUM and CHECKSUM cards to the headers written to the file.
+            Default is False.
         """
 
         if format != "gadf":
@@ -177,7 +180,7 @@ class EventList:
             hdu_gti = gti.to_table_hdu(format=format)
             hdu_all.append(hdu_gti)
 
-        hdu_all.writeto(filename, overwrite=overwrite)
+        hdu_all.writeto(filename, overwrite=overwrite, checksum=checksum)
 
     @classmethod
     def from_stack(cls, event_lists, **kwargs):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -557,7 +557,9 @@ class Observation:
             **irf_dict,
         )
 
-    def write(self, path, overwrite=False, format="gadf", include_irfs=True):
+    def write(
+        self, path, overwrite=False, format="gadf", include_irfs=True, checksum=False
+    ):
         """
         Write this observation into `path` using the specified format
 
@@ -571,6 +573,9 @@ class Observation:
             Output format, currently only "gadf" is supported
         include_irfs: bool
             Whether to include irf components in the output file
+        checksum : bool
+            When True adds both DATASUM and CHECKSUM cards to the headers written to the file.
+            Default is False.
         """
         if format != "gadf":
             raise ValueError(f'Only the "gadf" format is supported, got {format}')
@@ -599,7 +604,7 @@ class Observation:
                 if irf is not None:
                     hdul.append(irf.to_table_hdu(format="gadf-dl3"))
 
-        hdul.writeto(path, overwrite=overwrite)
+        hdul.writeto(path, overwrite=overwrite, checksum=checksum)
 
     def copy(self, in_memory=False, **kwargs):
         """Copy observation

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -568,11 +568,11 @@ class Observation:
         path: str or `~pathlib.Path`
             Path for the output file
         overwrite: bool
-            If true, existing files are overwritten.
+            If true, existing files are overwritten. Default is False.
         format: str
-            Output format, currently only "gadf" is supported
+            Output format, currently only "gadf" is supported. Default is "gadf".
         include_irfs: bool
-            Whether to include irf components in the output file
+            Whether to include irf components in the output file. Default is True.
         checksum : bool
             When True adds both DATASUM and CHECKSUM cards to the headers written to the file.
             Default is False.

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -3,6 +3,7 @@ import pytest
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from astropy.table import Table
 from regions import CircleSkyRegion, RectangleSkyRegion
 from gammapy.data import GTI, EventList
@@ -81,6 +82,12 @@ class TestEventListBase:
             dummy_events.table.meta["HDUCLASS"] = "gadf"
             dummy_events.table.meta["HDUCLAS1"] = "events"
             dummy_events.write("test.fits", overwrite=True)
+
+    def test_write_checksum(self):
+        self.events.write("test.fits", overwrite=True, checksum=True)
+        hdu = fits.open("test.fits")["EVENTS"]
+        assert "CHECKSUM" in hdu.header
+        assert "DATASUM" in hdu.header
 
 
 @requires_data()

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.io import fits
 from astropy.time import Time
 from astropy.units import Quantity
 from gammapy.data import DataStore, Observation, ObservationFilter, Observations
@@ -400,6 +401,20 @@ def test_observation_write(tmp_path):
     assert obs_read.edisp is None
     assert obs_read.bkg is None
     assert obs_read.rad_max is None
+
+
+@requires_data()
+def test_observation_write_checksum(tmp_path):
+    obs = Observation.read(
+        "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
+    )
+    path = tmp_path / "obs.fits.gz"
+
+    obs.write(path, checksum=True)
+    hdul = fits.open(path)
+    for hdu in hdul:
+        assert "CHECKSUM" in hdu.header
+        assert "DATASUM" in hdu.header
 
 
 @requires_data()

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -434,11 +434,11 @@ class Datasets(collections.abc.MutableSequence):
         filename : str or `Path`
             File path or name of datasets yaml file
         filename_models : str or `Path`
-            File path or name of models yaml file
+            File path or name of models yaml file. Default is None.
         overwrite : bool
-            overwrite datasets FITS files
+            overwrite datasets FITS files. Default is False.
         write_covariance : bool
-            save covariance or not
+            save covariance or not. Default is False.
         checksum : bool
             When True adds both DATASUM and CHECKSUM cards to the headers written to the FITS files.
             Default is False.

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -420,7 +420,12 @@ class Datasets(collections.abc.MutableSequence):
         return datasets
 
     def write(
-        self, filename, filename_models=None, overwrite=False, write_covariance=True
+        self,
+        filename,
+        filename_models=None,
+        overwrite=False,
+        write_covariance=True,
+        checksum=False,
     ):
         """Serialize datasets to YAML and FITS files.
 
@@ -434,6 +439,9 @@ class Datasets(collections.abc.MutableSequence):
             overwrite datasets FITS files
         write_covariance : bool
             save covariance or not
+        checksum : bool
+            When True adds both DATASUM and CHECKSUM cards to the headers written to the FITS files.
+            Default is False.
         """
         path = make_path(filename)
 
@@ -442,7 +450,9 @@ class Datasets(collections.abc.MutableSequence):
         for dataset in self._datasets:
             d = dataset.to_dict()
             filename = d["filename"]
-            dataset.write(path.parent / filename, overwrite=overwrite)
+            dataset.write(
+                path.parent / filename, overwrite=overwrite, checksum=checksum
+            )
             data["datasets"].append(d)
 
         write_yaml(data, path, sort_keys=False)

--- a/gammapy/datasets/io.py
+++ b/gammapy/datasets/io.py
@@ -63,20 +63,24 @@ class OGIPDatasetWriter(DatasetWriter):
     filename : `pathlib.Path` or str
         Filename
     format : {"ogip", "ogip-sherpa"}
-        Which format to use
+        Which format to use. Default is 'ogip'.
     overwrite : bool
-        Overwrite existing files?
+        Overwrite existing files? Default is False.
+    checksum : bool
+        When True adds both DATASUM and CHECKSUM cards to the headers written to the files.
+        Default is False.
     """
 
     tag = ["ogip", "ogip-sherpa"]
 
-    def __init__(self, filename, format="ogip", overwrite=False):
+    def __init__(self, filename, format="ogip", overwrite=False, checksum=False):
         filename = make_path(filename)
         filename.parent.mkdir(exist_ok=True, parents=True)
 
         self.filename = filename
         self.format = format
         self.overwrite = overwrite
+        self.checksum = checksum
 
     @staticmethod
     def get_filenames(filename):
@@ -164,7 +168,12 @@ class OGIPDatasetWriter(DatasetWriter):
             Filename to use
         """
         kernel = dataset.edisp.get_edisp_kernel()
-        kernel.write(filename=filename, overwrite=self.overwrite, format=self.format)
+        kernel.write(
+            filename=filename,
+            overwrite=self.overwrite,
+            format=self.format,
+            checksum=self.checksum,
+        )
 
     def write_arf(self, dataset, filename):
         """Write effective area.
@@ -182,6 +191,7 @@ class OGIPDatasetWriter(DatasetWriter):
             filename=filename,
             overwrite=self.overwrite,
             format=self.format.replace("ogip", "ogip-arf"),
+            checksum=self.checksum,
         )
 
     def to_counts_hdulist(self, dataset, is_bkg=False):
@@ -235,7 +245,7 @@ class OGIPDatasetWriter(DatasetWriter):
             hdu = dataset.gti.to_table_hdu()
             hdulist.append(hdu)
 
-        hdulist.writeto(filename, overwrite=self.overwrite)
+        hdulist.writeto(filename, overwrite=self.overwrite, checksum=self.checksum)
 
     def write_bkg(self, dataset, filename):
         """Write off counts file.
@@ -248,7 +258,7 @@ class OGIPDatasetWriter(DatasetWriter):
             Filename to use
         """
         hdulist = self.to_counts_hdulist(dataset, is_bkg=True)
-        hdulist.writeto(filename, overwrite=self.overwrite)
+        hdulist.writeto(filename, overwrite=self.overwrite, checksum=self.checksum)
 
 
 class OGIPDatasetReader(DatasetReader):

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1250,7 +1250,7 @@ class MapDataset(Dataset):
 
         return cls(**kwargs)
 
-    def write(self, filename, overwrite=False):
+    def write(self, filename, overwrite=False, checksum=False):
         """Write Dataset to file.
 
         A MapDataset is serialised using the GADF format with a WCS geometry.
@@ -1262,8 +1262,13 @@ class MapDataset(Dataset):
             Filename to write to.
         overwrite : bool
             Overwrite file if it exists.
+        checksum : bool
+            When True adds both DATASUM and CHECKSUM cards to the headers written to the file.
+            Default is False.
         """
-        self.to_hdulist().writeto(str(make_path(filename)), overwrite=overwrite)
+        self.to_hdulist().writeto(
+            str(make_path(filename)), overwrite=overwrite, checksum=checksum
+        )
 
     @classmethod
     def _read_lazy(cls, name, filename, cache, format=format):

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -324,7 +324,7 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
         reader = OGIPDatasetReader(filename=filename)
         return reader.read()
 
-    def write(self, filename, overwrite=False, format="ogip"):
+    def write(self, filename, overwrite=False, format="ogip", checksum=False):
         """Write spectrum dataset on off to file.
 
         Can be serialised either as a `MapDataset` with a `RegionGeom`
@@ -339,14 +339,17 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
             Overwrite existing file.
         format : {"ogip", "ogip-sherpa", "gadf"}
             Format to use.
+        checksum : bool
+            When True adds both DATASUM and CHECKSUM cards to the headers written to the file.
+            Default is False.
         """
         from .io import OGIPDatasetWriter
 
         if format == "gadf":
-            super().write(filename=filename, overwrite=overwrite)
+            super().write(filename=filename, overwrite=overwrite, checksum=checksum)
         elif format in ["ogip", "ogip-sherpa"]:
             writer = OGIPDatasetWriter(
-                filename=filename, format=format, overwrite=overwrite
+                filename=filename, format=format, overwrite=overwrite, checksum=checksum
             )
             writer.write(self)
         else:

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1251,8 +1251,7 @@ def test_map_datasets_on_off_fits_io(images, tmp_path):
 def test_map_datasets_on_off_checksum(images, tmp_path):
     dataset = get_map_dataset_onoff(images)
     Datasets([dataset]).write(tmp_path / "test.yaml", checksum=True)
-    file = open(tmp_path / "test.yaml")
-    print(file.read())
+
     hdul = fits.open(tmp_path / "MapDatasetOnOff-test.fits")
     for hdu in hdul:
         assert "CHECKSUM" in hdu.header

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from astropy.table import Table
 from regions import CircleSkyRegion
 from gammapy.catalog import SourceCatalog3FHL
@@ -1244,6 +1245,18 @@ def test_map_datasets_on_off_fits_io(images, tmp_path):
     assert_allclose(dataset.acceptance_off.data, dataset_new.acceptance_off.data)
     assert_allclose(dataset.exposure.data, dataset_new.exposure.data)
     assert_allclose(dataset.mask_safe, dataset_new.mask_safe)
+
+
+@requires_data()
+def test_map_datasets_on_off_checksum(images, tmp_path):
+    dataset = get_map_dataset_onoff(images)
+    Datasets([dataset]).write(tmp_path / "test.yaml", checksum=True)
+    file = open(tmp_path / "test.yaml")
+    print(file.read())
+    hdul = fits.open(tmp_path / "MapDatasetOnOff-test.fits")
+    for hdu in hdul:
+        assert "CHECKSUM" in hdu.header
+        assert "DATASUM" in hdu.header
 
 
 def test_create_onoff(geom):

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
+from astropy.io import fits
 from astropy.table import Table
 from astropy.time import Time
 from gammapy.data import GTI
@@ -587,6 +588,16 @@ class TestSpectrumOnOff:
         assert newdataset.counts_off is None
         assert newdataset.edisp is None
         assert newdataset.gti is None
+
+    def test_to_ogip_files_checksum(self, tmp_path):
+        dataset = self.dataset.copy(name="test")
+        dataset.write(tmp_path / "test.fits", format="ogip", checksum=True)
+
+        for file in ["test.fits", "test_arf.fits", "test_rmf.fits", "test_bkg.fits"]:
+            hdul = fits.open(tmp_path / file)
+            for hdu in hdul:
+                assert "CHECKSUM" in hdu.header
+                assert "DATASUM" in hdu.header
 
     def test_spectrum_dataset_onoff_fits_io(self, tmp_path):
         self.dataset.write(tmp_path / "test.fits", format="gadf")

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -850,7 +850,7 @@ class IRFMap:
 
         return hdulist
 
-    def write(self, filename, overwrite=False, format="gadf"):
+    def write(self, filename, overwrite=False, format="gadf", checksum=False):
         """Write IRF map to fits
 
         Parameters
@@ -861,9 +861,12 @@ class IRFMap:
             Whether to overwrite
         format : {"gadf", "gtpsf"}
             File format
+        checksum : bool
+            When True adds both DATASUM and CHECKSUM cards to the headers written to the file.
+            Default is False.
         """
         hdulist = self.to_hdulist(format=format)
-        hdulist.writeto(str(filename), overwrite=overwrite)
+        hdulist.writeto(str(filename), overwrite=overwrite, checksum=checksum)
 
     def stack(self, other, weights=None, nan_to_num=True):
         """Stack IRF map with another one in place.

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -422,9 +422,7 @@ class Map(abc.ABC):
         """
         checksum = kwargs.pop("checksum", False)
         hdulist = self.to_hdulist(**kwargs)
-        hdulist.writeto(
-            str(make_path(filename)), overwrite=overwrite, checksum=checksum
-        )
+        hdulist.writeto(make_path(filename), overwrite=overwrite, checksum=checksum)
 
     def iter_by_axis(self, axis_name, keepdims=False):
         """ "Iterate over a given axis

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -416,9 +416,15 @@ class Map(abc.ABC):
         sparse : bool
             Sparsify the map by dropping pixels with zero amplitude.
             This option is only compatible with the 'gadf' format.
+        checksum : bool
+            When True adds both DATASUM and CHECKSUM cards to the headers written to the file.
+            Default is False.
         """
+        checksum = kwargs.pop("checksum", False)
         hdulist = self.to_hdulist(**kwargs)
-        hdulist.writeto(str(make_path(filename)), overwrite=overwrite)
+        hdulist.writeto(
+            str(make_path(filename)), overwrite=overwrite, checksum=checksum
+        )
 
     def iter_by_axis(self, axis_name, keepdims=False):
         """ "Iterate over a given axis

--- a/gammapy/maps/maps.py
+++ b/gammapy/maps/maps.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections.abc import MutableMapping
 import html
+from collections.abc import MutableMapping
 from astropy.io import fits
 from gammapy.maps import Map
 from gammapy.utils.scripts import make_path
@@ -145,7 +145,7 @@ class Maps(MutableMapping):
         with fits.open(str(make_path(filename)), memmap=False) as hdulist:
             return cls.from_hdulist(hdulist)
 
-    def write(self, filename, overwrite=False):
+    def write(self, filename, overwrite=False, checksum=False):
         """Write map dictionary to file.
 
         Parameters
@@ -154,11 +154,14 @@ class Maps(MutableMapping):
             Filename to write to.
         overwrite : bool
             Overwrite file if it exists.
+        checksum : bool
+            When True adds both DATASUM and CHECKSUM cards to the headers written to the file.
+            Default is False.
         """
         filename = make_path(filename)
 
         hdulist = self.to_hdulist()
-        hdulist.writeto(filename, overwrite=overwrite)
+        hdulist.writeto(filename, overwrite=overwrite, checksum=checksum)
 
     @classmethod
     def from_geom(cls, geom, names, kwargs_list=None):

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -471,7 +471,9 @@ class RegionNDMap(Map):
                 hdulist, format=format, ogip_column=ogip_column, hdu=hdu
             )
 
-    def write(self, filename, overwrite=False, format="gadf", hdu="SKYMAP"):
+    def write(
+        self, filename, overwrite=False, format="gadf", hdu="SKYMAP", checksum=False
+    ):
         """Write map to file
 
         Parameters
@@ -482,9 +484,14 @@ class RegionNDMap(Map):
             Which format to use.
         overwrite : bool
             Overwrite existing files?
+        checksum : bool
+            When True adds both DATASUM and CHECKSUM cards to the headers written to the file.
+            Default is False.
         """
         filename = make_path(filename)
-        self.to_hdulist(format=format, hdu=hdu).writeto(filename, overwrite=overwrite)
+        self.to_hdulist(format=format, hdu=hdu).writeto(
+            filename, overwrite=overwrite, checksum=checksum
+        )
 
     def to_hdulist(self, format="gadf", hdu="SKYMAP", hdu_bands=None, hdu_region=None):
         """Convert to `~astropy.io.fits.HDUList`.

--- a/gammapy/maps/wcs/tests/test_ndmap.py
+++ b/gammapy/maps/wcs/tests/test_ndmap.py
@@ -95,6 +95,22 @@ def test_wcsndmap_read_write(tmp_path, npix, binsz, frame, proj, skydir, axes):
     m3 = Map.read(path, map_type="wcs")
 
 
+@pytest.mark.parametrize(
+    ("npix", "binsz", "frame", "proj", "skydir", "axes"), wcs_test_geoms
+)
+def test_wcsndmap_write_checksum(tmp_path, npix, binsz, frame, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz, proj=proj, frame=frame, axes=axes)
+    path = tmp_path / "tmp.fits"
+
+    m0 = WcsNDMap(geom)
+    m0.write(path, overwrite=True, checksum=True)
+
+    hdul = fits.open(path)
+    for hdu in hdul:
+        assert "CHECKSUM" in hdu.header
+        assert "DATASUM" in hdu.header
+
+
 def test_wcsndmap_read_write_fgst(tmp_path):
     path = tmp_path / "tmp.fits"
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a checksum argument to all write methods in gammapy. This should support fixity metadata requirements from CTAO. Right @kosack ?
For now the checksum is set to False by default.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This has tests now. 
Note that checksum verification on read must be added too. But this will be in a follow-up PR.