### PR TITLE
Fix FluxMap.slice_by_coord

### DIFF
--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -1120,8 +1120,8 @@ class FluxMaps:
         idx_intervals = []
 
         for key, interval in zip(slices.keys(), slices.values()):
-            imin = self.geom.axes[key].coord_to_idx(interval.start)
-            imax = self.geom.axes[key].coord_to_idx(interval.stop)
+            imin = np.ravel(self.geom.axes[key].coord_to_idx(interval.start))[0]
+            imax = np.ravel(self.geom.axes[key].coord_to_idx(interval.stop))[0]
 
             idx_intervals.append(slice(imin, imax))
 

--- a/gammapy/estimators/map/tests/test_core.py
+++ b/gammapy/estimators/map/tests/test_core.py
@@ -487,3 +487,6 @@ def test_slice_by_coord():
     assert sliced_map.available_quantities == ref_map.available_quantities
     assert_allclose(sliced_map.gti.time_stop.value, 51545.3340, rtol=1e-3)
     assert sliced_map.reference_model == ref_map.reference_model
+
+    sliced_map2 = ref_map.slice_by_coord({"energy": slice(0.5 * u.TeV, 5.0 * u.TeV)})
+    assert sliced_map2.geom.axes["energy"].nbin == 1


### PR DESCRIPTION
MapAxis.coord_to_idx returns an array of 1 element, which breaks slicing.
This PR ensures that a number is passed to the slice, instead of an array.