### PR TITLE
Add support for checksum in yaml files

### DIFF
--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -392,6 +392,8 @@ class Datasets(collections.abc.MutableSequence):
             Whether to lazy load data into memory. Default is True.
         cache : bool
             Whether to cache the data after loading. Default is True.
+        checksum : bool
+            Whether to perform checksum verification. Default is False.
 
         Returns
         -------
@@ -401,7 +403,7 @@ class Datasets(collections.abc.MutableSequence):
         from . import DATASET_REGISTRY
 
         filename = make_path(filename)
-        data_list = read_yaml(filename)
+        data_list = read_yaml(filename, checksum=checksum)
 
         datasets = []
         for data in data_list["datasets"]:
@@ -417,7 +419,7 @@ class Datasets(collections.abc.MutableSequence):
         datasets = cls(datasets)
 
         if filename_models:
-            datasets.models = Models.read(filename_models)
+            datasets.models = Models.read(filename_models, checksum=checksum)
 
         return datasets
 
@@ -467,6 +469,7 @@ class Datasets(collections.abc.MutableSequence):
                 filename_models,
                 overwrite=overwrite,
                 write_covariance=write_covariance,
+                checksum=checksum,
             )
 
     def stack_reduce(self, name=None, nan_to_num=True):

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -379,7 +379,7 @@ class Datasets(collections.abc.MutableSequence):
         return copy.deepcopy(self)
 
     @classmethod
-    def read(cls, filename, filename_models=None, lazy=True, cache=True):
+    def read(cls, filename, filename_models=None, lazy=True, cache=True, checksum=True):
         """De-serialize datasets from YAML and FITS files.
 
         Parameters
@@ -460,7 +460,7 @@ class Datasets(collections.abc.MutableSequence):
         if path.exists() and not overwrite:
             raise IOError(f"File exists already: {path}")
 
-        write_yaml(data, path, sort_keys=False)
+        write_yaml(data, path, sort_keys=False, checksum=checksum)
 
         if filename_models:
             self.models.write(

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import json
+import warnings
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
@@ -1351,7 +1352,9 @@ def test_map_datasets_on_off_checksum(images, tmp_path):
         assert "CHECKSUM" in hdu.header
         assert "DATASUM" in hdu.header
 
-    Datasets.read(tmp_path / "test.yaml", lazy=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        Datasets.read(tmp_path / "test.yaml", lazy=False)
 
 
 def test_create_onoff(geom):

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1351,6 +1351,8 @@ def test_map_datasets_on_off_checksum(images, tmp_path):
         assert "CHECKSUM" in hdu.header
         assert "DATASUM" in hdu.header
 
+    Datasets.read(tmp_path / "test.yaml", lazy=False)
+
 
 def test_create_onoff(geom):
     # tests empty datasets created

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -3,6 +3,7 @@ import collections.abc
 import copy
 import html
 import logging
+import warnings
 from os.path import split
 import numpy as np
 import astropy.units as u
@@ -431,7 +432,12 @@ class DatasetModels(collections.abc.Sequence):
         data = yaml.safe_load(yaml_str)
         checksum_str = data.pop("checksum", None)
         if checksum:
-            verify_checksum(yaml_str, checksum_str)
+            yaml_str = yaml.dump(
+                data, sort_keys=False, indent=4, width=80, default_flow_style=False
+            )
+            if not verify_checksum(yaml_str, checksum_str):
+                warnings.warn("Checksum verification failed.", UserWarning)
+
         # TODO : for now metadata are not kept. Add proper metadata creation.
         data.pop("metadata", None)
         return cls.from_dict(data, path=path)

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 import yaml
 from gammapy.maps import Map, RegionGeom
 from gammapy.modeling import Covariance, Parameter, Parameters
-from gammapy.utils.check import add_checksum
+from gammapy.utils.check import add_checksum, verify_checksum
 from gammapy.utils.metadata import CreatorMetaData
 from gammapy.utils.scripts import make_name, make_path
 
@@ -411,16 +411,27 @@ class DatasetModels(collections.abc.Sequence):
         return [m.name for m in self._models]
 
     @classmethod
-    def read(cls, filename):
-        """Read from YAML file."""
+    def read(cls, filename, checksum=False):
+        """Read from YAML file.
+
+        Parameters
+        ----------
+        filename : str
+            input filename
+        checksum : bool
+            Whether to perform checksum verification. Default is False.
+        """
         yaml_str = make_path(filename).read_text()
         path, filename = split(filename)
-        return cls.from_yaml(yaml_str, path=path)
+        return cls.from_yaml(yaml_str, path=path, checksum=checksum)
 
     @classmethod
-    def from_yaml(cls, yaml_str, path=""):
+    def from_yaml(cls, yaml_str, path="", checksum=False):
         """Create from YAML string."""
         data = yaml.safe_load(yaml_str)
+        checksum_str = data.pop("checksum", None)
+        if checksum:
+            verify_checksum(yaml_str, checksum_str)
         # TODO : for now metadata are not kept. Add proper metadata creation.
         data.pop("metadata", None)
         return cls.from_dict(data, path=path)

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 import yaml
 from gammapy.maps import Map, RegionGeom
 from gammapy.modeling import Covariance, Parameter, Parameters
+from gammapy.utils.check import add_checksum
 from gammapy.utils.metadata import CreatorMetaData
 from gammapy.utils.scripts import make_name, make_path
 
@@ -468,6 +469,7 @@ class DatasetModels(collections.abc.Sequence):
         full_output=False,
         overwrite_templates=False,
         write_covariance=True,
+        checksum=False,
     ):
         """Write to YAML file.
 
