### PR TITLE
Simplify and cleanup yaml IO

### DIFF
--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -243,19 +243,40 @@ class AnalysisConfig(GammapyBaseConfig):
 
     @classmethod
     def read(cls, path):
-        """Read from YAML file."""
+        """Read from YAML file.
+
+        Parameters
+        ----------
+        path : str
+            input filepath
+        """
         config = read_yaml(path)
         config.pop("metadata", None)
         return AnalysisConfig(**config)
 
     @classmethod
     def from_yaml(cls, config_str):
-        """Create from YAML string."""
+        """Create from YAML string.
+
+        Parameters
+        ----------
+        config_str : str
+            yaml str
+
+        """
         settings = yaml.safe_load(config_str)
         return AnalysisConfig(**settings)
 
     def write(self, path, overwrite=False):
-        """Write to YAML file."""
+        """Write to YAML file.
+
+        Parameters
+        ----------
+        path : `pathlib.Path` or str
+            Path to write files.
+        overwrite : bool, optional
+            Overwrite existing file. Default is False.
+        """
         yaml_str = self.to_yaml()
         write_yaml(yaml_str, path, overwrite=overwrite)
 

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -256,7 +256,8 @@ class AnalysisConfig(GammapyBaseConfig):
 
     def write(self, path, overwrite=False):
         """Write to YAML file."""
-        write_yaml(self.to_yaml(), path, overwrite=overwrite)
+        yaml_str = self.to_yaml()
+        write_yaml(yaml_str, path, overwrite=overwrite)
 
     def to_yaml(self):
         """Convert to YAML string."""

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -11,7 +11,7 @@ from astropy import units as u
 import yaml
 from pydantic import BaseModel, ConfigDict
 from gammapy.makers import MapDatasetMaker
-from gammapy.utils.scripts import make_path, read_yaml
+from gammapy.utils.scripts import read_yaml, to_yaml, write_yaml
 from gammapy.utils.types import AngleType, EnergyType, PathType, TimeType
 
 __all__ = ["AnalysisConfig"]
@@ -255,19 +255,12 @@ class AnalysisConfig(GammapyBaseConfig):
 
     def write(self, path, overwrite=False):
         """Write to YAML file."""
-        path = make_path(path)
-
-        if path.exists() and not overwrite:
-            raise IOError(f"File exists already: {path}")
-
-        path.write_text(self.to_yaml())
+        write_yaml(self.to_yaml(), path, overwrite=overwrite)
 
     def to_yaml(self):
         """Convert to YAML string."""
         data = json.loads(self.model_dump_json())
-        return yaml.dump(
-            data, sort_keys=False, indent=4, width=80, default_flow_style=None
-        )
+        return to_yaml(data)
 
     def set_logging(self):
         """Set logging config.

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -245,6 +245,7 @@ class AnalysisConfig(GammapyBaseConfig):
     def read(cls, path):
         """Read from YAML file."""
         config = read_yaml(path)
+        config.pop("metadata", None)
         return AnalysisConfig(**config)
 
     @classmethod

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -9,7 +9,7 @@ from astropy import units as u
 from astropy.table import Table, vstack
 from gammapy.data import GTI
 from gammapy.modeling.models import DatasetModels, Models
-from gammapy.utils.scripts import make_name, make_path, read_yaml, write_yaml
+from gammapy.utils.scripts import make_name, make_path, read_yaml, to_yaml, write_yaml
 
 log = logging.getLogger(__name__)
 
@@ -469,7 +469,7 @@ class Datasets(collections.abc.MutableSequence):
         if path.exists() and not overwrite:
             raise IOError(f"File exists already: {path}")
 
-        write_yaml(data, path, sort_keys=False, checksum=checksum)
+        write_yaml(to_yaml(data), path, checksum=checksum)
 
         if filename_models:
             self.models.write(

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -468,8 +468,8 @@ class Datasets(collections.abc.MutableSequence):
 
         if path.exists() and not overwrite:
             raise IOError(f"File exists already: {path}")
-
-        write_yaml(to_yaml(data), path, checksum=checksum)
+        yaml_str = to_yaml(data)
+        write_yaml(yaml_str, path, checksum=checksum)
 
         if filename_models:
             self.models.write(

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -794,7 +794,7 @@ class FitResult:
             When True adds a CHECKSUM entry to the file.
             Default is False.
         """
