### PR TITLE
Add TimeInfoMetaData

### DIFF
--- a/gammapy/data/metadata.py
+++ b/gammapy/data/metadata.py
@@ -9,6 +9,7 @@ from gammapy.utils.metadata import (
     ObsInfoMetaData,
     PointingInfoMetaData,
     TargetMetaData,
+    TimeInfoMetaData,
 )
 from gammapy.utils.types import EarthLocationType, TimeType
 
@@ -56,12 +57,6 @@ class ObservationMetaData(MetaData):
         The observatory location.
     deadtime_fraction : float
         The observation deadtime fraction. Default is 0.
-    time_start : `~astropy.time.Time` or str
-        The observation start time.
-    time_stop : `~astropy.time.Time` or str
-        The observation stop time.
-    reference_time : `~astropy.time.Time` or str
-        The observation reference time.
     optional : dict, optional
         Additional optional metadata.
     """
@@ -72,9 +67,7 @@ class ObservationMetaData(MetaData):
     target: Optional[TargetMetaData] = None
     location: Optional[EarthLocationType] = None
     deadtime_fraction: float = Field(0.0, ge=0, le=1.0)
-    time_start: Optional[TimeType] = None
-    time_stop: Optional[TimeType] = None
-    reference_time: Optional[TimeType] = None
+    time_info: Optional[TimeInfoMetaData] = None
     creation: Optional[CreatorMetaData] = None
     optional: Optional[dict] = None
 

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -17,7 +17,7 @@ from astropy.utils import lazyproperty
 import matplotlib.pyplot as plt
 from gammapy.utils.deprecation import GammapyDeprecationWarning, deprecated
 from gammapy.utils.fits import LazyFitsData, earth_location_to_dict
-from gammapy.utils.metadata import CreatorMetaData, TargetMetaData
+from gammapy.utils.metadata import CreatorMetaData, TargetMetaData, TimeInfoMetaData
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import Checker
 from gammapy.utils.time import time_ref_to_dict, time_relative_to_ref
@@ -263,12 +263,16 @@ class Observation:
             location=location,
         )
 
-        meta = ObservationMetaData(
-            deadtime_fraction=deadtime_fraction,
-            location=location,
+        time_info = TimeInfoMetaData(
             time_start=gti.time_start[0],
             time_stop=gti.time_stop[-1],
             reference_time=reference_time,
+        )
+
+        meta = ObservationMetaData(
+            deadtime_fraction=deadtime_fraction,
+            location=location,
+            time_info=time_info,
             creation=CreatorMetaData(),
             target=TargetMetaData(),
         )

--- a/gammapy/data/tests/test_metadata.py
+++ b/gammapy/data/tests/test_metadata.py
@@ -30,12 +30,18 @@ def test_observation_metadata():
         "name": "Crab",
         "position": SkyCoord(83.6287, 22.0147, unit="deg", frame="icrs"),
     }
+    time_info = {
+        "reference_time": "2023-01-01 00:00:00",
+        "time_start": "2024-01-01 00:00:00",
+        "time_stop": "2024-01-01 00:30:00",
+    }
 
     input = {
         "obs_info": ObsInfoMetaData(**obs_info),
         "pointing": PointingInfoMetaData(),
         "location": "cta_north",
         "deadtime_fraction": 0.05,
+        "time_info": time_info,
         "target": TargetMetaData(**target),
         "optional": dict(test=0.5, other=True),
     }
@@ -47,6 +53,7 @@ def test_observation_metadata():
     assert_allclose(meta.location.lon.value, -17.892005)
     assert meta.target.name == "Crab"
     assert_allclose(meta.target.position.ra.deg, 83.6287)
+    assert_allclose(meta.time_info.time_stop.mjd, 60310.020833333)
     assert meta.optional["other"] is True
 
     with pytest.raises(ValidationError):
@@ -71,6 +78,8 @@ def test_observation_metadata_from_header(hess_eventlist_header):
 
     assert meta.obs_info.telescope == "HESS"
     assert_allclose(meta.pointing.altaz_mean.alt.deg, 41.389789)
+    assert_allclose(meta.time_info.time_start.mjd, 53343.92234)
+    assert_allclose(meta.time_info.time_stop.mjd, 53343.941866)
     assert meta.target.name == "Crab Nebula"
     assert_allclose(meta.location.lat.deg, -23.271778)
     assert "TELLIST" in meta.optional

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -875,8 +875,8 @@ def test_observation_event_sampler(signal_model, tmp_path):
         pointing=pointing,
         gti=GTI.create(time_start, time_stop),
         meta=ObservationMetaData(
-            time_start=time_start,
-            time_stop=time_stop,
+            #       time_start=time_start,
+            #       time_stop=time_stop,
             deadtime_fraction=0.01,
         ),
     )

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -8,7 +8,6 @@ from astropy.io import fits
 from astropy.table import Table
 from astropy.time import Time
 from gammapy.data import GTI, DataStore, Observation, ObservationsEventsSampler
-from gammapy.data.metadata import ObservationMetaData
 from gammapy.data.pointing import FixedPointingInfo
 from gammapy.datasets import MapDataset, MapDatasetEventSampler
 from gammapy.datasets.tests.test_map import get_map_dataset
@@ -868,17 +867,14 @@ def test_observation_event_sampler(signal_model, tmp_path):
     time_start = Time("2021-11-20T03:00:00")
     time_stop = Time("2021-11-20T03:30:00")
 
-    obs = Observation(
-        obs_id=1,
-        **irfs,
-        location=LOCATION,
+    obs = Observation.create(
         pointing=pointing,
-        gti=GTI.create(time_start, time_stop),
-        meta=ObservationMetaData(
-            #       time_start=time_start,
-            #       time_stop=time_stop,
-            deadtime_fraction=0.01,
-        ),
+        location=LOCATION,
+        obs_id=1,
+        tstart=time_start,
+        tstop=time_stop,
+        irfs=irfs,
+        deadtime_fraction=0.01,
     )
 
     dataset_kwargs = dict(

--- a/gammapy/utils/metadata.py
+++ b/gammapy/utils/metadata.py
@@ -249,7 +249,7 @@ class TimeInfoMetaData(MetaData):
     reference_time : `~astropy.time.Time` or str
         The observation reference time."""
 
-    _tag: ClassVar[Literal["pointing"]] = "time_info"
+    _tag: ClassVar[Literal["time_info"]] = "time_info"
 
     time_start: Optional[TimeType] = None
     time_stop: Optional[TimeType] = None

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -217,9 +217,8 @@ def test_time_info_metadata():
 def test_time_info_metadata_from_header(hess_eventlist_header):
     meta = TimeInfoMetaData.from_header(hess_eventlist_header, format="gadf")
 
-    print(meta)
-    assert meta.name == "Crab Nebula"
-    assert_allclose(meta.position.ra.deg, 83.63333333)
+    assert_allclose(meta.reference_time.mjd, 51910.00074287037)
+    assert_allclose(meta.time_start.mjd, 53343.92234009259)
 
 
 def test_subclass_to_from_header():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request fills a missing part in the `MetaData` scheme. So far, time range informations were stored directly in `ObservationMetaData` without a proper serialization scheme. 
Here we introduce a specific object to store observation time information with its associated `to_header` and `from_header`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
