### PR TITLE
Consistency format Part 1

### DIFF
--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -149,7 +149,7 @@ class GTI:
         ----------
         table_hdu : `~astropy.io.fits.BinTableHDU`
             table hdu.
-        format : str, optional
+        format : {"gadf"}
             Input format, currently only "gadf" is supported. Default is "gadf".
         """
         if format != "gadf":

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -574,7 +574,7 @@ class Observation:
             Path for the output file.
         overwrite : bool, optional
             Overwrite existing file. Default is False.
-        format : str, optional
+        format : {"gadf"}
             Output format, currently only "gadf" is supported. Default is "gadf".
         include_irfs : bool, optional
             Whether to include irf components in the output file. Default is True.

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -277,7 +277,7 @@ class FixedPointingInfo:
 
         Parameters
         ----------
-        format : str, optional
+        format : {"gadf"}
             Format, currently only "gadf" is supported. Default is "gadf".
         version : str, optional
             Version of the ``format``, this function currently supports

--- a/gammapy/data/utils.py
+++ b/gammapy/data/utils.py
@@ -30,10 +30,9 @@ def get_irfs_features(
         Offset calculated from the pointing position. Default is None.
         If neither the `position` nor the `fixed_offset` is specified,
         it uses the position of the center of the map by default.
-    names : list of str, optional
+    names : {"edisp-bias", "edisp-res", "psf-radius"}
         IRFs properties to be considered.
-        Available options are ["edisp-bias", "edisp-res", "psf-radius"]. Default is None.
-        If None, all the features are computed.
+        Default is None. If None, all the features are computed.
     containment_fraction : float, optional
         Containment_fraction to compute the `psf-radius`.
         Default is 68%.

--- a/gammapy/datasets/io.py
+++ b/gammapy/datasets/io.py
@@ -64,8 +64,8 @@ class OGIPDatasetWriter(DatasetWriter):
         Filename.
     format : {"ogip", "ogip-sherpa"}
         Which format to use. Default is 'ogip'.
-    overwrite : bool
-        Overwrite existing files? Default is False.
+    overwrite : bool, optional
+        Overwrite existing files. Default is False.
     checksum : bool
         When True adds both DATASUM and CHECKSUM cards to the headers written to the files.
         Default is False.

--- a/gammapy/estimators/map/asmooth.py
+++ b/gammapy/estimators/map/asmooth.py
@@ -39,9 +39,9 @@ class ASmoothMapEstimator(Estimator):
     spectrum : `SpectralModel`
         Spectral model assumption.
     method : {'asmooth', 'lima'}
-        Significance estimation method.
+        Significance estimation method. Default is 'lima'.
     threshold : float
-        Significance threshold.
+        Significance threshold. Default is 5.
     energy_edges : list of `~astropy.units.Quantity`, optional
         Edges of the target maps energy bins. The resulting bin edges won't be exactly equal to the input ones,
         but rather the closest values to the energy axis edges of the parent dataset.

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -121,7 +121,7 @@ class FluxPoints(FluxMaps):
             Filename.
         sed_type : {"dnde", "flux", "eflux", "e2dnde", "likelihood"}
             SED type.
-        format : {"gadf-sed", "lightcurve"}, optional
+        format : {"gadf-sed", "lightcurve"}
             Format string. Default is "gadf-sed".
         reference_model : `SpectralModel`
             Reference spectral model.

--- a/gammapy/estimators/profile.py
+++ b/gammapy/estimators/profile.py
@@ -22,10 +22,10 @@ class ImageProfileEstimator(Estimator):
     ----------
     x_edges : `~astropy.coordinates.Angle`, optional
         Coordinate edges to define a custom measurement grid.
-    method : ['sum', 'mean'], optional
-        Compute sum or mean within profile bins.
-    axis : ['lon', 'lat', 'radial'], optional
-        Along which axis to estimate the profile.
+    method : {'sum', 'mean'}
+        Compute sum or mean within profile bins. Default is 'sum'.
+    axis : {'lon', 'lat', 'radial'}
+        Along which axis to estimate the profile. Default is 'lon'.
     center : `~astropy.coordinates.SkyCoord`, optional
         Center coordinate for the radial profile option.
 

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -30,7 +30,7 @@ class BackgroundIRF(IRF):
         ----------
         table : `~astropy.table.Table`
             Table with background data.
-        format : {"gadf-dl3"}, optional
+        format : {"gadf-dl3"}
             Format specification. Default is "gadf-dl3".
 
         Returns

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -411,7 +411,7 @@ class IRF(metaclass=abc.ABCMeta):
             HDU list.
         hdu : str
             HDU name.
-        format : {"gadf-dl3"}, optional
+        format : {"gadf-dl3"}
             Format specification. Default is "gadf-dl3".
 
         Returns

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -266,7 +266,7 @@ class EDispKernel(IRF):
 
         Parameters
         ----------
-        format : {"ogip", "ogip-sherpa"}, optional
+        format : {"ogip", "ogip-sherpa"}
             Format to use. Default is "ogip".
 
         Returns
@@ -318,7 +318,7 @@ class EDispKernel(IRF):
 
         Parameters
         ----------
-        format : {"ogip", "ogip-sherpa"}, optional
+        format : {"ogip", "ogip-sherpa"}
             Format to use. Default is "ogip".
 
         Returns
@@ -387,7 +387,7 @@ class EDispKernel(IRF):
         ----------
         filename : str
             Filename.
-        format : {"ogip", "ogip-sherpa"}, optional
+        format : {"ogip", "ogip-sherpa"}
             Format to use. Default is "ogip".
 
         """

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -214,7 +214,7 @@ class EffectiveAreaTable2D(IRF):
         energy_axis_true : `MapAxis`, optional
             Energy binning, analytic function is evaluated at log centers.
             Default is None.
-        instrument : {'HESS', 'HESS2', 'CTA'}, optional
+        instrument : {'HESS', 'HESS2', 'CTA'}
             Instrument name. Default is 'HESS'.
 
         Returns

--- a/gammapy/irf/psf/parametric.py
+++ b/gammapy/irf/psf/parametric.py
@@ -106,7 +106,7 @@ class ParametricPSF(PSF):
 
         Parameters
         ----------
-        format : {"gadf-dl3"}, optional
+        format : {"gadf-dl3"}
             Format specification. Default is "gadf-dl3".
 
 


### PR DESCRIPTION
This PR is part 1 to resolve #4870.

**Description**
It provides a unified format for various string options.

**Dear reviewer**
In this PR there are a number of `format` options. Could you please double check that all options are actually listed within the docstring. 