### PR TITLE
[JAX prototype]: Get npred as jax  array

### DIFF
--- a/gammapy/datasets/utils.py
+++ b/gammapy/datasets/utils.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import numpy as np
 from astropy.coordinates import SkyCoord
+import jax.numpy as np
 from gammapy.maps import Map
 from gammapy.modeling.models.utils import cutout_template_models
 from . import Datasets
@@ -57,7 +57,8 @@ def apply_edisp(input_map, edisp):
     if edisp is not None:
         loc = input_map.geom.axes.index("energy_true")
         data = np.rollaxis(input_map.data, loc, len(input_map.data.shape))
-        data = np.dot(data, edisp.pdf_matrix)
+        data_edisp = np.array(edisp.pdf_matrix)
+        data = np.dot(data, data_edisp)
         data = np.rollaxis(data, -1, loc)
         energy_axis = edisp.axes["energy"].copy(name="energy")
     else:

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -707,7 +707,7 @@ class IRFMap:
         """Get nearest valid position."""
         is_valid = np.nan_to_num(self.mask_safe_image.get_by_coord(position))[0]
 
-        if not is_valid and np.any(self.mask_safe_image > 0):
+        if not is_valid and np.any(self.mask_safe_image.data > 0):
             log.warning(
                 f"Position {position} is outside "
                 "valid IRF map range, using nearest IRF defined within"

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1879,13 +1879,13 @@ class Map(abc.ABC):
         if isinstance(other, Map):
             if self.geom != other.geom:
                 raise ValueError("Map Arithmetic: Inconsistent geometries.")
-            other_data = other.data
         else:
             other = u.Quantity(other, copy=COPY_IF_NEEDED)
 
         unit = None
-        if operator is [np.multiply, np.true_divide]:
+        if operator in [np.multiply, np.true_divide]:
             unit = operator(self.unit, other.unit)
+            other_data = other.data if isinstance(other, Map) else other.value
         else:
             other_data = (
                 other.to_unit(self.unit).data

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1865,18 +1865,21 @@ class Map(abc.ABC):
             f"\tdtype : {self.data.dtype}\n"
         )
 
-    def _arithmetics(self, operator, other, copy):
-        """Perform arithmetic on maps after checking geometry consistency."""
+    def _check_arithmetics(self, other):
+        """Checking geometry consistency."""
         if isinstance(other, Map):
-            if self.geom == other.geom:
-                q = other.quantity
-            else:
+            if self.geom != other.geom:
                 raise ValueError("Map Arithmetic: Inconsistent geometries.")
+            return other
         else:
-            q = u.Quantity(other, copy=COPY_IF_NEEDED)
+            return u.Quantity(other, copy=COPY_IF_NEEDED)
 
+    def _apply_arithmetics(self, operator, other_data, copy, unit=None):
+        """Perform arithmetic operation on the array objects and replace unit if needed."""
         out = self.copy() if copy else self
-        out.quantity = operator(out.quantity, q)
+        out.data = operator(out.data, other_data)
+        if unit:
+            out._unit = u.Unit(unit)
         return out
 
     def _boolean_arithmetics(self, operator, other, copy):
@@ -1897,46 +1900,96 @@ class Map(abc.ABC):
         return out
 
     def __add__(self, other):
-        return self._arithmetics(np.add, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.add, other_data, copy=True)
 
     def __iadd__(self, other):
-        return self._arithmetics(np.add, other, copy=COPY_IF_NEEDED)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.add, other_data, copy=COPY_IF_NEEDED)
 
     def __sub__(self, other):
-        return self._arithmetics(np.subtract, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.subtract, other_data, copy=True)
 
     def __isub__(self, other):
-        return self._arithmetics(np.subtract, other, copy=COPY_IF_NEEDED)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.subtract, other_data, copy=COPY_IF_NEEDED)
 
     def __mul__(self, other):