@@ -483,6 +485,9 @@ class DatasetModels(collections.abc.Sequence):
             Overwrite templates FITS files. Default is False.
         write_covariance : bool, optional
             Whether to save the covariance. Default is True.
+        checksum : bool
+            When True adds a CHECKSUM entry to the file.
+            Default is False.
         """
         base_path, _ = split(path)
         path = make_path(path)
@@ -503,7 +508,10 @@ class DatasetModels(collections.abc.Sequence):
             self.write_covariance(base_path / filecovar, **kwargs)
             self._covar_file = filecovar
 
-        path.write_text(self.to_yaml(full_output, overwrite_templates))
+        yaml_str = self.to_yaml(full_output, overwrite_templates)
+        if checksum:
+            yaml_str = add_checksum(yaml_str)
+        path.write_text(yaml_str)
 
     def to_yaml(self, full_output=False, overwrite_templates=False):
         """Convert to YAML string."""

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -26,7 +26,7 @@ from gammapy.modeling.models import (
     TemplateNPredModel,
 )
 from gammapy.utils.deprecation import GammapyDeprecationWarning
-from gammapy.utils.scripts import read_yaml, write_yaml
+from gammapy.utils.scripts import make_path, read_yaml, write_yaml
 from gammapy.utils.testing import requires_data, requires_dependency
 
 
@@ -125,15 +125,27 @@ def test_sky_models_io(tmpdir, models):
 
 @requires_data()
 def test_sky_models_checksum(tmpdir, models):
+    import yaml
+
     models.write(
         tmpdir / "tmp.yaml", full_output=True, overwrite_templates=False, checksum=True
     )
     file = open(tmpdir / "tmp.yaml", "rb")
     yaml_content = file.read()
+    file.close()
 
     assert "checksum: " in str(yaml_content)
-    print(yaml_content)
-    assert False
+
+    data = yaml.safe_load(yaml_content)
+    data["checksum"] = "bad"
+    yaml_str = yaml.dump(
+        data, sort_keys=False, indent=4, width=80, default_flow_style=False
+    )
+    path = make_path(tmpdir) / "bad_checksum.yaml"
+    path.write_text(yaml_str)
+
+    with pytest.warns(UserWarning):
+        Models.read(tmpdir / "bad_checksum.yaml", checksum=True)
 
 
 @requires_data()

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -124,6 +124,17 @@ def test_sky_models_io(tmpdir, models):
 
 
 @requires_data()
+def test_sky_models_checksum(tmpdir, models):
+    models.write(
+        tmpdir / "tmp.yaml", full_output=True, overwrite_templates=False, checksum=True
+    )
+    file = open(tmpdir / "tmp.yaml", "rb")
+    yaml_content = file.read()
+
+    assert "checksum: " in str(yaml_content)
+
+
+@requires_data()
 def test_sky_models_io_auto_write(tmp_path, models):
     models_new = models.copy()
     fsource2 = str(tmp_path / "source2_test.fits")

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -132,6 +132,8 @@ def test_sky_models_checksum(tmpdir, models):
     yaml_content = file.read()
 
     assert "checksum: " in str(yaml_content)
+    print(yaml_content)
+    assert False
 
 
 @requires_data()

--- a/gammapy/utils/check.py
+++ b/gammapy/utils/check.py
@@ -46,9 +46,9 @@ def add_checksum(yaml_str, sort_keys=False, indent=4, width=50):
     checksum = {"checksum": yaml_checksum(yaml_str)}
     checksum = yaml.dump(
         checksum,
-        sort_keys=sort_keys,
-        indent=indent,
-        width=width,
+        sort_keys=True,
+        indent=4,  # indent,
+        width=80,  # width,
         default_flow_style=False,
     )
     return yaml_str + checksum

--- a/gammapy/utils/check.py
+++ b/gammapy/utils/check.py
@@ -23,3 +23,18 @@ def check_tutorials_setup(download_datasets_path="./gammapy-data"):
         os.environ["GAMMAPY_DATA"] = download_datasets_path
 
     cli_info.callback(system=True, version=True, dependencies=True, envvar=True)
+
+
+def yaml_checksum(yaml_content):
+    """Compute a MD5 checksum for a given yaml string input."""
+    import hashlib
+
+    # Calculate the MD5 checksum
+    checksum = hashlib.md5(yaml_content.encode("utf-8")).hexdigest()
+
+    return checksum
+
+
+def verify_checksum(yaml_content, checksum):
+    """Compare MD5 checksum for yaml_content with input checksum."""
+    return yaml_checksum(yaml_content) == checksum

--- a/gammapy/utils/check.py
+++ b/gammapy/utils/check.py
@@ -41,10 +41,14 @@ def verify_checksum(yaml_content, checksum):
     return yaml_checksum(yaml_content) == checksum
 
 
-def add_checksum(yaml_str):
+def add_checksum(yaml_str, sort_keys=False, indent=4, width=50):
     """Append a checksum at the end of the yaml string."""
     checksum = {"checksum": yaml_checksum(yaml_str)}
     checksum = yaml.dump(
-        checksum, sort_keys=False, indent=4, width=80, default_flow_style=False
+        checksum,
+        sort_keys=sort_keys,
+        indent=indent,
+        width=width,
+        default_flow_style=False,
     )
     return yaml_str + checksum

--- a/gammapy/utils/check.py
+++ b/gammapy/utils/check.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import os
+import yaml
 from gammapy.scripts.download import RELEASE, cli_download_datasets
 from gammapy.scripts.info import cli_info
 
@@ -38,3 +39,12 @@ def yaml_checksum(yaml_content):
 def verify_checksum(yaml_content, checksum):
     """Compare MD5 checksum for yaml_content with input checksum."""
     return yaml_checksum(yaml_content) == checksum
+
+
+def add_checksum(yaml_str):
+    """Append a checksum at the end of the yaml string."""
+    checksum = {"checksum": yaml_checksum(yaml_str)}
+    checksum = yaml.dump(
+        checksum, sort_keys=False, indent=4, width=80, default_flow_style=False
+    )
+    return yaml_str + checksum

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -6,6 +6,7 @@ from base64 import urlsafe_b64encode
 from pathlib import Path
 from uuid import uuid4
 import yaml
+from gammapy.utils.check import add_checksum
 
 __all__ = [
     "get_images_paths",
@@ -55,7 +56,7 @@ def read_yaml(filename, logger=None):
     return yaml.safe_load(text)
 
 
-def write_yaml(dictionary, filename, logger=None, sort_keys=True):
+def write_yaml(dictionary, filename, logger=None, sort_keys=True, checksum=False):
     """Write YAML file.
 
     Parameters
