### PR TITLE
Fix copy of TemplateSpatialModel when position is not the center of the map 

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1393,6 +1393,8 @@ class TemplateSpatialModel(SpatialModel):
         kwargs.setdefault("normalize", self.normalize)
         kwargs.setdefault("interp_kwargs", self._interp_kwargs)
         kwargs.setdefault("filename", self.filename)
+        kwargs.setdefault("lon_0", self.parameters["lon_0"].copy())
+        kwargs.setdefault("lat_0", self.parameters["lat_0"].copy())
         return self.__class__(copy_data=copy_data, **kwargs)
 
     @property

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -737,3 +737,12 @@ def test_template_ND(tmpdir):
     assert len(template_new.parameters) == 2
     assert template_new.parameters["norm"].value == 2
     assert template_new.parameters["cste"].value == 0
+
+
+@requires_data()
+def test_template_spatial_parameters_copy():
+    filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
+    model = TemplateSpatialModel.read(filename, normalize=False)
+    model.position = SkyCoord(0, 0, unit="deg", frame="galactic")
+    model_copy = model.copy()
+    assert_allclose(model.parameters.value, model_copy.parameters.value)


### PR DESCRIPTION
Get position from parameters on copy otherwise it is taken from the center of the map