### PR TITLE
MAINT: use new location for dev wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             allowed_fail: false
           - os: ubuntu-latest
             python: '3.9'
-            tox_env: 'py39-test-alldeps_noray-astropylts-numpy121'
+            tox_env: 'py39-test-alldeps_noray-astropy50-numpy121'
             allowed_fail: false
           - os: ubuntu-latest
             python: '3.9'
@@ -140,7 +140,7 @@ jobs:
       - name: check links
         continue-on-error: true
         run: |
-          tox -e linkcheck -- -j auto  
+          tox -e linkcheck -- -j auto
   conda-build:
     name: Linux python 3.9 conda-build all-deps
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
             tox_env: 'oldestdeps'
             allowed_fail: false
           - os: ubuntu-latest
-            python: '3.9'
+            python: '3.11'
             tox_env: 'devdeps'
             allowed_fail: true
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -13,14 +13,14 @@ requires =
     pip >= 19.3.1
 isolated_build = true
 indexserver =
-    NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    NIGHTLY = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
 [testenv]
 # Suppress display of matplotlib plots generated during docs build
 setenv = MPLBACKEND=agg
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = 
+passenv =
     HOME
     WINDIR
     LC_ALL
@@ -79,7 +79,7 @@ deps =
     oldestdeps: regions==0.5.*
     oldestdeps: pydantic==1.4.*
     oldestdeps: iminuit==2.8.*
-    
+
     devdeps: scipy>=0.0.dev0
     devdeps: numpy>=0.0.dev0
     devdeps: matplotlib>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,9 @@ extras =
     cov: cov
 
 commands =
+    # Force numpy reinstall to work around upper version limits dependencies put on numpy
+    devdeps: pip install -U --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+
     pip freeze
     !cov: pytest --pyargs gammapy {posargs}
     cov: pytest --doctest-rst --pyargs gammapy {toxinidir}/docs --cov gammapy --cov-config={toxinidir}/setup.cfg {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,12 @@ requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
 isolated_build = true
-indexserver =
-    NIGHTLY = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
 [testenv]
 # Suppress display of matplotlib plots generated during docs build
-setenv = MPLBACKEND=agg
+setenv =
+    MPLBACKEND = agg
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple
 
 # Pass through the following environment variables which may be needed for the CI
 passenv =
@@ -79,7 +79,8 @@ deps =
     devdeps: scipy>=0.0.dev0
     devdeps: numpy>=0.0.dev0
     devdeps: matplotlib>=0.0.dev0
-    devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: astropy>=0.0.dev0
+    devdeps: pyerfa>=0.0.dev0
     devdeps: git+https://github.com/scikit-hep/iminuit.git#egg=iminuit
 
     # build_docs: sphinx-gallery<0.13

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ passenv =
     LC_CTYPE
     CC
     CI
-    TRAVIS
     GAMMAPY_DATA
     PKG_CONFIG_PATH
 
@@ -55,7 +54,6 @@ description =
     numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
     astropy50: with astropy 5.0.*
-    astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -67,8 +65,6 @@ deps =
     numpy124: numpy==1.24.*
 
     astropy50: astropy==5.0.*
-    astropylts: astropy==5.0.*
-    astropylts: matplotlib==3.6.*
 
     oldestdeps: numpy==1.21.*
     oldestdeps: matplotlib==3.4.*


### PR DESCRIPTION
I would expect this to cause havoc as none of the actual dev versions of upstream were picked up correctly.
I may push other CI cleanups, but will have no capacity to fix much code to ensure e.g. numpy 2.0 compatibility (that will be necessary to make the devtest job pass)