### PR TITLE
No extrapolation for `PrimaryFlux`

### DIFF
--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -108,7 +108,8 @@ class PrimaryFlux(TemplateNDSpectralModel):
             region=None, axes=[log10x_axis, mass_axis], data=self.table[channel_name]
         )
 
-        super().__init__(region_map)
+        interp_kwargs = {"extrapolate": True, "fill_value": 0, "values_scale": "lin"}
+        super().__init__(region_map, interp_kwargs=interp_kwargs)
         self.mDM = mDM
         self.mass.frozen = True
 

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -18,12 +18,12 @@ def test_primary_flux():
 
     primflux = PrimaryFlux(channel="W", mDM=1 * u.TeV)
     actual = primflux(500 * u.GeV)
-    desired = 9.328234e-05 / u.GeV
+    desired = 9.3319318e-05 / u.GeV
     assert_quantity_allclose(actual, desired)
 
 
 @pytest.mark.parametrize(
-    "mass, expected_flux", [(1.6, 0.00024956), (11, 0.00501605), (75, 0.02027279)]
+    "mass, expected_flux", [(1.6, 0.00025037), (11, 0.00502079), (75, 0.02028309)]
 )
 @requires_data()
 def test_primary_flux_interpolation(mass, expected_flux):
@@ -58,7 +58,7 @@ def test_dm_annihilation_spectral_model(tmpdir):
     new_models = Models.read(filename)
 
     assert_quantity_allclose(integral_flux.value, 6.19575457e-14, rtol=1e-3)
-    assert_quantity_allclose(differential_flux.value, 2.97506768e-16, rtol=1e-3)
+    assert_quantity_allclose(differential_flux.value, 2.97831615e-16, rtol=1e-3)
 
     assert model.scale.is_norm
     assert new_models[0].spectral_model.channel == model.channel
@@ -92,7 +92,7 @@ def test_dm_decay_spectral_model(tmpdir):
     new_models = Models.read(filename)
 
     assert_quantity_allclose(integral_flux.value, 4.80283595e-2, rtol=1e-3)
-    assert_quantity_allclose(differential_flux.value, 2.30625401e-4, rtol=1e-3)
+    assert_quantity_allclose(differential_flux.value, 2.3088e-4, rtol=1e-3)
 
     assert model.scale.is_norm
     assert new_models[0].spectral_model.channel == model.channel

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -50,7 +50,7 @@ def test_dmfluxmap_annihilation(jfact_annihilation):
         * diff_flux.integral(energy_min=energy_min, energy_max=energy_max)
     ).to("cm-2 s-1")
     actual = int_flux[5, 5]
-    desired = 5.94207e-12 / u.cm**2 / u.s
+    desired = 5.96827647e-12 / u.cm**2 / u.s
     assert_quantity_allclose(actual, desired, rtol=1e-3)
 
 
@@ -66,5 +66,5 @@ def test_dmfluxmap_decay(jfact_decay):
         jfact_decay * diff_flux.integral(energy_min=energy_min, energy_max=energy_max)
     ).to("cm-2 s-1")
     actual = int_flux[5, 5]
-    desired = 6.98844e-3 / u.cm**2 / u.s
+    desired = 7.01927e-3 / u.cm**2 / u.s
     assert_quantity_allclose(actual, desired, rtol=1e-3)


### PR DESCRIPTION
I removed the extrapolation in energy for the `PrimaryFlux` since it doesn't makes sense extrapolate beyond the limit of the mass of the particle. We also don't know if we can extrapolate to zero.