### PR TITLE
Use `FixedPointingInfo` in notebook

### DIFF
--- a/examples/tutorials/analysis-1d/spectrum_simulation.py
+++ b/examples/tutorials/analysis-1d/spectrum_simulation.py
@@ -91,7 +91,12 @@ check_tutorials_setup()
 # Define simulation parameters parameters
 livetime = 1 * u.h
 
-pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+pointing_position = SkyCoord(0, 0, unit="deg", frame="galactic")
+# We want to simulate an observation pointing at a fixed position in the sky.
+# For this, we use the `FixedPointingInfo` class
+pointing = FixedPointingInfo(
+    fixed_icrs=pointing_position.icrs,
+)
 offset = 0.5 * u.deg
 
 # Reconstructed and true energy axis

--- a/examples/tutorials/analysis-3d/simulate_3d.py
+++ b/examples/tutorials/analysis-3d/simulate_3d.py
@@ -61,7 +61,7 @@ import matplotlib.pyplot as plt
 
 # %matplotlib inline
 from IPython.display import display
-from gammapy.data import Observation, observatory_locations
+from gammapy.data import FixedPointingInfo, Observation, observatory_locations
 from gammapy.datasets import MapDataset
 from gammapy.irf import load_irf_dict_from_file
 from gammapy.makers import MapDatasetMaker, SafeMaskMaker
@@ -92,7 +92,12 @@ irfs = load_irf_dict_from_file(
 
 # Define the observation parameters (typically the observation duration and the pointing position):
 livetime = 2.0 * u.hr
-pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+pointing_position = SkyCoord(0, 0, unit="deg", frame="galactic")
+# We want to simulate an observation pointing at a fixed position in the sky.
+# For this, we use the `FixedPointingInfo` class
+pointing = FixedPointingInfo(
+    fixed_icrs=pointing_position.icrs,
+)
 
 # Define map geometry for binned simulation
 energy_reco = MapAxis.from_edges(


### PR DESCRIPTION
This PR adapts tutorials to use `FixedPointingInfo` instead of `SkyCoord`.
@registerrier the current implementation creates a `FixedPointingInfo` from a `SkyCoord` while raising the warning. I did not change it.
One option might be to not remove support for `SkyCoord` in 1.2