### PR TITLE
Fix small errors in analysis-time tutorials

### DIFF
--- a/examples/tutorials/analysis-time/Variability_estimation.py
+++ b/examples/tutorials/analysis-time/Variability_estimation.py
@@ -6,12 +6,14 @@ Compute a series of time variability significance estimators for a lightcurve.
 Prerequisites
 -------------
 
-Understanding the light curve estimator, please refer to the :doc:`light curve notebook </tutorials/analysis-time/light_curve`.
-For more in-depth explanation on the creation of smaller observations for exploring time variability, refer to :doc:`light curve notebook </tutorials/analysis-time/light_curve_flare`
+Understanding the light curve estimator, please refer to the :doc:`</tutorials/analysis-time/light_curve` tutorial.
+For more in-depth explanation on the creation of smaller observations for exploring time variability, refer to the
+:doc:`</tutorials/analysis-time/light_curve_flare` tutorial.
 
 Context
 -------
-Frequently, after computing a lightcurve, we need to quantify its variability in the time domain, for example in the case of a flare, burst, decaying light curve in GRBs or heightened activity in general.
+Frequently, after computing a lightcurve, we need to quantify its variability in the time domain, for example
+in the case of a flare, burst, decaying light curve in GRBs or heightened activity in general.
 
 There are many ways to define the significance of the variability.
 
@@ -19,11 +21,16 @@ There are many ways to define the significance of the variability.
 
 Proposed approach
 -------------
-We will start by reading the pre-computed light curve for PKS 2155-304 that is stored in `$GAMMAPY_DATA` 
-To learn how to compute such an object, see the :doc:`light curve tutorial </tutorials/analysis-time/light_curve_flare`
+We will start by reading the pre-computed light curve for PKS 2155-304 that is stored in `$GAMMAPY_DATA`
+To learn how to compute such an object, see the :doc:`</tutorials/analysis-time/light_curve_flare` tutorial.
 
