### PR TITLE
Add an inverted option in `Observations.select_time`

### DIFF
--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -716,7 +716,7 @@ class Observations(collections.abc.MutableSequence):
         """List of observation IDs (`list`)."""
         return [str(obs.obs_id) for obs in self]
 
-    def select_time(self, time_intervals):
+    def select_time(self, time_intervals, inverted=False):
         """Select a time interval of the observations.
 
         Parameters
@@ -735,10 +735,14 @@ class Observations(collections.abc.MutableSequence):
 
         for time_interval in time_intervals:
             for obs in self:
-                if (obs.tstart < time_interval[1]) & (obs.tstop > time_interval[0]):
-                    new_obs = obs.select_time(time_interval)
-                    new_obs_list.append(new_obs)
-
+                if not inverted:
+                    if (obs.tstart < time_interval[1]) & (obs.tstop > time_interval[0]):
+                        new_obs = obs.select_time(time_interval)
+                        new_obs_list.append(new_obs)
+                else:
+                    if (obs.tstart > time_interval[1]) | (obs.tstop < time_interval[0]):
+                        new_obs = obs.select_time(time_interval)
+                        new_obs_list.append(new_obs)
         return self.__class__(new_obs_list)
 
     def _ipython_key_completions_(self):

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -227,6 +227,10 @@ def test_observations_select_time_time_intervals_list(data_store):
     assert_time_allclose(new_obss[1].gti.time_start[0], time_intervals[1][0])
     assert_time_allclose(new_obss[1].gti.time_stop[-1], time_intervals[1][1])
 
+    out_obs = obss.select_time(time_intervals[-1], inverted=True)
+
+    assert len(out_obs) == 8
+
 
 @requires_data()
 def test_observation_cta_1dc():


### PR DESCRIPTION
This pull request fix #5428.

I simply added an argument on `Observations.select_time` method. When it is set to True, the method return all observations that lies outside of the time_interval. 