### PR TITLE
Expose `gammapy.estimators.resample_energy_edges` in the tutorials and `HowTo`

### DIFF
--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -74,6 +74,18 @@ The on-axis equivalent number of observation hours on the source can be calculat
 
 .. accordion-footer::
 
+
+.. accordion-header::
+    :id: collapseHowToEnergyEdges
+    :title: Compute minimum number of counts of significance per bin
+    :link: ../tutorials/analysis-1d/spectral_analysis.html#compute-flux-points
+
+The `~gammapy.estimators.utils.resample_energy_edges` provides a way to resample the energy bins
+t o satisfy a minimum number of counts of significance per bin.
+
+.. accordion-footer::
+
+
 .. accordion-header::
     :id: collapseHowToSix
     :title: Choose units for plotting

--- a/examples/tutorials/analysis-1d/spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis.py
@@ -118,6 +118,7 @@ from gammapy.datasets import (
     SpectrumDatasetOnOff,
 )
 from gammapy.estimators import FluxPointsEstimator
+from gammapy.estimators.utils import resample_energy_edges
 from gammapy.makers import (
     ReflectedRegionsBackgroundMaker,
     SafeMaskMaker,
@@ -379,12 +380,14 @@ plt.show()
 # -------------------
 #
 # To round up our analysis we can compute flux points by fitting the norm
-# of the global model in energy bands. We’ll use a fixed energy binning
-# for now:
+# of the global model in energy bands.
+# We can utilise the `~gammapy.estimators.utils.resample_energy_edges`
+# for defining the energy bins in which the minimum number of `sqrt_ts` is 2.
+# To do so we first stack the individual datasets, only for obtaining the energies:
 #
 
-e_min, e_max = 0.7, 30
-energy_edges = np.geomspace(e_min, e_max, 11) * u.TeV
+dataset_stacked = Datasets(datasets).stack_reduce()
+energy_edges = resample_energy_edges(dataset_stacked, conditions={"sqrt_ts_min": 2})
 
 
 ######################################################################
@@ -449,7 +452,7 @@ dataset_stacked.models = model
 stacked_fit = Fit()
 result_stacked = stacked_fit.run([dataset_stacked])
 
-# make a copy to compare later
+# Make a copy to compare later
 model_best_stacked = model.copy()
 
 print(result_stacked)

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -256,12 +256,13 @@ def resample_energy_edges(dataset, conditions={}):
 
     Parameters
     ----------
-    dataset :`~gammapy.datasets.SpectrumDataset` or `~gammapy.datasets.SpectrumDatasetOnOff`
+    dataset : `~gammapy.datasets.SpectrumDataset` or `~gammapy.datasets.SpectrumDatasetOnOff`
         The input dataset.
     conditions : dict
         Keyword arguments containing the per-bin conditions used to resample the axis.
         Available options are: 'counts_min', 'background_min', 'excess_min', 'sqrt_ts_min',
         'npred_min', 'npred_background_min', 'npred_signal_min'. Default is {}.
+
     Returns
     -------
     energy_edges : list of `~astropy.units.Quantity`
@@ -319,7 +320,7 @@ def compute_lightcurve_fvar(lightcurve, flux_quantity="flux"):
 
     Parameters
     ----------
-    lightcurve : '~gammapy.estimators.FluxPoints'
+    lightcurve : `~gammapy.estimators.FluxPoints`
         The lightcurve object.
     flux_quantity : str
         Flux quantity to use for calculation. Should be 'dnde', 'flux', 'e2dnde' or 'eflux'. Default is 'flux'.


### PR DESCRIPTION
This PR is to partially address #4788 
It exposes the `gammapy.estimators.resample_energy_edges` in the `HowTo` and in one of the tutorials. 


**Dear reviewer**
This was the only tutorial I could think to adapt, however, I am open to suggestions of where else to adapt