### PR TITLE
Introduce a GTI Metadata class and container

### DIFF
--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -27,10 +27,6 @@ class GTI:
     ----------
     table : `~astropy.table.Table`
         GTI table
-    reference_time : `~astropy.time.Time`
-        the reference time
-        If None, use TIME_REF_DEFAULT.
-        Default is None
 
     Examples
     --------
@@ -104,34 +100,28 @@ class GTI:
         return copy.deepcopy(self)
 
     @classmethod
-    def create(cls, start, stop, reference_time=None):
+    def create(cls, start, stop, meta=None):
         """Creates a GTI table from start and stop times.
 
-        Parameters
-        ----------
-        start : `~astropy.time.Time` or `~astropy.units.Quantity`
-            Start times, if a quantity then w.r.t. reference time
-        stop : `~astropy.time.Time` or `~astropy.units.Quantity`
-            Stop times, if a quantity then w.r.t. reference time
-        reference_time : `~astropy.time.Time`
-            the reference time to use in GTI metadata definition.
-            If None, use TIME_REF_DEFAULT.
-            Default is None
+         Parameters
+         ----------
+         start : `~astropy.time.Time` or `~astropy.units.Quantity`
+             Start times, if a quantity then w.r.t. reference time
+         stop : `~astropy.time.Time` or `~astropy.units.Quantity`
+             Stop times, if a quantity then w.r.t. reference time
+        meta : `dict`
+             Dictionary containing the metadata
         """
-        if reference_time is None:
-            reference_time = TIME_REF_DEFAULT
-        reference_time = Time(reference_time)
-        reference_time.format = "mjd"
+        if meta is None:
+            meta = GTIMetaData.from_default()
 
         if not isinstance(start, Time):
-            start = reference_time + u.Quantity(start)
+            start = meta["reference_time"] + u.Quantity(start)
 
         if not isinstance(stop, Time):
-            stop = reference_time + u.Quantity(stop)
+            stop = meta["reference_time"] + u.Quantity(stop)
 
         table = Table({"START": np.atleast_1d(start), "STOP": np.atleast_1d(stop)})
-
-        meta = {"reference_time": reference_time}
 
         return cls(table, meta=meta)
 

--- a/gammapy/data/metadata.py
+++ b/gammapy/data/metadata.py
@@ -9,7 +9,7 @@ from gammapy.utils.fits import earth_location_from_dict
 from gammapy.utils.metadata import CreatorMetaData, MetaData
 from gammapy.utils.time import time_ref_from_dict
 
-__all__ = ["ObservationMetaData"]
+__all__ = ["ObservationMetaData", "GTIMetaData"]
 
 
 class ObservationMetaData(MetaData):
@@ -162,3 +162,18 @@ class ObservationMetaData(MetaData):
         kwargs["optional"] = optional
 
         return cls(**kwargs)
+
+
+class GTIMetaData(MetaData):
+    """Metadata containing information about the GTI.
+
+    Parameters
+    ----------
+    reference_time : Time, str
+        the GTI reference time
+    creation : `~gammapy.utils.CreatorMetaData`
+        the creation metadata
+    """
+
+    reference_time: Optional[Union[Time, str]]
+    creation: Optional[CreatorMetaData]

--- a/gammapy/data/metadata.py
+++ b/gammapy/data/metadata.py
@@ -170,9 +170,7 @@ class GTIMetaData(MetaData):
     Parameters
     ----------
     reference_time : Time, str
-        the GTI reference time
-    creation : `~gammapy.utils.CreatorMetaData`
-        the creation metadata
+        The GTI reference time.
     """
 
     reference_time: Optional[Union[Time, str]]
@@ -201,7 +199,7 @@ class GTIMetaData(MetaData):
         Parameters
         ----------
         format : str
-            the header data format. Default is gadf.
+            The header data format. Default is "gadf".
         """
 
         kwargs = {}


### PR DESCRIPTION
This pull request adds a GTIMetaData class and modifies `gti.py` accordingly. Only the `reference_time` is currently part of this MetaData object.
I am not sure about the possible usage of the future metadata from EventList, as there is no associated `GTI.events`, as for example there is for `Observations`.
