### PR TITLE
Add different options to compute stat_array on FluxPointsDatasets

### DIFF
--- a/examples/tutorials/analysis-1d/spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis.py
@@ -510,8 +510,8 @@ plt.show()
 # The `distrib` case provides an approximation if the `profile` is not available
 # which allows to take into accounts upper limit and asymetrics error.
 #
-# In the example below we can see that the `profle` case match exactly the result
-# from the joint analysis (from the ON/OFF dataset using labelled as wstat).
+# In the example below we can see that the `profile` case matches exactly the result
+# from the joint analysis of the ON/OFF datasets using `wstat` (as labelled)).
 
 
 def plot_stat(fp_dataset):

--- a/examples/tutorials/analysis-1d/spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis.py
@@ -497,7 +497,7 @@ plt.show()
 
 ######################################################################
 # A note on statistics
-# ---------
+# --------------------
 #
 # Different statistic are available for the FluxPointDataset :
 # * chi2 : etimate from chi2 statistics.

--- a/examples/tutorials/analysis-1d/spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis.py
@@ -502,11 +502,11 @@ plt.show()
 # --------------------
 #
 # Different statistic are available for the FluxPointDataset :
-# * chi2 : etimate from chi2 statistics.
+# * chi2 : estimate from chi2 statistics.
 # * profile : estimate from interpolation of the likelihood profile.
 # * distrib : estimate from probability distributions,
 #             assumes that flux points correspond to asymmetric gaussians
-#             and upper limits complemantary error functions.
+#             and upper limits complementary error functions.
 # Default is `chi2`, in that case upper limits are ignored and the mean of asymetrics error is used.
 # So it is recommended to use `profile` if `stat_scan` is available on flux points.
 # The `distrib` case provides an approximation if the `profile` is not available
@@ -557,7 +557,7 @@ plot_stat(flux_points_dataset)
 # In order to avoid discrepancies due to the treatment of upper limits
 # we can utilise the `~gammapy.estimators.utils.resample_energy_edges`
 # for defining energy bins in which the minimum number of `sqrt_ts` is 2.
-# In that case the all the statistics definitions gives equivalent results.
+# In that case all the statistics definitions give equivalent results.
 #
 
 energy_edges = resample_energy_edges(dataset_stacked, conditions={"sqrt_ts_min": 2})

--- a/examples/tutorials/analysis-1d/spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis.py
@@ -505,7 +505,7 @@ plt.show()
 # * chi2 : estimate from chi2 statistics.
 # * profile : estimate from interpolation of the likelihood profile.
 # * distrib : estimate from probability distributions,
-#             assumes that flux points correspond to asymmetric gaussians
+#             assuming that flux points correspond to asymmetric gaussians
 #             and upper limits complementary error functions.
 # Default is `chi2`, in that case upper limits are ignored and the mean of asymetrics error is used.
 # So it is recommended to use `profile` if `stat_scan` is available on flux points.
@@ -513,7 +513,7 @@ plt.show()
 # which allows to take into accounts upper limit and asymetrics error.
 #
 # In the example below we can see that the `profile` case matches exactly the result
-# from the joint analysis of the ON/OFF datasets using `wstat` (as labelled)).
+# from the joint analysis of the ON/OFF datasets using `wstat` (as labelled).
 
 
 def plot_stat(fp_dataset):

--- a/examples/tutorials/analysis-1d/spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis.py
@@ -406,6 +406,7 @@ display(flux_points.to_table(sed_type="dnde", formatted=True))
 fig, ax = plt.subplots()
 flux_points.plot(ax=ax, sed_type="e2dnde", color="darkorange")
 flux_points.plot_ts_profiles(ax=ax, sed_type="e2dnde")
+ax.set_xlim(0.6, 40)
 plt.show()
 
 ######################################################################
@@ -423,7 +424,8 @@ plt.show()
 flux_points_dataset = FluxPointsDataset(
     data=flux_points, models=model_best_joint.copy()
 )
