### PR TITLE
Adapt `Examples` in docstrings and documentation how to

### DIFF
--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -111,6 +111,32 @@ the code as well as the output value produced.
             (10., 20.)>
         radius: 3.0 deg
 
+To allow the code block to be placed correctly over multiple lines utilise the "...":
+
+.. code-block:: text
+
+        Examples
+        --------
+        >>> from gammapy.maps import WcsGeom, MapAxis
+        >>> energy_axis_true = MapAxis.from_energy_bounds(
+        ...            0.5, 20, 10, unit="TeV", name="energy_true"
+        ...        )
+
+
+For a larger code block it is also possible to utilise the following syntax.
+
+.. code-block:: text
+
+        Examples
+        --------
+        ::
+
+            from gammapy.maps import MapAxis
+            from gammapy.irf import EnergyDispersion2D
+            filename = '$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz'
+            edisp2d = EnergyDispersion2D.read(filename, hdu="EDISP")
+
+
 In order to perform tests of these snippets of code present in the docstrings of the Python files, you may run the
 following command.
 

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -356,14 +356,11 @@ class SourceCatalogGammaCat(SourceCatalog):
 
     Access source spectral data and plot it:
 
-    >>> ax= plt.subplot()
+    >>> ax = plt.subplot()
     >>> energy_range = [1, 10] * u.TeV
-    >>> source.spectral_model().plot(energy_range, ax=ax) #doctest:+ELLIPSIS
-    <AxesSubplot:...xlabel='Energy [TeV]', ylabel='dnde [1 / (cm2 s TeV)]'>
-    >>> source.spectral_model().plot_error(energy_range, ax=ax) #doctest:+ELLIPSIS
-    <AxesSubplot:...xlabel='Energy [TeV]', ylabel='dnde [1 / (cm2 s TeV)]'>
-    >>> source.flux_points.plot(ax=ax) #doctest:+ELLIPSIS
-    <AxesSubplot:...xlabel='Energy [TeV]', ylabel='dnde [1 / (cm2 s TeV)]'>
+    >>> source.spectral_model().plot(energy_range, ax=ax) # doctest: +SKIP
+    >>> source.spectral_model().plot_error(energy_range, ax=ax) # doctest: +SKIP
+    >>> source.flux_points.plot(ax=ax) # doctest: +SKIP
     """
 
     tag = "gamma-cat"

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -727,7 +727,7 @@ class SourceCatalogHGPS(SourceCatalog):
     Flux points table:
     <BLANKLINE>
     e_ref  e_min  e_max        dnde         dnde_errn       dnde_errp        dnde_ul     is_ul
-     TeV    TeV    TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
+     TeV    TeV    TeV   1 / (TeV s cm2) 1 / (TeV s cm2) 1 / (TeV s cm2) 1 / (TeV s cm2)
     ------ ------ ------ --------------- --------------- --------------- --------------- -----
      0.332  0.215  0.511       3.048e-11       6.890e-12       7.010e-12       4.455e-11 False
      0.787  0.511  1.212       5.383e-12       6.655e-13       6.843e-13       6.739e-12 False
@@ -762,17 +762,14 @@ class SourceCatalogHGPS(SourceCatalog):
       HESS J1843-033                3FGL     3FGL J1843.7-0322   0.178442
       HESS J1843-033                3FGL     3FGL J1844.3-0344   0.242835
       HESS J1843-033                 SNR             G28.6-0.1   0.330376
-    <BLANKLINE>
+
 
     Access source spectral data and plot it:
 
     >>> ax = plt.subplot()
-    >>> source.spectral_model().plot(source.energy_range, ax=ax) #doctest:+ELLIPSIS
-    <AxesSubplot:...xlabel='Energy [TeV]', ylabel='dnde [1 / (cm2 s TeV)]'>
-    >>> source.spectral_model().plot_error(source.energy_range, ax=ax) #doctest:+ELLIPSIS
-    <AxesSubplot:...xlabel='Energy [TeV]', ylabel='dnde [1 / (cm2 s TeV)]'>
-    >>> source.flux_points.plot(ax=ax) #doctest:+ELLIPSIS
-    <AxesSubplot:...xlabel='Energy [TeV]', ylabel='dnde [1 / (cm2 s TeV)]'>
+    >>> source.spectral_model().plot(source.energy_range, ax=ax) # doctest: +SKIP
+    >>> source.spectral_model().plot_error(source.energy_range, ax=ax) # doctest: +SKIP
+    >>> source.flux_points.plot(ax=ax) # doctest: +SKIP
 
     Gaussian component information can be accessed as well,
     either via the source, or via the catalog:

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -41,11 +41,12 @@ class GTI:
     >>> print(gti)
     GTI info:
     - Number of GTIs: 1
-    - Duration: 1687.0 s
-    - Start: 123890826.0 s MET
+    - Duration: 1687.0000000000016 s
+    - Start: 123890826.00000001 s MET
     - Start: 2004-12-04T22:08:10.184 (time standard: TT)
-    - Stop: 123892513.0 s MET
+    - Stop: 123892513.00000001 s MET
     - Stop: 2004-12-04T22:36:17.184 (time standard: TT)
+    <BLANKLINE>
 
     Load GTIs for a Fermi-LAT event list:
 
@@ -56,8 +57,9 @@ class GTI:
     - Duration: 183139597.9032163 s
     - Start: 239557417.49417615 s MET
     - Start: 2008-08-04T15:44:41.678 (time standard: TT)
-    - Stop: 460250000.0 s MET
+    - Stop: 460249999.99999994 s MET
     - Stop: 2015-08-02T23:14:24.184 (time standard: TT)
+    <BLANKLINE>
     """
 
     def __init__(self, table, reference_time=None):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -606,13 +606,9 @@ class Observation:
         Examples
         --------
         >>> from gammapy.data import Observation
