### PR TITLE
Remove is_norm from spectral model and add norm to FluxPointEstimator

### DIFF
--- a/examples/tutorials/analysis-3d/flux_profiles.py
+++ b/examples/tutorials/analysis-3d/flux_profiles.py
@@ -15,7 +15,7 @@ Context
 
 A useful tool to study and compare the spatial distribution of flux in
 images and data cubes is the measurement of flux profiles. Flux profiles
-can show spatial correlations of gamma-ray data with e.g. gas maps or
+can show spatial correlations of gamma-ray data with e.g. gas maps or
 other type of gamma-ray data. Most commonly flux profiles are measured
 along some preferred coordinate axis, either radially distance from a
 source of interest, along longitude and latitude coordinate axes or
@@ -178,7 +178,7 @@ plt.show()
 
 ######################################################################
 # Based on the spectral model we specified above we can also plot in any
-# other sed type, e.g. energy flux and define a different threshold when
+# other sed type, e.g. energy flux and define a different threshold when
 # to plot upper limits:
 #
 
@@ -272,9 +272,8 @@ flux_profile_estimator = FluxProfileEstimator(
     spectrum=PowerLawSpectralModel(index=2.3),
     energy_edges=[10, 100, 2000] * u.GeV,
     selection_optional=["ul", "scan"],
-    norm_values=np.linspace(-1, 5, 11),
 )
-
+flux_profile_estimator.norm.scan_values = np.linspace(-1, 5, 11)
 profile = flux_profile_estimator.run(datasets=dataset)
 
 

--- a/examples/tutorials/api/models.py
+++ b/examples/tutorials/api/models.py
@@ -295,7 +295,7 @@ plt.show()
 
 
 ######################################################################
-# All spatial models have an associated sky region to it e.g. to
+# All spatial models have an associated sky region to it e.g. to
 # illustrate the extension of the model on a sky image. The returned object
 # is an `~regions.SkyRegion` object:
 #
@@ -322,7 +322,7 @@ plt.show()
 
 
 ######################################################################
-# The `~gammapy.modeling.models.SpatialModel.to_region()` method can also be useful to write e.g. ds9 region
+# The `~gammapy.modeling.models.SpatialModel.to_region()` method can also be useful to write e.g. ds9 region
 # files using `write_ds9` from the `regions` package:
 #
 
@@ -450,7 +450,7 @@ plt.show()
 # parameter resides on the `~gammapy.modeling.models.SpectralModel`, specifying a spectral
 # component is compulsory. The temporal and spatial components are
 # optional. The temporal model needs to be specified only for timing
-# analysis. In some cases (e.g. when doing a spectral analysis) there is
+# analysis. In some cases (e.g. when doing a spectral analysis) there is
 # no need for a spatial component either, and only a spectral model is
 # associated with the source.
 #
@@ -462,7 +462,7 @@ print(model_spectrum)
 ######################################################################
 # Additionally the spatial model of `~gammapy.modeling.models.SkyModel`
 # can be used to represent source models based on templates, where the
-# spatial and energy axes are correlated. It can be created e.g. from an
+# spatial and energy axes are correlated. It can be created e.g. from an
 # existing FITS file:
 #
 
@@ -537,7 +537,7 @@ print(models["my-source"])
 
 
 ######################################################################
-# **Note:** To make the access by name unambiguous, models are required to
+# **Note:** To make the access by name unambiguous, models are required to
 # have a unique name, otherwise an error will be thrown.
 #
 # To see which models are available you can use the ``.names`` attribute:
