### PR TITLE
Add context manager for multiprocessing configuration

### DIFF
--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -563,6 +563,18 @@ def test_global_n_jobs_default_handling():
     assert fpe.n_jobs == 1
 
 
+def test_global_default_context_manger():
+    fpe = FluxPointsEstimator(energy_edges=[1, 3, 10] * u.TeV)
+
+    assert fpe.parallel_backend == parallel.ParallelBackendEnum.multiprocessing
+
+    with parallel.multiprocessing_manager(backend="ray"):
+        assert fpe.parallel_backend == "ray"
+
+        fpe = FluxPointsEstimator(energy_edges=[1, 3, 10] * u.TeV)
+        assert fpe.parallel_backend == "ray"
+
+
 @requires_dependency("ray")
 def test_flux_points_parallel_ray(fpe_pwl):
     datasets, fpe = fpe_pwl

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -563,18 +563,6 @@ def test_global_n_jobs_default_handling():
     assert fpe.n_jobs == 1
 
 
-def test_global_default_context_manger():
-    fpe = FluxPointsEstimator(energy_edges=[1, 3, 10] * u.TeV)
-
-    assert fpe.parallel_backend == parallel.ParallelBackendEnum.multiprocessing
-
-    with parallel.multiprocessing_manager(backend="ray"):
-        assert fpe.parallel_backend == "ray"
-
-        fpe = FluxPointsEstimator(energy_edges=[1, 3, 10] * u.TeV)
-        assert fpe.parallel_backend == "ray"
-
-
 @requires_dependency("ray")
 def test_flux_points_parallel_ray(fpe_pwl):
     datasets, fpe = fpe_pwl

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -108,15 +108,17 @@ class multiprocessing_manager:
     """
 
     def __init__(self, backend=None, pool_kwargs=None, method=None, method_kwargs=None):
-        global BACKEND_DEFAULT, POOL_KWARGS_DEFAULT, METHOD_DEFAULT, METHOD_KWARGS_DEFAULT
+        global BACKEND_DEFAULT, POOL_KWARGS_DEFAULT, METHOD_DEFAULT, METHOD_KWARGS_DEFAULT, N_JOBS_DEFAULT
         self._backend = BACKEND_DEFAULT
         self._pool_kwargs = POOL_KWARGS_DEFAULT
         self._method = METHOD_DEFAULT
         self._method_kwargs = METHOD_KWARGS_DEFAULT
+        self._n_jobs = N_JOBS_DEFAULT
         if backend is not None:
             BACKEND_DEFAULT = ParallelBackendEnum.from_str(backend).value
         if pool_kwargs is not None:
             POOL_KWARGS_DEFAULT = pool_kwargs
+            N_JOBS_DEFAULT = pool_kwargs.get("processes", N_JOBS_DEFAULT)
         if method is not None:
             METHOD_DEFAULT = PoolMethodEnum(method).value
         if method_kwargs is not None:
@@ -126,11 +128,12 @@ class multiprocessing_manager:
         pass
 
     def __exit__(self, type, value, traceback):
-        global BACKEND_DEFAULT, POOL_KWARGS_DEFAULT, METHOD_DEFAULT, METHOD_KWARGS_DEFAULT
+        global BACKEND_DEFAULT, POOL_KWARGS_DEFAULT, METHOD_DEFAULT, METHOD_KWARGS_DEFAULT, N_JOBS_DEFAULT
         BACKEND_DEFAULT = self._backend
         POOL_KWARGS_DEFAULT = self._pool_kwargs
         METHOD_DEFAULT = self._method
         METHOD_KWARGS_DEFAULT = self._method_kwargs
+        N_JOBS_DEFAULT = self._n_jobs
 
 
 class ParallelMixin:

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -38,7 +38,7 @@ BACKEND_DEFAULT = ParallelBackendEnum.multiprocessing
 N_JOBS_DEFAULT = 1
 POOL_KWARGS_DEFAULT = dict(processes=N_JOBS_DEFAULT)
 METHOD_DEFAULT = PoolMethodEnum.starmap
-METHOD_KWARGS_DEFAULT = None
+METHOD_KWARGS_DEFAULT = {}
 
 
 def get_multiprocessing():
@@ -178,7 +178,9 @@ def run_multiprocessing(
     task_name : str, optional
         Name of the task to display in the progress bar. Default is "".
     """
