### PR TITLE
Cleanup docstring in `gammapy.maps`: `coord.py`, `geom.py`, `io.py` and `maps.py`

### DIFF
--- a/gammapy/maps/coord.py
+++ b/gammapy/maps/coord.py
@@ -115,7 +115,7 @@ class MapCoord:
 
     @property
     def frame(self):
-        """Coordinate system as a str."""
+        """Coordinate system as a string."""
         return self._frame
 
     @property
@@ -125,7 +125,7 @@ class MapCoord:
 
     @property
     def skycoord(self):
-        """Coordinate object as an `~astropy.coordinates.SkyCoord`."""
+        """Coordinate object as a `~astropy.coordinates.SkyCoord`."""
         return SkyCoord(self.lon, self.lat, unit="deg", frame=self.frame)
 
     @classmethod
@@ -201,7 +201,7 @@ class MapCoord:
         ----------
         data : tuple, dict, `~gammapy.maps.MapCoord` or `~astropy.coordinates.SkyCoord`
             Object containing coordinate arrays.
-        frame : {"icrs", "galactic", None}
+        frame : {"icrs", "galactic", None}, optional
             Set the coordinate system for longitude and latitude. If
             None longitude and latitude will be assumed to be in
             the coordinate system native to a given map geometry. Default is None.
@@ -293,14 +293,14 @@ class MapCoord:
 
     @property
     def flat(self):
-        """Return flattened, valid coordinates"""
+        """Return flattened, valid coordinates."""
         coords = self.broadcasted
         is_finite = np.isfinite(coords[0])
         return coords.apply_mask(is_finite)
 
     @property
     def broadcasted(self):