@@ -666,7 +666,7 @@ class MyCustomSpectralModel(SpectralModel):
     """
 
     tag = "MyCustomSpectralModel"
-    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", min=0, is_norm=True)
+    amplitude = Parameter("amplitude", "1e-12 cm-2 s-1 TeV-1", min=0)
     index = Parameter("index", 2, min=0)
     reference = Parameter("reference", "1 TeV", frozen=True)
     mean = Parameter("mean", "1 TeV", min=0)

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -229,7 +229,6 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         1,
         unit="",
         interp="log",
-        is_norm=True,
     )
     tag = ["DarkMatterAnnihilationSpectralModel", "dm-annihilation"]
 
@@ -335,7 +334,6 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         1,
         unit="",
         interp="log",
-        is_norm=True,
     )
     tag = ["DarkMatterDecaySpectralModel", "dm-decay"]
 

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -60,7 +60,6 @@ def test_dm_annihilation_spectral_model(tmpdir):
     assert_quantity_allclose(integral_flux.value, 6.19575457e-14, rtol=1e-3)
     assert_quantity_allclose(differential_flux.value, 2.97506768e-16, rtol=1e-3)
 
-    assert model.scale.is_norm
     assert new_models[0].spectral_model.channel == model.channel
     assert new_models[0].spectral_model.z == model.z
     assert_allclose(new_models[0].spectral_model.jfactor.value, model.jfactor.value)
@@ -94,7 +93,6 @@ def test_dm_decay_spectral_model(tmpdir):
     assert_quantity_allclose(integral_flux.value, 4.80283595e-2, rtol=1e-3)
     assert_quantity_allclose(differential_flux.value, 2.30625401e-4, rtol=1e-3)
 
-    assert model.scale.is_norm
     assert new_models[0].spectral_model.channel == model.channel
     assert new_models[0].spectral_model.z == model.z
     assert_allclose(new_models[0].spectral_model.jfactor.value, model.jfactor.value)

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -72,11 +72,11 @@ class FluxPointsDataset(Dataset):
         message    : Hesse terminated successfully.
 
     >>> print(result.parameters.to_table())
-      type      name     value         unit      ... max frozen is_norm link
-    -------- --------- ---------- -------------- ... --- ------ ------- ----
-    spectral     index 2.2159e+00                ... nan  False   False
-    spectral amplitude 2.1619e-13 cm-2 s-1 TeV-1 ... nan  False    True
-    spectral reference 1.0000e+00            TeV ... nan   True   False
+      type      name     value         unit      ... max frozen link
+    -------- --------- ---------- -------------- ... --- ------ ----
+    spectral     index 2.2159e+00                ... nan  False
+    spectral amplitude 2.1619e-13 cm-2 s-1 TeV-1 ... nan  False
+    spectral reference 1.0000e+00            TeV ... nan   True
 
     Note: In order to reproduce the example, you need the tests datasets folder.
     You may download it with the command

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -125,13 +125,12 @@ class MapDatasetEventSampler:
             time_axis_eval.time_mid, energy=energy_new.center
         )
 
-        norm_parameters = model.spectral_model.parameters.norm_parameters
-        norm = norm_parameters[0].quantity
+        norm = model.spectral_model(energy=energy_new.center)
 
         if temp_eval.unit.is_equivalent(norm.unit):
-            flux_diff = temp_eval.to(norm.unit)
+            flux_diff = temp_eval.to(norm.unit) * norm.value[:, None]
         else:
-            flux_diff = temp_eval * norm
+            flux_diff = temp_eval * norm[:, None]
 
         flux_inte = flux_diff * energy_new.bin_width[:, None]
 

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -103,7 +103,7 @@ class FluxEstimator(ParameterEstimator):
             )
 
         scale_model = ScaleSpectralModel(ref_model)
-        scale_model.norm = self.norm
+        scale_model.norm = self.norm.copy()
         return scale_model
 
     def estimate_npred_excess(self, datasets):

--- a/gammapy/estimators/points/lightcurve.py
+++ b/gammapy/estimators/points/lightcurve.py
@@ -38,17 +38,12 @@ class LightCurveEstimator(FluxPointsEstimator):
     time_intervals : list of `astropy.time.Time`
         Start and stop time for each interval to compute the LC
     source : str or int
-        For which source in the model to compute the flux points. Default is 0
+        For which source in the model to compute the flux points. Default is 0.
+    norm : ~gammapy.modeling.Parameter`
+        Norm parameter used for the fit.
+        Default is None and a new parameter is created automatically.
     atol : `~astropy.units.Quantity`
         Tolerance value for time comparison with different scale. Default 1e-6 sec.
-    norm_min : float
-        Minimum value for the norm used for the fit statistic profile evaluation.
-    norm_max : float
-        Maximum value for the norm used for the fit statistic profile evaluation.
-    norm_n_values : int
-        Number of norm values used for the fit statistic profile.
-    norm_values : `numpy.ndarray`
-        Array of norm values to be used for the fit statistic profile.
     n_sigma : int
         Number of sigma to use for asymmetric error computation. Default is 1.
     n_sigma_ul : int

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -37,14 +37,9 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
     ----------
     source : str or int
         For which source in the model to compute the flux points.
-    norm_min : float
-        Minimum value for the norm used for the fit statistic profile evaluation.
-    norm_max : float
-        Maximum value for the norm used for the fit statistic profile evaluation.
-    norm_n_values : int
-        Number of norm values used for the fit statistic profile.
-    norm_values : `numpy.ndarray`
-        Array of norm values to be used for the fit statistic profile.
+    norm : ~gammapy.modeling.Parameter`
+        Norm parameter used for the fit.
+        Default is None and a new parameter is created automatically.
     n_sigma : int
         Number of sigma to use for asymmetric error computation. Default is 1.
     n_sigma_ul : int
@@ -214,8 +209,7 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
             result.update({"norm_ul": np.nan})
 
         if "scan" in self.selection_optional:
-            norm = super()._set_norm_parameter()
-            norm_scan = norm.scan_values
+            norm_scan = self.norm.scan_values
             result.update({"norm_scan": norm_scan, "stat_scan": np.nan * norm_scan})
 
         return result

--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -223,11 +223,11 @@ def test_lightcurve_estimator_fit_options():
 
     estimator = LightCurveEstimator(
         energy_edges=energy_edges,
-        norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional="all",
         fit=Fit(backend="minuit", optimize_opts=dict(tol=0.2, strategy=1)),
     )
+    estimator.norm.scan_n_values = 3
 
     assert_allclose(estimator.fit.optimize_opts["tol"], 0.2)
 
@@ -246,10 +246,10 @@ def test_lightcurve_estimator_spectrum_datasets():
 
     estimator = LightCurveEstimator(
         energy_edges=[1, 30] * u.TeV,
-        norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional="all",
     )
+    estimator.norm.scan_n_values = 3
 
     lightcurve = estimator.run(datasets)
     table = lightcurve.to_table(format="lightcurve")
@@ -307,10 +307,10 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
 
     estimator = LightCurveEstimator(
         energy_edges=[1, 5, 30] * u.TeV,
-        norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional="all",
     )
+    estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
     table = lightcurve.to_table(format="lightcurve")
 
@@ -434,10 +434,10 @@ def test_lightcurve_estimator_spectrum_datasets_with_mask_fit():
     selection = ["scan"]
     estimator = LightCurveEstimator(
         energy_edges=[1, 30] * u.TeV,
-        norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional=selection,
     )
+    estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
     table = lightcurve.to_table(format="lightcurve")
     assert_allclose(table["time_min"], [55197.0, 55197.041667])
@@ -453,8 +453,9 @@ def test_lightcurve_estimator_spectrum_datasets_default():
     datasets = get_spectrum_datasets()
     selection = ["scan"]
     estimator = LightCurveEstimator(
-        energy_edges=[1, 30] * u.TeV, norm_n_values=3, selection_optional=selection
+        energy_edges=[1, 30] * u.TeV, selection_optional=selection
     )
+    estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
     table = lightcurve.to_table(format="lightcurve")
     assert_allclose(table["time_min"], [55197.0, 55197.041667])
@@ -473,10 +474,10 @@ def test_lightcurve_estimator_spectrum_datasets_notordered():
     ]
     estimator = LightCurveEstimator(
         energy_edges=[1, 100] * u.TeV,
-        norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional=["scan"],
     )
+    estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
     table = lightcurve.to_table(format="lightcurve")
     assert_allclose(table["time_min"], [55197.0, 55197.041667])
@@ -491,10 +492,10 @@ def test_lightcurve_estimator_spectrum_datasets_largerbin():
     time_intervals = [Time(["2010-01-01T00:00:00", "2010-01-01T02:00:00"])]
     estimator = LightCurveEstimator(
         energy_edges=[1, 30] * u.TeV,
-        norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional=["scan"],
     )
+    estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
     table = lightcurve.to_table(format="lightcurve")
 
@@ -522,10 +523,10 @@ def test_lightcurve_estimator_spectrum_datasets_emptybin():
     ]
     estimator = LightCurveEstimator(
         energy_edges=[1, 30] * u.TeV,
-        norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional=["scan"],
     )
+    estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
     table = lightcurve.to_table(format="lightcurve")
 
@@ -542,7 +543,8 @@ def test_lightcurve_estimator_spectrum_datasets_timeoverlaped():
         Time(["2010-01-01T01:00:00", "2010-01-01T02:00:00"]),
     ]
     with pytest.raises(ValueError) as excinfo:
-        estimator = LightCurveEstimator(norm_n_values=3, time_intervals=time_intervals)
+        estimator = LightCurveEstimator(time_intervals=time_intervals)
+        estimator.norm.scan_n_values = 3
         estimator.run(datasets)
 
     msg = "Overlapping time bins"
@@ -559,10 +561,10 @@ def test_lightcurve_estimator_spectrum_datasets_gti_not_include_in_time_interval
     ]
     estimator = LightCurveEstimator(
         energy_edges=[1, 30] * u.TeV,
-        norm_n_values=3,
         time_intervals=time_intervals,
         selection_optional=["scan"],
     )
+    estimator.norm.scan_n_values = 3
     with pytest.raises(ValueError) as excinfo:
         estimator.run(datasets)
     msg = "LightCurveEstimator: No datasets in time intervals"

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -482,7 +482,7 @@ def test_run_pwl_parameter_range(fpe_pwl):
     assert_allclose(actual, [0.0, 0.0, 0.0], atol=1e-2)
 
     actual = table_no_bounds["norm"].data
-    assert_allclose(actual, [-511.76675, -153.610019, -853.544154], rtol=1e-3)
+    assert_allclose(actual, [-511.76675, -155.75408, -853.547117], rtol=1e-3)
 
     actual = table_no_bounds["norm_err"].data
     assert_allclose(actual, [504.601499, 416.69248, 851.223077], rtol=1e-2)

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -88,11 +88,11 @@ def create_fpe(model):
     dataset.models = model
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
-        norm_n_values=11,
         source="source",
         selection_optional="all",
         fit=Fit(backend="minuit", optimize_opts=dict(tol=0.2, strategy=1)),
     )
+    fpe.norm.scan_n_values = 11
     datasets = [dataset]
     return datasets, fpe
 
@@ -146,10 +146,11 @@ def fpe_map_pwl():
     datasets = [dataset_1, dataset_2]
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
-        norm_n_values=3,
         source="source",
         selection_optional="all",
     )
+    fpe.norm.scan_n_values = 3
+
     return datasets, fpe
 
 
@@ -163,10 +164,10 @@ def fpe_map_pwl_reoptimize():
     datasets = [dataset]
     fpe = FluxPointsEstimator(
         energy_edges=energy_edges,
-        norm_values=[0.8, 1, 1.2],
         reoptimize=True,
         source="source",
     )
+    fpe.norm.scan_values = [0.8, 1, 1.2]
     return datasets, fpe
 
 
@@ -460,11 +461,11 @@ def test_run_pwl_parameter_range(fpe_pwl):
     datasets, fpe = create_fpe(pl)
 
     fp = fpe.run(datasets)
+
     table_no_bounds = fp.to_table()
 
-    pl.amplitude.min = 0
-    pl.amplitude.max = 1e-12
-
+    fpe.norm.min = 0
+    fpe.norm.max = 1e4
     fp = fpe.run(datasets)
     table_with_bounds = fp.to_table()
 
@@ -481,7 +482,7 @@ def test_run_pwl_parameter_range(fpe_pwl):
     assert_allclose(actual, [0.0, 0.0, 0.0], atol=1e-2)
 
     actual = table_no_bounds["norm"].data
-    assert_allclose(actual, [-511.76675, -155.75408, -853.547117], rtol=1e-3)
+    assert_allclose(actual, [-511.76675, -153.610019, -853.544154], rtol=1e-3)
 
     actual = table_no_bounds["norm_err"].data
     assert_allclose(actual, [504.601499, 416.69248, 851.223077], rtol=1e-2)

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -189,7 +189,6 @@ class ModelBase:
                     "error",
                     "interp",
                     "scale_method",
-                    "is_norm",
                 ]:
                     default = init[item]
 

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -77,13 +77,6 @@ class SkyModel(ModelBase):
         self.datasets_names = datasets_names
         self._check_unit()
 
-        is_norm = np.array([par.is_norm for par in spectral_model.parameters])
-
-        if not np.any(is_norm):
-            raise ValueError(
-                "Spectral model used with SkyModel requires a norm type parameter."
-            )
-
         super().__init__(covariance_data=covariance_data)
 
     @property

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -548,6 +548,7 @@ class PointSpatialModel(SpatialModel):
 
         return dx * dy
 
+    @property
     def is_energy_dependent(self):
         return False
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -676,7 +676,7 @@ class ConstantSpectralModel(SpectralModel):
     """
 
     tag = ["ConstantSpectralModel", "const"]
