### PR TITLE
Remove json_encoders in AnalysisConfig

### DIFF
--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping
 from enum import Enum
 from pathlib import Path
 from typing import List, Optional
-from astropy import units as u
 import yaml
 from pydantic import BaseModel, ConfigDict
 from gammapy.makers import MapDatasetMaker
@@ -84,7 +83,6 @@ class GammapyBaseConfig(BaseModel):
         extra="forbid",
         validate_default=True,
         use_enum_values=True,
-        json_encoders={u.Quantity: lambda v: f"{v.value} {v.unit}"},
     )
 
     def _repr_html_(self):

--- a/gammapy/utils/types.py
+++ b/gammapy/utils/types.py
@@ -12,6 +12,7 @@ from .scripts import make_path
 __all__ = [
     "AngleType",
     "EnergyType",
+    "QuantityType",
     "TimeType",
     "PathType",
     "EarthLocationType",
@@ -92,6 +93,11 @@ def validate_energy(v):
     return v
 
 
+def validate_quantity(v):
+    """Validator for `~astropy.units.Quantity`."""
+    return u.Quantity(v)
+
+
 def validate_time(v):
     """Validator for `~astropy.time.Time`."""
     return Time(v)
@@ -151,6 +157,13 @@ EnergyType = Annotated[
     u.Quantity,
     PlainSerializer(lambda v: f"{v.value} {v.unit}", **SERIALIZE_KWARGS),
     BeforeValidator(validate_energy),
+    scalar_validator,
+]
+
+QuantityType = Annotated[
+    u.Quantity,
+    PlainSerializer(lambda v: f"{v.value} {v.unit}", **SERIALIZE_KWARGS),
+    BeforeValidator(validate_quantity),
     scalar_validator,
 ]
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request removes `json_encoders` from the `GammapyBaseConfig` pydantic model to comply with deprecated features. It also introduces a `QuantityType` but it is unused and un-tested so far. It could be removed.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
