### PR TITLE
Add `energy_true` to `MapDataset.create()` in tutorial

### DIFF
--- a/examples/tutorials/analysis-3d/cta_data_analysis.py
+++ b/examples/tutorials/analysis-3d/cta_data_analysis.py
@@ -2,7 +2,7 @@
 Basic image exploration and fitting
 ===================================
 
-Detect sources, produce a sky image and a spectrum using CTA 1DC data.
+Detect sources, produce a sky image and a spectrum using CTA-1DC data.
 
 Introduction
 ------------
@@ -11,7 +11,7 @@ Introduction
 for simulated CTA data with Gammapy.**
 
 The dataset we will use is three observation runs on the Galactic
-center. This is a tiny (and thus quick to process and play with and
+Center. This is a tiny (and thus quick to process and play with and
 learn) subset of the simulated CTA dataset that was produced for the
 first data challenge in August 2017.
 
@@ -32,8 +32,6 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
-
-# %matplotlib inline
 import matplotlib.pyplot as plt
 from IPython.display import display
 from gammapy.data import DataStore
@@ -74,8 +72,8 @@ check_tutorials_setup()
 # A Gammapy analysis usually starts by creating a
 # `~gammapy.data.DataStore` and selecting observations.
 #
-# This is shown in detail in the other notebook, here we just pick three
-# observations near the galactic center.
+# This is shown in detail in other notebooks (see e.g. the :doc:`/tutorials/starting/analysis_2` tutorial),
+# here we choose three observations near the Galactic Center.
 #
 
 data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps")
@@ -111,6 +109,9 @@ display(data_store.obs_table.select_obs_id(obs_id)[obs_cols])
 axis = MapAxis.from_edges(
     np.logspace(-1.0, 1.0, 10), unit="TeV", name="energy", interp="log"
 )
+axis_true = energy_axis_true = MapAxis.from_bounds(
+    0.01, 20, nbin=20, name="energy_true", unit="TeV", interp="log"
+)
 geom = WcsGeom.create(
     skydir=(0, 0), npix=(500, 400), binsz=0.02, frame="galactic", axes=[axis]
 )
@@ -123,8 +124,7 @@ print(geom)
 #
 
 # %%time
-stacked = MapDataset.create(geom=geom)
-stacked.edisp = None
+stacked = MapDataset.create(geom=geom, energy_axis_true=axis_true)
 maker = MapDatasetMaker(selection=["counts", "background", "exposure", "psf"])
 maker_safe_mask = SafeMaskMaker(methods=["offset-max"], offset_max=2.5 * u.deg)
 
@@ -329,7 +329,7 @@ print(stacked_dataset)
 
 
 ######################################################################
-# Call `plot_npred_signal` to plot the predicted counts.
+# Call `~gammapy.visualization.plot_npred_signal` to plot the predicted counts.
 #
 
 
@@ -361,7 +361,7 @@ flux_points.to_table(sed_type="dnde", formatted=True)
 #
 # Let’s plot the spectral model and points. You could do it directly, but
 # for convenience we bundle the model and the flux points in a
-# `FluxPointDataset`:
+# `~gammapy.datasets.FluxPointsDataset`:
 #
 
 flux_points_dataset = FluxPointsDataset(data=flux_points, models=model)

--- a/examples/tutorials/analysis-3d/cta_data_analysis.py
+++ b/examples/tutorials/analysis-3d/cta_data_analysis.py
@@ -106,11 +106,19 @@ display(data_store.obs_table.select_obs_id(obs_id)[obs_cols])
 # analysis
 #
 
-axis = MapAxis.from_edges(
-    np.logspace(-1.0, 1.0, 10), unit="TeV", name="energy", interp="log"
+axis = MapAxis.from_energy_bounds(
+    0.1,
+    10,
+    nbin=10,
+    unit="TeV",
+    name="energy",
 )
-axis_true = MapAxis.from_bounds(
-    0.01, 20, nbin=20, name="energy_true", unit="TeV", interp="log"
+axis_true = MapAxis.from_energy_bounds(
+    0.05,
+    20,
+    nbin=20,
+    name="energy_true",
+    unit="TeV",
 )
 geom = WcsGeom.create(
     skydir=(0, 0), npix=(500, 400), binsz=0.02, frame="galactic", axes=[axis]

--- a/examples/tutorials/analysis-3d/cta_data_analysis.py
+++ b/examples/tutorials/analysis-3d/cta_data_analysis.py
@@ -109,7 +109,7 @@ display(data_store.obs_table.select_obs_id(obs_id)[obs_cols])
 axis = MapAxis.from_edges(
     np.logspace(-1.0, 1.0, 10), unit="TeV", name="energy", interp="log"
 )
-axis_true = energy_axis_true = MapAxis.from_bounds(
+axis_true = MapAxis.from_bounds(
     0.01, 20, nbin=20, name="energy_true", unit="TeV", interp="log"
 )
 geom = WcsGeom.create(


### PR DESCRIPTION
This PR is to include the `energy_true_axis` to `MapDataset.create()`, where it was originally missing in the 'Basic image exploration and fitting' tutorial. 