### PR TITLE
Fermi pulsar catalogs base class

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -52,10 +52,11 @@ class SourceCatalogObject:
     _source_name_key = "Source_Name"
     _row_index_key = "_row_index"
 
-    def __init__(self, data, data_extended=None):
+    def __init__(self, data, data_extended=None, data_spectral=None):
         self.data = Bunch(**data)
         if data_extended:
             self.data_extended = Bunch(**data_extended)
+        self.data_spectral = Bunch(**data_spectral) if data_spectral else None
 
     def _repr_html_(self):
         try:
@@ -257,18 +258,44 @@ class SourceCatalog(abc.ABC):
             name_extended = data["Source_Name"].strip()
         else:
             name_extended = None
+
+        if self._source_name_key in data and self._source_name_key == "PSR_Name":
+            name_spectral = data[self._source_name_key].strip()
+        elif self._source_name_key in data and self._source_name_key == "PSRJ":
+            name_spectral = f"PSR{data[self._source_name_key].strip()}"
+        elif "Source_name" in data:
+            name_spectral = data["Source_name"].strip()
+        else:
+            name_spectral = None
+
         try:
             idx = self._lookup_extended_source_idx[name_extended]
             data_extended = table_row_to_dict(self.extended_sources_table[idx])
         except (KeyError, AttributeError):
             data_extended = None
 
-        source = self.source_object_class(data, data_extended)
+        try:
+            idx = self._lookup_spectral_source_idx[name_spectral]
+            data_spectral = table_row_to_dict(self.spectral_table[idx])
+        except (KeyError, AttributeError):
+            data_spectral = None
+
+        source = self.source_object_class(data, data_extended, data_spectral)
         return source
 
     @lazyproperty
+    def _lookup_spectral_source_idx(self):
+        if self._source_name_key == "PSRJ":
+            source_name_key = "NickName"
+        else:
+            source_name_key = self._source_name_key
+        names = [_.strip() for _ in self.spectral_table[source_name_key]]
+        idx = range(len(names))
+        return dict(zip(names, idx))
+
+    @lazyproperty
     def _lookup_extended_source_idx(self):
-        names = [_.strip() for _ in self.extended_sources_table["Source_Name"]]
+        names = [_.strip() for _ in self.extended_sources_table[self._source_name_key]]
         idx = range(len(names))
         return dict(zip(names, idx))
 
@@ -293,6 +320,8 @@ def _skycoord_from_table(table):
         lon, lat, frame = "RA", "DEC", "icrs"
     elif {"ra", "dec"}.issubset(keys):
         lon, lat, frame = "ra", "dec", "icrs"
+    elif {"RAJD", "DECJD"}.issubset(keys):
+        lon, lat, frame = "RAJD", "DECJD", "icrs"
     else:
         raise KeyError("No column GLON / GLAT or RA / DEC or RAJ2000 / DEJ2000 found.")
 

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -283,12 +283,12 @@ class SourceCatalog(abc.ABC):
             name_spectral = None
         return name_spectral
 
-    def _get_source_name_key(self):
+    def _get_spectral_table_source_name_key(self):
         return self._source_name_key
 
     @lazyproperty
     def _lookup_spectral_source_idx(self):
-        source_name_key = self._get_source_name_key()
+        source_name_key = self._get_spectral_table_source_name_key()
         names = [_.strip() for _ in self.spectral_table[source_name_key]]
         idx = range(len(names))
         return dict(zip(names, idx))

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -259,14 +259,7 @@ class SourceCatalog(abc.ABC):
         else:
             name_extended = None
 
-        if self._source_name_key in data and self._source_name_key == "PSR_Name":
-            name_spectral = data[self._source_name_key].strip()
-        elif self._source_name_key in data and self._source_name_key == "PSRJ":
-            name_spectral = f"PSR{data[self._source_name_key].strip()}"
-        elif "Source_name" in data:
-            name_spectral = data["Source_name"].strip()
-        else:
-            name_spectral = None
+        name_spectral = self._get_name_spectral(data)
 
         try:
             idx = self._lookup_extended_source_idx[name_extended]
@@ -283,12 +276,19 @@ class SourceCatalog(abc.ABC):
         source = self.source_object_class(data, data_extended, data_spectral)
         return source
 
+    def _get_name_spectral(self, data):
+        if "Source_name" in data:
+            name_spectral = data["Source_name"].strip()
+        else:
+            name_spectral = None
+        return name_spectral
+
+    def _get_source_name_key(self):
+        return self._source_name_key
+
     @lazyproperty
     def _lookup_spectral_source_idx(self):
