### PR TITLE
Add MapDatasetMetaData container

### DIFF
--- a/gammapy/datasets/__init__.py
+++ b/gammapy/datasets/__init__.py
@@ -10,6 +10,9 @@ from .map import (
     create_map_dataset_geoms,
 )
 from .simulate import MapDatasetEventSampler, ObservationEventSampler
+from .map import MapDataset, MapDatasetOnOff, create_map_dataset_geoms
+from .metadata import MapDatasetMetaData
+from .simulate import MapDatasetEventSampler
 from .spectrum import SpectrumDataset, SpectrumDatasetOnOff
 
 DATASET_REGISTRY = Registry(
@@ -39,4 +42,5 @@ __all__ = [
     "OGIPDatasetReader",
     "SpectrumDataset",
     "SpectrumDatasetOnOff",
+    "MapDatasetMetaData",
 ]

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -307,6 +307,8 @@ class MapDataset(Dataset):
     meta_table : `~astropy.table.Table`
         Table listing information on observations used to create the dataset.
         One line per observation for stacked datasets.
+    meta : `~gammapy.datasets.MapDatasetMetaData`
+        Associated meta data container
 
 
     Notes
@@ -390,8 +392,8 @@ class MapDataset(Dataset):
         mask_fit=None,
         gti=None,
         meta_table=None,
-        meta=None,
         name=None,
+        meta=None,
     ):
         self._name = make_name(name)
         self._evaluators = {}
@@ -422,7 +424,18 @@ class MapDataset(Dataset):
         self.gti = gti
         self.models = models
         self.meta_table = meta_table
-        self._meta = meta
+        if meta is None:
+            self._meta = MapDatasetMetaData()
+        else:
+            self._meta = meta
+
+    @property
+    def meta(self):
+        return self._meta
+
+    @meta.setter
+    def meta(self, value):
+        self._meta = value
 
     # TODO: keep or remove?
     @property
@@ -611,13 +624,6 @@ class MapDataset(Dataset):
         """Largest energy range among all pixels, defined by mask_safe and mask_fit."""
         energy_min_map, energy_max_map = self.energy_range
         return np.nanmin(energy_min_map.quantity), np.nanmax(energy_max_map.quantity)
-
-    @property
-    def meta(self):
-        """Return metadata container."""
-        if self._meta is None:
-            self._meta = MapDatasetMetaData()
-        return self._meta
 
     def npred(self):
         """Total predicted source and background counts.
@@ -2219,6 +2225,8 @@ class MapDatasetOnOff(MapDataset):
         One line per observation for stacked datasets.
     name : str
         Name of the dataset.
+    meta : `~gammapy.datasets.MapDatasetMetaData`
+        Associated meta data container
 
 
     See Also
@@ -2245,6 +2253,7 @@ class MapDatasetOnOff(MapDataset):
         mask_safe=None,
         gti=None,
         meta_table=None,
+        meta=None,
     ):
         self._name = make_name(name)
         self._evaluators = {}
@@ -2261,6 +2270,7 @@ class MapDatasetOnOff(MapDataset):
         self.models = models
         self.mask_safe = mask_safe
         self.meta_table = meta_table
+        self._meta = meta
 
     def __str__(self):
         str_ = super().__str__()

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -616,7 +616,7 @@ class MapDataset(Dataset):
     def meta(self):
         """Return metadata container."""
         if self._meta is None:
-            self._meta = MapDatasetMetaData.from_default()
+            self._meta = MapDatasetMetaData()
         return self._meta
 
     def npred(self):
@@ -1032,6 +1032,9 @@ class MapDataset(Dataset):
             self.meta_table = hstack_columns(self.meta_table, other.meta_table)
         elif other.meta_table:
             self.meta_table = other.meta_table.copy()
+
+        if self.meta and other.meta:
+            self.meta.stack(other.meta)
 
     def stat_array(self):
         """Statistic function value per bin given the current model parameters."""

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -25,6 +25,7 @@ from gammapy.utils.scripts import make_name, make_path
 from gammapy.utils.table import hstack_columns
 from .core import Dataset
 from .evaluator import MapEvaluator
+from .metadata import MapDatasetMetaData
 from .utils import get_axes
 
 __all__ = [
@@ -389,6 +390,7 @@ class MapDataset(Dataset):
         mask_fit=None,
         gti=None,
         meta_table=None,
+        meta=None,
         name=None,
     ):
         self._name = make_name(name)
@@ -420,6 +422,7 @@ class MapDataset(Dataset):
         self.gti = gti
         self.models = models
         self.meta_table = meta_table
+        self._meta = meta
 
     # TODO: keep or remove?
     @property
@@ -608,6 +611,13 @@ class MapDataset(Dataset):
         """Largest energy range among all pixels, defined by mask_safe and mask_fit."""
         energy_min_map, energy_max_map = self.energy_range
         return np.nanmin(energy_min_map.quantity), np.nanmax(energy_max_map.quantity)
+
+    @property
+    def meta(self):
+        """Return metadata container."""
+        if self._meta is None:
+            self._meta = MapDatasetMetaData.from_default()
+        return self._meta
 
     def npred(self):
         """Total predicted source and background counts.

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1356,6 +1356,7 @@ class MapDataset(Dataset):
 
         header = hdu_primary.header
         header["NAME"] = self.name
+        header.update(self.meta.to_header())
 
         hdulist = fits.HDUList([hdu_primary])
         if self.counts is not None:
