### PR TITLE
Adding a function to guess the format of a FluxPoints object for serialization

### DIFF
--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -436,7 +436,7 @@ class FluxPoints(FluxMaps):
                 table_flat["time_max"] = [time_max.mjd]
 
                 fp = self.slice_by_idx(slices={"time": idx})
-                table = fp.to_table(sed_type=sed_type)
+                table = fp.to_table(sed_type=sed_type, format="gadf-sed")
 
                 for column in table.columns:
                     table_flat[column] = table[column][np.newaxis]
@@ -483,7 +483,7 @@ class FluxPoints(FluxMaps):
                 table_flat["x_ref"] = [(x_max + x_min) / 2]
 
                 fp = self.slice_by_idx(slices={"projected-distance": idx})
-                table = fp.to_table(sed_type=sed_type)
+                table = fp.to_table(sed_type=sed_type, format="gadf-sed")
 
                 for column in table.columns:
                     table_flat[column] = table[column][np.newaxis]

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -246,7 +246,7 @@ class FluxPoints(FluxMaps):
             Table.
         sed_type : {"dnde", "flux", "eflux", "e2dnde", "likelihood"}, optional
             SED type. Default is None.
-        format : {"gadf-sed", "lightcurve", "profile"}
+        format : {"gadf-sed", "lightcurve", "profile"}, optional
             Table format. If None, it is extracted from the table column content. Default is None.
         reference_model : `SpectralModel`, optional
             Reference spectral model. Default is None.

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -156,7 +156,7 @@ class FluxPoints(FluxMaps):
             gti=gti,
         )
 
-    def write(self, filename, sed_type=None, overwrite=False):
+    def write(self, filename, sed_type=None, format=None, overwrite=False):
         """Write flux points.
 
         Parameters
@@ -165,6 +165,23 @@ class FluxPoints(FluxMaps):
             Filename.
         sed_type : {"dnde", "flux", "eflux", "e2dnde", "likelihood"}, optional
             SED type. Default is None.
+        format : {"gadf-sed", "lightcurve", "binned-time-series", "profile"}, optional
+            Format specification. The following formats are supported:
+
+                * "gadf-sed": format for SED flux points see :ref:`gadf:flux-points`
+                  for details
+                * "lightcurve": Gammapy internal format to store energy dependent
+                  lightcurves. Basically a generalisation of the "gadf" format, but
+                  currently there is no detailed documentation available.
+                * "binned-time-series": table format support by Astropy's
+                  `~astropy.timeseries.BinnedTimeSeries`.
+                * "profile": Gammapy internal format to store energy dependent
+                  flux profiles. Basically a generalisation of the "gadf" format, but
+                  currently there is no detailed documentation available.
+
+                If None, the format will be guessed by looking at the axes that are present in the object.
+                Default is None.
+
         overwrite : bool, optional
             Overwrite existing file. Default is False.
         """
@@ -172,7 +189,7 @@ class FluxPoints(FluxMaps):
 
         if sed_type is None:
             sed_type = self.sed_type_init
-        table = self.to_table(sed_type=sed_type)
+        table = self.to_table(sed_type=sed_type, format=format)
 
         # TODO: rather ugly - better method?
         if ".fits" not in filename.suffixes:
@@ -302,13 +319,30 @@ class FluxPoints(FluxMaps):
         else:
             return "gadf-sed"
 
