### PR TITLE
Brought gammapy.visualization.plot_distribution in line with its documentation

### DIFF
--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -138,3 +138,6 @@ def test_plot_distribution():
         axes, res = plot_distribution(
             wcs_map=map_, func="norm", kwargs_hist={"bins": 40}
         )
+
+        fig, ax = plt.subplots(nrows=1, ncols=1)
+        plot_distribution(map_empty, ax=ax)

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -341,8 +341,8 @@ def plot_distribution(
         )
         cells_in_grid = rows * cols
     else:
-        axes = ax
-        cells_in_grid = len(ax.flatten())
+        axes = np.array([ax])
+        cells_in_grid = axes.size
 
     if not isinstance(axes, np.ndarray):
         axes = np.array([axes])


### PR DESCRIPTION
Running 
```
fig, ax = plt.subplots(nrows=1, ncols=1)
gammapy.visualization.plot_distribution(ts_map, ax=ax)
```
results in an error, since gammapy.visualization.plot_distribution expects an array of axes in its current form, which does not fit the description, which explicitly allows singular axes objects and lists of axes objects:
```
Parameters
----------
wcs_map : `~gammapy.maps.WcsNDMap`
    A map that contains data to be plotted.
ax : `~matplotlib.axes.Axes` or list of `~matplotlib.axes.Axes`
    Axis object to plot on. If a list of Axis is provided it has to be the same length as the length of _map.data.
```
This pull request implements a fix, but maybe it is not in line with what the original author of the function intended (and still makes implicit assumptions about the input. As implemented, it expects an object or an array like object, on which np.array([obj]) can be called.)
