### PR TITLE
Allow extrapolation only along spatial dimension in `mask_safe_edisp`

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -930,10 +930,17 @@ class MapDataset(Dataset):
 
         if "migra" in geom.axes.names:
             geom = geom.squash("migra")
-            mask_safe_edisp = self.mask_safe_image.interp_to_geom(geom.to_image())
+            mask_safe_edisp = self.mask_safe_image.interp_to_geom(
+                geom.to_image(), fill_value=None
+            )
             return mask_safe_edisp.to_cube(geom.axes)
 
-        return self.mask_safe.interp_to_geom(geom)
+        # allow extrapolation only along spatial dimension
+        # to support case where mask_safe geom and irfs geom are different
+        geom_same_axes = geom.to_image().to_cube(self.mask_safe.geom.axes)
+        mask_safe_edisp = self.mask_safe.interp_to_geom(geom_same_axes, fill_value=None)
+        mask_safe_edisp = mask_safe_edisp.interp_to_geom(geom)
+        return mask_safe_edisp
 
     def to_masked(self, name=None, nan_to_num=True):
         """Return masked dataset.

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1051,12 +1051,14 @@ class Map(abc.ABC):
                 )
             map_copy.data /= map_copy.geom.solid_angle().to_value("deg2")
 
-        if map_copy.is_mask:
+        if map_copy.is_mask and fill_value is not None:
             # TODO: check this NaN handling is needed
             data = map_copy.get_by_coord(coords)
             data = np.nan_to_num(data, nan=fill_value).astype(bool)
         else:
             data = map_copy.interp_by_coord(coords, fill_value=fill_value, **kwargs)
+            if map_copy.is_mask:
+                data = data.astype(bool)
 
         if preserve_counts:
             data *= geom.solid_angle().to_value("deg2")

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1031,6 +1031,7 @@ class Map(abc.ABC):
             the map is a differential quantity (e.g. intensity). Default is False.
         fill_value : float, optional
             The value to use for points outside the interpolation domain.
+            If None, values outside the domain are extrapolated.
             Default is 0.
         **kwargs : dict, optional
             Keyword arguments passed to `Map.interp_by_coord`.

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -437,6 +437,24 @@ def test_interp_to_geom():
     assert isinstance(interp_wcs_map, WcsNDMap)
     assert interp_wcs_map.geom == wcs_geom_target
 
+    # WcsNDMap is_mask
+    geom_wcs = WcsGeom.create(
+        npix=(5, 3), proj="CAR", binsz=0.1, axes=[energy], skydir=(0, 0)
+    )
+
+    wcs_map = Map.from_geom(geom_wcs, unit="", data=True)
+    wcs_geom_target = WcsGeom.create(
+        skydir=(30, 30),
+        width=(10, 10),
+        binsz=0.1 * u.deg,
+        axes=[energy_target],
+        frame="galactic",
+    )
+    interp_wcs_map = wcs_map.interp_to_geom(
+        wcs_geom_target, method="linear", fill_value=None
+    )
+    assert np.all(interp_wcs_map.data)
+
     # HpxNDMap
     geom_hpx = HpxGeom.create(binsz=60, axes=[energy], skydir=(0, 0))
     hpx_map = Map.from_geom(geom_hpx, unit="")


### PR DESCRIPTION
Support for extrapolation in `interp_to_geom` if geom is mask.
Allow extrapolation only along spatial dimension in `mask_safe_edisp`
to support case where `mask_safe` geom and irfs geom are different.

This a better  solution to resolve the problem described in #5236.