### PR TITLE
Add function to scale colorbar height

### DIFF
--- a/examples/tutorials/analysis-2d/detect.py
+++ b/examples/tutorials/analysis-2d/detect.py
@@ -167,7 +167,7 @@ maps = estimator.run(dataset)
 
 fig, (ax1, ax2, ax3) = plt.subplots(
     ncols=3,
-    figsize=(15, 3),
+    figsize=(20, 3),
     subplot_kw={"projection": counts.geom.wcs},
     gridspec_kw={"left": 0.1, "right": 0.98},
 )
@@ -202,7 +202,7 @@ ax = maps["sqrt_ts"].plot(add_cbar=True)
 ax.scatter(
     sources["ra"],
     sources["dec"],
-    transform=plt.gca().get_transform("icrs"),
+    transform=ax.get_transform("icrs"),
     color="none",
     edgecolor="w",
     marker="o",

--- a/examples/tutorials/analysis-2d/ring_background.py
+++ b/examples/tutorials/analysis-2d/ring_background.py
@@ -238,7 +238,7 @@ excess_map = lima_maps["npred_excess"]
 
 # We can plot the excess and significance maps
 fig, (ax1, ax2) = plt.subplots(
-    figsize=(11, 5), subplot_kw={"projection": lima_maps.geom.wcs}, ncols=2
+    figsize=(11, 4), subplot_kw={"projection": lima_maps.geom.wcs}, ncols=2
 )
 
 ax1.set_title("Significance map")

--- a/examples/tutorials/analysis-time/pulsar_analysis.py
+++ b/examples/tutorials/analysis-time/pulsar_analysis.py
@@ -295,7 +295,7 @@ background = (
 )
 
 fig, (ax1, ax2) = plt.subplots(
-    figsize=(11, 5), ncols=2, subplot_kw={"projection": counts.geom.wcs}
+    figsize=(11, 4), ncols=2, subplot_kw={"projection": counts.geom.wcs}
 )
 
 counts.plot(ax=ax1, add_cbar=True)
@@ -319,7 +319,7 @@ npred_excess = estimator_results.npred_excess
 sqrt_ts = estimator_results.sqrt_ts
 
 fig, (ax1, ax2) = plt.subplots(
-    figsize=(11, 5), ncols=2, subplot_kw={"projection": npred_excess.geom.wcs}
+    figsize=(11, 4), ncols=2, subplot_kw={"projection": npred_excess.geom.wcs}
 )
 
 npred_excess.plot(ax=ax1, add_cbar=True)

--- a/examples/tutorials/api/irfs.py
+++ b/examples/tutorials/api/irfs.py
@@ -281,7 +281,8 @@ exposure_map = make_map_exposure_true_energy(
     pointing=pointing, livetime="42 h", aeff=aeff_3d, geom=geom
 )
 
-exposure_map.plot_grid(add_cbar=True)
+exposure_map.plot_grid(add_cbar=True, figsize=(17, 7))
+plt.show()
 
 
 ######################################################################

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2123,7 +2123,7 @@ class MapDataset(Dataset):
         energy_axis = self._geom.axes["energy"].squash()
         return self.resample_energy_axis(energy_axis=energy_axis, name=name)
 
-    def peek(self, figsize=(12, 10)):
+    def peek(self, figsize=(12, 8)):
         """Quick-look summary plots.
 
         Parameters
@@ -2142,7 +2142,7 @@ class MapDataset(Dataset):
             nrows=2,
             subplot_kw={"projection": self._geom.wcs},
             figsize=figsize,
-            gridspec_kw={"hspace": 0.1, "wspace": 0.1},
+            gridspec_kw={"hspace": 0.25, "wspace": 0.1},
         )
 
         axes = axes.flat

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -172,7 +172,7 @@ class Background3D(BackgroundIRF):
 
     def plot_at_energy(
         self,
-        energy=None,
+        energy=1 * u.TeV,
         add_cbar=True,
         ncols=3,
         figsize=None,
@@ -184,8 +184,8 @@ class Background3D(BackgroundIRF):
 
         Parameters
         ----------
-        energy : `~astropy.units.Quantity`
-            List of energies.
+        energy : `~astropy.units.Quantity`, optional
+            List of energies. Default is 1 TeV.
         add_cbar : bool, optional
             Add color bar. Default is True.
         ncols : int, optional
@@ -294,14 +294,14 @@ class Background2D(BackgroundIRF):
         )
 
     def plot_at_energy(
-        self, energy=None, add_cbar=True, ncols=3, figsize=None, **kwargs
+        self, energy=1 * u.TeV, add_cbar=True, ncols=3, figsize=None, **kwargs
     ):
         """Plot the background rate in FoV coordinates at a given energy.
 
         Parameters
         ----------
-        energy : `~astropy.units.Quantity`
-            List of energy.
+        energy : `~astropy.units.Quantity`, optional
+            List of energy. Default is 1 TeV.
         add_cbar : bool, optional
             Add color bar. Default is True.
         ncols : int, optional

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -319,7 +319,26 @@ class Background2D(BackgroundIRF):
     def plot(
         self, ax=None, add_cbar=True, axes_loc=None, kwargs_colorbar=None, **kwargs
     ):
-        """Plot energy offset dependence of the background model."""
+        """Plot energy offset dependence of the background model.
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`, optional
+            Matplotlib axes. Default is None.
+        add_cbar : bool, optional
+            Add a colorbar to the plot. Default is True.
+        axes_loc : dict, optional
+            Keyword arguments passed to `~mpl_toolkits.axes_grid1.axes_divider.AxesDivider.append_axes`.
+        kwargs_colorbar : dict, optional
+            Keyword arguments passed to `~matplotlib.pyplot.colorbar`.
+        kwargs : dict
+            Keyword arguments passed to `~matplotlib.pyplot.pcolormesh`.
+
+        Returns
+        -------
+        ax : `~matplotlib.axes.Axes`
+            Matplotlib axes.
+        """
         ax = plt.gca() if ax is None else ax
 
         energy_axis, offset_axis = self.axes["energy"], self.axes["offset"]

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 from gammapy.maps import MapAxes, MapAxis
 from gammapy.maps.axes import UNIT_STRING_FORMAT
+from gammapy.visualization.utils import add_colorbar
 from .core import IRF
 from .io import gadf_is_pointlike
 
@@ -224,7 +225,7 @@ class Background3D(BackgroundIRF):
             ax.set_title(str(ee))
             if add_cbar:
                 label = f"Background [{bkg_unit.to_string(UNIT_STRING_FORMAT)}]"
-                cbar = ax.figure.colorbar(caxes, ax=ax, label=label, fraction=cfraction)
+                cbar = add_colorbar(caxes, ax=ax, label=label)
                 cbar.formatter.set_powerlimits((0, 0))
 
             row, col = np.unravel_index(i, shape=(rows, cols))
@@ -323,7 +324,7 @@ class Background2D(BackgroundIRF):
             label = (
                 f"Background rate [{self.quantity.unit.to_string(UNIT_STRING_FORMAT)}]"
             )
-            ax.figure.colorbar(caxes, ax=ax, label=label)
+            add_colorbar(caxes, ax=ax, label=label)
 
     def plot_offset_dependence(self, ax=None, energy=None, **kwargs):
         """Plot background rate versus offset for a given energy.

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -176,6 +176,7 @@ class Background3D(BackgroundIRF):
         add_cbar=True,
         ncols=3,
         figsize=None,
+        axes_loc=None,
         kwargs_colorbar=None,
         **kwargs,
     ):
@@ -191,8 +192,10 @@ class Background3D(BackgroundIRF):
             Number of columns to plot. Default is 3.
         figsize : tuple, optional
             Figure size. Default is None.
+        axes_loc : dict, optional
+            Keyword arguments passed to `~mpl_toolkits.axes_grid1.axes_divider.AxesDivider.append_axes`.
         kwargs_colorbar : dict, optional
-            Keyword argument passed to ~gammapy.visualisation.utils.add_colorbar`.
+            Keyword arguments passed to `~matplotlib.pyplot.colorbar`.
         **kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.pcolormesh`.
         """
@@ -237,7 +240,7 @@ class Background3D(BackgroundIRF):
             if add_cbar:
                 label = f"Background [{bkg_unit.to_string(UNIT_STRING_FORMAT)}]"
                 kwargs_colorbar.setdefault("label", label)
-                cbar = add_colorbar(caxes, ax=ax, **kwargs_colorbar)
+                cbar = add_colorbar(caxes, ax=ax, axes_loc=axes_loc, **kwargs_colorbar)
                 cbar.formatter.set_powerlimits((0, 0))
 
             row, col = np.unravel_index(i, shape=(rows, cols))
@@ -313,7 +316,9 @@ class Background2D(BackgroundIRF):
             energy=energy, add_cbar=add_cbar, ncols=ncols, figsize=figsize, **kwargs
         )
 
