### PR TITLE
Fix energy dependent temporal model simulation

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -125,13 +125,12 @@ class MapDatasetEventSampler:
             time_axis_eval.time_mid, energy=energy_new.center
         )
 
-        norm_parameters = model.spectral_model.parameters.norm_parameters
-        norm = norm_parameters[0].quantity
+        norm = model.spectral_model(energy=energy_new.center)
 
         if temp_eval.unit.is_equivalent(norm.unit):
-            flux_diff = temp_eval.to(norm.unit)
+            flux_diff = temp_eval.to(norm.unit) * norm.value[:, None]
         else:
-            flux_diff = temp_eval * norm
+            flux_diff = temp_eval * norm[:, None]
 
         flux_inte = flux_diff * energy_new.bin_width[:, None]
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -237,16 +237,19 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_sky_model):
     energy_dependent_temporal_sky_model.spatial_model = PointSpatialModel(
         lon_0="0 deg", lat_0="0 deg", frame="galactic"
     )
+    energy_dependent_temporal_sky_model.spectral_model.const.value = 2
+
     dataset.models = energy_dependent_temporal_sky_model
     evaluator = dataset.evaluators["test-source"]
 
+    expected = np.array([854.26361, 7.840697, 266.404988, -28.936178])
     events = sampler._sample_coord_time_energy(dataset, evaluator.model)
 
-    assert len(events) == 1254
+    assert len(events) == 2514
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [854.108591, 6.22904, 266.404988, -28.936178],
+        expected,
         rtol=1e-6,
     )
 


### PR DESCRIPTION
Fix energy dependent temporal model simulation in order to take into account the spectral model value. In principle this fix would allow the spectral model to be any `NormSpectralModel` (which is not allowed for now).

It seems also odd to me that the validity of the model is checked within the sampler
`TypeError: Event sampler expects ConstantSpectralModel for a time varying source. Got PowerLawNormSpectralModel`
This should be done within the `SkyModel` as for spatial templates.