### PR TITLE
Fix example and docstrings in irfs

### DIFF
--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -610,7 +610,7 @@ class IRF(metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        other : `gammapy.irfs.IRF`
+        other : `~gammapy.irfs.IRF`
             The IRF to compare against.
         rtol_axes : float, optional
             Relative tolerance for the axis comparison.

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -166,32 +166,33 @@ class EDispKernel(IRF):
 
         Parameters
         ----------
-        energy_axis_true : `MapAxis`
+        energy_axis_true : `~gammapy.maps.MapAxis`
             True energy axis.
-        energy_axis : `MapAxis`, optional
+        energy_axis : `~gammapy.maps.MapAxis`, optional
             Reconstructed energy axis. Default is None.
 
         Examples
         --------
-        If ``energy_true`` equals ``energy``, you get a diagonal matrix::
+        If ``energy_true`` equals ``energy``, you get a diagonal matrix:
 
-            from gammapy.irf import EDispKernel
-            from gammapy.maps import MapAxis
+        >>> from gammapy.irf import EDispKernel
+        >>> from gammapy.maps import MapAxis
+        >>> import astropy.units as u
 
-            energy_true_axis = MapAxis.from_energy_edges(
-                    [0.5, 1, 2, 4, 6] * u.TeV, name="energy_true"
-                )
-            edisp = EDispKernel.from_diagonal_response(energy_true_axis)
-            edisp.plot_matrix()
+        >>> energy_true_axis = MapAxis.from_energy_edges(
+        ...            [0.5, 1, 2, 4, 6] * u.TeV, name="energy_true"
+        ...        )
+        >>> edisp = EDispKernel.from_diagonal_response(energy_true_axis)
+        >>> edisp.plot_matrix() # doctest: +SKIP
 
-        Example with different energy binnings::
+        Example with different energy binnings:
 
-            energy_true_axis = MapAxis.from_energy_edges(
-                    [0.5, 1, 2, 4, 6] * u.TeV, name="energy_true"
-                )
-            energy_axis = MapAxis.from_energy_edges([2, 4, 6] * u.TeV)
-            edisp = EDispKernel.from_diagonal_response(energy_true_axis, energy_axis)
-            edisp.plot_matrix()
+        >>> energy_true_axis = MapAxis.from_energy_edges(
+        ...     [0.5, 1, 2, 4, 6] * u.TeV, name="energy_true"
+        ... )
+        >>> energy_axis = MapAxis.from_energy_edges([2, 4, 6] * u.TeV)
+        >>> edisp = EDispKernel.from_diagonal_response(energy_true_axis, energy_axis)
+        >>> edisp.plot_matrix() # doctest: +SKIP
         """
         from .map import get_overlap_fraction
 

--- a/gammapy/irf/edisp/map.py
+++ b/gammapy/irf/edisp/map.py
@@ -99,7 +99,7 @@ class EDispMap(IRFMap):
 
         Parameters
         ----------
-        energy_axis : `MapAxis`
+        energy_axis : `~gammapy.maps.MapAxis`
             Reconstructed energy axis.
         position : `~astropy.coordinates.SkyCoord`
             The target position. Should be a single coordinates.
@@ -419,7 +419,7 @@ class EDispKernelMap(IRFMap):
 
         Parameters
         ----------
-        edisp : `~gammapy.irfs.EDispKernel`
+        edisp : `~gammapy.irf.EDispKernel`
             The input 1D kernel.
         geom : `~gammapy.maps.Geom`, optional
             The (2D) geometry object to use. If None, an all sky geometry with 2 bins is created.
@@ -502,7 +502,7 @@ class EDispKernelMap(IRFMap):
         )
 
     def resample_energy_axis(self, energy_axis, weights=None):
-        """Return a resampled EdispKernelMap.
+        """Return a resampled `EDispKernelMap`.
 
         Bins are grouped according to the edges of the reconstructed energy axis provided.
         The true energy is left unchanged.


### PR DESCRIPTION
This pull request fixes the example in `gammapy/irf/edisp/kernel` so that it actually runs when testing docstrings.

Also fixed a few docstrings 