-This tutorial will demonstrate how to compute different estimates which measure the significance of variability. These estimators range from basic ones that calculate the peak-to-trough variation, to more complex ones like fractional excess and point-to-point fractional variance, which consider the entire light curve. We also show an approach which utilises the change points inn Bayesian blocks as indicators of variability.
+This tutorial will demonstrate how to compute different estimates which measure the significance of variability.
+These estimators range from basic ones that calculate the peak-to-trough variation, to more complex ones like
+fractional excess and point-to-point fractional variance, which consider the entire light curve. We also show an
+approach which utilises the change points in Bayesian blocks as indicators of variability.
+
 """
+
 ######################################################################
 # Setup
 # -----
@@ -41,7 +48,7 @@ from gammapy.estimators.utils import (
 )
 
 ######################################################################
-# Load the light curve for the PKS 2155-304 flare directly from “$GAMMAPY_DATA/estimators”
+# Load the light curve for the PKS 2155-304 flare directly from `$GAMMAPY_DATA/estimators`.
 
 lc_1d = FluxPoints.read(
     "$GAMMAPY_DATA/estimators/pks2155_hess_lc/pks2155_hess_lc.fits", format="lightcurve"
@@ -54,10 +61,12 @@ plt.show()
 ######################################################################
 # Methods to characterize variability
 # -----------------------------------
+#
 #  Amplitude maximum variation, relative variability amplitude and variability amplitude
 #
 # The amplitude maximum variation is the simplest method to define variability (as described in
-# [Boller et al., 2016](https://ui.adsabs.harvard.edu/abs/2016A&A...588A.103B/abstract)) as it just computes
+# `Boller et al., 2016 <https://ui.adsabs.harvard.edu/abs/2016A&A...588A.103B/abstract>`__)
+# as it just computes
 # the level of tension between the lowest and highest measured fluxes in the lightcurve.
 # This estimator requires fully Gaussian errors.
 
@@ -82,8 +91,8 @@ print(amplitude_maximum_significance)
 
 ######################################################################
 # There are other methods based on the peak-to-trough difference to assess the variability in a lightcurve.
-# Here we present as example the relative variability amplitude as presented in [Kovalev et al., 2004]
-# (https://iopscience.iop.org/article/10.1086/497430):
+# Here we present as example the relative variability amplitude as presented in
+# `Kovalev et al., 2004 <https://iopscience.iop.org/article/10.1086/497430>`__:
 
 relative_variability_amplitude = (f_max - f_min) / (f_max + f_min)
 
@@ -100,7 +109,7 @@ relative_variability_significance = (
 print(relative_variability_significance)
 
 ######################################################################
-# And the variability amplitude as presented in [Heidt & Wagner, 1996](https://ui.adsabs.harvard.edu/abs/1996A%26A...305...42H/abstract):
+# The variability amplitude as presented in `Heidt & Wagner, 1996 <https://ui.adsabs.harvard.edu/abs/1996A%26A...305...42H/abstract>`__ is:
 
 variability_amplitude = np.sqrt((f_max - f_min) ** 2 - 2 * f_mean_err**2)
 
@@ -127,7 +136,7 @@ print(variability_amplitude_significance)
 #  Fractional excess variance, point-to-point fractional variance and doubling/halving time
 # -----------------------------------------------------------------------------------------
 # The fractional excess variance as presented by
-# [Vaughan et al., 2003](https://ui.adsabs.harvard.edu/abs/2003MNRAS.345.1271V/abstract)) is a simple but effective
+# `Vaughan et al., 2003 <https://ui.adsabs.harvard.edu/abs/2003MNRAS.345.1271V/abstract>`__) is a simple but effective
 # method to assess the significance of a time variability feature in an object, for example an AGN flare.
 # It is important to note that it requires Gaussian errors to be applicable.
 # The excess variance computation is implemented in `~gammapy.estimators.utils`.
@@ -137,7 +146,7 @@ print(fvar_table)
 
 ######################################################################
 # A similar estimator is the point-to-point fractional variance, as defined by
-# [Edelson et al., 2002](https://ui.adsabs.harvard.edu/abs/2002ApJ...568..610E/abstract)
+# `Edelson et al., 2002 <https://ui.adsabs.harvard.edu/abs/2002ApJ...568..610E/abstract>`__
 # which samples the lightcurve on smaller time granularity.
 # In general, the point-to-point fractional variance being higher than the fractional excess variance is indicative
 # of the presence of very short timescale variability.
@@ -146,8 +155,8 @@ fpp_table = compute_lightcurve_fpp(lc_1d)
 print(fpp_table)
 
 ######################################################################
-# The characteristic doubling and halving time, as introduced by
-# [Brown, 2013](https://durham-repository.worktribe.com/output/1478453/) of the light curve can also be computed.
+# The characteristic doubling and halving time of the light curve, as introduced by
+# `Brown, 2013 <https://durham-repository.worktribe.com/output/1478453/>`__, can also be computed.
 # This provides information on the shape of the variability feature, in particular how quickly it rises and falls.
 
 dtime_table = compute_lightcurve_doublingtime(lc_1d, flux_quantity="flux")
@@ -156,10 +165,15 @@ print(dtime_table)
 ######################################################################
 # Bayesian blocks
 # ---------------
-# The presence of temporal variability in a lightcurve can be assessed by using bayesian blocks ([reference
-# paper](https://ui.adsabs.harvard.edu/abs/2013ApJ...764..167S/abstract)). A good and simple-to-use implementation of the algorithm is found in `astropy.stats`([documentation](https://docs.astropy.org/en/stable/api/astropy.stats.bayesian_blocks.html)). This implementation uses Gaussian statistics, as opposed to the [first introductory paper](https://iopscience.iop.org/article/10.1086/306064) which was based on Poissonian statistics.
+# The presence of temporal variability in a lightcurve can be assessed by using bayesian blocks
+# (`Scargle et al., 2013 <https://ui.adsabs.harvard.edu/abs/2013ApJ...764..167S/abstract>`__).
+# A good and simple-to-use implementation of the algorithm is found in
+# `astropy.stats.bayesian_blocks`.
+# This implementation uses Gaussian statistics, as opposed to the `first introductory paper <https://iopscience.iop.org/article/10.1086/306064>`__
+# which is based on Poissonian statistics.
 #
-# By passing the flux and error on the flux as `measures` to the method we can obtain the list of optimal bin edges defined by the bayesian blocks algorithm.
+# By passing the flux and error on the flux as `measures` to the method we can obtain the list of optimal bin edges
+# defined by the bayesian blocks algorithm.
 
 time = lc_1d.geom.axes["time"].time_mid.mjd
 
@@ -198,7 +212,8 @@ plt.ylim(bottom=0)
 plt.show()
 
 ######################################################################
-# The result giving a significance estimation for variability in the lightcurve is the number of *change points*, i.e. the number of internal bin edges: if at least one change point is identified by the algorithm, there is significant variability.
+# The result giving a significance estimation for variability in the lightcurve is the number of *change points*,
+# i.e. the number of internal bin edges: if at least one change point is identified by the algorithm, there is significant variability.
 
 ncp = len(bayesian_edges) - 2
 print(ncp)

--- a/examples/tutorials/analysis-time/Variability_estimation.py
+++ b/examples/tutorials/analysis-time/Variability_estimation.py
@@ -1,14 +1,15 @@
 """
 Estimation of time variability in a lightcurve
 ==============================================