-        from gammapy.modeling.models import _write_models
+        from gammapy.modeling.models.core import _write_models
 
         output = {}
         if self.optimize_result is not None:

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -586,10 +586,12 @@ class FitStepResult:
     def to_dict(self):
         """Convert to dictionary."""
         return {
-            "backend": self.backend,
-            "method": self.method,
-            "success": self.success,
-            "message": self.message,
+            self.__class__.__name__: {
+                "backend": self.backend,
+                "method": self.method,
+                "success": self.success,
+                "message": self.message,
+            }
         }
 
 
@@ -680,8 +682,8 @@ class OptimizeResult(FitStepResult):
     def to_dict(self):
         """Convert to dictionary."""
         output = super().to_dict()
-        output["nfev"] = self.nfev
-        output["total_stat"] = self._total_stat
+        output[self.__class__.__name__]["nfev"] = self.nfev
+        output[self.__class__.__name__]["total_stat"] = float(self._total_stat)
         return output
 
 
@@ -794,9 +796,9 @@ class FitResult:
         """
         output = {}
         if self.optimize_result is not None:
-            output["optimize_result"] = self.optimize_result.to_dict()
+            output.update(self.optimize_result.to_dict())
         if self.covariance_result is not None:
-            output["covariance_result"] = self.covariance_result.to_dict()
+            output.update(self.covariance_result.to_dict())
         self.models.write(
             path,
             overwrite,

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -12,7 +12,6 @@ from .iminuit import (
     covariance_iminuit,
     optimize_iminuit,
 )
-from .modeling.models import _write_models
 from .scipy import confidence_scipy, optimize_scipy
 from .sherpa import optimize_sherpa
 
@@ -795,6 +794,8 @@ class FitResult:
             When True adds a CHECKSUM entry to the file.
             Default is False.
         """
+        from gammapy.modeling.models import _write_models
+
         output = {}
         if self.optimize_result is not None:
             output.update(self.optimize_result.to_dict())

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -12,6 +12,7 @@ from .iminuit import (
     covariance_iminuit,
     optimize_iminuit,
 )
+from .modeling.models import _write_models
 from .scipy import confidence_scipy, optimize_scipy
 from .sherpa import optimize_sherpa
 
@@ -799,7 +800,8 @@ class FitResult:
             output.update(self.optimize_result.to_dict())
         if self.covariance_result is not None:
             output.update(self.covariance_result.to_dict())