@@ -1409,6 +1410,7 @@ class MapDataset(Dataset):
         """
         name = make_name(name)
         kwargs = {"name": name}
+        kwargs["meta"] = MapDatasetMetaData.from_header(hdulist["PRIMARY"].header)
 
         if "COUNTS" in hdulist:
             kwargs["counts"] = Map.from_hdulist(hdulist, hdu="counts", format=format)
@@ -2270,7 +2272,10 @@ class MapDatasetOnOff(MapDataset):
         self.models = models
         self.mask_safe = mask_safe
         self.meta_table = meta_table
-        self._meta = meta
+        if meta is None:
+            self._meta = MapDatasetMetaData()
+        else:
+            self._meta = meta
 
     def __str__(self):
         str_ = super().__str__()

--- a/gammapy/datasets/metadata.py
+++ b/gammapy/datasets/metadata.py
@@ -14,11 +14,8 @@ __all__ = ["MapDatasetMetaData"]
 
 MapDataset_METADATA_FITS_KEYS = {
     "MapDataset": {
-        "creation": "CREATION",
         "event_types": "EVT_TYPE",
         "optional": "OPTIONAL",
-        "pointing": "POINTING",
-        "obs_info": "OBS_INFO",
     },
 }
 

--- a/gammapy/datasets/metadata.py
+++ b/gammapy/datasets/metadata.py
@@ -1,4 +1,6 @@
 from typing import ClassVar, Literal, Optional, Union
+import numpy as np
+from astropy.coordinates import SkyCoord
 from pydantic import ConfigDict
 from gammapy.utils.metadata import (
     METADATA_FITS_KEYS,
@@ -16,7 +18,7 @@ MapDataset_METADATA_FITS_KEYS = {
         "telescope": "TELESCOP",
         "observation_mode": "OBS_MODE",
         "pointing": "POINTING",
-        "obs_ids": "OBS_IDS",
+        "obs_id": "OBS_ID",
         "event_types": "EVT_TYPE",
         "optional": "OPTIONAL",
     },
@@ -40,8 +42,8 @@ class MapDatasetMetaData(MetaData):
         observing mode.
     pointing : ~astropy.coordinates.SkyCoord
         Telescope pointing direction.
-    obs_ids : int
-        Observation ids stacked in the dataset.
+    obs_id : int
+        Observation id in the dataset.
     event_types : int
         Event types used in analysis.
     optional : dict
@@ -56,7 +58,7 @@ class MapDatasetMetaData(MetaData):
     telescope: Optional[Union[str, list[str]]] = None
     observation_mode: Optional[Union[str, list]] = None
     pointing: Optional[Union[PointingInfoMetaData, list[PointingInfoMetaData]]] = None
-    obs_ids: Optional[Union[str, list[str]]] = None
+    obs_id: Optional[Union[str, list[str]]] = None
     event_type: Optional[Union[str, list[str]]] = None
     optional: Optional[dict] = None
 
@@ -64,3 +66,40 @@ class MapDatasetMetaData(MetaData):
         kwargs = {}
         kwargs["creation"] = CreatorMetaData()
         return self.__class__(**kwargs)
+
+    @classmethod
+    def from_meta_table(cls, table):
+        """Create MapDatasetMetaData from MapDataset.meta_table
+
+        Parameters
+        ----------
+            table: `~astropy.table.Table`
+
+        """
+        kwargs = {}
+        kwargs["creation"] = CreatorMetaData()
+        if "TELESCOP" in table.colnames:
+            kwargs["telescope"] = table["TELESCOP"].data[0]
+        if "OBS_ID" in table.colnames:
+            kwargs["obs_id"] = table["OBS_ID"].data[0].astype(str)
+        if "OBS_MODE" in table.colnames:
+            kwargs["observation_mode"] = table["OBS_MODE"].data[0]
+        pointing_radec, pointing_altaz = None, None
+        if "RA_PNT" in table.colnames:
+            pointing_radec = SkyCoord(
+                ra=table["RA_PNT"].data[0], dec=table["DEC_PNT"].data[0], unit="deg"
+            )
+        if "ALT_PNT" in table.colnames:
+            pointing_altaz = SkyCoord(
+                alt=table["ALT_PNT"].data[0],
+                az=table["AZ_PNT"].data[0],
+                unit="deg",
+                frame="altaz",
+            )
+        pointings = []
+        for pra, paz in zip(
+            np.atleast_1d(pointing_radec), np.atleast_1d(pointing_altaz)
+        ):
+            pointings = PointingInfoMetaData(radec_mean=pra, altaz_mean=paz)
+        kwargs["pointing"] = pointings
+        return cls(**kwargs)

--- a/gammapy/datasets/metadata.py
+++ b/gammapy/datasets/metadata.py
@@ -1,11 +1,29 @@
 import logging
-from typing import Optional, Union
-import numpy as np
-from astropy.coordinates import SkyCoord
-from pydantic import ValidationError, validator
-from gammapy.utils.metadata import CreatorMetaData, MetaData
+from typing import ClassVar, Literal, Optional, Union
+from pydantic import ConfigDict
+from gammapy.utils.metadata import (
+    METADATA_FITS_KEYS,
+    CreatorMetaData,
+    MetaData,
+    PointingInfoMetaData,
+)
 
 __all__ = ["MapDatasetMetaData"]
+
+MapDataset_METADATA_FITS_KEYS = {
+    "MapDataset": {
+        "creation": "CREATION",
+        "instrument": "INSTRUM",
+        "telescope": "TELESCOP",
+        "observation_mode": "OBS_MODE",
+        "pointing": "POINTING",
+        "obs_ids": "OBS_IDS",
+        "event_types": "EVT_TYPE",
+        "optional": "OPTIONAL",
+    },
+}
+
+METADATA_FITS_KEYS.update(MapDataset_METADATA_FITS_KEYS)
 
 
 class MapDatasetMetaData(MetaData):
@@ -13,99 +31,35 @@ class MapDatasetMetaData(MetaData):
 
     Parameters
     ----------
-    creation : `~gammapy.utils.CreatorMetaData`
-        the creation metadata
+    creation : `~gammapy.utils.CreatorMetaData`, optional
+         The creation metadata.
     instrument : str
-        the instrument used during observation
+        the instrument used during observation.
     telescope : str
-        The specific telescope subarray
+        The specific telescope subarray.
     observation_mode : str
-        observing mode
+        observing mode.
     pointing : ~astropy.coordinates.SkyCoord
-        Telescope pointing direction
+        Telescope pointing direction.
     obs_ids : int
-        Observation ids stacked in the dataset
+        Observation ids stacked in the dataset.
     event_types : int
-        Event types used in analysis
+        Event types used in analysis.
     optional : dict
-        Any other meta information
+        Additional optional metadata.
     """
 
