### PR TITLE
Add max_niter as option in TSMapEstimator

### DIFF
--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -116,6 +116,9 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         of jobs limited to the number of physical CPUs.
     parallel_backend : {"multiprocessing", "ray"}
         Which backend to use for multiprocessing. Defaults to `~gammapy.utils.parallel.BACKEND_DEFAULT`.
+    max_niter : int
+        Maximal number of iterations used by the root finding algorithm.
+        Default is 100.
 
     Notes
     -----
@@ -183,6 +186,7 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         n_jobs=None,
         parallel_backend=None,
         norm=None,
+        max_niter=100,
     ):
         if kernel_width is not None:
             kernel_width = Angle(kernel_width)
@@ -207,6 +211,7 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         self.n_jobs = n_jobs
         self.parallel_backend = parallel_backend
         self.sum_over_energy_groups = sum_over_energy_groups
+        self.max_niter = max_niter
 
         self.selection_optional = selection_optional
         self.energy_edges = energy_edges
@@ -217,6 +222,7 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
             selection_optional=selection_optional,
             ts_threshold=threshold,
             norm=self.norm,
+            max_niter=self.max_niter,
         )
 
     @property
@@ -681,7 +687,7 @@ class BrentqFluxEstimator(Estimator):
         n_sigma,
         n_sigma_ul,
         selection_optional=None,
-        max_niter=20,
+        max_niter=100,
         ts_threshold=None,
         norm=None,
     ):


### PR DESCRIPTION
Add max_niter as option in TSMapEstimator (passed to BrentqFluxEstimator) and increase max default to 100 instead of 20 (joint maps converge for niter~20-30).