-    const = Parameter("const", "1e-12 cm-2 s-1 TeV-1", is_norm=True)
+    const = Parameter("const", "1e-12 cm-2 s-1 TeV-1")
 
     @staticmethod
     def evaluate(energy, const):
@@ -776,7 +776,6 @@ class PowerLawSpectralModel(SpectralModel):
         "1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        is_norm=True,
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
 
@@ -901,7 +900,7 @@ class PowerLawNormSpectralModel(SpectralModel):
     """
 
     tag = ["PowerLawNormSpectralModel", "pl-norm"]
-    norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
+    norm = Parameter("norm", 1, unit="", interp="log")
     tilt = Parameter("tilt", 0, frozen=True)
     reference = Parameter("reference", "1 TeV", frozen=True)
 
@@ -1012,7 +1011,6 @@ class PowerLaw2SpectralModel(SpectralModel):
         value="1e-12 cm-2 s-1",
         scale_method="scale10",
         interp="log",
-        is_norm=True,
     )
     index = Parameter("index", 2)
     emin = Parameter("emin", "0.1 TeV", frozen=True)
@@ -1104,7 +1102,6 @@ class BrokenPowerLawSpectralModel(SpectralModel):
         value="1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        is_norm=True,
     )
     ebreak = Parameter("ebreak", "1 TeV")
 
@@ -1158,7 +1155,6 @@ class SmoothBrokenPowerLawSpectralModel(SpectralModel):
         value="1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        is_norm=True,
     )
     ebreak = Parameter("ebreak", "1 TeV")
     reference = Parameter("reference", "1 TeV", frozen=True)
@@ -1196,9 +1192,6 @@ class PiecewiseNormSpectralModel(SpectralModel):
     def __init__(self, energy, norms=None, interp="log"):
         self._energy = energy
         self._interp = interp
-        self._norm = Parameter(
-            "_norm", 1, unit="", interp="log", is_norm=True, frozen=True
-        )
 
         if norms is None:
             norms = np.ones(len(energy))
@@ -1209,7 +1202,7 @@ class PiecewiseNormSpectralModel(SpectralModel):
         if len(norms) < 2:
             raise ValueError("Input arrays must contain at least 2 elements")
 
-        parameters_list = [self._norm]
+        parameters_list = []
         if not isinstance(norms[0], Parameter):
             parameters_list += [
                 Parameter(f"norm_{k}", norm) for k, norm in enumerate(norms)
@@ -1228,7 +1221,7 @@ class PiecewiseNormSpectralModel(SpectralModel):
     @property
     def norms(self):
         """Norm values"""
-        return u.Quantity([p.value for p in self.parameters if p.name != "_norm"])
+        return u.Quantity([p.value for p in self.parameters])
 
     def evaluate(self, energy, **norms):
         scale = interpolation_scale(scale=self._interp)
@@ -1236,12 +1229,10 @@ class PiecewiseNormSpectralModel(SpectralModel):
         e_nodes = scale(self.energy.to(energy.unit).value)
         v_nodes = scale(self.norms)
         log_interp = scale.inverse(np.interp(e_eval, e_nodes, v_nodes))
-        return self._norm.quantity * log_interp
+        return log_interp
 
     def to_dict(self, full_output=False):
         data = super().to_dict(full_output=full_output)
-        if data["spectral"]["parameters"][0]["name"] == "_norm":
-            data["spectral"]["parameters"].pop(0)
         data["spectral"]["energy"] = {
             "data": self.energy.data.tolist(),
             "unit": str(self.energy.unit),
@@ -1298,7 +1289,6 @@ class ExpCutoffPowerLawSpectralModel(SpectralModel):
         value="1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        is_norm=True,
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
@@ -1360,7 +1350,7 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
     tag = ["ExpCutoffPowerLawNormSpectralModel", "ecpl-norm"]
 
     index = Parameter("index", 1.5)
-    norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
+    norm = Parameter("norm", 1, unit="", interp="log")
     reference = Parameter("reference", "1 TeV", frozen=True)
     lambda_ = Parameter("lambda_", "0.1 TeV-1")
     alpha = Parameter("alpha", "1.0", frozen=True)
@@ -1425,7 +1415,6 @@ class ExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
         "1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        is_norm=True,
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     ecut = Parameter("ecut", "10 TeV")
@@ -1474,7 +1463,6 @@ class SuperExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
         "1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        is_norm=True,
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     ecut = Parameter("ecut", "10 TeV")
@@ -1520,7 +1508,6 @@ class SuperExpCutoffPowerLaw4FGLSpectralModel(SpectralModel):
         "1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        is_norm=True,
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     expfactor = Parameter("expfactor", "1e-2")
@@ -1569,7 +1556,6 @@ class SuperExpCutoffPowerLaw4FGLDR3SpectralModel(SpectralModel):
         value="1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        is_norm=True,
     )
     reference = Parameter("reference", "1 TeV", frozen=True)
     expfactor = Parameter("expfactor", "1e-2")
@@ -1625,7 +1611,6 @@ class LogParabolaSpectralModel(SpectralModel):
         "1e-12 cm-2 s-1 TeV-1",
         scale_method="scale10",
         interp="log",
-        is_norm=True,
     )
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 2)
@@ -1684,7 +1669,7 @@ class LogParabolaNormSpectralModel(SpectralModel):
 
     tag = ["LogParabolaNormSpectralModel", "lp-norm"]
 
-    norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
+    norm = Parameter("norm", 1, unit="", interp="log")
     reference = Parameter("reference", "10 TeV", frozen=True)
     alpha = Parameter("alpha", 0)
     beta = Parameter("beta", 0)
@@ -1749,14 +1734,12 @@ class TemplateSpectralModel(SpectralModel):
         Meta information, meta['filename'] will be used for serialization
     """
 
