### PR TITLE
Add new class to directly simulate observations

### DIFF
--- a/gammapy/datasets/__init__.py
+++ b/gammapy/datasets/__init__.py
@@ -4,7 +4,7 @@ from .core import Dataset, Datasets
 from .flux_points import FluxPointsDataset
 from .io import OGIPDatasetReader, OGIPDatasetWriter
 from .map import MapDataset, MapDatasetOnOff, create_map_dataset_geoms
-from .simulate import MapDatasetEventSampler
+from .simulate import MapDatasetEventSampler, ObservationEventSampler
 from .spectrum import SpectrumDataset, SpectrumDatasetOnOff
 
 DATASET_REGISTRY = Registry(
@@ -28,6 +28,7 @@ __all__ = [
     "MapDataset",
     "MapDatasetEventSampler",
     "MapDatasetOnOff",
+    "ObservationEventSampler",
     "OGIPDatasetWriter",
     "OGIPDatasetReader",
     "SpectrumDataset",

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -563,7 +563,6 @@ class MapDatasetEventSampler:
         events = EventList.from_stack([events_bkg, events_src])
 
         events = self.event_det_coords(observation, events)
-        events.table.sort("TIME")
         events.table["EVENT_ID"] = np.arange(len(events.table))
         events.table.meta.update(
             self.event_list_meta(dataset, observation, self.keep_mc_id)

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -655,10 +655,7 @@ class SimulatedObservationMaker(MapDatasetEventSampler):
         pointing_icrs = observation.pointing.fixed_icrs
         geom = WcsGeom.create(
             skydir=pointing_icrs,
-            width=(
-                self.spatial_width.to_value(u.deg),
-                self.spatial_width.to_value(u.deg),
-            ),
+            width=self.spatial_width,
             binsz=self.spatial_bin_size.to_value(u.deg),
             frame="icrs",
             axes=[self.energy_axis],

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -303,20 +303,23 @@ class MapDatasetEventSampler:
         events : `gammapy.data.EventList`
             Background events.
         """
-        background = dataset.npred_background()
 
-        temporal_model = ConstantTemporalModel()
+        table = Table()
+        if dataset.background:
+            background = dataset.npred_background()
 
-        table = self._sample_coord_time(background, temporal_model, dataset.gti)
+            temporal_model = ConstantTemporalModel()
 
-        table["ENERGY"] = table["ENERGY_TRUE"]
-        table["RA"] = table["RA_TRUE"]
-        table["DEC"] = table["DEC_TRUE"]
+            table = self._sample_coord_time(background, temporal_model, dataset.gti)
 
-        if self.keep_mc_id:
-            table["MC_ID"] = 0
-            table.meta["MID{:05d}".format(0)] = 0
-            table.meta["MMN{:05d}".format(0)] = dataset.background_model.name
+            table["ENERGY"] = table["ENERGY_TRUE"]
+            table["RA"] = table["RA_TRUE"]
+            table["DEC"] = table["DEC_TRUE"]
+
+            if self.keep_mc_id:
+                table["MC_ID"] = 0
+                table.meta["MID{:05d}".format(0)] = 0
+                table.meta["MMN{:05d}".format(0)] = dataset.background_model.name
 
         return EventList(table)
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -8,7 +8,7 @@ from astropy.coordinates import SkyCoord, SkyOffsetFrame
 from astropy.table import Table
 from astropy.time import Time
 from gammapy import __version__
-from gammapy.data import EventList, Observation, PointingMode, observatory_locations
+from gammapy.data import EventList, PointingMode, observatory_locations
 from gammapy.maps import MapAxis, MapCoord, RegionNDMap, TimeMapAxis, WcsGeom
 from gammapy.modeling.models import (
     ConstantSpectralModel,
@@ -20,7 +20,7 @@ from gammapy.modeling.models import (
 from gammapy.utils.random import get_random_state
 from .map import MapDataset
 
-__all__ = ["MapDatasetEventSampler"]
+__all__ = ["MapDatasetEventSampler", "ObservationEventSampler"]
 
 
 class MapDatasetEventSampler:
@@ -576,11 +576,11 @@ class MapDatasetEventSampler:
         return events.select_row_subset(selection)
 
 
-class SimulatedObservationMaker(MapDatasetEventSampler):
+class ObservationEventSampler(MapDatasetEventSampler):
     """
     Sample event lists for a given observation and signal models.
 
-    Signal events are sampled from the predicted counts distribution given by the product of the sky models and the 
+    Signal events are sampled from the predicted counts distribution given by the product of the sky models and the
     expected exposure. They are then folded with the instrument response functions.
     To improve performance, IRFs are evaluated on a pre-defined binning,
     not at each individual event energy / coordinate.

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -582,7 +582,7 @@ class MapDatasetEventSampler:
 
 class SimulatedObservationMaker(MapDatasetEventSampler):
     """
-    Sample event lists for a given observation.
+    Sample event lists for a given observation and signal models.
     """
 
     def __init__(
@@ -600,18 +600,24 @@ class SimulatedObservationMaker(MapDatasetEventSampler):
         self.bin_size = map_bin_size
 
     def run(self, observation: Observation, models=None):
-        """Run the event sampler, applying IRF corrections.
+        """Sample events for given observation and signal models.
+
+        The signal distribution is sampled from the given models
+        in true coordinates and energy. The true quantities are
+        then folded with the IRFs to obtain the observable quantities.
 
         Parameters
         ----------
         observation : `~gammapy.data.Observation`
             Observation to be simulated.
         models : `~gammapy.modeling.Models`
+            Signal models to simulate.
+            Can be None to only sample background events.
 
         Returns
         -------
-        events : `~gammapy.data.EventList`
-            Event list.
+        observation : `~gammapy.data.Observation`
+            A copy of the input observation with event list filled.
         """
         # import here to prevent circular import
         from gammapy.makers import MapDatasetMaker

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -580,8 +580,8 @@ class SimulatedObservationMaker(MapDatasetEventSampler):
     """
     Sample event lists for a given observation and signal models.
 
-    Signal events are sampled from the given sky models and then
-    folded with the instrument response functions.
+    Signal events are sampled from the predicted counts distribution given by the product of the sky models and the 
+    expected exposure. They are then folded with the instrument response functions.
     To improve performance, IRFs are evaluated on a pre-defined binning,
     not at each individual event energy / coordinate.
 
@@ -600,9 +600,9 @@ class SimulatedObservationMaker(MapDatasetEventSampler):
         Defines random number generator initialisation via the `~gammapy.utils.random.get_random_state` function.
     oversample_energy_factor : int, optional
         Defines an oversampling factor for the energies; it is used only when sampling
-        an energy-dependent time-varying source.
+        an energy-dependent time-varying source. Default is 10.
     t_delta : `~astropy.units.Quantity`, optional
-        Time interval used to sample the time-dependent source.
+        Time interval used to sample the time-dependent source. Default is 0.5 s.
     keep_mc_id : bool, optional
         Flag to tag sampled events from a given model with a Montecarlo identifier.
         Default is True. If set to False, no identifier will be assigned.
@@ -629,7 +629,7 @@ class SimulatedObservationMaker(MapDatasetEventSampler):
         self.keep_mc_id = keep_mc_id
 
     def _create_dataset(self, observation, models=None, dataset_name=None):
-        """create dataest used for sampling"""
+        """create dataset used for sampling."""
 
         # import here to prevent circular import
         from gammapy.makers import MapDatasetMaker
@@ -687,7 +687,7 @@ class SimulatedObservationMaker(MapDatasetEventSampler):
         dataset.models = models
         return dataset
 
-    def run(self, observation: Observation, models=None, dataset_name=None):
+    def run(self, observation, models=None, dataset_name=None):
         """Sample events for given observation and signal models.
 
         The signal distribution is sampled from the given models
@@ -700,7 +700,7 @@ class SimulatedObservationMaker(MapDatasetEventSampler):
             Observation to be simulated.
         models : `~gammapy.modeling.Models`, optional
             Models to simulate.
-            Can be None to only sample background events.
+            Can be None to only sample background events. Default is None.
         dataset_name : str, optional
             If `models` contains one or multiple `FoVBackgroundModel`
             it should match the `dataset_name` of the background model to use.

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -848,7 +848,7 @@ def test_MC_ID_flag(model_alternative):
 
 @requires_data()
 def test_simulated_observation_maker(signal_model, tmp_path):
-    from gammapy.datasets.simulate import SimulatedObservationMaker
+    from gammapy.datasets.simulate import ObservationEventSampler
 
     irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
@@ -872,7 +872,7 @@ def test_simulated_observation_maker(signal_model, tmp_path):
         ),
     )
 
-    maker = SimulatedObservationMaker(
+    maker = ObservationEventSampler(
         spatial_width=5 * u.deg,
         energy_axis=MapAxis.from_energy_bounds(
             10 * u.GeV, 100 * u.TeV, nbin=5, per_decade=True

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -873,7 +873,7 @@ def test_simulated_observation_maker(signal_model, tmp_path):
     )
 
     maker = SimulatedObservationMaker(
-        map_width=5 * u.deg,
+        spatial_width=5 * u.deg,
         energy_axis=MapAxis.from_energy_bounds(
             10 * u.GeV, 100 * u.TeV, nbin=5, per_decade=True
         ),

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -8,6 +8,7 @@ from astropy.io import fits
 from astropy.table import Table
 from astropy.time import Time
 from gammapy.data import GTI, DataStore, Observation
+from gammapy.data.metadata import ObservationMetaData
 from gammapy.data.pointing import FixedPointingInfo
 from gammapy.datasets import MapDataset, MapDatasetEventSampler
 from gammapy.datasets.tests.test_map import get_map_dataset
@@ -30,7 +31,7 @@ LOCATION = EarthLocation(lon="-70d18m58.84s", lat="-24d41m0.34s", height="2000m"
 
 
 @pytest.fixture()
-def models():
+def signal_model():
     spatial_model = GaussianSpatialModel(
         lon_0="0 deg", lat_0="0 deg", sigma="0.2 deg", frame="galactic"
     )
@@ -50,15 +51,18 @@ def models():
     table.meta = dict(MJDREFI=t_ref.mjd, MJDREFF=0, TIMEUNIT="s", TIMESYS="utc")
     temporal_model = LightCurveTemplateTemporalModel.from_table(table)
 
-    model = SkyModel(
+    return SkyModel(
         spatial_model=spatial_model,
         spectral_model=spectral_model,
         temporal_model=temporal_model,
         name="test-source",
     )
 
+
+@pytest.fixture()
+def models(signal_model):
     bkg_model = FoVBackgroundModel(dataset_name="test")
-    return [model, bkg_model]
+    return [signal_model, bkg_model]
 
 
 @pytest.fixture()
@@ -840,3 +844,44 @@ def test_MC_ID_flag(model_alternative):
     assert "MID00002" not in meta.keys()
     assert "MID00003" not in meta.keys()
     assert "NMCIDS" not in meta.keys()
+
+
+@requires_data()
+def test_simulated_observation_maker(signal_model, tmp_path):
+    from gammapy.datasets.simulate import SimulatedObservationMaker
+
+    irfs = load_irf_dict_from_file(
+        "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
+    )
+    pointing = FixedPointingInfo(
+        fixed_icrs=SkyCoord(83.63311446, 22.01448714, unit="deg", frame="icrs"),
+    )
+    time_start = Time("2021-11-20T03:00:00")
+    time_stop = Time("2021-11-20T03:30:00")
+
+    obs = Observation(
+        obs_id=1,
+        **irfs,
+        location=LOCATION,
+        pointing=pointing,
+        gti=GTI.create(time_start, time_stop),
+        meta=ObservationMetaData(
+            time_start=time_start,
+            time_stop=time_stop,
+            dead_time_fraction=0.01,
+        ),
+    )
+
+    maker = SimulatedObservationMaker(
+        map_width=5 * u.deg,
+        energy_axis=MapAxis.from_energy_bounds(
+            10 * u.GeV, 100 * u.TeV, nbin=5, per_decade=True
+        ),
+        energy_axis_true=MapAxis.from_energy_bounds(
+            10 * u.GeV, 100 * u.TeV, nbin=5, per_decade=True, name="energy_true"
+        ),
+    )
+
+    sim_obs = maker.run(obs, [signal_model])
+    assert sim_obs.events is not None
+    assert len(sim_obs.events.table) > 0


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
This is relatively old, from one of the previous coding sprints and I never opened the pull request but was now reminded in the context of the running CTA simulations.

This adds a new simulator class, which what we discussed at the time is a better API: treating the `MapDataset` as internal implementation detail of the simulator and making the API take `observation, models`, returning a new observation with the filled-in events.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
