### PR TITLE
Remove operations with quantity in gammapy.maps 

### DIFF
--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -707,7 +707,7 @@ class IRFMap:
         """Get nearest valid position."""
         is_valid = np.nan_to_num(self.mask_safe_image.get_by_coord(position))[0]
 
-        if not is_valid and np.any(self.mask_safe_image > 0):
+        if not is_valid and np.any(self.mask_safe_image.data > 0):
             log.warning(
                 f"Position {position} is outside "
                 "valid IRF map range, using nearest IRF defined within"

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1879,13 +1879,13 @@ class Map(abc.ABC):
         if isinstance(other, Map):
             if self.geom != other.geom:
                 raise ValueError("Map Arithmetic: Inconsistent geometries.")
-            other_data = other.data
         else:
             other = u.Quantity(other, copy=COPY_IF_NEEDED)
 
         unit = None
-        if operator is [np.multiply, np.true_divide]:
+        if operator in [np.multiply, np.true_divide]:
             unit = operator(self.unit, other.unit)
+            other_data = other.data if isinstance(other, Map) else other.value
         else:
             other_data = (
                 other.to_unit(self.unit).data

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1865,18 +1865,21 @@ class Map(abc.ABC):
             f"\tdtype : {self.data.dtype}\n"
         )
 
-    def _arithmetics(self, operator, other, copy):
-        """Perform arithmetic on maps after checking geometry consistency."""
+    def _check_arithmetics(self, other):
+        """Checking geometry consistency."""
         if isinstance(other, Map):
-            if self.geom == other.geom:
-                q = other.quantity
-            else:
+            if self.geom != other.geom:
                 raise ValueError("Map Arithmetic: Inconsistent geometries.")
+            return other
         else:
-            q = u.Quantity(other, copy=COPY_IF_NEEDED)
+            return u.Quantity(other, copy=COPY_IF_NEEDED)
 
+    def _apply_arithmetics(self, operator, other_data, copy, unit=None):
+        """Perform arithmetic operation on the array objects and replace unit if needed."""
         out = self.copy() if copy else self
-        out.quantity = operator(out.quantity, q)
+        out.data = operator(out.data, other_data)
+        if unit:
+            out._unit = u.Unit(unit)
         return out
 
     def _boolean_arithmetics(self, operator, other, copy):
@@ -1897,46 +1900,96 @@ class Map(abc.ABC):
         return out
 
     def __add__(self, other):
-        return self._arithmetics(np.add, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.add, other_data, copy=True)
 
     def __iadd__(self, other):
-        return self._arithmetics(np.add, other, copy=COPY_IF_NEEDED)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.add, other_data, copy=COPY_IF_NEEDED)
 
     def __sub__(self, other):
-        return self._arithmetics(np.subtract, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.subtract, other_data, copy=True)
 
     def __isub__(self, other):
-        return self._arithmetics(np.subtract, other, copy=COPY_IF_NEEDED)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.subtract, other_data, copy=COPY_IF_NEEDED)
 
     def __mul__(self, other):
