### PR TITLE
Pass `events.time_ref` to `observation.pointing.to_fits_header`in `observation.write`

### DIFF
--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -578,7 +578,9 @@ class Observation:
         events = self.events
         if events is not None:
             events_hdu = events.to_table_hdu(format=format)
-            events_hdu.header.update(self.pointing.to_fits_header())
+            events_hdu.header.update(
+                self.pointing.to_fits_header(time_ref=events.time_ref)
+            )
             hdul.append(events_hdu)
 
         gti = self.gti

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -395,8 +395,8 @@ def test_observation_write(tmp_path):
     assert obs_read.obs_id == 23523
     assert_allclose(obs_read.observatory_earth_location.lat.deg, -23.271778)
 
-    assert obs_read.events.table.meta["MJDREFF"] == mjdreff
-    assert obs_read.events.table.meta["MJDREFI"] == mjdrefi
+    assert_allclose(obs_read.events.table.meta["MJDREFF"], mjdreff)
+    assert_allclose(obs_read.events.table.meta["MJDREFI"], mjdrefi)
 
     # unsupported format
     with pytest.raises(ValueError):

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -378,6 +378,10 @@ def test_observation_write(tmp_path):
     obs = Observation.read(
         "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
     )
+    mjdreff, mjdrefi = (
+        obs.events.table.meta["MJDREFF"],
+        obs.events.table.meta["MJDREFI"],
+    )
     path = tmp_path / "obs.fits.gz"
 
     obs.meta.creation.origin = "test"
@@ -392,6 +396,9 @@ def test_observation_write(tmp_path):
     assert obs_read.rad_max is None
     assert obs_read.obs_id == 23523
     assert_allclose(obs_read.observatory_earth_location.lat.deg, -23.271778)
+
+    assert obs_read.events.table.meta["MJDREFF"] == mjdreff
+    assert obs_read.events.table.meta["MJDREFI"] == mjdrefi
 
     # unsupported format
     with pytest.raises(ValueError):

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -378,10 +378,8 @@ def test_observation_write(tmp_path):
     obs = Observation.read(
         "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
     )
-    mjdreff, mjdrefi = (
-        obs.events.table.meta["MJDREFF"],
-        obs.events.table.meta["MJDREFI"],
-    )
+    mjdreff = obs.events.table.meta["MJDREFF"]
+    mjdrefi = obs.events.table.meta["MJDREFI"]
     path = tmp_path / "obs.fits.gz"
 
     obs.meta.creation.origin = "test"


### PR DESCRIPTION
This PR fix #5256. 

I pass the time reference of the eventlist to `pointing.to_fits_header` in `observation.write` so that the MJDREFF and MJDREFI written in the header of the eventlist is not set to 0 but to the good value.