### PR TITLE
Fix broken links in docs

### DIFF
--- a/examples/models/spectral/plot_absorbed.py
+++ b/examples/models/spectral/plot_absorbed.py
@@ -16,7 +16,7 @@ where :math:`\tau(E, z)` is the optical depth predicted by the model
 redshift z of the source, and :math:`\alpha` is a scale factor
 (default: 1) for the optical depth.
 
-The available EBL models are defined in `~gammapy.modeling.models.spectral.EBL_DATA_BUILTIN`.
+The available EBL models are defined in `~gammapy.modeling.models.EBL_DATA_BUILTIN`.
 """
 
 # %%
@@ -27,12 +27,12 @@ The available EBL models are defined in `~gammapy.modeling.models.spectral.EBL_D
 from astropy import units as u
 import matplotlib.pyplot as plt
 from gammapy.modeling.models import (
+    EBL_DATA_BUILTIN,
     EBLAbsorptionNormSpectralModel,
     Models,
     PowerLawSpectralModel,
     SkyModel,
 )
-from gammapy.modeling.models.spectral import EBL_DATA_BUILTIN
 
 # Print the available EBL models
 print(EBL_DATA_BUILTIN.keys())

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -234,7 +234,7 @@ dataset = fov_bkg_maker.run(dataset)
 # This method is only used for 1D spectral analysis.
 #
 # For more details and usage, see
-# the :doc:`Reflected background </user-guide/makers/ring>`
+# the :doc:`Reflected background </user-guide/makers/reflected>`
 #
 # Data reduction loop
 # -------------------

--- a/gammapy/modeling/models/__init__.py
+++ b/gammapy/modeling/models/__init__.py
@@ -24,6 +24,7 @@ from .spatial import (
     TemplateSpatialModel,
 )
 from .spectral import (
+    EBL_DATA_BUILTIN,
     BrokenPowerLawSpectralModel,
     CompoundSpectralModel,
     ConstantSpectralModel,
@@ -128,6 +129,7 @@ __all__ = [
     "TemplateNPredModel",
     "TEMPORAL_MODEL_REGISTRY",
     "TemporalModel",
+    "EBL_DATA_BUILTIN",
 ]
 
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -55,14 +55,18 @@ __all__ = [
     "SuperExpCutoffPowerLaw4FGLDR3SpectralModel",
     "SuperExpCutoffPowerLaw4FGLSpectralModel",
     "TemplateSpectralModel",
+    "TemplateNDSpectralModel",
+    "EBL_DATA_BUILTIN",
 ]
 
-EBL_DATA_BUILTIN = {}
-EBL_DATA_BUILTIN["franceschini"] = "$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz"
-EBL_DATA_BUILTIN["dominguez"] = "$GAMMAPY_DATA/ebl/ebl_dominguez11.fits.gz"
-EBL_DATA_BUILTIN["finke"] = "$GAMMAPY_DATA/ebl/frd_abs.fits.gz"
-EBL_DATA_BUILTIN["franceschini17"] = "$GAMMAPY_DATA/ebl/ebl_franceschini_2017.fits.gz"
-EBL_DATA_BUILTIN["saldana-lopez21"] = "$GAMMAPY_DATA/ebl/ebl_saldana-lopez_2021.fits.gz"
+
+EBL_DATA_BUILTIN = {
+    "franceschini": "$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz",
+    "dominguez": "$GAMMAPY_DATA/ebl/ebl_dominguez11.fits.gz",
+    "finke": "$GAMMAPY_DATA/ebl/frd_abs.fits.gz",
+    "franceschini17": "$GAMMAPY_DATA/ebl/ebl_franceschini_2017.fits.gz",
+    "saldana-lopez21": "$GAMMAPY_DATA/ebl/ebl_saldana-lopez_2021.fits.gz",
+}
 
 
 def scale_plot_flux(flux, energy_power=0):


### PR DESCRIPTION
This PR fix #4922. 

In order for the `EBL_DATA_BUILTIN` link to work, I have to expose the `EBL_DATA_BUILTIN` in `gammapy.modeling.models`. I don't think there is any other solution for that. 

Also the link for `prior` is working "virtually". It just that the prior classes are not exposed. But when they will, the link will work. 

PS: I also added `TemplateNDSpectralModel` in the `__all__` of `gammapy.modeling.models.spectral.py` to remove the complaint for accessing a protected member in `gammapy.modeling.models.__init__.py`.