### PR TITLE
Add CovarianceMixin for multicomponent models classes

### DIFF
--- a/gammapy/modeling/covariance.py
+++ b/gammapy/modeling/covariance.py
@@ -210,3 +210,32 @@ class Covariance:
 
     def __array__(self):
         return self.data
+
+
+class CovarianceMixin:
+    """Mixin class for covariance property on multi-components models"""
+
+    def _check_covariance(self):
+        if not self.parameters == self._covariance.parameters:
+            self._covariance = Covariance.from_stack(
+                [model.covariance for model in self._models]
+            )
+
+    @property
+    def covariance(self):
+        """Covariance as a `~gammapy.modeling.Covariance` object."""
+        self._check_covariance()
+
+        for model in self._models:
+            self._covariance.set_subcovariance(model.covariance)
+
+        return self._covariance
+
+    @covariance.setter
+    def covariance(self, covariance):
+        self._check_covariance()
+        self._covariance.data = covariance
+
+        for model in self._models:
+            subcovar = self._covariance.get_subcovariance(model.covariance.parameters)
+            model.covariance = subcovar

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -12,7 +12,8 @@ from astropy.table import Table
 import matplotlib.pyplot as plt
 import yaml
 from gammapy.maps import Map, RegionGeom
-from gammapy.modeling import Covariance, CovarianceMixin, Parameter, Parameters
+from gammapy.modeling import Covariance, Parameter, Parameters
+from gammapy.modeling.covariance import CovarianceMixin
 from gammapy.utils.check import add_checksum, verify_checksum
 from gammapy.utils.metadata import CreatorMetaData
 from gammapy.utils.scripts import make_name, make_path

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -8,7 +8,8 @@ import astropy.units as u
 from astropy.nddata import NoOverlapError
 from astropy.time import Time
 from gammapy.maps import Map, MapAxis, WcsGeom
-from gammapy.modeling import CovarianceMixin, Parameters
+from gammapy.modeling import Parameters
+from gammapy.modeling.covariance import CovarianceMixin
 from gammapy.modeling.parameter import _get_parameters_str
 from gammapy.utils.compat import COPY_IF_NEEDED
 from gammapy.utils.fits import LazyFitsData

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -30,7 +30,7 @@ __all__ = [
 ]
 
 
-class SkyModel(ModelBase, CovarianceMixin):
+class SkyModel(CovarianceMixin, ModelBase):
     """Sky model component.
 
     This model represents a factorised sky model.

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -8,7 +8,7 @@ import astropy.units as u
 from astropy.nddata import NoOverlapError
 from astropy.time import Time
 from gammapy.maps import Map, MapAxis, WcsGeom
-from gammapy.modeling import Covariance, Parameters
+from gammapy.modeling import CovarianceMixin, Parameters
 from gammapy.modeling.parameter import _get_parameters_str
 from gammapy.utils.compat import COPY_IF_NEEDED
 from gammapy.utils.fits import LazyFitsData
@@ -29,7 +29,7 @@ __all__ = [
 ]
 
 
-class SkyModel(ModelBase):
+class SkyModel(ModelBase, CovarianceMixin):
     """Sky model component.
 
     This model represents a factorised sky model.
@@ -84,12 +84,6 @@ class SkyModel(ModelBase):
         models = self.spectral_model, self.spatial_model, self.temporal_model
         return [model for model in models if model is not None]
 
-    def _check_covariance(self):
-        if not self.parameters == self._covariance.parameters:
-            self._covariance = Covariance.from_stack(
-                [model.covariance for model in self._models],
-            )
-
     def _check_unit(self):
         axis = MapAxis.from_energy_bounds(
             "0.1 TeV", "10 TeV", nbin=1, name="energy_true"
@@ -126,24 +120,6 @@ class SkyModel(ModelBase):
             raise ValueError(
                 f"SkyModel unit {obt_unit} is not equivalent to {ref_unit}"
             )
-
-    @property
-    def covariance(self):
-        self._check_covariance()
-
-        for model in self._models:
-            self._covariance.set_subcovariance(model.covariance)
-
-        return self._covariance
-
-    @covariance.setter
-    def covariance(self, covariance):
-        self._check_covariance()
-        self._covariance.data = covariance
-
-        for model in self._models:
-            subcovar = self._covariance.get_subcovariance(model.covariance.parameters)
-            model.covariance = subcovar
 
     @property
     def name(self):

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -703,7 +703,7 @@ class ConstantSpectralModel(SpectralModel):
         return np.ones(np.atleast_1d(energy).shape) * const
 
 
-class CompoundSpectralModel(SpectralModel, CovarianceMixin):
+class CompoundSpectralModel(CovarianceMixin, SpectralModel):
     """Arithmetic combination of two spectral models.
 
     For more information see :ref:`compound-spectral-model`.

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -779,31 +779,6 @@ class CompoundSpectralModel(SpectralModel, CovarianceMixin):
         op = getattr(operator, data["operator"])
         return cls(model1, model2, op)
 
-    def _check_covariance(self):
-        if not self.parameters == self._covariance.parameters:
-            self._covariance = Covariance.from_stack(
-                [model.covariance for model in self._models]
-            )
-
-    @property
-    def covariance(self):
-        """Covariance as a `~gammapy.modeling.Covariance` object."""
-        self._check_covariance()
-
-        for model in self._models:
-            self._covariance.set_subcovariance(model.covariance)
-
-        return self._covariance
-
-    @covariance.setter
-    def covariance(self, covariance):
-        self._check_covariance()
-        self._covariance.data = covariance
-
-        for model in self._models:
-            subcovar = self._covariance.get_subcovariance(model.covariance.parameters)
-            model.covariance = subcovar
-
 
 class PowerLawSpectralModel(SpectralModel):
     r"""Spectral power-law model.

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -15,6 +15,7 @@ from astropy.units import Quantity
 from astropy.utils.decorators import classproperty
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
+from covariance import CovarianceMixin
 from gammapy.maps import MapAxis, RegionNDMap
 from gammapy.maps.axes import UNIT_STRING_FORMAT
 from gammapy.modeling import Parameter, Parameters
@@ -703,7 +704,7 @@ class ConstantSpectralModel(SpectralModel):
         return np.ones(np.atleast_1d(energy).shape) * const
 
 
-class CompoundSpectralModel(SpectralModel):
+class CompoundSpectralModel(SpectralModel, CovarianceMixin):
     """Arithmetic combination of two spectral models.
 
     For more information see :ref:`compound-spectral-model`.

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -15,7 +15,6 @@ from astropy.units import Quantity
 from astropy.utils.decorators import classproperty
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
-from covariance import CovarianceMixin
 from gammapy.maps import MapAxis, RegionNDMap
 from gammapy.maps.axes import UNIT_STRING_FORMAT
 from gammapy.modeling import Parameter, Parameters
@@ -28,7 +27,7 @@ from gammapy.utils.interpolation import (
 )
 from gammapy.utils.roots import find_roots
 from gammapy.utils.scripts import make_path
-from ..covariance import Covariance
+from ..covariance import CovarianceMixin
 from .core import ModelBase
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Move the covariance related properties to a CovarianceMixin class and use it for  all multi-component models classes including CompoundSpectralModel.