### PR TITLE
Adjust `to_edisp_kernel` input to `MapAxis`

### DIFF
--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -45,7 +45,6 @@ from gammapy.modeling.models import (
     SkyModel,
     UniformPrior,
 )
-from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 from gammapy.utils.types import JsonQuantityEncoder
 
@@ -542,22 +541,21 @@ def test_downsample_energy(geom, geom_etrue):
     mask.data[1:] = True
     counts += 1
     exposure = Map.from_geom(geom_etrue, unit="m2s")
-    with pytest.raises(GammapyDeprecationWarning):
-        edisp = EDispKernelMap.from_gauss(geom.axes[0], geom_etrue.axes[0], 0.1, 0.0)
-        dataset = MapDataset(
-            counts=counts,
-            exposure=exposure,
-            mask_safe=mask,
-            edisp=edisp,
-        )
-        dataset_downsampled = dataset.downsample(2, axis_name="energy")
-        dataset_resampled = dataset.resample_energy_axis(geom.axes[0].downsample(2))
+    edisp = EDispKernelMap.from_gauss(geom.axes[0], geom_etrue.axes[0], 0.1, 0.0)
+    dataset = MapDataset(
+        counts=counts,
+        exposure=exposure,
+        mask_safe=mask,
+        edisp=edisp,
+    )
+    dataset_downsampled = dataset.downsample(2, axis_name="energy")
+    dataset_resampled = dataset.resample_energy_axis(geom.axes[0].downsample(2))
 
-        assert dataset_downsampled.edisp.edisp_map.data.shape == (3, 1, 1, 2)
-        assert_allclose(
-            dataset_downsampled.edisp.edisp_map.data[:, :, 0, 0],
-            dataset_resampled.edisp.edisp_map.data[:, :, 0, 0],
-        )
+    assert dataset_downsampled.edisp.edisp_map.data.shape == (3, 1, 1, 2)
+    assert_allclose(
+        dataset_downsampled.edisp.edisp_map.data[:, :, 0, 0],
+        dataset_resampled.edisp.edisp_map.data[:, :, 0, 0],
+    )
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -20,6 +20,7 @@ from gammapy.modeling.models import (
     PowerLawSpectralModel,
     SkyModel,
 )
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.random import get_random_state
 from gammapy.utils.regions import compound_region_to_regions
 from gammapy.utils.testing import assert_time_allclose, mpl_plot_check, requires_data
@@ -295,68 +296,73 @@ def test_spectrum_dataset_stack_nondiagonal_no_bkg(spectrum_dataset):
     energy = spectrum_dataset.counts.geom.axes["energy"]
     geom = spectrum_dataset.counts.geom
 
-    edisp1 = EDispKernelMap.from_gauss(
-        energy_axis=energy,
-        energy_axis_true=energy.copy(name="energy_true"),
-        sigma=0.1,
-        bias=0,
-        geom=geom.to_image(),
-    )
-    edisp1.exposure_map.data += 1
+    with pytest.raises(GammapyDeprecationWarning):
+        edisp1 = EDispKernelMap.from_gauss(
+            energy_axis=energy,
+            energy_axis_true=energy.copy(name="energy_true"),
+            sigma=0.1,
+            bias=0,
+            geom=geom.to_image(),
+        )
+        edisp1.exposure_map.data += 1
 
-    aeff = EffectiveAreaTable2D.from_parametrization(
-        energy_axis_true=energy.copy(name="energy_true"), instrument="HESS"
-    )
+        aeff = EffectiveAreaTable2D.from_parametrization(
+            energy_axis_true=energy.copy(name="energy_true"), instrument="HESS"
+        )
 
-    livetime = 100 * u.s
+        livetime = 100 * u.s
 
-    geom_true = geom.as_energy_true
-    exposure = make_map_exposure_true_energy(
-        geom=geom_true, livetime=livetime, pointing=geom_true.center_skydir, aeff=aeff
-    )
+        geom_true = geom.as_energy_true
+        exposure = make_map_exposure_true_energy(
+            geom=geom_true,
+            livetime=livetime,
+            pointing=geom_true.center_skydir,
+            aeff=aeff,
+        )
 
