### PR TITLE
Reduce memory usage of solid_angle 

### DIFF
--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -816,7 +816,10 @@ class WcsGeom(Geom):
 
     @lazyproperty
     def _solid_angle(self):
-        coord = self.to_image().get_coord(mode="edges").skycoord
+        if self.is_regular:
+            coord = self.to_image().get_coord(mode="edges").skycoord
+        else:
+            coord = self.get_coord(mode="edges").skycoord
 
         # define pixel corners
         low_left = coord[..., :-1, :-1]
@@ -843,9 +846,11 @@ class WcsGeom(Geom):
         area_up_left = 0.5 * up * left * np.sin(angle_up_left)
         # TODO: for non-negative cdelt a negative solid angle is returned
         #  find out why and fix properly
-        return np.abs(
-            u.Quantity(area_low_right + area_up_left, "sr", copy=False)
-        ).reshape(self.data_shape_image)
+
+        value = np.abs(u.Quantity(area_low_right + area_up_left, "sr", copy=False))
+        if self.is_regular:
+            value = value.reshape(self.data_shape_image)
+        return value
 
     def bin_volume(self):
         """Bin volume as a `~astropy.units.Quantity`."""

--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -808,7 +808,7 @@ class WcsGeom(Geom):
 
         The array has the same dimension as the WcsGeom object
         if the spatial shape is not unique along the extra axis,
-        otherwise the array shape matches of the spatial dimensions.
+        otherwise the array shape matches the spatial dimensions.
 
         To return solid angles for the spatial dimensions only use::
 

--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -806,7 +806,9 @@ class WcsGeom(Geom):
     def solid_angle(self):
         """Solid angle array as a `~astropy.units.Quantity` in ``sr``.
 
-        The array has the same dimension as the WcsGeom object.
+        The array has the same dimension as the WcsGeom object
+        if the spatial shape is not unique along the extra axis,
+        otherwise the array shape matches of the spatial dimensions.
 
         To return solid angles for the spatial dimensions only use::
 

--- a/gammapy/maps/wcs/tests/test_geom.py
+++ b/gammapy/maps/wcs/tests/test_geom.py
@@ -199,7 +199,7 @@ def test_wcsgeom_solid_angle():
     solid_angle = geom.solid_angle()
 
     # Check array size
-    assert solid_angle.shape == (2, npix, npix)
+    assert solid_angle.shape == (1, npix, npix)
 
     # Test at b = 0 deg
     assert solid_angle.unit == "sr"


### PR DESCRIPTION
Computes the solid angle only in 2d to save memory for regular geom.
(the multi-resolution maps use case is untested anyway). 