-        return self._arithmetics(np.multiply, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        new_unit = self._unit * other._unit
+        return self._apply_arithmetics(
+            np.multiply, other_data, copy=True, unit=new_unit
+        )
 
     def __imul__(self, other):
-        return self._arithmetics(np.multiply, other, copy=COPY_IF_NEEDED)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        new_unit = self._unit * other._unit
+        return self._apply_arithmetics(
+            np.multiply, other_data, copy=COPY_IF_NEEDED, unit=new_unit
+        )
 
     def __truediv__(self, other):
-        return self._arithmetics(np.true_divide, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        new_unit = self._unit / other._unit
+        return self._apply_arithmetics(
+            np.true_divide, other_data, copy=True, unit=new_unit
+        )
 
     def __itruediv__(self, other):
-        return self._arithmetics(np.true_divide, other, copy=COPY_IF_NEEDED)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        new_unit = self._unit / other._unit
+        return self._apply_arithmetics(
+            np.true_divide, other_data, copy=COPY_IF_NEEDED, unit=new_unit
+        )
 
     def __le__(self, other):
-        return self._arithmetics(np.less_equal, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.less_equal, other_data, copy=True)
 
     def __lt__(self, other):
-        return self._arithmetics(np.less, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.less, other_data, copy=True)
 
     def __ge__(self, other):
-        return self._arithmetics(np.greater_equal, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.greater_equal, other_data, copy=True)
 
     def __gt__(self, other):
-        return self._arithmetics(np.greater, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.greater, other_data, copy=True)
 
     def __eq__(self, other):
-        return self._arithmetics(np.equal, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.equal, other_data, copy=True)
 
     def __ne__(self, other):
-        return self._arithmetics(np.not_equal, other, copy=True)
+        other = self._check_arithmetics(other)
+        other_data = other.data if isinstance(other, Map) else other.value
+        other_data = other_data * other._unit.to(self._unit)
+        return self._apply_arithmetics(np.not_equal, other_data, copy=True)
 
     def __and__(self, other):
         return self._boolean_arithmetics(np.logical_and, other, copy=True)

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1820,8 +1820,13 @@ class Map(abc.ABC):
         map : `Map`
             Map with new unit and converted data.
         """
-        data = self.quantity.to_value(unit)
-        return self.from_geom(self.geom, data=data, unit=unit)
+        unit = u.Unit(unit)
+        # TODO: this supports only simple scalings: use Unit.get_converter() in astropy>=6.1
+        try:
+            scale = self.unit._to(unit)
+        except u.UnitsError:
+            raise u.UnitConversionError(f"Cannot scale {self.unit} to {unit}")
+        return self.from_geom(self.geom, data=self.data * scale, unit=unit)
 
     def is_allclose(self, other, rtol_axes=1e-3, atol_axes=1e-6, **kwargs):
         """Compare two Maps for close equivalency.
@@ -1869,21 +1874,29 @@ class Map(abc.ABC):
             f"\tdtype : {self.data.dtype}\n"
         )
 
-    def _check_arithmetics(self, other):
-        """Checking geometry consistency."""
+    def _apply_arithmetics(self, operator, other, copy):
+        """Perform arithmetic operation on the array objects and replace unit if needed."""
         if isinstance(other, Map):
             if self.geom != other.geom:
                 raise ValueError("Map Arithmetic: Inconsistent geometries.")
-            return other
+            other_data = other.data
         else:
-            return u.Quantity(other, copy=COPY_IF_NEEDED)
+            other = u.Quantity(other, copy=COPY_IF_NEEDED)
 
-    def _apply_arithmetics(self, operator, other_data, copy, unit=None):
-        """Perform arithmetic operation on the array objects and replace unit if needed."""
+        unit = None
+        if operator is [np.multiply, np.true_divide]:
+            unit = operator(self.unit, other.unit)
+        else:
+            other_data = (
+                other.to_unit(self.unit).data
+                if isinstance(other, Map)
+                else other.to_value(self.unit)
+            )
+
         out = self.copy() if copy else self
         out.data = operator(out.data, other_data)
         if unit:
-            out._unit = u.Unit(unit)
+            out._unit = unit
         return out
 
     def _boolean_arithmetics(self, operator, other, copy):
@@ -1904,96 +1917,46 @@ class Map(abc.ABC):
         return out
 
     def __add__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.add, other_data, copy=True)
