### PR TITLE
Backport #5216: Compile against numpy 2.0 when building wheels, define target api version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,8 @@ requires = [
 	"setuptools >= 40.6.0",
 	"wheel",
 	"Cython",
-	'oldest-supported-numpy',
-	'setuptools_scm[toml]',
-	"extension-helpers",
+	'numpy>=2.0.0rc1',
+	'setuptools_scm[toml] >= 8',
 ]
 build-backend = "setuptools.build_meta"
 
@@ -34,3 +33,17 @@ filterwarnings = [
     "error::gammapy.utils.deprecation.GammapyDeprecationWarning",
     "error::matplotlib.MatplotlibDeprecationWarning",
 ]
+
+
+[tool.setuptools_scm]
+version_file = "gammapy/version.py"
+version_file_template = """\
+# Note that we need to fall back to the hard-coded version if either
+# setuptools_scm can't be imported or setuptools_scm can't determine the
+# version, so we catch the generic 'Exception'.
+try:
+    from setuptools_scm import get_version
+    version = get_version(root='..', relative_to=__file__)
+except Exception:
+    version = '{version}'
+"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,9 @@ packages = find:
 python_requires = >=3.9
 setup_requires = setuptools_scm
 install_requires =
-    numpy>=1.21,<2.0
+    numpy>=1.21
     scipy>=1.5,!=1.10
-    astropy>=5.0,<6.1
+    astropy>=5.0
     regions>=0.5.0
     pyyaml>=5.3
     click>=7.0


### PR DESCRIPTION
Compile against numpy 2.0 when building wheels, define target api version

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request ...

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
