### PR TITLE
Introduce context manager to set energy range to mask fit

### DIFF
--- a/gammapy/datasets/tests/test_utils.py
+++ b/gammapy/datasets/tests/test_utils.py
@@ -186,3 +186,8 @@ def test_set_and_restore_mask():
     assert_allclose(range1[0].quantity.to_value("TeV"), 0.01)
     assert_allclose(range1[1].quantity.to_value("TeV"), 100.0)
     assert_allclose(range2[0].quantity.to_value("TeV"), 0.01)
+
+    with set_and_restore_mask_fit(
+        datasets, 100 * u.TeV, 200 * u.TeV
+    ) as masked_datasets:
+        assert len(masked_datasets) == 0

--- a/gammapy/datasets/tests/test_utils.py
+++ b/gammapy/datasets/tests/test_utils.py
@@ -4,7 +4,12 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.datasets import Datasets, MapDataset, SpectrumDatasetOnOff
-from gammapy.datasets.utils import apply_edisp, set_and_restore_mask_fit, split_dataset, create_global_dataset
+from gammapy.datasets.utils import (
+    apply_edisp,
+    set_and_restore_mask_fit,
+    split_dataset,
+    create_global_dataset,
+)
 from gammapy.irf import EDispKernel
 from gammapy.maps import Map, MapAxis
 from gammapy.modeling.models import (

--- a/gammapy/datasets/utils.py
+++ b/gammapy/datasets/utils.py
@@ -422,44 +422,6 @@ def create_global_dataset(
     return MapDataset.create(geom=geom, energy_axis_true=energy_axis_true, name=name)
 
 
-def create_energy_mask(dataset, energy_min=None, energy_max=None):
-    """Build a mask for the dataset restricting its mask_fit to a given energy range.
-
-    Parameters
-    ----------
-    dataset : `~gammapy.datasets.Dataset`
-        the dataset to compute a mask for.
-    energy_min : `~astropy.units.Quantity`, optional
-        minimum energy. If None, use lower bound of the energy axis. Default is None.
-    energy_max : `~astropy.units.Quantity`, optional
-        maximum energy. If None, use upper bound of the energy axis. Default is None.
-    """
-    energy_axis = dataset._geom.axes["energy"]
-
-    if energy_min is None:
-        energy_min = energy_axis.bounds[0]
-
-    if energy_max is None:
-        energy_max = energy_axis.bounds[1]
-
-    energy_min, energy_max = u.Quantity(energy_min), u.Quantity(energy_max)
-
-    group = energy_axis.group_table(edges=[energy_min, energy_max])
-
-    is_normal = group["bin_type"] == "normal   "
-    group = group[is_normal]
-
-    mask_fit = dataset._geom.energy_mask(
-        group["energy_min"][0] * energy_axis.unit,
-        group["energy_max"][0] * energy_axis.unit,
-    )
-
-    if dataset.mask_fit is not None:
-        mask_fit *= dataset.mask_fit
-
-    return mask_fit
-
-
 class set_and_restore_mask_fit:
     """Context manager to set a `mask_fit` on dataset and restore the initial mask.
 

--- a/gammapy/datasets/utils.py
+++ b/gammapy/datasets/utils.py
@@ -422,6 +422,7 @@ def create_global_dataset(
     )
     return MapDataset.create(geom=geom, energy_axis_true=energy_axis_true, name=name)
 
+
 def create_energy_mask(dataset, energy_min=None, energy_max=None):
     """Build a mask for the dataset restricting its mask_fit to a given energy range.
 
@@ -429,10 +430,10 @@ def create_energy_mask(dataset, energy_min=None, energy_max=None):
     ----------
     dataset : `~gammapy.datasets.Dataset`
         the dataset to compute a mask for.
-    energy_min : `~astropy.units.Quantity`
-        minimum energy.
-    energy_max : `~astropy.units.Quantity`
-        maximum energy.
+    energy_min : `~astropy.units.Quantity`, optional
+        minimum energy. If None, use lower bound of the energy axis. Default is None.
+    energy_max : `~astropy.units.Quantity`, optional
+        maximum energy. If None, use upper bound of the energy axis. Default is None.
     """
     energy_axis = dataset._geom.axes["energy"]
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request introduces a context manager to set an energy range to the mask fit of a `Datasets` object. This is meant to replace the `Datasets.split_by_energy` method that `FluxPointsEstimator` is using. An advantage of this approach is to avoid building new evaluators for energy energy band. It is not clear it is sufficient to support multiprocessing though. 

Opinions @QRemy , @AtreyeeS , @adonath ?

Note that some code duplication can be further removed with the `create_energy_mask` method (namely the group table creation is also used in `Dataset.split_by_energy`)

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