+        return self._apply_arithmetics(np.add, other, copy=True)
 
     def __iadd__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.add, other_data, copy=COPY_IF_NEEDED)
+        return self._apply_arithmetics(np.add, other, copy=False)
 
     def __sub__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.subtract, other_data, copy=True)
+        return self._apply_arithmetics(np.subtract, other, copy=True)
 
     def __isub__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.subtract, other_data, copy=COPY_IF_NEEDED)
+        return self._apply_arithmetics(np.subtract, other, copy=False)
 
     def __mul__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        new_unit = self._unit * other._unit
-        return self._apply_arithmetics(
-            np.multiply, other_data, copy=True, unit=new_unit
-        )
+        return self._apply_arithmetics(np.multiply, other, copy=True)
 
     def __imul__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        new_unit = self._unit * other._unit
-        return self._apply_arithmetics(
-            np.multiply, other_data, copy=COPY_IF_NEEDED, unit=new_unit
-        )
+        return self._apply_arithmetics(np.multiply, other, copy=False)
 
     def __truediv__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        new_unit = self._unit / other._unit
-        return self._apply_arithmetics(
-            np.true_divide, other_data, copy=True, unit=new_unit
-        )
+        return self._apply_arithmetics(np.true_divide, other, copy=True)
 
     def __itruediv__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        new_unit = self._unit / other._unit
-        return self._apply_arithmetics(
-            np.true_divide, other_data, copy=COPY_IF_NEEDED, unit=new_unit
-        )
+        return self._apply_arithmetics(np.true_divide, other, copy=False)
 
     def __le__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.less_equal, other_data, copy=True)
+        return self._apply_arithmetics(np.less_equal, other, copy=True)
 
     def __lt__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.less, other_data, copy=True)
+        return self._apply_arithmetics(np.less, other, copy=True)
 
     def __ge__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.greater_equal, other_data, copy=True)
+        return self._apply_arithmetics(np.greater_equal, other, copy=True)
 
     def __gt__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.greater, other_data, copy=True)
+        return self._apply_arithmetics(np.greater, other, copy=True)
 
     def __eq__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.equal, other_data, copy=True)
+        return self._apply_arithmetics(np.equal, other, copy=True)
 
     def __ne__(self, other):
-        other = self._check_arithmetics(other)
-        other_data = other.data if isinstance(other, Map) else other.value
-        other_data = other_data * other._unit.to(self._unit)
-        return self._apply_arithmetics(np.not_equal, other_data, copy=True)
+        return self._apply_arithmetics(np.not_equal, other, copy=True)
 
     def __and__(self, other):
         return self._boolean_arithmetics(np.logical_and, other, copy=True)

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1626,11 +1626,12 @@ class Map(abc.ABC):
         shape = [1] * len(self.geom.data_shape)
         shape[axis_idx] = -1
 
-        values = self.quantity * axis.bin_width.reshape(shape)
-
+        values = self.data * axis.bin_width.value.reshape(shape)
+        unit = self.unit * axis.unit
         if axis_name == "rad":
             # take Jacobian into account
-            values = 2 * np.pi * axis.center.reshape(shape) * values
+            values = 2 * np.pi * axis.center.value.reshape(shape) * values
+            unit *= axis.unit
 
         data = np.insert(values.cumsum(axis=axis_idx), 0, 0, axis=axis_idx)
 
@@ -1639,7 +1640,7 @@ class Map(abc.ABC):
         )
         axes = self.geom.axes.replace(axis_shifted)
         geom = self.geom.to_image().to_cube(axes)
-        return self.__class__(geom=geom, data=data.value, unit=data.unit)
+        return self.__class__(geom=geom, data=data, unit=unit)
 
     def integral(self, axis_name, coords, **kwargs):
         """Compute integral along a given axis.
@@ -1674,13 +1675,15 @@ class Map(abc.ABC):
         axis_name : str, optional
             Along which axis to normalise.
         """
-        cumsum = self.cumsum(axis_name=axis_name).quantity
+        cumsum = self.cumsum(axis_name=axis_name)
 
         with np.errstate(invalid="ignore", divide="ignore"):
             axis = self.geom.axes.index_data(axis_name=axis_name)
