### PR TITLE
Raise error on invalid input shape in Map

### DIFF
--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -3,7 +3,7 @@
 import numpy as np
 import astropy.units as u
 from astropy.table import Table
-from gammapy.maps import MapAxis, RegionNDMap
+from gammapy.maps import Map, MapAxis, RegionGeom
 from gammapy.modeling import Parameter
 from gammapy.modeling.models import SpectralModel, TemplateNDSpectralModel
 from gammapy.utils.scripts import make_path
@@ -97,8 +97,10 @@ class PrimaryFlux(TemplateNDSpectralModel):
         log10x_axis = MapAxis.from_nodes(log10x, name="energy_true")
 
         channel_name = self.channel_registry[self.channel]
-        region_map = RegionNDMap.create(
-            region=None, axes=[log10x_axis, mass_axis], data=self.table[channel_name]
+
+        geom = RegionGeom(region=None, axes=[log10x_axis, mass_axis])
+        region_map = Map.from_geom(
+            geom=geom, data=self.table[channel_name].reshape(geom.data_shape)
         )
 
         interp_kwargs = {"extrapolate": True, "fill_value": 0, "values_scale": "lin"}

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -654,13 +654,17 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
         names = ["flux", "flux_errp", "flux_errn", "flux_ul", "ts"]
         maps = Maps.from_geom(geom=geom, names=names)
 
-        maps["flux"].quantity = self.data[tag]
-        maps["flux_errp"].quantity = self.data[f"Unc_{tag}"][:, 1]
-        maps["flux_errn"].quantity = -self.data[f"Unc_{tag}"][:, 0]
+        maps["flux"].quantity = self.data[tag].reshape(geom.data_shape)
+        maps["flux_errp"].quantity = self.data[f"Unc_{tag}"][:, 1].reshape(
+            geom.data_shape
+        )
+        maps["flux_errn"].quantity = -self.data[f"Unc_{tag}"][:, 0].reshape(
+            geom.data_shape
+        )
         maps["flux_ul"].quantity = compute_flux_points_ul(
             maps["flux"].quantity, maps["flux_errp"].quantity
-        )
-        maps["ts"].quantity = self.data[tag_sqrt_ts] ** 2
+        ).reshape(geom.data_shape)
+        maps["ts"].quantity = (self.data[tag_sqrt_ts] ** 2).reshape(geom.data_shape)
 
         return FluxPoints.from_maps(
             maps=maps,
@@ -949,12 +953,16 @@ class SourceCatalogObject3FGL(SourceCatalogObjectFermiBase):
         names = ["flux", "flux_errp", "flux_errn", "flux_ul"]
         maps = Maps.from_geom(geom=geom, names=names)
 
-        maps["flux"].quantity = self.data[tag]
-        maps["flux_errp"].quantity = self.data[f"Unc_{tag}"][:, 1]
-        maps["flux_errn"].quantity = -self.data[f"Unc_{tag}"][:, 0]
+        maps["flux"].quantity = self.data[tag].reshape(geom.data_shape)
+        maps["flux_errp"].quantity = self.data[f"Unc_{tag}"][:, 1].reshape(
+            geom.data_shape
+        )
+        maps["flux_errn"].quantity = -self.data[f"Unc_{tag}"][:, 0].reshape(
+            geom.data_shape
+        )
         maps["flux_ul"].quantity = compute_flux_points_ul(
             maps["flux"].quantity, maps["flux_errp"].quantity
-        )
+        ).reshape(geom.data_shape)
         is_ul = np.isnan(maps["flux_errn"])
         maps["flux_ul"].data[~is_ul] = np.nan
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -202,7 +202,7 @@ def get_map_dataset(geom, geom_etrue, edisp="edispmap", name="test", **kwargs):
     if edisp == "edispmap":
         edisp = EDispMap.from_diagonal_response(energy_axis_true=e_true)
         data = exposure.get_spectrum(geom.center_skydir).data
-        edisp.exposure_map.data = np.repeat(data, 2, axis=-1)
+        edisp.exposure_map.data = np.repeat(np.expand_dims(data, -1), 2, axis=-1)
     elif edisp == "edispkernelmap":
         edisp = EDispKernelMap.from_diagonal_response(
             energy_axis=e_reco, energy_axis_true=e_true

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -208,7 +208,7 @@ def get_map_dataset(geom, geom_etrue, edisp="edispmap", name="test", **kwargs):
             energy_axis=e_reco, energy_axis_true=e_true
         )
         data = exposure.get_spectrum(geom.center_skydir).data
