### PR TITLE
Expose remaining `utils` functions in API

### DIFF
--- a/docs/api-reference/utils.rst
+++ b/docs/api-reference/utils.rst
@@ -8,10 +8,6 @@ utils - Utilities
 
 .. currentmodule:: gammapy.utils
 
-.. automodapi:: gammapy.utils.array
-    :no-inheritance-diagram:
-    :include-all-objects:
-
 .. automodapi:: gammapy.utils.cluster
     :no-inheritance-diagram:
     :include-all-objects:

--- a/docs/api-reference/utils.rst
+++ b/docs/api-reference/utils.rst
@@ -8,11 +8,19 @@ utils - Utilities
 
 .. currentmodule:: gammapy.utils
 
+.. automodapi:: gammapy.utils.array
+    :no-inheritance-diagram:
+    :include-all-objects:
+
 .. automodapi:: gammapy.utils.cluster
     :no-inheritance-diagram:
     :include-all-objects:
-    
+
 .. automodapi:: gammapy.utils.coordinates
+    :no-inheritance-diagram:
+    :include-all-objects:
+
+.. automodapi:: gammapy.utils.fits
     :no-inheritance-diagram:
     :include-all-objects:
 
@@ -24,7 +32,7 @@ utils - Utilities
     :no-inheritance-diagram:
     :include-all-objects:
 
-.. automodapi:: gammapy.utils.fits
+.. automodapi:: gammapy.utils.parallel
     :no-inheritance-diagram:
     :include-all-objects:
 
@@ -33,10 +41,6 @@ utils - Utilities
     :include-all-objects:
 
 .. automodapi:: gammapy.utils.regions
-    :no-inheritance-diagram:
-    :include-all-objects:
-
-.. automodapi:: gammapy.utils.parallel
     :no-inheritance-diagram:
     :include-all-objects:
     


### PR DESCRIPTION

**Description**
There were a number of utils functions which were not included in the rst therefore were unexposed.