-        >>>
-        >>> obs = Observation.read(
-        >>>     "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
-        >>> )
-        >>>
+        >>> obs = Observation.read("$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz")
         >>> obs_copy = obs.copy(in_memory=True, obs_id=1234)
-        >>> print(obs_copy)
+        >>> print(obs_copy) # doctest: +SKIP
 
         Returns
         -------

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -91,11 +91,11 @@ class FluxPointsDataset(Dataset):
         message    : Hesse terminated successfully.
 
     >>> print(result.parameters.to_table())
-      type      name     value         unit      ... max frozen is_norm link
-    -------- --------- ---------- -------------- ... --- ------ ------- ----
-    spectral     index 2.2159e+00                ... nan  False   False
-    spectral amplitude 2.1619e-13 cm-2 s-1 TeV-1 ... nan  False    True
-    spectral reference 1.0000e+00            TeV ... nan   True   False
+    type    name     value         unit      ... frozen is_norm link prior
+    ---- --------- ---------- -------------- ... ------ ------- ---- -----
+             index 2.2159e+00                ...  False   False
+         amplitude 2.1619e-13 TeV-1 s-1 cm-2 ...  False    True
+         reference 1.0000e+00            TeV ...   True   False
 
     Note: In order to reproduce the example, you need the tests datasets folder.
     You may download it with the command:
@@ -382,9 +382,9 @@ class FluxPointsDataset(Dataset):
         >>> model = SkyModel(spectral_model=PowerLawSpectralModel())
         >>> dataset = FluxPointsDataset(model, flux_points)
         >>> #configuring optional parameters
-        >>> kwargs_spectrum = {"kwargs_model": {"color":"red", "ls":"--"}, "kwargs_fp":{"color":"green", "marker":"o"}}  # noqa: E501
+        >>> kwargs_spectrum = {"kwargs_model": {"color":"red", "ls":"--"}, "kwargs_fp":{"color":"green", "marker":"o"}}
         >>> kwargs_residuals = {"color": "blue", "markersize":4, "marker":'s', }
-        >>> dataset.plot_fit(kwargs_residuals=kwargs_residuals, kwargs_spectrum=kwargs_spectrum) # doctest: +SKIP noqa: E501
+        >>> dataset.plot_fit(kwargs_residuals=kwargs_residuals, kwargs_spectrum=kwargs_spectrum) # doctest: +SKIP
         """
 
         if self.data.geom.ndim > 3:

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -847,15 +847,15 @@ class MapDataset(Dataset):
 
         >>> energy_axis = MapAxis.from_energy_bounds(1.0, 10.0, 4, unit="TeV")
         >>> energy_axis_true = MapAxis.from_energy_bounds(
-                    0.5, 20, 10, unit="TeV", name="energy_true"
-                )
+        ...            0.5, 20, 10, unit="TeV", name="energy_true"
+        ...        )
         >>> geom = WcsGeom.create(
-                    skydir=(83.633, 22.014),
-                    binsz=0.02, width=(2, 2),
-                    frame="icrs",
-                    proj="CAR",
-                    axes=[energy_axis]
-                )
+        ...            skydir=(83.633, 22.014),
+        ...            binsz=0.02, width=(2, 2),
+        ...            frame="icrs",
+        ...            proj="CAR",
+        ...            axes=[energy_axis]
+        ...        )
         >>> empty = MapDataset.create(geom=geom, energy_axis_true=energy_axis_true, name="empty")
         """
 