-    creation: Optional[CreatorMetaData]
-    instrument: Optional[str]
-    telescope: Optional[Union[str, list[str]]]
-    observation_mode: Optional[Union[str, list]]
-    pointing: Optional[Union[SkyCoord, list[SkyCoord]]]
-    obs_ids: Optional[Union[int, list[int]]]
-    event_type: Optional[Union[int, list[int]]]
-    optional: Optional[dict]
+    model_config = ConfigDict(coerce_numbers_to_str=True)
 
-    @validator("creation")
-    def validate_creation(cls, v):
-        if v is None:
-            return CreatorMetaData.from_default()
-        elif isinstance(v, CreatorMetaData):
-            return v
-        else:
-            raise ValidationError(
-                f"Incorrect pointing. Expect CreatorMetaData got {type(v)} instead."
-            )
-
-    @validator("instrument")
-    def validate_instrument(cls, v):
-        if isinstance(v, str):
-            return v
-        elif v is None:
-            return v
-        else:
-            raise ValidationError(
-                f"Incorrect instrument. Expect str got {type(v)} instead."
-            )
-
-    @validator("telescope")
-    def validate_telescope(cls, v):
-        if isinstance(v, str):
-            return v
-        elif v is None:
-            return v
-        elif all(isinstance(_, str) for _ in v):
-            return v
-        else:
-            raise ValidationError(
-                f"Incorrect telescope type. Expect str got {type(v)} instead."
-            )
-
-    @validator("pointing")
-    def validate_pointing(cls, v):
-        if v is None:
-            return SkyCoord(np.nan, np.nan, unit="deg", frame="icrs")
-        elif isinstance(v, SkyCoord):
-            return v
-        elif all(isinstance(_, SkyCoord) for _ in v):
-            return v
-        else:
-            raise ValidationError(
-                f"Incorrect pointing. Expect SkyCoord got {type(v)} instead."
-            )
-
-    @validator("obs_ids", "event_type")
-    def validate_obs_ids(cls, v):
-        if v is None:
-            return -999
-        elif isinstance(v, int):
-            return v
-        elif all(isinstance(_, int) for _ in v):
-            return v
-        else:
-            raise ValidationError(
-                f"Incorrect pointing. Expect int got {type(v)} instead."
-            )
-
-    @classmethod
-    def from_default(cls):
-        """Creation metadata containing Gammapy version."""
-        creation = CreatorMetaData.from_default()
-        return cls(creation=creation)
+    _tag: ClassVar[Literal["MapDataset"]] = "MapDataset"
+    creation: Optional[CreatorMetaData] = CreatorMetaData()
+    instrument: Optional[str] = None
+    telescope: Optional[Union[str, list[str]]] = None
+    observation_mode: Optional[Union[str, list]] = None
+    pointing: Optional[Union[PointingInfoMetaData, list[PointingInfoMetaData]]] = None
+    obs_ids: Optional[Union[str, list[str]]] = None
+    event_type: Optional[Union[str, list[str]]] = None
+    optional: Optional[dict] = None
 
     def stack(self, other):
         kwargs = {}
@@ -115,35 +69,50 @@ class MapDatasetMetaData(MetaData):
             logging.warning(
                 f"Stacking data from different instruments {self.instrument} and {other.instrument}"
             )
-        tel = self.telescope
-        if isinstance(tel, str):
-            tel = [tel]
-        if other.telescope not in tel:
-            tel.append(other.telescope)
+        if self.telescope is not None:
+            tel = self.telescope
+            if isinstance(tel, str):
+                tel = [tel]
+            if other.telescope not in tel:
+                tel.append(other.telescope)
+        else:
+            tel = other.telescope
         kwargs["telescope"] = tel
 
-        observation_mode = self.observation_mode
-        if isinstance(observation_mode, str):
-            observation_mode = [observation_mode]
-        observation_mode.append(other.observation_mode)
+        if self.observation_mode is not None:
+            observation_mode = self.observation_mode
+            if isinstance(observation_mode, str):
+                observation_mode = [observation_mode]
+            observation_mode.append(other.observation_mode)
+        else:
+            observation_mode = other.observation_mode
         kwargs["observation_mode"] = observation_mode
 
-        pointing = self.pointing
-        if isinstance(pointing, SkyCoord):
-            pointing = [pointing]
-        pointing.append(other.pointing)
+        if self.pointing is not None:
+            pointing = self.pointing
+            if isinstance(pointing, PointingInfoMetaData):
+                pointing = [pointing]
+            pointing.append(other.pointing)
+        else:
+            pointing = other.pointing
         kwargs["pointing"] = pointing
 
-        obs_ids = self.obs_ids
-        if isinstance(obs_ids, int):
-            obs_ids = [obs_ids]
-        obs_ids.append(other.obs_ids)
+        if self.obs_ids is not None:
+            obs_ids = self.obs_ids
+            if isinstance(obs_ids, str):
+                obs_ids = [obs_ids]
+            obs_ids.append(other.obs_ids)
+        else:
+            obs_ids = other.obs_ids
         kwargs["obs_ids"] = obs_ids
 
-        event_type = self.event_type
-        if not isinstance(event_type, list):
-            event_type = [event_type]
-        event_type.append(other.event_type)
+        if self.event_type is not None:
+            event_type = self.event_type
+            if isinstance(event_type, str):
+                event_type = [event_type]
+            event_type.append(other.event_type)
+        else:
+            event_type = other.event_type
         kwargs["event_type"] = event_type
 
         if self.optional:

--- a/gammapy/datasets/metadata.py
+++ b/gammapy/datasets/metadata.py
@@ -18,6 +18,7 @@ MapDataset_METADATA_FITS_KEYS = {
         "event_types": "EVT_TYPE",
         "optional": "OPTIONAL",
         "pointing": "POINTING",
+        "obs_info": "OBS_INFO",
     },
 }
 

