### PR TITLE
Fix import of angular_separation for astropy 6

### DIFF
--- a/docs/development/pigs/pig-021.rst
+++ b/docs/development/pigs/pig-021.rst
@@ -97,7 +97,7 @@ An example of how this can be achieved with a custom implemented model is given 
 .. code::
 
     from gammapy.modeling.models import SpatialModel
-    from astropy.coordinates.angle_utilities import angular_separation
+    from astropy.coordinates import angular_separation
 
     class MyCustomGaussianModel(SpatialModel):
         """My custom gaussian model.

--- a/examples/tutorials/api/models.py
+++ b/examples/tutorials/api/models.py
@@ -760,7 +760,7 @@ models.write("my-custom-models.yaml", overwrite=True)
 # models.
 #
 
-from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates import angular_separation
 from gammapy.modeling.models import SpatialModel
 
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request fixes the import of `angular_separation` for astropy 6 (but it also works with 5.x).

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
