### PR TITLE
Adjust getting-started page

### DIFF
--- a/docs/getting-started/environments.rst
+++ b/docs/getting-started/environments.rst
@@ -29,13 +29,6 @@ and then just execute the following commands in the terminal:
     lines with ``sherpa`` and ``healpy``. Those are optional dependencies that
     currently aren't available on Windows.
 
-.. note::
-
-    For Apple silicon M1 (`arm64`) architectures you also have to open the
-    environment file and delete the `sherpa` entry, as currently there are
-    no conda packages available. However you can later install `sherpa`
-    in the environment using `python -m pip install sherpa`.
-
 Once the environment has been created you can activate it using:
 
 .. substitution-code-block:: bash

--- a/docs/getting-started/environments.rst
+++ b/docs/getting-started/environments.rst
@@ -8,12 +8,43 @@ We recommend to create an isolated virtual environment for each version of Gamma
 control over additional packages that you may use in your analysis. This will also help you on improving
 reproducibility within the user community.
 
+
 Conda Environments
 ------------------
-For convenience we also provide, for each stable release of Gammapy,
-a YAML file that allows you to easily create a specific conda execution environment.
-See  :ref:`start installation quick instructions <quickstart-setup>` section. To create a new custom
-environment for your analysis with conda you can use:
+
+For convenience we provide, for each stable release of Gammapy,
+a pre-defined conda environment file, so you can
+get additional useful packages together with Gammapy in a virtual isolated
+environment. First install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`__
+and then just execute the following commands in the terminal:
+
+.. substitution-code-block:: bash
+
+    $ curl -O https://gammapy.org/download/install/gammapy-|release|-environment.yml
+    $ conda env create -f gammapy-|release|-environment.yml
+
+.. note::
+
+    On Windows, you have to open up the conda environment file and delete the
+    lines with ``sherpa`` and ``healpy``. Those are optional dependencies that
+    currently aren't available on Windows.
+
+.. note::
+
+    For Apple silicon M1 (`arm64`) architectures you also have to open the
+    environment file and delete the `sherpa` entry, as currently there are
+    no conda packages available. However you can later install `sherpa`
+    in the environment using `python -m pip install sherpa`.
+
+Once the environment has been created you can activate it using:
+
+.. substitution-code-block:: bash
+
+    $ conda activate gammapy-|release|
+
+
+
+To create a new custom environment for your analysis with conda you can use:
 
 .. code-block:: bash
 

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -21,26 +21,18 @@ There are various ways for users to install Gammapy. We recommend setting up an
 environment using either conda or mamba. Here are two methods to quickly install Gammapy.
 
 .. panels::
-    :column: col-12 p-3
+    :column: col-lg-6 col-md-6 col-sm-12 col-xs-12 p-3
 
     Working with conda?
     ^^^^^^^^^^^^^^^^^^^
 
-    First set up and activate your environment:
-
-    .. code-block:: bash
-
-        $ conda create -n gammapy
-        $ conda activate gammapy
-
-    Gammapy can then be installed with `Anaconda <https://docs.continuum.io/anaconda/>`__:
+    Gammapy can be installed with `Anaconda <https://docs.continuum.io/anaconda/>`__:
 
     .. code-block:: bash
 
         $ conda install -c conda-forge gammapy
 
     ---
-    :column: col-12 p-3
 
     Prefer pip?
     ^^^^^^^^^^^

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -17,19 +17,30 @@ Getting started
 Installation
 ------------
 
+There are various ways for users to install Gammapy. We recommend setting up an
+environment using either conda or mamba. Here are two methods to quickly install Gammapy.
+
 .. panels::
-    :column: col-lg-6 col-md-6 col-sm-12 col-xs-12 p-3
+    :column: col-12 p-3
 
     Working with conda?
     ^^^^^^^^^^^^^^^^^^^
 