--- a/gammapy/datasets/metadata.py
+++ b/gammapy/datasets/metadata.py
@@ -1,0 +1,157 @@
+import logging
+from typing import Optional, Union
+import numpy as np
+from astropy.coordinates import SkyCoord
+from pydantic import ValidationError, validator
+from gammapy.utils.metadata import CreatorMetaData, MetaData
+
+__all__ = ["MapDatasetMetaData"]
+
+
+class MapDatasetMetaData(MetaData):
+    """Metadata containing information about the GTI.
+
+    Parameters
+    ----------
+    creation : `~gammapy.utils.CreatorMetaData`
+        the creation metadata
+    instrument : str
+        the instrument used during observation
+    telescope : str
+        The specific telescope subarray
+    observation_mode : str
+        observing mode
+    pointing : ~astropy.coordinates.SkyCoord
+        Telescope pointing direction
+    obs_ids : int
+        Observation ids stacked in the dataset
+    event_types : int
+        Event types used in analysis
+    optional : dict
+        Any other meta information
+    """
+
+    creation: Optional[CreatorMetaData]
+    instrument: Optional[str]
+    telescope: Optional[Union[str, list[str]]]
+    observation_mode: Optional[Union[str, list]]
+    pointing: Optional[Union[SkyCoord, list[SkyCoord]]]
+    obs_ids: Optional[Union[int, list[int]]]
+    event_type: Optional[Union[int, list[int]]]
+    optional: Optional[dict]
+
+    @validator("creation")
+    def validate_creation(cls, v):
+        if v is None:
+            return CreatorMetaData.from_default()
+        elif isinstance(v, CreatorMetaData):
+            return v
+        else:
+            raise ValidationError(
+                f"Incorrect pointing. Expect CreatorMetaData got {type(v)} instead."
+            )
+
+    @validator("instrument")
+    def validate_instrument(cls, v):
+        if isinstance(v, str):
+            return v
+        elif v is None:
+            return v
+        else:
+            raise ValidationError(
+                f"Incorrect instrument. Expect str got {type(v)} instead."
+            )
+
+    @validator("telescope")
+    def validate_telescope(cls, v):
+        if isinstance(v, str):
+            return v
+        elif v is None:
+            return v
+        elif all(isinstance(_, str) for _ in v):
+            return v
+        else:
+            raise ValidationError(
+                f"Incorrect telescope type. Expect str got {type(v)} instead."
+            )
+
+    @validator("pointing")
+    def validate_pointing(cls, v):
+        if v is None:
+            return SkyCoord(np.nan, np.nan, unit="deg", frame="icrs")
+        elif isinstance(v, SkyCoord):
+            return v
+        elif all(isinstance(_, SkyCoord) for _ in v):
+            return v
+        else:
+            raise ValidationError(
+                f"Incorrect pointing. Expect SkyCoord got {type(v)} instead."
+            )
+
+    @validator("obs_ids", "event_type")
+    def validate_obs_ids(cls, v):
+        if v is None:
+            return -999
+        elif isinstance(v, int):
+            return v
+        elif all(isinstance(_, int) for _ in v):
+            return v
+        else:
+            raise ValidationError(
+                f"Incorrect pointing. Expect int got {type(v)} instead."
+            )
+
+    @classmethod
+    def from_default(cls):
+        """Creation metadata containing Gammapy version."""
+        creation = CreatorMetaData.from_default()
+        return cls(creation=creation)
+
+    def stack(self, other):
+        kwargs = {}
+        kwargs["creation"] = self.creation
+        kwargs["instrument"] = self.instrument
+        if self.instrument != other.instrument:
+            logging.warning(
+                f"Stacking data from different instruments {self.instrument} and {other.instrument}"
+            )
+        tel = self.telescope
+        if isinstance(tel, str):
+            tel = [tel]
+        if other.telescope not in tel:
+            tel.append(other.telescope)
+        kwargs["telescope"] = tel
+
+        observation_mode = self.observation_mode
+        if isinstance(observation_mode, str):
+            observation_mode = [observation_mode]
+        observation_mode.append(other.observation_mode)
+        kwargs["observation_mode"] = observation_mode
+
+        pointing = self.pointing
+        if isinstance(pointing, SkyCoord):
+            pointing = [pointing]
+        pointing.append(other.pointing)
+        kwargs["pointing"] = pointing
+
+        obs_ids = self.obs_ids
+        if isinstance(obs_ids, int):
+            obs_ids = [obs_ids]
+        obs_ids.append(other.obs_ids)
+        kwargs["obs_ids"] = obs_ids
+
+        event_type = self.event_type
+        if not isinstance(event_type, list):
+            event_type = [event_type]
+        event_type.append(other.event_type)
+        kwargs["event_type"] = event_type
+
+        if self.optional:
+            optional = self.optional
+            for k in other.optional.keys():
+                if not isinstance(optional[k], list):
+                    optional[k] = [optional[k]]
+                optional[k].append(other.optional[k])
+            kwargs["optional"] = optional
+
+        return self.__class__(**kwargs)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -602,6 +602,7 @@ def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
     dataset_new = MapDataset.read(tmp_path / "test.fits")
 
     assert dataset_new.name == "test"
+    assert_allclose(dataset.meta.creation.date.mjd, dataset_new.meta.creation.date.mjd)
 
     assert dataset_new.mask.data.dtype == bool
 

--- a/gammapy/datasets/tests/test_metadata.py
+++ b/gammapy/datasets/tests/test_metadata.py
@@ -109,23 +109,3 @@ def test_mapdataset_metadata_stack():
     meta = meta1.stack(meta2)
     assert meta.creation.creator.split()[0] == "Gammapy"
     assert meta.obs_info is None
-
-
-def test_to_header():
-    obs_info_input = {
-        "telescope": "a",
-        "instrument": "H.E.S.S.",
-        "observation_mode": "wobble",
-        "obs_id": 111,
-    }
-    input1 = {
-        "pointing": PointingInfoMetaData(
-            radec_mean=SkyCoord(83.6287, 22.5147, unit="deg", frame="icrs")
-        ),
-        "obs_info": ObsInfoMetaData(**obs_info_input),
-        "optional": dict(test=0.5, other=True),
-    }
-    meta1 = MapDatasetMetaData(**input1)
-    hdr = meta1.to_header()
-    assert hdr["OBS_INFO"]["instrument"] == "H.E.S.S."
-    assert hdr["OBS_INFO"]["obs_id"] == 111

--- a/gammapy/datasets/tests/test_metadata.py
+++ b/gammapy/datasets/tests/test_metadata.py
@@ -127,5 +127,5 @@ def test_to_header():
     }
     meta1 = MapDatasetMetaData(**input1)
     hdr = meta1.to_header()