-        return self._arithmetics(np.multiply, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        new_unit = self._unit * other._unit
+        return self._apply_arithmetics(
+            np.multiply, other_data, copy=True, unit=new_unit
+        )
 
     def __imul__(self, other):
-        return self._arithmetics(np.multiply, other, copy=COPY_IF_NEEDED)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        new_unit = self._unit * other._unit
+        return self._apply_arithmetics(
+            np.multiply, other_data, copy=COPY_IF_NEEDED, unit=new_unit
+        )
 
     def __truediv__(self, other):
-        return self._arithmetics(np.true_divide, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        new_unit = self._unit / other._unit
+        return self._apply_arithmetics(
+            np.true_divide, other_data, copy=True, unit=new_unit
+        )
 
     def __itruediv__(self, other):
-        return self._arithmetics(np.true_divide, other, copy=COPY_IF_NEEDED)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        new_unit = self._unit / other._unit
+        return self._apply_arithmetics(
+            np.true_divide, other_data, copy=COPY_IF_NEEDED, unit=new_unit
+        )
 
     def __le__(self, other):
-        return self._arithmetics(np.less_equal, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.less_equal, other_data, copy=True)
 
     def __lt__(self, other):
-        return self._arithmetics(np.less, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.less, other_data, copy=True)
 
     def __ge__(self, other):
-        return self._arithmetics(np.greater_equal, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.greater_equal, other_data, copy=True)
 
     def __gt__(self, other):
-        return self._arithmetics(np.greater, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.greater, other_data, copy=True)
 
     def __eq__(self, other):
-        return self._arithmetics(np.equal, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.equal, other_data, copy=True)
 
     def __ne__(self, other):
-        return self._arithmetics(np.not_equal, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.not_equal, other_data, copy=True)
 
     def __and__(self, other):
         return self._boolean_arithmetics(np.logical_and, other, copy=True)

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1820,8 +1820,13 @@ class Map(abc.ABC):
         map : `Map`
             Map with new unit and converted data.
         """
-        data = self.quantity.to_value(unit)
-        return self.from_geom(self.geom, data=data, unit=unit)
+        unit = u.Unit(unit)
+        # TODO: this supports only simple scalings: use Unit.get_converter() in astropy>=6.1
+        try:
+            scale = self.unit._to(unit)
+        except u.UnitsError:
+            raise u.UnitConversionError(f"Cannot scale {self.unit} to {unit}")
+        return self.from_geom(self.geom, data=self.data * scale, unit=unit)
 
     def is_allclose(self, other, rtol_axes=1e-3, atol_axes=1e-6, **kwargs):
         """Compare two Maps for close equivalency.
@@ -1869,21 +1874,29 @@ class Map(abc.ABC):
             f"\tdtype : {self.data.dtype}\n"
         )
 
-    def _check_arithmetics(self, other):
-        """Checking geometry consistency."""
+    def _apply_arithmetics(self, operator, other, copy):
+        """Perform arithmetic operation on the array objects and replace unit if needed."""
         if isinstance(other, Map):
             if self.geom != other.geom:
                 raise ValueError("Map Arithmetic: Inconsistent geometries.")
-            return other
+            other_data = other.data
         else:
-            return u.Quantity(other, copy=COPY_IF_NEEDED)
+            other = u.Quantity(other, copy=COPY_IF_NEEDED)
 
-    def _apply_arithmetics(self, operator, other_data, copy, unit=None):
-        """Perform arithmetic operation on the array objects and replace unit if needed."""
+        unit = None
+        if operator is [np.multiply, np.true_divide]:
+            unit = operator(self.unit, other.unit)
+        else:
+            other_data = (
+                other.to_unit(self.unit).data
+                if isinstance(other, Map)
+                else other.to_value(self.unit)
+            )
+
         out = self.copy() if copy else self
         out.data = operator(out.data, other_data)
         if unit:
-            out._unit = u.Unit(unit)
+            out._unit = unit
         return out
 
     def _boolean_arithmetics(self, operator, other, copy):
@@ -1904,96 +1917,46 @@ class Map(abc.ABC):
         return out
 
     def __add__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.add, other_data, copy=True)
+        return self._apply_arithmetics(np.add, other, copy=True)
 
     def __iadd__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.add, other_data, copy=COPY_IF_NEEDED)
+        return self._apply_arithmetics(np.add, other, copy=False)
 
     def __sub__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.subtract, other_data, copy=True)
+        return self._apply_arithmetics(np.subtract, other, copy=True)
 
     def __isub__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.subtract, other_data, copy=COPY_IF_NEEDED)
+        return self._apply_arithmetics(np.subtract, other, copy=False)
 
     def __mul__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        new_unit = self._unit * other._unit
