### PR TITLE
Sherpa pip channel

### DIFF
--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -20,13 +20,6 @@ and then just execute the following commands in the terminal:
     lines with ``sherpa`` and ``healpy``. Those are optional dependencies that
     currently aren't available on Windows.
 
-.. note::
-
-    For Apple silicon M1 (`arm64`) architectures you also have to open the
-    environment file and delete the `sherpa` entry, as currently there are
-    no conda packages available. However you can later install `sherpa`
-    in the environment using `python -m pip install sherpa`.
-
 Once the environment has been created you can activate it using:
 
 .. substitution-code-block:: bash

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -46,7 +46,6 @@ dependencies:
   - naima
   - pandas
   - reproject
-  - sherpa
   # dev dependencies
   - black=22.6.0
   - codespell
@@ -82,3 +81,4 @@ dependencies:
       - ray
       - PyGithub
       - pypandoc
+      - sherpa


### PR DESCRIPTION
Since we have a few dependencies in the explicit pip channel of the environment file, I moved sherpa in this section so that we don't need the note on sherpa with Apple Silicon in the quickstart page of the documentation. 
Now sherpa installation should work on all Linux and Apple OS. 