### PR TITLE
Return the coordinate for the doubling time as an astropy.Time object

### DIFF
--- a/gammapy/estimators/tests/test_utils.py
+++ b/gammapy/estimators/tests/test_utils.py
@@ -17,7 +17,7 @@ from gammapy.estimators.utils import (
     resample_energy_edges,
 )
 from gammapy.maps import Map, MapAxis
-from gammapy.utils.testing import requires_data
+from gammapy.utils.testing import assert_time_allclose, requires_data
 
 
 class TestFindPeaks:
@@ -191,6 +191,11 @@ def test_compute_lightcurve_doublingtime():
     dtime = compute_lightcurve_doublingtime(lightcurve)
     ddtime = dtime["doublingtime"].quantity
     ddtime_err = dtime["doubling_err"].quantity
+    dcoord = dtime["doubling_coord"]
 
     assert_allclose(ddtime, [[[245305.49]], [[481572.59]]] * u.s)
     assert_allclose(ddtime_err, [[[45999.766]], [[11935.665]]] * u.s)
+    assert_time_allclose(
+        dcoord,
+        Time([[[55197.99960648]], [[55197.99960648]]], format="mjd", scale="utc"),
+    )

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -439,10 +439,12 @@ def compute_lightcurve_doublingtime(lightcurve, flux_quantity="flux"):
             energies[1:],
             doubling_dict["doubling"],
             doubling_dict["doubling_err"],
-            doubling_dict["doubling_coord"],
+            lightcurve.geom.axes["time"].reference_time
+            + doubling_dict["doubling_coord"],
             doubling_dict["halving"],
             doubling_dict["halving_err"],
-            doubling_dict["halving_coord"],
+            lightcurve.geom.axes["time"].reference_time
+            + doubling_dict["halving_coord"],
         ],
         names=(
             "min_energy",


### PR DESCRIPTION
This pull request modifies the `estimators.utils.compute_lightcurve_doublingtime` function so that the coordinates at which the doubling and halving time are found are returned as a time object (relative to the reference time of the lightcurve)
