### PR TITLE
Add leakage protection factor in the Timmer Konig algorithm

### DIFF
--- a/gammapy/stats/tests/test_variability.py
+++ b/gammapy/stats/tests/test_variability.py
@@ -164,11 +164,16 @@ def test_tk():
         temp, 15, 1 * u.h, power_spectrum_params=params
     )
 
+    time_series4, time_axis4 = TimmerKonig_lightcurve_simulator(
+        lambda x: x ** (-3), 20, 1 * u.s, leakage_protection=100
+    )
+
     assert len(time_series) == 20
     assert isinstance(time_axis, u.Quantity)
     assert time_axis.unit == u.s
     assert len(time_series2) == 21
     assert len(time_series3) == 15
+    assert len(time_series4) == 20
 
 
 def test_structure_function():

--- a/gammapy/stats/tests/test_variability.py
+++ b/gammapy/stats/tests/test_variability.py
@@ -165,7 +165,7 @@ def test_tk():
     )
 
     time_series4, time_axis4 = TimmerKonig_lightcurve_simulator(
-        lambda x: x ** (-3), 20, 1 * u.s, leakage_protection=100
+        lambda x: x ** (-3), 20, 1 * u.s, leakage_protection=100.0
     )
 
     assert len(time_series) == 20
@@ -174,6 +174,18 @@ def test_tk():
     assert len(time_series2) == 21
     assert len(time_series3) == 15
     assert len(time_series4) == 20
+
+
+def test_tk_badleakage():
+    with pytest.raises(ValueError):
+        TimmerKonig_lightcurve_simulator(
+            lambda x: x ** (-3), 20, 1 * u.s, leakage_protection=0.1
+        )
+
+    with pytest.raises(Warning):
+        TimmerKonig_lightcurve_simulator(
+            lambda x: x ** (-3), 20, 1 * u.s, leakage_protection=1.001
+        )
 
 
 def test_structure_function():

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -383,6 +383,12 @@ def TimmerKonig_lightcurve_simulator(
     fourier_coeffs = np.insert(fourier_coeffs, 0, 0)
     time_series = np.fft.ifft(fourier_coeffs).real
 
+    if leakage_protection > 1:
+        extract = random_state.randint(
+            npoints - 1, leakage_protection * npoints - npoints
+        )
+        time_series = np.take(time_series, range(extract, extract + npoints))
+
     tmax = time_series.max()
     if tmax < np.abs(time_series.min()):
         time_series = -time_series
@@ -390,11 +396,5 @@ def TimmerKonig_lightcurve_simulator(
     time_series = 0.5 + 0.5 * time_series / tmax
 
     time_axis = np.linspace(0, npoints * spacing.value, npoints) * spacing.unit
-
-    if leakage_protection > 1:
-        extract = random_state.randint(
-            npoints - 1, leakage_protection * npoints - npoints
-        )
-        time_series = np.take(time_series, range(extract, extract + npoints))
 
     return time_series, time_axis

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -289,7 +289,7 @@ def TimmerKonig_lightcurve_simulator(
     power_spectrum,
     npoints,
     spacing,
-    leakage_protection=1,
+    leakage_protection=1.0,
     random_state="random-seed",
     power_spectrum_params=None,
 ):
@@ -304,7 +304,7 @@ def TimmerKonig_lightcurve_simulator(
         Number of points in the output time series.
     spacing : `~astropy.units.Quantity`
         Sample spacing, inverse of the sampling rate. The units are inherited by the resulting time axis.
-    leakage_protection : int
+    leakage_protection : float
         Factor by which to multiply the length of the time series to avoid red noise leakage.
     random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
         Defines random number generator initialisation.
@@ -349,7 +349,7 @@ def TimmerKonig_lightcurve_simulator(
 
     random_state = get_random_state(random_state)
 
-    frequencies = np.fft.fftfreq(npoints * leakage_protection, spacing.value)
+    frequencies = np.fft.fftfreq(int(npoints * leakage_protection), spacing.value)
 
     # To obtain real data only the positive or negative part of the frequency is necessary.
     real_frequencies = np.sort(np.abs(frequencies[frequencies < 0]))
@@ -383,9 +383,9 @@ def TimmerKonig_lightcurve_simulator(
     fourier_coeffs = np.insert(fourier_coeffs, 0, 0)
     time_series = np.fft.ifft(fourier_coeffs).real
 
-    if leakage_protection > 1:
+    if leakage_protection != 1.0:
         extract = random_state.randint(
-            npoints - 1, leakage_protection * npoints - npoints
+            npoints - 1, int(leakage_protection * npoints) - npoints
         )
         time_series = np.take(time_series, range(extract, extract + npoints))
 

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -350,12 +350,13 @@ def TimmerKonig_lightcurve_simulator(
     random_state = get_random_state(random_state)
 
     if leakage_protection < 1.0:
-        raise ValueError("The leakage protection factor must be at least 1.0")
+        raise ValueError("The leakage protection factor must be at least 1.0.")
 
     npoints_extended = int(npoints * leakage_protection)
     if leakage_protection > 1.0 and npoints_extended == npoints:
         raise Warning(
-            "The extended number of points is the same length as the desired number"
+            "The extended time series is the same length as the final desired time series."
+            "To have an effective protection from noise leakage and avoid aliasing, increase <leakage_protection>."
         )
     frequencies = np.fft.fftfreq(npoints_extended, spacing.value)
 

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -356,7 +356,7 @@ def TimmerKonig_lightcurve_simulator(
     if leakage_protection > 1.0 and npoints_extended == npoints:
         raise Warning(
             "The extended time series is the same length as the final desired time series."
-            "To have an effective protection from noise leakage and avoid aliasing, increase <leakage_protection>."
+            "To have an effective protection from noise leakage and avoid aliasing, increase the leakage_protection option."
         )
     frequencies = np.fft.fftfreq(npoints_extended, spacing.value)
 

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -304,7 +304,7 @@ def TimmerKonig_lightcurve_simulator(
         Number of points in the output time series.
     spacing : `~astropy.units.Quantity`
         Sample spacing, inverse of the sampling rate. The units are inherited by the resulting time axis.
-    leakage_protection : float
+    leakage_protection : float, optional
         Factor by which to multiply the length of the time series to avoid red noise leakage.
     random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
         Defines random number generator initialisation.


### PR DESCRIPTION
This PR adds a small modification to the TimmerKonig algorithm. Now there is the possibility of using an additional (optional) input which is a multiplicative factor of the time series length `npoints` to avoid spectral leakage. The final time series of length `npoints` is extracted randomly at the end from the longer time series of length `npoints * leakage_protection`.
A specific test was added.
