### PR TITLE
Observations `__getitem__` method addition 

### DIFF
--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -659,11 +659,7 @@ class Observations(collections.abc.MutableSequence):
             self.append(obs)
 
     def __getitem__(self, item):
-        if (isinstance(item, np.ndarray) and item.size == 0) or (
-            isinstance(item, list) and not item
-        ):
-            return self.__class__()
-        elif isinstance(item, (list, np.ndarray)) and all(
+        if isinstance(item, (list, np.ndarray)) and all(
             isinstance(x, str) for x in item
         ):
             return self.__class__([self._observations[self.index(_)] for _ in item])

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -658,11 +658,19 @@ class Observations(collections.abc.MutableSequence):
         for obs in observations:
             self.append(obs)
 
-    def __getitem__(self, key):
-        if isinstance(key, slice):
-            return self.__class__(self._observations[key])
+    def __getitem__(self, item):
+        if (isinstance(item, np.ndarray) and item.size == 0) or (
+            isinstance(item, list) and not item
+        ):
+            return self.__class__()
+        elif isinstance(item, (list, np.ndarray)) and all(
+            isinstance(x, str) for x in item
+        ):
+            return self.__class__([self._observations[self.index(_)] for _ in item])
+        elif isinstance(item, (slice, list, np.ndarray)):
+            return self.__class__(list(np.array(self._observations)[item]))
         else:
-            return self._observations[self.index(key)]
+            return self._observations[self.index(item)]
 
     def __delitem__(self, key):
         del self._observations[self.index(key)]

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -635,12 +635,23 @@ def test_observations_getitem(data_store):
     assert len(obs_2) == 2
     assert obs_2.ids == ["20136", "20151"]
 
-    obs_3 = obs_1[np.array(mask)]
+    ind = [0, 2]
+    obs_2 = obs_1[ind]
 
-    assert len(obs_3) == 2
-    assert obs_3.ids == ["20136", "20151"]
+    assert len(obs_2) == 2
+    assert obs_2.ids == ["20136", "20151"]
+
+    obs_2 = obs_1[np.array(mask)]
+
+    assert len(obs_2) == 2
+    assert obs_2.ids == ["20136", "20151"]
 
     assert obs_1[["20136", "20151"]].ids == ["20136", "20151"]
 
-    assert len(obs_1[[]]) == 0
-    assert len(obs_1[np.array([])]) == 0
+    obs_2 = obs_1[[]]
+    assert len(obs_2) == 0
+    assert isinstance(obs_2, Observations)
+
+    obs_2 = obs_1[np.array([])]
+    assert len(obs_2) == 0
+    assert isinstance(obs_2, Observations)

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -190,9 +190,6 @@ def test_observations_mutation(data_store):
     with pytest.raises(TypeError):
         obss[5] = "bad"
 
-    with pytest.raises(TypeError):
-        obss[["1", "2"]]
-
 
 def test_empty_observations():
     observations = Observations()
@@ -584,13 +581,6 @@ def test_stack_observations(data_store, caplog):
 
 
 @requires_data()
-def test_slice(data_store):
-    obs_1 = data_store.get_observations([20136, 20137, 20151])
-    assert isinstance(obs_1[0], Observation)
-    assert isinstance(obs_1[1:], Observations)
-
-
-@requires_data()
 def test_observations_generator(data_store):
     """Test Observations.generator()"""
     obs_1 = data_store.get_observations([20136, 20137, 20151])
@@ -628,3 +618,29 @@ def test_event_setter():
     events = EventList(Table())
     obs.events = events
     assert obs.events is events
+
+
+@requires_data()
+def test_observations_getitem(data_store):
+    """Test mask indexing on Observations"""
+    obs_1 = data_store.get_observations([20136, 20137, 20151])
+
+    assert isinstance(obs_1[0], Observation)
+    assert isinstance(obs_1[1:], Observations)
+    assert len(obs_1[1:]) == 2
+
+    mask = [True, False, True]
+    obs_2 = obs_1[mask]
+
+    assert len(obs_2) == 2
+    assert obs_2.ids == ["20136", "20151"]
+
+    obs_3 = obs_1[np.array(mask)]
+
+    assert len(obs_3) == 2
+    assert obs_3.ids == ["20136", "20151"]
+
+    assert obs_1[["20136", "20151"]].ids == ["20136", "20151"]
+
+    assert len(obs_1[[]]) == 0
+    assert len(obs_1[np.array([])]) == 0


### PR DESCRIPTION
This PR improves the `__getitem__` method of `Observations`. 
It add the possibilitY to access with array indexing. This is particularly useful to access part of the Observations using a mask. 
I also added the possibility to access part of the array using a list of string. Typically, this can be use to access part of the observations with obs_id. 