### PR TITLE
Adjust counts type in fake

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1374,6 +1374,7 @@ class MapDataset(Dataset):
         npred = self.npred()
         data = np.nan_to_num(npred.data, copy=True, nan=0.0, posinf=0.0, neginf=0.0)
         npred.data = random_state.poisson(data)
+        npred.data = npred.data.astype("float64")
         self.counts = npred
 
     def to_hdulist(self):

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1374,7 +1374,7 @@ class MapDataset(Dataset):
         npred = self.npred()
         data = np.nan_to_num(npred.data, copy=True, nan=0.0, posinf=0.0, neginf=0.0)
         npred.data = random_state.poisson(data)
-        npred.data = npred.data.astype("float64")
+        npred.data = npred.data.astype("float")
         self.counts = npred
 
     def to_hdulist(self):

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1699,6 +1699,7 @@ def test_map_dataset_on_off_fake(geom):
     assert_allclose(empty_dataset.counts.data[0, 50, 50], 0)
     assert_allclose(empty_dataset.counts.data.mean(), 0.99445, rtol=1e-3)
     assert_allclose(empty_dataset.counts_off.data.mean(), 10.00055, rtol=1e-3)
+    assert empty_dataset.counts.data.dtype == float
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1692,7 +1692,7 @@ def test_map_dataset_on_off_cutout(images):
     assert cutout_dataset.name != dataset.name
 
 
-def test_map_dataset_on_off_fake(geom, images):
+def test_map_dataset_on_off_fake(geom):
     rad_axis = MapAxis(nodes=np.linspace(0.0, 1.0, 51), unit="deg", name="rad")
     energy_true_axis = geom.axes["energy"].copy(name="energy_true")
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -284,7 +284,7 @@ def test_fake(sky_model, geom, geom_etrue):
     bkg_model = FoVBackgroundModel(dataset_name=stacked.name)
     stacked.models = [sky_model, bkg_model]
     stacked.counts = stacked.npred()
-    stacked.stack(dataset)
+    dataset.stack(stacked)
     assert_allclose(stacked.counts.data.sum(), 19234.3407, 1e-2)
 
 

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -285,7 +285,7 @@ def test_fake(sky_model, geom, geom_etrue):
     stacked.models = [sky_model, bkg_model]
     stacked.counts = stacked.npred()
     dataset.stack(stacked)
-    assert_allclose(stacked.counts.data.sum(), 19234.3407, 1e-2)
+    assert_allclose(dataset.counts.data.sum(), 19234.3407, 1e-2)
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -278,6 +278,14 @@ def test_fake(sky_model, geom, geom_etrue):
     assert real_dataset.counts.data.shape == dataset.counts.data.shape
     assert_allclose(real_dataset.counts.data.sum(), 9525.299054, rtol=1e-5)
     assert_allclose(dataset.counts.data.sum(), 9709)
+    assert dataset.counts.data.dtype == float
+
+    stacked = get_map_dataset(geom, geom_etrue)
+    bkg_model = FoVBackgroundModel(dataset_name=stacked.name)
+    stacked.models = [sky_model, bkg_model]
+    stacked.counts = stacked.npred()
+    stacked.stack(dataset)
+    assert_allclose(stacked.counts.data.sum(), 19234.3407, 1e-2)
 
 
 @requires_data()
@@ -1684,7 +1692,7 @@ def test_map_dataset_on_off_cutout(images):
     assert cutout_dataset.name != dataset.name
 
 
-def test_map_dataset_on_off_fake(geom):
+def test_map_dataset_on_off_fake(geom, images):
     rad_axis = MapAxis(nodes=np.linspace(0.0, 1.0, 51), unit="deg", name="rad")
     energy_true_axis = geom.axes["energy"].copy(name="energy_true")
 


### PR DESCRIPTION
Should we make the data type the same in the `fake` operation as the initial counts?

I came across this when trying to combing a `fake` dataset with a normal one. Do we want this kind of behaviour always?