### PR TITLE
Set a diagonal Edisp when `MapDataset.edisp` is `None`

### DIFF
--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -241,17 +241,10 @@ class MapEvaluator:
 
     @lazyproperty
     def _edisp_diagonal(self):
-        #        if self.edisp is not None:
-        edisp = EDispKernel.from_diagonal_response(
+        return EDispKernel.from_diagonal_response(
             energy_axis_true=self.edisp.axes["energy_true"],
             energy_axis=self.edisp.axes["energy"],
         )
-        #        else:
-        #            edisp = EDispKernel.from_diagonal_response(
-        #                energy_axis_true=energy,
-        #                energy_axis=energy,
-        #            )
-        return edisp
 
     def update_spatial_oversampling_factor(self, geom):
         """Update spatial oversampling_factor for model evaluation."""
@@ -402,10 +395,6 @@ class MapEvaluator:
     @lazyproperty
     def _compute_npred(self):
         """Compute npred."""
-        #        if self.edisp is None:
-        #            self.edisp = self._edisp_diagonal
-        #            print(self.edisp)
-        #
         if isinstance(self.model, TemplateNPredModel):
             npred = self.model.evaluate()
         else:

--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -241,10 +241,17 @@ class MapEvaluator:
 
     @lazyproperty
     def _edisp_diagonal(self):
-        return EDispKernel.from_diagonal_response(
+        #        if self.edisp is not None:
+        edisp = EDispKernel.from_diagonal_response(
             energy_axis_true=self.edisp.axes["energy_true"],
             energy_axis=self.edisp.axes["energy"],
         )
+        #        else:
+        #            edisp = EDispKernel.from_diagonal_response(
+        #                energy_axis_true=energy,
+        #                energy_axis=energy,
+        #            )
+        return edisp
 
     def update_spatial_oversampling_factor(self, geom):
         """Update spatial oversampling_factor for model evaluation."""
@@ -395,6 +402,10 @@ class MapEvaluator:
     @lazyproperty
     def _compute_npred(self):
         """Compute npred."""
+        #        if self.edisp is None:
+        #            self.edisp = self._edisp_diagonal
+        #            print(self.edisp)
+        #
         if isinstance(self.model, TemplateNPredModel):
             npred = self.model.evaluate()
         else:

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -309,7 +309,8 @@ class MapDataset(Dataset):
     psf : `~gammapy.irf.PSFMap` or `~gammapy.utils.fits.HDULocation`
         PSF kernel.
     edisp : `~gammapy.irf.EDispMap` or `~gammapy.utils.fits.HDULocation`
-        Energy dispersion kernel
+        Energy dispersion kernel.
+        When the Edisp is not defined, a diagonal edisp matrix is internally set.
     mask_safe : `~gammapy.maps.WcsNDMap` or `~gammapy.utils.fits.HDULocation`
         Mask defining the safe data range.
     gti : `~gammapy.data.GTI`

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -430,11 +430,12 @@ class MapDataset(Dataset):
             )
 
         self.edisp = edisp
-        #        if self.edisp is None:
-        #            self.edisp = EDispKernel.from_diagonal_response(
-        #                energy_axis_true=self.geoms["geom_exposure"].axes["energy_true"],
-        #                energy_axis=self.geoms["geom"].axes["energy"],
-        #            )
+        if self.edisp is None and self.exposure is not None:
+            log.warning("Edisp is not defined. A diagonal response matrix will be set.")
+            self.edisp = EDispMap.from_diagonal_response(
+                energy_axis_true=self.geoms["geom_exposure"].axes["energy_true"],
+            )
+
         self.mask_safe = mask_safe
         self.gti = gti
         self.models = models

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -431,7 +431,7 @@ class MapDataset(Dataset):
 
         self.edisp = edisp
         if self.edisp is None and self.exposure is not None:
-            log.info("Edisp is not defined. A diagonal response matrix will be set.")
+            log.warning("Edisp is not defined. A diagonal response matrix will be set.")
             self.edisp = EDispMap.from_diagonal_response(
                 energy_axis_true=self.geoms["geom_exposure"].axes["energy_true"],
             )

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -431,7 +431,7 @@ class MapDataset(Dataset):
 
         self.edisp = edisp
         if self.edisp is None and self.exposure is not None:
-            log.warning("Edisp is not defined. A diagonal response matrix will be set.")
+            log.info("Edisp is not defined. A diagonal response matrix will be set.")
             self.edisp = EDispMap.from_diagonal_response(
                 energy_axis_true=self.geoms["geom_exposure"].axes["energy_true"],
             )

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -430,6 +430,11 @@ class MapDataset(Dataset):
             )
 
         self.edisp = edisp
