### PR TITLE
Fix small typo in the docstring of the Cash likelihood

### DIFF
--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -28,7 +28,7 @@ def cash(n_on, mu_on, truncation_value=TRUNCATION_VALUE):
         Expected counts
     truncation_value : array_like
         Minimum value use for ``mu_on``
-        ``mu_on`` = ``truncation_value`` where ``n_on`` <= ``truncation_value``
+        ``mu_on`` = ``truncation_value`` where ``mu_on`` <= ``truncation_value``
         Default is 1e-25.
 
     Returns


### PR DESCRIPTION
This pull request fixes a small typo on the doc-string of the cash statistic likelihood implementation.

It was written ``mu_on`` = ``truncation_value`` where ``n_on`` <= ``truncation_value`` but the code does 
```
mu_on = np.where(mu_on <= truncation_value, truncation_value, mu_on)
```
so it actually should be `mu_on` twice in the docstring.