-    norm = Parameter("norm", 1, unit="", interp="log", is_norm=True, frozen=True)
     tag = ["TemplateSpectralModel", "template"]
 
     def __init__(
         self,
         energy,
         values,
-        norm=1.0,
         interp_kwargs=None,
         meta=None,
     ):
@@ -1774,7 +1757,7 @@ class TemplateSpectralModel(SpectralModel):
             points=(energy,), values=values, **interp_kwargs
         )
 
-        super().__init__(norm=norm)
+        super().__init__()
 
     @classmethod
     def read_xspec_model(cls, filename, param, **kwargs):
@@ -1826,9 +1809,9 @@ class TemplateSpectralModel(SpectralModel):
         kwargs.setdefault("interp_kwargs", {"values_scale": "lin"})
         return cls(energy=energy, values=values, **kwargs)
 
-    def evaluate(self, energy, norm):
+    def evaluate(self, energy):
         """Evaluate the model (static function)."""
-        return norm * self._evaluate((energy,), clip=True)
+        return self._evaluate((energy,), clip=True)
 
     def to_dict(self, full_output=False):
         data = super().to_dict(full_output)
@@ -1848,8 +1831,7 @@ class TemplateSpectralModel(SpectralModel):
         data = data["spectral"]
         energy = u.Quantity(data["energy"]["data"], data["energy"]["unit"])
         values = u.Quantity(data["values"]["data"], data["values"]["unit"])
