### PR TITLE
Reduce memory usage of get_psf_kernel

### DIFF
--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -8,6 +8,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Table
 from regions import CircleSkyRegion
+import gammapy.irf.psf.map as psf_map_module
 from gammapy.catalog import SourceCatalog3FHL
 from gammapy.data import GTI
 from gammapy.datasets import Datasets, MapDataset, MapDatasetOnOff
@@ -637,6 +638,21 @@ def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
 
     assert_allclose(stacked1.psf.psf_map, stacked.psf.psf_map)
     assert_allclose(stacked1.edisp.edisp_map, stacked.edisp.edisp_map)
+
+
+@requires_data()
+def test_map_auto_psf_upsampling(sky_model, geom, geom_etrue):
+    dataset_2 = get_map_dataset(geom, geom_etrue, name="test-2")
+    datasets = Datasets([dataset_2])
+
+    models = Models(datasets.models)
+    models.insert(0, sky_model)
+
+    datasets.models = models
+    psf_map_module.PSF_UPSAMPLING_FACTOR = None
+    npred = dataset_2.npred().data.sum()
+    assert_allclose(npred, 9525.340707, rtol=1e-3)
+    psf_map_module.PSF_UPSAMPLING_FACTOR = 4
 
 
 @requires_data()

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -291,7 +291,7 @@ def test_ts_map_with_model(fake_dataset):
 
     assert_allclose(maps["sqrt_ts"].data[:, 25, 25], 18.369942, atol=0.1)
     assert_allclose(maps["flux"].data[:, 25, 25], 3.513e-10, atol=1e-12)
-    assert_allclose(maps["flux_err"].data[0, 0, 0], 2.494462e-11, rtol=1e-4)
+    assert_allclose(maps["flux_err"].data[0, 0, 0], 2.413244e-11, rtol=1e-4)
 
     fake_dataset.models = [model]
     maps = estimator.run(fake_dataset)

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -308,8 +308,8 @@ def test_ts_map_with_model(fake_dataset):
         energy_edges=[200, 3500] * u.GeV,
     )
     maps = estimator.run(fake_dataset)
-    assert_allclose(maps["sqrt_ts"].data[:, 25, 25], 0.323203, atol=0.1)
-    assert_allclose(maps["flux"].data[:, 25, 25], 1.015509e-12, atol=1e-12)
+    assert_allclose(maps["sqrt_ts"].data[:, 25, 25], -0.279392, atol=0.1)
+    assert_allclose(maps["flux"].data[:, 25, 25], -2.015715e-13, atol=1e-12)
 
 
 @requires_data()

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -17,17 +17,18 @@ from .kernel import PSFKernel
 __all__ = ["PSFMap", "RecoPSFMap"]
 
 
-PSF_MAX_OVERSAMPLING = 4
+PSF_MAX_OVERSAMPLING = 4  # for backward compatibility
 
 
 def _psf_upsampling_factor(psf, geom, position, energy=None, precision_factor=12):
+    """Minimal factor between the bin half-width of the geom and the median R68% containment radius."""
     if energy is None:
         energy = geom.axes[psf.energy_name].center
     psf_r68 = psf.containment_radius(
         0.68, geom.axes[psf.energy_name].center, position=position
     )
-    psf_r68 = np.percentile(psf_r68, 50)
-    base_factor = (2 * psf_r68 / geom.pixel_scales.max()).to_value("")
+    psf_r68_median = np.percentile(psf_r68, 50)
+    base_factor = (2 * psf_r68_median / geom.pixel_scales.max()).to_value("")
     factor = np.minimum(
         int(np.ceil(precision_factor / base_factor)), PSF_MAX_OVERSAMPLING
     )
@@ -275,7 +276,7 @@ class PSFMap(IRFMap):
             Oversampling factor to compute the PSF.
             Default is None and it will be computed automatically.
         precision_factor : int, optional
-            Minimal factor between the bin half-width of the geom and the R68% containment radius.
+            Factor between the bin half-width of the geom and the median R68% containment radius.
             Used only for the oversampling method. Default is 10.
 
         Returns

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -20,7 +20,7 @@ __all__ = ["PSFMap", "RecoPSFMap"]
 PSF_MAX_OVERSAMPLING = 4
 
 
-def _psf_upsampling_factor(psf, geom, position, energy=None, precision_factor=10):
+def _psf_upsampling_factor(psf, geom, position, energy=None, precision_factor=12):
     if energy is None:
         energy = geom.axes[psf.energy_name].center
     psf_r68 = psf.containment_radius(
@@ -252,7 +252,7 @@ class PSFMap(IRFMap):
         max_radius=None,
         containment=0.999,
         factor=None,
-        precision_factor=10,
+        precision_factor=12,
     ):
         """Return a PSF kernel at the given position.
 

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -273,6 +273,7 @@ class PSFMap(IRFMap):
             the `max_radius` argument. Default is 0.999.
         factor : int, optional
             Oversampling factor to compute the PSF.
+            Default is None and it will be computed automatically.
         precision_factor : int, optional
             Minimal factor between the bin half-width of the geom and the R68% containment radius.
             Used only for the oversampling method. Default is 10.

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -302,13 +302,11 @@ class PSFMap(IRFMap):
             max_radius = np.max(radii)
 
         geom = geom.to_odd_npix(max_radius=max_radius).upsample(factor=factor)
-        coords = geom.to_image().get_coord(sparse=True)
+        coords = geom.get_coord(sparse=True)
         rad = coords.skycoord.separation(geom.center_skydir)
 
         coords = {
-            self.energy_name: geom.axes[self.energy_name].center.reshape(
-                geom.data_shape_axes
-            ),
+            self.energy_name: coords[self.energy_name],
             "rad": rad,
             "skycoord": position,
         }


### PR DESCRIPTION
Reduce memory usage of get_psf_kernel by looping over energy to compute the psf_kernel. So upsampling and coordinates computation are only performed for one image at the time. The loop could eventually be parallelised later. 

For the test I did with a large dataset on my laptop there was already a gain in time because it did not swap.

I will add a commit to check if removing the upsampling change a lot the results.