### PR TITLE
Fix `geom.energy_mask` docstring

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -625,8 +625,9 @@ class Geom(abc.ABC):
 
         Returns
         -------
-        mask : `~numpy.ndarray`
-            Energy mask.
+        mask : `~gammapy.maps.Map`
+            Map containing the energy mask. The geometry of the map
+            is the same as the geometry of the instance which called this method.
         """
         from . import Map
 


### PR DESCRIPTION
This PR fix #5144. 