-    assert hdr["INSTRUME"] == "H.E.S.S."
-    assert hdr["OBS_ID"] == "111"
+    assert hdr["OBS_INFO"]["instrument"] == "H.E.S.S."
+    assert hdr["OBS_INFO"]["obs_id"] == "111"

--- a/gammapy/datasets/tests/test_metadata.py
+++ b/gammapy/datasets/tests/test_metadata.py
@@ -32,7 +32,7 @@ def test_mapdataset_metadata():
     assert meta.obs_info.observation_mode == "wobble"
     assert_allclose(meta.pointing.radec_mean.dec.value, 22.0147)
     assert_allclose(meta.pointing.radec_mean.ra.deg, 83.6287)
-    assert meta.obs_info.obs_id == "112"
+    assert meta.obs_info.obs_id == 112
     assert meta.optional["other"] is True
     assert meta.creation.creator.split()[0] == "Gammapy"
     assert meta.event_type is None
@@ -80,8 +80,8 @@ def test_mapdataset_metadata_lists():
     assert meta.obs_info[0].observation_mode == "wobble"
     assert_allclose(meta.pointing[0].radec_mean.dec.value, 22.0147)
     assert_allclose(meta.pointing[1].radec_mean.ra.deg, 83.1287)
-    assert meta.obs_info[0].obs_id == "111"
-    assert meta.obs_info[1].obs_id == "112"
+    assert meta.obs_info[0].obs_id == 111
+    assert meta.obs_info[1].obs_id == 112
     assert meta.optional is None
     assert meta.event_type is None
 
@@ -128,4 +128,4 @@ def test_to_header():
     meta1 = MapDatasetMetaData(**input1)
     hdr = meta1.to_header()
     assert hdr["OBS_INFO"]["instrument"] == "H.E.S.S."
-    assert hdr["OBS_INFO"]["obs_id"] == "111"
+    assert hdr["OBS_INFO"]["obs_id"] == 111

--- a/gammapy/datasets/tests/test_metadata.py
+++ b/gammapy/datasets/tests/test_metadata.py
@@ -98,15 +98,8 @@ def test_mapdataset_metadata_stack():
     meta2 = MapDatasetMetaData(**input2)
 
     meta = meta1.stack(meta2)
-    assert meta.telescope == ["a", "b"]
-    assert meta.instrument == ["H.E.S.S."]
-    assert meta.observation_mode == ["wobble"]
-    assert_allclose(meta.pointing[1].radec_mean.dec.deg, 22.0147)
-    assert meta.obs_ids == ["111", "112"]
-    assert meta.optional["test"] == [0.5, 0.1]
-    assert meta.optional["other"] == [True, False]
-    assert meta.event_type is None
     assert meta.creation.creator.split()[0] == "Gammapy"
+    assert meta.obs_ids is None
 
 
 def test_to_header():

--- a/gammapy/datasets/tests/test_metadata.py
+++ b/gammapy/datasets/tests/test_metadata.py
@@ -1,0 +1,103 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from astropy.coordinates import SkyCoord
+from pydantic import ValidationError
+from gammapy.datasets import MapDatasetMetaData
+
+
+def test_mapdataset_meta_from_default():
+    meta = MapDatasetMetaData.from_default()
+
+    assert meta.creation.creator.split()[0] == "Gammapy"
+
+
+def test_mapdataset_metadata():
+    input = {
+        "telescope": "cta-north",
+        "instrument": "lst",
+        "observation_mode": "wobble",
+        "pointing": SkyCoord(83.6287, 22.0147, unit="deg", frame="icrs"),
+        "obs_ids": 112,
+        "optional": dict(test=0.5, other=True),
+    }
+    meta = MapDatasetMetaData(**input)
+
+    assert meta.telescope == "cta-north"
+    assert meta.instrument == "lst"
+    assert meta.observation_mode == "wobble"
+    assert_allclose(meta.pointing.dec.value, 22.0147)
+    assert_allclose(meta.pointing.ra.deg, 83.6287)
+    assert meta.obs_ids == 112
+    assert meta.optional["other"] is True
+    assert meta.creation.creator.split()[0] == "Gammapy"
+
+    with pytest.raises(ValidationError):
+        meta.pointing = 2.0
+
+    with pytest.raises(ValidationError):
+        meta.instrument = ["cta", "hess"]
+
+    meta.pointing = None
+    assert isinstance(meta.pointing, SkyCoord)
+    assert np.isnan(meta.pointing.ra.deg)
+
+    input_bad = input.copy()
+    input_bad["obs_ids"] = "bad"
+
+    with pytest.raises(ValueError):
+        MapDatasetMetaData(**input_bad)
+
+
+def test_mapdataset_metadata_lists():
+    input = {
+        "telescope": "cta-north",
+        "instrument": "lst",
+        "observation_mode": "wobble",
+        "pointing": [
+            SkyCoord(83.6287, 22.0147, unit="deg", frame="icrs"),
+            SkyCoord(83.1287, 22.5147, unit="deg", frame="icrs"),
+        ],
+        "obs_ids": [111, 222],
+    }
+    meta = MapDatasetMetaData(**input)
+    assert meta.telescope == "cta-north"
+    assert meta.instrument == "lst"
+    assert meta.observation_mode == "wobble"
+    assert_allclose(meta.pointing[0].dec.value, 22.0147)
+    assert_allclose(meta.pointing[1].ra.deg, 83.1287)
+    assert meta.obs_ids == [111, 222]
+    assert meta.optional is None
+    assert meta.event_type == -999
+
+
+def test_mapdataset_metadata_stack():
+    input1 = {
+        "telescope": "a",
+        "instrument": "H.E.S.S.",
+        "observation_mode": "wobble",
+        "pointing": SkyCoord(83.6287, 22.5147, unit="deg", frame="icrs"),
+        "obs_ids": 111,
+        "optional": dict(test=0.5, other=True),
+    }
+
+    input2 = {
+        "telescope": "b",
+        "instrument": "H.E.S.S.",
+        "observation_mode": "wobble",
+        "pointing": SkyCoord(83.6287, 22.0147, unit="deg", frame="icrs"),
+        "obs_ids": 112,
+        "optional": dict(test=0.1, other=False),
+    }
+
+    meta1 = MapDatasetMetaData(**input1)
+    meta2 = MapDatasetMetaData(**input2)
+
+    meta = meta1.stack(meta2)
+    assert meta.telescope == ["a", "b"]
+    assert meta.instrument == "H.E.S.S."
+    assert meta.observation_mode == ["wobble", "wobble"]
+    assert_allclose(meta.pointing[1].dec.deg, 22.0147)
+    assert meta.obs_ids == [111, 112]
+    assert meta.optional["other"] == [True, False]
+    assert len(meta.event_type) == 2