-    def plot(self, ax=None, add_cbar=True, kwargs_colorbar=None, **kwargs):
+    def plot(
+        self, ax=None, add_cbar=True, axes_loc=None, kwargs_colorbar=None, **kwargs
+    ):
         """Plot energy offset dependence of the background model."""
         ax = plt.gca() if ax is None else ax
 
@@ -339,7 +344,7 @@ class Background2D(BackgroundIRF):
                 f"Background rate [{self.quantity.unit.to_string(UNIT_STRING_FORMAT)}]"
             )
             kwargs_colorbar.setdefault("label", label)
-            add_colorbar(caxes, ax=ax, **kwargs_colorbar)
+            add_colorbar(caxes, ax=ax, axes_loc=axes_loc, **kwargs_colorbar)
 
     def plot_offset_dependence(self, ax=None, energy=None, **kwargs):
         """Plot background rate versus offset for a given energy.

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -171,7 +171,13 @@ class Background3D(BackgroundIRF):
         return self.to_2d().peek(figsize)
 
     def plot_at_energy(
-        self, energy=None, add_cbar=True, ncols=3, figsize=None, **kwargs
+        self,
+        energy=None,
+        add_cbar=True,
+        ncols=3,
+        figsize=None,
+        kwargs_colorbar=None,
+        **kwargs,
     ):
         """Plot the background rate in FoV coordinates at a given energy.
 
@@ -185,9 +191,13 @@ class Background3D(BackgroundIRF):
             Number of columns to plot. Default is 3.
         figsize : tuple, optional
             Figure size. Default is None.
