### PR TITLE
Support for array valued regions

### DIFF
--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -3,7 +3,6 @@ import copy
 import logging
 from gammapy.utils.cache import cachemethod
 import numpy as np
-import matplotlib.pyplot as plt
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from astropy.io import fits
@@ -23,6 +22,7 @@ from regions import (
     Regions,
     SkyRegion,
 )
+import matplotlib.pyplot as plt
 
 from gammapy.utils.regions import (
     compound_region_center,
@@ -482,7 +482,7 @@ class RegionGeom(Geom):
         """
         wcs_geom = self.to_wcs_geom()
 
-        weights = wcs_geom.region_weights(
+        weights = wcs_geom.to_image().region_weights(
             regions=[self.region], oversampling_factor=factor
         )
 

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -135,8 +135,8 @@ class RegionGeom(Geom):
     @property
     def is_regular(self):
         """"""
-        if hasattr(self.region, "radius"):
-            return np.isscalar(self.region.radius.value)
+        if hasattr(self.region, "is_regular"):
+            return self.region.is_regular
         return True
 
     @property

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -22,13 +22,14 @@ from regions import (
     Regions,
     SkyRegion,
 )
-import matplotlib.pyplot as plt
+
 from gammapy.utils.regions import (
     compound_region_center,
     compound_region_to_regions,
     regions_to_compound_region,
 )
 from gammapy.visualization.utils import ARTIST_TO_LINE_PROPERTIES
+
 from ..axes import MapAxes
 from ..coord import MapCoord
 from ..core import Map
@@ -130,6 +131,11 @@ class RegionGeom(Geom):
             return self.region.center.frame.name
         except AttributeError:
             return wcs_to_celestial_frame(self.wcs).name
+
+    @property
+    def is_regular(self):
+        """"""
+        return np.isscalar(self.region.radius)
 
     @property
     def binsz_wcs(self):
@@ -251,7 +257,16 @@ class RegionGeom(Geom):
         if self.is_all_point_sky_regions:
             return np.ones(coords.skycoord.shape, dtype=bool)
 
-        return self.region.contains(coords.skycoord, self.wcs)
+        if not self.is_regular:
+            idx = self.axes.coord_to_idx(coords)
+            cls = self.region.__class__
+            region = cls(
+                center=self.region.center, radius=self.region.radius[idx].squeeze()
+            )
+        else:
+            region = self.region
+
+        return region.contains(coords.skycoord, self.wcs)
 
     def contains_wcs_pix(self, pix):
         """Check if a given WCS pixel coordinate is contained in the region.
@@ -420,7 +435,8 @@ class RegionGeom(Geom):
             )
         else:
             width = self.width
-        wcs_geom_region = WcsGeom(wcs=self.wcs)
+
+        wcs_geom_region = WcsGeom(wcs=self.wcs, npix=self.wcs.array_shape)
         wcs_geom = wcs_geom_region.cutout(position=self.center_skydir, width=width)
         wcs_geom = wcs_geom.to_cube(self.axes)
         return wcs_geom