-        norm = [p["value"] for p in data["parameters"] if p["name"] == "norm"][0]
-        return cls(energy=energy, values=values, norm=norm)
+        return cls(energy=energy, values=values)
 
     @classmethod
     def from_region_map(cls, map, **kwargs):
@@ -1967,7 +1949,7 @@ class ScaleSpectralModel(SpectralModel):
     """
 
     tag = ["ScaleSpectralModel", "scale"]
-    norm = Parameter("norm", 1, unit="", interp="log", is_norm=True)
+    norm = Parameter("norm", 1, unit="", interp="log")
 
     def __init__(self, model, norm=norm.quantity):
         self.model = model
@@ -2223,8 +2205,7 @@ class NaimaSpectralModel(SpectralModel):
 
         for name in param_names:
             value = getattr(self.particle_distribution, name)
-            is_norm = name == "amplitude"
-            parameter = Parameter(name, value, is_norm=is_norm)
+            parameter = Parameter(name, value)
             parameters.append(parameter)
 
         # In case of a synchrotron radiative model, append B to the fittable parameters
@@ -2379,7 +2360,9 @@ class GaussianSpectralModel(SpectralModel):
 
     tag = ["GaussianSpectralModel", "gauss"]
     amplitude = Parameter(
-        "amplitude", 1e-12 * u.Unit("cm-2 s-1"), interp="log", is_norm=True
+        "amplitude",
+        1e-12 * u.Unit("cm-2 s-1"),
+        interp="log",
     )
     mean = Parameter("mean", 1 * u.TeV)
     sigma = Parameter("sigma", 2 * u.TeV)

--- a/gammapy/modeling/models/spectral_crab.py
+++ b/gammapy/modeling/models/spectral_crab.py
@@ -21,7 +21,7 @@ class MeyerCrabSpectralModel(SpectralModel):
     Reference: https://ui.adsabs.harvard.edu/abs/2010A%26A...523A...2M, Appendix D
     """
 