@@ -1282,8 +1282,8 @@ class MapDataset(Dataset):
         >>> dataset = MapDataset.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
         >>> reg = CircleSkyRegion(SkyCoord(0,0, unit="deg", frame="galactic"), radius=1.0 * u.deg)
         >>> kwargs_spatial = {"cmap": "RdBu_r", "vmin":-5, "vmax":5, "add_cbar": True}
-        >>> kwargs_spectral = {"region":reg, "markerfacecolor": "blue", "markersize": 8, "marker": "s"}  # noqa: E501
-        >>> dataset.plot_residuals(kwargs_spatial=kwargs_spatial, kwargs_spectral=kwargs_spectral) # doctest: +SKIP noqa: E501
+        >>> kwargs_spectral = {"region":reg, "markerfacecolor": "blue", "markersize": 8, "marker": "s"}
+        >>> dataset.plot_residuals(kwargs_spatial=kwargs_spatial, kwargs_spectral=kwargs_spectral) # doctest: +SKIP
         """
         ax_spatial, ax_spectral = get_axes(
             ax_spatial,

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -53,9 +53,9 @@ class PlotMixin:
         >>> # optional configurations
         >>> kwargs_excess = {"color": "blue", "markersize":8, "marker":'s', }
         >>> kwargs_npred_signal = {"color": "black", "ls":"--"}
-        >>> kwargs_spectrum = {"kwargs_excess":kwargs_excess, "kwargs_npred_signal":kwargs_npred_signal}  # noqa: E501
-        >>> kwargs_residuals = {"color": "black", "markersize":4, "marker":'s', }  # optional configuration  # noqa: E501
-        >>> dataset.plot_fit(kwargs_residuals=kwargs_residuals, kwargs_spectrum=kwargs_spectrum)  # doctest: +SKIP  noqa: E501
+        >>> kwargs_spectrum = {"kwargs_excess":kwargs_excess, "kwargs_npred_signal":kwargs_npred_signal}
+        >>> kwargs_residuals = {"color": "black", "markersize":4, "marker":'s', }
+        >>> dataset.plot_fit(kwargs_residuals=kwargs_residuals, kwargs_spectrum=kwargs_spectrum)  # doctest: +SKIP
         """
         gs = GridSpec(7, 1)
         ax_spectrum, ax_residuals = get_axes(
@@ -147,7 +147,7 @@ class PlotMixin:
         >>> kwargs_safe = {"color":"green", "alpha":0.2} #optinonal arguments to configure
         >>> kwargs_fit = {"color":"pink", "alpha":0.2}
         >>> ax=dataset.plot_counts()  # doctest: +SKIP
-        >>> dataset.plot_masks(ax=ax, kwargs_fit=kwargs_fit, kwargs_safe=kwargs_safe)  # doctest: +SKIP  # noqa: E501
+        >>> dataset.plot_masks(ax=ax, kwargs_fit=kwargs_fit, kwargs_safe=kwargs_safe)  # doctest: +SKIP
         """
 
         kwargs_fit = kwargs_fit or {}
@@ -204,7 +204,7 @@ class PlotMixin:
         >>> #Plot the excess in blue and the npred in black dotted lines
         >>> kwargs_excess = {"color": "blue", "markersize":8, "marker":'s', }
         >>> kwargs_npred_signal = {"color": "black", "ls":"--"}
-        >>> dataset.plot_excess(kwargs_excess=kwargs_excess, kwargs_npred_signal=kwargs_npred_signal)  # doctest: +SKIP  # noqa: E501
+        >>> dataset.plot_excess(kwargs_excess=kwargs_excess, kwargs_npred_signal=kwargs_npred_signal)  # doctest: +SKIP
         """
         kwargs_excess = kwargs_excess or {}
         kwargs_npred_signal = kwargs_npred_signal or {}

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -146,7 +146,7 @@ class ExcessMapEstimator(Estimator):
       geom                   : WcsGeom
       axes                   : ['lon', 'lat', 'energy']
       shape                  : (320, 240, 1)
-      quantities             : ['npred', 'npred_excess', 'counts', 'ts', 'sqrt_ts', 'norm', 'norm_err']  # noqa: E501
+      quantities             : ['npred', 'npred_excess', 'counts', 'ts', 'sqrt_ts', 'norm', 'norm_err']
       ref. model             : pl
       n_sigma                : 1
       n_sigma_ul             : 2

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -126,8 +126,8 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
     >>> model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
     >>> dataset = MapDataset.read("$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc.fits.gz")
     >>> estimator = TSMapEstimator(
-                model, kernel_width="1 deg",energy_edges=[10, 100] * u.GeV, downsampling_factor=4
-            )
+    ...            model, kernel_width="1 deg", energy_edges=[10, 100] * u.GeV, downsampling_factor=4
+    ...        )
     >>> maps = estimator.run(dataset)
     >>> print(maps)
     FluxMaps
