### PR TITLE
Fix tests fail due to precision

### DIFF
--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -263,7 +263,7 @@ class TestSourceCatalogObjectHGPS:
         assert_allclose(p["lon_0"].value, 266.287384)
         assert_allclose(p["lat_0"].value, -1.243260383605957)
         assert_allclose(p["radius"].value, 0.95)
-        assert_allclose(p["width"].value, 0.05)
+        assert_allclose(p["width"].value, 0.05, rtol=1e-6)
 
     @staticmethod
     def test_flux_points_meta(cat):

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ test =
     sphinx
 docs =
     astropy>=5.0,<5.3
+    numpy<2.0
     sphinx-astropy
     sphinx
     sphinx-click

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find:
 python_requires = >=3.9
 setup_requires = setuptools_scm
 install_requires =
-    numpy>=1.21
+    numpy>=1.21, <2.0
     scipy>=1.5,!=1.10
     astropy>=5.0
     regions>=0.5.0
@@ -79,7 +79,6 @@ test =
     sphinx
 docs =
     astropy>=5.0,<5.3
-    numpy<2.0
     sphinx-astropy
     sphinx
     sphinx-click

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find:
 python_requires = >=3.9
 setup_requires = setuptools_scm
 install_requires =
-    numpy>=1.21, <2.0
+    numpy>=1.21
     scipy>=1.5,!=1.10
     astropy>=5.0
     regions>=0.5.0


### PR DESCRIPTION
-Fix tests fail due to precision
-impose numpy<2 otherwise fails with conda and docs build.