+        kwargs_colorbar : dict, optional
+            Keyword argument passed to ~gammapy.visualisation.utils.add_colorbar`.
         **kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.pcolormesh`.
         """
+        kwargs_colorbar = kwargs_colorbar or {}
+
         n = len(energy)
         cols = min(ncols, n)
         rows = 1 + (n - 1) // cols
@@ -223,9 +233,11 @@ class Background3D(BackgroundIRF):
             self.axes["fov_lat"].format_plot_xaxis(ax)
             self.axes["fov_lon"].format_plot_yaxis(ax)
             ax.set_title(str(ee))
+
             if add_cbar:
                 label = f"Background [{bkg_unit.to_string(UNIT_STRING_FORMAT)}]"
-                cbar = add_colorbar(caxes, ax=ax, label=label)
+                kwargs_colorbar.setdefault("label", label)
+                cbar = add_colorbar(caxes, ax=ax, **kwargs_colorbar)
                 cbar.formatter.set_powerlimits((0, 0))
 
             row, col = np.unravel_index(i, shape=(rows, cols))
@@ -301,7 +313,7 @@ class Background2D(BackgroundIRF):
             energy=energy, add_cbar=add_cbar, ncols=ncols, figsize=figsize, **kwargs
         )
 
-    def plot(self, ax=None, add_cbar=True, **kwargs):
+    def plot(self, ax=None, add_cbar=True, kwargs_colorbar=None, **kwargs):
         """Plot energy offset dependence of the background model."""
         ax = plt.gca() if ax is None else ax
 
@@ -311,6 +323,8 @@ class Background2D(BackgroundIRF):
         kwargs.setdefault("cmap", "GnBu")
         kwargs.setdefault("edgecolors", "face")
         kwargs.setdefault("norm", LogNorm())
+
+        kwargs_colorbar = kwargs_colorbar or {}
 
         with quantity_support():
             caxes = ax.pcolormesh(
@@ -324,7 +338,8 @@ class Background2D(BackgroundIRF):
             label = (
                 f"Background rate [{self.quantity.unit.to_string(UNIT_STRING_FORMAT)}]"
             )
-            add_colorbar(caxes, ax=ax, label=label)
+            kwargs_colorbar.setdefault("label", label)
+            add_colorbar(caxes, ax=ax, **kwargs_colorbar)
 
     def plot_offset_dependence(self, ax=None, energy=None, **kwargs):
         """Plot background rate versus offset for a given energy.

--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -7,6 +7,7 @@ from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from matplotlib.colors import PowerNorm
 from gammapy.maps import MapAxes, MapAxis, RegionGeom
+from gammapy.visualization.utils import add_colorbar
 from ..core import IRF
 
 __all__ = ["EnergyDispersion2D"]
@@ -259,7 +260,7 @@ class EnergyDispersion2D(IRF):
 
         if add_cbar:
             label = "Probability density [A.U]."
-            ax.figure.colorbar(caxes, ax=ax, label=label)
+            add_colorbar(caxes, ax=ax, label=label)
 
         return ax
 

--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -216,7 +216,9 @@ class EnergyDispersion2D(IRF):
         ax.legend(loc="upper left")
         return ax
 
-    def plot_bias(self, ax=None, offset=None, add_cbar=False, **kwargs):
+    def plot_bias(
+        self, ax=None, offset=None, add_cbar=False, kwargs_colorbar=None, **kwargs
+    ):
         """Plot migration as a function of true energy for a given offset.
 
         Parameters
@@ -227,6 +229,9 @@ class EnergyDispersion2D(IRF):
             Offset. Default is None.
         add_cbar : bool, optional
             Add a colorbar to the plot. Default is False.
+        kwargs_colorbar : dict, optional
+            Keyword argument passed to ~gammapy.visualisation.utils.add_colorbar`.
+            Default is None.
         kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.pcolormesh`.
 
@@ -237,6 +242,8 @@ class EnergyDispersion2D(IRF):
         """
         kwargs.setdefault("cmap", "GnBu")
         kwargs.setdefault("norm", PowerNorm(gamma=0.5))
+
+        kwargs_colorbar = kwargs_colorbar or {}
 
         ax = plt.gca() if ax is None else ax
 
@@ -260,7 +267,8 @@ class EnergyDispersion2D(IRF):
 
         if add_cbar:
             label = "Probability density [A.U]."
-            add_colorbar(caxes, ax=ax, label=label)
+            kwargs_colorbar.setdefault("label", label)
+            add_colorbar(caxes, ax=ax, **kwargs_colorbar)
 
         return ax
 

