### PR TITLE
Backport PR #5271: Allow extrapolation only along spatial dimension in `mask_safe_edisp`

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -700,10 +700,17 @@ class MapDataset(Dataset):
 
         if "migra" in geom.axes.names:
             geom = geom.squash("migra")
-            mask_safe_edisp = self.mask_safe_image.interp_to_geom(geom.to_image())
+            mask_safe_edisp = self.mask_safe_image.interp_to_geom(
+                geom.to_image(), fill_value=None
+            )
             return mask_safe_edisp.to_cube(geom.axes)
 
-        return self.mask_safe.interp_to_geom(geom)
+        # allow extrapolation only along spatial dimension
+        # to support case where mask_safe geom and irfs geom are different
+        geom_same_axes = geom.to_image().to_cube(self.mask_safe.geom.axes)
+        mask_safe_edisp = self.mask_safe.interp_to_geom(geom_same_axes, fill_value=None)
+        mask_safe_edisp = mask_safe_edisp.interp_to_geom(geom)
+        return mask_safe_edisp
 
     def to_masked(self, name=None, nan_to_num=True):
         """Return masked dataset.

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -431,6 +431,24 @@ def test_interp_to_geom():
     assert isinstance(interp_wcs_map, WcsNDMap)
     assert interp_wcs_map.geom == wcs_geom_target
 
+    # WcsNDMap is_mask
+    geom_wcs = WcsGeom.create(
+        npix=(5, 3), proj="CAR", binsz=0.1, axes=[energy], skydir=(0, 0)
+    )
+
+    wcs_map = Map.from_geom(geom_wcs, unit="", data=True)
+    wcs_geom_target = WcsGeom.create(
+        skydir=(30, 30),
+        width=(10, 10),
+        binsz=0.1 * u.deg,
+        axes=[energy_target],
+        frame="galactic",
+    )
+    interp_wcs_map = wcs_map.interp_to_geom(
+        wcs_geom_target, method="linear", fill_value=None
+    )
+    assert np.all(interp_wcs_map.data)
+
     # HpxNDMap
     geom_hpx = HpxGeom.create(binsz=60, axes=[energy], skydir=(0, 0))
     hpx_map = Map.from_geom(geom_hpx, unit="")


### PR DESCRIPTION
Backport PR #5271