### PR TITLE
Remove unnecessary `# TODO`

### DIFF
--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -335,7 +335,6 @@ class TestSpectrumMakerChain:
         assert_quantity_allclose(aeff_actual, results["aeff"], rtol=1e-3)
         assert_quantity_allclose(edisp_actual, results["edisp"], rtol=1e-3)
 
-        # TODO: Introduce assert_stats_allclose
         info = dataset.info_dict()
 
         assert info["counts"] == results["n_on"]

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -775,7 +775,6 @@ class RegionGeom(Geom):
                 region_table = QTable.read(hdulist[region_hdu])
                 regions_pix = Regions.parse(data=region_table, format="fits")
             except TypeError:
-                # TODO: this is needed to support regions=0.5
                 region_table = Table.read(hdulist[region_hdu])
                 regions_pix = Regions.parse(data=region_table, format="fits")
 

--- a/gammapy/modeling/covariance.py
+++ b/gammapy/modeling/covariance.py
@@ -201,7 +201,6 @@ class Covariance:
 
     @property
     def scipy_mvn(self):
-        # TODO: use this, as in https://github.com/cdeil/multinorm/blob/master/multinorm.py
         return scipy.stats.multivariate_normal(
             self.parameters.value, self.data, allow_singular=True
         )

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -295,7 +295,6 @@ class Fit:
         if optimize_result:
             optimize_result.models.covariance = matrix.data.copy()
 
-        # TODO: decide what to return, and fill the info correctly!
         return CovarianceResult(
             backend=backend,
             method=method,
@@ -662,49 +661,41 @@ class FitResult:
         """Minuit object."""
         return self.optimize_result.minuit
 
-    # TODO: is the convenience access needed?
     @property
     def parameters(self):
         """Best fit parameters of the optimization step."""
         return self.optimize_result.parameters
 
-    # TODO: is the convenience access needed?
     @property
     def models(self):
         """Best fit parameters of the optimization step."""
         return self.optimize_result.models
 
-    # TODO: is the convenience access needed?
     @property
     def total_stat(self):
         """Total stat of the optimization step."""
         return self.optimize_result.total_stat
 
-    # TODO: is the convenience access needed?
     @property
     def trace(self):
         """Parameter trace of the optimisation step."""
         return self.optimize_result.trace
 
-    # TODO: is the convenience access needed?
     @property
     def nfev(self):
         """Number of function evaluations of the optimisation step."""
         return self.optimize_result.nfev
 
-    # TODO: is the convenience access needed?
     @property
     def backend(self):
         """Optimizer backend used for the fit."""
         return self.optimize_result.backend
 
-    # TODO: is the convenience access needed?
     @property
     def method(self):
         """Optimizer method used for the fit."""
         return self.optimize_result.method
 
-    # TODO: is the convenience access needed?
     @property
     def message(self):
         """Optimizer status message."""

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -58,7 +58,6 @@ def test_cli_download_notebooks_dev(tmp_path):
 @requires_dependency("tqdm")
 @pytest.mark.remote_data
 def test_cli_download_datasets(tmp_path):
-    # TODO: this test downloads all datasets which is really slow...
     option_out = f"--out={tmp_path}"
 
     args = ["download", "datasets", option_out]

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -80,10 +80,7 @@ class HDULocation:
         return hdu_list[self.hdu_name]
 
     def load(self):
-        """Load HDU as appropriate class.
-
-        TODO: this should probably go via an extensible registry.
-        """
+        """Load HDU as appropriate class."""
         from gammapy.irf import IRF_REGISTRY
 
         hdu_class = self.hdu_class


### PR DESCRIPTION
This PR is to remove some `# TODO` that are no longer necessary because they are already implemented.

For `gammapy/modeling/fit.py`, I believe all the convenience access functions are needed. I personally utilise them all the time. 