### PR TITLE
Fix `observatory_earth_location`

### DIFF
--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -378,6 +378,8 @@ class Observation:
     @property
     def observatory_earth_location(self):
         """Observatory location as an `~astropy.coordinates.EarthLocation` object."""
+        if self._location is None:
+            return self.meta.location
         return self._location
 
     @lazyproperty


### PR DESCRIPTION
If an Observation is created by the DataStore.obs method, no location is given as an argument. Therefore the `observatory_earth_location` will be None.

Simple fix of catching the case by reading the location from the meta data.

Maybe the location should always be given by the meta data and not at the __init__ but I wasn't sure and wanted to keep it compatible with older versions