### PR TITLE
Fix tutorial `plt.show()` not showing figures

### DIFF
--- a/examples/tutorials/api/datasets.py
+++ b/examples/tutorials/api/datasets.py
@@ -314,6 +314,7 @@ e_min, e_max = dataset_cta.energy_range
 e_min.plot(add_cbar=True)
 plt.show()
 
+# %%
 # To see the high energy threshold at each point
 
 e_max.plot(add_cbar=True)

--- a/examples/tutorials/api/mask_maps.py
+++ b/examples/tutorials/api/mask_maps.py
@@ -430,12 +430,15 @@ plt.show()
 # `binary_dilate` methods, respectively.
 #
 
+fig, (ax1, ax2) = plt.subplots(
+    figsize=(11, 5), ncols=2, subplot_kw={"projection": significance_mask_inv.geom.wcs}
+)
+
 mask = significance_mask_inv.binary_erode(width=0.2 * u.deg, kernel="disk")
-mask.plot()
-plt.show()
+mask.plot(ax=ax1)
 
 mask = significance_mask_inv.binary_dilate(width=0.2 * u.deg)
-mask.plot()
+mask.plot(ax=ax2)
 plt.show()
 
 

--- a/examples/tutorials/api/observation_clustering.py
+++ b/examples/tutorials/api/observation_clustering.py
@@ -137,6 +137,7 @@ for obs in grouped_observations["group_high_zenith"]:
 ax.set_ylabel("Muon efficiency")
 ax.set_xlabel("Zenith angle (deg)")
 ax.axvline(median_zenith.value, ls="--", color="black")
+plt.show()
 
 
 ######################################################################
@@ -225,6 +226,7 @@ ax.plot(
     label="Group 2",
 )
 ax.legend()
+plt.show()
 
 
 ######################################################################

--- a/examples/tutorials/data/cta.py
+++ b/examples/tutorials/data/cta.py
@@ -276,6 +276,8 @@ plt.show()
 irfs["psf"].peek()
 plt.show()
 
+
+# %%
 # This is how for analysis you could slice out the PSF
 # at a given field of view offset
 irfs["psf"].plot_containment_radius_vs_energy(


### PR DESCRIPTION
If the `plt.show()` functionality is used in the same cell more than once, then it is not rendered correctly in the documentation.

This PR solves this by creating separate cells for each one of those and a subplot for the other. 

See https://github.com/sphinx-gallery/sphinx-gallery/issues/1025, sphinx-gallery do not plan on changing this functionality