### PR TITLE
Fix covariance for CompoundSpectralModel 

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -27,6 +27,7 @@ from gammapy.utils.interpolation import (
 )
 from gammapy.utils.roots import find_roots
 from gammapy.utils.scripts import make_path
+from ..covariance import Covariance
 from .core import ModelBase
 
 log = logging.getLogger(__name__)
@@ -777,6 +778,31 @@ class CompoundSpectralModel(SpectralModel):
         model2 = model2_cls.from_dict({"spectral": data["model2"]})
         op = getattr(operator, data["operator"])
         return cls(model1, model2, op)
+
+    def _check_covariance(self):
+        if not self.parameters == self._covariance.parameters:
+            self._covariance = Covariance.from_stack(
+                [model.covariance for model in self._models]
+            )
+
+    @property
+    def covariance(self):
+        """Covariance as a `~gammapy.modeling.Covariance` object."""
+        self._check_covariance()
+
+        for model in self._models:
+            self._covariance.set_subcovariance(model.covariance)
+
+        return self._covariance
+
+    @covariance.setter
+    def covariance(self, covariance):
+        self._check_covariance()
+        self._covariance.data = covariance
+
+        for model in self._models:
+            subcovar = self._covariance.get_subcovariance(model.covariance.parameters)
+            model.covariance = subcovar
 
 
 class PowerLawSpectralModel(SpectralModel):

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -774,6 +774,20 @@ def test_template_spectral_model_compound():
     assert np.allclose(new_model(energy), 2 * values)
 
 
+def test_covariance_spectral_model_compound():
+    model = TEST_MODELS[2]["model"] + TEST_MODELS[1]["model"]
+    covar = np.eye(len(model.parameters))
+    covar[0, -1] = 1.0
+    covar[-1, 0] = 1.0
+    covar[0, 1] = 1.0
+    covar[-1, -3] = 1.0
+
+    model.covariance = covar
+    assert_allclose(model.covariance.data, covar)
+    assert_allclose(model.model1.covariance.data, covar[:3, :3])
+    assert_allclose(model.model2.covariance.data, covar[-3:, -3:])
+
+
 def test_evaluate_spectral_model_compound():
     energy = [1.00e06, 1.25e06, 1.58e06, 1.99e06] * u.MeV
     model = TEST_MODELS[-2]["model"]


### PR DESCRIPTION
Set correctly the sub-covariance on the individual models of   CompoundSpectralModel.
As suggested by @adonath this should go in before  #5316, then the Mixin class can be introduced to reduce code duplication. 