-flux_points_dataset.plot_fit()
+ax, _ = flux_points_dataset.plot_fit()
+ax.set_xlim(0.6, 40)
 plt.show()
 
 

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -170,7 +170,7 @@ class FluxPointsDataset(Dataset):
         if stat_type == "chi2":
             self.mask_valid = (~self.data.is_ul).data & np.isfinite(self.data.dnde)
         elif stat_type == "distrib":
-            self.mask_valid = self.data.is_ul.data | np.isfinite(self.data.dnde)
+            self.mask_valid = (self.data.is_ul.data & np.isfinite(self.data.dnde_ul) | np.isfinite(self.data.dnde)
         elif stat_type == "profile":
             self.stat_kwargs.setdefault("interp_scale", "sqrt")
             self.stat_kwargs.setdefault("extrapolate", True)

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -62,11 +62,17 @@ class FluxPointsDataset(Dataset):
         Method used to compute the statistics:
         * chi2 : etimate from chi2 statistics.
         * profile : estimate from interpolation of the likelihood profile.
-        * distrib : estimate from probability distributions
-                    assuming that flux points correspond to asymmetric gaussians
-                    and upper limits complemantary error functions.
+        * distrib : Assuming gaussian errors the likelihood is given by the
+                    probability density function of the normal distribution.
+                    For the upper limit case it is necessary to marginalize over the unknown measurement,
+                    So we integrate the normal distribution up to the upper limit value
+                    which gives the complementary error function.
+                    See eq. C7 of Mohanty et al (2013) :
+                    https://iopscience.iop.org/article/10.1088/0004-637X/773/2/168/pdf
+
         Default is `chi2`, in that case upper limits are ignored and the mean of asymetrics error is used.
         However it is recommended to use `profile` if `stat_scan` is available on flux points.
+        The `distrib` case provides an approximation if the profile is not available.
     stat_kwargs : dict
         Extra arguments specifying the interpolation scheme of the likelihood profile.
         Used only if `stat_type=="profile"`. In that case the default is :

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -60,7 +60,7 @@ class FluxPointsDataset(Dataset):
         One line per observation for stacked datasets.
     stat_type : bool
         Method used to compute the statistics:
-        * chi2 : etimate from chi2 statistics.
+        * chi2 : estimate from chi2 statistics.
         * profile : estimate from interpolation of the likelihood profile.
         * distrib : Assuming gaussian errors the likelihood is given by the
                     probability density function of the normal distribution.
@@ -424,7 +424,7 @@ class FluxPointsDataset(Dataset):
     def _stat_array_distrib(self):
         """Estimate statistic from probability distributions,
         assumes that flux points correspond to asymmetric gaussians
-        and upper limits complemantary error functions.
+        and upper limits complementary error functions.
         """
         model = self.flux_pred()
 

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -58,7 +58,7 @@ class FluxPointsDataset(Dataset):
     meta_table : `~astropy.table.Table`
         Table listing information on observations used to create the dataset.
         One line per observation for stacked datasets.
-    stat_type : bool
+    stat_type : str
         Method used to compute the statistics:
         * chi2 : estimate from chi2 statistics.
         * profile : estimate from interpolation of the likelihood profile.
@@ -155,13 +155,15 @@ class FluxPointsDataset(Dataset):
             mask_safe = np.ones(self.data.dnde.data.shape, dtype=bool)
         self.mask_safe = mask_safe
 
-    @property
-    def available_stat_type(self):
-        return dict(
+        self._available_stat_type = dict(
             chi2=self._stat_array_chi2,
             profile=self._stat_array_profile,
             distrib=self._stat_array_distrib,
         )
+
+    @property
+    def available_stat_type(self):
+        return self._available_stat_type.keys()
 
     @property
     def stat_type(self):
@@ -172,7 +174,7 @@ class FluxPointsDataset(Dataset):
 
         if stat_type not in self.available_stat_type:
             raise ValueError(
-                f"Invalid stat_type: possible options are {list(self.available_stat_type.keys())}"
+                f"Invalid stat_type: possible options are {list(self.available_stat_type)}"
             )
 
         if stat_type == "chi2":
@@ -382,7 +384,7 @@ class FluxPointsDataset(Dataset):
 
     def stat_array(self):
         """Fit statistic array."""
-        return self.available_stat_type[self.stat_type]()
+        return self._available_stat_type[self.stat_type]()
 
     def _stat_array_chi2(self):
         """Chi2 statistics."""

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -129,7 +129,7 @@ class FluxPointsDataset(Dataset):
         name=None,
         meta_table=None,
         sample_points=False,
-        n_samples=1000,
+        n_samples=100,
         random_state=0,
     ):
         if not data.geom.has_energy_axis:
@@ -352,7 +352,9 @@ class FluxPointsDataset(Dataset):
                         random_state=self.random_state,
                     )
                     samplesp[samplesp < loc] = 2 * loc - samplesp[samplesp < loc]