--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -217,7 +217,13 @@ class EnergyDispersion2D(IRF):
         return ax
 
     def plot_bias(
-        self, ax=None, offset=None, add_cbar=False, kwargs_colorbar=None, **kwargs
+        self,
+        ax=None,
+        offset=None,
+        add_cbar=False,
+        axes_loc=None,
+        kwargs_colorbar=None,
+        **kwargs,
     ):
         """Plot migration as a function of true energy for a given offset.
 
@@ -229,9 +235,10 @@ class EnergyDispersion2D(IRF):
             Offset. Default is None.
         add_cbar : bool, optional
             Add a colorbar to the plot. Default is False.
+        axes_loc : dict, optional
+            Keyword arguments passed to `~mpl_toolkits.axes_grid1.axes_divider.AxesDivider.append_axes`.
         kwargs_colorbar : dict, optional
-            Keyword argument passed to ~gammapy.visualisation.utils.add_colorbar`.
-            Default is None.
+            Keyword arguments passed to `~matplotlib.pyplot.colorbar`.
         kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.pcolormesh`.
 
@@ -268,7 +275,7 @@ class EnergyDispersion2D(IRF):
         if add_cbar:
             label = "Probability density [A.U]."
             kwargs_colorbar.setdefault("label", label)
-            add_colorbar(caxes, ax=ax, **kwargs_colorbar)
+            add_colorbar(caxes, ax=ax, axes_loc=axes_loc, **kwargs_colorbar)
 
         return ax
 

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -9,6 +9,7 @@ from matplotlib.colors import PowerNorm
 from gammapy.maps import MapAxis
 from gammapy.maps.axes import UNIT_STRING_FORMAT
 from gammapy.utils.scripts import make_path
+from gammapy.visualization.utils import add_colorbar
 from ..core import IRF
 
 __all__ = ["EDispKernel"]
@@ -546,7 +547,7 @@ class EDispKernel(IRF):
 
         if add_cbar:
             label = "Probability density (A.U.)"
-            ax.figure.colorbar(caxes, ax=ax, label=label)
+            add_colorbar(caxes, ax=ax, label=label)
 
         energy_axis_true.format_plot_xaxis(ax=ax)
         energy_axis.format_plot_yaxis(ax=ax)

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -516,7 +516,7 @@ class EDispKernel(IRF):
 
         return var / norm
 
-    def plot_matrix(self, ax=None, add_cbar=False, **kwargs):
+    def plot_matrix(self, ax=None, add_cbar=False, kwargs_colorbar=None, **kwargs):
         """Plot PDF matrix.
 
         Parameters
@@ -525,6 +525,10 @@ class EDispKernel(IRF):
             Matplotlib axes. Default is None.
         add_cbar : bool, optional
             Add a colorbar to the plot. Default is False.
