### PR TITLE
Make spectrum x-axis tick labels invisible by default in `plot_fit`

### DIFF
--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -536,6 +536,8 @@ class FluxPointsDataset(Dataset):
         gs = GridSpec(7, 1)
         if ax_spectrum is None:
             ax_spectrum = fig.add_subplot(gs[:5, :])
+            if ax_residuals is None:
+                plt.setp(ax_spectrum.get_xticklabels(), visible=False)
 
         if ax_residuals is None:
             ax_residuals = fig.add_subplot(gs[5:, :], sharex=ax_spectrum)

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -58,6 +58,10 @@ class PlotMixin:
         >>> dataset.plot_fit(kwargs_residuals=kwargs_residuals, kwargs_spectrum=kwargs_spectrum)  # doctest: +SKIP
         """
         gs = GridSpec(7, 1)
+        if ax_spectrum is None and ax_residuals is None:
+            bool_visible_xticklabel = False
+        else:
+            bool_visible_xticklabel = True
         ax_spectrum, ax_residuals = get_axes(
             ax_spectrum,
             ax_residuals,
@@ -77,6 +81,7 @@ class PlotMixin:
         method = kwargs_residuals.get("method", "diff")
         label = self._residuals_labels[method]
         ax_residuals.set_ylabel(f"Residuals\n{label}")
+        plt.setp(ax_spectrum.get_xticklabels(), visible=bool_visible_xticklabel)
 
         return ax_spectrum, ax_residuals
 

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -58,10 +58,7 @@ class PlotMixin:
         >>> dataset.plot_fit(kwargs_residuals=kwargs_residuals, kwargs_spectrum=kwargs_spectrum)  # doctest: +SKIP
         """
         gs = GridSpec(7, 1)
-        if ax_spectrum is None and ax_residuals is None:
-            bool_visible_xticklabel = False
-        else:
-            bool_visible_xticklabel = True
+        bool_visible_xticklabel = not (ax_spectrum is None and ax_residuals is None)
         ax_spectrum, ax_residuals = get_axes(
             ax_spectrum,
             ax_residuals,


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request resolves #5339

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This PR is ready for review.