-        edisp.exposure_map.data = np.repeat(data, 2, axis=-1)
+        edisp.exposure_map.data = np.repeat(np.expand_dims(data, -1), 2, axis=-1)
     else:
         edisp = None
 

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -53,7 +53,9 @@ def squash_fluxpoints(flux_point, axis):
         geom = geom.to_cube([flux_point.geom.axes["energy"]])
 
     maps["norm"] = Map.from_geom(geom, data=minimizer.x)
-    maps["norm_err"] = Map.from_geom(geom, data=np.sqrt(minimizer.hess_inv.todense()))
+    maps["norm_err"] = Map.from_geom(
+        geom, data=np.sqrt(minimizer.hess_inv.todense()).reshape(geom.data_shape)
+    )
     maps["n_dof"] = Map.from_geom(geom, data=flux_point.geom.axes[axis.name].nbin)
 
     if "norm_ul" in flux_point.available_quantities:
@@ -63,8 +65,9 @@ def squash_fluxpoints(flux_point, axis):
 
     maps["stat"] = Map.from_geom(geom, data=f(minimizer.x))
 
+    geom_scan = geom.to_cube([MapAxis.from_nodes(value_scan, name="norm")])
     maps["stat_scan"] = Map.from_geom(
-        geom=geom.to_cube([MapAxis.from_nodes(value_scan, name="norm")]), data=stat_scan
+        geom=geom_scan, data=stat_scan.reshape(geom_scan.data_shape)
     )
     try:
         maps["stat_null"] = Map.from_geom(geom, data=np.sum(flux_point.stat_null.data))

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -799,7 +799,9 @@ class IRFMap:
 
             geom_exposure = geom_psf.squash("rad")
             exposure_map = Map.from_geom(
-                geom=geom_exposure, data=table["Exposure"].data, unit="cm2 s"
+                geom=geom_exposure,
+                data=table["Exposure"].data.reshape(geom_exposure.data_shape),
+                unit="cm2 s",
             )
             return cls(psf_map=psf_map, exposure_map=exposure_map)
         else:

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -306,8 +306,8 @@ def make_psf_map(psf, pointing, geom, exposure_map=None):
         obstime=None,
     )
 
-    coords["energy_true"] = geom.axes["energy_true"].center.reshape((-1, 1, 1, 1))
-    coords["rad"] = geom.axes["rad"].center.reshape((1, -1, 1, 1))
+    coords["energy_true"] = broadcast_axis_values_to_geom(geom, "energy_true")
+    coords["rad"] = broadcast_axis_values_to_geom(geom, "rad")
 
     # Compute PSF values
     data = psf.evaluate(**coords)