+        kwargs_colorbar : dict, optional
+            Keyword argument passed to ~gammapy.visualisation.utils.add_colorbar`.
+        kwargs : dict
+            Keyword arguments passed to `~matplotlib.pyplot.pcolormesh`.
 
         Returns
         -------
@@ -534,6 +538,8 @@ class EDispKernel(IRF):
         kwargs.setdefault("cmap", "GnBu")
         norm = PowerNorm(gamma=0.5, vmin=0, vmax=1)
         kwargs.setdefault("norm", norm)
+
+        kwargs_colorbar = kwargs_colorbar or {}
 
         ax = plt.gca() if ax is None else ax
 
@@ -547,7 +553,8 @@ class EDispKernel(IRF):
 
         if add_cbar:
             label = "Probability density (A.U.)"
-            add_colorbar(caxes, ax=ax, label=label)
+            kwargs_colorbar.setdefault("label", label)
+            add_colorbar(caxes, ax=ax, **kwargs_colorbar)
 
         energy_axis_true.format_plot_xaxis(ax=ax)
         energy_axis.format_plot_yaxis(ax=ax)

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -516,7 +516,9 @@ class EDispKernel(IRF):
 
         return var / norm
 
-    def plot_matrix(self, ax=None, add_cbar=False, kwargs_colorbar=None, **kwargs):
+    def plot_matrix(
+        self, ax=None, add_cbar=False, axes_loc=None, kwargs_colorbar=None, **kwargs
+    ):
         """Plot PDF matrix.
 
         Parameters
@@ -525,8 +527,10 @@ class EDispKernel(IRF):
             Matplotlib axes. Default is None.
         add_cbar : bool, optional
             Add a colorbar to the plot. Default is False.
+        axes_loc : dict, optional
+            Keyword arguments passed to `~mpl_toolkits.axes_grid1.axes_divider.AxesDivider.append_axes`.
         kwargs_colorbar : dict, optional
-            Keyword argument passed to ~gammapy.visualisation.utils.add_colorbar`.
+            Keyword arguments passed to `~matplotlib.pyplot.colorbar`.
         kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.pcolormesh`.
 
@@ -554,7 +558,7 @@ class EDispKernel(IRF):
         if add_cbar:
             label = "Probability density (A.U.)"
             kwargs_colorbar.setdefault("label", label)
-            add_colorbar(caxes, ax=ax, **kwargs_colorbar)
+            add_colorbar(caxes, ax=ax, axes_loc=axes_loc, **kwargs_colorbar)
 
         energy_axis_true.format_plot_xaxis(ax=ax)
         energy_axis.format_plot_yaxis(ax=ax)

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -5,6 +5,7 @@ from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from gammapy.maps import MapAxes, MapAxis
 from gammapy.maps.axes import UNIT_STRING_FORMAT
+from gammapy.visualization.utils import add_colorbar
 from .core import IRF
 
 __all__ = ["EffectiveAreaTable2D"]
@@ -174,7 +175,7 @@ class EffectiveAreaTable2D(IRF):
 
         if add_cbar:
             label = f"Effective Area [{aeff.unit.to_string(UNIT_STRING_FORMAT)}]"
-            ax.figure.colorbar(caxes, ax=ax, label=label)
+            add_colorbar(caxes, ax=ax, label=label)
 
         return ax
 

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -150,7 +150,9 @@ class EffectiveAreaTable2D(IRF):
         ax.legend(loc="best")
         return ax
 
-    def plot(self, ax=None, add_cbar=True, kwargs_colorbar=None, **kwargs):
+    def plot(
+        self, ax=None, add_cbar=True, axes_loc=None, kwargs_colorbar=None, **kwargs
+    ):
         """Plot effective area image."""
         ax = plt.gca() if ax is None else ax
 
@@ -178,7 +180,7 @@ class EffectiveAreaTable2D(IRF):
         if add_cbar:
             label = f"Effective Area [{aeff.unit.to_string(UNIT_STRING_FORMAT)}]"
             kwargs_colorbar.setdefault("label", label)
-            add_colorbar(caxes, ax=ax, **kwargs_colorbar)
+            add_colorbar(caxes, ax=ax, axes_loc=axes_loc, **kwargs_colorbar)
 
         return ax
 

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -150,7 +150,7 @@ class EffectiveAreaTable2D(IRF):
         ax.legend(loc="best")
         return ax
 
-    def plot(self, ax=None, add_cbar=True, **kwargs):
+    def plot(self, ax=None, add_cbar=True, kwargs_colorbar=None, **kwargs):
         """Plot effective area image."""
         ax = plt.gca() if ax is None else ax
 
@@ -167,6 +167,8 @@ class EffectiveAreaTable2D(IRF):
         kwargs.setdefault("vmin", vmin)
         kwargs.setdefault("vmax", vmax)
 
+        kwargs_colorbar = kwargs_colorbar or {}
+
         with quantity_support():
             caxes = ax.pcolormesh(energy.edges, offset.edges, aeff.value.T, **kwargs)
 
@@ -175,7 +177,8 @@ class EffectiveAreaTable2D(IRF):
 
         if add_cbar:
             label = f"Effective Area [{aeff.unit.to_string(UNIT_STRING_FORMAT)}]"
-            add_colorbar(caxes, ax=ax, label=label)
+            kwargs_colorbar.setdefault("label", label)
+            add_colorbar(caxes, ax=ax, **kwargs_colorbar)
 
         return ax
 

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -153,7 +153,26 @@ class EffectiveAreaTable2D(IRF):
     def plot(
         self, ax=None, add_cbar=True, axes_loc=None, kwargs_colorbar=None, **kwargs
     ):
-        """Plot effective area image."""
+        """Plot effective area image.
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`, optional
+            Matplotlib axes. Default is None.
+        add_cbar : bool, optional
+            Add a colorbar to the plot. Default is True.
+        axes_loc : dict, optional
+            Keyword arguments passed to `~mpl_toolkits.axes_grid1.axes_divider.AxesDivider.append_axes`.
+        kwargs_colorbar : dict, optional
+            Keyword arguments passed to `~matplotlib.pyplot.colorbar`.
+        kwargs : dict
+            Keyword arguments passed to `~matplotlib.pyplot.pcolormesh`.
+
+        Returns
+        -------
+        ax : `~matplotlib.axes.Axes`
+            Matplotlib axes.
+        """
         ax = plt.gca() if ax is None else ax
 
         energy = self.axes["energy_true"]

--- a/gammapy/irf/psf/core.py
+++ b/gammapy/irf/psf/core.py
@@ -171,7 +171,9 @@ class PSF(IRF):
         ax.yaxis.set_major_formatter(mtick.FormatStrFormatter("%.1e"))
         return ax
 
-    def plot_containment_radius(self, ax=None, fraction=0.68, add_cbar=True, **kwargs):
+    def plot_containment_radius(
+        self, ax=None, fraction=0.68, add_cbar=True, kwargs_colorbar=None, **kwargs
+    ):
         """Plot containment image with energy and theta axes.
 
         Parameters
@@ -183,6 +185,8 @@ class PSF(IRF):
             Default is 0.68.
         add_cbar : bool, optional
             Add a colorbar. Default is True.
+        kwargs_colorbar : dict, optional
+            Keyword argument passed to ~gammapy.visualisation.utils.add_colorbar`.
         **kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.pcolormesh`.
 
@@ -208,6 +212,8 @@ class PSF(IRF):
         kwargs.setdefault("vmin", np.nanmin(containment.value))
         kwargs.setdefault("vmax", np.nanmax(containment.value))
 