@@ -136,7 +136,7 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
       geom                   : WcsGeom
       axes                   : ['lon', 'lat', 'energy']
       shape                  : (400, 200, 1)
-      quantities             : ['ts', 'norm', 'niter', 'norm_err', 'npred', 'npred_excess', 'stat', 'stat_null', 'success']  # noqa: E501
+      quantities             : ['ts', 'norm', 'niter', 'norm_err', 'npred', 'npred_excess', 'stat', 'stat_null', 'success']
       ref. model             : pl
       n_sigma                : 1
       n_sigma_ul             : 2

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -454,7 +454,7 @@ class FluxPoints(FluxMaps):
         >>> table = fp.to_table(sed_type="flux", formatted=True)
         >>> print(table[:2])
         e_ref e_min e_max     flux      flux_err    flux_ul      ts    sqrt_ts is_ul
-         TeV   TeV   TeV  1 / (cm2 s) 1 / (cm2 s) 1 / (cm2 s)
+         TeV   TeV   TeV  1 / (s cm2) 1 / (s cm2) 1 / (s cm2)
         ----- ----- ----- ----------- ----------- ----------- -------- ------- -----
         1.334 1.000 1.780   1.423e-11   3.135e-13         nan 2734.000  52.288 False
         2.372 1.780 3.160   5.780e-12   1.082e-13         nan 4112.000  64.125 False

--- a/gammapy/estimators/points/profile.py
+++ b/gammapy/estimators/points/profile.py
@@ -60,12 +60,12 @@ class FluxProfileEstimator(FluxPointsEstimator):
     >>> end_pos = SkyCoord("1d", "0d", frame='galactic')
 
     >>> regions = make_orthogonal_rectangle_sky_regions(
-                start_pos=start_pos,
-                end_pos=end_pos,
-                wcs=dataset.counts.geom.wcs,
-                height=2 * u.deg,
-                nbin=21
-            )
+    ...            start_pos=start_pos,
+    ...            end_pos=end_pos,
+    ...            wcs=dataset.counts.geom.wcs,
+    ...            height=2 * u.deg,
+    ...            nbin=21
+    ...        )
 
     >>> # set up profile estimator and run
     >>> prof_maker = FluxProfileEstimator(regions=regions, energy_edges=[10, 2000] * u.GeV)
@@ -77,7 +77,7 @@ class FluxProfileEstimator(FluxPointsEstimator):
       geom                   : RegionGeom
       axes                   : ['lon', 'lat', 'energy', 'projected-distance']
       shape                  : (1, 1, 1, 21)
-      quantities             : ['norm', 'norm_err', 'ts', 'npred', 'npred_excess', 'stat', 'counts', 'success']  # noqa: E501
+      quantities             : ['norm', 'norm_err', 'ts', 'npred', 'npred_excess', 'stat', 'stat_null', 'counts', 'success']
       ref. model             : pl
       n_sigma                : 1
       n_sigma_ul             : 2

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -35,11 +35,9 @@ class EDispKernel(IRF):
 
     >>> from gammapy.maps import MapAxis
     >>> from gammapy.irf import EDispKernel
