### PR TITLE
Fix FluxPoints.recompute_ul for multidimensional flux points

### DIFF
--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -806,7 +806,7 @@ class FluxPoints(FluxMaps):
         flux_points = deepcopy(self)
 
         value_scan = self.stat_scan.geom.axes["norm"].center
-        shape_axes = self.stat_scan.geom._shape[slice(3, None)]
+        shape_axes = self.stat_scan.geom._shape[slice(3, None)][::-1]
         for idx in np.ndindex(shape_axes):
             stat_scan = np.abs(
                 self.stat_scan.data[idx].squeeze() - self.stat.data[idx].squeeze()

--- a/gammapy/estimators/points/tests/test_lightcurve.py
+++ b/gammapy/estimators/points/tests/test_lightcurve.py
@@ -708,17 +708,24 @@ def test_recompute_ul():
     datasets = get_spectrum_datasets()
     selection = ["all"]
     estimator = LightCurveEstimator(
-        energy_edges=[1, 3, 30] * u.TeV, selection_optional=selection, n_sigma_ul=2
+        energy_edges=[1, 3, 10, 30] * u.TeV, selection_optional=selection, n_sigma_ul=2
     )
     lightcurve = estimator.run(datasets)
+
     assert_allclose(
-        lightcurve.dnde_ul.data[0], [[[3.260703e-13]], [[1.159354e-14]]], rtol=1e-3
+        lightcurve.dnde_ul.data[0],
+        [[[3.26070325e-13]], [[3.82484628e-14]], [[4.16433528e-15]]],
+        rtol=1e-3,
     )
 
     new_lightcurve = lightcurve.recompute_ul(n_sigma_ul=4)
+
     assert_allclose(
-        new_lightcurve.dnde_ul.data[0], [[[3.758136e-13]], [[1.373942e-14]]], rtol=1e-3
+        new_lightcurve.dnde_ul.data[0],
+        [[[3.75813611e-13]], [[4.63590079e-14]], [[5.64634904e-15]]],
+        rtol=1e-3,
     )
+
     assert new_lightcurve.meta["n_sigma_ul"] == 4
 
     # test if scan is not present


### PR DESCRIPTION
Resolves #5155
Adapted the test such as energy and time don't have the same number of bins (we should always do that to catch dimension bugs).