### PR TITLE
Adapt FluxPointsDataset to fit light curves

### DIFF
--- a/examples/tutorials/analysis-time/light_curve_simulation.py
+++ b/examples/tutorials/analysis-time/light_curve_simulation.py
@@ -80,6 +80,7 @@ log = logging.getLogger(__name__)
 # And some gammapy specific imports
 #
 
+import warnings
 from gammapy.data import FixedPointingInfo, Observation, observatory_locations
 from gammapy.datasets import Datasets, FluxPointsDataset, SpectrumDataset
 from gammapy.estimators import LightCurveEstimator
@@ -91,6 +92,10 @@ from gammapy.modeling.models import (
     ExpDecayTemporalModel,
     PowerLawSpectralModel,
     SkyModel,
+)
+
+warnings.filterwarnings(
+    action="ignore", message="overflow encountered in exp", module="astropy"
 )
 
 ######################################################################
@@ -266,16 +271,11 @@ plt.show()
 # Fitting the obtained light curve
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# The fitting will proceed through a joint fit of the flux points. First,
-# we need to obtain a set of `FluxPointDatasets`, one for each time bin
-#
+# We will first convert the obtained light curve to a `FluxPointsDataset`
+# and fit it with a spectral and temporal model
 
 # Create the datasets by iterating over the returned lightcurve
-datasets = Datasets()
-
-for idx, fp in enumerate(lc_1d.iter_by_axis(axis_name="time")):
-    dataset = FluxPointsDataset(data=fp, name=f"time-bin-{idx}")
-    datasets.append(dataset)
+dataset_fp = FluxPointsDataset(data=lc_1d, name="dataset_lc")
 
 
 ######################################################################
@@ -290,18 +290,22 @@ spectral_model1 = PowerLawSpectralModel(
 )
 temporal_model1 = ExpDecayTemporalModel(t0="10 h", t_ref=gti_t0.mjd * u.d)
 
+
 model = SkyModel(
     spectral_model=spectral_model1,
     temporal_model=temporal_model1,
     name="model-test",
 )
 
-datasets.models = model
+dataset_fp.models = model
+print(dataset_fp)
+
 
 # %%time
-# Do a joint fit
+# Fit the dataset
 fit = Fit()
-result = fit.run(datasets=datasets)
+result = fit.run(dataset_fp)
+display(result.parameters.to_table())
 
 
 ######################################################################

--- a/examples/tutorials/analysis-time/light_curve_simulation.py
+++ b/examples/tutorials/analysis-time/light_curve_simulation.py
@@ -313,20 +313,7 @@ display(result.parameters.to_table())
 # temporal model in relative units for one particular energy range
 #
 
-fig, ax = plt.subplots(
-    figsize=(8, 6),
-    gridspec_kw={"left": 0.16, "bottom": 0.2, "top": 0.98, "right": 0.98},
-)
-lc_1TeV_10TeV = lc_1d.slice_by_idx({"energy": slice(2, 3)})
-lc_1TeV_10TeV.plot(ax=ax, sed_type="norm", axis_name="time")
-
-time_range = lc_1TeV_10TeV.geom.axes["time"].time_bounds
-temporal_model1.plot(ax=ax, time_range=time_range, label="Best fit model")
-
-ax.set_yscale("linear")
-ax.legend()
-plt.show()
-
+dataset_fp.plot_spectrum(axis_name="time")
 
 ######################################################################
 # Fit the datasets

--- a/examples/tutorials/analysis-time/light_curve_simulation.py
+++ b/examples/tutorials/analysis-time/light_curve_simulation.py
@@ -80,7 +80,7 @@ log = logging.getLogger(__name__)
 # And some gammapy specific imports
 #
 
-from gammapy.data import Observation, observatory_locations
+from gammapy.data import FixedPointingInfo, Observation, observatory_locations
 from gammapy.datasets import Datasets, FluxPointsDataset, SpectrumDataset
 from gammapy.estimators import LightCurveEstimator
 from gammapy.irf import load_irf_dict_from_file