-        if self._source_name_key == "PSRJ":
-            source_name_key = "NickName"
-        else:
-            source_name_key = self._source_name_key
+        source_name_key = self._get_source_name_key()
         names = [_.strip() for _ in self.spectral_table[source_name_key]]
         idx = range(len(names))
         return dict(zip(names, idx))

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -51,12 +51,12 @@ class SourceCatalogObject:
     Parameters
     ----------
     data : dict
-        Dictionnary of data from a catalog for a given source.
+        Dictionary of data from a catalog for a given source.
     data_extended : dict
-        Dictionnary of data from a catalog for a given source in the case where the
+        Dictionary of data from a catalog for a given source in the case where the
         catalog contains an extended sources table (Fermi-LAT).
     data_spectral : dict
-        Dictionnary of data from a catalof for a given source in the case where the
+        Dictionary of data from a catalof for a given source in the case where the
         catalog contains a spectral table (Fermi-LAT 2PC and 3PC).
     """
 
@@ -273,13 +273,17 @@ class SourceCatalog(abc.ABC):
         name_spectral = self._get_name_spectral(data)
 
         try:
-            idx = self._lookup_extended_source_idx[name_extended]
+            idx = self._lookup_additional_table(
+                self.extended_sources_table[self._source_name_key]
+            )[name_extended]
             data_extended = table_row_to_dict(self.extended_sources_table[idx])
         except (KeyError, AttributeError):
             data_extended = None
 
         try:
-            idx = self._lookup_spectral_source_idx[name_spectral]
+            idx = self._lookup_additional_table(
+                self.spectral_table[self._source_name_key]
+            )[name_spectral]
             data_spectral = table_row_to_dict(self.spectral_table[idx])
         except (KeyError, AttributeError):
             data_spectral = None
@@ -294,12 +298,15 @@ class SourceCatalog(abc.ABC):
             name_spectral = None
         return name_spectral
 
-    def _get_spectral_table_source_name_key(self):
-        return self._source_name_key
+    def _lookup_additional_table(self, selected_table):
+        """"""
+        names = [_.strip() for _ in selected_table]
+        idx = range(len(names))
+        return dict(zip(names, idx))
 
     @lazyproperty
     def _lookup_spectral_source_idx(self):
-        """Return a dictionnary of names-idx pairs corresponding to the
+        """Return a dictionary of names-idx pairs corresponding to the
         entry of the spectral table (for Fermi-LAT pulsar catalogs).
         """
         source_name_key = self._get_spectral_table_source_name_key()
@@ -309,7 +316,7 @@ class SourceCatalog(abc.ABC):
 
     @lazyproperty
     def _lookup_extended_source_idx(self):
-        """Return a dictionnary of names-idx pairs corresponding to the
+        """Return a dictionary of names-idx pairs corresponding to the
         entry of the extended table (for Fermi-LAT catalogs).
         """
         names = [_.strip() for _ in self.extended_sources_table[self._source_name_key]]

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -47,6 +47,17 @@ class SourceCatalogObject:
     it doesn't hold a reference back to it, except for a key
     ``_row_index`` of type ``int`` that links to the catalog table
     row the source information comes from.
+
+    Parameters
+    ----------
+    data : dict
+        Dictionnary of data from a catalog for a given source.
+    data_extended : dict
+        Dictionnary of data from a catalog for a given source in the case where the
+        catalog contains an extended sources table (Fermi-LAT).
+    data_spectral : dict
+        Dictionnary of data from a catalof for a given source in the case where the
+        catalog contains a spectral table (Fermi-LAT 2PC and 3PC).
     """
 
     _source_name_key = "Source_Name"
@@ -288,6 +299,9 @@ class SourceCatalog(abc.ABC):
 
     @lazyproperty
     def _lookup_spectral_source_idx(self):
+        """Return a dictionnary of names-idx pairs corresponding to the
+        entry of the spectral table (for Fermi-LAT pulsar catalogs).
+        """
         source_name_key = self._get_spectral_table_source_name_key()
         names = [_.strip() for _ in self.spectral_table[source_name_key]]
         idx = range(len(names))
@@ -295,6 +309,9 @@ class SourceCatalog(abc.ABC):
 
     @lazyproperty
     def _lookup_extended_source_idx(self):
+        """Return a dictionnary of names-idx pairs corresponding to the
+        entry of the extended table (for Fermi-LAT catalogs).
+        """
         names = [_.strip() for _ in self.extended_sources_table[self._source_name_key]]
         idx = range(len(names))
         return dict(zip(names, idx))

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -95,8 +95,7 @@ class SourceCatalogObjectFermiPCBase(SourceCatalogObject, abc.ABC):
 
     def _info_spectral_points(self):
         ss = "\n*** Spectral points ***\n\n"
