### PR TITLE
Fix TODO for docstring in `excess.py`

### DIFF
--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -614,7 +614,7 @@ class Observation:
     def copy(self, in_memory=False, **kwargs):
         """Copy observation.
 
-        Overwriting `Observation` arguments requires the 'in_memory' argument to be true.
+        Overwriting `Observation` arguments requires the ``in_memory`` argument to be true.
 
         Parameters
         ----------
@@ -625,14 +625,14 @@ class Observation:
 
         Examples
         --------
-        >>>from gammapy.data import Observation
+        >>> from gammapy.data import Observation
         >>>
-        >>>obs = Observation.read(
-        >>>    "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
-        >>>)
+        >>> obs = Observation.read(
+        >>>     "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+        >>> )
         >>>
-        >>>obs_copy = obs.copy(in_memory=True, obs_id=1234)
-        >>>print(obs_copy)
+        >>> obs_copy = obs.copy(in_memory=True, obs_id=1234)
+        >>> print(obs_copy)
 
         Returns
         -------

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -20,8 +20,24 @@ log = logging.getLogger(__name__)
 
 
 def convolved_map_dataset_counts_statistics(dataset, kernel, mask, correlate_off):
-    """Return CountsDataset objects containing smoothed maps from the MapDataset."""
-    # TODO: Add a full docstring
+    """Return CountsDataset objects containing smoothed maps from the MapDataset.
+
+    Parameters
+    ----------
+    dataset : `~gammapy.datasets.MapDataset` or `~gammapy.datasets.MapDatasetOnOff`
+        Map dataset.
+    kernel : `~astropy.convolution.Tophat2DKernel`
+        Kernel.
+    mask : `~gammapy.maps.Map`
+        Mask map.
+    correlate_off : bool
+        Correlate OFF events.
+
+    Returns
+    -------
+    counts_dataset : `~gammapy.stats.CashCountsStatistic` or `~gammapy.stats.WStatCountsStatistic`
+        The CountsDataset.
+    """
     # Kernel is modified later make a copy here
     kernel = copy.deepcopy(kernel)
     kernel_data = kernel.data / kernel.data.max()
@@ -80,8 +96,8 @@ class ExcessMapEstimator(Estimator):
 
     Parameters
     ----------
-    correlation_radius : ~astropy.coordinate.Angle
-        correlation radius to use
+    correlation_radius : `~astropy.coordinate.Angle`
+        Correlation radius to use.
     n_sigma : float
         Confidence level for the asymmetric errors expressed in number of sigma.
     n_sigma_ul : float


### PR DESCRIPTION
**Description**

This pull request is to fix one of the TODO.
It also fixes the docstring in `ExcessMapEstimator` and the `copy()` example in `Observation`.

**Dear reviewer**
Do we want to expose `convolved_map_dataset_counts_statistics`, because it is currently hidden from the API?
