### PR TITLE
MNT: fix an implicit incompatibility with Python 3.12 (pkg_resources isn't shipped with stdlib)

### DIFF
--- a/gammapy/__init__.py
+++ b/gammapy/__init__.py
@@ -32,13 +32,14 @@ the following sub-packages (e.g. `gammapy.makers`):
 
 __all__ = ["__version__", "song"]
 
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 
 try:
-    __version__ = pkg_resources.get_distribution(__name__).version
-except pkg_resources.DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
+del version, PackageNotFoundError
 
 
 def song(karaoke=False):


### PR DESCRIPTION
**Description**

Noticed this while working on #4951:
`__init__.py` has an undeclared dependency on `pkg_resources` which is a subpackaged shipped with `setuptools`. Python 3.12 was the first release which did `setuptools` builtin (it was never part of the standard library, but for a long time it looked like it did, so I've seen exactly this problem before).
I would recommend testing systematically against Python 3.12, but this is out of scope for this PR.