+        kwargs_colorbar = kwargs_colorbar or {}
+
         # Plotting
         with quantity_support():
             caxes = ax.pcolormesh(
@@ -219,7 +225,8 @@ class PSF(IRF):
 
         if add_cbar:
             label = f"Containment radius R{100 * fraction:.0f} ({containment.unit})"
-            add_colorbar(caxes, ax=ax, label=label)
+            kwargs_colorbar.setdefault("label", label)
+            add_colorbar(caxes, ax=ax, **kwargs_colorbar)
 
         return ax
 

--- a/gammapy/irf/psf/core.py
+++ b/gammapy/irf/psf/core.py
@@ -172,7 +172,13 @@ class PSF(IRF):
         return ax
 
     def plot_containment_radius(
-        self, ax=None, fraction=0.68, add_cbar=True, kwargs_colorbar=None, **kwargs
+        self,
+        ax=None,
+        fraction=0.68,
+        add_cbar=True,
+        axes_loc=None,
+        kwargs_colorbar=None,
+        **kwargs,
     ):
         """Plot containment image with energy and theta axes.
 
@@ -185,8 +191,10 @@ class PSF(IRF):
             Default is 0.68.
         add_cbar : bool, optional
             Add a colorbar. Default is True.
+        axes_loc : dict, optional
+            Keyword arguments passed to `~mpl_toolkits.axes_grid1.axes_divider.AxesDivider.append_axes`.
         kwargs_colorbar : dict, optional
-            Keyword argument passed to ~gammapy.visualisation.utils.add_colorbar`.
+            Keyword arguments passed to `~matplotlib.pyplot.colorbar`.
         **kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.pcolormesh`.
 
@@ -226,7 +234,7 @@ class PSF(IRF):
         if add_cbar:
             label = f"Containment radius R{100 * fraction:.0f} ({containment.unit})"
             kwargs_colorbar.setdefault("label", label)
-            add_colorbar(caxes, ax=ax, **kwargs_colorbar)
+            add_colorbar(caxes, ax=ax, axes_loc=axes_loc, **kwargs_colorbar)
 
         return ax
 

--- a/gammapy/irf/psf/core.py
+++ b/gammapy/irf/psf/core.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mtick
 from gammapy.maps.axes import UNIT_STRING_FORMAT
 from gammapy.utils.array import array_stats_str
+from gammapy.visualization.utils import add_colorbar
 from ..core import IRF
 
 
@@ -218,7 +219,7 @@ class PSF(IRF):
 
         if add_cbar:
             label = f"Containment radius R{100 * fraction:.0f} ({containment.unit})"
-            ax.figure.colorbar(caxes, ax=ax, label=label)
+            add_colorbar(caxes, ax=ax, label=label)
 
         return ax
 

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -16,6 +16,7 @@ import matplotlib.pyplot as plt
 import gammapy.utils.parallel as parallel
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
 from gammapy.utils.units import unit_from_fits_image_hdu
+from gammapy.visualization.utils import add_colorbar
 from ..geom import pix_tuple_to_idx
 from ..utils import INVALID_INDEX
 from .core import WcsMap
@@ -431,7 +432,8 @@ class WcsNDMap(WcsMap):
         im = ax.imshow(data, **kwargs)
 
         if add_cbar:
-            fig.colorbar(im, ax=ax, label=str(self.unit))
+            add_colorbar(im, ax, label=str(self.unit))
+            # fig.colorbar(im, ax=ax, label=str(self.unit))
 
         if self.geom.is_allsky:
             ax = self._plot_format_allsky(ax)

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -368,7 +368,15 @@ class WcsNDMap(WcsMap):
         data = block_reduce(self.data * weights, tuple(block_size), func=func)
         return self._init_copy(geom=geom, data=data.astype(self.data.dtype))
 
-    def plot(self, ax=None, fig=None, add_cbar=False, stretch="linear", **kwargs):
+    def plot(
+        self,
+        ax=None,
+        fig=None,
+        add_cbar=False,
+        stretch="linear",
+        kwargs_colorbar=None,
+        **kwargs,
+    ):
         """
         Plot image on matplotlib WCS axes.
 
@@ -383,6 +391,8 @@ class WcsNDMap(WcsMap):
         stretch : str, optional
             Passed to `astropy.visualization.simple_norm`.
              Default is "linear".
+        kwargs_colorbar : dict, optional
+            Keyword argument passed to ~gammapy.visualisation.utils.add_colorbar`.
         **kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.imshow`.
 
@@ -411,6 +421,8 @@ class WcsNDMap(WcsMap):
         kwargs.setdefault("origin", "lower")
         kwargs.setdefault("cmap", "afmhot")
 
+        kwargs_colorbar = kwargs_colorbar or {}
+
         mask = np.isfinite(data)
 
         if self.is_mask:
@@ -432,8 +444,9 @@ class WcsNDMap(WcsMap):
         im = ax.imshow(data, **kwargs)
 
         if add_cbar:
-            add_colorbar(im, ax, label=str(self.unit))
-            # fig.colorbar(im, ax=ax, label=str(self.unit))
+            label = str(self.unit)
+            kwargs_colorbar.setdefault("label", label)
+            add_colorbar(im, ax=ax, **kwargs_colorbar)
 
         if self.geom.is_allsky:
             ax = self._plot_format_allsky(ax)

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -374,6 +374,7 @@ class WcsNDMap(WcsMap):
         fig=None,
         add_cbar=False,
         stretch="linear",
+        axes_loc=None,
         kwargs_colorbar=None,
         **kwargs,
     ):
@@ -391,8 +392,10 @@ class WcsNDMap(WcsMap):
         stretch : str, optional
             Passed to `astropy.visualization.simple_norm`.
              Default is "linear".
+        axes_loc : dict, optional
+            Keyword arguments passed to `~mpl_toolkits.axes_grid1.axes_divider.AxesDivider.append_axes`.
         kwargs_colorbar : dict, optional
