### PR TITLE
Expose cluster features in API

### DIFF
--- a/docs/api-reference/utils.rst
+++ b/docs/api-reference/utils.rst
@@ -8,6 +8,10 @@ utils - Utilities
 
 .. currentmodule:: gammapy.utils
 
+.. automodapi:: gammapy.utils.cluster
+    :no-inheritance-diagram:
+    :include-all-objects:
+    
 .. automodapi:: gammapy.utils.coordinates
     :no-inheritance-diagram:
     :include-all-objects:

--- a/gammapy/data/__init__.py
+++ b/gammapy/data/__init__.py
@@ -10,6 +10,7 @@ from .obs_table import ObservationTable
 from .observations import Observation, Observations
 from .observers import observatory_locations
 from .pointing import FixedPointingInfo, PointingInfo, PointingMode
+from .utils import get_irfs_features
 
 __all__ = [
     "DataStore",
@@ -25,4 +26,5 @@ __all__ = [
     "observatory_locations",
     "PointingInfo",
     "PointingMode",
+    "get_irfs_features",
 ]

--- a/gammapy/data/utils.py
+++ b/gammapy/data/utils.py
@@ -5,6 +5,8 @@ from astropy.table import Table
 from gammapy.irf import EDispKernelMap, PSFMap
 from gammapy.utils.cluster import standard_scaler
 
+__all__ = ["get_irfs_features"]
+
 
 def get_irfs_features(
     observations,
@@ -15,7 +17,7 @@ def get_irfs_features(
     containment_fraction=0.68,
     apply_standard_scaler=False,
 ):
-    """Get features from irfs properties at a given position. Used for observations clustering.
+    """Get features from IRFs properties at a given position. Used for observations clustering.
 
     Parameters
     ----------

--- a/gammapy/utils/cluster.py
+++ b/gammapy/utils/cluster.py
@@ -33,9 +33,7 @@ def standard_scaler(features):
     return scaled_features
 
 
-def hierarchical_clustering(
-    features, linkage_kwargs=None, fcluster_kwargs=None, standard_scaler=False
-):
+def hierarchical_clustering(features, linkage_kwargs=None, fcluster_kwargs=None):
     """Hierarchical clustering using given features.
 
     Parameters
@@ -54,7 +52,6 @@ def hierarchical_clustering(
         Table containing the features and an extra column for the groups labels.
 
     """
-    # TODO: standard_scaler is not utilised here?
     features = features.copy()
     features_array = np.array(
         [

--- a/gammapy/utils/cluster.py
+++ b/gammapy/utils/cluster.py
@@ -11,8 +11,8 @@ def standard_scaler(features):
 
     Calculated through:
 
-       .. math::
-           f_\text{scaled} = \frac{f-\text{mean}(f)}{\text{std}(f)} .
+    .. math::
+        f_\text{scaled} = \frac{f-\text{mean}(f)}{\text{std}(f)} .
 
     Parameters
     ----------
@@ -40,10 +40,12 @@ def hierarchical_clustering(features, linkage_kwargs=None, fcluster_kwargs=None)
     ----------
     features : `~astropy.table.Table`
         Table containing the features.
-    linkage_kwargs : dict
+    linkage_kwargs : dict, optional
         Arguments forwarded to `scipy.cluster.hierarchy.linkage`.
-    fcluster_kwargs : dict
+        Default is None, which uses method="ward" and metric="euclidean".
+    fcluster_kwargs : dict, optional
         Arguments forwarded to `scipy.cluster.hierarchy.fcluster`.
+        Default is None, which uses criterion="maxclust" and t=3.
 
 
     Returns

--- a/gammapy/utils/cluster.py
+++ b/gammapy/utils/cluster.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utilities for hierarchical/agglomerative clustering."""
-
 import numpy as np
 import scipy.cluster.hierarchy as sch
+
+__all__ = ["standard_scaler", "hierarchical_clustering"]
 
 
 def standard_scaler(features):


### PR DESCRIPTION
This PR is to expose the clustering features in the API.

The following is correctly exposed:
`gammapy.data.utils.get_irfs_features`

**Dear reviewer**
I am not sure how to expose the following:
`gammapy.utils.cluster.standard_scaler`
`gammapy.utils.cluster.hierarchical_clustering`