-        return self._apply_arithmetics(
-            np.multiply, other_data, copy=True, unit=new_unit
-        )
+        return self._apply_arithmetics(np.multiply, other, copy=True)
 
     def __imul__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        new_unit = self._unit * other._unit
-        return self._apply_arithmetics(
-            np.multiply, other_data, copy=COPY_IF_NEEDED, unit=new_unit
-        )
+        return self._apply_arithmetics(np.multiply, other, copy=False)
 
     def __truediv__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        new_unit = self._unit / other._unit
-        return self._apply_arithmetics(
-            np.true_divide, other_data, copy=True, unit=new_unit
-        )
+        return self._apply_arithmetics(np.true_divide, other, copy=True)
 
     def __itruediv__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        new_unit = self._unit / other._unit
-        return self._apply_arithmetics(
-            np.true_divide, other_data, copy=COPY_IF_NEEDED, unit=new_unit
-        )
+        return self._apply_arithmetics(np.true_divide, other, copy=False)
 
     def __le__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.less_equal, other_data, copy=True)
+        return self._apply_arithmetics(np.less_equal, other, copy=True)
 
     def __lt__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.less, other_data, copy=True)
+        return self._apply_arithmetics(np.less, other, copy=True)
 
     def __ge__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.greater_equal, other_data, copy=True)
+        return self._apply_arithmetics(np.greater_equal, other, copy=True)
 
     def __gt__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.greater, other_data, copy=True)
+        return self._apply_arithmetics(np.greater, other, copy=True)
 
     def __eq__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.equal, other_data, copy=True)
+        return self._apply_arithmetics(np.equal, other, copy=True)
 
     def __ne__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.not_equal, other_data, copy=True)
+        return self._apply_arithmetics(np.not_equal, other, copy=True)
 
     def __and__(self, other):
         return self._boolean_arithmetics(np.logical_and, other, copy=True)

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1626,11 +1626,12 @@ class Map(abc.ABC):
         shape = [1] * len(self.geom.data_shape)
         shape[axis_idx] = -1
 
-        values = self.quantity * axis.bin_width.reshape(shape)
-
+        values = self.data * axis.bin_width.value.reshape(shape)
+        unit = self.unit * axis.unit
         if axis_name == "rad":
             # take Jacobian into account
-            values = 2 * np.pi * axis.center.reshape(shape) * values
+            values = 2 * np.pi * axis.center.value.reshape(shape) * values
+            unit *= axis.unit
 
         data = np.insert(values.cumsum(axis=axis_idx), 0, 0, axis=axis_idx)
 
@@ -1639,7 +1640,7 @@ class Map(abc.ABC):
         )
         axes = self.geom.axes.replace(axis_shifted)
         geom = self.geom.to_image().to_cube(axes)
-        return self.__class__(geom=geom, data=data.value, unit=data.unit)
+        return self.__class__(geom=geom, data=data, unit=unit)
 
     def integral(self, axis_name, coords, **kwargs):
         """Compute integral along a given axis.
@@ -1674,13 +1675,15 @@ class Map(abc.ABC):
         axis_name : str, optional
             Along which axis to normalise.
         """
-        cumsum = self.cumsum(axis_name=axis_name).quantity
+        cumsum = self.cumsum(axis_name=axis_name)
 
         with np.errstate(invalid="ignore", divide="ignore"):
             axis = self.geom.axes.index_data(axis_name=axis_name)
-            normed = self.quantity / cumsum.max(axis=axis, keepdims=True)
+            normed = self.data / cumsum.data.max(axis=axis, keepdims=True)
+            unit = self.unit / cumsum.unit
 
-        self.quantity = np.nan_to_num(normed)
+        self.data = np.nan_to_num(normed)
+        self._unit = unit
 
     @classmethod
     def from_stack(cls, maps, axis=None, axis_name=None):

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -7,6 +7,7 @@ import json
 from collections import OrderedDict
 from itertools import repeat
 import numpy as np
