### PR TITLE
Fix datasets.models.covariance after fit to match FitResults.models.covariance

### DIFF
--- a/gammapy/datasets/actors.py
+++ b/gammapy/datasets/actors.py
@@ -23,6 +23,8 @@ class DatasetsActor(Datasets):
         Datasets
     """
 
+    _local_attr = ["models", "parameters"]
+
     def __init__(self, datasets=None):
         from ray import get
 
@@ -45,6 +47,7 @@ class DatasetsActor(Datasets):
                 datasets.remove(d0)  # moved to remote so removed from main process
             self._datasets = datasets_list
             self._ray_get = get
+            self._covariance = None
 
         # trigger actors auto_init_wrapper (so overhead so appears on init)
         self.name
@@ -73,7 +76,9 @@ class DatasetsActor(Datasets):
                 d._to_update = {}
             return results
 
-        if inspect.ismethod(getattr(self._datasets[0], name)):
+        if name in self._local_attr:
+            return super().__getattribute__(name)
+        elif inspect.ismethod(getattr(self._datasets[0], name)):
             return wrapper
         else:
             return wrapper()

--- a/gammapy/datasets/actors.py
+++ b/gammapy/datasets/actors.py
@@ -167,13 +167,7 @@ class MapDatasetActor(RayFrontendMixin):
         if name == "models":
             if value is None:
                 value = DatasetModels()
-            value = DatasetModels(
-                [
-                    m
-                    for m in value
-                    if m.datasets_names is None or self.name in m.datasets_names
-                ]
-            )
+            value = value.select(datasets_names=self.name)
         super().__setattr__(name, value)
 
     def _get_remote(self, attr, *args, from_actors=False, **kwargs):

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -184,7 +184,7 @@ class Datasets(collections.abc.MutableSequence):
         The order of the unique models remains.
         """
         if models:
-            self._covariance = models.covariance
+            self._covariance = DatasetModels(models).covariance
         for dataset in self:
             dataset.models = models
 

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -188,9 +188,6 @@ class Datasets(collections.abc.MutableSequence):
         for dataset in self:
             dataset.models = models
 
-    def set_covariance(self, covariance):
-        self._covariance = covariance
-
     @property
     def names(self):
         return [d.name for d in self._datasets]

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -145,6 +145,7 @@ class Datasets(collections.abc.MutableSequence):
             unique_names.append(dataset.name)
 
         self._datasets = datasets
+        self._covariance = None
 
     @property
     def parameters(self):
@@ -168,8 +169,12 @@ class Datasets(collections.abc.MutableSequence):
             if dataset.models is not None:
                 for model in dataset.models:
                     models[model] = model
+        models = DatasetModels(list(models.keys()))
 
-        return DatasetModels(list(models.keys()))
+        if self._covariance and self._covariance.parameters == models.parameters:
+            return DatasetModels(models, covariance_data=self._covariance.data)
+        else:
+            return models
 
     @models.setter
     def models(self, models):
