### PR TITLE
Add a time_reference arguments to `_template_model_from_cta_sdc`

### DIFF
--- a/gammapy/modeling/models/tests/test_utils.py
+++ b/gammapy/modeling/models/tests/test_utils.py
@@ -25,6 +25,14 @@ def test__template_model_from_cta_sdc(tmp_path):
     assert_allclose(mod1.t_ref.value, mod.t_ref.value, rtol=1e-7)
 
 
+def test__template_model_from_cta_sdc_reference_time():
+    filename = "$GAMMAPY_DATA/gravitational_waves/GW_example_DC_file.fits.gz"
+    t_ref = Time("2028-01-01T00:00:00", format="isot", scale="utc")
+    mod = _template_model_from_cta_sdc(filename, t_ref=t_ref)
+
+    assert_allclose(mod.reference_time.mjd, t_ref.mjd, rtol=1e-5)
+
+
 @requires_data()
 @requires_dependency("healpy")
 def test_read_hermes_cube():

--- a/gammapy/modeling/models/tests/test_utils.py
+++ b/gammapy/modeling/models/tests/test_utils.py
@@ -26,12 +26,12 @@ def test__template_model_from_cta_sdc(tmp_path):
 
 
 @requires_data()
-def test__template_model_from_cta_sdc_reference_time():
+def test__reference_time():
     filename = "$GAMMAPY_DATA/gravitational_waves/GW_example_DC_file.fits.gz"
     t_ref = Time("2028-01-01T00:00:00", format="isot", scale="utc")
     mod = _template_model_from_cta_sdc(filename, t_ref=t_ref)
 
-    assert_allclose(mod.reference_time.mjd, t_ref.mjd, rtol=1e-5)
+    assert_allclose(mod.reference_time.mjd, t_ref.mjd, rtol=1e-7)
 
 
 @requires_data()

--- a/gammapy/modeling/models/tests/test_utils.py
+++ b/gammapy/modeling/models/tests/test_utils.py
@@ -25,6 +25,7 @@ def test__template_model_from_cta_sdc(tmp_path):
     assert_allclose(mod1.t_ref.value, mod.t_ref.value, rtol=1e-7)
 
 
+@requires_data()
 def test__template_model_from_cta_sdc_reference_time():
     filename = "$GAMMAPY_DATA/gravitational_waves/GW_example_DC_file.fits.gz"
     t_ref = Time("2028-01-01T00:00:00", format="isot", scale="utc")

--- a/gammapy/modeling/models/utils.py
+++ b/gammapy/modeling/models/utils.py
@@ -37,18 +37,21 @@ def _template_model_from_cta_sdc(filename, t_ref=None):
         time_hdu = hdul["TIMES"]
         time_header = time_hdu.header
         if t_ref:
-            time_header.setdefault("MJDREFF", int(math.modf(t_ref)[1]))
-            time_header.setdefault("MJDREFI", math.modf(t_ref)[0])
+            time_header.setdefault("MJDREFF", math.modf(t_ref.mjd)[0])
+            time_header.setdefault("MJDREFI", int(math.modf(t_ref.mjd)[1]))
+            scale = t_ref.scale
+            time_header.setdefault("scale", scale)
         else:
             time_header.setdefault("MJDREFF", 0.5)
             time_header.setdefault("MJDREFI", 55555)
-        time_header.setdefault("scale", "tt")
+            scale = "tt"
+            time_header.setdefault("scale", scale)
         time_min = time_hdu.data["Initial Time"]
         time_max = time_hdu.data["Final Time"]
         edges = np.append(time_min, time_max[-1]) * u.Unit(time_header["TUNIT1"])
         data = hdul["SPECTRA"]
 
-        time_ref = time_ref_from_dict(time_header)
+        time_ref = time_ref_from_dict(time_header, scale=scale)
         time_axis = MapAxis.from_edges(edges=edges, name="time", interp="log")
 
         reg_map = RegionNDMap.create(

--- a/gammapy/modeling/models/utils.py
+++ b/gammapy/modeling/models/utils.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import math
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -14,7 +15,7 @@ from . import LightCurveTemplateTemporalModel, Models, SkyModel, TemplateSpatial
 __all__ = ["read_hermes_cube"]
 
 
-def _template_model_from_cta_sdc(filename):
+def _template_model_from_cta_sdc(filename, t_ref=None):
     """To create a `LightCurveTemplateTemporalModel` from the energy-dependent temporal model files of the cta-sdc1.
 
     This format is subject to change.
@@ -35,8 +36,12 @@ def _template_model_from_cta_sdc(filename):
         )
         time_hdu = hdul["TIMES"]
         time_header = time_hdu.header
-        time_header.setdefault("MJDREFF", 0.5)
-        time_header.setdefault("MJDREFI", 55555)
+        if t_ref:
+            time_header.setdefault("MJDREFF", int(math.modf(t_ref)[1]))
+            time_header.setdefault("MJDREFI", math.modf(t_ref)[0])
+        else:
+            time_header.setdefault("MJDREFF", 0.5)
+            time_header.setdefault("MJDREFI", 55555)
         time_header.setdefault("scale", "tt")
         time_min = time_hdu.data["Initial Time"]
         time_max = time_hdu.data["Final Time"]


### PR DESCRIPTION
This PR adds a reference time argument to the function `gammapy.modeling.model.utils._template_model_from_cta_sdc`. This can be useful in the cases when a given SDC model has to have a specific reference time (e.g. flaring sources) and not a generic one.