### PR TITLE
Deprecate `EventList.write()` Part 2/2

### DIFF
--- a/docs/user-guide/dl3.rst
+++ b/docs/user-guide/dl3.rst
@@ -138,12 +138,11 @@ Writing event lists and GTIs to file
 ------------------------------------
 
 To write the events or GTIs separately, one can just save the underlying
-`astropy.table.Table`. There is also a ``write`` method available for
-`~gammapy.data.Observation` which will write the `~gammapy.data.EventList`
-if ``include_irfs`` is set to ``False``.
-It is usually best to save the events and their associated GTIs together in the
-same FITS file. This can be done using the `~gammapy.data.Observation.write`
-method:
+`astropy.table.Table`. To have an event file written in a correct DL3 format, it is 
+necessary to utilise the  ``write`` method available for`~gammapy.data.Observation`.
+It will write the `~gammapy.data.EventList` and their associated GTIs together in the
+same FITS file according to the format specifications. To avoid writing IRFs along the 
+``EventList`` one has to set ``include_irfs`` to ``False``. See the example below:
 
 .. testcode::
 

--- a/docs/user-guide/dl3.rst
+++ b/docs/user-guide/dl3.rst
@@ -138,13 +138,16 @@ Writing event lists and GTIs to file
 ------------------------------------
 
 To write the events or GTIs separately, one can just save the underlying
-`astropy.table.Table`. However, it is usually best to save the events and
-their associated GTIs together in the same FITS file. This can be done using
-the `~gammapy.data.EventList.write` method:
+`astropy.table.Table`. There is also a ``write`` method available for
+`~gammapy.data.Observation` which will write the `~gammapy.data.EventList`
+if ``include_irfs`` is set to ``False``.
+It is usually best to save the events and their associated GTIs together in the
+same FITS file. This can be done using the `~gammapy.data.Observation.write`
+method:
 
 .. testcode::
 
-    from gammapy.data import EventList, GTI
+    from gammapy.data import EventList, GTI, Observation
 
     filename = "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
 
@@ -152,11 +155,11 @@ the `~gammapy.data.EventList.write` method:
     gti = GTI.read(filename)
 
     # Save separately
-    events.write("test_events.fits.gz", gti=None, overwrite=True)
     gti.write("test_gti.fits.gz")
 
-    # Save together
-    events.write("test_events_with_GTI.fits.gz", gti=gti)
+    # Save together. First initiate an Observation object
+    obs = Observation(gti=gti, events=events)
+    obs.write("test_events_with_GTI.fits.gz", include_irfs=False)
 
 
 Using gammapy.data

--- a/examples/tutorials/analysis-3d/event_sampling.py
+++ b/examples/tutorials/analysis-3d/event_sampling.py
@@ -408,7 +408,7 @@ plt.show()
 #
 # The event sampler can also work with a template model. Here we use the
 # interstellar emission model map of the Fermi 3FHL, which can be found in
-# the GAMMAPY data repository.
+# the `$GAMMAPY_DATA` repository.
 #
 # We proceed following the same steps showed above and we finally have a
 # look at the event’s properties:
@@ -434,7 +434,7 @@ models_diffuse.write(file_model, overwrite=True)
 dataset.models = models_diffuse
 print(dataset.models)
 
-""
+
 # %%time
 sampler = MapDatasetEventSampler(random_state=0)
 events = sampler.run(dataset, observation)

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -13,6 +13,7 @@ from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from gammapy.maps import MapAxis, MapCoord, RegionGeom, WcsNDMap
 from gammapy.maps.axes import UNIT_STRING_FORMAT
+from gammapy.utils.deprecation import deprecated
 from gammapy.utils.fits import earth_location_from_dict
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import Checker
@@ -139,6 +140,10 @@ class EventList:
 
         return fits.BinTableHDU(self.table, name="EVENTS")
 