-    norm = Parameter("norm", value=1, frozen=True, is_norm=True)
+    norm = Parameter("norm", value=1, frozen=True)
     coefficients = [-0.00449161, 0, 0.0473174, -0.179475, -0.53616, -10.2708]
 
     @staticmethod

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -444,7 +444,6 @@ def test_to_dict_not_default():
     assert "error" not in index_dict
     assert "interp" not in index_dict
     assert "scale_method" not in index_dict
-    assert "is_norm" not in index_dict
 
     model_2 = model.from_dict(mdict)
     assert model_2.index.min == model.index.min

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -677,9 +677,7 @@ def test_template_spectral_model_single_value():
 
     assert_allclose(result.data, 1e-12)
 
-    model.norm.value = 0.5
     data = model.to_dict()
-    assert_allclose(data["spectral"]["parameters"][0]["value"], 0.5)
     model2 = TemplateSpectralModel.from_dict(data)
     assert model2.to_dict() == data
 
@@ -1197,9 +1195,3 @@ def test_template_ND_EBL(tmpdir):
     assert_allclose(template_new.map.data, region_map.data)
     assert len(template.parameters) == 1
     assert_allclose(template.parameters["redshift"].value, 0.1)
-
-
-def test_is_norm_spectral_models():
-    for test_model in TEST_MODELS:
-        m = test_model["model"]
-        assert np.any([p.is_norm for p in m.parameters])

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -92,8 +92,6 @@ class Parameter:
         Method used to set ``factor`` and ``scale``
     interp : {"lin", "sqrt", "log"}
         Parameter scaling to use for the scan.