-    geom = spectrum_dataset.counts.geom
-    counts = RegionNDMap.from_geom(geom=geom)
+        geom = spectrum_dataset.counts.geom
+        counts = RegionNDMap.from_geom(geom=geom)
 
-    gti = GTI.create(start=0 * u.s, stop=livetime)
-    spectrum_dataset1 = SpectrumDataset(
-        counts=counts,
-        exposure=exposure,
-        edisp=edisp1,
-        meta_table=Table({"OBS_ID": [0]}),
-        gti=gti.copy(),
-    )
+        gti = GTI.create(start=0 * u.s, stop=livetime)
+        spectrum_dataset1 = SpectrumDataset(
+            counts=counts,
+            exposure=exposure,
+            edisp=edisp1,
+            meta_table=Table({"OBS_ID": [0]}),
+            gti=gti.copy(),
+        )
 
-    edisp2 = EDispKernelMap.from_gauss(
-        energy_axis=energy,
-        energy_axis_true=energy.copy(name="energy_true"),
-        sigma=0.2,
-        bias=0.0,
-        geom=geom,
-    )
-    edisp2.exposure_map.data += 1
+    with pytest.raises(GammapyDeprecationWarning):
+        edisp2 = EDispKernelMap.from_gauss(
+            energy_axis=energy,
+            energy_axis_true=energy.copy(name="energy_true"),
+            sigma=0.2,
+            bias=0.0,
+            geom=geom,
+        )
+        edisp2.exposure_map.data += 1
 
-    gti2 = GTI.create(start=100 * u.s, stop=200 * u.s)
+        gti2 = GTI.create(start=100 * u.s, stop=200 * u.s)
 
-    spectrum_dataset2 = SpectrumDataset(
-        counts=counts,
-        exposure=exposure.copy(),
-        edisp=edisp2,
-        meta_table=Table({"OBS_ID": [1]}),
-        gti=gti2,
-    )
-    spectrum_dataset1.stack(spectrum_dataset2)
+        spectrum_dataset2 = SpectrumDataset(
+            counts=counts,
+            exposure=exposure.copy(),
+            edisp=edisp2,
+            meta_table=Table({"OBS_ID": [1]}),
+            gti=gti2,
+        )
+        spectrum_dataset1.stack(spectrum_dataset2)
 
-    assert_allclose(spectrum_dataset1.meta_table["OBS_ID"][0], [0, 1])
+        assert_allclose(spectrum_dataset1.meta_table["OBS_ID"][0], [0, 1])
 
-    assert spectrum_dataset1.background_model is None
-    assert_allclose(spectrum_dataset1.gti.time_sum.to_value("s"), 200)
-    assert_allclose(
-        spectrum_dataset1.exposure.quantity[2].to_value("m2 s"), 1573851.079861
-    )
-    kernel = edisp1.get_edisp_kernel()
-    assert_allclose(kernel.get_bias(1 * u.TeV), 0.0, atol=1.2e-3)
-    assert_allclose(kernel.get_resolution(1 * u.TeV), 0.1581, atol=1e-2)
+        assert spectrum_dataset1.background_model is None
+        assert_allclose(spectrum_dataset1.gti.time_sum.to_value("s"), 200)
+        assert_allclose(
+            spectrum_dataset1.exposure.quantity[2].to_value("m2 s"), 1573851.079861
+        )
+        kernel = edisp1.get_edisp_kernel()
+        assert_allclose(kernel.get_bias(1 * u.TeV), 0.0, atol=1.2e-3)
+        assert_allclose(kernel.get_resolution(1 * u.TeV), 0.1581, atol=1e-2)
 
 
 def test_peek(spectrum_dataset):

--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -4,11 +4,10 @@ import numpy as np
 import scipy.special
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
-from astropy.units import Quantity
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from matplotlib.colors import PowerNorm
-from gammapy.maps import MapAxes, MapAxis, RegionGeom
+from gammapy.maps import MapAxes, RegionGeom
 from gammapy.utils.deprecation import deprecated_renamed_argument
 from gammapy.visualization.utils import add_colorbar
 from ..core import IRF
@@ -153,21 +152,6 @@ class EnergyDispersion2D(IRF):
         from gammapy.makers.utils import make_edisp_kernel_map
 
         offset = Angle(offset)
