### PR TITLE
Use two argument form of Time to parse reference time

### DIFF
--- a/gammapy/utils/time.py
+++ b/gammapy/utils/time.py
@@ -100,7 +100,11 @@ def time_ref_from_dict(meta, format="mjd", scale="tt"):
         Time object with ``format='MJD'``.
     """
     scale = meta.get("TIMESYS", scale).lower()
-    return Time(meta["MJDREFI"], meta["MJDREFF"], format=format, scale=scale)
+
+    # some files seem to have MJDREFF as string, not as float
+    mjdrefi = float(meta["MJDREFI"])
+    mjdreff = float(meta["MJDREFF"])
+    return Time(mjdrefi, mjdreff, format=format, scale=scale)
 
 
 def time_ref_to_dict(time=None, scale="tt"):

--- a/gammapy/utils/time.py
+++ b/gammapy/utils/time.py
@@ -99,10 +99,8 @@ def time_ref_from_dict(meta, format="mjd", scale="tt"):
     time : `~astropy.time.Time`
         Time object with ``format='MJD'``.
     """
-    # Note: the float call here is to make sure we use 64-bit
-    mjd = float(meta["MJDREFI"]) + float(meta["MJDREFF"])
     scale = meta.get("TIMESYS", scale).lower()
-    return Time(mjd, format=format, scale=scale)
+    return Time(meta["MJDREFI"], meta["MJDREFF"], format=format, scale=scale)
 
 
 def time_ref_to_dict(time=None, scale="tt"):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

The code added `MJDREFI` and `MJDREFF` to a single float 64 number.
However, the main reason of having the integer part and floating point part separately, is to retain higher precision than a single float 64 number.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