--- a/gammapy/datasets/tests/test_metadata.py
+++ b/gammapy/datasets/tests/test_metadata.py
@@ -20,7 +20,7 @@ def test_mapdataset_metadata():
         "instrument": "lst",
         "observation_mode": "wobble",
         "pointing": PointingInfoMetaData(radec_mean=position),
-        "obs_ids": 112,
+        "obs_id": 112,
         "optional": dict(test=0.5, other=True),
     }
     meta = MapDatasetMetaData(**input)
@@ -30,7 +30,7 @@ def test_mapdataset_metadata():
     assert meta.observation_mode == "wobble"
     assert_allclose(meta.pointing.radec_mean.dec.value, 22.0147)
     assert_allclose(meta.pointing.radec_mean.ra.deg, 83.6287)
-    assert meta.obs_ids == "112"
+    assert meta.obs_id == "112"
     assert meta.optional["other"] is True
     assert meta.creation.creator.split()[0] == "Gammapy"
     assert meta.event_type is None
@@ -58,7 +58,7 @@ def test_mapdataset_metadata_lists():
                 radec_mean=SkyCoord(83.1287, 22.5147, unit="deg", frame="icrs")
             ),
         ],
-        "obs_ids": [111, 222],
+        "obs_id": [111, 222],
     }
     meta = MapDatasetMetaData(**input)
     assert meta.telescope == "cta-north"
@@ -66,7 +66,7 @@ def test_mapdataset_metadata_lists():
     assert meta.observation_mode == "wobble"
     assert_allclose(meta.pointing[0].radec_mean.dec.value, 22.0147)
     assert_allclose(meta.pointing[1].radec_mean.ra.deg, 83.1287)
-    assert meta.obs_ids == ["111", "222"]
+    assert meta.obs_id == ["111", "222"]
     assert meta.optional is None
     assert meta.event_type is None
 
@@ -79,7 +79,7 @@ def test_mapdataset_metadata_stack():
         "pointing": PointingInfoMetaData(
             radec_mean=SkyCoord(83.6287, 22.5147, unit="deg", frame="icrs")
         ),
-        "obs_ids": 111,
+        "obs_id": 111,
         "optional": dict(test=0.5, other=True),
     }
 
@@ -90,7 +90,7 @@ def test_mapdataset_metadata_stack():
         "pointing": PointingInfoMetaData(
             radec_mean=SkyCoord(83.6287, 22.0147, unit="deg", frame="icrs")
         ),
-        "obs_ids": 112,
+        "obs_id": 112,
         "optional": dict(test=0.1, other=False),
     }
 
@@ -99,7 +99,7 @@ def test_mapdataset_metadata_stack():
 
     meta = meta1.stack(meta2)
     assert meta.creation.creator.split()[0] == "Gammapy"
-    assert meta.obs_ids is None
+    assert meta.obs_id is None
 
 
 def test_to_header():
@@ -110,10 +110,10 @@ def test_to_header():
         "pointing": PointingInfoMetaData(
             radec_mean=SkyCoord(83.6287, 22.5147, unit="deg", frame="icrs")
         ),
-        "obs_ids": 111,
+        "obs_id": 111,
         "optional": dict(test=0.5, other=True),
     }
     meta1 = MapDatasetMetaData(**input1)
     hdr = meta1.to_header()
     assert hdr["INSTRUM"] == "H.E.S.S."
-    assert hdr["OBS_IDS"] == "111"
+    assert hdr["OBS_ID"] == "111"

--- a/gammapy/datasets/tests/test_metadata.py
+++ b/gammapy/datasets/tests/test_metadata.py
@@ -38,9 +38,6 @@ def test_mapdataset_metadata():
     with pytest.raises(ValidationError):
         meta.pointing = 2.0
 
-    with pytest.raises(ValidationError):
-        meta.instrument = ["cta", "hess"]
-
     input_bad = input.copy()
     input_bad["bad"] = position
 
@@ -102,10 +99,11 @@ def test_mapdataset_metadata_stack():
 
     meta = meta1.stack(meta2)
     assert meta.telescope == ["a", "b"]
-    assert meta.instrument == "H.E.S.S."
-    assert meta.observation_mode == ["wobble", "wobble"]
+    assert meta.instrument == ["H.E.S.S."]
+    assert meta.observation_mode == ["wobble"]
     assert_allclose(meta.pointing[1].radec_mean.dec.deg, 22.0147)
     assert meta.obs_ids == ["111", "112"]
+    assert meta.optional["test"] == [0.5, 0.1]
     assert meta.optional["other"] == [True, False]
     assert meta.event_type is None
     assert meta.creation.creator.split()[0] == "Gammapy"

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -364,7 +364,7 @@ class MapDatasetMaker(Maker):
 
     @staticmethod
     def _make_metadata(table):
-        return MapDatasetMetaData.from_meta_table(table)
+        return MapDatasetMetaData._from_meta_table(table)
 
     def run(self, dataset, observation):
         """Make map dataset.

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -3,6 +3,7 @@ import logging
 import astropy.units as u
 from astropy.table import Table
 from regions import PointSkyRegion
+from gammapy.datasets import MapDatasetMetaData
 from gammapy.irf import EDispKernelMap, PSFMap, RecoPSFMap
 from gammapy.maps import Map
 from .core import Maker
@@ -361,6 +362,10 @@ class MapDatasetMaker(Maker):
 
         return meta_table
 
+    @staticmethod
+    def _make_metadata(table):
+        return MapDatasetMetaData.from_meta_table(table)
+
     def run(self, dataset, observation):
         """Make map dataset.
 