+
 Compute a series of time variability significance estimators for a lightcurve.
 
 Prerequisites
 -------------
 
-Understanding the light curve estimator, please refer to the :doc:`</tutorials/analysis-time/light_curve` tutorial.
+Understanding the light curve estimator, please refer to the :doc:`/tutorials/analysis-time/light_curve` tutorial.
 For more in-depth explanation on the creation of smaller observations for exploring time variability, refer to the
-:doc:`</tutorials/analysis-time/light_curve_flare` tutorial.
+:doc:`/tutorials/analysis-time/light_curve_flare` tutorial.
 
 Context
 -------
@@ -20,9 +21,10 @@ There are many ways to define the significance of the variability.
 **Objective: Estimate the level time variability in a lightcurve through different methods.**
 
 Proposed approach
--------------
+-----------------
+
 We will start by reading the pre-computed light curve for PKS 2155-304 that is stored in `$GAMMAPY_DATA`
-To learn how to compute such an object, see the :doc:`</tutorials/analysis-time/light_curve_flare` tutorial.
+To learn how to compute such an object, see the :doc:`/tutorials/analysis-time/light_curve_flare` tutorial.
 
 This tutorial will demonstrate how to compute different estimates which measure the significance of variability.
 These estimators range from basic ones that calculate the peak-to-trough variation, to more complex ones like
@@ -62,7 +64,8 @@ plt.show()
 # Methods to characterize variability
 # -----------------------------------
 #
-#  Amplitude maximum variation, relative variability amplitude and variability amplitude
+# The 3 methods shown here are: amplitude maximum variation, relative variability amplitude
+# and variability amplitude.
 #
 # The amplitude maximum variation is the simplest method to define variability (as described in
 # `Boller et al., 2016 <https://ui.adsabs.harvard.edu/abs/2016A&A...588A.103B/abstract>`__)

--- a/examples/tutorials/analysis-time/Variability_estimation.py
+++ b/examples/tutorials/analysis-time/Variability_estimation.py
@@ -64,8 +64,11 @@ plt.show()
 # Methods to characterize variability
 # -----------------------------------
 #
-# The 3 methods shown here are: amplitude maximum variation, relative variability amplitude
-# and variability amplitude.
+# The three methods shown here are:
+#
+# -  amplitude maximum variation
+# -  relative variability amplitude
+# -  variability amplitude.
 #
 # The amplitude maximum variation is the simplest method to define variability (as described in
 # `Boller et al., 2016 <https://ui.adsabs.harvard.edu/abs/2016A&A...588A.103B/abstract>`__)
@@ -138,8 +141,8 @@ print(variability_amplitude_significance)
 ######################################################################
 #  Fractional excess variance, point-to-point fractional variance and doubling/halving time
 # -----------------------------------------------------------------------------------------
-# The fractional excess variance as presented by
-# `Vaughan et al., 2003 <https://ui.adsabs.harvard.edu/abs/2003MNRAS.345.1271V/abstract>`__) is a simple but effective
+# The fractional excess variance, as presented by
+# `Vaughan et al., 2003 <https://ui.adsabs.harvard.edu/abs/2003MNRAS.345.1271V/abstract>`__, is a simple but effective
 # method to assess the significance of a time variability feature in an object, for example an AGN flare.
 # It is important to note that it requires Gaussian errors to be applicable.
 # The excess variance computation is implemented in `~gammapy.estimators.utils`.
@@ -149,7 +152,7 @@ print(fvar_table)
 
 ######################################################################
 # A similar estimator is the point-to-point fractional variance, as defined by