-    Gammapy can be installed with `Anaconda <https://docs.continuum.io/anaconda/>`__ or Miniconda:
+    First set up and activate your environment:
+
+    .. code-block:: bash
+
+        $ conda create -n gammapy
+        $ conda activate gammapy
+
+    Gammapy can then be installed with `Anaconda <https://docs.continuum.io/anaconda/>`__:
 
     .. code-block:: bash
 
         $ conda install -c conda-forge gammapy
 
     ---
+    :column: col-12 p-3
 
     Prefer pip?
     ^^^^^^^^^^^

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -17,8 +17,8 @@ Getting started
 Installation
 ------------
 
-There are various ways for users to install Gammapy. We recommend setting up an
-environment using either conda or mamba. Here are two methods to quickly install Gammapy.
+There are various ways for users to install Gammapy. **We recommend setting up a virtual
+environment using either conda or mamba.** Here are two methods to quickly install Gammapy.
 
 .. panels::
     :column: col-lg-6 col-md-6 col-sm-12 col-xs-12 p-3

--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -5,12 +5,12 @@
 Installation
 ============
 
-There are many ways to install Python and Gammapy as a user. On this page we list the most common ones.
-In general **we recommend to use virtual environments** when using Gammapy. This ways you have full
-control over additional packages that you may use in your analysis and you work with
-well defined computing environments, that you can share and allow **reproducibility of your
-scientific analysis results**. If you want to learn about using virtual environments see :ref:`virtual-envs`.
-You can also :ref:`install Gammapy for development <dev_setup>`.
+There are numerous ways to install Python and Gammapy as a user. On this page, we list the most common ones.
+In general, **we recommend using** :ref:`virtual environments <virtual-envs>` when using Gammapy. This
+way you have complete control over the additional packages that you may use in your analysis and you work with
+well defined computing environments. This enables you to easily share your work and ensure **reproducibility of your
+scientific analysis results**. You can also :ref:`install Gammapy for development <dev_setup>`.
+
 
 .. _anaconda:
 
@@ -35,28 +35,28 @@ To install a specific version of Gammapy just execute:
 
 .. code-block:: bash
 
-    $ conda install -c conda-forge gammapy=0.19
+    $ conda install -c conda-forge gammapy=1.0
 
-If you encountered any issues you can check the :ref:`troubleshoot` guide.
+If you encounter any issues you can check the :ref:`troubleshoot` guide.
 
 Using Mamba
 -----------
 Alternatively, you can use `Mamba <https://mamba.readthedocs.io/>`__ for the installation.
-Mamba is an alternative package manager that support most of conda’s command but offers higher installation
+Mamba is an alternative package manager that supports most of conda’s commands but offers higher installation
 speed and more reliable environment solutions. To install ``mamba`` in the Conda base environment:
 
 .. code-block:: bash
 
     $ conda install mamba -n base -c conda-forge
 
-then:
+Then install Gammapy through:
 
 .. code-block:: bash
 
     $ mamba install gammapy
 
-Mamba supports of the commands that are available for conda. So updating and installing specific versions
-works the same way as above except for replacing the ``conda`` with the ``mamba`` command.
+Mamba supports the same commands available in conda. Therefore, updating and installing specific versions
+follows the same process as above, just simply replace the ``conda`` command with the ``mamba`` command.
 
 .. _install-pip:
 
@@ -86,25 +86,25 @@ To install Gammapy with all optional dependencies, you can specify:
    $ python -m pip install gammapy[all]
 
 
-To update an existing installation you can use:
+To update an existing installation use:
 
 .. code-block:: bash
 
    $ python -m pip install gammapy --upgrade
 
-To install a specific version of Gammapy you can use:
+To install a specific version of Gammapy use:
 
 .. code-block:: bash
 
-    $ python -m pip install gammapy==0.19
+    $ python -m pip install gammapy==1.0
 
-To install the current Gammapy **development** version using `pip`_ you can use:
+To install the current Gammapy **development** version with `pip`_ use:
 
 .. code-block:: bash
 
    $ python -m pip install git+https://github.com/gammapy/gammapy.git#egg=gammapy
 
