### PR TITLE
Add an n_event_bunch to sampler classes to alleviate memory issues when sampling bright sources

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -37,9 +37,9 @@ class MapDatasetEventSampler:
     keep_mc_id : bool, optional
         Flag to tag sampled events from a given model with a Montecarlo identifier.
         Default is True. If set to False, no identifier will be assigned.
-    n_event_bunch : int, optional
+    n_event_bunch : int
         Size of events bunches to sample. If None, sample all events in memory.
-        Default is None.
+        Default is 10000.
     """
 
     def __init__(
@@ -48,7 +48,7 @@ class MapDatasetEventSampler:
         oversample_energy_factor=10,
         t_delta=0.5 * u.s,
         keep_mc_id=True,
-        n_event_bunch=None,
+        n_event_bunch=10000,
     ):
         self.random_state = get_random_state(random_state)
         self.oversample_energy_factor = oversample_energy_factor
@@ -579,7 +579,6 @@ class MapDatasetEventSampler:
 
         events.table["EVENT_ID"] = np.arange(len(events.table))
         if observation is not None:
-            print("det coords")
             events = self.event_det_coords(observation, events)
             events.table.meta.update(
                 self.event_list_meta(dataset, observation, self.keep_mc_id)
@@ -611,9 +610,9 @@ class ObservationEventSampler(MapDatasetEventSampler):
     keep_mc_id : bool, optional
         Flag to tag sampled events from a given model with a Montecarlo identifier.
         Default is True. If set to False, no identifier will be assigned.
-    n_event_bunch : int, optional
+    n_event_bunch : int
         Size of events bunches to sample. If None, sample all events in memory.
-        Default is None.
+        Default is 10000.
     dataset_kwargs : dict, optional
         Arguments passed to `~gammapy.datasets.create_map_dataset_from_observation()`
     """
@@ -624,7 +623,7 @@ class ObservationEventSampler(MapDatasetEventSampler):
         oversample_energy_factor=10,
         t_delta=0.5 * u.s,
         keep_mc_id=True,
-        n_event_bunch=None,
+        n_event_bunch=10000,
         dataset_kwargs=None,
     ):
         self.dataset_kwargs = dataset_kwargs

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -37,6 +37,9 @@ class MapDatasetEventSampler:
     keep_mc_id : bool, optional
         Flag to tag sampled events from a given model with a Montecarlo identifier.
         Default is True. If set to False, no identifier will be assigned.
+    n_event_bunch : int, optional
+        Size of events bunches to sample. If None, sample all events in memory.
+        Default is None.
     """
 
     def __init__(
@@ -45,11 +48,13 @@ class MapDatasetEventSampler:
         oversample_energy_factor=10,
         t_delta=0.5 * u.s,
         keep_mc_id=True,
+        n_event_bunch=None,
     ):
         self.random_state = get_random_state(random_state)
         self.oversample_energy_factor = oversample_energy_factor
         self.t_delta = t_delta
         self.keep_mc_id = keep_mc_id
+        self.n_event_bunch = n_event_bunch
 
     def _repr_html_(self):
         try:
@@ -346,7 +351,9 @@ class MapDatasetEventSampler:
             frame="icrs",
         )
 
-        coords_reco = edisp_map.sample_coord(coord, self.random_state)
+        coords_reco = edisp_map.sample_coord(
+            coord, self.random_state, self.n_event_bunch
+        )
         events.table["ENERGY"] = coords_reco["energy"]
         return events
 
@@ -374,7 +381,8 @@ class MapDatasetEventSampler:
             frame="icrs",
         )
 
-        coords_reco = psf_map.sample_coord(coord, self.random_state)
+        coords_reco = psf_map.sample_coord(coord, self.random_state, self.n_event_bunch)
+
         events.table["RA"] = coords_reco["lon"] * u.deg
         events.table["DEC"] = coords_reco["lat"] * u.deg
         return events
@@ -553,6 +561,7 @@ class MapDatasetEventSampler:
             Event list.
         """
         events_src = self.sample_sources(dataset)
+
         if len(events_src.table) > 0:
             if dataset.psf:
                 events_src = self.sample_psf(dataset.psf, events_src)
@@ -568,11 +577,13 @@ class MapDatasetEventSampler:
         events_bkg = self.sample_background(dataset)
         events = EventList.from_stack([events_bkg, events_src])
 
