### PR TITLE
More complex background spectral model exposed

### DIFF
--- a/docs/user-guide/makers/fov.rst
+++ b/docs/user-guide/makers/fov.rst
@@ -87,6 +87,9 @@ in the `fov_bkg_maker`.
     )
 
 
+Note: to prevent poorly constrained `norm` parameters or large variance in
+the last bins, the binning should be adjusted to have wider bins at higher energies.
+This ensures there are enough statistics per bin, enabling the fit to converge.
 
 
 .. minigallery:: gammapy.makers.FoVBackgroundMaker

--- a/docs/user-guide/makers/fov.rst
+++ b/docs/user-guide/makers/fov.rst
@@ -19,8 +19,7 @@ Gammapy provides the `~gammapy.makers.FoVBackgroundMaker`. The latter creates a
 and a `~gammapy.modeling.models.NormSpectralModel` which allows to renormalize the background cube, and
 possibly to change its spectral distribution. By default, only the `norm` parameter of a
 `~gammapy.modeling.models.PowerLawNormSpectralModel` is left free. Here we show the addition of a `~gammapy.modeling.models.PowerLawNormSpectralModel`
-in which the `norm` and `tilt` parameters are unfrozen as an example. It is also possible to implement other normed
-models, such as the `~gammapy.modeling.models.PiecewiseNormSpectralModel`.
+in which the `norm` and `tilt` parameters are unfrozen as an example.
 
 .. testcode::
 
@@ -64,6 +63,30 @@ models, such as the `~gammapy.modeling.models.PiecewiseNormSpectralModel`.
 		dataset = safe_mask_maker.run(dataset, obs)
 		dataset = fov_bkg_maker.run(dataset)
 		stacked.stack(dataset)
+
+
+
+It is also possible to implement other normed models, such as the
+`~gammapy.modeling.models.PiecewiseNormSpectralModel`. To do so,
+you can utilise most of the above code with an adaption to the `spectral_model` applied
+in the `fov_bkg_maker`.
+
+.. code-block:: python
+
+    from gammapy.modeling.models import PiecewiseNormSpectralModel
+
+    spectral_model = PiecewiseNormSpectralModel(
+        energy=energy_axis.edges,
+        norms=np.ones_like(energy_axis.edges)
+    )
+
+    fov_bkg_maker = FoVBackgroundMaker(
+        method="fit",
+        exclusion_mask=exclusion_mask,
+        spectral_model=spectral_model
+    )
+
+
 
 
 .. minigallery:: gammapy.makers.FoVBackgroundMaker

--- a/examples/tutorials/starting/analysis_2.py
+++ b/examples/tutorials/starting/analysis_2.py
@@ -184,7 +184,9 @@ stacked = MapDataset.create(
 #
 # The `~gammapy.makers.MapDatasetMaker` object is initialized as well as
 # the `~gammapy.makers.SafeMaskMaker` that carries here a maximum offset
-# selection.
+# selection. The `~gammapy.makers.FoVBackgroundMaker` utilised here has the
+# default ``spectral_model`` but it is possible to set your own. For further
+# details see the :doc:`FoV background </user-guide/makers/fov>`.
 #
 
 offset_max = 2.5 * u.deg


### PR DESCRIPTION
This resolves  #4947.

It adds in the docs that it is possible to utilise a more complex model (PieceWise) in your FoVbkgmaker. 

I am open to also adding the priors as mentioned in the coding sprint, however, if we had this is the data reduction step it could force some of the fitted values to be better than they are. And therefore people will not know this is the case.
i.e. setting a prior on the `norm` such that the values vary between +-0.2, it could mean without the prior the norm wants to fit at 1.5, but if the prior is added it would not reach this and only be at  i.e. 1.2

Let me know your thoughts?