### PR TITLE
Specify the sampled model in `MapDatasetEventSampler`

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Simulate observations."""
 import html
+import logging
 from copy import deepcopy
 import numpy as np
 import astropy.units as u
@@ -20,6 +21,8 @@ from gammapy.utils.random import get_random_state
 from .map import create_map_dataset_from_observation
 
 __all__ = ["MapDatasetEventSampler", "ObservationEventSampler"]
+
+log = logging.getLogger(__name__)
 
 
 class MapDatasetEventSampler:
@@ -258,7 +261,7 @@ class MapDatasetEventSampler:
 
         events_all = EventList(Table())
         for idx, evaluator in enumerate(dataset.evaluators.values()):
-            print(f"Evaluating model: {evaluator.model.name}")
+            log.info(f"Evaluating model: {evaluator.model.name}")
             if evaluator.needs_update:
                 evaluator.update(
                     dataset.exposure,
@@ -311,7 +314,7 @@ class MapDatasetEventSampler:
 
         table = Table()
         if dataset.background:
-            print("Evaluating background...")
+            log.info("Evaluating background...")
             background = dataset.npred_background()
 
             temporal_model = ConstantTemporalModel()
@@ -588,7 +591,7 @@ class MapDatasetEventSampler:
 
         geom = dataset._geom
         selection = geom.contains(events.map_coord(geom))
-        print("Event sampling completed.")
+        log.info("Event sampling completed.")
         return events.select_row_subset(selection)
 
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Simulate observations."""
 import html
+import logging
 from copy import deepcopy
 import numpy as np
 import astropy.units as u
@@ -20,6 +21,9 @@ from gammapy.utils.random import get_random_state
 from .map import create_map_dataset_from_observation
 
 __all__ = ["MapDatasetEventSampler", "ObservationEventSampler"]
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class MapDatasetEventSampler:
@@ -258,6 +262,7 @@ class MapDatasetEventSampler:
 
         events_all = EventList(Table())
         for idx, evaluator in enumerate(dataset.evaluators.values()):
+            logger.info(f"Evaluating model: {evaluator.model.name}")
             if evaluator.needs_update:
                 evaluator.update(
                     dataset.exposure,
@@ -310,6 +315,7 @@ class MapDatasetEventSampler:
 
         table = Table()
         if dataset.background:
+            logger.info("Evaluating background...")
             background = dataset.npred_background()
 
             temporal_model = ConstantTemporalModel()
@@ -586,6 +592,7 @@ class MapDatasetEventSampler:
 
         geom = dataset._geom
         selection = geom.contains(events.map_coord(geom))
+        logger.info("Event sampling completed.")
         return events.select_row_subset(selection)
 
 

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Simulate observations."""
 import html
-import logging
 from copy import deepcopy
 import numpy as np
 import astropy.units as u
@@ -21,9 +20,6 @@ from gammapy.utils.random import get_random_state
 from .map import create_map_dataset_from_observation
 
 __all__ = ["MapDatasetEventSampler", "ObservationEventSampler"]
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
 
 class MapDatasetEventSampler:
@@ -262,7 +258,7 @@ class MapDatasetEventSampler:
 
         events_all = EventList(Table())
         for idx, evaluator in enumerate(dataset.evaluators.values()):
-            logger.info(f"Evaluating model: {evaluator.model.name}")
+            print(f"Evaluating model: {evaluator.model.name}")
             if evaluator.needs_update:
                 evaluator.update(
                     dataset.exposure,
@@ -315,7 +311,7 @@ class MapDatasetEventSampler:
 
         table = Table()
         if dataset.background:
-            logger.info("Evaluating background...")
+            print("Evaluating background...")
             background = dataset.npred_background()
 
             temporal_model = ConstantTemporalModel()
@@ -592,7 +588,7 @@ class MapDatasetEventSampler:
 
         geom = dataset._geom
         selection = geom.contains(events.map_coord(geom))
-        logger.info("Event sampling completed.")
+        print("Event sampling completed.")
         return events.select_row_subset(selection)
 
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import logging
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -482,7 +483,7 @@ def test_event_det_coords(dataset, models):
 
 
 @requires_data()
-def test_mde_run(dataset, models, capsys, tmp_path):
+def test_mde_run(dataset, models, caplog, tmp_path):
     irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
@@ -499,13 +500,21 @@ def test_mde_run(dataset, models, capsys, tmp_path):
     )
 
     dataset.models = models
+
+    logging.getLogger().setLevel(logging.INFO)
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.run(dataset=dataset, observation=obs)
 
-    captured = capsys.readouterr()
-    str = "Evaluating model: test-source\nEvaluating background...\nEvent sampling completed.\n"
+    captured = caplog.records
+    str = [
+        "Evaluating model: test-source",
+        "Evaluating background...",
+        "Event sampling completed.",
+    ]
 
-    assert captured.out == str
+    assert captured[1].message == str[0]
+    assert captured[2].message == str[1]
+    assert captured[4].message == str[2]
 
     dataset_bkg = dataset.copy(name="new-dataset")
     dataset_bkg.models = [FoVBackgroundModel(dataset_name=dataset_bkg.name)]

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -610,7 +610,6 @@ def test_sampler_output(dataset, model_alternative, caplog):
     bkg_model = FoVBackgroundModel(dataset_name="test")
     new_mod = Models([model_alternative[0], bkg_model])
     dataset.models = new_mod
-    print(dataset)
 
     sampler = MapDatasetEventSampler(random_state=0)
     sampler.run(dataset=dataset, observation=obs)


### PR DESCRIPTION
This PR is intended to solve the issue #5202 and it introduces the possibility to print out the name of the model sampled by the `MapDatasetEventSampler`. 