### PR TITLE
Parallel support for WcsNDMap map convolution

### DIFF
--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -482,6 +482,24 @@ class Map(abc.ABC):
         for idx in np.ndindex(self.geom.shape_axes):
             yield self.data[idx[::-1]], idx[::-1]
 
+    def iter_by_image_index(self):
+        """Iterate over image planes of the map.
+
+        The image plane index is in data order, so that the data array can be
+        indexed directly.
+
+        Yields
+        ------
+        idx : tuple
+            ``idx`` is a tuple of int, the index of the image plane.
+
+        See also
+        --------
+        iter_by_image : iterate by image returning a map
+        """
+        for idx in np.ndindex(self.geom.shape_axes):
+            yield idx[::-1]
+
     def coadd(self, map_in, weights=None):
         """Add the contents of ``map_in`` to this map.
 

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
+from itertools import repeat
 import numpy as np
 import scipy.interpolate
 import scipy.ndimage as ndi
@@ -12,6 +13,7 @@ from astropy.nddata import block_reduce
 from regions import PixCoord, PointPixelRegion, PointSkyRegion, SkyRegion
 import matplotlib.colors as mpcolors
 import matplotlib.pyplot as plt
+import gammapy.utils.parallel as parallel
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
 from gammapy.utils.units import unit_from_fits_image_hdu
 from ..geom import pix_tuple_to_idx
@@ -831,8 +833,6 @@ class WcsNDMap(WcsMap):
         """
         from gammapy.irf import PSFKernel
 
-        convolve = scipy.signal.convolve
-
         if self.geom.is_image and not isinstance(kernel, PSFKernel):
             if kernel.ndim > 2:
                 raise ValueError(
@@ -859,8 +859,6 @@ class WcsNDMap(WcsMap):
                 "WcsNDMap.convolve: mode='valid' is not supported."
             )
 
-        data = np.empty(geom.data_shape, dtype=np.float32)
-
         shape_axes_kernel = kernel.shape[slice(0, -2)]
 
         if len(shape_axes_kernel) > 0:
@@ -871,17 +869,33 @@ class WcsNDMap(WcsMap):
                 )
 
         if self.geom.is_image and kernel.ndim == 3:
-            for idx in range(kernel.shape[0]):
-                data[idx] = convolve(
-                    self.data.astype(np.float32), kernel[idx], method=method, mode=mode
-                )
+            indexes = range(kernel.shape[0])
+            images = repeat(self.data.astype(np.float32))
         else:
-            for img, idx in self.iter_by_image_data():
-                ikern = Ellipsis if kernel.ndim == 2 else idx
-                data[idx] = convolve(
-                    img.astype(np.float32), kernel[ikern], method=method, mode=mode
-                )
+            indexes = list(self.iter_by_image_index())
+            images = (self.data[idx] for idx in indexes)
+        kernels = (
+            kernel[Ellipsis] if kernel.ndim == 2 else kernel[idx] for idx in indexes
+        )
+
+        convolved = parallel.run_multiprocessing(
+            self._convolve,
+            zip(
+                images,
+                kernels,
+                repeat(method),
+                repeat(mode),
+            ),
+            task_name="Convolution",
+        )
+        data = np.empty(geom.data_shape, dtype=np.float32)
+        for idx_res, idx in enumerate(indexes):
+            data[idx] = convolved[idx_res]
         return self._init_copy(data=data, geom=geom)
+
+    def _convolve(self, image, kernel, method, mode):
+        """scipy.signal.convolve without kwargs for parallel evaluation"""
+        return scipy.signal.convolve(image, kernel, method=method, mode=mode)
 
     def smooth(self, width, kernel="gauss", **kwargs):
         """Smooth the map.

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -893,7 +893,8 @@ class WcsNDMap(WcsMap):
             data[idx] = convolved[idx_res]
         return self._init_copy(data=data, geom=geom)
 
-    def _convolve(self, image, kernel, method, mode):
+    @staticmethod
+    def _convolve(image, kernel, method, mode):
         """scipy.signal.convolve without kwargs for parallel evaluation"""
         return scipy.signal.convolve(image, kernel, method=method, mode=mode)
 


### PR DESCRIPTION
This PR replaces the loop over multiple images/kernels  by a call to run_multiprocessing so the convolution can be executed in parallel using the context manager introduced in #4845