-Or like this, if you want to study or edit the code locally:
+If you want to study or edit the code locally, use the following:
 
 .. code-block:: bash
 
@@ -112,7 +112,7 @@ Or like this, if you want to study or edit the code locally:
    $ cd gammapy
    $ python -m pip install .
 
-If you encountered any issues you can check the :ref:`troubleshoot` guide.
+If you encounter any issues you can check the :ref:`troubleshoot` guide.
 
 .. _install-other:
 
@@ -138,8 +138,8 @@ Example:
         python3-pip python3-matplotlib \
         ipython3-notebook python3-gammapy
 
-    $ python3 -m pip install antigravity
+    $ python3 -m pip install gammapy
 
 Note that the Linux package managers typically have release cycles of 6 months,
 or yearly or longer, meaning that you'll typically  get an older version of
-Gammapy. But you can always get a recent version via `pip` or `conda` (see above).
+Gammapy. However, you can always get the recent version via `pip` or `conda` (see above).

--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -71,13 +71,6 @@ using `pip`_:
    $ python -m pip install gammapy
 
 This will install Gammapy with the required dependencies only.
-
-.. note::
-
-    For Apple silicon M1 (`arm64`) architectures you also have to open the
-    environment file and delete the `sherpa` entry, as currently there are
-    no conda packages available. However you can later install `sherpa`
-    in the environment using `python -m pip install sherpa`.
     
 To install Gammapy with all optional dependencies, you can specify:
 

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -19,9 +19,10 @@ execute the following commands in the terminal:
 
 .. note::
 
-    For Apple silicon M1 (`arm64`) architectures you also have to open the
-    environment file and delete the `sherpa` entry, as currently there are
-    no conda packages available. However you can later install `sherpa`
+    For gammapy versions **prior to v1.2**, if you're using
+    Apple silicon M1 (`arm64`) architectures you have to open the
+    environment file and delete the `sherpa` entry. Currently there are
+    no conda packages available. You can then install `sherpa`
     in the environment using `python -m pip install sherpa`.
 
 

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -11,6 +11,19 @@ execute the following commands in the terminal:
     $ curl -O https://gammapy.org/download/install/gammapy-|release|-environment.yml
     $ conda env create -f gammapy-|release|-environment.yml
 
+.. note::
+
+    On Windows, you have to open up the conda environment file and delete the
+    lines with ``sherpa`` and ``healpy``. Those are optional dependencies that
+    currently aren't available on Windows.
+
+.. note::
+
+    For Apple silicon M1 (`arm64`) architectures you also have to open the
+    environment file and delete the `sherpa` entry, as currently there are
+    no conda packages available. However you can later install `sherpa`
+    in the environment using `python -m pip install sherpa`.
+
 
 The best way to get started and learn Gammapy are the :ref:`tutorials`.
 You can download the Gammapy tutorial notebooks and the example
@@ -19,6 +32,7 @@ want to install the datasets and proceed with the following commands:
 
 .. substitution-code-block:: bash
 
+    $ conda activate gammapy-|release|
     $ gammapy download notebooks
     $ gammapy download datasets
     $ conda env config vars set GAMMAPY_DATA=$PWD/gammapy-datasets/|release|

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -3,6 +3,15 @@
 Recommended Setup
 -----------------
 
+We recommend using :ref:`virtual environments <virtual-envs>`, to do so
+execute the following commands in the terminal:
+
+.. substitution-code-block:: bash
+
+    $ curl -O https://gammapy.org/download/install/gammapy-|release|-environment.yml
+    $ conda env create -f gammapy-|release|-environment.yml
+
+
 The best way to get started and learn Gammapy are the :ref:`tutorials`.
 You can download the Gammapy tutorial notebooks and the example
 datasets. The total size to download is ~180 MB. Select the location where you

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -1,7 +1,7 @@
 .. _quickstart-setup:
 
-Quickstart Setup
-----------------
+Recommended Setup
+-----------------
 
 The best way to get started and learn Gammapy are the :ref:`tutorials`.
 You can download the Gammapy tutorial notebooks and the example

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -3,37 +3,8 @@
 Quickstart Setup
 ----------------
 