-    is_norm : bool
-        Whether the parameter represents the flux norm of the model.
     prior : `~gammapy.modeling.models.Prior`
         Prior set on the parameter.
     """
@@ -115,7 +113,6 @@ class Parameter:
         scan_values=None,
         scale_method="scale10",
         interp="lin",
-        is_norm=False,
         prior=None,
     ):
         if not isinstance(name, str):
@@ -128,7 +125,6 @@ class Parameter:
         self.max = max
         self.frozen = frozen
         self._error = error
-        self._is_norm = is_norm
         self._type = None
 
         # TODO: move this to a setter method that can be called from `__set__` also!
@@ -193,11 +189,6 @@ class Parameter:
     def prior_stat_sum(self):
         if self.prior is not None:
             return self.prior(self)
-
-    @property
-    def is_norm(self):
-        """Whether the parameter represents the norm of the model"""
-        return self._is_norm
 
     @property
     def type(self):
@@ -458,7 +449,6 @@ class Parameter:
             "frozen": self.frozen,
             "interp": self.interp,
             "scale_method": self.scale_method,
-            "is_norm": self.is_norm,
         }
 
         if self._link_label_io is not None:
@@ -599,11 +589,6 @@ class Parameters(collections.abc.Sequence):
     def copy(self):
         """A deep copy"""
         return copy.deepcopy(self)
-
-    @property
-    def norm_parameters(self):
-        """List of norm parameters"""
-        return self.__class__([par for par in self._parameters if par.is_norm])
 
     @property
     def free_parameters(self):

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -161,7 +161,7 @@ def test_parameters_to_table(pars):
 
     table = pars.to_table()
     assert len(table) == 2
-    assert len(table.columns) == 11
+    assert len(table.columns) == 10
     assert table["link"][0] == "test"
     assert table["link"][1] == ""
 


### PR DESCRIPTION
Remove is_norm from spectral model and add a norm parameter to FluxPointEstimator.
In my opinion this is simpler and easier to configure.
For now it is just a prototype to see how much it would change.