### PR TITLE
Support negative offset for Background2d.to_3d

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -134,6 +134,7 @@ class Background3D(BackgroundIRF):
         This takes the values at Y = 0 and X >= 0.
         """
         # TODO: this is incorrect as it misses the Jacobian?
+
         idx_lon = self.axes["fov_lon"].coord_to_idx(0 * u.deg)[0]
         idx_lat = self.axes["fov_lat"].coord_to_idx(0 * u.deg)[0]
         data = self.quantity[:, idx_lon:, idx_lat].copy()
@@ -245,10 +246,16 @@ class Background2D(BackgroundIRF):
 
     def to_3d(self):
         """Convert to Background3D."""
+        offsets = self.axes["offset"].edges
+        edges_neg = np.negative(offsets)[::-1][:-1]
+        if (offsets < 0.0).any():
+            edges_pos = offsets[1:]
+        else:
+            edges_pos = offsets
         edges = np.concatenate(
             (
-                np.negative(self.axes["offset"].edges)[::-1][:-1],
-                self.axes["offset"].edges,
+                edges_neg,
+                edges_pos,
             )
         )
         fov_lat = MapAxis.from_edges(edges=edges, name="fov_lat")

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -247,17 +247,9 @@ class Background2D(BackgroundIRF):
     def to_3d(self):
         """Convert to Background3D."""
         offsets = self.axes["offset"].edges
-        edges_neg = np.negative(offsets)[::-1][:-1]
-        if (offsets < 0.0).any():
-            edges_pos = offsets[1:]
-        else:
-            edges_pos = offsets
-        edges = np.concatenate(
-            (
-                edges_neg,
-                edges_pos,
-            )
-        )
+        edges_neg = np.negative(offsets)[::-1]
+        edges_neg = edges_neg[edges_neg <= 0]
+        edges = np.concatenate((edges_neg, offsets[offsets > 0]))
         fov_lat = MapAxis.from_edges(edges=edges, name="fov_lat")
         fov_lon = MapAxis.from_edges(edges=edges, name="fov_lon")
 

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -137,7 +137,6 @@ def test_plot_at_energy(bkg_3d):
 
 
 def test_background_3d_missing_values(bkg_3d_interp):
-
     res = bkg_3d_interp.evaluate(
         fov_lon=0.5 * u.deg,
         fov_lat=0.5 * u.deg,
@@ -423,3 +422,20 @@ def test_write_bkg_3d():
     bg = Background3D.read("background.fits", hdu="BACKGROUND")
 
     assert bg.fov_alignment.value == "ALTAZ"
+
+
+def test_to2d_to3d():
+    # Test for issue 4950
+    energy = [0.1, 10, 1000] * u.TeV
+    energy_axis = MapAxis.from_energy_edges(energy)
+    nbin = 21
+    fov_lon_axis = MapAxis.from_bounds(-2 * u.deg, 2 * u.deg, nbin=nbin, name="fov_lon")
+    fov_lat_axis = MapAxis.from_bounds(-2 * u.deg, 2 * u.deg, nbin=nbin, name="fov_lat")
+    data = np.ones((2, nbin, nbin))
+    bkg = Background3D(
+        axes=[energy_axis, fov_lon_axis, fov_lat_axis], data=data, unit="s-1 GeV-1 sr-1"
+    )
+    bkg2d = bkg.to_2d()
+    assert_allclose(bkg2d.axes["offset"].center[0].value, 0.0, atol=1e-5)
+    bkg3d = bkg2d.to_3d()
+    assert bkg3d.axes["fov_lon"].is_allclose(fov_lon_axis)

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -431,7 +431,7 @@ def test_to2d_to3d():
     nbin = 21
     fov_lon_axis = MapAxis.from_bounds(-2 * u.deg, 2 * u.deg, nbin=nbin, name="fov_lon")
     fov_lat_axis = MapAxis.from_bounds(-2 * u.deg, 2 * u.deg, nbin=nbin, name="fov_lat")
-    data = np.ones((2, nbin, nbin))
+    data = np.ones((2, nbin, nbin)) * 1.5
     bkg = Background3D(
         axes=[energy_axis, fov_lon_axis, fov_lat_axis], data=data, unit="s-1 GeV-1 sr-1"
     )
@@ -439,3 +439,4 @@ def test_to2d_to3d():
     assert_allclose(bkg2d.axes["offset"].center[0].value, 0.0, atol=1e-5)
     bkg3d = bkg2d.to_3d()
     assert bkg3d.axes["fov_lon"].is_allclose(fov_lon_axis)
+    assert_allclose(bkg3d.data[0][10], bkg.data[0][10], rtol=1e-5)


### PR DESCRIPTION
This fixes #4950

I don't think having the first bin centered on zero is necessarily prevented by the GADF, so I just adapted the `to_3d` function