### PR TITLE
Impose that the black version in the YAML environment corresponds to …

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -48,7 +48,7 @@ dependencies:
   - reproject
   - sherpa
   # dev dependencies
-  - black
+  - black=22.6.0
   - codespell
   - flake8
   - isort


### PR DESCRIPTION
This PR introduces a force on the version of black installed by `environment-dev.yml`, so that it is the same as the one used for the CI and pre-commit hooks. This ensures that if somebody locally runs `black <SOME_FOLDER>`, no undesired formatting is introduced.
