### PR TITLE
Add boundary condition to create a PeriodicMapAxis

### DIFF
--- a/gammapy/maps/__init__.py
+++ b/gammapy/maps/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Sky maps."""
-from .axes import LabelMapAxis, MapAxes, MapAxis, TimeMapAxis
+from .axes import LabelMapAxis, MapAxes, MapAxis, PeriodicMapAxis, TimeMapAxis
 from .coord import MapCoord
 from .core import Map
 from .geom import Geom
@@ -21,6 +21,7 @@ __all__ = [
     "MapAxis",
     "MapCoord",
     "Maps",
+    "PeriodicMapAxis",
     "RegionGeom",
     "RegionNDMap",
     "TimeMapAxis",

--- a/gammapy/maps/__init__.py
+++ b/gammapy/maps/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Sky maps."""
-from .axes import LabelMapAxis, MapAxes, MapAxis, PeriodicMapAxis, TimeMapAxis
+from .axes import LabelMapAxis, MapAxes, MapAxis, TimeMapAxis
 from .coord import MapCoord
 from .core import Map
 from .geom import Geom
@@ -21,7 +21,6 @@ __all__ = [
     "MapAxis",
     "MapCoord",
     "Maps",
-    "PeriodicMapAxis",
     "RegionGeom",
     "RegionNDMap",
     "TimeMapAxis",

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3427,3 +3427,49 @@ class LabelMapAxis:
         return LabelMapAxis(
             labels=[self.center[0] + "..." + self.center[-1]], name=self._name
         )
+
+
+class PeriodicMapAxis(MapAxis):
+    """
+    A periodic MapAxis. Only linear interpolation is supported.
+
+    Parameters
+    ----------
+    nodes : `~numpy.ndarray` or `~astropy.units.Quantity`
+        Array of node values.  These will be interpreted as either bin
+        edges or centers according to ``node_type``.
+    name : str, optional
+        Axis name. Default is "".
+    node_type : str, optional
+        Flag indicating whether coordinate nodes correspond to pixel
+        edges (node_type = 'edges') or pixel centers (node_type =
+        'center').  'center' should be used where the map values are
+        defined at a specific coordinate (e.g. differential
+        quantities). 'edges' should be used where map values are
+        defined by an integral over coordinate intervals (e.g. a
+        counts histogram). Default is "edges".
+    unit : str, optional
+        String specifying the data units. Default is "".
+    """
+
+    def wrap_coords(self, coords):
+        """Wrap coords between axis edges"""
+        m1, m2 = self.edges_min[0], self.edges_max[-1]
+        coords_copy = copy.deepcopy(coords)
+        coords_copy[coords_copy >= m2] = (coords_copy[coords_copy >= m2] - m1) % (
+            m2 - m1
+        ) + m1
+        coords_copy[coords_copy < m1] = (coords_copy[coords_copy < m1] - m1) % (
+            m2 - m1
+        ) + m1
+        return coords_copy
+
+    def coord_to_idx(self, coords):
+        """wraps the coords between the axis edges"""
+        coords_new = self.wrap_coords(coords)
+        return super().coord_to_idx(coords_new)
+
+    def coord_to_pix(self, coords):
+        """wraps the coords between the axis edges"""
+        coords_new = self.wrap_coords(coords)
+        return super().coord_to_pix(coords_new)

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -141,10 +141,9 @@ class MapAxis:
         else:
             nodes = np.array(nodes)
 
-        available_boundary = {"periodic", "monotonic"}
-        if boundary_type not in available_boundary:
+        if boundary_type not in list(BoundaryEnum):
             raise ValueError(f"Invalid boundary_type: {boundary_type}")
-        if boundary_type == "periodic" and interp != "lin":
+        if boundary_type == BoundaryEnum.periodic and interp != "lin":
             raise ValueError("Periodic Axis only supports linear interpolation")
 
         self._name = name
@@ -820,8 +819,8 @@ class MapAxis:
         """
 
         m1, m2 = self.edges_min[0], self.edges_max[-1]
-        out_of_range = (coords >= m2) | (coords < m1)
-        return np.where(out_of_range, (coords - m1) % (m2 - m1) + m1, coords)
+        out_of_range = (coord >= m2) | (coord < m1)
+        return np.where(out_of_range, (coord - m1) % (m2 - m1) + m1, coord)
 
     def pix_to_idx(self, pix, clip=False):
         """Convert pixel to index.

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -820,10 +820,8 @@ class MapAxis:
         """
 
         m1, m2 = self.edges_min[0], self.edges_max[-1]
-        coords_copy = copy.deepcopy(coord)
-        mask = np.where((coords_copy >= m2) | (coords_copy < m1))
-        coords_copy[mask] = (coords_copy[mask] - m1) % (m2 - m1) + m1
-        return coords_copy
+        out_of_range = (coords >= m2) | (coords < m1)
+        return np.where(out_of_range, (coords - m1) % (m2 - m1) + m1, coords)
 
     def pix_to_idx(self, pix, clip=False):
         """Convert pixel to index.

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -8,7 +8,14 @@ from astropy.time import Time
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from gammapy.data import GTI
-from gammapy.maps import LabelMapAxis, MapAxes, MapAxis, RegionNDMap, TimeMapAxis
+from gammapy.maps import (
+    LabelMapAxis,
+    MapAxes,
+    MapAxis,
+    PeriodicMapAxis,
+    RegionNDMap,
+    TimeMapAxis,
+)
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import assert_time_allclose, mpl_plot_check, requires_data
 from gammapy.utils.time import time_ref_to_dict
@@ -982,3 +989,15 @@ def test_energy_bin_per_decade_not_strict_bounds():
     )
 
     assert_allclose(axis.edges[0:-nbin] * 10.0, axis.edges[nbin:], rtol=1e-5, atol=0)
