### PR TITLE
Fix MapEvaluator for the apply_edisp=False case

### DIFF
--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -7,6 +7,7 @@ from astropy.coordinates import angular_separation
 from astropy.utils import lazyproperty
 from regions import CircleSkyRegion
 import matplotlib.pyplot as plt
+from gammapy.irf import EDispKernel
 from gammapy.maps import HpxNDMap, Map, RegionNDMap, WcsNDMap
 from gammapy.modeling.models import PointSpatialModel, TemplateNPredModel
 from .utils import apply_edisp
@@ -188,6 +189,7 @@ class MapEvaluator:
             self.edisp = edisp.get_edisp_kernel(
                 position=self.model.position, energy_axis=energy_axis
             )
+            del self._edisp_diagonal
 
         # lookup psf
         if psf and self.model.spatial_model:
@@ -229,6 +231,13 @@ class MapEvaluator:
         self.reset_cache_properties()
         self._computation_cache = None
         self._cached_parameter_previous = None
+
+    @lazyproperty
+    def _edisp_diagonal(self):
+        return EDispKernel.from_diagonal_response(
+            energy_axis_true=self.edisp.axes["energy_true"],
+            energy_axis=self.edisp.axes["energy"],
+        )
 
     def update_spatial_oversampling_factor(self, geom):
         """Update spatial oversampling_factor for model evaluation."""
@@ -366,7 +375,13 @@ class MapEvaluator:
         npred_reco : `~gammapy.maps.Map`
             Predicted counts in reconstructed energy bins.
         """
-        return apply_edisp(npred, self.edisp)
+        if self.model.apply_irf["edisp"]:
+            return apply_edisp(npred, self.edisp)
+        else:
+            if "energy_true" in npred.geom.axes.names:
+                return apply_edisp(npred, self._edisp_diagonal)
+            else:
+                return npred
 
     @lazyproperty
     def _compute_npred(self):
@@ -512,8 +527,6 @@ class MapEvaluator:
             ]
         if not self.model.apply_irf["exposure"]:
             methods.remove(self.apply_exposure)
-        if not self.model.apply_irf["edisp"]:
-            methods.remove(self.apply_edisp)
         return methods
 
     def peek(self, figsize=(12, 15)):

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -534,8 +534,10 @@ class Test_template_cube_MapEvaluator:
 
     @staticmethod
     def test_apply_edisp_false(diffuse_evaluator):
+        # TODO: needs_update=True if apply_irf change ?
         diffuse_evaluator.model.apply_irf["edisp"] = False
         diffuse_evaluator.use_cache = False
+        del diffuse_evaluator.methods_sequence
         out = diffuse_evaluator.compute_npred()
         assert "energy" in out.geom.axes.names
         assert out.data.shape == (2, 4, 5)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -532,6 +532,16 @@ class Test_template_cube_MapEvaluator:
         assert_allclose(out.data.sum(), 1.106403e12, rtol=5e-3)
         assert_allclose(out.data[0, 0, 0], 8.778828e09, rtol=5e-3)
 
+    @staticmethod
+    def test_apply_edisp_false(diffuse_evaluator):
+        diffuse_evaluator.model.apply_irf["edisp"] = False
+        diffuse_evaluator.use_cache = False
+        out = diffuse_evaluator.compute_npred()
+        assert "energy" in out.geom.axes.names
+        assert out.data.shape == (2, 4, 5)
+        assert_allclose(out.data.sum(), 1.106403e12, rtol=5e-3)
+        assert_allclose(out.data[0, 0, 0], 8.778828e09, rtol=5e-3)
+
 
 class TestSkyModelMapEvaluator:
     @staticmethod

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -133,6 +133,13 @@ def diffuse_evaluator(diffuse_model, exposure, psf, edisp):
 
 
 @pytest.fixture(scope="session")
+def diffuse_evaluator_edisp_false(diffuse_model, exposure, psf, edisp):
+    model = diffuse_model.copy()
+    model.apply_irf["edisp"] = False
+    return MapEvaluator(model, exposure, psf=psf, edisp=edisp)
+
+
+@pytest.fixture(scope="session")
 def sky_models(sky_model):
     sky_model_2 = sky_model.copy(name="source-2")
     sky_model_3 = sky_model.copy(name="source-3")
@@ -533,12 +540,8 @@ class Test_template_cube_MapEvaluator:
         assert_allclose(out.data[0, 0, 0], 8.778828e09, rtol=5e-3)
 
     @staticmethod
-    def test_apply_edisp_false(diffuse_evaluator):
-        # TODO: needs_update=True if apply_irf change ?
-        diffuse_evaluator.model.apply_irf["edisp"] = False
-        diffuse_evaluator.use_cache = False
-        del diffuse_evaluator.methods_sequence
-        out = diffuse_evaluator.compute_npred()
+    def test_apply_edisp_false(diffuse_evaluator_edisp_false):
+        out = diffuse_evaluator_edisp_false.compute_npred()
         assert "energy" in out.geom.axes.names
         assert out.data.shape == (2, 4, 5)
         assert_allclose(out.data.sum(), 1.106403e12, rtol=5e-3)


### PR DESCRIPTION
Fix MapEvaluator for the apply_edisp=False case, to avoid inconsistant geometry error because npred has the exposure geom for the models with apply_edisp=False and the counts geom for the others.