@@ -467,7 +483,7 @@ class RegionGeom(Geom):
         """
         wcs_geom = self.to_wcs_geom()
 
-        weights = wcs_geom.to_image().region_weights(
+        weights = wcs_geom.region_weights(
             regions=[self.region], oversampling_factor=factor
         )
 
@@ -475,7 +491,7 @@ class RegionGeom(Geom):
         weights = weights.data[mask]
 
         # Get coordinates
-        coords = wcs_geom.get_coord(sparse=True).apply_mask(mask)
+        coords = wcs_geom.get_coord(sparse=True)
         return coords, weights
 
     def to_binsz(self, binsz):
@@ -571,10 +587,10 @@ class RegionGeom(Geom):
         else:
             in_region = self.contains(coords.skycoord)
 
-            x = np.zeros(coords.skycoord.shape)
+            x = np.zeros(in_region.shape)
             x[~in_region] = np.nan
 
-            y = np.zeros(coords.skycoord.shape)
+            y = np.zeros(in_region.shape)
             y[~in_region] = np.nan
 
             pix = (x, y)

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -135,7 +135,9 @@ class RegionGeom(Geom):
     @property
     def is_regular(self):
         """"""
-        return np.isscalar(self.region.radius.value)
+        if hasattr(self.region, "radius"):
+            return np.isscalar(self.region.radius.value)
+        return True
 
     @property
     def binsz_wcs(self):

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -3,6 +3,7 @@ import copy
 import logging
 from gammapy.utils.cache import cachemethod
 import numpy as np
+import matplotlib.pyplot as plt
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from astropy.io import fits
@@ -134,7 +135,7 @@ class RegionGeom(Geom):
     @property
     def is_regular(self):
         """"""
-        return np.isscalar(self.region.radius)
+        return np.isscalar(self.region.radius.value)
 
     @property
     def binsz_wcs(self):
@@ -257,7 +258,7 @@ class RegionGeom(Geom):
             return np.ones(coords.skycoord.shape, dtype=bool)
 
         if not self.is_regular:
-            idx = self.axes.coord_to_idx(coords)
+            idx = self.axes.coord_to_idx(coords)[0]
             cls = self.region.__class__
             region = cls(
                 center=self.region.center, radius=self.region.radius[idx].squeeze()
@@ -434,7 +435,7 @@ class RegionGeom(Geom):
             )
         else:
             width = self.width
-        wcs_geom_region = WcsGeom(wcs=self.wcs, npix=self.wcs.array_shape)
+        wcs_geom_region = WcsGeom(wcs=self.wcs)
         wcs_geom = wcs_geom_region.cutout(position=self.center_skydir, width=width)
         wcs_geom = wcs_geom.to_cube(self.axes)
         return wcs_geom
@@ -489,7 +490,7 @@ class RegionGeom(Geom):
         weights = weights.data[mask]
 
         # Get coordinates
-        coords = wcs_geom.get_coord(sparse=True)
+        coords = wcs_geom.get_coord(sparse=True).apply_mask(mask)
         return coords, weights
 
     def to_binsz(self, binsz):
@@ -583,7 +584,7 @@ class RegionGeom(Geom):
         if self.region is None:
             pix = (0, 0)
         else:
-            in_region = self.contains(coords.skycoord)
+            in_region = self.contains(coords)
 
             x = np.zeros(in_region.shape)
             x[~in_region] = np.nan

--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -83,7 +83,6 @@ class RegionGeom(Geom):
 
     """
 
-    is_regular = True
     is_allsky = False
     is_hpx = False
     is_region = True
@@ -435,7 +434,6 @@ class RegionGeom(Geom):
             )
         else:
             width = self.width
-
         wcs_geom_region = WcsGeom(wcs=self.wcs, npix=self.wcs.array_shape)
         wcs_geom = wcs_geom_region.cutout(position=self.center_skydir, width=width)
         wcs_geom = wcs_geom.to_cube(self.axes)

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -619,7 +619,7 @@ class ArrayQuantityLength(RegionAttr):
 
     def _validate(self, value):
         if not isinstance(value, u.Quantity):