-    def to_table(self, sed_type=None, formatted=False):
+    def to_table(self, sed_type=None, format=None, formatted=False):
         """Create table for a given SED type.
 
         Parameters
         ----------
         sed_type : {"likelihood", "dnde", "e2dnde", "flux", "eflux"}
             SED type to convert to. Default is `likelihood`.
+        format : {"gadf-sed", "lightcurve", "binned-time-series", "profile"}, optional
+            Format specification. The following formats are supported:
+
+                * "gadf-sed": format for SED flux points see :ref:`gadf:flux-points`
+                  for details
+                * "lightcurve": Gammapy internal format to store energy dependent
+                  lightcurves. Basically a generalisation of the "gadf" format, but
+                  currently there is no detailed documentation available.
+                * "binned-time-series": table format support by Astropy's
+                  `~astropy.timeseries.BinnedTimeSeries`.
+                * "profile": Gammapy internal format to store energy dependent
+                  flux profiles. Basically a generalisation of the "gadf" format, but
+                  currently there is no detailed documentation available.
+
+                If None, the format will be guessed by looking at the axes that are present in the object.
+                Default is None.
+
         formatted : bool
             Formatted version with column formats applied. Numerical columns are
             formatted to .3f and .3e respectively. Default is False.
@@ -336,7 +370,8 @@ class FluxPoints(FluxMaps):
         if sed_type is None:
             sed_type = self.sed_type_init
 
-        format = self._guess_format
+        if format is None:
+            format = self._guess_format()
 
         if format == "gadf-sed":
             # TODO: what to do with GTI info?

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -262,6 +262,7 @@ class FluxPoints(FluxMaps):
 
         if format is None:
             format = cls._table_guess_format(table)
+            log.info("Inferred format: " + format)
 
         if sed_type is None:
             sed_type = table.meta.get("SED_TYPE", None)
@@ -385,6 +386,7 @@ class FluxPoints(FluxMaps):
 
         if format is None:
             format = self._guess_format()
+            log.info("Inferred format: " + format)
 
         if format == "gadf-sed":
             # TODO: what to do with GTI info?

--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -96,7 +96,7 @@ def test_lightcurve_properties_time(lc):
 
 
 def test_lightcurve_properties_flux(lc):
-    table = lc.to_table(sed_type="flux", format="lightcurve")
+    table = lc.to_table(sed_type="flux")
     flux = table["flux"].quantity
     assert flux.unit == "cm-2 s-1"
     assert_allclose(flux.value, [[1e-11], [3e-11]])
@@ -109,7 +109,7 @@ def test_lightcurve_properties_flux(lc):
 
 @pytest.mark.parametrize("sed_type", ["dnde", "flux", "likelihood"])
 def test_lightcurve_read_write(tmp_path, lc, sed_type):
-    lc.write(tmp_path / "tmp.fits", format="lightcurve", sed_type=sed_type)
+    lc.write(tmp_path / "tmp.fits", sed_type=sed_type)
 
     lc = FluxPoints.read(tmp_path / "tmp.fits", format="lightcurve")
     assert_allclose(lc.gti.time_start[0].mjd, 55197.000766, rtol=1e-5)
@@ -253,7 +253,7 @@ def test_lightcurve_estimator_spectrum_datasets():
     estimator.norm.scan_n_values = 3
 
     lightcurve = estimator.run(datasets)
-    table = lightcurve.to_table(format="lightcurve")
+    table = lightcurve.to_table()
     assert_allclose(table["time_min"], [55197.0, 55197.041667])
     assert_allclose(table["time_max"], [55197.041667, 55197.083333])
     assert_allclose(table["e_ref"], [[5.623413], [5.623413]])
@@ -313,7 +313,7 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
     )
     estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
-    table = lightcurve.to_table(format="lightcurve")
+    table = lightcurve.to_table()
 
     assert_allclose(table["time_min"], [55197.0, 55197.041667])
     assert_allclose(table["time_max"], [55197.041667, 55197.083333])
@@ -440,7 +440,7 @@ def test_lightcurve_estimator_spectrum_datasets_with_mask_fit():
     )
     estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
-    table = lightcurve.to_table(format="lightcurve")
+    table = lightcurve.to_table()
     assert_allclose(table["time_min"], [55197.0, 55197.041667])
     assert_allclose(table["time_max"], [55197.041667, 55197.083333])
     assert_allclose(table["stat"], [[6.603043], [0.421051]], rtol=1e-3)
@@ -458,7 +458,7 @@ def test_lightcurve_estimator_spectrum_datasets_default():
     )
     estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
-    table = lightcurve.to_table(format="lightcurve")
+    table = lightcurve.to_table()
     assert_allclose(table["time_min"], [55197.0, 55197.041667])
     assert_allclose(table["time_max"], [55197.041667, 55197.083333])
     assert_allclose(table["norm"], [[0.911963], [0.906931]], rtol=1e-3)
@@ -480,7 +480,7 @@ def test_lightcurve_estimator_spectrum_datasets_notordered():
     )
     estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
-    table = lightcurve.to_table(format="lightcurve")
+    table = lightcurve.to_table()
     assert_allclose(table["time_min"], [55197.0, 55197.041667])
     assert_allclose(table["time_max"], [55197.041667, 55197.083333])
     assert_allclose(table["norm"], [[0.911963], [0.906931]], rtol=1e-3)
@@ -498,7 +498,7 @@ def test_lightcurve_estimator_spectrum_datasets_largerbin():
     )
     estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
-    table = lightcurve.to_table(format="lightcurve")
+    table = lightcurve.to_table()
 
     assert_allclose(table["time_min"], [55197.0])
     assert_allclose(table["time_max"], [55197.083333])
@@ -529,7 +529,7 @@ def test_lightcurve_estimator_spectrum_datasets_emptybin():
     )
     estimator.norm.scan_n_values = 3
     lightcurve = estimator.run(datasets)
-    table = lightcurve.to_table(format="lightcurve")
+    table = lightcurve.to_table()
 
     assert_allclose(table["time_min"], [55197.0])
     assert_allclose(table["time_max"], [55197.083333])
@@ -606,7 +606,7 @@ def test_lightcurve_estimator_map_datasets():
         selection_optional=["scan"],
     )
     lightcurve = estimator.run(datasets)
-    table = lightcurve.to_table(format="lightcurve")
+    table = lightcurve.to_table()
     assert_allclose(table["time_min"], [55197.0, 55197.041667])
     assert_allclose(table["time_max"], [55197.041667, 55197.083333])
     assert_allclose(table["e_ref"], [[10.857111], [10.857111]])
@@ -631,7 +631,7 @@ def test_lightcurve_estimator_map_datasets():
         selection_optional=["scan"],
     )
     lightcurve2 = estimator2.run(datasets)
-    table = lightcurve2.to_table(format="lightcurve")
+    table = lightcurve2.to_table()
     assert_allclose(table["time_min"][0], [55197.0])
     assert_allclose(table["time_max"][0], [55197.083333])
     assert_allclose(table["e_ref"][0], [10.857111], rtol=1e-5)
@@ -665,7 +665,7 @@ def test_lightcurve_estimator_map_datasets_ray_actors():
         selection_optional=["scan"],
     )
     lightcurve = estimator.run(datasets)
-    table = lightcurve.to_table(format="lightcurve")
+    table = lightcurve.to_table()
     assert_allclose(table["time_min"], [55197.0, 55197.041667])
     assert_allclose(table["time_max"], [55197.041667, 55197.083333])
     assert_allclose(table["e_ref"], [[10.857111], [10.857111]])
@@ -690,7 +690,7 @@ def test_lightcurve_estimator_map_datasets_ray_actors():
         selection_optional=["scan"],
     )
     lightcurve2 = estimator2.run(datasets)
-    table = lightcurve2.to_table(format="lightcurve")
+    table = lightcurve2.to_table()
     assert_allclose(table["time_min"][0], [55197.0])
     assert_allclose(table["time_max"][0], [55197.083333])
     assert_allclose(table["e_ref"][0], [10.857111], rtol=1e-5)

--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -44,7 +44,7 @@ def lc():
     )
     gti = GTI.create("0h", "1h", "2010-01-01T00:00:00")
 
-    return FluxPoints.from_table(table=table, format="lightcurve", gti=gti)
+    return FluxPoints.from_table(table=table, gti=gti)
 
 
 @pytest.fixture(scope="session")
@@ -65,7 +65,7 @@ def lc_2d():
         ],
     )
 
-    return FluxPoints.from_table(table=table, format="lightcurve")
+    return FluxPoints.from_table(table=table)
 
 
 def test_lightcurve_str(lc):
@@ -111,7 +111,7 @@ def test_lightcurve_properties_flux(lc):
 def test_lightcurve_read_write(tmp_path, lc, sed_type):
     lc.write(tmp_path / "tmp.fits", sed_type=sed_type)
 
-    lc = FluxPoints.read(tmp_path / "tmp.fits", format="lightcurve")
+    lc = FluxPoints.read(tmp_path / "tmp.fits")
     assert_allclose(lc.gti.time_start[0].mjd, 55197.000766, rtol=1e-5)
 
     # Check if time-related info round-trips
@@ -283,9 +283,7 @@ def test_lightcurve_estimator_spectrum_datasets():
     assert table.meta["MJDREFI"] == 0
 
     # TODO: fix reference model I/O
-    fp = FluxPoints.from_table(
-        table=table, format="lightcurve", reference_model=PowerLawSpectralModel()
-    )
+    fp = FluxPoints.from_table(table=table, reference_model=PowerLawSpectralModel())
     assert fp.norm.geom.axes.names == ["energy", "time"]
     assert fp.counts.geom.axes.names == ["dataset", "energy", "time"]
     assert fp.stat_scan.geom.axes.names == ["norm", "energy", "time"]
@@ -407,9 +405,7 @@ def test_lightcurve_estimator_spectrum_datasets_2_energy_bins():
         rtol=1e-3,
     )
 
-    fp = FluxPoints.from_table(
-        table=table, format="lightcurve", reference_model=PowerLawSpectralModel()
-    )
+    fp = FluxPoints.from_table(table=table, reference_model=PowerLawSpectralModel())
     assert fp.norm.geom.axes.names == ["energy", "time"]
     assert fp.counts.geom.axes.names == ["dataset", "energy", "time"]
     assert fp.stat_scan.geom.axes.names == ["norm", "energy", "time"]

--- a/gammapy/estimators/points/tests/test_profile.py
+++ b/gammapy/estimators/points/tests/test_profile.py
@@ -63,7 +63,7 @@ def test_profile_content():
     )
     result = prof_maker.run(mapdataset_onoff)
 
-    imp_prof = result.to_table(sed_type="flux", format="profile")
+    imp_prof = result.to_table(sed_type="flux")
     assert_allclose(imp_prof[7]["x_min"], 0.1462, atol=1e-4)
     assert_allclose(imp_prof[7]["x_ref"], 0.1575, atol=1e-4)
     assert_allclose(imp_prof[7]["counts"], [[100.0], [100.0]], atol=1e-2)
@@ -98,7 +98,7 @@ def test_radial_profile():
     )
     result = prof_maker.run(dataset)
 
-    imp_prof = result.to_table(sed_type="flux", format="profile")
+    imp_prof = result.to_table(sed_type="flux")
 
     assert_allclose(imp_prof[7]["x_min"], 0.14, atol=1e-4)
     assert_allclose(imp_prof[7]["x_ref"], 0.15, atol=1e-4)
@@ -135,7 +135,7 @@ def test_radial_profile_one_interval():
     )
     result = prof_maker.run(dataset)
 
-    imp_prof = result.to_table(sed_type="flux", format="profile")
+    imp_prof = result.to_table(sed_type="flux")
 
     assert_allclose(imp_prof[7]["counts"], [[1960]], atol=1e-5)
     assert_allclose(imp_prof[7]["npred_excess"], [[1568.0]], rtol=1e-3)
@@ -163,7 +163,7 @@ def test_serialisation(tmpdir):
     est = FluxProfileEstimator(regions, energy_edges=[0.1, 10] * u.TeV)
     result = est.run(dataset)
 
-    result.write(tmpdir / "profile.fits", format="profile")
+    result.write(tmpdir / "profile.fits")
 
     profile = FluxPoints.read(
         tmpdir / "profile.fits",
@@ -208,17 +208,17 @@ def test_profile_with_model_or_mask():
         sum_over_energy_groups=True,
     )
     result = prof_maker.run(dataset)
-    imp_prof = result.to_table(sed_type="flux", format="profile")
+    imp_prof = result.to_table(sed_type="flux")
     assert_allclose(imp_prof[7]["npred_excess"], [[-1.115967]], rtol=1e-3)
 
     dataset.models = None
     result = prof_maker.run(dataset)
-    imp_prof = result.to_table(sed_type="flux", format="profile")
+    imp_prof = result.to_table(sed_type="flux")
     assert_allclose(imp_prof[7]["npred_excess"], [[112.95312]], rtol=1e-3)
 
     dataset.mask_fit = ~geom.region_mask([regions[7]])
     result = prof_maker.run(dataset)
-    imp_prof = result.to_table(sed_type="flux", format="profile")
+    imp_prof = result.to_table(sed_type="flux")
     assert_allclose(imp_prof[7]["npred_excess"], [[0]], rtol=1e-3)
 
 
@@ -242,7 +242,7 @@ def test_profile_multiprocessing():
         parallel_backend="multiprocessing",
     )
     result = prof_maker.run(dataset)
-    imp_prof = result.to_table(sed_type="flux", format="profile")
+    imp_prof = result.to_table(sed_type="flux")
     assert_allclose(imp_prof[7]["npred_excess"], [[-1.115967]], rtol=1e-3)
 
 
@@ -268,7 +268,7 @@ def test_profile_multiprocessing_ray_with_manager():
         assert prof_maker.n_jobs == 2
         assert prof_maker.parallel_backend == "ray"
         result = prof_maker.run(dataset)
-        imp_prof = result.to_table(sed_type="flux", format="profile")
+        imp_prof = result.to_table(sed_type="flux")
         assert_allclose(imp_prof[7]["npred_excess"], [[-1.115967]], rtol=1e-3)
 
 
@@ -293,5 +293,5 @@ def test_profile_multiprocessing_ray():
         parallel_backend="ray",
     )
     result = prof_maker.run(dataset)
-    imp_prof = result.to_table(sed_type="flux", format="profile")
+    imp_prof = result.to_table(sed_type="flux")
     assert_allclose(imp_prof[7]["npred_excess"], [[-1.115967]], rtol=1e-3)

--- a/gammapy/estimators/points/tests/test_profile.py
+++ b/gammapy/estimators/points/tests/test_profile.py
@@ -167,7 +167,6 @@ def test_serialisation(tmpdir):
 
     profile = FluxPoints.read(
         tmpdir / "profile.fits",
-        format="profile",
         reference_model=PowerLawSpectralModel(),
     )
 

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -274,7 +274,7 @@ def test_run_pwl(fpe_pwl, tmpdir):
     assert_allclose(npred_excess_ul, [742.87486, 479.169719, 49.019125], rtol=1e-3)
 
     # test GADF I/O
-    fp.write(tmpdir / "test.fits", format="gadf-sed")
+    fp.write(tmpdir / "test.fits")
     fp_new = FluxPoints.read(tmpdir / "test.fits")
     assert fp_new.meta["sed_type_init"] == "likelihood"
 
@@ -317,7 +317,7 @@ def test_run_ecpl(fpe_ecpl, tmpdir):
     assert_allclose(actual, [7.678454, 4.735691, 0.399243], rtol=1e-2)
 
     # test GADF I/O
-    fp.write(tmpdir / "test.fits", format="gadf-sed")
+    fp.write(tmpdir / "test.fits")
     fp_new = FluxPoints.read(tmpdir / "test.fits")
     assert fp_new.meta["sed_type_init"] == "likelihood"
 
@@ -360,7 +360,7 @@ def test_run_map_pwl(fpe_map_pwl, tmpdir):
     assert_allclose(actual, [1.628398e02, 1.452456e-01, 2.008018e03], rtol=1e-2)
 
     # test GADF I/O
-    fp.write(tmpdir / "test.fits", format="gadf-sed")
+    fp.write(tmpdir / "test.fits")
     fp_new = FluxPoints.read(tmpdir / "test.fits")
     assert fp_new.meta["sed_type_init"] == "likelihood"
 
@@ -412,7 +412,7 @@ def test_flux_points_estimator_no_norm_scan(fpe_pwl, tmpdir):
     assert "stat_scan" not in fp._data
 
     # test GADF I/O
-    fp.write(tmpdir / "test.fits", format="gadf-sed")
+    fp.write(tmpdir / "test.fits")
     fp_new = FluxPoints.read(tmpdir / "test.fits")
     assert fp_new.meta["sed_type_init"] == "likelihood"
 


### PR DESCRIPTION
In this PR I introduce a method for `estimators.FluxPoints` which tries to guess the format - "gadf-sed", "lightcurve" or "profile" - of the object itself for serialization.

This change was suggested by @AtreyeeS and @adonath in a previous issue, see #3871 