### PR TITLE
Add TimeMapAxis.to_gti()

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2891,6 +2891,20 @@ class TimeMapAxis:
             name=name,
         )
 
+    def to_gti(self):
+        """Convert the axis to a GTI.
+
+        Returns
+        -------
+        gti : `GTI`
+        GTI table
+        """
+        from gammapy.data import GTI
+
+        return GTI.create(
+            self.edges_min, self.edges_max, reference_time=self.reference_time
+        )
+
     def to_header(self, format="gadf", idx=0):
         """Create FITS header
 

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -664,6 +664,15 @@ def test_from_gti_bounds():
     assert_time_allclose(axis.time_max[-1], expected)
 
 
+def test_to_gti(time_intervals):
+    time_axis = TimeMapAxis(
+        time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"]
+    )
+    gti = time_axis.to_gti()
+    assert len(gti.table) == 20
+    assert TimeMapAxis.from_gti(gti) == time_axis
+
+
 def test_map_with_time_axis(time_intervals):
     time_axis = TimeMapAxis(
         time_intervals["t_min"], time_intervals["t_max"], time_intervals["t_ref"]


### PR DESCRIPTION
Since time handling methods (intersection, union, etc) mostly reside on GTI, it is useful to be able to convert back and forth between time axis and GTIs. This is necessary, eg: in #4828 to find the intersection of the time bin with the GTIs