### PR TITLE
Make `jfactor` a parameter for DarkMatter models

### DIFF
--- a/examples/tutorials/api/astro_dark_matter.py
+++ b/examples/tutorials/api/astro_dark_matter.py
@@ -219,7 +219,7 @@ channel = "Z"
 massDM = 10 * u.TeV
 diff_flux = DarkMatterAnnihilationSpectralModel(mass=massDM, channel=channel)
 int_flux = (
-    jfact * diff_flux.integral(energy_min=0.1 * u.TeV, energy_max=10 * u.TeV)
+    jfact.to_value("GeV2 cm-5") * diff_flux.integral(energy_min=0.1 * u.TeV, energy_max=10 * u.TeV)
 ).to("cm-2 s-1")
 
 flux_map = WcsNDMap(geom=geom, data=int_flux.value, unit="cm-2 s-1")
@@ -243,7 +243,7 @@ channel = "Z"
 massDM = 10 * u.TeV
 diff_flux = DarkMatterDecaySpectralModel(mass=massDM, channel=channel)
 int_flux = (
-    jfact_decay * diff_flux.integral(energy_min=0.1 * u.TeV, energy_max=10 * u.TeV)
+    jfact_decay.to_value("GeV cm-2") * diff_flux.integral(energy_min=0.1 * u.TeV, energy_max=10 * u.TeV)
 ).to("cm-2 s-1")
 
 flux_map = WcsNDMap(geom=geom, data=int_flux.value, unit="cm-2 s-1")

--- a/examples/tutorials/api/astro_dark_matter.py
+++ b/examples/tutorials/api/astro_dark_matter.py
@@ -219,7 +219,8 @@ channel = "Z"
 massDM = 10 * u.TeV
 diff_flux = DarkMatterAnnihilationSpectralModel(mass=massDM, channel=channel)
 int_flux = (
-    jfact.to_value("GeV2 cm-5") * diff_flux.integral(energy_min=0.1 * u.TeV, energy_max=10 * u.TeV)
+    jfact.to_value("GeV2 cm-5")
+    * diff_flux.integral(energy_min=0.1 * u.TeV, energy_max=10 * u.TeV)
 ).to("cm-2 s-1")
 
 flux_map = WcsNDMap(geom=geom, data=int_flux.value, unit="cm-2 s-1")
@@ -243,7 +244,8 @@ channel = "Z"
 massDM = 10 * u.TeV
 diff_flux = DarkMatterDecaySpectralModel(mass=massDM, channel=channel)
 int_flux = (
-    jfact_decay.to_value("GeV cm-2") * diff_flux.integral(energy_min=0.1 * u.TeV, energy_max=10 * u.TeV)
+    jfact_decay.to_value("GeV cm-2")
+    * diff_flux.integral(energy_min=0.1 * u.TeV, energy_max=10 * u.TeV)
 ).to("cm-2 s-1")
 
 flux_map = WcsNDMap(geom=geom, data=int_flux.value, unit="cm-2 s-1")

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -250,30 +250,6 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         data["spectral"]["k"] = self.k
         return data
 
