### PR TITLE
Adapt class validation in metadata

### DIFF
--- a/gammapy/utils/metadata.py
+++ b/gammapy/utils/metadata.py
@@ -5,7 +5,7 @@ from typing import ClassVar, Literal, Optional, get_args
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 from gammapy.utils.fits import skycoord_from_dict
 from gammapy.version import version
 from .types import AltAzSkyCoordType, ICRSSkyCoordType, SkyCoordType, TimeType
@@ -147,7 +147,10 @@ class MetaData(BaseModel):
             except TypeError:
                 pass
 
-        return cls(**kwargs)
+        try:
+            return cls(**kwargs)
+        except ValidationError:
+            return cls.model_construct(**kwargs)
 
     def to_yaml(self):
         """Dump metadata content to yaml."""

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -50,6 +50,18 @@ def test_creator_to_header():
     assert header["CREATED"] == "2022-01-01 00:00:00.000"
 
 
+def test_creator_from_header():
+    # Create header with a 'bad' date
+    hdu = fits.PrimaryHDU()
+    hdu.header["CREATOR"] = "gammapy"
+    hdu.header["CREATED"] = "Tues 6 Feb"
+
+    meta = CreatorMetaData.from_header(hdu.header)
+
+    assert meta.date == hdu.header["CREATED"]
+    assert meta.creator == hdu.header["CREATOR"]
+
+
 def test_subclass():
     class TestMetaData(MetaData):
         _tag: ClassVar[Literal["tag"]] = "tag"

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -50,7 +50,7 @@ def test_creator_to_header():
     assert header["CREATED"] == "2022-01-01 00:00:00.000"
 
 
-def test_creator_from_header():
+def test_creator_from_incorrect_header():
     # Create header with a 'bad' date
     hdu = fits.PrimaryHDU()
     hdu.header["CREATOR"] = "gammapy"


### PR DESCRIPTION
This PR is to adapt the validation of the `from_header` function in metadata. 

Currently, if a header does not conform to the correct type there will be a validation error. 
This fixes this, by trying to proceed with the normal type, however, if that raises a ValidationError allowing the function to pass without validation. 

Previously this was failing with the `test_dataset_hawc` in `gammapy/makers/tests/test_map.py`, as the date from the CreatorMetaData was not of the correct type. This passes now, and I have also added a test

This will need to be merged before #4832