-# `Edelson et al., 2002 <https://ui.adsabs.harvard.edu/abs/2002ApJ...568..610E/abstract>`__
+# `Edelson et al., 2002 <https://ui.adsabs.harvard.edu/abs/2002ApJ...568..610E/abstract>`__,
 # which samples the lightcurve on smaller time granularity.
 # In general, the point-to-point fractional variance being higher than the fractional excess variance is indicative
 # of the presence of very short timescale variability.
@@ -175,7 +178,7 @@ print(dtime_table)
 # This implementation uses Gaussian statistics, as opposed to the `first introductory paper <https://iopscience.iop.org/article/10.1086/306064>`__
 # which is based on Poissonian statistics.
 #
-# By passing the flux and error on the flux as `measures` to the method we can obtain the list of optimal bin edges
+# By passing the flux and error on the flux as ``measures`` to the method we can obtain the list of optimal bin edges
 # defined by the bayesian blocks algorithm.
 
 time = lc_1d.geom.axes["time"].time_mid.mjd

--- a/examples/tutorials/analysis-time/light_curve.py
+++ b/examples/tutorials/analysis-time/light_curve.py
@@ -25,9 +25,8 @@ run-wise binning, nightly, weekly etc.
 **Objective: The Crab nebula is not known to be variable at TeV
 energies, so we expect constant brightness within statistical and
 systematic errors. Compute per-observation and nightly fluxes of the
-four Crab nebula observations from the H.E.S.S. first public test data
-release**\ `o <https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/>`__\ **to
-check it.**
+four Crab nebula observations from the `H.E.S.S. first public test data
+release <https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/>`__.**
 
 Proposed approach
 -----------------
@@ -87,7 +86,7 @@ check_tutorials_setup()
 # using the high level interface of Gammapy.
 #
 # From the high level interface, the data reduction for those observations
-# is performed as followed
+# is performed as follows.
 #
 
 

--- a/examples/tutorials/analysis-time/light_curve.py
+++ b/examples/tutorials/analysis-time/light_curve.py
@@ -25,8 +25,8 @@ run-wise binning, nightly, weekly etc.
 **Objective: The Crab nebula is not known to be variable at TeV
 energies, so we expect constant brightness within statistical and
 systematic errors. Compute per-observation and nightly fluxes of the
-four Crab nebula observations from the `H.E.S.S. first public test data
-release <https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/>`__.**
+four Crab nebula observations from the H.E.S.S. first public test data
+release.**
 
 Proposed approach
 -----------------
@@ -102,7 +102,8 @@ conf_3d = AnalysisConfig()
 # Definition of the data selection
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# Here we use the Crab runs from the HESS DL3 data release 1
+# Here we use the Crab runs from the
+# `H.E.S.S. DL3 data release 1 <https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/>`__.
 #
 
 conf_3d.observations.obs_ids = [23523, 23526, 23559, 23592]
@@ -207,7 +208,7 @@ lc_3d = lc_maker_3d.run(analysis_3d.datasets)
 
 
 ######################################################################
-# The LightCurve object contains a table which we can explore.
+# The lightcurve `~gammapy.estimators.FluxPoints` object `lc_3d` contains a table which we can explore.
 #
 
 # Example showing how to change just before plotting the threshold on the signal significance
@@ -242,7 +243,8 @@ conf_1d = AnalysisConfig()
 # Definition of the data selection
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# Here we use the Crab runs from the HESS DL3 data release 1
+# Here we use the Crab runs from the
+# `H.E.S.S. DL3 data release 1 <https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/>`__
 #
 
 conf_1d.observations.obs_ids = [23523, 23526, 23559, 23592]