@@ -378,6 +383,7 @@ class MapDatasetMaker(Maker):
         """
         kwargs = {"gti": observation.gti}
         kwargs["meta_table"] = self.make_meta_table(observation)
+        kwargs["meta"] = self._make_metadata(kwargs["meta_table"])
 
         mask_safe = Map.from_geom(dataset.counts.geom, dtype=bool)
         mask_safe.data[...] = True

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -242,7 +242,7 @@ def test_make_meta_table(observations):
     meta = maker_obs._make_metadata(map_dataset_meta_table)
     assert meta.obs_info[0].observation_mode == "POINTING"
     assert meta.obs_info[0].telescope == "CTA"
-    assert meta.obs_info[0].obs_id == "110380"
+    assert meta.obs_info[0].obs_id == 110380
     assert_allclose(meta.pointing[0].radec_mean.dec.value, -29.6075)
 
 
@@ -553,11 +553,11 @@ def test_meta_data_creation(observations):
     dataset0 = maker.run(reference, observations[0])
     dataset1 = maker.run(reference, observations[1])
 
-    assert dataset0.meta.obs_info[0].obs_id == "110380"
-    assert dataset1.meta.obs_info[0].obs_id == "111140"
+    assert dataset0.meta.obs_info[0].obs_id == 110380
+    assert dataset1.meta.obs_info[0].obs_id == 111140
 
     # test stacking
     dataset0.stack(dataset1)
     stacked_meta = MapDatasetMetaData._from_meta_table(dataset0.meta_table)
-    assert stacked_meta.obs_info[0].obs_id == "110380"
-    assert stacked_meta.obs_info[1].obs_id == "111140"
+    assert stacked_meta.obs_info[0].obs_id == 110380
+    assert stacked_meta.obs_info[1].obs_id == 111140

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -240,10 +240,10 @@ def test_make_meta_table(observations):
     assert map_dataset_meta_table["OBS_MODE"] == "POINTING"
 
     meta = maker_obs._make_metadata(map_dataset_meta_table)
-    assert meta.observation_mode == "POINTING"
-    assert meta.telescope == "CTA"
-    assert meta.obs_id == "110380"
-    assert_allclose(meta.pointing.radec_mean.dec.value, -29.6075)
+    assert meta.obs_info[0].observation_mode == "POINTING"
+    assert meta.obs_info[0].telescope == "CTA"
+    assert meta.obs_info[0].obs_id == "110380"
+    assert_allclose(meta.pointing[0].radec_mean.dec.value, -29.6075)
 
 
 @requires_data()
@@ -553,10 +553,11 @@ def test_meta_data_creation(observations):
     dataset0 = maker.run(reference, observations[0])
     dataset1 = maker.run(reference, observations[1])
 
-    assert dataset0.meta.obs_id == "110380"
-    assert dataset1.meta.obs_id == "111140"
+    assert dataset0.meta.obs_info[0].obs_id == "110380"
+    assert dataset1.meta.obs_info[0].obs_id == "111140"
 
     # test stacking
     dataset0.stack(dataset1)
-    stacked_meta = MapDatasetMetaData.from_meta_table(dataset0.meta_table)
-    assert stacked_meta.obs_id == ["110380", "111140"]
+    stacked_meta = MapDatasetMetaData._from_meta_table(dataset0.meta_table)
+    assert stacked_meta.obs_info[0].obs_id == "110380"
+    assert stacked_meta.obs_info[1].obs_id == "111140"

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -16,7 +16,7 @@ from gammapy.data import (
     Observation,
     ObservationTable,
 )
-from gammapy.datasets import MapDataset
+from gammapy.datasets import MapDataset, MapDatasetMetaData
 from gammapy.datasets.map import RAD_AXIS_DEFAULT
 from gammapy.irf import Background2D, EDispKernelMap, EDispMap, PSFMap
 from gammapy.makers import FoVBackgroundMaker, MapDatasetMaker, SafeMaskMaker
@@ -239,6 +239,12 @@ def test_make_meta_table(observations):
     assert_allclose(map_dataset_meta_table["OBS_ID"], 110380)
     assert map_dataset_meta_table["OBS_MODE"] == "POINTING"
 
+    meta = maker_obs._make_metadata(map_dataset_meta_table)
+    assert meta.observation_mode == "POINTING"
+    assert meta.telescope == "CTA"
+    assert meta.obs_id == "110380"
+    assert_allclose(meta.pointing.radec_mean.dec.value, -29.6075)
+
 
 @requires_data()
 def test_make_map_no_count(observations):
@@ -442,6 +448,7 @@ def test_minimal_datastore():
     assert_allclose(stacked.exposure.data.sum(), 6.01909e10)
     assert_allclose(stacked.counts.data.sum(), 1446)
     assert_allclose(stacked.background.data.sum(), 1445.9841)
+    assert stacked.meta.creation.creator.split()[0] == "Gammapy"
 
 
 @requires_data()
@@ -537,3 +544,19 @@ def test_make_background_2d(observations):
 
     map_dataset = maker_obs.run(reference, obs)
     assert_allclose(map_dataset.background.data.sum(), 17636.60091226549)
+
+
+@requires_data()
+def test_meta_data_creation(observations):
+    reference = MapDataset.create(geom=geom(ebounds=[0.1, 1, 10]))
+    maker = MapDatasetMaker()
+    dataset0 = maker.run(reference, observations[0])
+    dataset1 = maker.run(reference, observations[1])
+
+    assert dataset0.meta.obs_id == "110380"
+    assert dataset1.meta.obs_id == "111140"
+
+    # test stacking
+    dataset0.stack(dataset1)
+    stacked_meta = MapDatasetMetaData.from_meta_table(dataset0.meta_table)
+    assert stacked_meta.obs_id == ["110380", "111140"]

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -2,7 +2,6 @@
 import html
 import logging
 import sys
-import numpy as np
 import astropy.units as u
 from astropy.coordinates import AltAz, Angle, EarthLocation, SkyCoord
 from astropy.io import fits
@@ -194,15 +193,22 @@ def skycoord_from_dict(header, frame="icrs", ext="PNT"):
     ext = "_" + ext if ext != "" else ""
 
     if frame == "altaz":
-        alt = header.get("ALT" + ext, np.nan)
-        az = header.get("AZ" + ext, np.nan)
-        return AltAz(alt=alt * u.deg, az=az * u.deg)
+        alt = header.get("ALT" + ext, None)
+        az = header.get("AZ" + ext, None)
+        return (
+            AltAz(alt=alt * u.deg, az=az * u.deg)
+            if (alt is not None and az is not None)
+            else None
+        )
     elif frame == "icrs":
-        coords = header.get("RA" + ext, np.nan), header.get("DEC" + ext, np.nan)
+        coords = header.get("RA" + ext, None), header.get("DEC" + ext, None)
     elif frame == "galactic":
-        coords = header.get("GLON" + ext, np.nan), header.get("GLAT" + ext, np.nan)
+        coords = header.get("GLON" + ext, None), header.get("GLAT" + ext, None)
     else:
         raise ValueError(
             f"Unsupported frame {frame}. Select in 'icrs', 'galactic', 'altaz'."
         )
-    return SkyCoord(coords[0], coords[1], unit="deg", frame=frame)
+    if coords[0] is not None and coords[1] is not None:
+        return SkyCoord(coords[0], coords[1], unit="deg", frame=frame)
+    else:
+        return None

--- a/gammapy/utils/metadata.py
+++ b/gammapy/utils/metadata.py
@@ -196,10 +196,9 @@ class ObsInfoMetaData(MetaData):
         The observation mode.
     """
 
