### PR TITLE
Small fix in printing OnOFF datasets

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2089,19 +2089,24 @@ class MapDatasetOnOff(MapDataset):
     def __str__(self):
         str_ = super().__str__()
 
+        if self.mask_safe:
+            mask = self.mask_safe.data.astype(bool)
+        else:
+            mask = slice(None)
+
         counts_off = np.nan
         if self.counts_off is not None:
-            counts_off = np.sum(self.counts_off.data)
+            counts_off = np.sum(self.counts_off.data[mask])
         str_ += "\t{:32}: {:.0f} \n".format("Total counts_off", counts_off)
 
         acceptance = np.nan
         if self.acceptance is not None:
-            acceptance = np.sum(self.acceptance.data)
+            acceptance = np.sum(self.acceptance.data[mask])
         str_ += "\t{:32}: {:.0f} \n".format("Acceptance", acceptance)
 
         acceptance_off = np.nan
         if self.acceptance_off is not None:
-            acceptance_off = np.sum(self.acceptance_off.data)
+            acceptance_off = np.sum(self.acceptance_off.data[mask])
         str_ += "\t{:32}: {:.0f} \n".format("Acceptance off", acceptance_off)
 
         return str_.expandtabs(tabsize=2)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1365,6 +1365,8 @@ def test_create_onoff(geom):
 def test_map_dataset_onoff_str(images):
     dataset = get_map_dataset_onoff(images)
     assert "MapDatasetOnOff" in str(dataset)
+    assert "counts_off" in str(dataset)
+    assert int(str(dataset)[-52:-48]) == 4273
 
 
 @requires_data()


### PR DESCRIPTION
This PR adapts to include only data in the safe range for printing `accpetance`, accpetance_off`, and `counts_off`, similar to counts, background, etc 