### PR TITLE
Fixing None objects in `Parameters.to_table()`

### DIFF
--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -2,6 +2,7 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+from astropy.table import Table
 from gammapy.modeling import Parameter, Parameters, PriorParameter, PriorParameters
 
 
@@ -155,7 +156,7 @@ def test_parameters_getitem(pars):
         pars[Parameter("bam!", 99)]
 
 
-def test_parameters_to_table(pars):
+def test_parameters_to_table(pars, tmp_path):
     pars["ham"].error = 1e-10
     pars["spam"]._link_label_io = "test"
 
@@ -164,6 +165,48 @@ def test_parameters_to_table(pars):
     assert len(table.columns) == 11
     assert table["link"][0] == "test"
     assert table["link"][1] == ""
+
+    assert table["prior"][0] == ""
+    assert table["type"][1] == ""
+
+    table.write(tmp_path / "test_parameters.fits")
+    Table.read(tmp_path / "test_parameters.fits")
+
+
+def test_parameters_create_table():
+    table = Parameters._create_default_table()
+
+    assert len(table) == 0
+    assert len(table.columns) == 11
+
+    assert table.colnames == [
+        "type",
+        "name",
+        "value",
+        "unit",
+        "error",
+        "min",
+        "max",
+        "frozen",
+        "is_norm",
+        "link",
+        "prior",
+    ]
+    assert table.dtype == np.dtype(
+        [
+            ("type", "<U1"),
+            ("name", "<U1"),
+            ("value", "<f8"),
+            ("unit", "<U1"),
+            ("error", "<f8"),
+            ("min", "<f8"),
+            ("max", "<f8"),
+            ("frozen", "?"),
+            ("is_norm", "?"),
+            ("link", "<U1"),
+            ("prior", "<U1"),
+        ]
+    )
 
 
 def test_parameters_set_parameter_factors(pars):


### PR DESCRIPTION
This pull request fix #5012. 

As mentioned in the issue, a table can be created with `None` object in it but not written to disk. This means that if you have a column of the table that is filled for the first time with `None`, it's inferred `dtype` will be `Object`. 

To fix that I have created a staticmethod that created a `Table` with predefined column name and associated dtype. Then to fill the table I pass a dictionary defined as `{name: value}` (where name match a column name) to `Table.add_row` . This way, only the field that are in the dictionary are filled. 

In the end it is exactly the same as before, but with stricter type, enabling to write the table to disk. 