### PR TITLE
Correct typo in init of fov background maker

### DIFF
--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -56,7 +56,7 @@ class FoVBackgroundMaker(Maker):
         min_npred_background=0,
         fit=None,
     ):
-        self.method = method
+        self._method = method
         self.exclusion_mask = exclusion_mask
         self.min_counts = min_counts
         self.min_npred_background = min_npred_background


### PR DESCRIPTION
This PR correct a typo on method in the init of the fov background maker. The method was set as `self.method` in the init, meaning that the property and its setter where not working at all. 