### PR TITLE
Remove use of np.rint in pix_tuple_to_idx

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -47,7 +47,7 @@ def pix_tuple_to_idx(pix):
             idx += [p]
         else:
             with np.errstate(invalid="ignore"):
-                p_idx = np.rint(p).astype(int)
+                p_idx = np.floor(p + 0.5).astype(int)
             p_idx[~np.isfinite(p)] = INVALID_INDEX.int
             idx += [p_idx]
 

--- a/gammapy/maps/wcs/tests/test_ndmap.py
+++ b/gammapy/maps/wcs/tests/test_ndmap.py
@@ -1045,3 +1045,18 @@ def test_plot_mask():
 
     with mpl_plot_check():
         mask.plot_grid()
+
+
+def test_histogram_center_value():
+    evt_energy = np.arange(100.0, 105, 0.5) * u.GeV
+    N_evt = evt_energy.shape[0]
+    center = SkyCoord(0, 0, unit="deg", frame="icrs")
+    radec = SkyCoord(
+        [center.ra] * N_evt, [center.dec] * N_evt, unit="deg"
+    )  # fake position list
+    energy_axis = MapAxis.from_edges(np.arange(100, 106, 1) * u.GeV, name="energy")
+    map1 = WcsNDMap.create(
+        skydir=center, binsz=0.1 * u.deg, width=0.1 * u.deg, axes=[energy_axis]
+    )
+    map1.fill_by_coord({"skycoord": radec, "energy": evt_energy})
+    assert_allclose(map1.data[0:2], [[[2.0]], [[2.0]]])

--- a/gammapy/maps/wcs/tests/test_ndmap.py
+++ b/gammapy/maps/wcs/tests/test_ndmap.py
@@ -1060,3 +1060,11 @@ def test_histogram_center_value():
     )
     map1.fill_by_coord({"skycoord": radec, "energy": evt_energy})
     assert_allclose(map1.data[0:2], [[[2.0]], [[2.0]]])
+
+    map1 = WcsNDMap.create(
+        skydir=center,
+        binsz=1 * u.deg,
+        width=3 * u.deg,
+    )
+    map1.fill_by_pix([[0.0, 0.5, 1.0, 1.5], [0.0, 0.5, 1.0, 1.5]])
+    assert_allclose(map1.data, [[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 1.0]])


### PR DESCRIPTION
This fixes #5360 by using `np.floor(pixel+0.5)` instead of `np.rint(pixel)` 

The issue with `np.rint` (and `np.round`) is that `For values exactly halfway between rounded decimal values, NumPy
rounds to the nearest even value. Thus 1.5 and 2.5 round to 2.0, -0.5 and 0.5 round to 0.0, etc.`

The implementation here is similar to the implementation in `astropy.wcs.world_to_array_index_values` , https://docs.astropy.org/en/stable/_modules/astropy/wcs/wcsapi/low_level_api.html#BaseLowLevelWCS.world_to_array_index_values


This solves the issue in #5360 - the new plot given in the MRE  now matches 
![Unknown](https://github.com/gammapy/gammapy/assets/32677370/d322280f-b157-4c73-9a17-f417183e47bd)

I am labelling this as a bug fix, but we can decide if we want to backport it. This did not affect any of the test results, so probably this issue is evident only in artificially constructed examples. 