@@ -361,7 +363,7 @@ time_intervals = [
 
 ######################################################################
 # To compute the LC on the time intervals defined above, we pass the
-# `LightCurveEstimator` the list of time intervals.
+# `~gammapy.estimators.LightCurveEstimator` the list of time intervals.
 #
 # Internally, datasets are grouped per time interval and a flux extraction
 # is performed for each group.

--- a/examples/tutorials/analysis-time/light_curve.py
+++ b/examples/tutorials/analysis-time/light_curve.py
@@ -7,7 +7,7 @@ Compute per-observation and nightly fluxes of four Crab nebula observations.
 Prerequisites
 -------------
 
--  Knowledge of the high level interface to perform data reduction, see
+-  Knowledge of the high level interface to perform data reduction, see the
    :doc:`/tutorials/starting/analysis_1` tutorial.
 
 Context

--- a/examples/tutorials/analysis-time/light_curve_flare.py
+++ b/examples/tutorials/analysis-time/light_curve_flare.py
@@ -51,8 +51,9 @@ In summary, we have to:
 -  Define the source model
 -  Extract the light curve from the reduced dataset
 
-Here, we will use the PKS 2155-304 observations from the H.E.S.S. first
-public test data release. We will use time intervals of 5 minutes
+Here, we will use the PKS 2155-304 observations from the
+`H.E.S.S. first public test data release <https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/>`__.
+We will use time intervals of 5 minutes
 duration. The tutorial is implemented with the intermediate level API.
 
 Setup
@@ -183,7 +184,7 @@ print(short_observations[1].gti)
 # chosen.
 #
 # We need to define the ON extraction region. Its size follows typical
-# spectral extraction regions for HESS analyses.
+# spectral extraction regions for H.E.S.S. analyses.
 #
 
 # Target definition

--- a/examples/tutorials/analysis-time/light_curve_flare.py
+++ b/examples/tutorials/analysis-time/light_curve_flare.py
@@ -143,7 +143,7 @@ print(time_intervals[0].mjd)
 # Here we apply the list of time intervals to the observations with
 # `~gammapy.data.Observations.select_time()`.
 #
-# This will return a new list of Observations filtered by time_intervals.
+# This will return a new list of Observations filtered by `time_intervals`.
 # For each time interval, a new observation is created that converts the
 # intersection of the GTIs and time interval.
 #
@@ -217,7 +217,7 @@ safe_mask_masker = SafeMaskMaker(methods=["aeff-max"], aeff_percent=10)
 # Creation of the datasets
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# Now we perform the actual data reduction in the time_intervals.
+# Now we perform the actual data reduction in the `time_intervals`.
 #
 
 # %%time

--- a/examples/tutorials/analysis-time/light_curve_flare.py
+++ b/examples/tutorials/analysis-time/light_curve_flare.py
@@ -144,7 +144,7 @@ print(time_intervals[0].mjd)
 # Here we apply the list of time intervals to the observations with
 # `~gammapy.data.Observations.select_time()`.
 #
-# This will return a new list of Observations filtered by `time_intervals`.
+# This will return a new list of Observations filtered by ``time_intervals``.
 # For each time interval, a new observation is created that converts the
 # intersection of the GTIs and time interval.
 #
@@ -218,7 +218,7 @@ safe_mask_masker = SafeMaskMaker(methods=["aeff-max"], aeff_percent=10)
 # Creation of the datasets
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# Now we perform the actual data reduction in the `time_intervals`.
+# Now we perform the actual data reduction in the ``time_intervals``.
 #
 
 # %%time

--- a/examples/tutorials/analysis-time/light_curve_simulation.py
+++ b/examples/tutorials/analysis-time/light_curve_simulation.py
@@ -9,44 +9,44 @@ Prerequisites
 
 -  To understand how a single binned simulation works, please refer to
    :doc:`/tutorials/analysis-1d/spectrum_simulation` tutorial and 
-   :doc:`/tutorials/analysis-3d/simulate_3d` tutorial for 1D and 3D simulations
+   :doc:`/tutorials/analysis-3d/simulate_3d` tutorial for 1D and 3D simulations,
    respectively.
 -  For details of light curve extraction using gammapy, refer to the two
    tutorials :doc:`/tutorials/analysis-time/light_curve` and
-   :doc:`/tutorials/analysis-time/light_curve_flare` tutorial.
+   :doc:`/tutorials/analysis-time/light_curve_flare`.
 
 Context
 -------
 
 Frequently, studies of variable sources (eg: decaying GRB light curves,
-AGN flares, etc) require time variable simulations. For most use cases,
+AGN flares, etc.) require time variable simulations. For most use cases,
 generating an event list is an overkill, and it suffices to use binned
 simulations using a temporal model.
 
 **Objective: Simulate and fit a time decaying light curve of a source
-with CTA using the CTA 1DC response**
+with CTA using the CTA 1DC response.**
 
 Proposed approach
 -----------------
 
 We will simulate 10 spectral datasets within given time intervals (Good
 Time Intervals) following a given spectral (a power law) and temporal
-profile (an exponential decay, with a decay time of 6 hr ). These are
+profile (an exponential decay, with a decay time of 6 hr). These are
 then analysed using the light curve estimator to obtain flux points.
 
 Modelling and fitting of lightcurves can be done either - directly on
