### PR TITLE
Make non-FITS table file from FluxPoints overwritable

### DIFF
--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -267,7 +267,7 @@ class FluxPoints(FluxMaps):
         table = self.to_table(sed_type=sed_type, format=format)
 
         if ".fits" not in filename.suffixes:
-            table.write(filename)
+            table.write(filename, overwrite=overwrite)
             return
 
         primary_hdu = fits.PrimaryHDU()

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -211,12 +211,14 @@ class TestFluxPoints:
         assert str(flux_points) == str(actual)
 
     def test_write_ecsv(self, tmp_path, flux_points):
+        filename = tmp_path / "flux_points.ecsv"
+        filename.touch()
         flux_points.write(
-            tmp_path / "flux_points.ecsv",
+            filename,
             sed_type=flux_points.sed_type_init,
             overwrite=True,
         )
-        actual = FluxPoints.read(tmp_path / "flux_points.ecsv")
+        actual = FluxPoints.read(filename)
         actual._data.pop("is_ul", None)
         flux_points._data.pop("is_ul", None)
         assert str(flux_points) == str(actual)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->

See #5253.

<!-- Briefly: what changes are done here? -->

Propagated `astropy.table.Table.write()` overwrite to `FluxPoints.write()` when file extension is not `.fits`.

<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request closes #5253.