-                    samplesp = np.random.choice(samplesp, size=int(self.n_samples / 2))
+                    samplesp = self.random_state.choice(
+                        samplesp, size=int(self.n_samples / 2)
+                    )
 
                     scalen = self.data.dnde_errn.data.flatten()[k]
                     samplesn = norm.rvs(
@@ -362,7 +364,9 @@ class FluxPointsDataset(Dataset):
                         random_state=self.random_state,
                     )
                     samplesn[samplesn > loc] = 2 * loc - samplesn[samplesn > loc]
-                    samplesn = np.random.choice(samplesn, size=int(self.n_samples / 2))
+                    samplesn = self.random_state.choice(
+                        samplesn, size=int(self.n_samples / 2)
+                    )
 
                     subsamples = np.concatenate((samplesn, samplesp))
 

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -67,9 +67,9 @@ class FluxPointsDataset(Dataset):
                     and upper limits complemantary error functions.
         Default is `chi2`, in that case upper limits are ignored and the mean of asymetrics error is used.
         However it is recommended to use `profile` if `stat_scan` is available on flux points.
-    stat_kwargs : int
-        Exta arguments passed to the stat function
-        Used only if `stat_type=="distrib"`. In that case the default is :
+    stat_kwargs : dict
+        Extra arguments specifying the interpolation scheme of the likelihood profile.
+        Used only if `stat_type=="profile"`. In that case the default is :
         `stat_kwargs={"interp_scale":"sqrt", "extrapolate":True}
 
     Examples

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -170,9 +170,9 @@ class FluxPointsDataset(Dataset):
             )
 
         if stat_type == "chi2":
-            self.mask_valid = (~self.data.is_ul).data & np.isfinite(self.data.dnde)
+            self._mask_valid = (~self.data.is_ul).data & np.isfinite(self.data.dnde)
         elif stat_type == "distrib":
-            self.mask_valid = (
+            self._mask_valid = (
                 self.data.is_ul.data & np.isfinite(self.data.dnde_ul)
             ) | np.isfinite(self.data.dnde)
         elif stat_type == "profile":
@@ -180,6 +180,10 @@ class FluxPointsDataset(Dataset):
             self.stat_kwargs.setdefault("extrapolate", True)
             self._profile_interpolators = self._get_valid_profile_interpolators()
         self._stat_type = stat_type
+
+    @property
+    def mask_valid(self):
+        return self._mask_valid
 
     @property
     def mask_safe(self):
@@ -396,13 +400,13 @@ class FluxPointsDataset(Dataset):
         value_scan = self.data.stat_scan.geom.axes["norm"].center
         shape_axes = self.data.stat_scan.geom._shape[slice(3, None)]
         interpolators = np.empty(shape_axes, dtype=object)
-        self.mask_valid = np.ones(self.data.dnde.data.shape, dtype=bool)
+        self._mask_valid = np.ones(self.data.dnde.data.shape, dtype=bool)
         for idx in np.ndindex(shape_axes):
             stat_scan = np.abs(
                 self.data.stat_scan.data[idx].squeeze()
                 - self.data.stat.data[idx].squeeze()
             )
-            self.mask_valid[idx] = np.all(np.isfinite(stat_scan))
+            self._mask_valid[idx] = np.all(np.isfinite(stat_scan))
             interpolators[idx] = interpolate_profile(
                 value_scan,
                 stat_scan,

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -404,7 +404,7 @@ class FluxPointsDataset(Dataset):
 
     def _get_valid_profile_interpolators(self):
         value_scan = self.data.stat_scan.geom.axes["norm"].center
-        shape_axes = self.data.stat_scan.geom._shape[slice(3, None)]
+        shape_axes = self.data.stat_scan.geom._shape[slice(3, None)][::-1]
         interpolators = np.empty(shape_axes, dtype=object)
         self._mask_valid = np.ones(self.data.dnde.data.shape, dtype=bool)
         for idx in np.ndindex(shape_axes):

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -145,6 +145,12 @@ class FluxPointsDataset(Dataset):
         self.models = models
         self.meta_table = meta_table
 
+        self._available_stat_type = dict(
+            chi2=self._stat_array_chi2,
+            profile=self._stat_array_profile,
+            distrib=self._stat_array_distrib,
+        )
+
         if stat_kwargs is None:
             stat_kwargs = dict()
         self.stat_kwargs = stat_kwargs
@@ -155,15 +161,9 @@ class FluxPointsDataset(Dataset):
             mask_safe = np.ones(self.data.dnde.data.shape, dtype=bool)
         self.mask_safe = mask_safe
 
-        self._available_stat_type = dict(
-            chi2=self._stat_array_chi2,
-            profile=self._stat_array_profile,
-            distrib=self._stat_array_distrib,
-        )
-
     @property
     def available_stat_type(self):
-        return self._available_stat_type.keys()
+        return list(self._available_stat_type.keys())
 
     @property
     def stat_type(self):
@@ -174,7 +174,7 @@ class FluxPointsDataset(Dataset):
 
         if stat_type not in self.available_stat_type:
             raise ValueError(
-                f"Invalid stat_type: possible options are {list(self.available_stat_type)}"
+                f"Invalid stat_type: possible options are {self.available_stat_type}"
             )
 
         if stat_type == "chi2":

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -435,7 +435,7 @@ class FluxPointsDataset(Dataset):
         value = model[mask_valid]
         try:
             mask_p = (model >= self.data.dnde.data)[mask_valid]
-            scale = np.zeros(mask_valid.shape)
+            scale = np.zeros(mask_p.shape)
             scale[mask_p] = self.data.dnde_errp.data[mask_valid][mask_p]
             scale[~mask_p] = self.data.dnde_errn.data[mask_valid][~mask_p]
         except AttributeError:

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -396,10 +396,12 @@ class FluxPointsDataset(Dataset):
 
     def _stat_array_profile(self):
         """Estimate statitistic from interpolation of the likelihood profile."""
-        model = (self.flux_pred() / self.data.dnde_ref).to_value("")
+        model = np.zeros(self.data.dnde.data.shape) + (
+            self.flux_pred() / self.data.dnde_ref
+        ).to_value("")
         stat = np.zeros(model.shape)
-        for idx, interp in enumerate(self._profile_interpolators):
-            stat[idx] = interp(model[idx])
+        for idx in np.ndindex(self._profile_interpolators.shape):
+            stat[idx] = self._profile_interpolators[idx](model[idx])
         return stat
 
     def _get_valid_profile_interpolators(self):
@@ -426,7 +428,9 @@ class FluxPointsDataset(Dataset):
         assumes that flux points correspond to asymmetric gaussians
         and upper limits complementary error functions.
         """
-        model = self.flux_pred().to_value(self.data.dnde.unit)
+        model = np.zeros(self.data.dnde.data.shape) + self.flux_pred().to_value(
+            self.data.dnde.unit
+        )
 
         stat = np.zeros(model.shape)
 

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -172,7 +172,7 @@ class FluxPointsDataset(Dataset):
 
         if stat_type not in self.available_stat_type:
             raise ValueError(
-                "Invalid stat_type: possible options are {list(self.available_stat_type.keys())}"
+                f"Invalid stat_type: possible options are {list(self.available_stat_type.keys())}"
             )
 
         if stat_type == "chi2":

--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -102,6 +102,19 @@ def test_flux_point_dataset_flux_pred(dataset):
     assert_allclose(dataset.flux_pred()[0].value, 0.000472, rtol=1e-3)
 
 
+@requires_data()
+def test_flux_point_dataset_stat(dataset):
+    dataset.stat_type = "chi2"
+    fit = Fit()
+    fit.run([dataset])
+    assert_allclose(dataset.stat_sum(), 25.205933, rtol=1e-3)
+
+    dataset.stat_type = "distrib"
+    fit = Fit()
+    fit.run([dataset])
+    assert_allclose(dataset.stat_sum(), 36.153428, rtol=1e-3)
+
+
 def test_flux_point_dataset_with_time_axis(tmp_path):
     meta = dict(TIMESYS="utc", SED_TYPE="flux")
 
@@ -157,6 +170,9 @@ def test_flux_point_dataset_with_time_axis(tmp_path):
         flux_points_dataset.plot_fit()
     with pytest.raises(ValueError):
         flux_points_dataset.plot_residuals()
+
+    flux_points_dataset.stat_type = "distrib"
+    assert_allclose(flux_points_dataset.stat_sum(), 193.8093, rtol=1e-3)
 
 
 @requires_data()

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -309,6 +309,15 @@ def test_run_pwl(fpe_pwl, tmpdir):
     fp_new = FluxPoints.read(tmpdir / "test.fits")
     assert fp_new.meta["sed_type_init"] == "likelihood"
 
+    # test datasets stat
+    fp_dataset = FluxPointsDataset(data=fp, models=fp.reference_model)
+    fp_dataset.stat_type = "chi2"
+    assert_allclose(fp_dataset.stat_sum(), 3.82374, rtol=1e-4)
+    fp_dataset.stat_type = "profile"
+    assert_allclose(fp_dataset.stat_sum(), 3.790053, rtol=1e-4)
+    fp_dataset.stat_type = "distrib"
+    assert_allclose(fp_dataset.stat_sum(), 3.783325, rtol=1e-4)
+
 
 def test_run_ecpl(fpe_ecpl, tmpdir):
     datasets, fpe = fpe_ecpl

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -254,6 +254,9 @@ def interpolate_profile(x, y, interp_scale="sqrt", extrapolate=False):
         of parabolic shape, a "sqrt" scaling is recommended. In other cases or
         for fine sampled profiles a "lin" can also be used.
         Default is "sqrt".
+    extrapolate : bool
+        Extrapolate or not if the evaluation value is outside the range of x values.
+        Default is False.
 
     Returns
     -------

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -240,7 +240,7 @@ class LinearScale(InterpolationScale):
         return values
 
 
-def interpolate_profile(x, y, interp_scale="sqrt"):
+def interpolate_profile(x, y, interp_scale="sqrt", extrapolate=False):
     """Helper function to interpolate one-dimensional profiles.
 
     Parameters
@@ -261,4 +261,8 @@ def interpolate_profile(x, y, interp_scale="sqrt"):
         Interpolator.
     """
     method_dict = {"sqrt": "quadratic", "lin": "linear"}
-    return scipy.interpolate.interp1d(x, y, kind=method_dict[interp_scale])
+    kwargs = dict(kind=method_dict[interp_scale])
+    if extrapolate:
+        kwargs["bounds_error"] = False
+        kwargs["fill_value"] = "extrapolate"
+    return scipy.interpolate.interp1d(x, y, **kwargs)


### PR DESCRIPTION
Add different options to compute stat_array on FluxPointsDatasets :
- chi2 : etimate from chi2 statistics.
- profile : estimate from interpolation of the likelihood profile.
- distrib : estimate from probability distributions,
             assumes that flux points correspond to asymmetric gaussians and upper limits complemantary error functions.

 Default is `chi2`, in that case upper limits are ignored and the mean of asymetrics error is used.
The `distrib` case provides an approximation if the `profile` is not available
 which allows to take into accounts upper limits and asymetrics errors.

Updated /tutorials/analysis-1d/spectral_analysis.py to present the different cases:
![image](https://github.com/gammapy/gammapy/assets/25845654/3d997a81-d4ca-40f4-a708-af6d66bb8cd1)
Without ul the results are the same:
![image](https://github.com/gammapy/gammapy/assets/25845654/f3ec38f1-d893-4605-8baf-9a4e1b1c7533)
