### PR TITLE
QOL changes in Timmer&Konig

### DIFF
--- a/gammapy/stats/tests/test_variability.py
+++ b/gammapy/stats/tests/test_variability.py
@@ -152,7 +152,7 @@ def test_tk():
         lambda x: x ** (-3), 20, 1 * u.s
     )
     time_series2, time_axis2 = TimmerKonig_lightcurve_simulator(
-        lambda x: x**0.5, 21, 2 * u.h
+        lambda x: x**0.5, 21, 2 * u.h, nchunks=1, poisson=True
     )
 
     def temp(x, norm, index):
@@ -161,11 +161,11 @@ def test_tk():
     params = {"norm": 1.5, "index": 3}
 
     time_series3, time_axis3 = TimmerKonig_lightcurve_simulator(
-        temp, 15, 1 * u.h, power_spectrum_params=params
+        temp, 15, 1 * u.h, nchunks=100, power_spectrum_params=params
     )
 
     time_series4, time_axis4 = TimmerKonig_lightcurve_simulator(
-        lambda x: x ** (-3), 20, 1 * u.s, leakage_protection=100.0
+        lambda x: x ** (-3), 200, 1 * u.s, mean=2.0, std=0.1
     )
 
     assert len(time_series) == 20
@@ -173,19 +173,9 @@ def test_tk():
     assert time_axis.unit == u.s
     assert len(time_series2) == 21
     assert len(time_series3) == 15
-    assert len(time_series4) == 20
-
-
-def test_tk_badleakage():
-    with pytest.raises(ValueError):
-        TimmerKonig_lightcurve_simulator(
-            lambda x: x ** (-3), 20, 1 * u.s, leakage_protection=0.1
-        )
-
-    with pytest.raises(Warning):
-        TimmerKonig_lightcurve_simulator(
-            lambda x: x ** (-3), 20, 1 * u.s, leakage_protection=1.001
-        )
+    assert len(time_series4) == 200
+    assert_allclose(time_series4.mean(), 2.0)
+    assert_allclose(time_series4.std(), 0.1)
 
 
 def test_structure_function():

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -292,8 +292,8 @@ def TimmerKonig_lightcurve_simulator(
     nchunks=10,
     random_state="random-seed",
     power_spectrum_params=None,
-    mean=0,
-    std=1,
+    mean=0.0,
+    std=1.0,
     poisson=False,
 ):
     """Implementation of the Timmer-Koenig algorithm to simulate a time series from a power spectrum.

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -292,8 +292,8 @@ def TimmerKonig_lightcurve_simulator(
     nchunks=10,
     random_state="random-seed",
     power_spectrum_params=None,
-    mean=None,
-    std=None,
+    mean=0,
+    std=1,
     poisson=False,
 ):
     """Implementation of the Timmer-Koenig algorithm to simulate a time series from a power spectrum.