-        """Return broadcasted coordinates"""
+        """Return broadcasted coordinates."""
         vals = np.broadcast_arrays(*self._data.values(), subok=True)
         data = dict(zip(self._data.keys(), vals))
         return self.__class__(

--- a/gammapy/maps/coord.py
+++ b/gammapy/maps/coord.py
@@ -37,11 +37,10 @@ class MapCoord:
     data : `dict` of `~numpy.ndarray`
         Dictionary of coordinate arrays.
     frame : {"icrs", "galactic", None}
-        Spatial coordinate system.  If None then the coordinate system
-        will be set to the native coordinate system of the geometry.
-    match_by_name : bool
-        Match coordinates to axes by name?
-        If false coordinates will be matched by index.
+        Spatial coordinate system. If None then the coordinate system
+        will be set to the native coordinate system of the geometry. Default is None.
+    match_by_name : bool, optional
+        Match coordinates to axes by name. If False, coordinates will be matched by index. Default is True.
     """
 
     def __init__(self, data, frame=None, match_by_name=True):
@@ -89,6 +88,7 @@ class MapCoord:
 
     @property
     def size(self):
+        """Product of all shape elements."""
         return np.prod(self.shape)
 
     @property
@@ -115,16 +115,17 @@ class MapCoord:
 
     @property
     def frame(self):
-        """Coordinate system (str)."""
+        """Coordinate system as a str."""
         return self._frame
 
     @property
     def match_by_name(self):
-        """Boolean flag: axis lookup by name (True) or index (False)."""
+        """Boolean flag: axis lookup by name return True or by index return False."""
         return self._match_by_name
 
     @property
     def skycoord(self):
+        """Coordinate object as an `~astropy.coordinates.SkyCoord`."""
         return SkyCoord(self.lon, self.lat, unit="deg", frame=self.frame)
 
     @classmethod
@@ -137,6 +138,12 @@ class MapCoord:
         ----------
         coords : tuple
             Tuple of `~numpy.ndarray`.
+        frame : {"icrs", "galactic", None}
+            Set the coordinate system for longitude and latitude. If
+            None, longitude and latitude will be assumed to be in
+            the coordinate system native to a given map geometry. Default is None.
+        axis_names : list of str, optional
+            Axis names to use.
 
         Returns
         -------
@@ -157,7 +164,7 @@ class MapCoord:
 
     @classmethod
     def _from_tuple(cls, coords, frame=None, axis_names=None):
-        """Create from tuple of coordinate vectors."""
+        """Create from a tuple of coordinate vectors."""
         if isinstance(coords[0], (list, np.ndarray)) or np.isscalar(coords[0]):
             return cls._from_lonlat(coords, frame=frame, axis_names=axis_names)
         elif isinstance(coords[0], SkyCoord):
@@ -194,12 +201,12 @@ class MapCoord:
         ----------
         data : tuple, dict, `~gammapy.maps.MapCoord` or `~astropy.coordinates.SkyCoord`
             Object containing coordinate arrays.
-        frame : {"icrs", "galactic", None}, optional
+        frame : {"icrs", "galactic", None}
             Set the coordinate system for longitude and latitude. If
             None longitude and latitude will be assumed to be in
-            the coordinate system native to a given map geometry.
-        axis_names : list of str
-            Axis names use if a tuple is provided
+            the coordinate system native to a given map geometry. Default is None.
+        axis_names : list of str, optional
+            Axis names uses if a tuple is provided. Default is None.
 
         Examples
         --------
@@ -293,7 +300,7 @@ class MapCoord:
 
     @property
     def broadcasted(self):
-        """Return broadcasted coords"""
+        """Return broadcasted coordinates"""
         vals = np.broadcast_arrays(*self._data.values(), subok=True)
         data = dict(zip(self._data.keys(), vals))
         return self.__class__(

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -88,7 +88,7 @@ class Geom(abc.ABC):
 
         Parameters
         ----------
-        dtype : data-type, optional
+        dtype : str, optional
             The desired data-type for the array. Default is "float32"
 
         Returns
@@ -255,7 +255,7 @@ class Geom(abc.ABC):
             coordinate vector for axis i.
         clip : bool
             Choose whether to clip indices to the valid range of the
-            geometry. If false then indices for coordinates outside
+            geometry. If False then indices for coordinates outside
             the geometry range will be set -1. Default is False.
 
         Returns
@@ -296,7 +296,7 @@ class Geom(abc.ABC):
             Tuple of pixel coordinates.
         clip : bool
             Choose whether to clip indices to the valid range of the
-            geometry. If false then indices for coordinates outside
+            geometry. If False then indices for coordinates outside
             the geometry range will be set -1. Default is False.
 
         Returns
@@ -565,7 +565,7 @@ class Geom(abc.ABC):
 
     @abc.abstractmethod
     def solid_angle(self):
-        """Solid angle as an `~astropy.units.Quantity` object (in ``sr``)."""
+        """Solid angle as a `~astropy.units.Quantity` object (in ``sr``)."""
         pass
 
     @property

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -33,12 +33,12 @@ def pix_tuple_to_idx(pix):
     Parameters
     ----------
     pix : tuple
-        Tuple of pixel coordinates with one element for each dimension
+        Tuple of pixel coordinates with one element for each dimension.
 
     Returns
     -------
     idx : `~numpy.ndarray`
-        Array of pixel indices
+        Array of pixel indices.
     """
     idx = []
     for p in pix:
@@ -57,7 +57,7 @@ def pix_tuple_to_idx(pix):
 class Geom(abc.ABC):
     """Map geometry base class.
 
-    See also: `~gammapy.maps.WcsGeom` and `~gammapy.maps.HpxGeom`
+    See also: `~gammapy.maps.WcsGeom` and `~gammapy.maps.HpxGeom`.
     """
 
     # workaround for the lru_cache pickle issue
@@ -88,13 +88,13 @@ class Geom(abc.ABC):
 
         Parameters
         ----------
-        dtype : data-type
+        dtype : data-type, optional
             The desired data-type for the array. Default is "float32"
 
         Returns
         -------
         memory : `~astropy.units.Quantity`
-            Estimated memory usage in megabytes (MB)
+            Estimated memory usage in megabytes (MB).
         """
         return (np.empty(self.data_shape, dtype).nbytes * u.byte).to("MB")
 
@@ -126,12 +126,12 @@ class Geom(abc.ABC):
         ----------
         hdulist :  `~astropy.io.fits.HDUList`
             HDU list containing HDUs for map data and bands.
-        hdu : str
-            Name or index of the HDU with the map data.
-        hdu_bands : str
-            Name or index of the HDU with the BANDS table.  If not
+        hdu : str or int, optional
+            Name or index of the HDU with the map data. Default is None.
+        hdu_bands : str, optional
+            Name or index of the HDU with the BANDS table. If not
             defined this will be inferred from the FITS header of the
-            map HDU.
+            map HDU. Default is None.
 
         Returns
         -------
@@ -175,16 +175,16 @@ class Geom(abc.ABC):
         ----------
         idx : tuple, optional
             A tuple of indices with one index for each non-spatial
-            dimension.  If defined only pixels for the image plane with
-            this index will be returned.  If none then all pixels
-            will be returned.
-        local : bool
-            Flag to return local or global pixel indices.  Local
+            dimension. If defined only pixels for the image plane with
+            this index will be returned. If none then all pixels
+            will be returned. Default is None.
+        local : bool, optional
+            Flag to return local or global pixel indices. Local
             indices run from 0 to the number of pixels in a given
-            image plane.
+            image plane. Default is False.
         flat : bool, optional
             Return a flattened array containing only indices for
-            pixels contained in the geometry.
+            pixels contained in the geometry. Default is False.
 
         Returns
         -------
@@ -199,7 +199,7 @@ class Geom(abc.ABC):
         """Get the coordinate array for this geometry.
 
         Returns a coordinate array with the same shape as the data
-        array.  Pixels outside the geometry are set to NaN.
+        array. Pixels outside the geometry are set to NaN.
         Coordinates for a single image plane can be accessed by
         setting ``idx`` to the index tuple of a plane.
 
@@ -207,12 +207,12 @@ class Geom(abc.ABC):
         ----------
         idx : tuple, optional
             A tuple of indices with one index for each non-spatial
-            dimension.  If defined only coordinates for the image
-            plane with this index will be returned.  If none then
-            coordinates for all pixels will be returned.
+            dimension. If defined only coordinates for the image
+            plane with this index will be returned. If none then
+            coordinates for all pixels will be returned. Default is None.
         flat : bool, optional
             Return a flattened array containing only coordinates for
-            pixels contained in the geometry.
+            pixels contained in the geometry. Default is False.
 
         Returns
         -------
@@ -255,8 +255,8 @@ class Geom(abc.ABC):
             coordinate vector for axis i.
         clip : bool
             Choose whether to clip indices to the valid range of the
-            geometry.  If false then indices for coordinates outside
-            the geometry range will be set -1.
+            geometry. If false then indices for coordinates outside
+            the geometry range will be set -1. Default is False.
 
         Returns
         -------
@@ -288,7 +288,7 @@ class Geom(abc.ABC):
     def pix_to_idx(self, pix, clip=False):
         """Convert pixel coordinates to pixel indices.
 
-        Returns -1 for pixel coordinates that lie outside of the map.
+        Returns -1 for pixel coordinates that lie outside the map.
 
         Parameters
         ----------
@@ -296,8 +296,8 @@ class Geom(abc.ABC):
             Tuple of pixel coordinates.
         clip : bool
             Choose whether to clip indices to the valid range of the
-            geometry.  If false then indices for coordinates outside
-            the geometry range will be set -1.
+            geometry. If false then indices for coordinates outside
+            the geometry range will be set -1. Default is False.
 
         Returns
         -------
@@ -344,7 +344,7 @@ class Geom(abc.ABC):
         Parameters
         ----------
         slices : dict
-            Dict of axes names and integers or `slice` object pairs. Contains one
+            Dictionary of axes names and integers or `slice` object pairs. Contains one
             element for each non-spatial dimension. For integer indexing the
             corresponding axes is dropped from the map. Axes not specified in the
             dict are kept unchanged.
@@ -358,14 +358,14 @@ class Geom(abc.ABC):
         return self._init_copy(axes=axes)
 
     def rename_axes(self, names, new_names):
-        """Rename axes contained in the geometry
+        """Rename axes contained in the geometry.
 
         Parameters
         ----------
         names : list or str
             Names of the axes.
         new_names : list or str
-            New names of the axes (list must be of same length than `names`).
+            New names of the axes. The list must be of same length than `names`.
 
         Returns
         -------
@@ -377,17 +377,17 @@ class Geom(abc.ABC):
 
     @property
     def as_energy_true(self):
-        """If the geom contains an energy axis rename it to energy true"""
+        """If the geom contains an axis named 'energy' rename it to 'energy_true'."""
         return self.rename_axes(names="energy", new_names="energy_true")
 
     @property
     def has_energy_axis(self):
-        """Whether geom has an energy axis"""
+        """Whether geom has an energy axis (either 'energy' or 'energy_true')."""
         return ("energy" in self.axes.names) ^ ("energy_true" in self.axes.names)
 
     @abc.abstractmethod
     def to_image(self):
-        """Create 2D image geometry (drop non-spatial dimensions).
+        """Create a 2D image geometry (drop non-spatial dimensions).
 
         Returns
         -------
@@ -565,7 +565,7 @@ class Geom(abc.ABC):
 
     @abc.abstractmethod
     def solid_angle(self):
-        """Solid angle (`~astropy.units.Quantity` in ``sr``)."""
+        """Solid angle as an `~astropy.units.Quantity` object (in ``sr``)."""
         pass
 
     @property
@@ -577,7 +577,7 @@ class Geom(abc.ABC):
 
     @property
     def is_flat(self):
-        """Whether the geom non spatial axes have length 1, equivalent to an image."""
+        """Whether the geom non-spatial axes have length 1, equivalent to an image."""
         if self.is_image:
             return True
         else:
@@ -621,12 +621,12 @@ class Geom(abc.ABC):
         Parameters
         ----------
         energy_min, energy_max : `~astropy.units.Quantity`
-            Energy range
+            Energy range.
 
         Returns
         -------
         mask : `~numpy.ndarray`
-            Energy mask
+            Energy mask.
         """
         from . import Map
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -89,7 +89,7 @@ class Geom(abc.ABC):
         Parameters
         ----------
         dtype : str, optional
-            The desired data-type for the array. Default is "float32"
+            The desired data-type for the array. Default is "float32".
 
         Returns
         -------

--- a/gammapy/maps/io.py
+++ b/gammapy/maps/io.py
@@ -36,13 +36,13 @@ def find_bands_hdu(hdu_list, hdu):
     Parameters
     ----------
     hdu_list : `~astropy.io.fits.HDUList`
-
+        The FITS HDU list.
     hdu : `~astropy.io.fits.BinTableHDU` or `~astropy.io.fits.ImageHDU`
-
+        The HDU to check.
     Returns
     -------
     hduname : str
-        Extension name of the BANDS HDU.  None if no BANDS HDU was found.
+        Extension name of the BANDS HDU. Returns None if no BANDS HDU was found.
     """
     if "BANDSHDU" in hdu.header:
         return hdu.header["BANDSHDU"]

--- a/gammapy/maps/maps.py
+++ b/gammapy/maps/maps.py
@@ -24,7 +24,7 @@ class Maps(MutableMapping):
 
     @property
     def geom(self):
-        """Map geometry (`Geom`)"""
+        """Map geometry as a `Geom` object."""
         return self._geom
 
     def __setitem__(self, key, value):
@@ -42,7 +42,7 @@ class Maps(MutableMapping):
         return self._data[key]
 
     def __len__(self):
-        """Returns length of MapDict."""
+        """Returns the length of MapDict."""
         return len(self._data)
 
     def __delitem__(self, key):
@@ -78,9 +78,9 @@ class Maps(MutableMapping):
 
         Parameters
         ----------
-        hdu_bands : str
-            Name of the HDU with the BANDS table. Default is 'BANDS'
-            If set to None, each map will have its own hdu_band
+        hdu_bands : str, optional
+            Name of the HDU with the BANDS table. If set to None, each map will have its own hdu_band.
+            Default is 'BANDS'.
 
         Returns
         -------
@@ -99,17 +99,17 @@ class Maps(MutableMapping):
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu_bands="BANDS"):
-        """Create map dictionary from list of HDUs.
+        """Create map dictionary from a HDU list.
 
-        Because FITS keywords are case insensitive, all key names will return as lower-case.
+        Because FITS keywords are case-insensitive, all key names will return as lower-case.
 
         Parameters
         ----------
         hdulist : `~astropy.io.fits.HDUList`
             List of HDUs.
-        hdu_bands : str
-            Name of the HDU with the BANDS table. Default is 'BANDS'
-            If set to None, each map should have its own hdu_band
+        hdu_bands : str, optional
+            Name of the HDU with the BANDS table. If set to None, each map should have its own hdu_band.
+            Default is 'BANDS'.
 
         Returns
         -------
@@ -130,7 +130,7 @@ class Maps(MutableMapping):
     def read(cls, filename):
         """Read map dictionary from file.
 
-        Because FITS keywords are case insensitive, all key names will return as lower-case.
+        Because FITS keywords are case-insensitive, all key names will return as lower-case.
 
         Parameters
         ----------
@@ -154,7 +154,7 @@ class Maps(MutableMapping):
             Filename to write to.
         overwrite : bool, optional
             Overwrite existing file. Default is False.
-        checksum : bool
+        checksum : bool, optional
             When True adds both DATASUM and CHECKSUM cards to the headers written to the file.
             Default is False.
         """
@@ -165,16 +165,16 @@ class Maps(MutableMapping):
 
     @classmethod
     def from_geom(cls, geom, names, kwargs_list=None):
-        """Create map dictionary from geometry.
+        """Create map dictionary from a geometry.
 
         Parameters
         ----------
         geom : `~gammapy.maps.Geom`
-            the input geometry that will be used by all maps
+            The input geometry that will be used by all maps.
         names : list of str
-            the list of all map names
+            The list of all map names.
         kwargs_list : list of dict
-            the list of arguments to be passed to `~gammapy.maps.Map.from_geom()`
+            the list of arguments to be passed to `~gammapy.maps.Map.from_geom()`.
 
         Returns
         -------

--- a/gammapy/maps/maps.py
+++ b/gammapy/maps/maps.py
@@ -24,7 +24,7 @@ class Maps(MutableMapping):
 
     @property
     def geom(self):
-        """Map geometry as a `Geom` object."""
+        """Map geometry as a `~gammapy.maps.Geom` object."""
         return self._geom
 
     def __setitem__(self, key, value):


### PR DESCRIPTION
This PR is related to issue https://github.com/gammapy/gammapy/issues/4811.

It address the part of the issue concerning gammapy.maps. Especially on `coord.py`, `geom.py`, `io.py` and `maps.py`.