### PR TITLE
Copy on and off phase intervals in `PhaseBackgroundMaker`

### DIFF
--- a/gammapy/makers/background/phase.py
+++ b/gammapy/makers/background/phase.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from copy import deepcopy
 import numpy as np
 from regions import PointSkyRegion
 from gammapy.data import EventList
@@ -27,8 +28,8 @@ class PhaseBackgroundMaker(Maker):
     tag = "PhaseBackgroundMaker"
 
     def __init__(self, on_phase, off_phase, phase_column_name="PHASE"):
-        self.on_phase = self._check_intervals(on_phase)
-        self.off_phase = self._check_intervals(off_phase)
+        self.on_phase = self._check_intervals(deepcopy(on_phase))
+        self.off_phase = self._check_intervals(deepcopy(off_phase))
         self.phase_column_name = phase_column_name
 
     def __str__(self):

--- a/gammapy/makers/background/tests/test_phase.py
+++ b/gammapy/makers/background/tests/test_phase.py
@@ -109,6 +109,14 @@ def test_check_phase_intervals(pars):
     )
 
 
+def test_copy_interval():
+    on = (0.8, 1.2)
+    off = [(0.1, 0.3), (0.4, 0.5)]
+    PhaseBackgroundMaker(on_phase=on, off_phase=off)
+    assert on == (0.8, 1.2)
+    assert off == [(0.1, 0.3), (0.4, 0.5)]
+
+
 @requires_data()
 @pytest.mark.parametrize(
     "pars",


### PR DESCRIPTION
This PR modify the `PhasebackgroundMaker` so that the phase intervals that are passed to the maker are copied. This is because `_check_intervals` can modify the phase intervals, which can lead to undefined behaviour, especially since this methods is private. 