-The best way to get started and learn Gammapy are the :ref:`tutorials`. For
-convenience we provide a pre-defined conda environment file, so you can
-get additional useful packages together with Gammapy in a virtual isolated
-environment. First install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`__
-and then just execute the following commands in the terminal:
-
-.. substitution-code-block:: bash
-
-    $ curl -O https://gammapy.org/download/install/gammapy-|release|-environment.yml
-    $ conda env create -f gammapy-|release|-environment.yml
-
-.. note::
-
-    On Windows, you have to open up the conda environment file and delete the
-    lines with ``sherpa`` and ``healpy``. Those are optional dependencies that
-    currently aren't available on Windows.
-
-.. note::
-
-    For Apple silicon M1 (`arm64`) architectures you also have to open the
-    environment file and delete the `sherpa` entry, as currently there are
-    no conda packages available. However you can later install `sherpa`
-    in the environment using `python -m pip install sherpa`.
-
-Once the environment has been created you can activate it using:
-
-.. substitution-code-block:: bash
-
-    $ conda activate gammapy-|release|
-
-You can now proceed to download the Gammapy tutorial notebooks and the example
+The best way to get started and learn Gammapy are the :ref:`tutorials`.
+You can download the Gammapy tutorial notebooks and the example
 datasets. The total size to download is ~180 MB. Select the location where you
 want to install the datasets and proceed with the following commands:
 
@@ -60,7 +31,7 @@ variable directly in your shell with:
     else instead of ``export``, and also the profile setup file will be different.
     On Windows, you should set the ``GAMMAPY_DATA`` environment variable in the
     "Environment Variables" settings dialog, as explained e.g.
-    `here <https://docs.python.org/3/using/windows.html#excursus-setting-environment-variables>`__
+    `here <https://docs.python.org/3/using/windows.html#excursus-setting-environment-variables>`__.
 
 Finally start a notebook server by executing:
 
@@ -69,5 +40,5 @@ Finally start a notebook server by executing:
     $ cd notebooks
     $ jupyter notebook
 
-If you are new to conda, Python and Jupyter, maybe also read the :ref:`using-gammapy` guide.
-If you encountered any issues you can check the :ref:`troubleshoot` guide.
+If you are new to conda, Python and Jupyter, it is recommended to also read the :ref:`using-gammapy` guide.
+If you encounter any issues you can check the :ref:`troubleshoot` guide.

--- a/docs/getting-started/troubleshooting.rst
+++ b/docs/getting-started/troubleshooting.rst
@@ -9,15 +9,14 @@ Troubleshooting
 
 Check your setup
 ----------------
-You might want to display some info about Gammapy installed. You can execute
-the following command, and it should print detailed information about your
-installation to the terminal:
+To access detailed information about your Gammapy installation, you can execute the following
+command. It will provide insight into the installation directly to the terminal.
 
 .. code-block:: bash
 
     gammapy info
 
-If there is some issue, the following commands could help you to figure out
+If you encounter some issues, the following commands can help you in troubleshooting
 your setup:
 
 .. code-block:: bash
@@ -30,24 +29,24 @@ your setup:
     env | grep PATH
     python -c 'import gammapy; print(gammapy); print(gammapy.__version__)'
 
-You can also use the following commands to check which conda environment is active and which
-ones you have set up:
+You can also use the following commands to check which conda environment is active and to
+list all available environments:
 
 .. code-block:: bash
 
     conda info
     conda env list
 
-If you're new to conda, you could also print out the `conda cheat sheet`_, which
-lists the common commands to install packages and work with environments.
+For those that are new to conda, you can consult the `conda cheat sheet`_, which
+lists the common commands for installing packages and working with environments.
 
 
 Install issues
 --------------
 