-            raise ValueError(f"The {self.name} must be an astropy " "Quantity object")
+            raise ValueError(f"The {self.name} must be an astropy  `Quantity object`")
 
 
 class ArrayLength(RegionAttr):

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -618,7 +618,7 @@ class ArrayQuantityLength(RegionAttr):
     """
 
     def _validate(self, value):
-        if not (isinstance(value, u.Quantity)):
+        if not isinstance(value, u.Quantity):
             raise ValueError(f"The {self.name} must be an astropy " "Quantity object")
 
 

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -18,7 +18,6 @@ from astropy.table import Table
 from gammapy.utils.scripts import make_path
 from regions import (
     CircleAnnulusSkyRegion,
-    CirclePixelRegion,
     CircleSkyRegion,
     CirclePixelRegion,
     CompoundSkyRegion,
@@ -633,6 +632,7 @@ class CircleSkyRegionArray(CircleSkyRegion):
     """Circle sky region with array support for radius"""
 
     radius = ArrayQuantityLength("radius")
+    is_regular = False
 
     def to_pixel(self, wcs):
         center, pixscale, _ = pixel_scale_angle_at_skycoord(self.center, wcs)
@@ -644,6 +644,7 @@ class CirclePixelRegionArray(CirclePixelRegion):
     """Pixel sky region with array support for radius"""
 
     radius = ArrayLength("radius")
+    is_regular = False
 
     @property
     def bounding_box(self):

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -20,6 +20,7 @@ from regions import (
     CircleAnnulusSkyRegion,
     CirclePixelRegion,
     CircleSkyRegion,
+    CirclePixelRegion,
     CompoundSkyRegion,
     EllipseSkyRegion,
     RectangleSkyRegion,
@@ -657,3 +658,59 @@ class CirclePixelRegionArray(CirclePixelRegion):
         ymin = self.center.y - radius
         ymax = self.center.y + radius
         return BoundingBox.from_float(xmin, xmax, ymin, ymax)
+
+
+# This code is only needed because regions forbids array valued attributes
+
+
+class ArrayQuantityLength(RegionAttribute):
+    """
+    Descriptor class for `~regions.SkyRegion`, which takes a scalar
+    `~astropy.units.Quantity` object.
+    """
+
+    def _validate(self, value):
+        if not isinstance(value, u.Quantity):
+            raise ValueError(f"The {self.name} must be an astropy  `Quantity object`")
+
+
+class ArrayLength(RegionAttribute):
+    """
+    Descriptor class for `~regions.PixelRegion`, which takes a scalar
+    python/numpy number.
+    """
+
+    def _validate(self, value):
+        pass
+
+
+class CircleSkyRegionArray(CircleSkyRegion):
+    """Circle sky region with array support for radius"""
+
+    radius = ArrayQuantityLength("radius")
+
+    def to_pixel(self, wcs):
+        center, pixscale, _ = pixel_scale_angle_at_skycoord(self.center, wcs)
+        radius = (self.radius / pixscale).to(u.pix).value
+        return CirclePixelRegionArray(center, radius, self.meta, self.visual)
+
+
+class CirclePixelRegionArray(CirclePixelRegion):
+    """Pixel sky region with array support for radius"""
+
+    radius = ArrayLength("radius")
+
+    @property
+    def bounding_box(self):
+        """Bounding box (`~regions.RegionBoundingBox`)."""
+        radius = max(self.radius)
+        xmin = self.center.x - radius
+        xmax = self.center.x + radius
+        ymin = self.center.y - radius
+        ymax = self.center.y + radius
+        return RegionBoundingBox.from_float(xmin, xmax, ymin, ymax)
+
+    @property
+    def area(self):
+        # Extra axes to match dimensions from a RegionGeom
+        return super().area[:, np.newaxis, np.newaxis]

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -10,14 +10,15 @@ without a WCS (see "sky and pixel regions" in PIG 10), or some HEALPix integrati
 """
 
 import operator
+
 import numpy as np