+from numpy import ndindex
 from astropy import units as u
 from astropy.io import fits
 import matplotlib.pyplot as plt
@@ -471,7 +472,7 @@ class Map(abc.ABC):
         --------
         iter_by_image_data : iterate by image returning data and index.
         """
-        for idx in np.ndindex(self.geom.shape_axes):
+        for idx in ndindex(self.geom.shape_axes):
             if keepdims:
                 names = self.geom.axes.names
                 slices = {name: slice(_, _ + 1) for name, _ in zip(names, idx)}
@@ -495,7 +496,7 @@ class Map(abc.ABC):
         --------
         iter_by_image : iterate by image returning a map.
         """
-        for idx in np.ndindex(self.geom.shape_axes):
+        for idx in ndindex(self.geom.shape_axes):
             yield self.data[idx[::-1]], idx[::-1]
 
     def iter_by_image_index(self):
@@ -513,7 +514,7 @@ class Map(abc.ABC):
         --------
         iter_by_image : iterate by image returning a map.
         """
-        for idx in np.ndindex(self.geom.shape_axes):
+        for idx in ndindex(self.geom.shape_axes):
             yield idx[::-1]
 
     def coadd(self, map_in, weights=None):
@@ -1177,7 +1178,7 @@ class Map(abc.ABC):
             ),
             task_name="Reprojection",
         )
-        for idx in np.ndindex(self.geom.shape_axes):
+        for idx in ndindex(self.geom.shape_axes):
             output_map.data[idx[0]] = maps[idx[0]].data
         return output_map
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1874,7 +1874,7 @@ class Map(abc.ABC):
             f"\tdtype : {self.data.dtype}\n"
         )
 
-    def _apply_arithmetics(self, operator, other, copy):
+    def _arithmetics(self, operator, other, copy):
         """Perform arithmetic operation on the array objects and replace unit if needed."""
         if isinstance(other, Map):
             if self.geom != other.geom:
@@ -1917,46 +1917,46 @@ class Map(abc.ABC):
         return out
 
     def __add__(self, other):
-        return self._apply_arithmetics(np.add, other, copy=True)
+        return self._arithmetics(np.add, other, copy=True)
 
     def __iadd__(self, other):
-        return self._apply_arithmetics(np.add, other, copy=False)
+        return self._arithmetics(np.add, other, copy=False)
 
     def __sub__(self, other):
-        return self._apply_arithmetics(np.subtract, other, copy=True)
+        return self._arithmetics(np.subtract, other, copy=True)
 
     def __isub__(self, other):
-        return self._apply_arithmetics(np.subtract, other, copy=False)
+        return self._arithmetics(np.subtract, other, copy=False)
 
     def __mul__(self, other):
-        return self._apply_arithmetics(np.multiply, other, copy=True)
+        return self._arithmetics(np.multiply, other, copy=True)
 
     def __imul__(self, other):
-        return self._apply_arithmetics(np.multiply, other, copy=False)
+        return self._arithmetics(np.multiply, other, copy=False)
 
     def __truediv__(self, other):
-        return self._apply_arithmetics(np.true_divide, other, copy=True)
+        return self._arithmetics(np.true_divide, other, copy=True)
 
     def __itruediv__(self, other):
-        return self._apply_arithmetics(np.true_divide, other, copy=False)
+        return self._arithmetics(np.true_divide, other, copy=False)
 
     def __le__(self, other):
-        return self._apply_arithmetics(np.less_equal, other, copy=True)
+        return self._arithmetics(np.less_equal, other, copy=True)
 
     def __lt__(self, other):
-        return self._apply_arithmetics(np.less, other, copy=True)
+        return self._arithmetics(np.less, other, copy=True)
 
     def __ge__(self, other):
-        return self._apply_arithmetics(np.greater_equal, other, copy=True)
+        return self._arithmetics(np.greater_equal, other, copy=True)
 
     def __gt__(self, other):
-        return self._apply_arithmetics(np.greater, other, copy=True)
+        return self._arithmetics(np.greater, other, copy=True)
 
     def __eq__(self, other):
-        return self._apply_arithmetics(np.equal, other, copy=True)
+        return self._arithmetics(np.equal, other, copy=True)
 
     def __ne__(self, other):
-        return self._apply_arithmetics(np.not_equal, other, copy=True)
+        return self._arithmetics(np.not_equal, other, copy=True)
 
     def __and__(self, other):
         return self._boolean_arithmetics(np.logical_and, other, copy=True)

--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -431,7 +431,7 @@ class HpxNDMap(HpxMap):
                 "Can only stack equivalent maps or cutout of the same map."
             )
 
-        data = other.quantity.to_value(self.unit)
+        data = other.data * other.unit.to(self.unit)
 
         if nan_to_num:
             not_finite = ~np.isfinite(data)

--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -431,7 +431,12 @@ class HpxNDMap(HpxMap):
                 "Can only stack equivalent maps or cutout of the same map."
             )
 
-        data = other.data * other.unit.to(self.unit)
+        if not self.unit.is_equivalent(other.unit):
+            raise ValueError(
+                f"Cannot stack maps: {self.unit} and {other.unit} are not equivalent."
+            )
+
+        data = (other.data * other.unit.to(self.unit)).astype(self.data.dtype)
 
         if nan_to_num:
             not_finite = ~np.isfinite(data)

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -691,7 +691,7 @@ class RegionNDMap(Map):
             Non-finite values are replaced by zero if True.
             Default is True.
         """