+
+
+def test_phase_map_axis():
+    axis1 = PeriodicMapAxis.from_bounds(-0.5, 0.5, 5)
+    coords = np.array([-1.0, -0.7, 0.1, 1.2])
+    assert_allclose(axis1.wrap_coords(coords), [0.0, 0.3, 0.1, 0.2], rtol=1e-5)
+
+    idx = axis1.coord_to_idx(coords=coords)
+    assert_allclose(idx, [2, 4, 2, 3], rtol=1e-5)
+
+    pix = axis1.coord_to_pix(coords=coords)
+    assert_allclose(pix, [2.0, 3.5, 2.5, 3.0], rtol=1e-5)

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -987,7 +987,7 @@ def test_energy_bin_per_decade_not_strict_bounds():
 def test_periodic_map_axis():
     axis1 = MapAxis.from_bounds(-0.5, 0.5, 5, boundary_type="periodic")
     coords = np.array([-1.0, -0.7, 0.1, 1.2])
-    assert_allclose(axis1._wrap_coords(coords), [0.0, 0.3, 0.1, 0.2], rtol=1e-5)
+    assert_allclose(axis1.wrap_coord(coords), [0.0, 0.3, 0.1, 0.2], rtol=1e-5)
 
     idx = axis1.coord_to_idx(coord=coords)
     assert_allclose(idx, [2, 4, 2, 3], rtol=1e-5)

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -8,14 +8,7 @@ from astropy.time import Time
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from gammapy.data import GTI
-from gammapy.maps import (
-    LabelMapAxis,
-    MapAxes,
-    MapAxis,
-    PeriodicMapAxis,
-    RegionNDMap,
-    TimeMapAxis,
-)
+from gammapy.maps import LabelMapAxis, MapAxes, MapAxis, RegionNDMap, TimeMapAxis
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import assert_time_allclose, mpl_plot_check, requires_data
 from gammapy.utils.time import time_ref_to_dict
@@ -991,13 +984,20 @@ def test_energy_bin_per_decade_not_strict_bounds():
     assert_allclose(axis.edges[0:-nbin] * 10.0, axis.edges[nbin:], rtol=1e-5, atol=0)
 
 
-def test_phase_map_axis():
-    axis1 = PeriodicMapAxis.from_bounds(-0.5, 0.5, 5)
+def test_periodic_map_axis():
+    axis1 = MapAxis.from_bounds(-0.5, 0.5, 5, boundary_type="periodic")
     coords = np.array([-1.0, -0.7, 0.1, 1.2])
-    assert_allclose(axis1.wrap_coords(coords), [0.0, 0.3, 0.1, 0.2], rtol=1e-5)
+    assert_allclose(axis1._wrap_coords(coords), [0.0, 0.3, 0.1, 0.2], rtol=1e-5)
 
-    idx = axis1.coord_to_idx(coords=coords)
+    idx = axis1.coord_to_idx(coord=coords)
     assert_allclose(idx, [2, 4, 2, 3], rtol=1e-5)
 
-    pix = axis1.coord_to_pix(coords=coords)
+    pix = axis1.coord_to_pix(coord=coords)
     assert_allclose(pix, [2.0, 3.5, 2.5, 3.0], rtol=1e-5)
+
+    with pytest.raises(ValueError):
+        axis1 = MapAxis.from_bounds(-0.5, 0.5, 5, boundary_type="other")
+    with pytest.raises(ValueError):
+        axis1 = MapAxis.from_bounds(
+            -0.5, 0.5, 5, boundary_type="periodic", interp="log"
+        )


### PR DESCRIPTION
This PR adds a PeriodicMapAxis.
Its rather simple, only one function, so arguably it does not need its own class at all.
But I think its conceptually simpler to have a separate name for such an axis.
It can be useful for phase analysis, or for asymmetric IRFs defined not in (Lon, lat) but (offset, theta), as brought up in one of the CTAC ASWG calls... 