-        events = self.event_det_coords(observation, events)
         events.table["EVENT_ID"] = np.arange(len(events.table))
-        events.table.meta.update(
-            self.event_list_meta(dataset, observation, self.keep_mc_id)
-        )
+        if observation is not None:
+            print("det coords")
+            events = self.event_det_coords(observation, events)
+            events.table.meta.update(
+                self.event_list_meta(dataset, observation, self.keep_mc_id)
+            )
 
         geom = dataset._geom
         selection = geom.contains(events.map_coord(geom))
@@ -600,6 +611,9 @@ class ObservationEventSampler(MapDatasetEventSampler):
     keep_mc_id : bool, optional
         Flag to tag sampled events from a given model with a Montecarlo identifier.
         Default is True. If set to False, no identifier will be assigned.
+    n_event_bunch : int, optional
+        Size of events bunches to sample. If None, sample all events in memory.
+        Default is None.
     dataset_kwargs : dict, optional
         Arguments passed to `~gammapy.datasets.create_map_dataset_from_observation()`
     """
@@ -610,12 +624,14 @@ class ObservationEventSampler(MapDatasetEventSampler):
         oversample_energy_factor=10,
         t_delta=0.5 * u.s,
         keep_mc_id=True,
+        n_event_bunch=None,
         dataset_kwargs=None,
     ):
         self.dataset_kwargs = dataset_kwargs
         self.random_state = get_random_state(random_state)
         self.oversample_energy_factor = oversample_energy_factor
         self.t_delta = t_delta
+        self.n_event_bunch = n_event_bunch
         self.keep_mc_id = keep_mc_id
 
     def run(self, observation, models=None, dataset_name=None):

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -855,19 +855,21 @@ def test_MC_ID_flag(model_alternative):
 
 
 @requires_data()
-def test_large_event_number_sample_sources(dataset):
+def test_bunch_event_number_sample_sources(dataset):
     spatial_model = GaussianSpatialModel(
         lon_0="0 deg", lat_0="0 deg", sigma="0.2 deg", frame="galactic"
     )
-    spectral_model = PowerLawSpectralModel(amplitude="1e-6 cm-2 s-1 TeV-1")
+    spectral_model = PowerLawSpectralModel(amplitude="4e-10 cm-2 s-1 TeV-1")
 
     dataset.models = [
-        SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)
+        SkyModel(spectral_model=spectral_model, spatial_model=spatial_model),
+        FoVBackgroundModel(dataset_name=dataset.name),
     ]
-    print(dataset.npred().data.sum())
-    sampler = MapDatasetEventSampler(random_state=0)
-    sampler.sample_sources(dataset=dataset)
-    assert False
+
+    sampler = MapDatasetEventSampler(random_state=0, n_event_bunch=1000)
+    events = sampler.run(dataset=dataset)
+
+    assert len(events.table) == 24128
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -855,6 +855,22 @@ def test_MC_ID_flag(model_alternative):
 
 
 @requires_data()
+def test_large_event_number_sample_sources(dataset):
+    spatial_model = GaussianSpatialModel(
+        lon_0="0 deg", lat_0="0 deg", sigma="0.2 deg", frame="galactic"
+    )
+    spectral_model = PowerLawSpectralModel(amplitude="1e-6 cm-2 s-1 TeV-1")
+
+    dataset.models = [
+        SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)
+    ]
+    print(dataset.npred().data.sum())
+    sampler = MapDatasetEventSampler(random_state=0)
+    sampler.sample_sources(dataset=dataset)
+    assert False
+
+
+@requires_data()
 def test_observation_event_sampler(signal_model, tmp_path):
     from gammapy.datasets.simulate import ObservationEventSampler
 

--- a/gammapy/irf/edisp/map.py
+++ b/gammapy/irf/edisp/map.py
@@ -190,7 +190,7 @@ class EDispMap(IRFMap):
         edisp_map.quantity = data / migra_axis.bin_width.reshape((1, -1, 1, 1))
         return cls(edisp_map, exposure_map)
 
-    def sample_coord(self, map_coord, random_state=0, chunk_size=None):
+    def sample_coord(self, map_coord, random_state=0, chunk_size=10000):
         """Apply the energy dispersion corrections on the coordinates of a set of simulated events.
 
         Parameters
@@ -203,7 +203,7 @@ class EDispMap(IRFMap):
             Default is 0.
         chunk_size : int
             If set, this will slice the input MapCoord into smaller chunks of chunk_size elements.
