### PR TITLE
Fix select_nested_models if there is no free parameters for the null hypothesis

### DIFF
--- a/gammapy/modeling/selection.py
+++ b/gammapy/modeling/selection.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from gammapy.modeling import Fit, Parameter
 from gammapy.stats.utils import sigma_to_ts
+from .fit import FitResult, OptimizeResult
 
 __all__ = ["select_nested_models"]
 
@@ -93,7 +94,21 @@ class TestStatisticNested:
             else:
                 p.value = val
                 p.frozen = True
-        fit_results_null = self.fit.run(datasets)
+        if len(datasets.models.parameters.free_parameters) > 0:
+            fit_results_null = self.fit.run(datasets)
+        else:
+            fit_results_null = FitResult(
+                OptimizeResult(
+                    models=datasets.models.copy(),
+                    nfev=0,
+                    total_stat=datasets.stat_sum(),
+                    trace=None,
+                    backend=None,
+                    method=None,
+                    success=None,
+                    message=None,
+                )
+            )
         stat_null = datasets.stat_sum()
 
         ts = stat_null - stat

--- a/gammapy/modeling/tests/test_selection.py
+++ b/gammapy/modeling/tests/test_selection.py
@@ -26,6 +26,23 @@ def test_test_statistic_detection(fermi_datasets):
 
 
 @requires_data()
+def test_test_statistic_detection_other_frozen(fermi_datasets):
+
+    with fermi_datasets.models.restore_status():
+        fermi_datasets.models.freeze()
+        model = fermi_datasets.models["Crab Nebula"]
+        results = select_nested_models(
+            fermi_datasets, [model.spectral_model.amplitude], [0]
+        )
+        results["fit_results_null"].nfev == 0
+        model.spectral_model.amplitude.value = 0
+        assert_allclose(
+            results["fit_results_null"].parameters.value,
+            fermi_datasets.models.parameters.value,
+        )
+
+
+@requires_data()
 def test_test_statistic_link(fermi_datasets):
 
     # TODO: better test with simulated data ?


### PR DESCRIPTION
If there is no free parameter the fit of the null hypothesis fails.
This PR fix it by returning directly the result.