-
-        if isinstance(energy_axis, Quantity):
-            log.warning(
-                "From v1.3 energy_axis should be given as a MapAxis, not a Quantity."
-            )
-            energy_axis = MapAxis.from_energy_edges(energy_axis)
-
-        if isinstance(energy_axis_true, Quantity):
-            log.warning(
-                "From v1.3 energy_axis_true should be given as a MapAxis, not a Quantity."
-            )
-            energy_axis_true = MapAxis.from_energy_edges(
-                energy_axis_true,
-                name="energy_true",
-            )
 
         if energy_axis is None:
             energy_axis = self.axes["energy_true"].copy(name="energy")

--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -4,10 +4,11 @@ import numpy as np
 import scipy.special
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
+from astropy.units import Quantity
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from matplotlib.colors import PowerNorm
-from gammapy.maps import MapAxes, RegionGeom
+from gammapy.maps import MapAxes, MapAxis, RegionGeom
 from gammapy.utils.deprecation import deprecated_renamed_argument
 from gammapy.visualization.utils import add_colorbar
 from ..core import IRF
@@ -153,9 +154,16 @@ class EnergyDispersion2D(IRF):
 
         offset = Angle(offset)
 
+        if isinstance(energy_axis, Quantity):
+            energy_axis = MapAxis.from_energy_edges(energy_axis)
         if energy_axis is None:
             energy_axis = self.axes["energy_true"].copy(name="energy")
 
+        if isinstance(energy_axis_true, Quantity):
+            energy_axis_true = MapAxis.from_energy_edges(
+                energy_axis_true,
+                name="energy_true",
+            )
         if energy_axis_true is None:
             energy_axis_true = self.axes["energy_true"]
 

--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -1,16 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import logging
 import numpy as np
 import scipy.special
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
+from astropy.units import Quantity
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
 from matplotlib.colors import PowerNorm
 from gammapy.maps import MapAxes, MapAxis, RegionGeom
+from gammapy.utils.deprecation import deprecated_renamed_argument
 from gammapy.visualization.utils import add_colorbar
 from ..core import IRF
 
 __all__ = ["EnergyDispersion2D"]
+
+
+log = logging.getLogger(__name__)
 
 
 class EnergyDispersion2D(IRF):
@@ -41,8 +47,9 @@ class EnergyDispersion2D(IRF):
     Create energy dispersion matrix (`~gammapy.irf.EnergyDispersion`)
     for a given field of view offset and energy binning:
 
-    >>> energy = MapAxis.from_bounds(0.1, 20, nbin=60, unit="TeV", interp="log").edges
-    >>> edisp = edisp2d.to_edisp_kernel(offset='1.2 deg', energy=energy, energy_true=energy)
+    >>> energy_axis = MapAxis.from_bounds(0.1, 20, nbin=60, unit="TeV", interp="log", name='energy')
+    >>> edisp = edisp2d.to_edisp_kernel(offset='1.2 deg', energy_axis=energy_axis,
+    ...                                 energy_axis_true=energy_axis.copy(name='energy_true'))
 
     See Also
     --------
@@ -117,7 +124,13 @@ class EnergyDispersion2D(IRF):
             data=data.value,
         )
 
