### PR TITLE
Allow `MapAxis` to be passed in `SpectralModel.plot()`

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -456,9 +456,7 @@ class SpectralModel(ModelBase):
         if self.is_norm_spectral_model:
             sed_type = "norm"
 
-        if (
-            isinstance(energy_bounds, (tuple, list, Quantity))
-        ):
+        if isinstance(energy_bounds, (tuple, list, Quantity)):
             energy_min, energy_max = energy_bounds
             energy = MapAxis.from_energy_bounds(
                 energy_min,
@@ -539,9 +537,7 @@ class SpectralModel(ModelBase):
         if self.is_norm_spectral_model:
             sed_type = "norm"
 
-        if (
-            isinstance(energy_bounds, (tuple, list, Quantity))
-        ):
+        if isinstance(energy_bounds, (tuple, list, Quantity)):
             energy_min, energy_max = energy_bounds
             energy = MapAxis.from_energy_bounds(
                 energy_min,

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -487,8 +487,7 @@ class SpectralModel(ModelBase):
 
     def plot_error(
         self,
-        energy_bounds=None,
-        energy_axis=None,
+        energy_bounds,
         ax=None,
         sed_type="dnde",
         energy_power=0,

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -428,9 +428,9 @@ class SpectralModel(ModelBase):
         Parameters
         ----------
         energy_bounds : `~astropy.units.Quantity`
-            Plot energy bounds passed to `~gammapy.maps.MapAxis.from_energy_bounds`.
-        energy_axis : `~gammapy.maps.MapAxis`
-            Plot the energy axis.
+            Energy bounds between which the model is to be plotted.
+        energy_axis : `~gammapy.maps.MapAxis`, optional
+            Axis defining the energy bounds between which the model is to be plotted.
         ax : `~matplotlib.axes.Axes`, optional
             Matplotlib axes. Default is None.
         sed_type : {"dnde", "flux", "eflux", "e2dnde"}
@@ -450,13 +450,19 @@ class SpectralModel(ModelBase):
         Notes
         -----
         Either ``energy_bounds`` or ``energy_axis`` must be defined.
+        If ``energy_bounds`` is supplied, an ``energy_axis`` is created internally with ``n_points``
+        bins between the given bounds. If both are supplied, an error will occur.
         """
         from gammapy.estimators.map.core import DEFAULT_UNIT
 
         if self.is_norm_spectral_model:
             sed_type = "norm"
 
-        if energy_bounds is not None:
+        if energy_bounds is not None and energy_axis:
+            raise AttributeError(
+                "Both `energy_bounds` or `energy_axis` cannot be defined."
+            )
+        elif energy_bounds is not None:
             energy_min, energy_max = energy_bounds
             energy = MapAxis.from_energy_bounds(
                 energy_min,
@@ -514,9 +520,9 @@ class SpectralModel(ModelBase):
         Parameters
         ----------
         energy_bounds : `~astropy.units.Quantity`
-            Plot energy bounds passed to `~gammapy.maps.MapAxis.from_energy_bounds`.
-        energy_axis : `~gammapy.maps.MapAxis`
-            Plot the energy axis.
+            Energy bounds between which the model is to be plotted.
+        energy_axis : `~gammapy.maps.MapAxis`, optional
+            Axis defining the energy bounds between which the model is to be plotted.
         ax : `~matplotlib.axes.Axes`, optional
             Matplotlib axes. Default is None.
         sed_type : {"dnde", "flux", "eflux", "e2dnde"}
@@ -536,13 +542,19 @@ class SpectralModel(ModelBase):
         Notes
         -----
         Either ``energy_bounds`` or ``energy_axis`` must be defined.
+        If ``energy_bounds`` is supplied, an ``energy_axis`` is created internally with ``n_points``
+        bins between the given bounds. If both are supplied, an error will occur.
         """
         from gammapy.estimators.map.core import DEFAULT_UNIT
 
         if self.is_norm_spectral_model:
             sed_type = "norm"
 
-        if energy_bounds is not None:
+        if energy_bounds is not None and energy_axis:
+            raise AttributeError(
+                "Both `energy_bounds` or `energy_axis` cannot be defined."
+            )
+        elif energy_bounds is not None:
             energy_min, energy_max = energy_bounds
             energy = MapAxis.from_energy_bounds(
                 energy_min,

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -405,7 +405,8 @@ class SpectralModel(ModelBase):
 
     def plot(
         self,
-        energy_bounds,
+        energy_bounds=None,
+        energy_axis=None,
         ax=None,
         sed_type="dnde",
         energy_power=0,
@@ -427,7 +428,9 @@ class SpectralModel(ModelBase):
         Parameters
         ----------
         energy_bounds : `~astropy.units.Quantity`
-            Plot energy bounds passed to MapAxis.from_energy_bounds.
+            Plot energy bounds passed to `~gammapy.maps.MapAxis.from_energy_bounds`.
+        energy_axis : `~gammapy.maps.MapAxis`
+            Plot the energy axis.
         ax : `~matplotlib.axes.Axes`, optional
             Matplotlib axes. Default is None.
         sed_type : {"dnde", "flux", "eflux", "e2dnde"}
@@ -443,20 +446,31 @@ class SpectralModel(ModelBase):
         -------
         ax : `~matplotlib.axes.Axes`, optional
             Matplotlib axes.
+
+        Notes
+        -----
+        Either ``energy_bounds`` or ``map_axis`` must be defined.
         """
         from gammapy.estimators.map.core import DEFAULT_UNIT
-
-        ax = plt.gca() if ax is None else ax
 
         if self.is_norm_spectral_model:
             sed_type = "norm"
 
-        energy_min, energy_max = energy_bounds
-        energy = MapAxis.from_energy_bounds(
-            energy_min,
-            energy_max,
-            n_points,
-        )
+        if energy_bounds is not None:
+            energy_min, energy_max = energy_bounds
+            energy = MapAxis.from_energy_bounds(
+                energy_min,
+                energy_max,
+                n_points,
+            )
+        elif energy_axis:
+            energy = energy_axis
+        elif not energy_bounds and not energy_axis:
+            raise AttributeError(
+                "Either `energy_bounds` or `energy_axis` must be defined."
+            )
+
+        ax = plt.gca() if ax is None else ax
 
         if ax.yaxis.units is None:
             ax.yaxis.set_units(DEFAULT_UNIT[sed_type] * energy.unit**energy_power)
@@ -473,7 +487,8 @@ class SpectralModel(ModelBase):
 
     def plot_error(
         self,
-        energy_bounds,
+        energy_bounds=None,
+        energy_axis=None,
         ax=None,
         sed_type="dnde",
         energy_power=0,
@@ -500,6 +515,8 @@ class SpectralModel(ModelBase):
         ----------
         energy_bounds : `~astropy.units.Quantity`
             Plot energy bounds passed to `~gammapy.maps.MapAxis.from_energy_bounds`.
+        energy_axis : `~gammapy.maps.MapAxis`
+            Plot the energy axis.
         ax : `~matplotlib.axes.Axes`, optional
             Matplotlib axes. Default is None.
         sed_type : {"dnde", "flux", "eflux", "e2dnde"}
@@ -515,20 +532,31 @@ class SpectralModel(ModelBase):
         -------
         ax : `~matplotlib.axes.Axes`, optional
             Matplotlib axes.
+
+        Notes
+        -----
+        Either ``energy_bounds`` or ``map_axis`` must be defined.
         """
         from gammapy.estimators.map.core import DEFAULT_UNIT
-
-        ax = plt.gca() if ax is None else ax
 
         if self.is_norm_spectral_model:
             sed_type = "norm"
 
-        energy_min, energy_max = energy_bounds
-        energy = MapAxis.from_energy_bounds(
-            energy_min,
-            energy_max,
-            n_points,
-        )
+        if energy_bounds is not None:
+            energy_min, energy_max = energy_bounds
+            energy = MapAxis.from_energy_bounds(
+                energy_min,
+                energy_max,
+                n_points,
+            )
+        elif energy_axis:
+            energy = energy_axis
+        elif not energy_bounds and not energy_axis:
+            raise AttributeError(
+                "Either `energy_bounds` or `energy_axis` must be defined."
+            )
+
+        ax = plt.gca() if ax is None else ax
 
         kwargs.setdefault("facecolor", "black")
         kwargs.setdefault("alpha", 0.2)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -449,7 +449,7 @@ class SpectralModel(ModelBase):
 
         Notes
         -----
-        Either ``energy_bounds`` or ``map_axis`` must be defined.
+        Either ``energy_bounds`` or ``energy_axis`` must be defined.
         """
         from gammapy.estimators.map.core import DEFAULT_UNIT
 
@@ -535,7 +535,7 @@ class SpectralModel(ModelBase):
 
         Notes
         -----
-        Either ``energy_bounds`` or ``map_axis`` must be defined.
+        Either ``energy_bounds`` or ``energy_axis`` must be defined.
         """
         from gammapy.estimators.map.core import DEFAULT_UNIT
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -448,7 +448,7 @@ class SpectralModel(ModelBase):
 
         Notes
         -----
-        If ``energy_bounds`` is supplied as a tuple or Quantity, an ``energy_axis`` is created internally with
+        If ``energy_bounds`` is supplied as a list, tuple, or Quantity, an ``energy_axis`` is created internally with
         ``n_points`` bins between the given bounds.
         """
         from gammapy.estimators.map.core import DEFAULT_UNIT
@@ -529,7 +529,7 @@ class SpectralModel(ModelBase):
 
         Notes
         -----
-        If ``energy_bounds`` is supplied as a tuple or Quantity, an ``energy_axis`` is created internally with
+        If ``energy_bounds`` is supplied as a list, tuple, or Quantity, an ``energy_axis`` is created internally with
         ``n_points`` bins between the given bounds.
         """
         from gammapy.estimators.map.core import DEFAULT_UNIT

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -11,6 +11,7 @@ import scipy.special
 import astropy.units as u
 from astropy import constants as const
 from astropy.table import Table
+from astropy.units import Quantity
 from astropy.utils.decorators import classproperty
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
@@ -405,8 +406,7 @@ class SpectralModel(ModelBase):
 
     def plot(
         self,
-        energy_bounds=None,
-        energy_axis=None,
+        energy_bounds,
         ax=None,
         sed_type="dnde",
         energy_power=0,
@@ -427,10 +427,9 @@ class SpectralModel(ModelBase):
 
         Parameters
         ----------
-        energy_bounds : `~astropy.units.Quantity`
-            Energy bounds between which the model is to be plotted.
-        energy_axis : `~gammapy.maps.MapAxis`, optional
-            Axis defining the energy bounds between which the model is to be plotted.
+        energy_bounds : `~astropy.units.Quantity`, list of `~astropy.units.Quantity` or `~gammapy.maps.MapAxis`
+            Energy bounds between which the model is to be plotted. Or an
+            axis defining the energy bounds between which the model is to be plotted.
         ax : `~matplotlib.axes.Axes`, optional
             Matplotlib axes. Default is None.
         sed_type : {"dnde", "flux", "eflux", "e2dnde"}
@@ -449,32 +448,27 @@ class SpectralModel(ModelBase):
 
         Notes
         -----
-        Either ``energy_bounds`` or ``energy_axis`` must be defined.
-        If ``energy_bounds`` is supplied, an ``energy_axis`` is created internally with ``n_points``
-        bins between the given bounds. If both are supplied, an error will occur.
+        If ``energy_bounds`` is supplied as a tuple or Quantity, an ``energy_axis`` is created internally with
+        ``n_points`` bins between the given bounds.
         """
         from gammapy.estimators.map.core import DEFAULT_UNIT
 
         if self.is_norm_spectral_model:
             sed_type = "norm"
 
-        if energy_bounds is not None and energy_axis:
-            raise AttributeError(
-                "Both `energy_bounds` or `energy_axis` cannot be defined."
-            )
-        elif energy_bounds is not None:
+        if (
+            isinstance(energy_bounds, tuple)
+            or isinstance(energy_bounds, Quantity)
+            or isinstance(energy_bounds, list)
+        ):
             energy_min, energy_max = energy_bounds
             energy = MapAxis.from_energy_bounds(
                 energy_min,
                 energy_max,
                 n_points,
             )
-        elif energy_axis:
-            energy = energy_axis
-        elif not energy_bounds and not energy_axis:
-            raise AttributeError(
-                "Either `energy_bounds` or `energy_axis` must be defined."
-            )
+        elif isinstance(energy_bounds, MapAxis):
+            energy = energy_bounds
 
         ax = plt.gca() if ax is None else ax
 
@@ -519,10 +513,9 @@ class SpectralModel(ModelBase):
 
         Parameters
         ----------
-        energy_bounds : `~astropy.units.Quantity`
-            Energy bounds between which the model is to be plotted.
-        energy_axis : `~gammapy.maps.MapAxis`, optional
-            Axis defining the energy bounds between which the model is to be plotted.
+        energy_bounds : `~astropy.units.Quantity`, list of `~astropy.units.Quantity` or `~gammapy.maps.MapAxis`
+            Energy bounds between which the model is to be plotted. Or an
+            axis defining the energy bounds between which the model is to be plotted.
         ax : `~matplotlib.axes.Axes`, optional
             Matplotlib axes. Default is None.
         sed_type : {"dnde", "flux", "eflux", "e2dnde"}
@@ -541,32 +534,27 @@ class SpectralModel(ModelBase):
 
         Notes
         -----
-        Either ``energy_bounds`` or ``energy_axis`` must be defined.
-        If ``energy_bounds`` is supplied, an ``energy_axis`` is created internally with ``n_points``
-        bins between the given bounds. If both are supplied, an error will occur.
+        If ``energy_bounds`` is supplied as a tuple or Quantity, an ``energy_axis`` is created internally with
+        ``n_points`` bins between the given bounds.
         """
         from gammapy.estimators.map.core import DEFAULT_UNIT
 
         if self.is_norm_spectral_model:
             sed_type = "norm"
 
-        if energy_bounds is not None and energy_axis:
-            raise AttributeError(
-                "Both `energy_bounds` or `energy_axis` cannot be defined."
-            )
-        elif energy_bounds is not None:
+        if (
+            isinstance(energy_bounds, tuple)
+            or isinstance(energy_bounds, Quantity)
+            or isinstance(energy_bounds, list)
+        ):
             energy_min, energy_max = energy_bounds
             energy = MapAxis.from_energy_bounds(
                 energy_min,
                 energy_max,
                 n_points,
             )
-        elif energy_axis:
-            energy = energy_axis
-        elif not energy_bounds and not energy_axis:
-            raise AttributeError(
-                "Either `energy_bounds` or `energy_axis` must be defined."
-            )
+        elif isinstance(energy_bounds, MapAxis):
+            energy = energy_bounds
 
         ax = plt.gca() if ax is None else ax
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -457,9 +457,7 @@ class SpectralModel(ModelBase):
             sed_type = "norm"
 
         if (
-            isinstance(energy_bounds, tuple)
-            or isinstance(energy_bounds, Quantity)
-            or isinstance(energy_bounds, list)
+            isinstance(energy_bounds, (tuple, list, Quantity))
         ):
             energy_min, energy_max = energy_bounds
             energy = MapAxis.from_energy_bounds(
@@ -542,9 +540,7 @@ class SpectralModel(ModelBase):
             sed_type = "norm"
 
         if (
-            isinstance(energy_bounds, tuple)
-            or isinstance(energy_bounds, Quantity)
-            or isinstance(energy_bounds, list)
+            isinstance(energy_bounds, (tuple, list, Quantity))
         ):
             energy_min, energy_max = energy_bounds
             energy = MapAxis.from_energy_bounds(

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -457,6 +457,12 @@ def test_model_plot():
     with pytest.raises(AttributeError):
         pwl.plot_error()
 
+    with pytest.raises(AttributeError):
+        pwl.plot(energy_bounds=(1 * u.TeV, 10 * u.TeV), energy_axis=energy_axis)
+
+    with pytest.raises(AttributeError):
+        pwl.plot_error(energy_bounds=(1 * u.TeV, 10 * u.TeV), energy_axis=energy_axis)
+
 
 def test_model_plot_sed_type():
     pwl = PowerLawSpectralModel(

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -431,12 +431,31 @@ def test_model_plot():
         amplitude=1e-12 * u.Unit("TeV-1 cm-2 s-1"), reference=1 * u.Unit("TeV"), index=2
     )
     pwl.amplitude.error = 0.1e-12 * u.Unit("TeV-1 cm-2 s-1")
+    energy_axis = MapAxis.from_energy_bounds(1 * u.TeV, 10 * u.TeV, 100)
 
     with mpl_plot_check():
         pwl.plot((1 * u.TeV, 10 * u.TeV))
 
     with mpl_plot_check():
+        pwl.plot([0.08, 20] * u.TeV)
+
+    with mpl_plot_check():
         pwl.plot_error((1 * u.TeV, 10 * u.TeV))
+
+    with mpl_plot_check():
+        pwl.plot_error([0.08, 20] * u.TeV)
+
+    with mpl_plot_check():
+        pwl.plot(energy_axis=energy_axis)
+
+    with mpl_plot_check():
+        pwl.plot_error(energy_axis=energy_axis)
+
+    with pytest.raises(AttributeError):
+        pwl.plot()
+
+    with pytest.raises(AttributeError):
+        pwl.plot_error()
 
 
 def test_model_plot_sed_type():

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -437,31 +437,25 @@ def test_model_plot():
         pwl.plot((1 * u.TeV, 10 * u.TeV))
 
     with mpl_plot_check():
-        pwl.plot([0.08, 20] * u.TeV)
+        pwl.plot_error((1 * u.TeV, 10 * u.TeV))
 
     with mpl_plot_check():
-        pwl.plot_error((1 * u.TeV, 10 * u.TeV))
+        pwl.plot([0.08, 20] * u.TeV)
 
     with mpl_plot_check():
         pwl.plot_error([0.08, 20] * u.TeV)
 
     with mpl_plot_check():
-        pwl.plot(energy_axis=energy_axis)
+        pwl.plot([0.08 * u.TeV, 20 * u.TeV])
 
     with mpl_plot_check():
-        pwl.plot_error(energy_axis=energy_axis)
+        pwl.plot_error([0.08 * u.TeV, 20 * u.TeV])
 
-    with pytest.raises(AttributeError):
-        pwl.plot()
+    with mpl_plot_check():
+        pwl.plot(energy_bounds=energy_axis)
 
-    with pytest.raises(AttributeError):
-        pwl.plot_error()
-
-    with pytest.raises(AttributeError):
-        pwl.plot(energy_bounds=(1 * u.TeV, 10 * u.TeV), energy_axis=energy_axis)
-
-    with pytest.raises(AttributeError):
-        pwl.plot_error(energy_bounds=(1 * u.TeV, 10 * u.TeV), energy_axis=energy_axis)
+    with mpl_plot_check():
+        pwl.plot_error(energy_bounds=energy_axis)
 
 
 def test_model_plot_sed_type():


### PR DESCRIPTION
This PR resolves #5171

We can now accept a `MapAxis` for spectral plotting both in `plot` and `plot_error`.

Note: `if energy_bounds is not None:` must be used rather just `if energy_bounds` due to the quantity handling in [astropy](https://github.com/astropy/astropy/pull/14124). 