-            normed = self.quantity / cumsum.max(axis=axis, keepdims=True)
+            normed = self.data / cumsum.data.max(axis=axis, keepdims=True)
+            unit = self.unit / cumsum.unit
 
-        self.quantity = np.nan_to_num(normed)
+        self.data = np.nan_to_num(normed)
+        self._unit = unit
 
     @classmethod
     def from_stack(cls, maps, axis=None, axis_name=None):

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -7,6 +7,7 @@ import json
 from collections import OrderedDict
 from itertools import repeat
 import numpy as np
+from numpy import ndindex
 from astropy import units as u
 from astropy.io import fits
 import matplotlib.pyplot as plt
@@ -471,7 +472,7 @@ class Map(abc.ABC):
         --------
         iter_by_image_data : iterate by image returning data and index.
         """
-        for idx in np.ndindex(self.geom.shape_axes):
+        for idx in ndindex(self.geom.shape_axes):
             if keepdims:
                 names = self.geom.axes.names
                 slices = {name: slice(_, _ + 1) for name, _ in zip(names, idx)}
@@ -495,7 +496,7 @@ class Map(abc.ABC):
         --------
         iter_by_image : iterate by image returning a map.
         """
-        for idx in np.ndindex(self.geom.shape_axes):
+        for idx in ndindex(self.geom.shape_axes):
             yield self.data[idx[::-1]], idx[::-1]
 
     def iter_by_image_index(self):
@@ -513,7 +514,7 @@ class Map(abc.ABC):
         --------
         iter_by_image : iterate by image returning a map.
         """
-        for idx in np.ndindex(self.geom.shape_axes):
+        for idx in ndindex(self.geom.shape_axes):
             yield idx[::-1]
 
     def coadd(self, map_in, weights=None):
@@ -1177,7 +1178,7 @@ class Map(abc.ABC):
             ),
             task_name="Reprojection",
         )
-        for idx in np.ndindex(self.geom.shape_axes):
+        for idx in ndindex(self.geom.shape_axes):
             output_map.data[idx[0]] = maps[idx[0]].data
         return output_map
 

--- a/gammapy/maps/core.py
+++ b/gammapy/maps/core.py
@@ -1874,7 +1874,7 @@ class Map(abc.ABC):
             f"\tdtype : {self.data.dtype}\n"
         )
 
-    def _apply_arithmetics(self, operator, other, copy):
+    def _arithmetics(self, operator, other, copy):
         """Perform arithmetic operation on the array objects and replace unit if needed."""
         if isinstance(other, Map):
             if self.geom != other.geom:
@@ -1917,46 +1917,46 @@ class Map(abc.ABC):
         return out
 
     def __add__(self, other):
-        return self._apply_arithmetics(np.add, other, copy=True)
+        return self._arithmetics(np.add, other, copy=True)
 
     def __iadd__(self, other):
-        return self._apply_arithmetics(np.add, other, copy=False)
+        return self._arithmetics(np.add, other, copy=False)
 
     def __sub__(self, other):
-        return self._apply_arithmetics(np.subtract, other, copy=True)
+        return self._arithmetics(np.subtract, other, copy=True)
 
     def __isub__(self, other):
-        return self._apply_arithmetics(np.subtract, other, copy=False)
+        return self._arithmetics(np.subtract, other, copy=False)
 
     def __mul__(self, other):
-        return self._apply_arithmetics(np.multiply, other, copy=True)
+        return self._arithmetics(np.multiply, other, copy=True)
 
     def __imul__(self, other):
-        return self._apply_arithmetics(np.multiply, other, copy=False)
+        return self._arithmetics(np.multiply, other, copy=False)
 
     def __truediv__(self, other):
-        return self._apply_arithmetics(np.true_divide, other, copy=True)
+        return self._arithmetics(np.true_divide, other, copy=True)
 
     def __itruediv__(self, other):
-        return self._apply_arithmetics(np.true_divide, other, copy=False)
+        return self._arithmetics(np.true_divide, other, copy=False)
 
     def __le__(self, other):
-        return self._apply_arithmetics(np.less_equal, other, copy=True)
+        return self._arithmetics(np.less_equal, other, copy=True)
 
     def __lt__(self, other):
-        return self._apply_arithmetics(np.less, other, copy=True)
+        return self._arithmetics(np.less, other, copy=True)
 
     def __ge__(self, other):
-        return self._apply_arithmetics(np.greater_equal, other, copy=True)
+        return self._arithmetics(np.greater_equal, other, copy=True)
 
     def __gt__(self, other):
-        return self._apply_arithmetics(np.greater, other, copy=True)
+        return self._arithmetics(np.greater, other, copy=True)
 
     def __eq__(self, other):
-        return self._apply_arithmetics(np.equal, other, copy=True)
+        return self._arithmetics(np.equal, other, copy=True)
 
     def __ne__(self, other):
-        return self._apply_arithmetics(np.not_equal, other, copy=True)
+        return self._arithmetics(np.not_equal, other, copy=True)
 
     def __and__(self, other):
         return self._boolean_arithmetics(np.logical_and, other, copy=True)

--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -431,7 +431,7 @@ class HpxNDMap(HpxMap):
                 "Can only stack equivalent maps or cutout of the same map."
             )
 
-        data = other.quantity.to_value(self.unit)
+        data = other.data * other.unit.to(self.unit)
 
         if nan_to_num:
             not_finite = ~np.isfinite(data)

--- a/gammapy/maps/hpx/ndmap.py
+++ b/gammapy/maps/hpx/ndmap.py
@@ -431,7 +431,12 @@ class HpxNDMap(HpxMap):
                 "Can only stack equivalent maps or cutout of the same map."
             )
 
-        data = other.data * other.unit.to(self.unit)
+        if not self.unit.is_equivalent(other.unit):
+            raise ValueError(
+                f"Cannot stack maps: {self.unit} and {other.unit} are not equivalent."
+            )
+
+        data = (other.data * other.unit.to(self.unit)).astype(self.data.dtype)
 
         if nan_to_num:
             not_finite = ~np.isfinite(data)

--- a/gammapy/maps/region/ndmap.py
+++ b/gammapy/maps/region/ndmap.py
@@ -691,7 +691,7 @@ class RegionNDMap(Map):
             Non-finite values are replaced by zero if True.
             Default is True.
         """
