### PR TITLE
Fix some `~astropy.coordinates.*' links in docstring

### DIFF
--- a/gammapy/data/obs_table.py
+++ b/gammapy/data/obs_table.py
@@ -189,9 +189,9 @@ class ObservationTable(Table):
 
         Parameters
         ----------
-        center : `~astropy.coordinate.SkyCoord`
+        center : `~astropy.coordinates.SkyCoord`
             Cone center coordinate.
-        radius : `~astropy.coordinate.Angle`
+        radius : `~astropy.coordinates.Angle`
             Cone opening angle. The maximal separation allowed between the center
             and the observation pointing direction.
         inverted : bool, optional

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -94,7 +94,7 @@ class ExcessMapEstimator(Estimator):
 
     Parameters
     ----------
-    correlation_radius : `~astropy.coordinate.Angle`
+    correlation_radius : `~astropy.coordinates.Angle`
         Correlation radius to use.
     n_sigma : float
         Confidence level for the asymmetric errors expressed in number of sigma.


### PR DESCRIPTION

**Description**

This pull request fixes 3 links towards astropy objects into docstrings.