-the output of the `LighCurveEstimator` (at the DL5 level) - fit the
+the output of the `~gammapy.estimators.LightCurveEstimator` (at the DL5 level) - fit the
 simulated datasets (at the DL4 level)
 
-In summary, necessary steps are:
+In summary, the necessary steps are:
 
 -  Choose observation parameters including a list of
    `gammapy.data.GTI`
--  Define temporal and spectral models from :ref:`model-gallery` as per
+-  Define temporal and spectral models from the :ref:`model-gallery` as per
    science case
 -  Perform the simulation (in 1D or 3D)
 -  Extract the light curve from the reduced dataset as shown
-   in :doc:`/tutorials/analysis-time/light_curve` tutorial.
+   in :doc:`/tutorials/analysis-time/light_curve` tutorial
 -  Optionally, we show here how to fit the simulated datasets using a
    source model
 
@@ -66,11 +66,6 @@ from astropy.time import Time
 
 # %matplotlib inline
 import matplotlib.pyplot as plt
-
-######################################################################
-# Setup
-# -----
-#
 from IPython.display import display
 
 log = logging.getLogger(__name__)
@@ -118,9 +113,10 @@ TimeMapAxis.time_format = "iso"
 # ------------------------
 #
 # We will simulate 10 spectra between 300 GeV and 10 TeV using an
-# `PowerLawSpectralModel` and a `ExpDecayTemporalModel`. The important
+# `~gammapy.modeling.models.PowerLawSpectralModel` and a
+# `~gammapy.modeling.models.ExpDecayTemporalModel`. The important
 # thing to note here is how to attach a different `GTI` to each dataset.
-# Since we use spectrum datasets here, we will use a `RegionGeom`.
+# Since we use spectrum datasets here, we will use a `~gammapy.maps.RegionGeom`.
 #
 
 # Loading IRFs
@@ -271,7 +267,7 @@ plt.show()
 # Fitting the obtained light curve
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# We will first convert the obtained light curve to a `FluxPointsDataset`
+# We will first convert the obtained light curve to a `~gammapy.datasets.FluxPointsDataset`
 # and fit it with a spectral and temporal model
 
 # Create the datasets by iterating over the returned lightcurve
@@ -281,7 +277,7 @@ dataset_fp = FluxPointsDataset(data=lc_1d, name="dataset_lc")
 ######################################################################
 # We will fit the amplitude, spectral index and the decay time scale. Note
 # that `t_ref` should be fixed by default for the
-# `ExpDecayTemporalModel`.
+# `~gammapy.modeling.models.ExpDecayTemporalModel`.
 #
 
 # Define the model:
@@ -324,7 +320,7 @@ dataset_fp.plot_spectrum(axis_name="time")
 # For modelling and fitting more complex flares, you should attach the
 # relevant model to each group of `datasets`. The parameters of a model
 # in a given group of dataset will be tied. For more details on joint
-# fitting in Gammapy, see :doc:`/tutorials/analysis-3d/analysis_3d`
+# fitting in Gammapy, see the :doc:`/tutorials/analysis-3d/analysis_3d`.
 #
 
 # Define the model:
@@ -344,7 +340,7 @@ display(model2.parameters.to_table())
 datasets.models = model2
 
 # %%time
-# Do a joint fit
+# Perform a joint fit
 fit = Fit()
 result = fit.run(datasets=datasets)
 
@@ -360,7 +356,7 @@ display(result.parameters.to_table())
 # Exercises
 # ---------
 #
-# 1. Re-do the analysis with `MapDataset` instead of `SpectralDataset`
+# 1. Re-do the analysis with `~gammapy.datasets.MapDataset` instead of a `~gammapy.datasets.SpectrumDataset`
 # 2. Model the flare of PKS 2155-304 which you obtained using
 #    the :doc:`/tutorials/analysis-time/light_curve_flare` tutorial.
 #    Use a combination of a Gaussian and Exponential flare profiles.

--- a/examples/tutorials/analysis-time/light_curve_simulation.py
+++ b/examples/tutorials/analysis-time/light_curve_simulation.py
@@ -42,7 +42,7 @@ In summary, necessary steps are:
 
 -  Choose observation parameters including a list of
    `gammapy.data.GTI`
--  Define temporal and spectral models from :ref:model-gallery as per
+-  Define temporal and spectral models from :ref:`model-gallery` as per
    science case
 -  Perform the simulation (in 1D or 3D)
 -  Extract the light curve from the reduced dataset as shown