-    model_config = ConfigDict(coerce_numbers_to_str=True)
     _tag: ClassVar[Literal["obs_info"]] = "obs_info"
 
-    obs_id: str
+    obs_id: int
     telescope: Optional[str] = None
     instrument: Optional[str] = None
     sub_array: Optional[str] = None

--- a/gammapy/utils/metadata.py
+++ b/gammapy/utils/metadata.py
@@ -196,9 +196,10 @@ class ObsInfoMetaData(MetaData):
         The observation mode.
     """
 
+    model_config = ConfigDict(coerce_numbers_to_str=True)
     _tag: ClassVar[Literal["obs_info"]] = "obs_info"
 
-    obs_id: int
+    obs_id: str
     telescope: Optional[str] = None
     instrument: Optional[str] = None
     sub_array: Optional[str] = None

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -89,10 +89,10 @@ def test_obs_info():
     obs_info = ObsInfoMetaData(obs_id="23523")
 
     assert obs_info.telescope is None
-    assert obs_info.obs_id == "23523"
+    assert obs_info.obs_id == 23523
 
-    obs_info.obs_id = "23523"
-    assert obs_info.obs_id == "23523"
+    obs_info.obs_id = 23523
+    assert obs_info.obs_id == 23523
 
     obs_info.instrument = "CTA-North"
     assert obs_info.instrument == "CTA-North"
@@ -103,7 +103,7 @@ def test_obs_info_from_header(hess_eventlist_header):
     meta = ObsInfoMetaData.from_header(hess_eventlist_header, format="gadf")
 
     assert meta.telescope == "HESS"
-    assert meta.obs_id == "23523"
+    assert meta.obs_id == 23523
     assert meta.observation_mode == "WOBBLE"
     assert meta.sub_array is None
 
@@ -113,7 +113,7 @@ def test_obs_info_to_header():
 
     header = obs_info.to_header("gadf")
 
-    assert header["OBS_ID"] == "23523"
+    assert header["OBS_ID"] == 23523
     assert header["TELESCOP"] == "CTA-South"
     assert "OBS_MODE" not in header
 

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -89,10 +89,10 @@ def test_obs_info():
     obs_info = ObsInfoMetaData(obs_id="23523")
 
     assert obs_info.telescope is None
-    assert obs_info.obs_id == 23523
+    assert obs_info.obs_id == "23523"
 
-    obs_info.obs_id = 23523
-    assert obs_info.obs_id == 23523
+    obs_info.obs_id = "23523"
+    assert obs_info.obs_id == "23523"
 
     obs_info.instrument = "CTA-North"
     assert obs_info.instrument == "CTA-North"
@@ -103,7 +103,7 @@ def test_obs_info_from_header(hess_eventlist_header):
     meta = ObsInfoMetaData.from_header(hess_eventlist_header, format="gadf")
 
     assert meta.telescope == "HESS"
-    assert meta.obs_id == 23523
+    assert meta.obs_id == "23523"
     assert meta.observation_mode == "WOBBLE"
     assert meta.sub_array is None
 
@@ -113,7 +113,7 @@ def test_obs_info_to_header():
 
     header = obs_info.to_header("gadf")
 
-    assert header["OBS_ID"] == 23523
+    assert header["OBS_ID"] == "23523"
     assert header["TELESCOP"] == "CTA-South"
     assert "OBS_MODE" not in header
 

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -161,6 +161,10 @@ def test_pointing_info_from_header(hess_eventlist_header):
     assert_allclose(meta.radec_mean.ra.deg, 83.633333)
     assert_allclose(meta.altaz_mean.alt.deg, 41.389789)
 
+    meta = PointingInfoMetaData.from_header({})
+    assert meta.altaz_mean is None
+    assert meta.radec_mean is None
+
 
 def test_target_metadata():
     meta = TargetMetaData(


### PR DESCRIPTION
Addresses  #4792. 

This PR adds a meta container on the MapDataset object. 

1. The stacking is not done in place currently. 
2. The `optional` dict keys are just stacked - and then users can decide what to do with it 
3. Stacking multiple instruments raises a warning - change to error and forbid?
4. The GTI table is already present on the map dataset, not replicating it here
5. Maybe another property `maker` can be added? To know how this dataset was created, eg: the outcome of some maker process or created by hand by the user. Or is that provenance information @bkhelifi 
6. In https://github.com/gammapy/gammapy/blob/main/gammapy/maps/utils.py#L77 we define INVALID_VALUE.int = np.nan
However, `isinstance(np.nan, int)` returns `False`, which raises `ValidationError`. I have put -999 as default for the event types, any better solution?

opinions please @registerrier @adonath @QRemy @maxnoe 

Still needs in future PRs:

- [ ] Deprecate the meta table?
- [ ] MapDatasetMaker.create_metadata()
- [ ] FluxPointsDataset meta object