### PR TITLE
Adapt `RadMax2D.plot_rad_max_vs_energy`

### DIFF
--- a/gammapy/irf/rad_max.py
+++ b/gammapy/irf/rad_max.py
@@ -2,6 +2,7 @@
 import astropy.units as u
 from astropy.visualization import quantity_support
 import matplotlib.pyplot as plt
+from matplotlib.ticker import FormatStrFormatter
 from gammapy.maps.axes import UNIT_STRING_FORMAT
 from .core import IRF
 
@@ -113,6 +114,7 @@ class RadMax2D(IRF):
         ax.set_ylim(0 * u.deg, None)
         ax.legend(loc="best")
         ax.set_ylabel(f"Rad max. [{ax.yaxis.units.to_string(UNIT_STRING_FORMAT)}]")
+        ax.yaxis.set_major_formatter(FormatStrFormatter("%.2f"))
         return ax
 
     @property


### PR DESCRIPTION
To resolve #5333

When we utilise `quantity_support` it overrides any formating, so to continue with this method to ensure the units are handled correctly we can simply set a formatter on the axis. 
This is also the method in `plot_containment_radius_vs_energy`.