-    >>> energy = MapAxis.from_energy_bounds(0.1,10,10, unit='TeV')
-    >>> energy_true = MapAxis.from_energy_bounds(0.1,10,10, unit='TeV', name='energy_true')
-    >>> edisp = EDispKernel.from_gauss(
-    >>>     energy_axis_true=energy_true, energy_axis=energy, sigma=0.1, bias=0
-    >>> )
+    >>> energy = MapAxis.from_energy_bounds(0.1, 10, 10, unit='TeV')
+    >>> energy_true = MapAxis.from_energy_bounds(0.1, 10, 10, unit='TeV', name='energy_true')
+    >>> edisp = EDispKernel.from_gauss(energy_axis_true=energy_true, energy_axis=energy, sigma=0.1, bias=0)
 
     Have a quick look:
 

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -50,8 +50,8 @@ class EffectiveAreaTable2D(IRF):
     >>> from gammapy.irf import EffectiveAreaTable2D
     >>> from gammapy.maps import MapAxis
     >>> energy_axis_true = MapAxis.from_energy_bounds(
-            "0.1 TeV", "100 TeV", nbin=30, name="energy_true"
-        )
+    ...        "0.1 TeV", "100 TeV", nbin=30, name="energy_true"
+    ...    )
     >>> offset_axis = MapAxis.from_bounds(0, 5, nbin=4, name="offset")
     >>> aeff = EffectiveAreaTable2D(axes=[energy_axis_true, offset_axis], data=1e10, unit="cm2")
     >>> print(aeff)

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -49,23 +49,23 @@ class MapDatasetMaker(Maker):
     >>> from gammapy.maps import WcsGeom, MapAxis
     >>> from gammapy.makers import MapDatasetMaker
 
-    >>>  #load an observation
+    >>> # Load an observation
     >>> data_store = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
     >>> obs = data_store.obs(23523)
 
-    >>> #prepare the geom
+    >>> # Prepare the geometry
     >>> energy_axis = MapAxis.from_energy_bounds(1.0, 10.0, 4, unit="TeV")
     >>> energy_axis_true = MapAxis.from_energy_bounds( 0.5, 20, 10, unit="TeV", name="energy_true")
     >>> geom = WcsGeom.create(
-            skydir=(83.633, 22.014),
-            binsz=0.02,
-            width=(2, 2),
-            frame="icrs",
-            proj="CAR",
-            axes=[energy_axis],
-        )
+    ...        skydir=(83.633, 22.014),
+    ...        binsz=0.02,
+    ...        width=(2, 2),
+    ...        frame="icrs",
+    ...        proj="CAR",
+    ...        axes=[energy_axis],
+    ...    )
 
-    >>> #Run the maker
+    >>> # Run the maker
     >>> empty = MapDataset.create(geom=geom, energy_axis_true=energy_axis_true, name="empty")
     >>> maker = MapDatasetMaker()
     >>> dataset = maker.run(empty, obs)

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -307,8 +307,8 @@ class Model:
         --------
         >>> from gammapy.modeling.models import Model
         >>> spectral_model = Model.create(
-                    "pl-2", model_type="spectral", amplitude="1e-10 cm-2 s-1", index=3
-                )
+        ...            "pl-2", model_type="spectral", amplitude="1e-10 cm-2 s-1", index=3
+        ...        )
         >>> type(spectral_model)
         <class 'gammapy.modeling.models.spectral.PowerLaw2SpectralModel'>
         """

--- a/gammapy/modeling/models/spectral_crab.py
+++ b/gammapy/modeling/models/spectral_crab.py
@@ -58,18 +58,18 @@ def create_crab_spectral_model(reference="meyer"):
     Let's first import what we need::
 
         >>> import astropy.units as u
-        >>> from gammapy.modeling.models import PowerLaw, create_crab_spectral_model
+        >>> from gammapy.modeling.models import PowerLawSpectralModel, create_crab_spectral_model
 
     Plot the 'hess_ecpl' reference Crab spectrum between 1 TeV and 100 TeV::
 
         >>> crab_hess_ecpl = create_crab_spectral_model('hess_ecpl')
-        >>> crab_hess_ecpl.plot([1, 100] * u.TeV)
+        >>> crab_hess_ecpl.plot([1, 100] * u.TeV)  #doctest: +SKIP
 
     Use a reference crab spectrum as unit to measure a differential flux (at 10 TeV)::
 
         >>> pwl = PowerLawSpectralModel(
-                index=2.3, amplitude=1e-12 * u.Unit('1 / (cm2 s TeV)'), reference=1 * u.TeV
-            )
+        ...        index=2.3, amplitude=1e-12 * u.Unit('1 / (cm2 s TeV)'), reference=1 * u.TeV
+        ...    )
         >>> crab = create_crab_spectral_model('hess_pl')
         >>> energy = 10 * u.TeV
         >>> dnde_cu = (pwl(energy) / crab(energy)).to('%')

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -499,28 +499,29 @@ class LightCurveTemplateTemporalModel(TemporalModel):
 
     >>> print(light_curve)
     LightCurveTemplateTemporalModel model summary:
-    Reference time: 59000.5 MJD
-    Start time: 59000.5 MJD
-    End time: 61862.5 MJD
-    Norm min: 0.01551196351647377
+     Reference time: 59000.49919925926 MJD
+     Start time: 58999.99919925926 MJD
+     End time: 61862.99919925926 MJD
+     Norm min: 0.01551196351647377
     Norm max: 1.0
+
     <BLANKLINE>
 
     Compute ``norm`` at a given time:
 
+    >>> from astropy.time import Time
     >>> t = Time(59001.195, format="mjd")
     >>> light_curve.evaluate(t)
-    array(0.02287888)
+    <Quantity [0.02288737]>
 
     Compute mean ``norm`` in a given time interval:
 
-    >>> from astropy.time import Time
     >>> import astropy.units as u
     >>> t_r = Time(59000.5, format='mjd')
     >>> t_min = t_r + [1, 4, 8] * u.d
     >>> t_max = t_r + [1.5, 6, 9] * u.d
     >>> light_curve.integral(t_min, t_max)
-    array([0.0074388942, 0.0071144081, 0.0068115544])
+    <Quantity [0.00375698, 0.0143724 , 0.00688029]>
     """
 
     tag = ["LightCurveTemplateTemporalModel", "template"]

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -798,13 +798,11 @@ class Parameters(collections.abc.Sequence):
 
         Examples
         --------