--- a/examples/tutorials/analysis-time/light_curve_simulation.py
+++ b/examples/tutorials/analysis-time/light_curve_simulation.py
@@ -166,7 +166,7 @@ display(model_simu.parameters.to_table())
 
 ######################################################################
 # Now, define the start and observation livetime wrt to the reference
-# time, `gti_t0`
+# time, ``gti_t0``
 #
 
 n_obs = 10
@@ -276,7 +276,7 @@ dataset_fp = FluxPointsDataset(data=lc_1d, name="dataset_lc")
 
 ######################################################################
 # We will fit the amplitude, spectral index and the decay time scale. Note
-# that `t_ref` should be fixed by default for the
+# that ``t_ref`` should be fixed by default for the
 # `~gammapy.modeling.models.ExpDecayTemporalModel`.
 #
 
@@ -318,7 +318,7 @@ dataset_fp.plot_spectrum(axis_name="time")
 # Here, we apply the models directly to the simulated datasets.
 #
 # For modelling and fitting more complex flares, you should attach the
-# relevant model to each group of `datasets`. The parameters of a model
+# relevant model to each group of ``datasets``. The parameters of a model
 # in a given group of dataset will be tied. For more details on joint
 # fitting in Gammapy, see the :doc:`/tutorials/analysis-3d/analysis_3d`.
 #

--- a/examples/tutorials/analysis-time/pulsar_analysis.py
+++ b/examples/tutorials/analysis-time/pulsar_analysis.py
@@ -1,6 +1,6 @@
 """
 Pulsar analysis
----------------
+===============
 
 Produce a phasogram, phased-resolved maps and spectra for pulsar analysis.
  
@@ -10,12 +10,12 @@ Introduction
 This notebook shows how to do a simple pulsar analysis with Gammapy. We will produce a
 phasogram, a phase-resolved map and a phase-resolved spectrum of the Vela pulsar. In
 order to build these products, we will use the
-`~PhaseBackgroundMaker` which takes into account the on and off phase to compute a
-`~MapDatasetOnOff` and a `~SpectrumDatasetOnOff` in the phase space.
+`~gammapy.makers.PhaseBackgroundMaker` which takes into account the on and off phase to compute a
+`~gammapy.datasets.MapDatasetOnOff` and a `~gammapy.datasets.SpectrumDatasetOnOff` in the phase space.
 
 This tutorial uses a simulated run of vel observation from the CTA DC1, which already contains a
 column for the pulsar phases. The phasing in itself is therefore not show here. It
-requires specific packages like Tempo2 or `(PINT) <https://nanograv-pint.readthedocs.io>`__. A gammapy
+requires specific packages like Tempo2 or `PINT <https://nanograv-pint.readthedocs.io>`__. A gammapy
 recipe shows how to compute phases with PINT in the framework of Gammapy.
 
 
@@ -59,8 +59,6 @@ warnings.filterwarnings("ignore")
 ######################################################################
 # Check setup
 # -----------
-
-
 from gammapy.utils.check import check_tutorials_setup
 
 check_tutorials_setup()
@@ -341,11 +339,11 @@ plt.show()
 #
 # We can also make a phase-resolved spectrum.
 # In order to do that, we are going to use the `~gammapy.makers.PhaseBackgroundMaker` to create a
-# `~gammapy.makers.SpectrumDatasetOnOff` with the ON and OFF taken in the phase space.
+# `~gammapy.datasets.SpectrumDatasetOnOff` with the ON and OFF taken in the phase space.
 # Note that this maker take the ON and OFF in the same spatial region.
 #
 # Here to create the `~gammapy.datasets.SpectrumDatasetOnOff`, we are going to redo the whole data reduction.
-# However, note that one can use the `to_spectrum_dataset()` method of `~gammapy.datasets.MapDatasetOnOff`
+# However, note that one can use the `~gammapy.datasets.MapDatasetOnOff.to_spectrum_dataset()` method
 # (with the `containment_correction` parameter set to True) if such a `~gammapy.datasets.MapDatasetOnOff`
 # has been created as shown above.
 


### PR DESCRIPTION
This PR is to correct some small errors in the analysis-time tutorials, for example spelling mistakes and correcting the referencing. 

Again this is a draft as I could not run the docs locally, so do not know if it is all corrected properly.