### PR TITLE
Coherent units in `TemporalModel.sample_time`

### DIFF
--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -198,7 +198,7 @@ class TemporalModel(ModelBase):
         t_delta = u.Quantity(t_delta)
         random_state = get_random_state(random_state)
 
-        ontime = u.Quantity((t_max - t_min).sec, t_delta.to("s").unit)
+        ontime = (t_max - t_min).to("s")
         n_step = (ontime / t_delta).to_value("").item()
         t_step = ontime / n_step
 

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -198,7 +198,7 @@ class TemporalModel(ModelBase):
         t_delta = u.Quantity(t_delta)
         random_state = get_random_state(random_state)
 
-        ontime = u.Quantity((t_max - t_min).sec, t_delta.unit)
+        ontime = u.Quantity((t_max - t_min).sec, t_delta.to("s").unit)
         n_step = (ontime / t_delta).to_value("").item()
         t_step = ontime / n_step
 


### PR DESCRIPTION
This is a very minimal fix to preserve units coherence in the `TemporalModel.sample_time`. 

The time sampling is indeed performed over a number of time bins which is calculated internally on the basis of the `ontime` and the `t_delta`. 
In the current version, the `ontime` is calculated in seconds but it takes the units from `t_delta`. The latter is by default in seconds, but it can be passed by the user. 
If the units of `ontime` and `t_delta` are not consistent, this introduces an issue.