@@ -133,8 +133,10 @@ energy_axis_true = MapAxis.from_edges(
 
 geom = RegionGeom.create("galactic;circle(0, 0, 0.11)", axes=[energy_axis])
 
-# Pointing position
-pointing = SkyCoord(0.5, 0.5, unit="deg", frame="galactic")
+# Pointing position to be supplied as a `FixedPointingInfo`
+pointing = FixedPointingInfo(
+    fixed_icrs=SkyCoord(0.5, 0.5, unit="deg", frame="galactic").icrs,
+)
 
 
 ######################################################################

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -379,7 +379,7 @@ class Datasets(collections.abc.MutableSequence):
         return copy.deepcopy(self)
 
     @classmethod
-    def read(cls, filename, filename_models=None, lazy=True, cache=True):
+    def read(cls, filename, filename_models=None, lazy=True, cache=True, **kwargs):
         """De-serialize datasets from YAML and FITS files.
 
         Parameters
@@ -392,6 +392,9 @@ class Datasets(collections.abc.MutableSequence):
             Whether to lazy load data into memory. Default is True.
         cache : bool
             Whether to cache the data after loading. Default is True.
+        kwargs : dict
+            Keyword arguments passed to individual datasets write methods
+
 
         Returns
         -------
@@ -411,7 +414,7 @@ class Datasets(collections.abc.MutableSequence):
                 data["filename"] = str(make_path(path / data["filename"]))
 
             dataset_cls = DATASET_REGISTRY.get_cls(data["type"])
-            dataset = dataset_cls.from_dict(data, lazy=lazy, cache=cache)
+            dataset = dataset_cls.from_dict(data, lazy=lazy, cache=cache, **kwargs)
             datasets.append(dataset)
 
         datasets = cls(datasets)
@@ -428,6 +431,7 @@ class Datasets(collections.abc.MutableSequence):
         overwrite=False,
         write_covariance=True,
         checksum=False,
+        **kwargs,
     ):
         """Serialize datasets to YAML and FITS files.
 
@@ -444,6 +448,9 @@ class Datasets(collections.abc.MutableSequence):
         checksum : bool
             When True adds both DATASUM and CHECKSUM cards to the headers written to the FITS files.
             Default is False.
+        kwargs : dict
+            Keyword arguments passed to individual datasets write methods
+
         """
         path = make_path(filename)
 
@@ -453,7 +460,7 @@ class Datasets(collections.abc.MutableSequence):
             d = dataset.to_dict()
             filename = d["filename"]
             dataset.write(
-                path.parent / filename, overwrite=overwrite, checksum=checksum
+                path.parent / filename, overwrite=overwrite, checksum=checksum, **kwargs
             )
             data["datasets"].append(d)
 

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -428,7 +428,6 @@ class Datasets(collections.abc.MutableSequence):
         overwrite=False,
         write_covariance=True,
         checksum=False,
-        **kwargs,
     ):
         """Serialize datasets to YAML and FITS files.
 

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -379,7 +379,7 @@ class Datasets(collections.abc.MutableSequence):
         return copy.deepcopy(self)
 
     @classmethod
-    def read(cls, filename, filename_models=None, lazy=True, cache=True, **kwargs):
+    def read(cls, filename, filename_models=None, lazy=True, cache=True):
         """De-serialize datasets from YAML and FITS files.
 
         Parameters
@@ -392,9 +392,6 @@ class Datasets(collections.abc.MutableSequence):
             Whether to lazy load data into memory. Default is True.
         cache : bool
             Whether to cache the data after loading. Default is True.
-        kwargs : dict
-            Keyword arguments passed to individual datasets write methods
-
 
         Returns
         -------
@@ -414,7 +411,7 @@ class Datasets(collections.abc.MutableSequence):
                 data["filename"] = str(make_path(path / data["filename"]))
 
             dataset_cls = DATASET_REGISTRY.get_cls(data["type"])
-            dataset = dataset_cls.from_dict(data, lazy=lazy, cache=cache, **kwargs)
+            dataset = dataset_cls.from_dict(data, lazy=lazy, cache=cache)
             datasets.append(dataset)
 
         datasets = cls(datasets)
@@ -448,9 +445,6 @@ class Datasets(collections.abc.MutableSequence):
         checksum : bool
             When True adds both DATASUM and CHECKSUM cards to the headers written to the FITS files.
             Default is False.
-        kwargs : dict
-            Keyword arguments passed to individual datasets write methods
-
         """
         path = make_path(filename)
 
@@ -460,7 +454,7 @@ class Datasets(collections.abc.MutableSequence):
             d = dataset.to_dict()
             filename = d["filename"]
             dataset.write(
-                path.parent / filename, overwrite=overwrite, checksum=checksum, **kwargs
+                path.parent / filename, overwrite=overwrite, checksum=checksum
             )
             data["datasets"].append(d)
 

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -282,7 +282,7 @@ class FluxPointsDataset(Dataset):
         # data section
         n_bins = 0
         if self.data is not None:
-            n_bins = np.product(self.data.geom.data_shape)
+            n_bins = np.prod(self.data.geom.data_shape)
         str_ += "\t{:32}: {} \n".format("Number of total flux points", n_bins)
 
         n_fit_bins = 0

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -148,9 +148,7 @@ class FluxPointsDataset(Dataset):
             models = DatasetModels(models)
             self._models = models.select(datasets_names=self.name)
 
-    def write(
-        self, filename, overwrite=False, checksum=False, format="gadf-sed", **kwargs
-    ):
+    def write(self, filename, overwrite=False, checksum=False, **kwargs):
         """Write flux point dataset to file.
 
         Parameters
@@ -162,18 +160,10 @@ class FluxPointsDataset(Dataset):
         checksum : bool
             When True adds both DATASUM and CHECKSUM cards to the headers written to the FITS file.
             Applies only if filename has .fits suffix. Default is False.
-        format : {"gadf-sed", "lightcurve"}
-            Format specification for contained fluxpoint. The following formats are supported:
-            * "gadf-sed": format for SED flux points see :ref:`gadf:flux-points`
-            for details.
-            * "lightcurve": Gammapy internal format to store energy dependent
-            lightcurves. Basically a generalisation of the "gadf" format, but
-            currently there is no detailed documentation available.
-            Default is "gadf-sed".
         **kwargs : dict, optional
              Keyword arguments passed to `~astropy.table.Table.write`.
         """
-        table = self.data.to_table(format=format)
+        table = self.data.to_table()
 
         if self.mask_fit is None:
             mask_fit = self.mask_safe
@@ -195,7 +185,7 @@ class FluxPointsDataset(Dataset):
             table.write(make_path(filename), overwrite=overwrite, **kwargs)
 
     @classmethod
-    def read(cls, filename, name=None, format="gadf-sed"):
+    def read(cls, filename, name=None):
         """Read pre-computed flux points and create a dataset.
 
         Parameters
@@ -204,14 +194,6 @@ class FluxPointsDataset(Dataset):
             Filename to read from.
         name : str, optional
             Name of the new dataset. Default is None.
-        format : {"gadf-sed", "lightcurve"}
-            Format specification for contained fluxpoint. The following formats are supported:
-            * "gadf-sed": format for SED flux points see :ref:`gadf:flux-points`
-            for details.
-            * "lightcurve": Gammapy internal format to store energy dependent
-            lightcurves. Basically a generalisation of the "gadf" format, but
-            currently there is no detailed documentation available.
-            Default is "gadf-sed".
         Returns
         -------
         dataset : `FluxPointsDataset`
@@ -232,27 +214,19 @@ class FluxPointsDataset(Dataset):
 
         return cls(
             name=make_name(name),
-            data=FluxPoints.from_table(table, format=format),
+            data=FluxPoints.from_table(table),
             mask_fit=mask_fit,
             mask_safe=mask_safe,
         )
 
     @classmethod
-    def from_dict(cls, data, format="gadf-sed", **kwargs):
+    def from_dict(cls, data, **kwargs):
         """Create flux point dataset from dict.
 
         Parameters
         ----------
         data : dict
             Dictionary containing data to create dataset from.
-        format : {"gadf-sed", "lightcurve"}
-            Format specification for contained fluxpoint. The following formats are supported:
-            * "gadf-sed": format for SED flux points see :ref:`gadf:flux-points`
-            for details.
-            * "lightcurve": Gammapy internal format to store energy dependent
-            lightcurves. Basically a generalisation of the "gadf" format, but
-            currently there is no detailed documentation available.
-            Default is "gadf-sed".
         Returns
         -------
         dataset : `FluxPointsDataset`
@@ -267,7 +241,7 @@ class FluxPointsDataset(Dataset):
         table.remove_columns(["mask_fit", "mask_safe"])
         return cls(
             name=data["name"],
-            data=FluxPoints.from_table(table, format=format),
+            data=FluxPoints.from_table(table),
             mask_fit=mask_fit,
             mask_safe=mask_safe,
         )

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -494,7 +494,7 @@ class FluxPointsDataset(Dataset):
             Keyword arguments passed to `gammapy.modeling.models.SpectralModel.plot` and
             `gammapy.modeling.models.SpectralModel.plot_error` to configure the plot style. Default is None.
         axis_name : str
-            Axis along which to plot the flux points for multiple axes. Default is energy
+            Axis along which to plot the flux points for multiple axes. Default is energy.
 
         Returns
         -------

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -118,7 +118,7 @@ def test_flux_point_dataset_with_time_axis(tmp_path):
             Column([[False, False], [True, True]], "is_ul"),
         ],
     )
