### PR TITLE
Fix `LabelMapAxis` so it doesn't reorder the labels

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3129,7 +3129,7 @@ class LabelMapAxis:
         if not len(unique_labels) == len(labels):
             raise ValueError("Node labels must be unique")
 
-        self._labels = unique_labels
+        self._labels = labels
         self._name = name
 
     @property

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3129,7 +3129,7 @@ class LabelMapAxis:
         if not len(unique_labels) == len(labels):
             raise ValueError("Node labels must be unique")
 
-        self._labels = labels
+        self._labels = np.array(labels)
         self._name = name
 
     @property

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -797,12 +797,16 @@ def test_label_map_axis_basics():
     labels = np.array([1, 4, 5])
     assert_allclose(labels, [1, 4, 5])
     assert_allclose(LabelMapAxis(labels).center, labels)
+    assert_allclose(LabelMapAxis(labels)._labels, labels)
 
     # Test case with non unique labels
     with pytest.raises(ValueError) as exc_info:
         LabelMapAxis([1, 1, 1])
-
     assert str(exc_info.value) == "Node labels must be unique"
+
+    # Ensure non alphabetical ordering
+    labels = np.array(["b", "a", "d", "c"])
+    assert_equal(LabelMapAxis(labels).center, labels)
 
 
 def test_label_map_axis_coord_to_idx():

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -793,6 +793,17 @@ def test_label_map_axis_basics():
     axis_copy = axis.copy()
     assert axis_copy.name == "label-axis"
 
+    # Ensure order is correct
+    labels = np.array([1, 4, 5])
+    assert_allclose(labels, [1, 4, 5])
+    assert_allclose(LabelMapAxis(labels).center, labels)
+
+    # Test case with non unique labels
+    with pytest.raises(ValueError) as exc_info:
+        LabelMapAxis([1, 1, 1])
+
+    assert str(exc_info.value) == "Node labels must be unique"
+
 
 def test_label_map_axis_coord_to_idx():
     axis = LabelMapAxis(labels=["label-1", "label-2", "label-3"], name="label-axis")


### PR DESCRIPTION
Resolves #5384


Note: had to ensure that labels was an array type, as this is what np.unique would do