+        #        if self.edisp is None:
+        #            self.edisp = EDispKernel.from_diagonal_response(
+        #                energy_axis_true=self.geoms["geom_exposure"].axes["energy_true"],
+        #                energy_axis=self.geoms["geom"].axes["energy"],
+        #            )
         self.mask_safe = mask_safe
         self.gti = gti
         self.models = models

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -247,7 +247,7 @@ class PlotMixin:
         ax3.set_title("Energy Dispersion")
 
         if self.edisp is not None:
-            kernel = self.edisp.get_edisp_kernel()
+            kernel = self.edisp.get_edisp_kernel(self._geom.axes["energy"])
             kernel.plot_matrix(ax=ax3, add_cbar=True)
 
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -2097,6 +2097,7 @@ def test_to_masked():
     assert_allclose(d1.counts.data.sum(), 170)
 
 
+@requires_data()
 def test_diagonal_edisp(geom_etrue, caplog):
     axis = MapAxis.from_energy_bounds(1, 10, 2, unit="TeV")
     geom = WcsGeom.create(npix=(10, 10), binsz=0.05, axes=[axis])

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -2104,5 +2104,5 @@ def test_diagonal_edisp(geom_etrue, caplog):
     psf = get_psf()
     exposure = get_exposure(geom_etrue)
     dataset = MapDataset(counts=counts, exposure=exposure, edisp=None, psf=psf)
-    #    assert "Edisp is not defined. A diagonal response matrix will be set." in [record.levelname for record in caplog.records]
+    assert "WARNING" in [record.levelname for record in caplog.records]
     assert dataset.edisp is not None

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -2095,3 +2095,14 @@ def test_to_masked():
     )
     d1 = datasetonoff.to_masked()
     assert_allclose(d1.counts.data.sum(), 170)
+
+
+def test_diagonal_edisp(geom_etrue, caplog):
+    axis = MapAxis.from_energy_bounds(1, 10, 2, unit="TeV")
+    geom = WcsGeom.create(npix=(10, 10), binsz=0.05, axes=[axis])
+    counts = Map.from_geom(geom, data=1)
+    psf = get_psf()
+    exposure = get_exposure(geom_etrue)
+    dataset = MapDataset(counts=counts, exposure=exposure, edisp=None, psf=psf)
+    #    assert "Edisp is not defined. A diagonal response matrix will be set." in [record.levelname for record in caplog.records]
+    assert dataset.edisp is not None

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -72,6 +72,7 @@ def test_spectrum_dataset_fits_io(spectrum_dataset, tmp_path):
     )
     hdulist = spectrum_dataset.to_hdulist()
     actual = [hdu.name for hdu in hdulist]
+    print(actual)
     desired = [
         "PRIMARY",
         "COUNTS",
@@ -83,6 +84,10 @@ def test_spectrum_dataset_fits_io(spectrum_dataset, tmp_path):
         "BACKGROUND",
         "BACKGROUND_BANDS",
         "BACKGROUND_REGION",
+        "EDISP",
+        "EDISP_BANDS",
+        "EDISP_EXPOSURE",
+        "EDISP_EXPOSURE_BANDS",
         "GTI",
         "META_TABLE",
     ]
@@ -96,8 +101,6 @@ def test_spectrum_dataset_fits_io(spectrum_dataset, tmp_path):
     assert_allclose(
         spectrum_dataset.npred_background().data, dataset_new.npred_background().data
     )
