### PR TITLE
Fixing warning raised when generating the documentation

### DIFF
--- a/examples/models/spectral/plot_absorbed.py
+++ b/examples/models/spectral/plot_absorbed.py
@@ -2,7 +2,7 @@ r"""
 .. _absorption-spectral-model:
 
 EBL absorption spectral model
-==============================
+=============================
 
 This model evaluates absorbed spectral model.
 

--- a/examples/models/spectral/plot_exp_cutoff_powerlaw_norm_spectral.py
+++ b/examples/models/spectral/plot_exp_cutoff_powerlaw_norm_spectral.py
@@ -2,7 +2,7 @@ r"""
 .. _exp-cutoff-powerlaw-norm-spectral-model:
 
 Exponential cutoff power law norm spectral model
-========================
+================================================
 
 This model parametrises a cutoff power law spectral correction with a norm parameter.
 

--- a/examples/models/spectral/plot_logparabola_norm_spectral.py
+++ b/examples/models/spectral/plot_logparabola_norm_spectral.py
@@ -2,7 +2,7 @@ r"""
 .. _logparabola-spectral-norm-model:
 
 Log parabola spectral norm model
-===========================
+================================
 
 This model parametrises a log parabola spectral correction with a norm parameter.
 

--- a/examples/models/spectral/plot_powerlaw_norm_spectral.py
+++ b/examples/models/spectral/plot_powerlaw_norm_spectral.py
@@ -2,7 +2,7 @@ r"""
 .. _powerlaw-spectral-norm-model:
 
 Power law norm spectral model
-========================
+=============================
 
 This model parametrises a power law spectral correction with a norm and tilt parameter.
 

--- a/examples/tutorials/analysis-1d/extended_source_spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/extended_source_spectral_analysis.py
@@ -251,7 +251,7 @@ plt.show()
 
 ######################################################################
 # Cumulative excess and significance
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Finally, we can look at cumulative significance and number of excesses.
 # This is done with the `info_table` method of

--- a/examples/tutorials/analysis-1d/sed_fitting.py
+++ b/examples/tutorials/analysis-1d/sed_fitting.py
@@ -8,8 +8,7 @@ Fit spectral models to combined Fermi-LAT and IACT flux points tables.
 Prerequisites
 -------------
 
--  Some knowledge about retrieving information from catalogs,
- see :doc:`/tutorials/api/catalog` tutorial.
+-  Some knowledge about retrieving information from catalogs, see :doc:`/tutorials/api/catalog` tutorial.
 
 Context
 -------

--- a/examples/tutorials/analysis-2d/detect.py
+++ b/examples/tutorials/analysis-2d/detect.py
@@ -7,9 +7,9 @@ Build a list of significant excesses in a Fermi-LAT map.
 Context
 -------
 
-The first task in a source catalogue production is to identify
+The first task in a source catalog production is to identify
 significant excesses in the data that can be associated to unknown
-sources and provide a preliminary parametrization in term of position,
+sources and provide a preliminary parametrization in terms of position,
 extent, and flux. In this notebook we will use Fermi-LAT data to
 illustrate how to detect candidate sources in counts images with known
 background.

--- a/examples/tutorials/analysis-3d/event_sampling.py
+++ b/examples/tutorials/analysis-3d/event_sampling.py
@@ -72,6 +72,7 @@ We will work with the following functions and classes:
 -  `~gammapy.modeling.models.SkyModel`
 -  `~gammapy.datasets.MapDatasetEventSampler`
 -  `~gammapy.data.EventList`
+
 """
 
 ######################################################################
@@ -526,7 +527,7 @@ for idx, tstart in enumerate(tstarts):
 
 ######################################################################
 # You can now load the event list and the corresponding IRFs with
-# `DataStore.from_events_files` :
+# `DataStore.from_events_files`:
 #
 
 path = Path("./event_sampling/")

--- a/examples/tutorials/analysis-time/pulsar_analysis.py
+++ b/examples/tutorials/analysis-time/pulsar_analysis.py
@@ -15,7 +15,7 @@ order to build these products, we will use the
 
 This tutorial uses a simulated run of vel observation from the CTA DC1, which already contains a
 column for the pulsar phases. The phasing in itself is therefore not show here. It
-requires specific packages like Tempo2 or [PINT]((https://nanograv-pint.readthedocs.io). A gammapy
+requires specific packages like Tempo2 or `(PINT) <https://nanograv-pint.readthedocs.io>`__. A gammapy
 recipe shows how to compute phases with PINT in the framework of Gammapy.
 
 

--- a/examples/tutorials/api/astro_dark_matter.py
+++ b/examples/tutorials/api/astro_dark_matter.py
@@ -211,7 +211,7 @@ plt.show()
 
 ######################################################################
 # Flux maps for annihilation
-# ---------
+# --------------------------
 #
 # Finally flux maps can be produced like this:
 #
@@ -235,7 +235,7 @@ plt.show()
 
 ######################################################################
 # Flux maps for decay
-# ---------
+# -------------------
 #
 # Finally flux maps for decay can be produced like this:
 #

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Source catalog and object base classes."""
 import abc