-            Default is None.
+            Default is 10000.
 
         Returns
         -------

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -320,7 +320,7 @@ class PSFMap(IRFMap):
         kernel_map = kernel_map.downsample(factor=factor, preserve_counts=True)
         return PSFKernel(kernel_map, normalize=True)
 
-    def sample_coord(self, map_coord, random_state=0):
+    def sample_coord(self, map_coord, random_state=0, chunk_size=None):
         """Apply PSF corrections on the coordinates of a set of simulated events.
 
         Parameters
@@ -330,6 +330,9 @@ class PSFMap(IRFMap):
         random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}, optional
             Defines random number generator initialisation.
             Passed to `~gammapy.utils.random.get_random_state`. Default is 0.
+        chunk_size : int
+            If set, this will slice the input MapCoord into smaller chunks of chunk_size elements.
+            Default is None.
 
         Returns
         -------
@@ -339,30 +342,40 @@ class PSFMap(IRFMap):
         random_state = get_random_state(random_state)
         rad_axis = self.psf_map.geom.axes["rad"]
 
-        coord = {
-            "skycoord": map_coord.skycoord.reshape(-1, 1),
-            self.energy_name: map_coord[self.energy_name].reshape(-1, 1),
-            "rad": rad_axis.center,
-        }
+        position = map_coord.skycoord
+        energy = map_coord[self.energy_name]
 
-        pdf = (
-            self.psf_map.interp_by_coord(coord)
-            * rad_axis.center.value
-            * rad_axis.bin_width.value
-        )
+        size = position.size
+        separation = np.ones(size) * u.deg
+        chunk_size = size if chunk_size is None else chunk_size
 
-        sample_pdf = InverseCDFSampler(pdf, axis=1, random_state=random_state)
-        pix_coord = sample_pdf.sample_axis()
-        separation = rad_axis.pix_to_coord(pix_coord)
+        index = 0
+
+        while index < size:
+            chunk = slice(index, index + chunk_size, 1)
+            coord = {
+                "skycoord": position[chunk].reshape(-1, 1),
+                self.energy_name: energy[chunk].reshape(-1, 1),
+                "rad": rad_axis.center,
+            }
+
+            pdf = (
+                self.psf_map.interp_by_coord(coord)
+                * rad_axis.center.value
+                * rad_axis.bin_width.value
+            )
+
+            sample_pdf = InverseCDFSampler(pdf, axis=1, random_state=random_state)
+            pix_coord = sample_pdf.sample_axis()
+            separation[chunk] = rad_axis.pix_to_coord(pix_coord)
+            index += chunk_size
 
         position_angle = random_state.uniform(360, size=len(map_coord.lon)) * u.deg
 
         event_positions = map_coord.skycoord.directional_offset_by(
             position_angle=position_angle, separation=separation
         )
-        return MapCoord.create(
-            {"skycoord": event_positions, self.energy_name: map_coord[self.energy_name]}
-        )
+        return MapCoord.create({"skycoord": event_positions, self.energy_name: energy})
 
     @classmethod
     def from_gauss(cls, energy_axis_true, rad_axis=None, sigma=0.1 * u.deg, geom=None):

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -320,7 +320,7 @@ class PSFMap(IRFMap):
         kernel_map = kernel_map.downsample(factor=factor, preserve_counts=True)
         return PSFKernel(kernel_map, normalize=True)
 
-    def sample_coord(self, map_coord, random_state=0, chunk_size=None):
+    def sample_coord(self, map_coord, random_state=0, chunk_size=10000):
         """Apply PSF corrections on the coordinates of a set of simulated events.
 
         Parameters
@@ -332,7 +332,7 @@ class PSFMap(IRFMap):
             Passed to `~gammapy.utils.random.get_random_state`. Default is 0.
         chunk_size : int
             If set, this will slice the input MapCoord into smaller chunks of chunk_size elements.
-            Default is None.
+            Default is 10000.
 
         Returns
         -------


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request proposes a solution to #5112 . 
The issue there is that IRF sampling requires large memory consumption which is proportional to the number of events sampled. This can become problematic for some bright sources.

The proposed solution is to introduce a slicing mechanism into `IRFMap.sample_coord()` to perform sampling by bunches of fixed and controled sizes. 
By default, the behavior is unchanged (sample all events at once), but a parameter can be set on `MapDatasetEventSampler` to limit the chunk size.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