@@ -347,8 +347,8 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None, use_region_center=T
         The resulting energy dispersion map.
     """
     coords = _get_fov_coords(pointing, edisp, geom, use_region_center=use_region_center)
-    coords["energy_true"] = geom.axes["energy_true"].center.reshape((-1, 1, 1, 1))
-    coords["migra"] = geom.axes["migra"].center.reshape((1, -1, 1, 1))
+    coords["energy_true"] = broadcast_axis_values_to_geom(geom, "energy_true")
+    coords["migra"] = broadcast_axis_values_to_geom(geom, "migra")
 
     # Compute EDisp values
     data = edisp.evaluate(**coords)

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -142,8 +142,7 @@ def make_map_exposure_true_energy(
 
     if not use_region_center:
         _, weights = geom.get_wcs_coord_and_weights()
-        data = np.average(data, axis=-1, weights=weights)
-
+        data = np.average(data, axis=-1, weights=weights, keepdims=True)
     return Map.from_geom(geom=geom, data=data.value, unit=data.unit, meta=meta)
 
 
@@ -264,7 +263,7 @@ def make_map_background_irf(
 
     if not use_region_center:
         region_coord, weights = geom.get_wcs_coord_and_weights()
-        data = np.sum(weights * data, axis=2)
+        data = np.sum(weights * data, axis=2, keepdims=True)
 
     bkg_map = Map.from_geom(geom, data=data)
 
@@ -355,7 +354,7 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None, use_region_center=T
 
     if not use_region_center:
         _, weights = geom.get_wcs_coord_and_weights()
-        data = np.average(data, axis=-1, weights=weights)
+        data = np.average(data, axis=-1, weights=weights, keepdims=True)
 
     # Create Map and fill relevant entries
     edisp_map = Map.from_geom(geom, data=data.to_value(""), unit="")

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -132,7 +132,8 @@ def make_map_exposure_true_energy(
         irf=aeff,
         obstime=None,
     )
-    coords["energy_true"] = geom.axes["energy_true"].center.reshape((-1, 1, 1))
+    broadcast_shape = (-1,) + len(coords) * (1,)
+    coords["energy_true"] = geom.axes["energy_true"].center.reshape(broadcast_shape)
     exposure = aeff.evaluate(**coords)
 
     data = (exposure * livetime).to("m2 s")

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -8,6 +8,7 @@ from astropy.table import Table
 from gammapy.data import FixedPointingInfo
 from gammapy.irf import BackgroundIRF, EDispMap, FoVAlignment, PSFMap
 from gammapy.maps import Map, RegionNDMap
+from gammapy.maps.utils import broadcast_axis_values_to_geom
 from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.stats import WStatCountsStatistic
 from gammapy.utils.coordinates import sky_to_fov
@@ -132,8 +133,8 @@ def make_map_exposure_true_energy(
         irf=aeff,
         obstime=None,
     )
-    broadcast_shape = (-1,) + len(coords) * (1,)
-    coords["energy_true"] = geom.axes["energy_true"].center.reshape(broadcast_shape)
+
+    coords["energy_true"] = broadcast_axis_values_to_geom(geom, "energy_true")
     exposure = aeff.evaluate(**coords)
 
     data = (exposure * livetime).to("m2 s")
@@ -256,7 +257,7 @@ def make_map_background_irf(
         use_region_center=use_region_center,
         obstime=obstime,
     )
-    coords["energy"] = geom.axes["energy"].edges.reshape((-1, 1, 1))
+    coords["energy"] = broadcast_axis_values_to_geom(geom, "energy", False)
 
     bkg_de = bkg.integrate_log_log(**coords, axis_name="energy")
     data = (bkg_de * d_omega * ontime).to_value("")

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -110,10 +110,10 @@ class Map(abc.ABC):
         if not value.shape == self.geom.data_shape:
             try:
                 value = np.broadcast_to(value, self.geom.data_shape, subok=True)
-            except Exception:
+            except ValueError as exc:
                 raise ValueError(
                     f"Input shape {value.shape} is not compatible with shape from geometry {self.geom.data_shape}"
-                ) from None
+                ) from exc
 
         self._data = value
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1735,7 +1735,7 @@ class Map(abc.ABC):
             data.append(m.quantity.to_value(maps[0].unit))
 
         return cls.from_geom(
-            data=np.stack(data), geom=geom.to_cube(axes=[axis]), unit=maps[0].unit
+            data=np.concatenate(data), geom=geom.to_cube(axes=[axis]), unit=maps[0].unit
         )
 
     def split_by_axis(self, axis_name):

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -108,7 +108,9 @@ class Map(abc.ABC):
             raise TypeError("Map data must be a Numpy array. Set unit separately")
 
         if not value.shape == self.geom.data_shape:
-            value = value.reshape(self.geom.data_shape)
+            raise ValueError(
+                f"Input shape {value.shape} does not match expected shape from geometry {self.geom.data_shape}"
+            )
 
         self._data = value
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1734,9 +1734,10 @@ class Map(abc.ABC):
 
             data.append(m.quantity.to_value(maps[0].unit))
 
-        return cls.from_geom(
-            data=np.stack(data), geom=geom.to_cube(axes=[axis]), unit=maps[0].unit
-        )
+        new_geom = geom.to_cube(axes=[axis])
+        data = np.concatenate(data).reshape(new_geom.data_shape)
+
+        return cls.from_geom(data=data, geom=new_geom, unit=maps[0].unit)
 
     def split_by_axis(self, axis_name):
         """Split a Map along an axis into multiple maps.

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1735,7 +1735,7 @@ class Map(abc.ABC):
             data.append(m.quantity.to_value(maps[0].unit))
 
         return cls.from_geom(
-            data=np.concatenate(data), geom=geom.to_cube(axes=[axis]), unit=maps[0].unit
+            data=np.stack(data), geom=geom.to_cube(axes=[axis]), unit=maps[0].unit
         )
 
     def split_by_axis(self, axis_name):

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -108,9 +108,12 @@ class Map(abc.ABC):
             raise TypeError("Map data must be a Numpy array. Set unit separately")
 
         if not value.shape == self.geom.data_shape:
