### PR TITLE
Remove mask in residual plotting

### DIFF
--- a/examples/tutorials/analysis-1d/extended_source_spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/extended_source_spectral_analysis.py
@@ -342,5 +342,4 @@ reduced.models = model
 
 # Plot the result
 ax_spectrum, ax_residuals = reduced.plot_fit()
-reduced.plot_masks(ax=ax_spectrum)
 plt.show()

--- a/examples/tutorials/analysis-1d/spectral_analysis.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis.py
@@ -363,7 +363,6 @@ display(result_joint.models.to_parameters_table())
 
 ax_spectrum, ax_residuals = datasets[0].plot_fit()
 ax_spectrum.set_ylim(0.1, 40)
-datasets[0].plot_masks(ax=ax_spectrum)
 plt.show()
 
 
@@ -534,7 +533,6 @@ def plot_stat(fp_dataset):
     lss = ["--", ":", "--"]
 
     for ks, stat in enumerate(stat_types):
-
         fp_dataset.stat_type = stat
 
         fit = Fit()

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1225,26 +1225,17 @@ class MapDataset(Dataset):
 
         """
         counts, npred = self.counts.copy(), self.npred()
-
-        if self.mask is None:
-            mask = self.counts.copy()
-            mask.data = 1
-        else:
-            mask = self.mask
-        counts *= mask
-        npred *= mask
-
         counts_spec = counts.get_spectrum(region)
         npred_spec = npred.get_spectrum(region)
         residuals = self._compute_residuals(counts_spec, npred_spec, method)
 
         if self.stat_type == "wstat":
-            counts_off = (self.counts_off * mask).get_spectrum(region)
+            counts_off = (self.counts_off).get_spectrum(region)
 
             with np.errstate(invalid="ignore"):
-                alpha = (self.background * mask).get_spectrum(region) / counts_off
+                alpha = self.background.get_spectrum(region) / counts_off
 
-            mu_sig = (self.npred_signal() * mask).get_spectrum(region)
+            mu_sig = self.npred_signal().get_spectrum(region)
             stat = WStatCountsStatistic(
                 n_on=counts_spec,
                 n_off=counts_off,

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -79,6 +79,8 @@ class PlotMixin:
         label = self._residuals_labels[method]
         ax_residuals.set_ylabel(f"Residuals\n{label}")
         plt.setp(ax_spectrum.get_xticklabels(), visible=bool_visible_xticklabel)
+        self.plot_masks(ax=ax_spectrum)
+        self.plot_masks(ax=ax_residuals)
 
         return ax_spectrum, ax_residuals
 


### PR DESCRIPTION
This PR resolves #5411 by removing the mask in `dataset.plot_residuals_spectral`

I also adapted `dataset.plot_fit` to internally call `dataset.plot_masks()` and two of the associated tutorials