@@ -314,10 +314,10 @@ def TimmerKonig_lightcurve_simulator(
         Passed to `~gammapy.utils.random.get_random_state`. Default is "random-seed".
     power_spectrum_params : dict, optional
         Dictionary of parameters to be provided to the power spectrum function.
-    mean : float, `~astropy.units.Quantity`, optional
-        Desired mean of the final series.
-    std : float, `~astropy.units.Quantity`m optional
-        Desired standard deviation of the final series.
+    mean : float, `~astropy.units.Quantity`
+        Desired mean of the final series. Default is 0.
+    std : float, `~astropy.units.Quantity`
+        Desired standard deviation of the final series. Default is 1.
     poisson : bool
         Whether to apply poissonian noise to the final time series. Default is False.
 
@@ -403,11 +403,7 @@ def TimmerKonig_lightcurve_simulator(
     time_series = time_series[setstart:setend]
 
     time_series = (time_series - time_series.mean()) / time_series.std()
-
-    if std:
-        time_series = time_series * std
-    if mean:
-        time_series += mean
+    time_series = time_series * std + mean
 
     if poisson:
         time_series = (

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -289,9 +289,12 @@ def TimmerKonig_lightcurve_simulator(
     power_spectrum,
     npoints,
     spacing,
-    leakage_protection=1.0,
+    nchunks=10,
     random_state="random-seed",
     power_spectrum_params=None,
+    mean=None,
+    std=None,
+    poisson=False,
 ):
     """Implementation of the Timmer-Koenig algorithm to simulate a time series from a power spectrum.
 
@@ -304,13 +307,20 @@ def TimmerKonig_lightcurve_simulator(
         Number of points in the output time series.
     spacing : `~astropy.units.Quantity`
         Sample spacing, inverse of the sampling rate. The units are inherited by the resulting time axis.
-    leakage_protection : float, optional
-        Factor by which to multiply the length of the time series to avoid red noise leakage. Default is 1.0.
-    random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
+    nchunks : int, optional
+        Factor by which to multiply the length of the time series to avoid red noise leakage. Default is 10.
+    random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}, optional
         Defines random number generator initialisation.
         Passed to `~gammapy.utils.random.get_random_state`. Default is "random-seed".
     power_spectrum_params : dict, optional
         Dictionary of parameters to be provided to the power spectrum function.
+    mean : float, `~astropy.units.Quantity`, optional
+        Desired mean of the final series.
+    std : float, `~astropy.units.Quantity`m optional
+        Desired standard deviation of the final series.
+    poisson : bool
+        Whether to apply poissonian noise to the final time series.
+
 
     Returns
     -------
@@ -349,16 +359,9 @@ def TimmerKonig_lightcurve_simulator(
 
     random_state = get_random_state(random_state)
 
-    if leakage_protection < 1.0:
-        raise ValueError("The leakage protection factor must be at least 1.0.")
+    npoints_ext = npoints * nchunks
 
-    npoints_extended = int(npoints * leakage_protection)
-    if leakage_protection > 1.0 and npoints_extended == npoints:
-        raise Warning(
-            "The extended time series is the same length as the final desired time series."
-            "To have an effective protection from noise leakage and avoid aliasing, increase the leakage_protection option."
-        )
-    frequencies = np.fft.fftfreq(npoints_extended, spacing.value)
+    frequencies = np.fft.fftfreq(npoints_ext, spacing.value)
 
     # To obtain real data only the positive or negative part of the frequency is necessary.
     real_frequencies = np.sort(np.abs(frequencies[frequencies < 0]))
@@ -372,7 +375,7 @@ def TimmerKonig_lightcurve_simulator(
     imaginary_part = random_state.normal(0, 1, len(periodogram) - 1)
 
     # Nyquist frequency component handling
-    if npoints % 2 == 0:
+    if npoints_ext % 2 == 0:
         idx0 = -2
         random_factor = random_state.normal(0, 1)
     else:
@@ -392,15 +395,23 @@ def TimmerKonig_lightcurve_simulator(
     fourier_coeffs = np.insert(fourier_coeffs, 0, 0)
     time_series = np.fft.ifft(fourier_coeffs).real
 
-    if npoints_extended > npoints:
-        extract = random_state.randint(1, npoints_extended - npoints)
-        time_series = np.take(time_series, range(extract, extract + npoints))
+    ndiv = npoints_ext // (2 * nchunks)
+    time_series = time_series[npoints_ext // 2 - ndiv : npoints_ext // 2 + ndiv]
 
-    tmax = time_series.max()
-    if tmax < np.abs(time_series.min()):
-        time_series = -time_series
+    time_series = (time_series - time_series.mean()) / time_series.std()
 
-    time_series = 0.5 + 0.5 * time_series / tmax
+    if std:
+        time_series = time_series * std
+    if mean:
+        time_series += mean
+
+    if poisson:
+        time_series = (
+            random_state.poisson(
+                np.where(time_series >= 0, time_series, 0) * spacing.value
+            )
+            / spacing.value
+        )
 
     time_axis = np.linspace(0, npoints * spacing.value, npoints) * spacing.unit
 

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -319,7 +319,7 @@ def TimmerKonig_lightcurve_simulator(
     std : float, `~astropy.units.Quantity`m optional
         Desired standard deviation of the final series.
     poisson : bool
-        Whether to apply poissonian noise to the final time series.
+        Whether to apply poissonian noise to the final time series. Default is False.
 
 
     Returns

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -396,7 +396,11 @@ def TimmerKonig_lightcurve_simulator(
     time_series = np.fft.ifft(fourier_coeffs).real
 
     ndiv = npoints_ext // (2 * nchunks)
-    time_series = time_series[npoints_ext // 2 - ndiv : npoints_ext // 2 + ndiv]
+    setstart = npoints_ext // 2 - ndiv
+    setend = npoints_ext // 2 + ndiv
+    if npoints % 2 != 0:
+        setend = setend + 1
+    time_series = time_series[setstart:setend]
 
     time_series = (time_series - time_series.mean()) / time_series.std()
 


### PR DESCRIPTION
This PR adds 3 quality of life changes for the timer and konig algorithm:

- A better handling of the red noise leakage through chunks
- Possibility of setting a custom mean and standard deviation
- Possibility of adding a poissonian noise (off by default)

These changes are very beneficial for the recipe presented in the Heidelberg coding sprint