-from scipy.optimize import Bounds, minimize
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from gammapy.utils.scripts import make_path
 from regions import (
     CircleAnnulusSkyRegion,
+    CirclePixelRegion,
     CircleSkyRegion,
     CompoundSkyRegion,
     EllipseSkyRegion,
@@ -26,6 +27,10 @@ from regions import (
     PolygonSkyRegion,
     PolygonPixelRegion,
 )
+from regions._utils import pixel_scale_angle_at_skycoord
+from regions.core import BoundingBox
+from regions.core.attributes import RegionAttr
+from scipy.optimize import Bounds, minimize
 
 from regions.core.pixcoord import PixCoord
 from regions.core.metadata import RegionMeta, RegionVisual
@@ -601,3 +606,54 @@ def extract_bright_star_regions(
         )
 
     return Regions(regions)
+
+
+# This code is only needed because regions forbids array valued attributes
+
+
+class ArrayQuantityLength(RegionAttr):
+    """
+    Descriptor class for `~regions.SkyRegion`, which takes a scalar
+    `~astropy.units.Quantity` object.
+    """
+
+    def _validate(self, value):
+        if not (isinstance(value, u.Quantity)):
+            raise ValueError(f"The {self.name} must be an astropy " "Quantity object")
+
+
+class ArrayLength(RegionAttr):
+    """
+    Descriptor class for `~regions.PixelRegion`, which takes a scalar
+    python/numpy number.
+    """
+
+    def _validate(self, value):
+        pass
+
+
+class CircleSkyRegionArray(CircleSkyRegion):
+    """Circle sky region with array support for radius"""
+
+    radius = ArrayQuantityLength("radius")
+
+    def to_pixel(self, wcs):
+        center, pixscale, _ = pixel_scale_angle_at_skycoord(self.center, wcs)
+        radius = (self.radius / pixscale).to(u.pix).value
+        return CirclePixelRegionArray(center, radius, self.meta, self.visual)
+
+
+class CirclePixelRegionArray(CirclePixelRegion):
+    """Pixel sky region with array support for radius"""
+
+    radius = ArrayLength("radius")
+
+    @property
+    def bounding_box(self):
+        """Bounding box (`~regions.BoundingBox`)."""
+        radius = max(self.radius)
+        xmin = self.center.x - radius
+        xmax = self.center.x + radius
+        ymin = self.center.y - radius
+        ymax = self.center.y + radius
+        return BoundingBox.from_float(xmin, xmax, ymin, ymax)

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -28,9 +28,8 @@ from regions import (
     PolygonSkyRegion,
     PolygonPixelRegion,
 )
-from regions._utils import pixel_scale_angle_at_skycoord
-from regions.core import BoundingBox
-from regions.core.attributes import RegionAttr
+from regions.core import RegionBoundingBox
+from regions.core.attributes import RegionAttribute
 from scipy.optimize import Bounds, minimize
 
 from regions.core.pixcoord import PixCoord
@@ -609,60 +608,6 @@ def extract_bright_star_regions(
     return Regions(regions)
 
 
-# This code is only needed because regions forbids array valued attributes
-
-
-class ArrayQuantityLength(RegionAttr):
-    """
-    Descriptor class for `~regions.SkyRegion`, which takes a scalar
-    `~astropy.units.Quantity` object.
-    """
-
-    def _validate(self, value):
-        if not isinstance(value, u.Quantity):
-            raise ValueError(f"The {self.name} must be an astropy  `Quantity object`")
-
-
-class ArrayLength(RegionAttr):
-    """
-    Descriptor class for `~regions.PixelRegion`, which takes a scalar
-    python/numpy number.
-    """
-
-    def _validate(self, value):
-        pass
-
-
-class CircleSkyRegionArray(CircleSkyRegion):
-    """Circle sky region with array support for radius"""
-
-    radius = ArrayQuantityLength("radius")
-
-    def to_pixel(self, wcs):
-        center, pixscale, _ = pixel_scale_angle_at_skycoord(self.center, wcs)
-        radius = (self.radius / pixscale).to(u.pix).value
-        return CirclePixelRegionArray(center, radius, self.meta, self.visual)
-
-
-class CirclePixelRegionArray(CirclePixelRegion):
-    """Pixel sky region with array support for radius"""
-
-    radius = ArrayLength("radius")
-
-    @property
-    def bounding_box(self):
-        """Bounding box (`~regions.BoundingBox`)."""
-        radius = max(self.radius)
-        xmin = self.center.x - radius
-        xmax = self.center.x + radius
-        ymin = self.center.y - radius
-        ymax = self.center.y + radius
-        return BoundingBox.from_float(xmin, xmax, ymin, ymax)
-
-
-# This code is only needed because regions forbids array valued attributes
-
-
 class ArrayQuantityLength(RegionAttribute):
     """
     Descriptor class for `~regions.SkyRegion`, which takes a scalar
@@ -703,7 +648,7 @@ class CirclePixelRegionArray(CirclePixelRegion):
     @property
     def bounding_box(self):
         """Bounding box (`~regions.RegionBoundingBox`)."""
-        radius = max(self.radius)
+        radius = np.atleast_1d(self.radius).max()
         xmin = self.center.x - radius
         xmax = self.center.x + radius
         ymin = self.center.y - radius

--- a/gammapy/utils/tests/test_regions.py
+++ b/gammapy/utils/tests/test_regions.py
@@ -15,6 +15,7 @@ from astropy.coordinates import SkyCoord, Angle
 from regions import (
     CircleSkyRegion,
     EllipseSkyRegion,
+    RegionBoundingBox,
     Regions,
     RegionMeta,
     RegionVisual,
@@ -23,6 +24,8 @@ from regions import (
 from astropy.wcs import WCS
 
 from gammapy.utils.regions import (
+    CirclePixelRegionArray,
+    CircleSkyRegionArray,
     SphericalCircleSkyRegion,
     compound_region_center,
     region_circle_to_ellipse,
@@ -35,8 +38,9 @@ from gammapy.utils.regions import (
     make_grid_rectangle_sky_regions,
 )
 
-from gammapy.maps import WcsGeom
+from gammapy.maps import WcsGeom, MapAxis, RegionGeom, RegionNDMap
 from gammapy.utils.testing import requires_data
+from gammapy.data import EventList
 
 
 def test_compound_region_center():
@@ -244,3 +248,118 @@ def test_make_grid_rectangle_sky_regions():
     assert_allclose(regions[0].center.b, -0.343 * u.deg, atol=1e-2)
     assert_allclose(regions[0].width, 4.0 * u.deg, rtol=1e-3)
     assert_allclose(regions[0].height, 2.0 * u.deg, rtol=1e-3)
+
+
+def make_test_wcs():
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [100, 100]
+    wcs.wcs.cdelt = [-0.1, 0.1]
+    wcs.wcs.crval = [0, 0]
+    wcs.wcs.ctype = ["RA---CAR", "DEC--CAR"]
+    return wcs
+
+
+def test_circle_sky_region_array_to_pixel():
+    center = SkyCoord(0, 0, unit="deg")
+    radius = [0.1, 0.2] * u.deg
+
+    region = CircleSkyRegionArray(center=center, radius=radius)
+
+    pixel_region = region.to_pixel(make_test_wcs())
+
+    assert isinstance(pixel_region, CirclePixelRegionArray)
+
+    # 0.1 deg / 0.1 deg/pix = 1 pix
+    assert_allclose(pixel_region.radius, [1.0, 2.0])
+
+
+def test_circle_pixel_region_array():
+    # bounding box
+    region = CirclePixelRegionArray(
+        center=PixCoord(x=10, y=20),
+        radius=np.array([1, 3, 2]),
+    )
+
+    bbox = region.bounding_box
+
+    expected = RegionBoundingBox.from_float(
+        xmin=7,
+        xmax=13,
+        ymin=17,
+        ymax=23,
+    )
+
+    assert bbox == expected
+
+    # area
+    radius = np.array([1, 2, 3])
+
+    region = CirclePixelRegionArray(
+        center=PixCoord(x=0, y=0),
+        radius=radius,
+    )
+
+    area = region.area
+
+    expected = np.pi * radius**2
+
+    assert area.shape == (3, 1, 1)
+    assert_allclose(area[:, 0, 0], expected)
+
+    # single_radius
+    region = CirclePixelRegionArray(
+        center=PixCoord(x=0, y=0),
+        radius=np.array([2]),
+    )
+
+    area = region.area
+
+    assert area.shape == (1, 1, 1)
+    assert_allclose(area[0, 0, 0], np.pi * 4)
+
+
+@requires_data()
+def test_array_valued_regions():
+    radius = [1, 2, 3, 4] * u.deg
+
+    radius = radius.reshape((-1, 1, 1))
+
+    circle = CircleSkyRegionArray(
+        center=SkyCoord(83.63 * u.deg, 22.01 * u.deg),
+        radius=radius,
+    )
+
+    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=4)
+
+    region_geom = RegionGeom.create(
+        region=circle,
+        axes=[axis],
+    )
+
+    assert_allclose(region_geom.center_skydir.ra, (83.63 * u.deg))
+    assert_allclose(region_geom.center_skydir.dec, (22.01 * u.deg))
+
+    assert region_geom.center_pix == (0.0, 0.0, 1.5)
+    assert_allclose(
+        region_geom.solid_angle().flatten(),
+        [0.00095698, 0.00382794, 0.00861285, 0.01531174] * u.sr,
+        rtol=1e-5,
+    )
+    assert_allclose(region_geom.width, [8.2, 8.2] * u.deg)
+
+    events = EventList.read(
+        "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
+    )
+
+    # Reference events per energy bin
+    expected = []
+    for (e_min, e_max), radius in zip(axis.iter_by_edges, circle.radius.flat):
+        events_selected = events.select_energy(energy_range=(e_min, e_max))
+        region = CircleSkyRegion(center=circle.center, radius=radius)
+        events_selected = events_selected.select_region(regions=region)
+        expected.append(len(events_selected.table))
+
+    counts = RegionNDMap.from_geom(geom=region_geom)
+    counts.fill_events(events)
+    assert_allclose(counts.data.flatten(), expected)
+    assert counts.data.shape == (4, 1, 1)


### PR DESCRIPTION
This is a prototype for the support of array valued regions in Gammapy, that I worked on a few years back. I did not have time to continue the work and will not in the near future, however I think it is worth opening the PR as a basis for discussions. 

CC @Tobychev and @kosack 

See also https://github.com/gammapy/gammapy/discussions/5417

Notebook demonstrating the core functionality: https://github.com/adonath/notebooks-public/blob/master/region-geom-array.ipynb

The overall vision / design is the following:

- `regions` does not support array valued regions (for no good reason). See also https://github.com/astropy/regions/issues/497
- From the Gammapy side we could introduce `CirclePixelRegionArray` and `CircleSkyRegionArray` as a workaround and overwrite or re-implement the functionality we need. For now there is no real need for other shapes than a circle.
- The `RegionGeom` gets a `is_regular` attribute, which handles the changing region size the same way we handle changing bin sizes with energy in `WcsGeom`
- The key technical part here is the broadcasting: the energy dependent quantities (center / radius) of the region have to be broadcasted to the same dimension as the energy array. Then everything becomes very simple and "just works" (see the linked notebook above)
- The biggest challenges are serialization, testing and documentation.
- We can introduce `CircleSkyRegionArray.from_rad_max()` for convenience. 