-        data = other.quantity.to_value(self.unit).astype(self.data.dtype)
+        data = (other.data * other.unit.to(self.unit)).astype(self.data.dtype)
 
         # TODO: re-think stacking of regions. Is making the union reasonable?
         # self.geom.union(other.geom)

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -1077,7 +1077,16 @@ class WcsNDMap(WcsMap):
                 "Can only stack equivalent maps or cutout of the same map."
             )
 
-        data = other.quantity[cutout_slices].to_value(self.unit)
+        if not self.unit.is_equivalent(other.unit):
+            raise ValueError(
+                f"Cannot stack maps: {self.unit} and {other.unit} are not equivalent."
+            )
+
+        data = other.data[cutout_slices]
+
+        if self.unit != "":
+            data = data * other.unit.to(self.unit)
+
         if nan_to_num:
             not_finite = ~np.isfinite(data)
             if np.any(not_finite):

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -1043,7 +1043,7 @@ class WcsNDMap(WcsMap):
         parent_slices = Ellipsis, slices[0], slices[1]
 
         return self.__class__.from_geom(
-            geom=geom_cutout, data=self.quantity[parent_slices]
+            geom=geom_cutout, data=self.data[parent_slices], unit=self.unit
         )
 
     def stack(self, other, weights=None, nan_to_num=True):

--- a/gammapy/maps/wcs/ndmap.py
+++ b/gammapy/maps/wcs/ndmap.py
@@ -1084,8 +1084,7 @@ class WcsNDMap(WcsMap):
 
         data = other.data[cutout_slices]
 
-        if self.unit != "":
-            data = data * other.unit.to(self.unit)
+        data = (data * other.unit.to(self.unit)).astype(self.data.dtype)
 
         if nan_to_num:
             not_finite = ~np.isfinite(data)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -3,10 +3,10 @@
 
 import logging
 import os
