### PR TITLE
Parallel support for FluxProfileEstimation

### DIFF
--- a/gammapy/estimators/points/profile.py
+++ b/gammapy/estimators/points/profile.py
@@ -1,8 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Tools to create profiles (i.e. 1D "slices" from 2D images)."""
+from itertools import repeat
 import numpy as np
 from astropy import units as u
 from regions import CircleAnnulusSkyRegion
+import gammapy.utils.parallel as parallel
 from gammapy.datasets import Datasets
 from gammapy.maps import MapAxis
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
@@ -22,6 +24,13 @@ class FluxProfileEstimator(FluxPointsEstimator):
     spectrum : `~gammapy.modeling.models.SpectralModel` (optional)
         Spectral model to compute the fluxes or brightness.
         Default is power-law with spectral index of 2.
+    n_jobs : int, optional
+        Number of processes used in parallel for the computation. Default is one,
+        unless `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified. The number
+        of jobs is limited to the number of physical CPUs.
+    parallel_backend : {"multiprocessing", "ray"}, optional
+        Which backend to use for multiprocessing.
+        Defaults to `~gammapy.utils.parallel.BACKEND_DEFAULT`.
     **kwargs : dict, optional
         Keywords forwarded to the `FluxPointsEstimator` (see documentation
         there for further description of valid keywords).
@@ -137,25 +146,32 @@ class FluxProfileEstimator(FluxPointsEstimator):
 
         datasets = Datasets(datasets=datasets)
 
-        maps = []
-        for region in self.regions:
-            datasets_to_fit = datasets.to_spectrum_datasets(region=region)
-            for dataset_spec, dataset_map in zip(datasets_to_fit, datasets):
-                dataset_spec.background.data = (
-                    dataset_map.npred()
-                    .to_region_nd_map(
-                        region, func=np.sum, weights=dataset_map.mask_safe
-                    )
-                    .data
-                )
-            datasets_to_fit.models = SkyModel(self.spectrum, name="test-source")
-            fp = super().run(datasets_to_fit)
-            maps.append(fp)
+        maps = parallel.run_multiprocessing(
+            self._run_region,
+            zip(repeat(datasets), self.regions),
+            backend=self.parallel_backend,
+            pool_kwargs=dict(processes=self.n_jobs),
+            task_name="Flux profile estimation",
+        )
 
         return FluxPoints.from_stack(
             maps=maps,
             axis=self.projected_distance_axis,
         )
+
+    def _run_region(self, datasets, region):
+        # TODO: test if it would be more efficient
+        # to not compute datasets_to_fit in parallel
+        # to avoid copying the full datasets
+        datasets_to_fit = datasets.to_spectrum_datasets(region=region)
+        for dataset_spec, dataset_map in zip(datasets_to_fit, datasets):
+            dataset_spec.background.data = (
+                dataset_map.npred()
+                .to_region_nd_map(region, func=np.sum, weights=dataset_map.mask_safe)
+                .data
+            )
+        datasets_to_fit.models = SkyModel(self.spectrum, name="test-source")
+        return super().run(datasets_to_fit)
 
     @property
     def config_parameters(self):

--- a/gammapy/estimators/points/tests/test_profile.py
+++ b/gammapy/estimators/points/tests/test_profile.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
+import gammapy.utils.parallel as parallel
 from gammapy.data import GTI
 from gammapy.datasets import MapDatasetOnOff
 from gammapy.estimators import FluxPoints, FluxProfileEstimator
@@ -15,7 +16,7 @@ from gammapy.utils.regions import (
     make_concentric_annulus_sky_regions,
     make_orthogonal_rectangle_sky_regions,
 )
-from gammapy.utils.testing import requires_data
+from gammapy.utils.testing import requires_data, requires_dependency
 
 
 def get_simple_dataset_on_off():
@@ -219,3 +220,78 @@ def test_profile_with_model_or_mask():
     result = prof_maker.run(dataset)
     imp_prof = result.to_table(sed_type="flux", format="profile")
     assert_allclose(imp_prof[7]["npred_excess"], [[0]], rtol=1e-3)
+
+
+@requires_data()
+def test_profile_multiprocessing():
+    dataset = simulate_map_dataset(name="test-map-pwl")
+
+    geom = dataset.counts.geom
+    regions = make_concentric_annulus_sky_regions(
+        center=geom.center_skydir,
+        radius_max=0.2 * u.deg,
+    )
+
+    prof_maker = FluxProfileEstimator(
+        regions,
+        selection_optional="all",
+        energy_edges=[0.1, 10] * u.TeV,
+        n_sigma_ul=3,
+        sum_over_energy_groups=True,
+        n_jobs=2,
+        parallel_backend="multiprocessing",
+    )
+    result = prof_maker.run(dataset)
+    imp_prof = result.to_table(sed_type="flux", format="profile")
+    assert_allclose(imp_prof[7]["npred_excess"], [[-1.115967]], rtol=1e-3)
+
+
+@requires_data()
+@requires_dependency("ray")
+def test_profile_multiprocessing_ray_with_manager():
+    dataset = simulate_map_dataset(name="test-map-pwl")
+
+    geom = dataset.counts.geom
+    regions = make_concentric_annulus_sky_regions(
+        center=geom.center_skydir,
+        radius_max=0.2 * u.deg,
+    )
+
+    with parallel.multiprocessing_manager(backend="ray", pool_kwargs=dict(processes=2)):
+        prof_maker = FluxProfileEstimator(
+            regions,
+            selection_optional="all",
+            energy_edges=[0.1, 10] * u.TeV,
+            n_sigma_ul=3,
+            sum_over_energy_groups=True,
+        )
+        assert prof_maker.n_jobs == 2
+        assert prof_maker.parallel_backend == "ray"
+        result = prof_maker.run(dataset)
+        imp_prof = result.to_table(sed_type="flux", format="profile")
+        assert_allclose(imp_prof[7]["npred_excess"], [[-1.115967]], rtol=1e-3)
+
+
+@requires_data()
+@requires_dependency("ray")
+def test_profile_multiprocessing_ray():
+    dataset = simulate_map_dataset(name="test-map-pwl")
+
+    geom = dataset.counts.geom
+    regions = make_concentric_annulus_sky_regions(
+        center=geom.center_skydir,
+        radius_max=0.2 * u.deg,
+    )
+
+    prof_maker = FluxProfileEstimator(
+        regions,
+        selection_optional="all",
+        energy_edges=[0.1, 10] * u.TeV,
+        n_sigma_ul=3,
+        sum_over_energy_groups=True,
+        n_jobs=2,
+        parallel_backend="ray",
+    )
+    result = prof_maker.run(dataset)
+    imp_prof = result.to_table(sed_type="flux", format="profile")
+    assert_allclose(imp_prof[7]["npred_excess"], [[-1.115967]], rtol=1e-3)


### PR DESCRIPTION
Replacing the loop over regions to use run_multiprocessing instead is straightforward. However I left a  TODO for later because I have to test if it would be more efficient to not compute datasets_to_fit in parallel to avoid copying the full datasets. For example for diffuse emission the dataset would be the full galactic plane so we may run into memory issue or just be slower because the copy takes too long.