-            raise ValueError(
-                f"Input shape {value.shape} does not match expected shape from geometry {self.geom.data_shape}"
-            )
+            try:
+                value = np.broadcast_to(value, self.geom.data_shape, subok=True)
+            except Exception:
+                raise ValueError(
+                    f"Input shape {value.shape} is not compatible with shape from geometry {self.geom.data_shape}"
+                ) from None
 
         self._data = value
 

--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -212,9 +212,10 @@ class HpxNDMap(HpxMap):
                         cnames.append(c)
             nbin = len(cnames)
             if nbin == 1:
-                map_out.data = hdu.data.field(cnames[0])
+                map_out.data = hdu.data.field(cnames[0]).reshape(geom.data_shape)
             else:
                 for idx, cname in enumerate(cnames):
+                    # TODO: check whether reshaping is needed here. Is this tested?
                     idx = np.unravel_index(idx, shape)
                     map_out.data[idx + (slice(None),)] = hdu.data.field(cname)
 

--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -399,7 +399,7 @@ class HpxNDMap(HpxMap):
         if self.geom.is_allsky:
             idx = geom._ipix
         else:
-            idx = self.geom.to_image().global_to_local((geom._ipix,))
+            idx = self.geom.to_image().global_to_local((geom._ipix,))[0]
 
         data = self.data[..., idx]
         return self.__class__(geom=geom, data=data, unit=self.unit, meta=self.meta)

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -652,6 +652,7 @@ class RegionNDMap(Map):
             raise ValueError(f"Format not supported {format}")
 
         geom = RegionGeom.create(region=None, axes=axes)
+        data = data.reshape(geom.data_shape)
         return cls(geom=geom, data=data, unit=unit, meta=table.meta, dtype=data.dtype)
 
     @classmethod

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -816,7 +816,7 @@ class RegionNDMap(Map):
 
         elif format == "gadf":
             table = Table()
