### PR TITLE
Add wrapper around 3ML minimizer wrappers 

### DIFF
--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -14,6 +14,7 @@ from .iminuit import (
 )
 from .scipy import confidence_scipy, optimize_scipy
 from .sherpa import optimize_sherpa
+from .threeML_wrapper import optimize_3ml
 
 __all__ = ["Fit"]
 
@@ -36,6 +37,7 @@ class Registry:
             "minuit": optimize_iminuit,
             "sherpa": optimize_sherpa,
             "scipy": optimize_scipy,
+            "3ml": optimize_3ml,
         },
         "covariance": {
             "minuit": covariance_iminuit,

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -180,6 +180,25 @@ def test_optimize(backend):
     assert len(result.trace) == result.nfev
 
 
+@pytest.mark.parametrize("method", ["MINUIT", "SCIPY"])
+def test_optimize_3ml(method):
+    backend = "3ml"
+    dataset = MyDataset()
+
+    kwargs = {"method": method}
+
+    fit = Fit(store_trace=True, backend=backend, optimize_opts=kwargs)
+    result = fit.optimize([dataset])
+
+    pars = dataset.models.parameters
+
+    assert_allclose(result.total_stat, 0, atol=1)
+
+    assert_allclose(pars["x"].value, 2, rtol=1e-2)
+    assert_allclose(pars["y"].value, 3e2, rtol=1e-3)
+    assert_allclose(pars["z"].value, 4e-2, rtol=1e-2)
+
+
 @pytest.mark.parametrize("backend", ["minuit"])
 def test_confidence(backend):
     dataset = MyDataset()

--- a/gammapy/modeling/threeML_wrapper.py
+++ b/gammapy/modeling/threeML_wrapper.py
@@ -1,0 +1,53 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""3ml minimization wrapper"""
+import numpy as np
+from astromodels import Parameter as AstroParameter
+from .iminuit import MinuitLikelihood
+
+
+def optimize_3ml(parameters, function, store_trace=False, **kwargs):
+    """iminuit optimization.
+
+    Parameters
+    ----------
+    parameters : `~gammapy.modeling.Parameters`
+        Parameters with starting values.
+    function : callable
+        Likelihood function.
+    store_trace : bool, optional
+        Store trace of the fit. Default is False.
+    **kwargs : dict
+        Options passed to `iminuit.Minuit` constructor. If there is an entry
+        'migrad_opts', those options will be passed to `iminuit.Minuit.migrad()`.
+
+    Returns
+    -------
+    result : (factors, info, optimizer)
+        Tuple containing the best fit factors, some information and the optimizer instance.
+    """
+    from threeML.minimizer.minimization import get_minimizer
+
+    method = kwargs.pop("method", "MINUIT")
+    optimizer_class = get_minimizer(method)
+
+    func_3ml = MinuitLikelihood(function, parameters, store_trace=store_trace)
+    parameters_3ml = {}
+    for p in parameters:
+        min_ = None if np.isnan(p.factor_min) else p.factor_min
+        max_ = None if np.isnan(p.factor_max) else p.factor_max
+
+        parameters_3ml[p.name] = AstroParameter(
+            name="".join(filter(str.isalnum, p.name)),
+            value=p.factor,
+            min_value=min_,
+            max_value=max_,
+            free=not p.frozen,
+        )
+
+    optimizer = optimizer_class(
+        parameters=parameters_3ml, function=func_3ml.fcn, **kwargs
+    )
+    factors, fval = optimizer._minimize()
+    info = {"success": None, "message": None, "trace": func_3ml.trace, "nfev": None}
+
+    return factors, info, optimizer


### PR DESCRIPTION
This PR add a wrapper around 3ML minimizer wrappers so we can use them via gammapy.modelling.Fit(backend="3ml").

For now this is a draft, it works for the simple test dataset with minuit and scipy but I haven't installed the other optimizers yet to test locally.