-            Keyword argument passed to ~gammapy.visualisation.utils.add_colorbar`.
+            Keyword arguments passed to `~matplotlib.pyplot.colorbar`.
         **kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.imshow`.
 
@@ -446,7 +449,7 @@ class WcsNDMap(WcsMap):
         if add_cbar:
             label = str(self.unit)
             kwargs_colorbar.setdefault("label", label)
-            add_colorbar(im, ax=ax, **kwargs_colorbar)
+            add_colorbar(im, ax=ax, axes_loc=axes_loc, **kwargs_colorbar)
 
         if self.geom.is_allsky:
             ax = self._plot_format_allsky(ax)

--- a/gammapy/visualization/__init__.py
+++ b/gammapy/visualization/__init__.py
@@ -4,6 +4,7 @@ from .datasets import plot_npred_signal, plot_spectrum_datasets_off_regions
 from .heatmap import annotate_heatmap, plot_heatmap
 from .panel import MapPanelPlotter
 from .utils import (
+    add_colorbar,
     plot_contour_line,
     plot_distribution,
     plot_map_rgb,
@@ -15,6 +16,7 @@ __all__ = [
     "colormap_hess",
     "colormap_milagro",
     "MapPanelPlotter",
+    "add_colorbar",
     "plot_contour_line",
     "plot_heatmap",
     "plot_map_rgb",

--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -9,11 +9,35 @@ from gammapy.maps import Map, MapAxis, WcsNDMap
 from gammapy.utils.random import get_random_state
 from gammapy.utils.testing import mpl_plot_check, requires_data
 from gammapy.visualization import (
+    add_colorbar,
     plot_contour_line,
     plot_distribution,
     plot_map_rgb,
     plot_theta_squared_table,
 )
+
+
+@requires_data()
+def test_add_colorbar():
+    map_ = Map.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
+
+    fig, ax = plt.subplots()
+    with mpl_plot_check():
+        img = ax.imshow(map_.sum_over_axes().data[0, :, :])
+        add_colorbar(img, ax=ax, label="Colorbar label")
+
+    axes_loc = {"position": "left", "size": "2%", "pad": "15%"}
+    fig, ax = plt.subplots()
+    with mpl_plot_check():
+        img = ax.imshow(map_.sum_over_axes().data[0, :, :])
+        add_colorbar(img, ax=ax, axes_loc=axes_loc)
+
+    kwargs = {"use_gridspec": False, "orientation": "horizontal"}
+    fig, ax = plt.subplots()
+    with mpl_plot_check():
+        img = ax.imshow(map_.sum_over_axes().data[0, :, :])
+        cbar = add_colorbar(img, ax=ax, **kwargs)
+        assert cbar.orientation == "horizontal"
 
 
 def test_map_panel_plotter():

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -28,13 +28,36 @@ ARTIST_TO_LINE_PROPERTIES = {
 }
 
 
-def add_colorbar(img, ax, **kwargs):
-    """Add colorbar to a given axis."""
+def add_colorbar(img, ax, axes_loc=None, **kwargs):
+    """
+    Add colorbar to a given axis.
+
+    Parameters
+    ----------
+    img : `~matplotlib.image.AxesImage`
+        The image to plot the colorbar for.
+    ax : `~matplotlib.axes.Axes`
+        Matplotlib axes.
+    axes_loc : dict, optional
+        Keyword arguments passed to `~mpl_toolkits.axes_grid1.axes_divider.AxesDivider.append_axes`.
+    kwargs : dict, optional
+        Keyword arguments passed to `~matplotlib.pyplot.colorbar`.
+
+    Returns
+    -------
+    cbar : `~matplotlib.pyplot.colorbar`
+        The colorbar.
+    """
     kwargs.setdefault("use_gridspec", True)
     kwargs.setdefault("orientation", "vertical")
 
+    axes_loc = axes_loc or {}
+    axes_loc.setdefault("position", "right")
+    axes_loc.setdefault("size", "5%")
+    axes_loc.setdefault("pad", "2%")
+
     divider = make_axes_locatable(ax)
-    cax = divider.append_axes(position="right", size="5%", pad="2%")
+    cax = divider.append_axes(**axes_loc)
     cbar = plt.colorbar(img, cax=cax, **kwargs)
     return cbar
 
@@ -59,7 +82,7 @@ def plot_map_rgb(map_, ax=None, **kwargs):
     Returns
     -------
     ax : `~astropy.visualization.wcsaxes.WCSAxes`
-        WCS axis object
+        WCS axis object.
 
     Examples
     --------
@@ -98,7 +121,7 @@ def plot_map_rgb(map_, ax=None, **kwargs):
 
 
 def plot_contour_line(ax, x, y, **kwargs):
-    """Plot smooth curve from contour points"""
+    """Plot smooth curve from contour points."""
     xf = x
     yf = y
 

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -47,6 +47,30 @@ def add_colorbar(img, ax, axes_loc=None, **kwargs):
     -------
     cbar : `~matplotlib.pyplot.colorbar`
         The colorbar.
+
+    Examples
+    --------
+    ::
+
+        from gammapy.maps import Map
+        from gammapy.visualization.utils import add_colorbar
+        import matplotlib.pyplot as plt
+        map_ = Map.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
+        axes_loc = {"position": "right", "size": "2%", "pad": "10%"}
+        kwargs_colorbar = {'label':'Colorbar label'}
+
+        # Example outside gammapy
+        fig = plt.figure(figsize=(6, 3))
+        ax = fig.add_subplot(111)
+        img = ax.imshow(map_.sum_over_axes().data[0,:,:])
+        add_colorbar(img, ax=ax, axes_loc=axes_loc, **kwargs_colorbar)
+
+        # `add_colorbar` is available for the `plot` function here:
+        fig = plt.figure(figsize=(6, 3))
+        ax = fig.add_subplot(111)
+        map_.sum_over_axes().plot(ax=ax, add_cbar=True, axes_loc=axes_loc,
+                                  kwargs_colorbar=kwargs_colorbar)
+
     """
     kwargs.setdefault("use_gridspec", True)
     kwargs.setdefault("orientation", "vertical")

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -5,6 +5,7 @@ from scipy.interpolate import CubicSpline
 from scipy.optimize import curve_fit
 from scipy.stats import norm
 from astropy.visualization import make_lupton_rgb
+import matplotlib.axes as maxes
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
@@ -79,6 +80,7 @@ def add_colorbar(img, ax, axes_loc=None, **kwargs):
     axes_loc.setdefault("position", "right")
     axes_loc.setdefault("size", "5%")
     axes_loc.setdefault("pad", "2%")
+    axes_loc.setdefault("axes_class", maxes.Axes)
 
     divider = make_axes_locatable(ax)
     cax = divider.append_axes(**axes_loc)

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -28,13 +28,14 @@ ARTIST_TO_LINE_PROPERTIES = {
 }
 
 
-def add_colorbar(img, ax, label=None):
+def add_colorbar(img, ax, **kwargs):
     """Add colorbar to a given axis."""
+    kwargs.setdefault("use_gridspec", True)
+    kwargs.setdefault("orientation", "vertical")
+
     divider = make_axes_locatable(ax)
     cax = divider.append_axes(position="right", size="5%", pad="2%")
-    cbar = plt.colorbar(
-        img, cax=cax, orientation="vertical", use_gridspec=True, label=label
-    )
+    cbar = plt.colorbar(img, cax=cax, **kwargs)
     return cbar
 
 

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -6,8 +6,10 @@ from scipy.optimize import curve_fit
 from scipy.stats import norm
 from astropy.visualization import make_lupton_rgb
 import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 __all__ = [
+    "add_colorbar",
     "plot_contour_line",
     "plot_map_rgb",
     "plot_theta_squared_table",
@@ -24,6 +26,16 @@ ARTIST_TO_LINE_PROPERTIES = {
     "linewidth": "markerwidth",
     "lw": "markerwidth",
 }
+
+
+def add_colorbar(img, ax, label=None):
+    """Add colorbar to a given axis."""
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes(position="right", size="5%", pad="2%")
+    cbar = plt.colorbar(
+        img, cax=cax, orientation="vertical", use_gridspec=True, label=label
+    )
+    return cbar
 
 
 def plot_map_rgb(map_, ax=None, **kwargs):
@@ -120,7 +132,7 @@ def plot_contour_line(ax, x, y, **kwargs):
 
 
 def plot_theta_squared_table(table):
-    """Plot the theta2 distribution of counts, excess and signifiance.
+    """Plot the theta2 distribution of counts, excess and significance.
 
     Take the table containing the ON counts, the OFF counts, the acceptance,
     the off acceptance and the alpha (normalisation between ON and OFF)
@@ -200,7 +212,7 @@ def plot_distribution(
 
     Parameters
     ----------
-    wcs_map : an instance of `~gammapy.maps.WcsNDMap`
+    wcs_map : `~gammapy.maps.WcsNDMap`
         A map that contains data to be plotted.
     ax : `~matplotlib.axes.Axes` or list of `~matplotlib.axes.Axes`
         Axis object to plot on. If a list of Axis is provided it has to be the same length as the length of _map.data.

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -53,7 +53,7 @@ def add_colorbar(img, ax, axes_loc=None, **kwargs):
     ::
 
         from gammapy.maps import Map
-        from gammapy.visualization.utils import add_colorbar
+        from gammapy.visualization import add_colorbar
         import matplotlib.pyplot as plt
         map_ = Map.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
         axes_loc = {"position": "right", "size": "2%", "pad": "10%"}


### PR DESCRIPTION
**Description**
 This PR is to resolve #4052

The [suggestion](https://github.com/gammapy/gammapy/issues/4052#issuecomment-1235445757) by Axel did not work for the `plt.tight_layout()` in the `peek` methods, even with `use_gridspec` set to `True`. So I had to find another possibility.

Instead, I utilised the `make_axes_locatable` functionality in the [mpl_toolkits](https://matplotlib.org/stable/gallery/axes_grid1/demo_colorbar_with_axes_divider.html) of matplotlib.

**Note**: `divider = make_axes_locatable(ax)` makes them the same as the ax
`size` is a percentage of the main axis width to be set as the cbar width
`pad` is similarly determined as the percentage of the main axes width to pad by