-import numpy as np
 import astropy.units as u
 from astropy.nddata import NoOverlapError
 from astropy.time import Time
+import jax.numpy as np
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling import Covariance, Parameters
 from gammapy.modeling.parameter import _get_parameters_str
@@ -75,7 +75,7 @@ class SkyModel(ModelBase):
 
         self.apply_irf = apply_irf
         self.datasets_names = datasets_names
-        self._check_unit()
+        # self._check_unit()
 
         super().__init__(covariance_data=covariance_data)
 
@@ -384,10 +384,11 @@ class SkyModel(ModelBase):
             1,
         ]
         shape[geom.axes.index_data("energy_true")] = -1
-        value = self.spectral_model.integral(
+        value, unit = self.spectral_model.integral(
             energy[:-1],
             energy[1:],
-        ).reshape(shape)
+        )
+        value = value.reshape(shape)
 
         if self.spatial_model:
             value = (
@@ -402,7 +403,7 @@ class SkyModel(ModelBase):
 
         value = value * np.ones(geom.data_shape)
 
-        return Map.from_geom(geom=geom, data=value.value, unit=value.unit)
+        return Map.from_geom(geom=geom, data=value, unit=unit)
 
     def _compute_time_integral(self, value, geom, gti):
         """Multiply input value with time integral for the given geometry and GTI."""

--- a/jax_spectral.ipynb
+++ b/jax_spectral.ipynb
@@ -1,0 +1,685 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2b3a52a2-3282-456e-9ce8-27fe8f7c38ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.modeling.models import *\n",
+    "import astropy.units as u\n",
+    "from gammapy.maps import *\n",
+    "import jax.numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f249e60e-2c8b-4601-87cd-66cd65626cf7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = PowerLawSpectralModel()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6b6d4cb2-2f8e-4f84-9f8c-10951f309070",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_true = MapAxis.from_edges(\n",
+    "    np.logspace(-1, 1, 5), unit=\"TeV\", name=\"energy_true\", interp=\"log\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c48ad269-c687-478d-b96a-fce405309634",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$[0.17782794,~0.56234132,~1.7782794,~5.6234133] \\; \\mathrm{TeV}$"
+      ],
+      "text/plain": [
+       "<Quantity [0.17782794, 0.56234132, 1.77827942, 5.62341329] TeV>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "energy_true.center"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "695b9b39-3618-4a51-859f-54e1e5808291",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geom = RegionGeom.create(region=None, axes=[energy_true])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8c828002-82a8-4e20-9342-2800b8768ce3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array([1.0000000e-12, 1.1111111e-13], dtype=float32)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p.evaluate([1.0, 3.0]*u.TeV, p.index.quantity, p.amplitude.value, p.reference.quantity)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "77d21742-79e5-48f8-9c09-3cbe2809916d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array([3.1622777e-11, 3.1622775e-12, 3.1622776e-13, 3.1622779e-14],      dtype=float32)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p(energy_true.center)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f09578d4-fcc4-4364-ac77-d212eaa12079",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sk = SkyModel(spectral_model=p, name=\"model\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d8bca579-b655-4136-a189-9fd257a8cb98",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array([[[3.1622777e-11]],\n",
+       "\n",
+       "       [[3.1622775e-12]],\n",
+       "\n",
+       "       [[3.1622776e-13]],\n",
+       "\n",
+       "       [[3.1622779e-14]]], dtype=float32)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sk.evaluate_geom(geom)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "903012b6-369e-402c-9987-3d7eda485d60",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Array([6.8377222e-12, 2.1622777e-12, 6.8377221e-13, 2.1622777e-13],      dtype=float32),\n",
+       " Unit(\"1 / (s cm2)\"))"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p.integral(energy_true.edges[0:-1], energy_true.edges[1:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "dc494e5d-9b86-4f22-95d3-728a420a0ec7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre>RegionNDMap\n",
+       "\n",
+       "\tgeom  : RegionGeom \n",
+       " \taxes  : [&#x27;lon&#x27;, &#x27;lat&#x27;, &#x27;energy_true&#x27;]\n",
+       "\tshape : (1, 1, 4)\n",
+       "\tndim  : 3\n",
+       "\tunit  : 1 / (s cm2)\n",
+       "\tdtype : float32\n",
+       "</pre>"
+      ],
+      "text/plain": [
+       "<gammapy.maps.region.ndmap.RegionNDMap at 0x146931700>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sk.integrate_geom(geom)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cb5f247e-5aeb-4ce4-8fb9-73e2ddf82516",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.datasets import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "41ddc39c-d6a3-48d6-85d7-2063d9adae8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = SpectrumDatasetOnOff.read(\n",
+    "     \"$GAMMAPY_DATA/PKS2155-steady/pks2155-304_steady.fits.gz\", name=\"dataset\"\n",
+    " )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "f94c3906-862b-4deb-8b4f-db2ac5c68026",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre>RegionNDMap\n",
+       "\n",
+       "\tgeom  : RegionGeom \n",
+       " \taxes  : [&#x27;lon&#x27;, &#x27;lat&#x27;, &#x27;energy_true&#x27;]\n",
+       "\tshape : (1, 1, 25)\n",
+       "\tndim  : 3\n",
+       "\tunit  : m2 s\n",
+       "\tdtype : float32\n",
+       "</pre>"
+      ],
+      "text/plain": [
+       "<gammapy.maps.region.ndmap.RegionNDMap at 0x150351fd0>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset.exposure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "94c482aa-c69e-45e2-869a-c8484d61ed66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.models = Models([sk])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "6af8595a-fd6c-4353-a971-bc731ad47322",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre>RegionNDMap\n",
+       "\n",
+       "\tgeom  : RegionGeom \n",
+       " \taxes  : [&#x27;lon&#x27;, &#x27;lat&#x27;, &#x27;energy&#x27;]\n",
+       "\tshape : (1, 1, 10)\n",
+       "\tndim  : 3\n",
+       "\tunit  : \n",
+       "\tdtype : float32\n",
+       "</pre>"
+      ],
+      "text/plain": [
+       "<gammapy.maps.region.ndmap.RegionNDMap at 0x150fdd970>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset.npred()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "de83b81e-67d5-49e7-aee5-db611307fcfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux = dataset.evaluators[\"model\"].compute_flux_psf_convolved()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "48b3906a-59ff-4189-8c10-546c062b8caa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app_exp = dataset.evaluators[\"model\"].apply_exposure(flux)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "290f377b-e6f0-46ec-8f4a-5af6194d654f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array([[[0.       ]],\n",
+       "\n",
+       "       [[0.       ]],\n",
+       "\n",
+       "       [[4.5555506]],\n",
+       "\n",
+       "       [[5.987772 ]],\n",
+       "\n",
+       "       [[4.7940173]],\n",
+       "\n",
+       "       [[3.737797 ]],\n",
+       "\n",
+       "       [[2.7315361]],\n",
+       "\n",
+       "       [[1.8784888]],\n",
+       "\n",
+       "       [[1.2557182]],\n",
+       "\n",
+       "       [[0.8052822]]], dtype=float32)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset.evaluators[\"model\"].apply_edisp(app_exp).data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "f8aaf058-a28d-4089-b43b-989e205b87dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Array([[[0.       ]],\n",
+       "\n",
+       "       [[0.       ]],\n",
+       "\n",
+       "       [[4.5555506]],\n",
+       "\n",
+       "       [[5.987772 ]],\n",
+       "\n",
+       "       [[4.7940173]],\n",
+       "\n",
+       "       [[3.737797 ]],\n",
+       "\n",
+       "       [[2.7315361]],\n",
+       "\n",
+       "       [[1.8784888]],\n",
+       "\n",
+       "       [[1.2557182]],\n",
+       "\n",
+       "       [[0.8052822]]], dtype=float32)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset.npred_signal().data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "d9e60a00-d0cd-49d0-932c-879c7bcd26dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Array([[[ 0.       ]],\n",
+       "\n",
+       "       [[ 0.       ]],\n",
+       "\n",
+       "       [[15.6100445]],\n",
+       "\n",
+       "       [[11.376652 ]],\n",
+       "\n",
+       "       [[ 6.407409 ]],\n",
+       "\n",
+       "       [[ 3.6114166]],\n",
+       "\n",
+       "       [[ 2.1609063]],\n",
+       "\n",
+       "       [[ 1.0000001]],\n",
+       "\n",
+       "       [[ 0.7991466]],\n",
+       "\n",
+       "       [[ 0.       ]]], dtype=float32)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset.npred_background().data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "5aa4d03c-c650-435a-aa67-7b0d881a706b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Array([[[ 0.       ]],\n",
+       "\n",
+       "       [[ 0.       ]],\n",
+       "\n",
+       "       [[35.775642 ]],\n",
+       "\n",
+       "       [[28.741076 ]],\n",
+       "\n",
+       "       [[17.608835 ]],\n",
+       "\n",
+       "       [[10.96063  ]],\n",
+       "\n",
+       "       [[ 7.053349 ]],\n",
+       "\n",
+       "       [[ 3.878489 ]],\n",
+       "\n",
+       "       [[ 2.8540115]],\n",
+       "\n",
+       "       [[ 0.8052822]]], dtype=float32)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset.npred().data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "d13e086a-fd6f-48dc-b4bc-53d3ad3f2fa0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.modeling import Fit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "62e9acb0-8b75-4e97-a1d8-3069d6818e98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fit = Fit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "e99a3a5c-6179-49fe-9bb2-3580f4b25078",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.reference.quantity = 1000 * u.GeV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "4ea46631-9552-4a2c-a228-69f39adb0bca",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n",
+      "/Users/atreyeesinha/anaconda3/envs/gammapy-dev/lib/python3.9/site-packages/jax/_src/numpy/array_methods.py:68: UserWarning: Explicitly requested dtype float64 requested in astype is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  return lax_numpy.astype(arr, dtype, copy=copy, device=device)\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = fit.run([dataset])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "0bdab324-32a0-4eb3-8841-a99ee5e789bc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table length=3</i>\n",
+       "<table id=\"table5676394672\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>model</th><th>type</th><th>name</th><th>value</th><th>unit</th><th>error</th><th>min</th><th>max</th><th>frozen</th><th>is_norm</th><th>link</th><th>prior</th></tr></thead>\n",
+       "<thead><tr><th>str5</th><th>str1</th><th>str9</th><th>float64</th><th>str14</th><th>float64</th><th>float64</th><th>float64</th><th>bool</th><th>bool</th><th>str1</th><th>str1</th></tr></thead>\n",
+       "<tr><td>model</td><td></td><td>index</td><td>3.4074e+00</td><td></td><td>2.745e-01</td><td>nan</td><td>nan</td><td>False</td><td>False</td><td></td><td></td></tr>\n",
+       "<tr><td>model</td><td></td><td>amplitude</td><td>3.8516e-12</td><td>TeV-1 s-1 cm-2</td><td>5.308e-13</td><td>nan</td><td>nan</td><td>False</td><td>True</td><td></td><td></td></tr>\n",
+       "<tr><td>model</td><td></td><td>reference</td><td>1.0000e+03</td><td>GeV</td><td>0.000e+00</td><td>nan</td><td>nan</td><td>True</td><td>False</td><td></td><td></td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table length=3>\n",
+       "model type    name     value         unit      ... frozen is_norm link prior\n",
+       " str5 str1    str9    float64       str14      ...  bool    bool  str1  str1\n",
+       "----- ---- --------- ---------- -------------- ... ------ ------- ---- -----\n",
+       "model          index 3.4074e+00                ...  False   False           \n",
+       "model      amplitude 3.8516e-12 TeV-1 s-1 cm-2 ...  False    True           \n",
+       "model      reference 1.0000e+03            GeV ...   True   False           "
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result.models.to_parameters_table()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "b59f11ec-504b-4524-828b-6253c037d785",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "par = p.parameters[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dfcf53c8-13f7-4dc0-9a39-a8ae450d0137",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This is a draft just hacking into the gammapy code base to test the use of jax. NOT to be merged.

For an on off spectral analysis, we could get the `npred_signal` as a jax array.
Pair coding with @cgalelli and Alessandro