@@ -178,8 +183,13 @@ class Datasets(collections.abc.MutableSequence):
         Duplicate model objects have been removed.
         The order of the unique models remains.
         """
+        if models:
+            self._covariance = models.covariance
         for dataset in self:
             dataset.models = models
+
+    def set_covariance(self, covariance):
+        self._covariance = covariance
 
     @property
     def names(self):

--- a/gammapy/datasets/tests/test_datasets.py
+++ b/gammapy/datasets/tests/test_datasets.py
@@ -162,6 +162,7 @@ def test_datasets_write(tmp_path):
         )
 
 
+@requires_data()
 def test_datasets_fit():
     axis = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=2)
     geom = WcsGeom.create(

--- a/gammapy/datasets/tests/test_datasets.py
+++ b/gammapy/datasets/tests/test_datasets.py
@@ -7,7 +7,8 @@ from astropy.coordinates import SkyCoord
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
 from gammapy.datasets.tests.test_map import get_map_dataset
 from gammapy.maps import MapAxis, WcsGeom
-from gammapy.modeling.models import SkyModel
+from gammapy.modeling import Fit
+from gammapy.modeling.models import FoVBackgroundModel, Models, SkyModel
 from gammapy.modeling.tests.test_fit import MyDataset
 from gammapy.utils.testing import requires_data
 
@@ -159,3 +160,57 @@ def test_datasets_write(tmp_path):
             filename_models=tmp_path / "test_model",
             overwrite=False,
         )
+
+
+def test_datasets_fit():
+    axis = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=2)
+    geom = WcsGeom.create(
+        skydir=(266.40498829, -28.93617776),
+        binsz=0.05,
+        width=(20, 20),
+        frame="icrs",
+        axes=[axis],
+    )
+
+    axis = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=3, name="energy_true")
+    geom_etrue = WcsGeom.create(
+        skydir=(266.40498829, -28.93617776),
+        binsz=0.05,
+        width=(20, 20),
+        frame="icrs",
+        axes=[axis],
+    )
+
+    dataset_1 = get_map_dataset(geom, geom_etrue, name="test-1")
+    dataset_1.mask_fit = None
+    dataset_1.background /= 400
+    dataset_2 = get_map_dataset(geom, geom_etrue, name="test-2")
+    dataset_2.mask_fit = None
+    dataset_2.background /= 400
+
+    datasets = Datasets([dataset_1, dataset_2])
+
+    model = SkyModel.create("pl", "point", name="src")
+    model.spatial_model.position = dataset_1.exposure.geom.center_skydir
+
+    model2 = model.copy()
+    model2.spatial_model.lon_0.value += 0.1
+    model2.spatial_model.lat_0.value += 0.1
+
+    models = Models(
+        [
+            model,
+            model2,
+            FoVBackgroundModel(dataset_name=dataset_1.name),
+            FoVBackgroundModel(dataset_name=dataset_2.name),
+        ]
+    )
+
+    datasets.models = models
+    dataset_1.fake()
+    dataset_2.fake()
+
+    fit = Fit()
+    results = fit.run(datasets)
+
+    assert_allclose(results.models.covariance.data, datasets.models.covariance.data)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -758,7 +758,6 @@ def test_map_fit_ray(sky_model, geom, geom_etrue):
     dataset_1 = get_map_dataset(geom, geom_etrue, name="test-1")
     dataset_2 = get_map_dataset(geom, geom_etrue, name="test-2")
     datasets = Datasets([dataset_1, dataset_2])
-
     models = Models(datasets.models)
     models.insert(0, sky_model)
 
@@ -772,12 +771,21 @@ def test_map_fit_ray(sky_model, geom, geom_etrue):
     models["test-1-bkg"].spectral_model.norm.value = 0.49
     models["test-2-bkg"].spectral_model.norm.value = 0.99
 
+    datasets.models = None
+
     actors = DatasetsActor(datasets)
+    assert len(actors.models) == 0
+
+    actors.models = models
     assert len(actors.models) == len(models)
     assert len(actors.parameters) == len(models.parameters.unique_parameters)
 
+    assert len(actors[0].models) == len(models) - 1
+
     fit = Fit()
     result = fit.run(datasets=actors)
+
+    assert_allclose(result.models.covariance.data, actors.models.covariance.data)
 
     assert result.success
     assert result.optimize_result.backend == "minuit"

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -773,6 +773,9 @@ def test_map_fit_ray(sky_model, geom, geom_etrue):
     models["test-2-bkg"].spectral_model.norm.value = 0.99
 
     actors = DatasetsActor(datasets)
+    assert len(actors.models) == len(models)
+    assert len(actors.parameters) == len(models.parameters.unique_parameters)
+
     fit = Fit()
     result = fit.run(datasets=actors)
 

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -183,8 +183,8 @@ class Fit:
             optimize_result.models.parameters, covariance_result.matrix
         )
 
-        datasets.models.covariance = Covariance(
-            datasets.models.parameters, covariance_result.matrix
+        datasets.set_covariance(
+            Covariance(datasets.models.parameters, covariance_result.matrix)
         )
 
         return FitResult(

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -169,6 +169,8 @@ class Fit:
             Fit result.
         """
 
+        datasets, parameters = self._parse_datasets(datasets=datasets)
+
         optimize_result = self.optimize(datasets=datasets)
 
         if self.backend not in registry.register["covariance"]:
@@ -183,9 +185,7 @@ class Fit:
             optimize_result.models.parameters, covariance_result.matrix
         )
 
-        datasets._covariance(
-            Covariance(datasets.models.parameters, covariance_result.matrix)
-        )
+        datasets._covariance = Covariance(parameters, covariance_result.matrix)
 
         return FitResult(
             optimize_result=optimize_result,

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -183,6 +183,10 @@ class Fit:
             optimize_result.models.parameters, covariance_result.matrix
         )
 
+        datasets.models.covariance = Covariance(
+            datasets.models.parameters, covariance_result.matrix
+        )
+
         return FitResult(
             optimize_result=optimize_result,
             covariance_result=covariance_result,

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -183,7 +183,7 @@ class Fit:
             optimize_result.models.parameters, covariance_result.matrix
         )
 
-        datasets.set_covariance(
+        datasets._covariance(
             Covariance(datasets.models.parameters, covariance_result.matrix)
         )
 

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -357,6 +357,8 @@ class DatasetModels(collections.abc.Sequence):
             models = []
 
         if isinstance(models, (Models, DatasetModels)):
+            if covariance_data is None and models.covariance is not None:
+                covariance_data = models.covariance.data
             models = models._models
         elif isinstance(models, ModelBase):
             models = [models]


### PR DESCRIPTION
Fix datasets.models.covariance after fit to match FitResults.models.covariance.
It simply add a  private `_covariance` attribute on datasets that will be used to set the covariance properly in `.models` property  if the parameters of the covariance and the datasets.models match.