-    @classmethod
-    def from_dict(cls, data):
-        """Create spectral model from a dictionary.
-
-        Parameters
-        ----------
-        data : dict
-            Dictionary with model data.
-
-        Returns
-        -------
-        model : `DarkMatterAnnihilationSpectralModel`
-            Dark matter annihilation spectral model.
-        """
-        data = data["spectral"]
-        data.pop("type")
-        parameters = data.pop("parameters")
-        parameters = {p["name"]: p for p in parameters}
-        scale = parameters["scale"]["value"]
-        jfactor = u.Quantity(
-            parameters["jfactor"]["value"], parameters["jfactor"]["unit"]
-        )
-        return cls(scale=scale, jfactor=jfactor, **data)
-
 
 class DarkMatterDecaySpectralModel(SpectralModel):
     r"""Dark matter decay spectral model.
@@ -361,26 +337,3 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         data["spectral"]["z"] = self.z
         return data
 
-    @classmethod
-    def from_dict(cls, data):
-        """Create spectral model from dictionary.
-
-        Parameters
-        ----------
-        data : dict
-            Dictionary with model data.
-
-        Returns
-        -------
-        model : `DarkMatterDecaySpectralModel`
-            Dark matter decay spectral model.
-        """
-        data = data["spectral"]
-        data.pop("type")
-        parameters = data.pop("parameters")
-        parameters = {p["name"]: p for p in parameters}
-        scale = parameters["scale"]["value"]
-        dfactor = u.Quantity(
-            parameters["dfactor"]["value"], parameters["dfactor"]["unit"]
-        )
-        return cls(scale=scale, dfactor=dfactor, **data)

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -269,7 +269,9 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         parameters = data.pop("parameters")
         parameters = {p["name"]: p for p in parameters}
         scale = parameters["scale"]["value"]
-        jfactor = u.Quantity(parameters["jfactor"]["value"], parameters["jfactor"]["unit"])
+        jfactor = u.Quantity(
+            parameters["jfactor"]["value"], parameters["jfactor"]["unit"]
+        )
         return cls(scale=scale, jfactor=jfactor, **data)
 
 
@@ -378,5 +380,7 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         parameters = data.pop("parameters")
         parameters = {p["name"]: p for p in parameters}
         scale = parameters["scale"]["value"]
-        dfactor = u.Quantity(parameters["dfactor"]["value"], parameters["dfactor"]["unit"])
+        dfactor = u.Quantity(
+            parameters["dfactor"]["value"], parameters["dfactor"]["unit"]
+        )
         return cls(scale=scale, dfactor=dfactor, **data)

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -336,4 +336,3 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         data["spectral"]["mass"] = self.mass.to_string()
         data["spectral"]["z"] = self.z
         return data
-

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -46,7 +46,9 @@ def test_dm_annihilation_spectral_model(tmpdir):
     integral_flux = model.integral(energy_min=energy_min, energy_max=energy_max).to(
         "cm-2 s-1"
     )
-    differential_flux = model.evaluate(energy=1 * u.TeV, scale=1, jfactor=jfactor).to("cm-2 s-1 TeV-1")
+    differential_flux = model.evaluate(energy=1 * u.TeV, scale=1, jfactor=jfactor).to(
+        "cm-2 s-1 TeV-1"
+    )
 
     sky_model = SkyModel(
         spectral_model=model,
@@ -79,7 +81,9 @@ def test_dm_decay_spectral_model(tmpdir):
     integral_flux = model.integral(energy_min=energy_min, energy_max=energy_max).to(
         "cm-2 s-1"
     )
-    differential_flux = model.evaluate(energy=1 * u.TeV, scale=1, dfactor=dfactor).to("cm-2 s-1 TeV-1")
+    differential_flux = model.evaluate(energy=1 * u.TeV, scale=1, dfactor=dfactor).to(
+        "cm-2 s-1 TeV-1"
+    )
 
     sky_model = SkyModel(
         spectral_model=model,

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -46,7 +46,7 @@ def test_dm_annihilation_spectral_model(tmpdir):
     integral_flux = model.integral(energy_min=energy_min, energy_max=energy_max).to(
         "cm-2 s-1"
     )
-    differential_flux = model.evaluate(energy=1 * u.TeV, scale=1).to("cm-2 s-1 TeV-1")
+    differential_flux = model.evaluate(energy=1 * u.TeV, scale=1, jfactor=jfactor).to("cm-2 s-1 TeV-1")
 
     sky_model = SkyModel(
         spectral_model=model,
@@ -71,15 +71,15 @@ def test_dm_annihilation_spectral_model(tmpdir):
 def test_dm_decay_spectral_model(tmpdir):
     channel = "b"
     massDM = 5 * u.TeV
-    jfactor = 3.41e19 * u.Unit("GeV cm-2")
+    dfactor = 3.41e19 * u.Unit("GeV cm-2")
     energy_min = 0.01 * u.TeV
     energy_max = 10 * u.TeV
 
-    model = DarkMatterDecaySpectralModel(mass=massDM, channel=channel, jfactor=jfactor)
+    model = DarkMatterDecaySpectralModel(mass=massDM, channel=channel, dfactor=dfactor)
     integral_flux = model.integral(energy_min=energy_min, energy_max=energy_max).to(
         "cm-2 s-1"
     )
-    differential_flux = model.evaluate(energy=1 * u.TeV, scale=1).to("cm-2 s-1 TeV-1")
+    differential_flux = model.evaluate(energy=1 * u.TeV, scale=1, dfactor=dfactor).to("cm-2 s-1 TeV-1")
 
     sky_model = SkyModel(
         spectral_model=model,
@@ -95,6 +95,6 @@ def test_dm_decay_spectral_model(tmpdir):
 
     assert new_models[0].spectral_model.channel == model.channel
     assert new_models[0].spectral_model.z == model.z
-    assert_allclose(new_models[0].spectral_model.jfactor.value, model.jfactor.value)
+    assert_allclose(new_models[0].spectral_model.dfactor.value, model.dfactor.value)
     assert new_models[0].spectral_model.mass.value == 5
     assert new_models[0].spectral_model.mass.unit == u.TeV

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -46,7 +46,7 @@ def test_dmfluxmap_annihilation(jfact_annihilation):
 
     diff_flux = DarkMatterAnnihilationSpectralModel(mass=massDM, channel=channel)
     int_flux = (
-        jfact_annihilation
+        jfact_annihilation.to_value("GeV2 cm-5")
         * diff_flux.integral(energy_min=energy_min, energy_max=energy_max)
     ).to("cm-2 s-1")
     actual = int_flux[5, 5]
@@ -63,7 +63,8 @@ def test_dmfluxmap_decay(jfact_decay):
 
     diff_flux = DarkMatterDecaySpectralModel(mass=massDM, channel=channel)
     int_flux = (
-        jfact_decay * diff_flux.integral(energy_min=energy_min, energy_max=energy_max)
+        jfact_decay.to_value("GeV cm-2")
+        * diff_flux.integral(energy_min=energy_min, energy_max=energy_max)
     ).to("cm-2 s-1")
     actual = int_flux[5, 5]
     desired = 7.01927e-3 / u.cm**2 / u.s

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -279,6 +279,10 @@ class ModelBase:
             data["parameters"], cls.default_parameters
         )
 
+        for key in data.keys():
+            if key not in ["type", "parameters"] and key not in kwargs:
+                kwargs[key] = data[key]
+
         return cls.from_parameters(parameters, **kwargs)
 
     def __str__(self):


### PR DESCRIPTION
It is common in dark matter analyses to have a prior on the J-Factor (see [here](https://arxiv.org/pdf/2111.15009.pdf)). 
In order to achieve this, the `jfactor` of the `DarkMatterAnnihilationSpectralModel` has to become a parameter.

I also renamed the J-Factor to D-Factor for the `DarkMatterDecaySpectralModel` and did the same there, this is also very common :)