-    flux_points = FluxPoints.from_table(table=table, format="lightcurve")
+    flux_points = FluxPoints.from_table(table=table)
     flux_points_dataset = FluxPointsDataset(data=flux_points)
     temporal_model = ExpDecayTemporalModel()
     temporal_model.t_ref.value = Time(["2010-01-01"]).mjd
@@ -147,7 +147,6 @@ def test_flux_point_dataset_with_time_axis(tmp_path):
     datasets = Datasets.read(
         filename=tmp_path / "tmp_datasets.yaml",
         filename_models=tmp_path / "tmp_models.yaml",
-        format="lightcurve",
     )
 
     new_dataset = datasets[0]

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -135,7 +135,9 @@ def test_flux_point_dataset_with_time_axis(tmp_path):
         rtol=1e-3,
     )
     assert_allclose(flux_points_dataset.stat_sum(), 193.8093, rtol=1e-3)
-    assert_allclose(flux_points_dataset.residuals()[0][0], 9.94782173e-12, rtol=1e-5)
+    assert_allclose(
+        flux_points_dataset.residuals()[0][0].value, 9.94782173e-12, rtol=1e-5
+    )
     Datasets([flux_points_dataset]).write(
         filename=tmp_path / "tmp_datasets.yaml",
         filename_models=tmp_path / "tmp_models.yaml",

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -95,7 +95,6 @@ def test_flux_point_dataset_str(dataset):
 
 @requires_data()
 def test_flux_point_dataset_flux_pred(dataset):
-
     assert_allclose(dataset.flux_pred()[0].value, 0.00022766, rtol=1e-2)
     dataset.models[0].temporal_model = ExpDecayTemporalModel(
         t0=5.0 * u.hr, t_ref=51543.5 * u.d
@@ -103,7 +102,7 @@ def test_flux_point_dataset_flux_pred(dataset):
     assert_allclose(dataset.flux_pred()[0].value, 0.000472, rtol=1e-3)
 
 
-def test_flux_point_dataset_creation():
+def test_flux_point_dataset_with_time_axis(tmp_path):
     meta = dict(TIMESYS="utc", SED_TYPE="flux")
 
     table = Table(
@@ -119,10 +118,44 @@ def test_flux_point_dataset_creation():
             Column([[False, False], [True, True]], "is_ul"),
         ],
     )
-
     flux_points = FluxPoints.from_table(table=table, format="lightcurve")
+    flux_points_dataset = FluxPointsDataset(data=flux_points)
+    temporal_model = ExpDecayTemporalModel()
+    temporal_model.t_ref.value = Time(["2010-01-01"]).mjd
+    temporal_model.t0.quantity = 5.0 * u.hr
+    model = SkyModel(
+        spectral_model=PowerLawSpectralModel(), temporal_model=temporal_model
+    )
+    flux_points_dataset.models = model
+    assert flux_points_dataset.flux_pred().shape == (2, 2, 1, 1)
+    assert flux_points_dataset.mask.shape == (2, 2, 1, 1)
+    assert_allclose(
+        flux_points_dataset.flux_pred()[0].value,
+        [[[5.21782717e-14]], [[1.30445679e-14]]],
+        rtol=1e-3,
+    )
+    assert_allclose(flux_points_dataset.stat_sum(), 193.8093, rtol=1e-3)
+    Datasets([flux_points_dataset]).write(
+        filename=tmp_path / "tmp_datasets.yaml",
+        filename_models=tmp_path / "tmp_models.yaml",
+        format="lightcurve",
+    )
+
+    datasets = Datasets.read(
+        filename=tmp_path / "tmp_datasets.yaml",
+        filename_models=tmp_path / "tmp_models.yaml",
+        format="lightcurve",
+    )
+
+    new_dataset = datasets[0]
+    assert_allclose(new_dataset.data.dnde, flux_points_dataset.data.dnde, 1e-4)
+
+    with mpl_plot_check():
+        flux_points_dataset.plot_spectrum(axis_name="time")
     with pytest.raises(ValueError):
-        FluxPointsDataset(data=flux_points)
+        flux_points_dataset.plot_fit()
+    with pytest.raises(ValueError):
+        flux_points_dataset.plot_residuals()
 
 
 @requires_data()
@@ -193,6 +226,5 @@ class TestFluxPointFit:
 
     @staticmethod
     def test_fp_dataset_plot_fit(dataset):
-
         with mpl_plot_check():
             dataset.plot_fit(kwargs_residuals=dict(method="diff/model"))

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -141,7 +141,6 @@ def test_flux_point_dataset_with_time_axis(tmp_path):
     Datasets([flux_points_dataset]).write(
         filename=tmp_path / "tmp_datasets.yaml",
         filename_models=tmp_path / "tmp_models.yaml",
-        format="lightcurve",
     )
 
     datasets = Datasets.read(

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -135,6 +135,7 @@ def test_flux_point_dataset_with_time_axis(tmp_path):
         rtol=1e-3,
     )
     assert_allclose(flux_points_dataset.stat_sum(), 193.8093, rtol=1e-3)
+    assert_allclose(flux_points_dataset.residuals()[0][0], 9.94782173e-12, rtol=1e-5)
     Datasets([flux_points_dataset]).write(
         filename=tmp_path / "tmp_datasets.yaml",
         filename_models=tmp_path / "tmp_models.yaml",


### PR DESCRIPTION
After #4828, `FluxPointsDataset` can now work with a time axis.
This PR adapt `FluxPointsDataset`  to directly use lightcurves instead of a joint fitting of multiple flux points datasets, and adapts the tutorial

The `plot_residuals` visualisation is complex for multi dimensional flux points, so I raise an error. Another option could be to plot a grid, but I don't know if its useful.
