### PR TITLE
Fix `datasets.info_table()` discrepancy between cumulative mode.

### DIFF
--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -505,8 +505,8 @@ class Datasets(collections.abc.MutableSequence):
         Parameters
         ----------
         cumulative : bool
-            Cumulate info across all observations. If True, all the information that depend on a
-            model, such as 'stat_sum', will be lost. Default is False.
+            Cumulate info across all observations. If True, all information depending
+            on a model will be lost. Default is False.
 
         Returns
         -------

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -505,7 +505,8 @@ class Datasets(collections.abc.MutableSequence):
         Parameters
         ----------
         cumulative : bool
-            Cumulate info across all observations. Default is False.
+            Cumulate info across all observations. If True, all the information that depend on a
+            model, such as 'stat_sum', will be lost. Default is False.
 
         Returns
         -------
@@ -515,19 +516,18 @@ class Datasets(collections.abc.MutableSequence):
         if not self.is_all_same_type:
             raise ValueError("Info table not supported for mixed dataset type.")
 
-        name = "stacked" if cumulative else self[0].name
-        stacked = self[0].to_masked(name=name)
+        rows = []
 
-        rows = [stacked.info_dict()]
-
-        for dataset in self[1:]:
-            if cumulative:
+        if cumulative:
+            name = "stacked"
+            stacked = self[0].to_masked(name=name)
+            rows.append(stacked.info_dict())
+            for dataset in self[1:]:
                 stacked.stack(dataset)
-                row = stacked.info_dict()
-            else:
-                row = dataset.info_dict()
-
-            rows.append(row)
+                rows.append(stacked.info_dict())
+        else:
+            for dataset in self:
+                rows.append(dataset.info_dict())
 
         return Table(rows)
 

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -525,7 +525,7 @@ class Datasets(collections.abc.MutableSequence):
                 stacked.stack(dataset)
                 row = stacked.info_dict()
             else:
-                row = dataset.info_dict()
+                row = dataset.to_masked(name=dataset.name).info_dict()
 
             rows.append(row)
 

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -505,8 +505,8 @@ class Datasets(collections.abc.MutableSequence):
         Parameters
         ----------
         cumulative : bool
-            Cumulate information across all datasets. If True, all information depending
-            on a model will be lost. Default is False.
+            Cumulate information across all datasets. If True, all model-dependent
+            information will be lost. Default is False.
 
         Returns
         -------

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -505,7 +505,7 @@ class Datasets(collections.abc.MutableSequence):
         Parameters
         ----------
         cumulative : bool
-            Cumulate info across all observations. If True, all information depending
+            Cumulate information across all datasets. If True, all information depending
             on a model will be lost. Default is False.
 
         Returns

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -525,7 +525,7 @@ class Datasets(collections.abc.MutableSequence):
                 stacked.stack(dataset)
                 row = stacked.info_dict()
             else:
-                row = dataset.to_masked(name=dataset.name).info_dict()
+                row = dataset.info_dict()
 
             rows.append(row)
 

--- a/gammapy/datasets/tests/test_datasets.py
+++ b/gammapy/datasets/tests/test_datasets.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 import pytest
+import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import SkyCoord
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
@@ -88,10 +89,15 @@ def test_datasets_info_table():
     table = datasets_hess.info_table()
     assert table["name"][0] == "23523"
     assert table["name"][1] == "23526"
+    assert np.isnan(table["npred_signal"][0])
 
-    table = datasets_hess.info_table(cumulative=True)
-    assert table["name"][0] == "stacked"
-    assert table["name"][1] == "stacked"
+    table_cumul = datasets_hess.info_table(cumulative=True)
+    assert table_cumul["name"][0] == "stacked"
+    assert table_cumul["name"][1] == "stacked"
+    assert np.isnan(table_cumul["npred_signal"][0])
+    assert table_cumul["alpha"][1] == table_cumul["alpha"][0]
+
+    assert table["excess"].sum() == table_cumul["excess"][1]
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_datasets.py
+++ b/gammapy/datasets/tests/test_datasets.py
@@ -2,7 +2,7 @@
 import os
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 from astropy.coordinates import SkyCoord
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
 from gammapy.datasets.tests.test_map import get_map_dataset
@@ -90,14 +90,32 @@ def test_datasets_info_table():
     assert table["name"][0] == "23523"
     assert table["name"][1] == "23526"
     assert np.isnan(table["npred_signal"][0])
+    assert_equal(table["counts"], [124, 126])
+    assert_allclose(table["background"], [7.666, 8.583], rtol=1e-3)
 
     table_cumul = datasets_hess.info_table(cumulative=True)
     assert table_cumul["name"][0] == "stacked"
     assert table_cumul["name"][1] == "stacked"
     assert np.isnan(table_cumul["npred_signal"][0])
     assert table_cumul["alpha"][1] == table_cumul["alpha"][0]
+    assert_equal(table_cumul["counts"], [124, 250])
+    assert_allclose(table_cumul["background"], [7.666, 16.25], rtol=1e-3)
 
     assert table["excess"].sum() == table_cumul["excess"][1]
+    assert table["counts"].sum() == table_cumul["counts"][1]
+    assert table["background"].sum() == table_cumul["background"][1]
+
+    datasets_hess[0].mask_safe.data = ~datasets_hess[0].mask_safe.data
+    assert datasets_hess.info_table()["counts"][0] == 65
+
+    datasets_hess[0].mask_safe.data = np.ones_like(
+        datasets_hess[0].mask_safe.data, dtype=bool
+    )
+    datasets_hess[1].mask_safe.data = np.ones_like(
+        datasets_hess[1].mask_safe.data, dtype=bool
+    )
+    assert_equal(datasets_hess.info_table()["counts"], [189, 199])
+    assert_equal(datasets_hess.info_table(cumulative=True)["counts"], [189, 388])
 
 
 @requires_data()


### PR DESCRIPTION
This PR fix #5019. 

The discrepancy describe in the issue come from different part of the code: 

- In `info_table` the first dataset was always stacked (alone) whereas the other ones where only stacked if cumulative was `True`. This means that if cumulative was `False`, the first dataset of the table loose its possible model information, therefore `stat_sum = nan`, while it would be some value for the other datasets of the table. 
- In the `_count_statistic` method, `self.background`was passed instead of `self.npred_background()`, therefore the excess, background and sqrt_ts information where not the same if cumulative is `True` or `False`. This is because if cumulative is `True`, the datasets are stack and while stacking `self.background` take the stack of `self.npred_background()` and not `self.background`.

I also added a more robust check for `npred_signal()` so that it is not computed if there are no "signal model".

I still need to add some test for these changes. 