### PR TITLE
Remove warning message for table in `SensitivityEstimator`

### DIFF
--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import logging
 import numpy as np
 from astropy.table import Column, Table
 from gammapy.maps import Map
@@ -140,18 +139,9 @@ class SensitivityEstimator(Estimator):
         criterion = self._get_criterion(
             excess.data.squeeze(), dataset.background.data.squeeze()
         )
-        logging.warning(
-            "Column 'energy' is deprecated since v1.2, it is replaced by column 'e_ref'."
-        )
 
         return Table(
             [
-                Column(
-                    data=energy,
-                    name="energy",
-                    format="5g",
-                    description="Reconstructed Energy",
-                ),
                 Column(
                     data=energy,
                     name="e_ref",

--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -141,7 +141,7 @@ class SensitivityEstimator(Estimator):
             excess.data.squeeze(), dataset.background.data.squeeze()
         )
         logging.warning(
-            "Table column name energy will be deprecated by e_ref since v1.2"
+            "Column 'energy' is deprecated since v1.2, it is replaced by column 'e_ref'."
         )
 
         return Table(

--- a/gammapy/estimators/points/tests/test_sensitivity.py
+++ b/gammapy/estimators/points/tests/test_sensitivity.py
@@ -98,11 +98,11 @@ def test_integral_estimation(spectrum_dataset, caplog):
     flux_points = FluxPoints.from_table(
         table, sed_type="e2dnde", reference_model=sens.spectrum
     )
-    assert "WARNING" in [_.levelname for _ in caplog.records]
-    assert (
+    warning_message = (
         "Column 'energy' is deprecated since v1.2, it is replaced by column 'e_ref'."
-        in [_.message for _ in caplog.records]
     )
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert warning_message in [_.message for _ in caplog.records]
 
     assert_allclose(table["excess"].data.squeeze(), 270540, rtol=1e-3)
     assert_allclose(flux_points.flux.data.squeeze(), 7.52e-9, rtol=1e-3)

--- a/gammapy/estimators/points/tests/test_sensitivity.py
+++ b/gammapy/estimators/points/tests/test_sensitivity.py
@@ -41,15 +41,8 @@ def test_cta_sensitivity_estimator(spectrum_dataset, caplog):
     sens = SensitivityEstimator(gamma_min=25, bkg_syst_fraction=0.075)
     table = sens.run(dataset_on_off)
 
-    warning_message = (
-        "Column 'energy' is deprecated since v1.2, it is replaced by column 'e_ref'."
-    )
-    assert "WARNING" in [_.levelname for _ in caplog.records]
-    assert warning_message in [_.message for _ in caplog.records]
-
     assert len(table) == 4
     assert table.colnames == [
-        "energy",
         "e_ref",
         "e_min",
         "e_max",
@@ -98,11 +91,6 @@ def test_integral_estimation(spectrum_dataset, caplog):
     flux_points = FluxPoints.from_table(
         table, sed_type="e2dnde", reference_model=sens.spectrum
     )
-    warning_message = (
-        "Column 'energy' is deprecated since v1.2, it is replaced by column 'e_ref'."
-    )
-    assert "WARNING" in [_.levelname for _ in caplog.records]
-    assert warning_message in [_.message for _ in caplog.records]
 
     assert_allclose(table["excess"].data.squeeze(), 270540, rtol=1e-3)
     assert_allclose(flux_points.flux.data.squeeze(), 7.52e-9, rtol=1e-3)

--- a/gammapy/estimators/points/tests/test_sensitivity.py
+++ b/gammapy/estimators/points/tests/test_sensitivity.py
@@ -42,7 +42,7 @@ def test_cta_sensitivity_estimator(spectrum_dataset, caplog):
     table = sens.run(dataset_on_off)
 
     warning_message = (
-        "Table column name energy will be " "deprecated by e_ref since v1.2"
+        "Column 'energy' is deprecated since v1.2, it is replaced by column 'e_ref'."
     )
     assert "WARNING" in [_.levelname for _ in caplog.records]
     assert warning_message in [_.message for _ in caplog.records]
@@ -99,9 +99,10 @@ def test_integral_estimation(spectrum_dataset, caplog):
         table, sed_type="e2dnde", reference_model=sens.spectrum
     )
     assert "WARNING" in [_.levelname for _ in caplog.records]
-    assert "Table column name energy will be deprecated by e_ref since v1.2" in [
-        _.message for _ in caplog.records
-    ]
+    assert (
+        "Column 'energy' is deprecated since v1.2, it is replaced by column 'e_ref'."
+        in [_.message for _ in caplog.records]
+    )
 
     assert_allclose(table["excess"].data.squeeze(), 270540, rtol=1e-3)
     assert_allclose(flux_points.flux.data.squeeze(), 7.52e-9, rtol=1e-3)


### PR DESCRIPTION
This PR fixes #4614

This was implemented in v1.1, so should have been removed in v1.2, as per the rule that once something is deprecated we have 1 major release before we remove it.