### PR TITLE
Add examples to functions in `estimators`

### DIFF
--- a/gammapy/estimators/energydependentmorphology.py
+++ b/gammapy/estimators/energydependentmorphology.py
@@ -83,6 +83,9 @@ class EnergyDependentMorphologyEstimator(Estimator):
         If None, the fit backend default is minuit.
         Default is None.
 
+    Examples
+    --------
+    For a usage example see :doc:`/tutorials/analysis-3d/energy_dependent_estimation` tutorial.
     """
 
     tag = "EnergyDependentMorphologyEstimator"

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -33,10 +33,30 @@ class ParameterEstimator(Estimator):
             * "scan": estimate fit statistic profiles.
 
         Default is None so the optional steps are not executed.
-    fit : `Fit`
+    fit : `~gammapy.modeling.Fit`
         Fit instance specifying the backend and fit options.
     reoptimize : bool
         Re-optimize other free model parameters. Default is True.
+
+    Examples
+    --------
+    >>> from gammapy.datasets import SpectrumDatasetOnOff, Datasets
+    >>> from gammapy.modeling.models import SkyModel, PowerLawSpectralModel
+    >>> from gammapy.estimators import ParameterEstimator
+    >>>
+    >>> filename = "$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs23523.fits"
+    >>> dataset = SpectrumDatasetOnOff.read(filename)
+    >>> datasets = Datasets([dataset])
+    >>> spectral_model = PowerLawSpectralModel(amplitude="3e-11 cm-2s-1TeV-1", index=2.7)
+    >>>
+    >>> model = SkyModel(spectral_model=spectral_model, name="Crab")
+    >>> model.spectral_model.amplitude.scan_n_values = 10
+    >>>
+    >>> for dataset in datasets:
+    ...     dataset.models = model
+    >>>
+    >>> estimator = ParameterEstimator(selection_optional="all")
+    >>> result = estimator.run(datasets, parameter="amplitude")
     """
 
     tag = "ParameterEstimator"

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -82,7 +82,7 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
         limited to the number of physical CPUs.
     parallel_backend : {"multiprocessing", "ray"}
         Which backend to use for multiprocessing.
-    norm : ~gammapy.modeling.Parameter` or dict
+    norm : `~gammapy.modeling.Parameter` or dict
         Norm parameter used for the fit
         Default is None and a new parameter is created automatically,
         with value=1, name="norm", scan_min=0.2, scan_max=5, and scan_n_values = 11.


### PR DESCRIPTION
This PR is to add examples to the docstrings of the functions in `gammapy.estimators`.

This is connected to https://github.com/gammapy/gammapy/issues/5016