-    assert dataset_new.edisp is None
-    assert dataset_new.edisp is None
     assert dataset_new.name == "test"
 
     assert_allclose(spectrum_dataset.exposure.data, dataset_new.exposure.data)

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -72,7 +72,6 @@ def test_spectrum_dataset_fits_io(spectrum_dataset, tmp_path):
     )
     hdulist = spectrum_dataset.to_hdulist()
     actual = [hdu.name for hdu in hdulist]
-    print(actual)
     desired = [
         "PRIMARY",
         "COUNTS",
@@ -101,6 +100,7 @@ def test_spectrum_dataset_fits_io(spectrum_dataset, tmp_path):
     assert_allclose(
         spectrum_dataset.npred_background().data, dataset_new.npred_background().data
     )
+    assert dataset_new.edisp is not None
     assert dataset_new.name == "test"
 
     assert_allclose(spectrum_dataset.exposure.data, dataset_new.exposure.data)

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -410,14 +410,7 @@ class MapDatasetMaker(Maker):
             kwargs["psf"] = psf
 
         if "edisp" not in self.selection:
-            log.warning(
-                "'edisp' is not selected. A diagonal response matrix will be set anyway."
-            )
-            edisp = EDispKernelMap.from_diagonal_response(
-                energy_axis_true=dataset.geoms["geom_exposure"].axes["energy_true"],
-                energy_axis=dataset.geoms["geom"].axes["energy"],
-                geom=dataset.edisp.edisp_map.geom,
-            )
+            edisp = dataset.edisp
 
         if "edisp" in self.selection:
             if dataset.edisp.edisp_map.geom.axes[0].name.upper() == "MIGRA":

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -409,6 +409,16 @@ class MapDatasetMaker(Maker):
             psf = self.make_psf(dataset.psf.psf_map.geom, observation)
             kwargs["psf"] = psf
 
+        if "edisp" not in self.selection:
+            log.warning(
+                "'edisp' is not selected. A diagonal response matrix will be set anyway."
+            )
+            edisp = EDispKernelMap.from_diagonal_response(
+                energy_axis_true=dataset.geoms["geom_exposure"].axes["energy_true"],
+                energy_axis=dataset.geoms["geom"].axes["energy"],
+                geom=dataset.edisp.edisp_map.geom,
+            )
+
         if "edisp" in self.selection:
             if dataset.edisp.edisp_map.geom.axes[0].name.upper() == "MIGRA":
                 edisp = self.make_edisp(dataset.edisp.edisp_map.geom, observation)
@@ -416,7 +426,6 @@ class MapDatasetMaker(Maker):
                 edisp = self.make_edisp_kernel(
                     dataset.edisp.edisp_map.geom, observation
                 )
-
-            kwargs["edisp"] = edisp
+        kwargs["edisp"] = edisp
 
         return dataset.__class__(name=dataset.name, **kwargs)

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -260,7 +260,7 @@ def test_region_center_spectrum_dataset_maker_magic_dl3(
 
     assert isinstance(dataset, SpectrumDataset)
     assert dataset.exposure.meta["is_pointlike"]
-    assert "WARNING" in [record.levelname for record in caplog.records]
+    assert "WARNING" not in [record.levelname for record in caplog.records]
     assert dataset.edisp is not None
 
     # use_center = False should raise a warning

--- a/gammapy/makers/tests/test_spectrum.py
+++ b/gammapy/makers/tests/test_spectrum.py
@@ -260,7 +260,8 @@ def test_region_center_spectrum_dataset_maker_magic_dl3(
 
     assert isinstance(dataset, SpectrumDataset)
     assert dataset.exposure.meta["is_pointlike"]
-    assert "WARNING" not in [record.levelname for record in caplog.records]
+    assert "WARNING" in [record.levelname for record in caplog.records]
+    assert dataset.edisp is not None
 
     # use_center = False should raise a warning
     dataset_average = maker_average.run(


### PR DESCRIPTION
This PR should resolve #5274.
It introduces the possibility to create a diagonal edisp matrix when the `dataset` does not have one. This will avoid that `Fit` and `FluxPointsEstimator ` will fail when the edisp is not defined.
Tests have been updated accordingly.