@@ -68,8 +69,13 @@ def write_yaml(dictionary, filename, logger=None, sort_keys=True):
         Logger. Default is None.
     sort_keys : bool, optional
         Whether to sort keys. Default is True.
+    checksum : bool, optional
+        Whether to add checksum keyword. Default is False.
     """
     text = yaml.safe_dump(dictionary, default_flow_style=False, sort_keys=sort_keys)
+
+    if checksum:
+        text = add_checksum(text, sort_keys=sort_keys)
 
     path = make_path(filename)
     path.parent.mkdir(exist_ok=True)

--- a/gammapy/utils/tests/test_check.py
+++ b/gammapy/utils/tests/test_check.py
@@ -1,0 +1,17 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import yaml
+from gammapy.utils.check import verify_checksum, yaml_checksum
+
+
+def test_yaml_checksum():
+    data = {
+        "a": 50,
+        "b": 3.14e-12,
+    }
+    yaml_str = yaml.dump(
+        data, sort_keys=False, indent=4, width=80, default_flow_style=False
+    )
+    checksum = yaml_checksum(yaml_str)
+
+    assert checksum == "47fd166725c49519c7c31c19f53b53dd"
+    assert verify_checksum(yaml_str, "47fd166725c49519c7c31c19f53b53dd")

--- a/gammapy/utils/tests/test_check.py
+++ b/gammapy/utils/tests/test_check.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import yaml
-from gammapy.utils.check import verify_checksum, yaml_checksum
+from gammapy.utils.check import add_checksum, verify_checksum, yaml_checksum
 
 
 def test_yaml_checksum():
@@ -15,3 +15,6 @@ def test_yaml_checksum():
 
     assert checksum == "47fd166725c49519c7c31c19f53b53dd"
     assert verify_checksum(yaml_str, "47fd166725c49519c7c31c19f53b53dd")
+
+    yaml_with_checksum = add_checksum(yaml_str)
+    assert "checksum: 47fd166725c49519c7c31c19f53b53dd" in yaml_with_checksum

--- a/gammapy/utils/tests/test_scripts.py
+++ b/gammapy/utils/tests/test_scripts.py
@@ -1,6 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import warnings
 import pytest
-from gammapy.utils.scripts import get_images_paths, recursive_merge_dicts
+import yaml
+from gammapy.utils.scripts import (
+    get_images_paths,
+    make_path,
+    read_yaml,
+    recursive_merge_dicts,
+    write_yaml,
+)
 
 
 @pytest.mark.xfail
@@ -18,3 +26,30 @@ def test_recursive_merge_dicts():
     assert new["b"]["g"] == 98
     assert new["a"] == 42
     assert new["d"] == 99
+
+
+def test_read_write_yaml_checksum(tmp_path):
+    data = {"b": 1234, "a": "other"}
+    path = make_path(tmp_path / "test.yaml")
+    write_yaml(data, path, sort_keys=False, checksum=True)
+
+    yaml_content = path.read_text()
+    assert "checksum: " in yaml_content
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        res = read_yaml(path, checksum=True)
+    assert "checksum" not in res.keys()
+
+    yaml_content = yaml_content.replace("1234", "12345")
+    bad = make_path(tmp_path) / "bad_checksum.yaml"
+    bad.write_text(yaml_content)
+    with pytest.warns(UserWarning):
+        read_yaml(bad, checksum=True)
+
+    res["checksum"] = "bad"
+    yaml_str = yaml.dump(data, sort_keys=True, default_flow_style=False)
+    path.write_text(yaml_str)
+
+    with pytest.warns(UserWarning):
+        read_yaml(bad, checksum=True)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request is part of the effort to support fixity metadata in Gammapy products. For FITS files we rely on the CHECKSUM and DATASUM keywords with astropy. We lack a solution for yaml files storing `Models` and `Datasets`.

This PR proposes a mechanism to compute a MD5 hash for the content of the yaml file and include it as the last entry in the yaml dictionary.


**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