+import html
 import numbers
 from copy import deepcopy
-import html
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
@@ -278,7 +278,7 @@ class SourceCatalog(abc.ABC):
         return _skycoord_from_table(self.table)
 
     def to_models(self, **kwargs):
-        """Create Models object from catalogue"""
+        """Create Models object from catalog."""
         return Models([_.sky_model(**kwargs) for _ in self])
 
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -523,7 +523,7 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
             tag = "Flux2_History"
             if tag not in self.data or "time_axis_2" not in self.data:
                 raise ValueError(
-                    "2-month interval is not available for this catalogue version"
+                    "2-month interval is not available for this catalog version"
                 )
             time_axis = self.data["time_axis_2"]
             tag_sqrt_ts = "Sqrt_TS2_History"

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -874,7 +874,7 @@ class SourceCatalogHGPS(SourceCatalog):
         return SourceCatalogObjectHGPSComponent(data=data)
 
     def to_models(self, which="best", components_status="independent"):
-        """Create Models object from catalogue
+        """Create Models object from catalog.
 
         Parameters
         ----------

--- a/gammapy/catalog/lhaaso.py
+++ b/gammapy/catalog/lhaaso.py
@@ -177,7 +177,7 @@ class SourceCatalog1LHAASO(SourceCatalog):
         super().__init__(table=table, source_name_key=source_name_key)
 
     def to_models(self, which="both"):
-        """Create Models object from catalogue
+        """Create Models object from catalog.
         * ``which="both"`` - Use first model or create a composite template if both models are available.
         * ``which="KM2A"`` - Sky model for KM2A analysis if available.
         * ``which="WCDA"`` - Sky model for WCDA analysis if available.

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -71,7 +71,7 @@ class ExcessMapEstimator(Estimator):
 
         By default the excess estimator correlates the off counts as well to avoid
         artifacts at the edges of the :term:`FoV` for stacked on-off datasets.
-        However when the on-off dataset has been derived from a ring background
+        However, when the on-off dataset has been derived from a ring background
         estimate, this leads to the off counts being correlated twice. To avoid
         artifacts and the double correlation, the `ExcessMapEstimator` has to
         be applied per dataset and the resulting maps need to be stacked, taking
@@ -89,13 +89,11 @@ class ExcessMapEstimator(Estimator):
         Confidence level for the sensitivity expressed in number of sigma.
     gamma_min_sensitivity : float, optional
         Minimum number of gamma-rays. Default is 10.
-        Usde only for for sensitivity computation if `apply_threshold_sensitivity`is True.
     bkg_syst_fraction_sensitivity : float, optional
-        Fraction of background counts above which the number of gamma-rays is . Default is 0.05
-        Used only for for sensitivity computation if `apply_threshold_sensitivity`is True.
+        Fraction of background counts that are above the gamma-ray counts. Default is 0.05.
     apply_threshold_sensitivity : bool
-        If True use ``bkg_syst_fraction_sensitivity` and `gamma_min_sensitivity`
-        in sensitivity computation. Default is False which is setting used for the HGPS catalogue.
+        If True, use `bkg_syst_fraction_sensitivity` and `gamma_min_sensitivity` in the sensitivity computation.
+        Default is False which is the same setting as the HGPS catalog.
     selection_optional : list of str
         Which additional maps to estimate besides delta TS, significance and symmetric error.
         Available options are:

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -405,9 +405,11 @@ class SpatialModel(ModelBase):
         which: list of str
             Which errors to plot.
             Available options are:
+
                 * "all": all the optional steps are plotted
                 * "position": plot the position error of the spatial model.
                 * "extension": plot the extension error of the spatial model.
+
         kwargs_position : dict
             Keyword arguments passed to `~SpatialModel.plot_position_error`
         kwargs_extension : dict


### PR DESCRIPTION
This PR fix warning that were raised when generating the documentation. It is mostly indentation issue and underline of tutorial section. It does not change at all the display of our documentation, it just remove the warning. 

On the `ExcessMapEstimator` docstring, I removed the description sentence of `gamma_min_sensitivity` and `bkg_syst_fraction_sensitivity` because it was referring to `apply_threshold_sensitivity` before definition. So the documentation could not build the actual reference. 

We also reviewed some formulations of sentences in the same docstring with @Astro-Kirsty. 