### PR TITLE
Convert negative `npred` values to zero in `MapDatasetEventSampler`

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -191,6 +191,7 @@ class MapDatasetEventSampler:
 
         npred = self._evaluate_timevar_source(dataset, model=model)
         data = npred.data[np.isfinite(npred.data)]
+        data[data < 0] = 0
 
         try:
             n_events = self.random_state.poisson(np.sum(data))
@@ -225,6 +226,7 @@ class MapDatasetEventSampler:
             Table of sampled events.
         """
         data = npred.data[np.isfinite(npred.data)]
+        data[data < 0] = 0
         n_events = self.random_state.poisson(np.sum(data))
 
         coords = npred.sample_coord(n_events=n_events, random_state=self.random_state)

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -191,7 +191,7 @@ class MapDatasetEventSampler:
 
         npred = self._evaluate_timevar_source(dataset, model=model)
         data = npred.data[np.isfinite(npred.data)]
-        data[data < 0] = 0
+        data = np.clip(data, 0, None)
 
         try:
             n_events = self.random_state.poisson(np.sum(data))
@@ -226,7 +226,7 @@ class MapDatasetEventSampler:
             Table of sampled events.
         """
         data = npred.data[np.isfinite(npred.data)]
-        data[data < 0] = 0
+        data = np.clip(data, 0, None)
         n_events = self.random_state.poisson(np.sum(data))
 
         coords = npred.sample_coord(n_events=n_events, random_state=self.random_state)

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -276,6 +276,22 @@ def test_fail_sample_coord_time_energy(
 
 
 @requires_data()
+def test_negative_npred(dataset):
+    spatial_model = PointSpatialModel(lon_0="0 deg", lat_0="0 deg", frame="galactic")
+    spectral_model = PowerLawSpectralModel(amplitude="-4e-10 cm-2 s-1 TeV-1")
+
+    dataset.models = [
+        SkyModel(spectral_model=spectral_model, spatial_model=spatial_model),
+        FoVBackgroundModel(dataset_name=dataset.name),
+    ]
+
+    sampler = MapDatasetEventSampler(random_state=0, n_event_bunch=1000)
+    events = sampler.run(dataset=dataset)
+
+    assert len(events.table) == 15
+
+
+@requires_data()
 def test_sample_coord_time_energy_random_seed(
     dataset, energy_dependent_temporal_sky_model
 ):


### PR DESCRIPTION
It may happen that the `npred` for a given model assume negative values. It can introduce some issues in the correct total number of events which will be sampled for the model. The PR introduces the possibility to convert all the negative `npred` values into zeros. It would solve also the issue #5178 .