-        self.models.write(
+        _write_models(
+            self.models,
             path,
             overwrite,
             full_output,

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -788,7 +788,7 @@ class FitResult:
         overwrite : bool, optional
             Overwrite existing file. Default is False.
         full_output : bool, optional
-            Store full parameter output. Default is False.
+            Store full parameter output. Default is True.
         overwrite_templates : bool, optional
             Overwrite templates FITS files. Default is False.
         checksum : bool, optional

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -524,7 +524,7 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
             yaml_str += to_yaml(extra_dict)
         yaml_str += self.to_yaml(full_output, overwrite_templates)
 
-        write_yaml(yaml_str, overwrite=overwrite, checksum=checksum)
+        write_yaml(yaml_str, path, overwrite=overwrite, checksum=checksum)
 
     def to_yaml(self, full_output=False, overwrite_templates=False):
         """Convert to YAML string."""

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -534,7 +534,7 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
             Default is False.
         """
         _write_models(
-            self.models,
+            self,
             path,
             overwrite,
             full_output,

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -443,7 +443,7 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
         ----------
         filename : str
             input filename
-        checksum : bool
+        checksum : bool, optional
             Whether to perform checksum verification. Default is False.
         """
         yaml_str = make_path(filename).read_text()
@@ -452,7 +452,19 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
 
     @classmethod
     def from_yaml(cls, yaml_str, path="", checksum=False):
-        """Create from YAML string."""
+        """Create from YAML string.
+
+        Parameters
+        ----------
+        yaml_str : str
+            yaml str
+        path : str
+            base path of model files
+        checksum : bool, optional
+            Whether to perform checksum verification. Default is False.
+
+
+        """
         data = from_yaml(yaml_str, checksum=checksum)
         # TODO : for now metadata are not kept. Add proper metadata creation.
         data.pop("metadata", None)
@@ -518,7 +530,7 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
             Overwrite templates FITS files. Default is False.
         write_covariance : bool, optional
             Whether to save the covariance. Default is True.
-        checksum : bool
+        checksum : bool, optional
             When True adds a CHECKSUM entry to the file.
             Default is False.
         """
@@ -533,7 +545,15 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
         )
 
     def to_yaml(self, full_output=False, overwrite_templates=False):
-        """Convert to YAML string."""
+        """Convert to YAML string.
+
+        Parameters
+        ----------
+         full_output : bool, optional
+            Store full parameter output. Default is False.
+        overwrite_templates : bool, optional
+            Overwrite templates FITS files. Default is False.
+        """
         data = self.to_dict(full_output, overwrite_templates)
         return to_yaml(data)
 

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -454,6 +454,8 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
     def from_yaml(cls, yaml_str, path="", checksum=False):
         """Create from YAML string."""
         data = from_yaml(yaml_str, checksum=checksum)
+        # TODO : for now metadata are not kept. Add proper metadata creation.
+        data.pop("metadata", None)
         return cls.from_dict(data, path=path)
 
     @classmethod

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -3,19 +3,16 @@ import collections.abc
 import copy
 import html
 import logging
-import warnings
 from os.path import split
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 import matplotlib.pyplot as plt
-import yaml
 from gammapy.maps import Map, RegionGeom
 from gammapy.modeling import Covariance, Parameter, Parameters
 from gammapy.modeling.covariance import CovarianceMixin
-from gammapy.utils.check import verify_checksum
-from gammapy.utils.scripts import make_name, make_path, to_yaml, write_yaml
+from gammapy.utils.scripts import from_yaml, make_name, make_path, to_yaml, write_yaml
 
 __all__ = ["Model", "Models", "DatasetModels", "ModelBase"]
 
@@ -456,17 +453,7 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
     @classmethod
     def from_yaml(cls, yaml_str, path="", checksum=False):
         """Create from YAML string."""
-        data = yaml.safe_load(yaml_str)
-        checksum_str = data.pop("checksum", None)
-        if checksum:
-            yaml_str = yaml.dump(
-                data, sort_keys=False, indent=4, width=80, default_flow_style=False
-            )
-            if not verify_checksum(yaml_str, checksum_str):
-                warnings.warn("Checksum verification failed.", UserWarning)
-
-        # TODO : for now metadata are not kept. Add proper metadata creation.
-        data.pop("metadata", None)
+        data = from_yaml(yaml_str, checksum=checksum)
         return cls.from_dict(data, path=path)
 
     @classmethod

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -15,7 +15,6 @@ from gammapy.maps import Map, RegionGeom
 from gammapy.modeling import Covariance, Parameter, Parameters
 from gammapy.modeling.covariance import CovarianceMixin
 from gammapy.utils.check import verify_checksum
-from gammapy.utils.metadata import CreatorMetaData
 from gammapy.utils.scripts import make_name, make_path, to_yaml, write_yaml
 
 __all__ = ["Model", "Models", "DatasetModels", "ModelBase"]
@@ -529,9 +528,7 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
     def to_yaml(self, full_output=False, overwrite_templates=False):
         """Convert to YAML string."""
         data = self.to_dict(full_output, overwrite_templates)
-        text = to_yaml(data)
-        creation = CreatorMetaData()
-        return text + creation.to_yaml()
+        return to_yaml(data)
 
     def update_link_label(self):
         """Update linked parameters labels used for serialisation and print."""

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -26,7 +26,7 @@ from gammapy.modeling.models import (
     TemplateNPredModel,
 )
 from gammapy.utils.deprecation import GammapyDeprecationWarning
-from gammapy.utils.scripts import make_path, read_yaml, write_yaml
+from gammapy.utils.scripts import make_path, read_yaml, to_yaml, write_yaml
 from gammapy.utils.testing import requires_data, requires_dependency
 
 
@@ -306,7 +306,7 @@ def test_absorption_io(tmp_path):
     assert_allclose(new_model.param, model.param)
     assert_allclose(new_model.data, model.data)
 
-    write_yaml(model_dict, tmp_path / "tmp.yaml")
+    write_yaml(to_yaml(model_dict), tmp_path / "tmp.yaml")
     read_yaml(tmp_path / "tmp.yaml")
 
 

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -338,10 +338,11 @@ def test_write(tmpdir):
     fit = Fit()
     result = fit.run(datasets)
 
-    result_dict = result.to_dict()
+    result_dict = result.covariance_result.to_dict()
     assert (
         result_dict["covariance_result"]["backend"] == result.covariance_result.backend
     )
+    result_dict = result.optimize_result.to_dict()
     assert result_dict["optimize_result"]["nfev"] == result.optimize_result.nfev
     assert (
         result_dict["optimize_result"]["total_stat"]
@@ -353,6 +354,4 @@ def test_write(tmpdir):
     optimize_result = fit.optimize(datasets)
     result = FitResult(optimize_result=optimize_result)
 
-    result_dict = result.to_dict()
-    assert "covariance_result" not in result_dict
     result.write(path=tmpdir / "test-fit-result.yaml", overwrite=True)

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -12,6 +12,7 @@ from gammapy.modeling.models import (
     Models,
     SkyModel,
 )
+from gammapy.utils.scripts import read_yaml
 from gammapy.utils.testing import requires_data, requires_dependency
 
 
@@ -340,18 +341,26 @@ def test_write(tmpdir):
 
     result_dict = result.covariance_result.to_dict()
     assert (
-        result_dict["covariance_result"]["backend"] == result.covariance_result.backend
+        result_dict["CovarianceResult"]["backend"] == result.covariance_result.backend
     )
     result_dict = result.optimize_result.to_dict()
-    assert result_dict["optimize_result"]["nfev"] == result.optimize_result.nfev
+    assert result_dict["OptimizeResult"]["nfev"] == result.optimize_result.nfev
     assert (
-        result_dict["optimize_result"]["total_stat"]
-        == result.optimize_result.total_stat
+        result_dict["OptimizeResult"]["total_stat"] == result.optimize_result.total_stat
     )
 
-    result.write(path=tmpdir / "test-fit-result.yaml")
+    filename = tmpdir / "test-fit-result.yaml"
+
+    result.write(filename)
+    data = read_yaml(filename)
+    assert "CovarianceResult" in data
+    assert "OptimizeResult" in data
 
     optimize_result = fit.optimize(datasets)
     result = FitResult(optimize_result=optimize_result)
 
-    result.write(path=tmpdir / "test-fit-result.yaml", overwrite=True)
+    result.write(filename, overwrite=True)
+    data = read_yaml(filename)
+
+    assert "CovarianceResult" not in data
+    assert "OptimizeResult" in data

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -100,14 +100,8 @@ def to_yaml(dictionary, sort_keys=False):
     ----------
     dictionary : dict
         Python dictionary.
-    filename : `~pathlib.Path`
-        Filename.
-    logger : `~logging.Logger`, optional
-        Logger. Default is None.
     sort_keys : bool, optional
         Whether to sort keys. Default is False.
-    checksum : bool, optional
-        Whether to add checksum keyword. Default is False.
     """
     from gammapy.utils.metadata import CreatorMetaData
 
@@ -136,6 +130,8 @@ def write_yaml(
         Whether to sort keys. Default is True.
     checksum : bool, optional
         Whether to add checksum keyword. Default is False.
+    overwrite : bool, optional
+        Overwrite existing file. Default is False.
     """
 
     if checksum:

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -84,10 +84,13 @@ def to_yaml(dictionary, sort_keys=False):
     checksum : bool, optional
         Whether to add checksum keyword. Default is False.
     """
+    from gammapy.utils.metadata import CreatorMetaData
+
     yaml_format = YAML_FORMAT.copy()
     yaml_format["sort_keys"] = sort_keys
     text = yaml.safe_dump(dictionary, **yaml_format)
-    return text
+    creation = CreatorMetaData()
+    return text + creation.to_yaml()
 
 
 def write_yaml(

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -19,6 +19,7 @@ __all__ = [
 
 PATH_DOCS = Path(__file__).resolve().parent / ".." / ".." / "docs"
 SKIP = ["_static", "_build", "_checkpoints", "docs/user-guide/model-gallery/"]
+YAML_FORMAT = dict(sort_keys=False, indent=4, width=80, default_flow_style=False)
 
 
 def get_images_paths(folder=PATH_DOCS):
@@ -67,8 +68,8 @@ def read_yaml(filename, logger=None, checksum=False):
     return data
 
 
-def write_yaml(dictionary, filename, logger=None, sort_keys=True, checksum=False):
-    """Write YAML file.
+def to_yaml(dictionary, sort_keys=False):
+    """dict to yaml
 
     Parameters
     ----------
@@ -83,13 +84,38 @@ def write_yaml(dictionary, filename, logger=None, sort_keys=True, checksum=False
     checksum : bool, optional
         Whether to add checksum keyword. Default is False.
     """
-    text = yaml.safe_dump(dictionary, default_flow_style=False, sort_keys=sort_keys)
+    yaml_format = YAML_FORMAT.copy()
+    yaml_format["sort_keys"] = sort_keys
+    text = yaml.safe_dump(dictionary, **yaml_format)
+    return text
+
+
+def write_yaml(
+    text, filename, logger=None, sort_keys=False, checksum=False, overwrite=False
+):
+    """Write YAML file.
+
+    Parameters
+    ----------
+    text : str
+        yaml str
+    filename : `~pathlib.Path`
+        Filename.
+    logger : `~logging.Logger`, optional
+        Logger. Default is None.
+    sort_keys : bool, optional
+        Whether to sort keys. Default is True.
+    checksum : bool, optional
+        Whether to add checksum keyword. Default is False.
+    """
 
     if checksum:
         text = add_checksum(text, sort_keys=sort_keys)
 
     path = make_path(filename)
     path.parent.mkdir(exist_ok=True)
+    if path.exists() and not overwrite:
+        raise IOError(f"File exists already: {path}")
     if logger is not None:
         logger.info(f"Writing {path}")
     path.write_text(text)

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -63,8 +63,7 @@ def from_yaml(text, sort_keys=False, checksum=False):
         yaml_str = yaml.dump(data, **yaml_format)
         if not verify_checksum(yaml_str, checksum_str):
             warnings.warn("Checksum verification failed.", UserWarning)
-    # TODO : for now metadata are not kept. Add proper metadata creation.
-    data.pop("metadata", None)
+
     return data
 
 
@@ -90,7 +89,7 @@ def read_yaml(filename, logger=None, checksum=False):
         logger.info(f"Reading {path}")
 
     text = path.read_text()
-    return from_yaml(text)
+    return from_yaml(text, checksum=checksum)
 
 
 def to_yaml(dictionary, sort_keys=False):

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from uuid import uuid4
 import yaml
 from gammapy.utils.check import add_checksum, verify_checksum
+from gammapy.utils.deprecation import deprecated_renamed_argument
 
 __all__ = [
     "from_yaml",
@@ -117,6 +118,7 @@ def to_yaml(dictionary, sort_keys=False):
     return text + creation.to_yaml()
 
 
+@deprecated_renamed_argument("dictionary", "text", "v1.3")
 def write_yaml(
     text, filename, logger=None, sort_keys=False, checksum=False, overwrite=False
 ):

--- a/gammapy/utils/tests/test_scripts.py
+++ b/gammapy/utils/tests/test_scripts.py
@@ -7,6 +7,7 @@ from gammapy.utils.scripts import (
     make_path,
     read_yaml,
     recursive_merge_dicts,
+    to_yaml,
     write_yaml,
 )
 
@@ -29,7 +30,7 @@ def test_recursive_merge_dicts():
 
 
 def test_read_write_yaml_checksum(tmp_path):
-    data = {"b": 1234, "a": "other"}
+    data = to_yaml({"b": 1234, "a": "other"})
     path = make_path(tmp_path / "test.yaml")
     write_yaml(data, path, sort_keys=False, checksum=True)
 


### PR DESCRIPTION
Simplify and cleanup yaml IO:
-use more the functions in utlis so we don't rewrite the code related to checksum, overwrite, log,  (and maybe meta data creator? )...
-simplify FitResult. write to use directly Models.write with an extra_dict (so we don't need #5311)