### PR TITLE
Support additional axes in Mapdataset.create

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -9,7 +9,7 @@ from regions import CircleSkyRegion
 import matplotlib.pyplot as plt
 from gammapy.data import GTI, PointingMode
 from gammapy.irf import EDispKernelMap, EDispMap, PSFKernel, PSFMap, RecoPSFMap
-from gammapy.maps import LabelMapAxis, Map, MapAxis, WcsGeom
+from gammapy.maps import LabelMapAxis, Map, MapAxes, MapAxis, WcsGeom
 from gammapy.modeling.models import DatasetModels, FoVBackgroundModel, Models
 from gammapy.stats import (
     CashCountsStatistic,
@@ -65,7 +65,8 @@ def create_map_dataset_geoms(
     Parameters
     ----------
     geom : `~gammapy.maps.WcsGeom`
-        Reference target geometry in reconstructed energy, used for counts and background maps.
+        Reference target geometry with a reconstructed energy axis. It is used for counts and background maps.
+        Additional external data axes can be added to support e.g. event types.
     energy_axis_true : `~gammapy.maps.MapAxis`
         True energy axis used for IRF maps.
     migra_axis : `~gammapy.maps.MapAxis`
@@ -90,19 +91,28 @@ def create_map_dataset_geoms(
     else:
         energy_axis_true = geom.axes["energy"].copy(name="energy_true")
 
+    external_axes = geom.axes.drop("energy")
     geom_image = geom.to_image()
-    geom_exposure = geom_image.to_cube([energy_axis_true])
+    geom_exposure = geom_image.to_cube(MapAxes([energy_axis_true]) + external_axes)
     geom_irf = geom_image.to_binsz(binsz=binsz_irf)
 
     if reco_psf:
-        geom_psf = geom_irf.to_cube([rad_axis, geom.axes["energy"]])
+        geom_psf = geom_irf.to_cube(
+            MapAxes([rad_axis, geom.axes["energy"]]) + external_axes
+        )
     else:
-        geom_psf = geom_irf.to_cube([rad_axis, energy_axis_true])
+        geom_psf = geom_irf.to_cube(
+            MapAxes([rad_axis, energy_axis_true]) + external_axes
+        )
 
     if migra_axis:
-        geom_edisp = geom_irf.to_cube([migra_axis, energy_axis_true])
+        geom_edisp = geom_irf.to_cube(
+            MapAxes([migra_axis, energy_axis_true]) + external_axes
+        )
     else:
-        geom_edisp = geom_irf.to_cube([geom.axes["energy"], energy_axis_true])
+        geom_edisp = geom_irf.to_cube(
+            MapAxes([geom.axes["energy"], energy_axis_true]) + external_axes
+        )
 
     return {
         "geom": geom,

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -942,6 +942,41 @@ def test_create_with_migra(tmp_path):
     assert dataset_new.edisp.edisp_map.data.shape == (3, 50, 10, 10)
 
 
+def test_create_high_dimension():
+    # tests empty datasets created with additional axes
+    label_axis = LabelMapAxis(["a", "b"], name="type")
+    rad_axis = MapAxis(nodes=np.linspace(0.0, 1.0, 51), unit="deg", name="rad")
+    migra_axis = MapAxis(nodes=np.linspace(0.0, 3.0, 51), unit="", name="migra")
+    e_reco = MapAxis.from_edges(
+        np.logspace(-1.0, 1.0, 3), name="energy", unit=u.TeV, interp="log"
+    )
+    e_true = MapAxis.from_edges(
+        np.logspace(-1.0, 1.0, 4), name="energy_true", unit=u.TeV, interp="log"
+    )
+    geom = WcsGeom.create(binsz=0.02, width=(2, 2), axes=[label_axis, e_reco])
+    empty_dataset = MapDataset.create(
+        geom=geom, energy_axis_true=e_true, rad_axis=rad_axis
+    )
+
+    assert empty_dataset.counts.data.shape == (2, 2, 100, 100)
+
+    assert empty_dataset.exposure.data.shape == (2, 3, 100, 100)
+
+    assert empty_dataset.psf.psf_map.data.shape == (2, 3, 50, 10, 10)
+    assert empty_dataset.psf.exposure_map.data.shape == (2, 3, 1, 10, 10)
+
+    assert empty_dataset.edisp.edisp_map.data.shape == (2, 3, 2, 10, 10)
+    assert empty_dataset.edisp.exposure_map.data.shape == (2, 3, 1, 10, 10)
+    assert_allclose(empty_dataset.edisp.edisp_map.data.sum(), 600)
+
+    empty_dataset2 = MapDataset.create(
+        geom=geom, energy_axis_true=e_true, rad_axis=rad_axis, migra_axis=migra_axis
+    )
+
+    assert empty_dataset2.edisp.edisp_map.data.shape == (2, 3, 50, 10, 10)
+    assert empty_dataset2.edisp.exposure_map.data.shape == (2, 3, 1, 10, 10)
+
+
 def test_stack(sky_model):
     axis = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=3)
     geom = WcsGeom.create(

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -650,7 +650,7 @@ class IRFMap:
         self._irf_map = irf_map
         self.exposure_map = exposure_map
         # TODO: only allow for limited set of additional axes?
-        irf_map.geom.axes[:2].assert_names(self.required_axes)
+        irf_map.geom.axes.assert_names(self.required_axes, allow_extra=True)
 
     @property
     @abc.abstractmethod

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -649,7 +649,8 @@ class IRFMap:
     def __init__(self, irf_map, exposure_map):
         self._irf_map = irf_map
         self.exposure_map = exposure_map
-        irf_map.geom.axes.assert_names(self.required_axes)
+        # TODO: only allow for limited set of additional axes?
+        irf_map.geom.axes[:2].assert_names(self.required_axes)
 
     @property
     @abc.abstractmethod

--- a/gammapy/irf/edisp/map.py
+++ b/gammapy/irf/edisp/map.py
@@ -337,7 +337,7 @@ class EDispKernelMap(IRFMap):
             Energy dispersion kernel map.
         """
         # TODO: allow only list of additional axes
-        geom.axes[:2].assert_names(cls.required_axes)
+        geom.axes.assert_names(cls.required_axes, allow_extra=True)
         geom_exposure = geom.squash(axis_name="energy")
         exposure = Map.from_geom(geom_exposure, unit="m2 s")
 

--- a/gammapy/irf/edisp/map.py
+++ b/gammapy/irf/edisp/map.py
@@ -336,7 +336,8 @@ class EDispKernelMap(IRFMap):
         edisp_map : `EDispKernelMap`
             Energy dispersion kernel map.
         """
-        geom.axes.assert_names(cls.required_axes)
+        # TODO: allow only list of additional axes
+        geom.axes[:2].assert_names(cls.required_axes)
         geom_exposure = geom.squash(axis_name="energy")
         exposure = Map.from_geom(geom_exposure, unit="m2 s")
 
@@ -346,7 +347,7 @@ class EDispKernelMap(IRFMap):
         data = get_overlap_fraction(energy_axis, energy_axis_true)
 
         edisp_kernel_map = Map.from_geom(geom, unit="")
-        edisp_kernel_map.quantity += data.reshape(geom.data_shape_axes)
+        edisp_kernel_map.quantity += np.resize(data, geom.data_shape_axes)
         return cls(edisp_kernel_map=edisp_kernel_map, exposure_map=exposure)
 
     def get_edisp_kernel(self, position=None, energy_axis=None):

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -2109,24 +2109,26 @@ class MapAxes(Sequence):
 
         return cls(axes_out, n_spatial_axes=n_spatial_axes)
 
-    def assert_names(self, required_names):
+    def assert_names(self, required_names, allow_extra=False):
         """Assert required axis names and order.
 
         Parameters
         ----------
         required_names : list of str
             Required names.
+        allow_extra : bool
+            Allow extra axes beyond required ones.
         """
         message = (
             "Incorrect axis order or names. Expected axis "
             f"order: {required_names}, got: {self.names}."
         )
 
-        if not len(self) == len(required_names):
+        if not allow_extra and not len(self) == len(required_names):
             raise ValueError(message)
 
         try:
-            for ax, required_name in zip(self, required_names):
+            for ax, required_name in zip(self[: len(required_names)], required_names):
                 ax.assert_name(required_name)
 
         except ValueError:

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -733,6 +733,26 @@ def test_axes_basics():
     assert new_axes != axes
 
 
+def test_map_axes_assert_names():
+    axis_a = MapAxis([1, 2, 3], name="axis_a")
+    axis_b = MapAxis([1, 2, 3, 4], name="axis_b")
+    axis_c = LabelMapAxis(["a", "b"], name="axis_c")
+
+    axes = MapAxes([axis_a, axis_b, axis_c])
+
+    axes.assert_names(["axis_a", "axis_b", "axis_c"])
+    axes.assert_names(["axis_a", "axis_b"], allow_extra=True)
+
+    with pytest.raises(ValueError):
+        axes.assert_names(["axis_a", "axis_b"])
+
+    with pytest.raises(ValueError):
+        axes.assert_names(["axis_c", "axis_b", "axis_a"])
+
+    with pytest.raises(ValueError):
+        axes.assert_names(["axis_b"], allow_extra=True)
+
+
 def test_axes_getitem():
     axis1 = MapAxis.from_bounds(1, 4, 3, name="a1")
     axis2 = axis1.copy(name="a2")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request introduces support for more complex `Geom` objects for `MapDataset.create`. This will allow higher dimensionality products e.g. (ra, dec, energy, event_type) or (ra, dec, energy, phase) or for 1D datasets (energy, obs_id).

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