-        flux_points_table = self.flux_points_table
-        if flux_points_table is None:
+        if self.flux_points_table is None:
             ss += "No spectral points available.\n"
             return ss
         lines = format_flux_points_table(self.flux_points_table).pformat(
@@ -135,12 +134,11 @@ class SourceCatalogObjectFermiPCBase(SourceCatalogObject, abc.ABC):
     @property
     def flux_points(self):
         """Flux points (`~gammapy.estimators.FluxPoints`)."""
-        flux_points_table = self.flux_points_table
-        if flux_points_table is None:
+        if self.flux_points_table is None:
             return None
 
         return FluxPoints.from_table(
-            table=flux_points_table,
+            table=self.flux_points_table,
             reference_model=self.sky_model(),
             format="gadf-sed",
         )

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -41,6 +41,111 @@ def compute_flux_points_ul(quantity, quantity_errp):
     return 2 * quantity_errp + quantity
 
 
+class SourceCatalogObjectFermiPCBase(SourceCatalogObject, abc.ABC):
+    """Base class for Fermi-LAT Pulsar catalogs."""
+
+    def __str__(self):
+        return self.info()
+
+    def info(self, info="all"):
+
+        if info == "all":
+            info = "basic,more,position,pulsar,spectral,lightcurve"
+
+        ss = ""
+        ops = info.split(",")
+        if "basic" in ops:
+            ss += self._info_basic()
+        if "more" in ops:
+            ss += self._info_more()
+        if "pulsar" in ops:
+            ss += self._info_pulsar()
+        if "position" in ops:
+            ss += self._info_position()
+        if "spectral" in ops:
+            ss += self._info_spectral_fit()
+            ss += self._info_spectral_points()
+        if "lightcurve" in ops:
+            ss += self._info_phasogram()
+        return ss
+
+    def _info_basic(self):
+        ss = "\n*** Basic info ***\n\n"
+        ss += "Catalog row index (zero-based) : {}\n".format(self.row_index)
+        ss += "{:<20s} : {}\n".format("Source name", self.name)
+        return ss
+
+    def _info_more(self):
+        return ""
+
+    def _info_pulsar(self):
+        return "\n"
+
+    def _info_position(self):
+        source_pos = self.position
+        ss = "\n*** Position info ***\n\n"
+        ss += "{:<20s} : {:.3f}\n".format("RA", source_pos.ra)
+        ss += "{:<20s} : {:.3f}\n".format("DEC", source_pos.dec)
+        ss += "{:<20s} : {:.3f}\n".format("GLON", source_pos.galactic.l)
+        ss += "{:<20s} : {:.3f}\n".format("GLAT", source_pos.galactic.b)
+        return ss
+
+    def _info_spectral_fit(self):
+        return "\n"
+
+    def _info_spectral_points(self):
+        ss = "\n*** Spectral points ***\n\n"
+        flux_points_table = self.flux_points_table
+        if flux_points_table is None:
+            ss += "No spectral points available.\n"
+            return ss
+        lines = format_flux_points_table(self.flux_points_table).pformat(
+            max_width=-1, max_lines=-1
+        )
+        ss += "\n".join(lines)
+        ss += "\n"
+        return ss
+
+    def _info_phasogram(self):
+        return ""
+
+    def spatial_model(self):
+        source_pos = self.position
+        ra = source_pos.ra
+        dec = source_pos.dec
+
+        model = PointSpatialModel(lon_0=ra, lat_0=dec, frame="icrs")
+        return model
+
+    def sky_model(self, name=None):
+        """Sky model (`~gammapy.modeling.models.SkyModel`)."""
+        spectral_model = self.spectral_model()
+        if spectral_model is None:
+            return None
+
+        if name is None:
+            name = self.name
+
+        return SkyModel(
+            spatial_model=self.spatial_model(),
+            spectral_model=spectral_model,
+            name=name,
+        )
+
+    @property
+    def flux_points(self):
+        """Flux points (`~gammapy.estimators.FluxPoints`)."""
+        flux_points_table = self.flux_points_table
+        if flux_points_table is None:
+            return None
+
+        return FluxPoints.from_table(
+            table=flux_points_table,
+            reference_model=self.sky_model(),
+            format="gadf-sed",
+        )
+
+
 class SourceCatalogObjectFermiBase(SourceCatalogObject, abc.ABC):
     """Base class for Fermi-LAT catalogs."""
 


### PR DESCRIPTION
Split of PR #4699. Here is the base class part. 
 
This introduces a base class for object of the pulsar catalog of Fermi (both 2PC and 3PC).

The part where I modify the core class `SourceCatalog` could be extracted into another base class, say `SourceCatalogPC`, but it will add another level of inheritance. I don't have a strong opinion on that. 