-If you have problems and think you might not be using the right Python or
-importing Gammapy isn't working or giving you the right version, checking your
-Python executable and import path might help you find the issue:
+If you're experiencing issues and believe you are using the incorrect Python or Gammapy version, or
+if you encounter problems importing Gammapy, you should check your Python executable and import path
+to help you resolve the issue:
 
 .. code-block:: python
 
@@ -55,7 +54,7 @@ Python executable and import path might help you find the issue:
     print(sys.executable)
     print(sys.path)
 
-To check which Gammapy you are using you can use this:
+To check your Gammapy version use the following commands:
 
 .. code-block:: python
 
@@ -63,7 +62,8 @@ To check which Gammapy you are using you can use this:
     print(gammapy)
     print(gammapy.__version__)
 
-Now you should be all set and to use Gammapy. Let's move on to the
+
+You should now be ready to start using Gammapy. Let's move on to the
 :ref:`tutorials`.
 
 
@@ -71,4 +71,4 @@ Help!?
 ------
 
 If you have any questions or issues, please ask for help on the Gammapy Slack,
-mailing list or on GitHub, see `Gammapy contact`_.
+mailing list or on GitHub (see `Gammapy contact`_).

--- a/docs/getting-started/usage.rst
+++ b/docs/getting-started/usage.rst
@@ -7,7 +7,7 @@ Using Gammapy
 =============
 
 To use Gammapy you need a basic knowledge of Python, Numpy, Astropy, as well as
-matplotlib for plotting. Many standard gamma-ray analyses can be done with few
+matplotlib for plotting. Many standard gamma-ray analyses can be done with a few
 lines of configuration and code, so you can get pretty far by copy and pasting
 and adapting the working examples from the Gammapy documentation. But
 eventually, if you want to script more complex analyses, or inspect analysis
@@ -18,7 +18,8 @@ Jupyter notebooks
 -----------------
 
 To learn more about Gammapy, and also for interactive data analysis in general,
-we recommend you use Jupyter notebooks. Assuming you have followed the steps above to install Gammapy and activate the conda environment, you can start
+we recommend you use Jupyter notebooks. Assuming you have followed the steps above to install
+Gammapy and activate the conda environment, you can start
 `JupyterLab`_ like this:
 
 .. code-block:: bash
@@ -75,7 +76,7 @@ method** from IPython:
     In [3]: CashCountsStatistic?
 
 Of course, you can also use the Gammapy online docs if you prefer, clicking in links
-(i.e. `gammapy.stats.CashCountsStatistic`) or using *search docs* field in the upper left.
+(i.e. `gammapy.stats.CashCountsStatistic`) or using *Search the docs* field in the upper left.
 
 As an example, here's how you can create `gammapy.data.DataStore` and
 `gammapy.data.EventList` objects and start exploring H.E.S.S. data:
@@ -121,7 +122,7 @@ Python scripts
 --------------
 
 Another common way to use Gammapy is to write a Python script.
-Try it and put the following code into a file called ``example.py``:
+Try it by putting the following code into a file called ``example.py``:
 
 .. testcode::
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -46,7 +46,6 @@ dependencies:
   - naima
   - pandas
   - reproject
-  - sherpa
   # dev dependencies
   - black=22.6.0
   - codespell

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -46,6 +46,7 @@ dependencies:
   - naima
   - pandas
   - reproject
+  - sherpa
   # dev dependencies
   - black=22.6.0
   - codespell

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -46,7 +46,6 @@ dependencies:
   - naima
   - pandas
   - reproject
-  - sherpa
   # dev dependencies
   - black=22.6.0
   - codespell
@@ -78,6 +77,7 @@ dependencies:
   - pyinstrument
   - memray
   - pip:
+      - sherpa
       - pytest-sphinx
       - ray[default]>=2.9
       - PyGithub


### PR DESCRIPTION
**Description**
This PR is to resolve #4838. It adjusts the `Getting started` page to be far more simple and realistic to how we would typically install gammapy. 

Then the other pages (`Installation`, `Virtual Environments` etc) are adjusted accordingly. 

https://astro-kirsty.github.io/gammapy-docs-preview/