-    backend = ParallelBackendEnum.from_str(backend)
+
+    if backend is None:
+        backend = BACKEND_DEFAULT
 
     if method is None:
         method = METHOD_DEFAULT
@@ -191,6 +193,7 @@ def run_multiprocessing(
 
     processes = pool_kwargs.get("processes", N_JOBS_DEFAULT)
 
+    backend = ParallelBackendEnum.from_str(backend)
     multiprocessing = PARALLEL_BACKEND_MODULES[backend]()
 
     if backend == ParallelBackendEnum.multiprocessing:

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -138,8 +138,11 @@ class ParallelMixin:
 
     @parallel_backend.setter
     def parallel_backend(self, value):
-        """Parallel backend setter as a string."""
-        self._parallel_backend = ParallelBackendEnum.from_str(value).value
+        """Parallel backend setter (str)"""
+        if value is None:
+            self._parallel_backend = None
+        else:
+            self._parallel_backend = ParallelBackendEnum.from_str(value).value
 
 
 def run_multiprocessing(

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -78,7 +78,34 @@ def is_ray_available():
 
 
 class multiprocessing_manager:
-    """context manager to update the global configuration for multiprocessing"""
+    """context manager to update the global configuration for multiprocessing
+
+    Parameters
+    ----------
+    backend : {'multiprocessing', 'ray'}
+        Backend to use.
+    pool_kwargs : dict
+        Keyword arguments passed to the pool. The number of processes is limited
+        to the number of physical CPUs.
+    method : {'starmap', 'apply_async'}
+        Pool method to use.
+    method_kwargs : dict
+        Keyword arguments passed to the method
+
+    Examples
+    --------
+    ::
+        import gammapy.utils.parallel as parallel
+        from gammapy.estimators import FluxPointsEstimator
+
+        fpe = FluxPointsEstimator(energy_edges=[1, 3, 10] * u.TeV)
+
+        with parallel.multiprocessing_manager(
+                backend="multiprocessing",
+                pool_kwargs=dict(processes=2),
+            ):
+            fpe.run(datasets)
+    """
 
     def __init__(self, backend=None, pool_kwargs=None, method=None, method_kwargs=None):
         global BACKEND_DEFAULT, POOL_KWARGS_DEFAULT, METHOD_DEFAULT, METHOD_KWARGS_DEFAULT

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -87,11 +87,11 @@ class multiprocessing_manager:
         self._method = METHOD_DEFAULT
         self._method_kwargs = METHOD_KWARGS_DEFAULT
         if backend is not None:
-            BACKEND_DEFAULT = backend
+            BACKEND_DEFAULT = ParallelBackendEnum.from_str(backend).value
         if pool_kwargs is not None:
             POOL_KWARGS_DEFAULT = pool_kwargs
         if method is not None:
-            METHOD_DEFAULT = method
+            METHOD_DEFAULT = PoolMethodEnum(method).value
         if method_kwargs is not None:
             METHOD_KWARGS_DEFAULT = method_kwargs
 

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -78,7 +78,10 @@ def is_ray_available():
 
 
 class multiprocessing_manager:
-    """context manager to update the global configuration for multiprocessing
+    """Context manager to update the default configuration for multiprocessing.
+
+    Only the default configuration will be modified, if class arguments like
+    `n_jobs` and `parallel_backend` are set they will overwrite the default configuration.
 
     Parameters
     ----------

--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -17,8 +17,6 @@ class ParallelBackendEnum(Enum):
     @classmethod
     def from_str(cls, value):
         """Get enum from string."""
-        if value is None:
-            value = BACKEND_DEFAULT
 
         if value == "ray" and not is_ray_available():
             log.warning("Ray is not installed, falling back to multiprocessing backend")

--- a/gammapy/utils/tests/test_parallel.py
+++ b/gammapy/utils/tests/test_parallel.py
@@ -132,9 +132,17 @@ def test_multiprocessing_manager():
     fpe = FluxPointsEstimator(energy_edges=[1, 3, 10] * u.TeV)
     assert fpe.parallel_backend == parallel.ParallelBackendEnum.multiprocessing
 
-    with parallel.multiprocessing_manager(backend="ray"):
+    with parallel.multiprocessing_manager(backend="ray", pool_kwargs=dict(processes=2)):
         assert fpe.parallel_backend == "ray"
+        assert fpe.n_jobs == 2
 
         fpe = FluxPointsEstimator(energy_edges=[1, 3, 10] * u.TeV)
         assert fpe.parallel_backend == "ray"
     assert fpe.parallel_backend == parallel.ParallelBackendEnum.multiprocessing
+
+    fpe = FluxPointsEstimator(
+        energy_edges=[1, 3, 10] * u.TeV, n_jobs=2, parallel_backend="multiprocessing"
+    )
+    with parallel.multiprocessing_manager(backend="ray", pool_kwargs=dict(processes=3)):
+        assert fpe.parallel_backend == "multiprocessing"
+        assert fpe.n_jobs == 2

--- a/gammapy/utils/tests/test_parallel.py
+++ b/gammapy/utils/tests/test_parallel.py
@@ -111,6 +111,7 @@ def test_run_multiprocessing_simple_ray_apply_async():
     assert task.sum_squared == N * (N + 1) * (2 * N + 1) / 6
 
 
+@requires_dependency("ray")
 def test_multiprocessing_manager():
     with parallel.multiprocessing_manager(
         backend="ray",

--- a/gammapy/utils/tests/test_parallel.py
+++ b/gammapy/utils/tests/test_parallel.py
@@ -124,4 +124,4 @@ def test_multiprocessing_manager():
     assert parallel.BACKEND_DEFAULT == parallel.ParallelBackendEnum.multiprocessing
     assert parallel.POOL_KWARGS_DEFAULT["processes"] == 1
     assert parallel.METHOD_DEFAULT == parallel.PoolMethodEnum.starmap
-    assert parallel.METHOD_KWARGS_DEFAULT is None
+    assert "callback" not in parallel.METHOD_KWARGS_DEFAULT

--- a/gammapy/utils/tests/test_parallel.py
+++ b/gammapy/utils/tests/test_parallel.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import astropy.units as u
 import gammapy.utils.parallel as parallel
+from gammapy.estimators import FluxPointsEstimator
 from gammapy.utils.testing import requires_dependency
 
 
@@ -125,3 +127,13 @@ def test_multiprocessing_manager():
     assert parallel.POOL_KWARGS_DEFAULT["processes"] == 1
     assert parallel.METHOD_DEFAULT == parallel.PoolMethodEnum.starmap
     assert "callback" not in parallel.METHOD_KWARGS_DEFAULT
+
+    fpe = FluxPointsEstimator(energy_edges=[1, 3, 10] * u.TeV)
+    assert fpe.parallel_backend == parallel.ParallelBackendEnum.multiprocessing
+
+    with parallel.multiprocessing_manager(backend="ray"):
+        assert fpe.parallel_backend == "ray"
+
+        fpe = FluxPointsEstimator(energy_edges=[1, 3, 10] * u.TeV)
+        assert fpe.parallel_backend == "ray"
+    assert fpe.parallel_backend == parallel.ParallelBackendEnum.multiprocessing

--- a/gammapy/utils/tests/test_parallel.py
+++ b/gammapy/utils/tests/test_parallel.py
@@ -107,3 +107,21 @@ def test_run_multiprocessing_simple_ray_apply_async():
         backend="ray",
     )
     assert task.sum_squared == N * (N + 1) * (2 * N + 1) / 6
+
+
+def test_multiprocessing_manager():
+    with parallel.multiprocessing_manager(
+        backend="ray",
+        method="apply_async",
+        pool_kwargs=dict(processes=2),
+        method_kwargs=dict(callback=None),
+    ):
+        assert parallel.BACKEND_DEFAULT == "ray"
+        assert parallel.POOL_KWARGS_DEFAULT["processes"] == 2
+        assert parallel.METHOD_DEFAULT == "apply_async"
+        assert "callback" in parallel.METHOD_KWARGS_DEFAULT
+
+    assert parallel.BACKEND_DEFAULT == parallel.ParallelBackendEnum.multiprocessing
+    assert parallel.POOL_KWARGS_DEFAULT["processes"] == 1
+    assert parallel.METHOD_DEFAULT == parallel.PoolMethodEnum.starmap
+    assert parallel.METHOD_KWARGS_DEFAULT is None


### PR DESCRIPTION
This PR introduce a context manager to modify the global configuration options used in run_multiprocessing as discussed in https://github.com/gammapy/gammapy/pull/4675#issuecomment-1731457679
So we don't need to set up these options at the class level and any loop could be run in parallel if implemented using run_multiprocessing.