-        ::
-
-            >>> from gammapy.modeling.models import PowerLawSpectralModel
-            >>> pwl = PowerLawSpectralModel(index=2)
-            >>> with pwl.parameters.restore_status():
-            >>>     pwl.parameters["index"].value = 3
-            >>> print(pwl.parameters["index"].value)
+        >>> from gammapy.modeling.models import PowerLawSpectralModel
+        >>> pwl = PowerLawSpectralModel(index=2)
+        >>> with pwl.parameters.restore_status():
+        ...     pwl.parameters["index"].value = 3
+        >>> print(pwl.parameters["index"].value) # doctest: +SKIP
         """
         return restore_parameters_status(self, restore_values)
 

--- a/gammapy/utils/units.py
+++ b/gammapy/utils/units.py
@@ -32,11 +32,11 @@ def standardise_unit(unit):
     --------
     >>> from gammapy.utils.units import standardise_unit
     >>> standardise_unit('ph cm-2 s-1')
-    Unit("1 / (cm2 s)")
+    Unit("1 / (s cm2)")
     >>> standardise_unit('ct cm-2 s-1')
-    Unit("1 / (cm2 s)")
+    Unit("1 / (s cm2)")
     >>> standardise_unit('cm-2 s-1')
-    Unit("1 / (cm2 s)")
+    Unit("1 / (s cm2)")
     """
     unit = u.Unit(unit)
     bases, powers = [], []

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -117,11 +117,11 @@ def plot_map_rgb(map_, ax=None, **kwargs):
     >>> import astropy.units as u
     >>> map_ = Map.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
     >>> axis_rgb = MapAxis.from_energy_edges(
-    >>>     [0.1, 0.2, 0.5, 10], unit=u.TeV, name="energy", interp="log"
-    >>> )
+    ...     [0.1, 0.2, 0.5, 10], unit=u.TeV, name="energy", interp="log"
+    ... )
     >>> map_ = map_.resample_axis(axis_rgb)
     >>> kwargs = {"stretch": 0.5, "Q": 1, "minimum": 0.15}
-    >>> plot_map_rgb(map_.smooth(0.08*u.deg), **kwargs)
+    >>> plot_map_rgb(map_.smooth(0.08*u.deg), **kwargs) #doctest: +SKIP
     """
     geom = map_.geom
     if len(geom.axes) != 1 or geom.axes[0].nbin != 3:


### PR DESCRIPTION
This PR is to adapt the documentation on "Examples" and to fix various "Examples" which encounter a problem when running `pytest --doctest-modules --ignore-glob=*/tests gammapy`.

I also removed "noqa: E501" in a number of places which was causing errors in some docstring testing. These are supposed to catch the error when a line is too long, but they were placed incorrectly. 


Note: I ran the both the pytest to check and built the docs to ensure they look fine.