+    @deprecated(
+        since="v1.2",
+        message="To write an EventList utilise Observation.write() with include_irfs=False",
+    )
     def write(self, filename, gti=None, overwrite=False, format="gadf", checksum=False):
         """Write the event list to a FITS file.
 

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -6,8 +6,9 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Table
 from regions import CircleSkyRegion, RectangleSkyRegion
-from gammapy.data import GTI, EventList
+from gammapy.data import GTI, EventList, Observation
 from gammapy.maps import MapAxis, WcsGeom
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.testing import mpl_plot_check, requires_data
 
 
@@ -31,22 +32,12 @@ class TestEventListBase:
 
     def test_write(self):
         # Without GTI
-        self.events.write("test.fits", overwrite=True)
-        read_again = EventList.read("test.fits")
+        obs = Observation(events=self.events)
+        # Write function is through obs
+        obs.write("test.fits.gz", include_irfs=False, overwrite=True)
+        read_again = EventList.read("test.fits.gz")
 
-        # the meta dictionaries match because the input one
-        # already has the EXTNAME keyword
-        assert self.events.table.meta == read_again.table.meta
         assert (self.events.table == read_again.table).all()
-
-        table = Table()
-        table["RA"] = [1, 2, 3]
-        table["DEC"] = [3, 2, 1]
-
-        dummy_events = EventList(table.copy())
-        dummy_events.write("test.fits", overwrite=True)
-        read_again = EventList.read("test.fits")
-
         assert read_again.table.meta["EXTNAME"] == "EVENTS"
         assert read_again.table.meta["HDUCLASS"] == "GADF"
         assert read_again.table.meta["HDUCLAS1"] == "EVENTS"
@@ -55,46 +46,28 @@ class TestEventListBase:
         gti = GTI.read(
             "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
         )
-        self.events.write("test.fits", overwrite=True, gti=gti)
+
+        obs = Observation(events=self.events, gti=gti)
+        obs.write("test.fits", overwrite=True)
         read_again_ev = EventList.read("test.fits")
         read_again_gti = GTI.read("test.fits")
 
-        assert self.events.table.meta == read_again_ev.table.meta
         assert (self.events.table == read_again_ev.table).all()
         assert gti.table.meta == read_again_gti.table.meta
         assert_allclose(gti.table["START"].mjd, read_again_gti.table["START"].mjd)
         assert_allclose(gti.table["STOP"].mjd, read_again_gti.table["STOP"].mjd)
 
         # test that it won't work if gti is not a GTI
-        with pytest.raises(TypeError):
-            self.events.write("test.fits", overwrite=True, gti=gti.table)
-        # test that it won't work if format is not "gadf"
-        with pytest.raises(ValueError):
-            self.events.write("test.fits", overwrite=True, format="something")
-        # test that it won't work if the basic headers are wrong
-
-        with pytest.raises(ValueError):
-            dummy_events = EventList(table.copy())
-            dummy_events.table.meta["HDUCLAS1"] = "response"
-            dummy_events.write("test.fits", overwrite=True)
-
-        with pytest.raises(ValueError):
-            dummy_events = EventList(table.copy())
-            dummy_events.table.meta["HDUCLASS"] = "ogip"
-            dummy_events.write("test.fits", overwrite=True)
-
-        # test that it we also get the error when the only the case is wrong
-        with pytest.raises(ValueError):
-            dummy_events = EventList(table.copy())
-            dummy_events.table.meta["HDUCLASS"] = "gadf"
-            dummy_events.table.meta["HDUCLAS1"] = "events"
-            dummy_events.write("test.fits", overwrite=True)
+        with pytest.raises(AttributeError):
+            obs = Observation(events=self.events, gti=gti.table)
+            obs.write("test.fits", overwrite=True)
 
     def test_write_checksum(self):
-        self.events.write("test.fits", overwrite=True, checksum=True)
-        hdu = fits.open("test.fits")["EVENTS"]
-        assert "CHECKSUM" in hdu.header
-        assert "DATASUM" in hdu.header
+        with pytest.raises(GammapyDeprecationWarning):
+            self.events.write("test.fits", overwrite=True, checksum=True)
+            hdu = fits.open("test.fits")["EVENTS"]
+            assert "CHECKSUM" in hdu.header
+            assert "DATASUM" in hdu.header
 
 
 @requires_data()


### PR DESCRIPTION
This is connected to #5042

This is Part 2 of adapting the `EventList` and its metadata. 
Part 1: #4832 needs to be merged before this one.


**List of what needs adapting: after deprecation**
- Needs to be well documented so that users understand to utilise `Observations.write()`
- test_write will need to removed (or adapted for include_irfs=False)