### PR TITLE
Include further keywords in `codemeta.json`

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -253,7 +253,7 @@
         }
     ],
     "codeRepository": "https://github.com/gammapy/gammapy",
-    "dateCreated": "2014-01-01",
+    "dateCreated": "2013-08-19",
     "datePublished": "2014-08-25",
     "dateModified": "2024-02-29",
     "description": "Gammapy analyzes gamma-ray data and creates sky images, spectra and lightcurves, from event lists and instrument response information; it can also determine the position, morphology and spectra of gamma-ray sources. It is used to analyze data from H.E.S.S., Fermi-LAT, HAWC, and the Cherenkov Telescope Array (CTA).",
@@ -269,7 +269,7 @@
     "url": "https://gammapy.org/",
     "softwareVersion": "v1.2",
     "applicationCategory": "Astronomy",
-    "applicationSubCategory": "Very-high energy gamma rays",
+    "applicationSubCategory": "Very-high-energy gamma rays",
     "programmingLanguage": "Python 3",
     "operatingSystem": "Linux, Mac OS, Windows",
     "referencePublication": "https://doi.org/10.1051/0004-6361/202346488",

--- a/codemeta.json
+++ b/codemeta.json
@@ -253,18 +253,30 @@
         }
     ],
     "codeRepository": "https://github.com/gammapy/gammapy",
-    "datePublished": "2024-02-29",
+    "dateCreated": "2014-01-01",
+    "datePublished": "2014-08-25",
+    "dateModified": "2024-02-29",
     "description": "Gammapy analyzes gamma-ray data and creates sky images, spectra and lightcurves, from event lists and instrument response information; it can also determine the position, morphology and spectra of gamma-ray sources. It is used to analyze data from H.E.S.S., Fermi-LAT, HAWC, and the Cherenkov Telescope Array (CTA).",
     "identifier": "https://doi.org/10.5281/zenodo.4701488",
     "keywords": [
         "Astronomy",
         "Gamma-rays",
-        "Data analysis"
+        "Data analysis",
+        "Scientific/Engineering"
     ],
     "license": "https://spdx.org/licenses/BSD-3-Clause",
     "name": "Gammapy: Python toolbox for gamma-ray astronomy",
     "url": "https://gammapy.org/",
     "softwareVersion": "v1.2",
+    "applicationCategory": "Astronomy",
+    "applicationSubCategory": "Very-high energy gamma rays",
+    "programmingLanguage": "Python 3",
+    "operatingSystem": "Linux, Mac OS, Windows",
+    "audience": {
+        "@id": "/audience/science-research",
+        "@type": "Audience",
+        "audienceType": "Science/Research"
+    },
     "maintainer": {
         "@id": "https://orcid.org/0000-0003-4568-7005",
         "@type": "Person",

--- a/codemeta.json
+++ b/codemeta.json
@@ -272,6 +272,7 @@
     "applicationSubCategory": "Very-high energy gamma rays",
     "programmingLanguage": "Python 3",
     "operatingSystem": "Linux, Mac OS, Windows",
+    "referencePublication": "https://doi.org/10.1051/0004-6361/202346488",
     "audience": {
         "@id": "/audience/science-research",
         "@type": "Audience",

--- a/dev/codemeta.py
+++ b/dev/codemeta.py
@@ -4,6 +4,7 @@ import json
 import logging
 from configparser import ConfigParser
 import click
+from datetime import date
 
 log = logging.getLogger(__name__)
 
@@ -23,6 +24,10 @@ def update_codemeta(maintainer, filename, setup_file=None):
     data["issueTracker"] = "https://github.com/gammapy/gammapy/issues"
     data["developmentStatus"] = ("active",)
     data["email"] = "GAMMAPY-COORDINATION-L@IN2P3.FR"
+
+    modified_date = str(date.today())
+    data["dateModified"] = modified_date
+
 
     if setup_file:
         # complete with software requirements from setup.cfg


### PR DESCRIPTION
This resolves #4617 and resolves #5095

Most of the keywords we want to add can be directly to the `json` file as they will not change across different versions. Do we actually need anything else defined in the `codemeta.py` if is the same across versions?
- Not sure about the `runtimePlatform`?
- In v1.0 we had: `dateCreated`, `datePublished` and `dateModified`. But now we do not use `dateModified`, how do we want to proceed?
- Do we want the `programmingLanguage` to be `Python` or `Python 3`