-        data = other.quantity.to_value(self.unit).astype(self.data.dtype)
+        data = (other.data * other.unit.to(self.unit)).astype(self.data.dtype)
 
         # TODO: re-think stacking of regions. Is making the union reasonable?
         # self.geom.union(other.geom)

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -1077,7 +1077,16 @@ class WcsNDMap(WcsMap):
                 "Can only stack equivalent maps or cutout of the same map."
             )
 
-        data = other.quantity[cutout_slices].to_value(self.unit)
+        if not self.unit.is_equivalent(other.unit):
+            raise ValueError(
+                f"Cannot stack maps: {self.unit} and {other.unit} are not equivalent."
+            )
+
+        data = other.data[cutout_slices]
+
+        if self.unit != "":
+            data = data * other.unit.to(self.unit)
+
         if nan_to_num:
             not_finite = ~np.isfinite(data)
             if np.any(not_finite):

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -1043,7 +1043,7 @@ class WcsNDMap(WcsMap):
         parent_slices = Ellipsis, slices[0], slices[1]
 
         return self.__class__.from_geom(
-            geom=geom_cutout, data=self.quantity[parent_slices]
+            geom=geom_cutout, data=self.data[parent_slices], unit=self.unit
         )
 
     def stack(self, other, weights=None, nan_to_num=True):

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -1084,8 +1084,7 @@ class WcsNDMap(WcsMap):
 
         data = other.data[cutout_slices]
 
-        if self.unit != "":
-            data = data * other.unit.to(self.unit)
+        data = (data * other.unit.to(self.unit)).astype(self.data.dtype)
 
         if nan_to_num:
             not_finite = ~np.isfinite(data)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request is a draft to try to separate unit and array handling in `gammapy.maps`. This is motivated by a possible usage of different tensors libraries instead of `numpy.ndarray`. Because astropy `Quantity` is a `ndarray` subclass, it is not possible to manipulate other tensors in `Map` without converting to `ndarray` when relying on `Map.quantity` for a number of operation.
This PR explores what needs to be done to separate array and unit handling. Currently this is likely causing problem if the unit conversion is not a simple scaling. But I am not sure we really use other types of unit conversions.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This is the