-    def to_edisp_kernel(self, offset, energy_true=None, energy=None):
+    @deprecated_renamed_argument(
+        ["energy_true", "energy"],
+        ["energy_axis_true", "energy_axis"],
+        ["v1.3", "v1.3"],
+        arg_in_kwargs=True,
+    )
+    def to_edisp_kernel(self, offset, energy_axis_true=None, energy_axis=None):
         """Detector response R(Delta E_reco, Delta E_true).
 
         Probability to reconstruct an energy in a given true energy band
@@ -127,9 +140,9 @@ class EnergyDispersion2D(IRF):
         ----------
         offset : `~astropy.coordinates.Angle`
             Offset.
-        energy_true : `~astropy.units.Quantity`, optional
+        energy_axis_true : `~gammapy.maps.MapAxis`, optional
             True energy axis. Default is None.
-        energy : `~astropy.units.Quantity`, optional
+        energy_axis : `~gammapy.maps.MapAxis`, optional
             Reconstructed energy axis. Default is None.
 
         Returns
@@ -141,18 +154,26 @@ class EnergyDispersion2D(IRF):
 
         offset = Angle(offset)
 
-        if energy is None:
-            energy_axis = self.axes["energy_true"].copy(name="energy")
-        else:
-            energy_axis = MapAxis.from_energy_edges(energy)
+        if isinstance(energy_axis, Quantity):
+            log.warning(
+                "From v1.3 energy_axis should be given as a MapAxis, not a Quantity."
+            )
+            energy_axis = MapAxis.from_energy_edges(energy_axis)
 
-        if energy_true is None:
-            energy_axis_true = self.axes["energy_true"]
-        else:
+        if isinstance(energy_axis_true, Quantity):
+            log.warning(
+                "From v1.3 energy_axis_true should be given as a MapAxis, not a Quantity."
+            )
             energy_axis_true = MapAxis.from_energy_edges(
-                energy_true,
+                energy_axis_true,
                 name="energy_true",
             )
+
+        if energy_axis is None:
+            energy_axis = self.axes["energy_true"].copy(name="energy")
+
+        if energy_axis_true is None:
+            energy_axis_true = self.axes["energy_true"]
 
         pointing = SkyCoord("0d", "0d")
 

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -150,7 +150,7 @@ class EDispKernel(IRF):
             pdf_threshold=pdf_threshold,
         )
         return edisp.to_edisp_kernel(
-            offset=offset_axis.center[0], energy=energy_axis.edges
+            offset=offset_axis.center[0], energy_axis=energy_axis
         )
 
     @classmethod

--- a/gammapy/irf/edisp/tests/test_core.py
+++ b/gammapy/irf/edisp/tests/test_core.py
@@ -66,9 +66,11 @@ class TestEnergyDispersion2D:
     def test_exporter(self):
         # Check RMF exporter
         offset = Angle(0.612, "deg")
-        e_reco = MapAxis.from_energy_bounds(1, 10, 7, "TeV").edges
-        e_true = MapAxis.from_energy_bounds(0.8, 5, 5, "TeV").edges
-        rmf = self.edisp.to_edisp_kernel(offset, energy_true=e_true, energy=e_reco)
+        e_reco_axis = MapAxis.from_energy_bounds(1, 10, 7, "TeV")
+        e_true_axis = MapAxis.from_energy_bounds(0.8, 5, 5, "TeV", name="energy_true")
+        rmf = self.edisp.to_edisp_kernel(
+            offset, energy_axis_true=e_true_axis, energy_axis=e_reco_axis
+        )
         assert_allclose(rmf.data.data[2, 3], 0.08, atol=5e-2)  # same tolerance as above
 
     def test_write(self):

--- a/gammapy/irf/edisp/tests/test_core.py
+++ b/gammapy/irf/edisp/tests/test_core.py
@@ -72,6 +72,11 @@ class TestEnergyDispersion2D:
             offset, energy_axis_true=e_true_axis, energy_axis=e_reco_axis
         )
         assert_allclose(rmf.data.data[2, 3], 0.08, atol=5e-2)  # same tolerance as above
+        # Test for v1.3
+        rmf2 = self.edisp.to_edisp_kernel(
+            offset, energy_axis_true=e_true_axis.edges, energy_axis=e_reco_axis.edges
+        )
+        assert_allclose(rmf2.data.data[2, 3], 0.08, atol=5e-2)
 
     def test_write(self):
         energy_axis_true = MapAxis.from_energy_bounds(


### PR DESCRIPTION
This PR is to resolve #5142. 
I left it as a draft as I am not sure if this is the correct procedure to take. 
This is two part issue, we want to change the variables to be consistent with the other naming for axis https://github.com/gammapy/gammapy/blob/86488ece61f41e92ff3212b9b870f5a9f7d68b79/gammapy/irf/edisp/map.py#L116
We also need to change the variable to no longer be a quantity but a `MapAxis`. 

This was the best way I could think to achieve this.

Note: there are a number of failing tests, but I did not want to fix them all with the deprecation warning until a method was decided upon.

I am open to suggestions. 