-            data = self.quantity.flatten()
+            data = self.quantity
             table["CHANNEL"] = np.arange(len(data), dtype=np.int16)
             table["DATA"] = data
         else:

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -57,6 +57,36 @@ class RegionNDMap(Map):
         self.meta = meta
         self._unit = u.Unit(unit)
 
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        """Set data.
+        Parameters
+        ----------
+        value : array-like
+            Data array.
+        """
+        if np.isscalar(value):
+            value = value * np.ones(self.geom.data_shape, dtype=type(value))
+
+        if isinstance(value, u.Quantity):
+            raise TypeError("Map data must be a Numpy array. Set unit separately")
+
+        input_shape = value.shape
+        if len(self.geom.data_shape) == 2 + len(value.shape):
+            if self.geom.data_shape[: len(value.shape)] == value.shape:
+                value = np.expand_dims(value, (-2, -1))
+
+        if self.geom.data_shape != value.shape:
+            raise ValueError(
+                f"Input shape {input_shape} is not compatible with shape from geometry {self.geom.data_shape}"
+            )
+
+        self._data = value
+
     def plot(self, ax=None, axis_name=None, **kwargs):
         """Plot the data contained in region map along the non-spatial axis.
 

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -692,7 +692,7 @@ class RegionNDMap(Map):
         geom = RegionGeom.from_hdulist(hdulist, format=format, hdu=hdu)
 
         table = Table.read(hdulist[hdu])
-        quantity = table[ogip_column].quantity
+        quantity = table[ogip_column].quantity.reshape(geom.data_shape)
 
         if ogip_column == "QUALITY":
             data, unit = np.logical_not(quantity.value.astype(bool)), ""

--- a/gammapy/maps/region/tests/test_ndmap.py
+++ b/gammapy/maps/region/tests/test_ndmap.py
@@ -136,7 +136,7 @@ def test_label_axis_io(tmpdir):
     label_axis = LabelMapAxis(labels=["dataset-1", "dataset-2"], name="dataset")
 
     m = RegionNDMap.create(region=None, axes=[energy_axis, label_axis])
-    m.data = np.arange(m.data.size)
+    m.data = np.arange(m.data.size).reshape((2, 5))
 
     filename = tmpdir / "test.fits"
 
@@ -391,7 +391,7 @@ def test_region_nd_map_interp_no_region():
     )
 
     m = RegionNDMap.create(region=None, axes=[energy_axis, time_axis])
-    m.data = np.arange(6).reshape((energy_axis.nbin, time_axis.nbin))
+    m.data = np.arange(6).reshape((time_axis.nbin, energy_axis.nbin))
 
     energy = [2, 6] * u.TeV
     time = time_ref + [[0.4], [1.5], [4.2]] * u.d

--- a/gammapy/maps/region/tests/test_ndmap.py
+++ b/gammapy/maps/region/tests/test_ndmap.py
@@ -106,7 +106,7 @@ def test_region_nd_map_plot_two_axes():
     )
 
     m = RegionNDMap.create("icrs;circle(0, 0, 1)", axes=[energy_axis, time_axis])
-    m.data = 10 + np.random.random(m.data.size)
+    m.data = 10 + np.random.random(m.data.shape)
 
     with mpl_plot_check():
         m.plot(axis_name="energy")

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -963,3 +963,30 @@ def test_map_dot_product():
     assert dot_map.data.shape == (4, 2, 3, 1, 1)
 
     assert_allclose(dot_map.data[0, :, 0, 0, 0], [1, 0])
+
+
+def test_data_shape_braodcast():
+    axis1 = MapAxis.from_edges((0, 1, 3), name="axis1")
+
+    map1 = WcsNDMap.create(npix=(5, 6), axes=[axis1])
+
+    with pytest.raises(ValueError):
+        map1.data = np.zeros((1, 2, 6, 5))
+
+    with pytest.raises(ValueError):
+        map1.data = np.zeros((2, 6, 5, 1))
+
+    map2: RegionNDMap = RegionNDMap.create(region=None, axes=[axis1])
+
+    map2.data = np.ones((2,))
+    assert_allclose(map2.data, 1)
+    assert map2.data.shape == (2, 1, 1)
+
+    map2.data = np.zeros((2, 1, 1))
+    assert_allclose(map2.data, 0)
+
+    with pytest.raises(ValueError):
+        map2.data = np.ones((2, 1))
+
+    with pytest.raises(ValueError):
+        map2.data = np.ones((1, 1, 2))

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -965,7 +965,7 @@ def test_map_dot_product():
     assert_allclose(dot_map.data[0, :, 0, 0, 0], [1, 0])
 
 
-def test_data_shape_braodcast():
+def test_data_shape_broadcast():
     axis1 = MapAxis.from_edges((0, 1, 3), name="axis1")
 
     map1 = WcsNDMap.create(npix=(5, 6), axes=[axis1])

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -100,3 +100,34 @@ def edges_from_lo_hi(edges_lo, edges_hi):
     except AttributeError:
         edges = np.insert(edges, len(edges), edges_hi[-1])
     return edges
+
+
+def broadcast_axis_values_to_geom(geom, axis_name, use_center=True):
+    """Reshape axis center array to the expected shape for broadcasting.
+
+    Parameters
+    ----------
+    geom : `~gammapy.maps.Geom`
+        the input Geom.
+    axis_name : str
+        input axis name. Must be part of the Geom non-spatial axes.
+    use_centers : bool
+        reshape center array if True, else use edges.
+
+    Returns
+    -------
+    array : `~numpy.array` or `~astropy.Quantity`
+        reshaped array.
+    """
+    if axis_name not in geom.axes.names:
+        raise ValueError(f"Can't find axis {axis_name} in input Geom.")
+
+    broadcast_shape = len(geom.data_shape) * [
+        1,
+    ]
+    broadcast_shape[geom.axes.index_data(axis_name)] = -1
+
+    if use_center:
+        return geom.axes[axis_name].center.reshape(broadcast_shape)
+    else:
+        return geom.axes[axis_name].edges.reshape(broadcast_shape)

--- a/gammapy/maps/wcs/tests/test_ndmap.py
+++ b/gammapy/maps/wcs/tests/test_ndmap.py
@@ -969,7 +969,7 @@ def test_memory_usage():
 def test_double_cutout():
     # regression test for https://github.com/gammapy/gammapy/issues/3368
     m = Map.create(width="10 deg")
-    m.data = np.arange(10_000, dtype="float")
+    m.data = np.arange(10_000, dtype="float").reshape((100, 100))
 
     position = SkyCoord("1d", "1d")
     m_c = m.cutout(position=position, width="3 deg")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

Connected to #5179 I wanted to see what fails if instead of silently converting the input data into the expected shape, an error is raised.

It seems most cases where this fails is just tests "being lazy" with toy data not in the correct shape and relying on this reshaping, not any actual data files being loaded that require this treatment.
 
