### PR TITLE
Check if metadata attribute is not None before serialization

### DIFF
--- a/gammapy/utils/metadata.py
+++ b/gammapy/utils/metadata.py
@@ -91,7 +91,7 @@ class MetaData(BaseModel):
 
         for key, item in fits_export_keys.items():
             value = self.model_dump().get(key)
-            if not isinstance(item, str):
+            if not isinstance(item, str) and value is not None:
                 # Not a one to one conversion
                 hdr_dict.update(item["output"](value))
             else:

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -162,7 +162,7 @@ def test_pointing_info_from_header(hess_eventlist_header):
     assert_allclose(meta.altaz_mean.alt.deg, 41.389789)
 
 
-def test_taget_metadata():
+def test_target_metadata():
     meta = TargetMetaData(
         name="center", position=SkyCoord(0.0, 0.0, unit="deg", frame="galactic")
     )
@@ -173,6 +173,10 @@ def test_taget_metadata():
 
     assert header["OBJECT"] == "center"
     assert_allclose(header["RA_OBJ"], 266.404988)
+
+    header = TargetMetaData(name="center").to_header("gadf")
+    assert header["OBJECT"] == "center"
+    assert "RA_OBJ" not in header.keys()
 
 
 @requires_data()

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -147,6 +147,9 @@ def test_pointing_info_to_header():
     assert_allclose(header["RA_PNT"], 83.6287)
     assert_allclose(header["AZ_PNT"], 20.0)
 
+    header = PointingInfoMetaData(radec_mean=position).to_header("gadf")
+    assert "AZ_PNT" not in header.keys()
+
     with pytest.raises(ValueError):
         PointingInfoMetaData(radec_mean=position, altaz_mean=altaz).to_header("bad")
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request solves issue #5075 . 
Before serializing a specific metadata attribute to a set of header keywords, the `to_header()` method now checks that it is not `None`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
