### PR TITLE
Fix TSmapEstimator stat_scan with sum_over_energy_group=False 

### DIFF
--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -580,6 +580,12 @@ def test_joint_ts_map_hawc():
     result = estimator.run(datasets)
     assert_allclose(result["flux"].data[0, 59, 59], 1.909396e-13, rtol=1e-3)
     assert_allclose(result["sqrt_ts"].data[0, 59, 59], 10.878956, rtol=1e-3)
+    assert result.stat_scan.geom.data_shape == (1, 109, 120, 120)
+    assert result.dnde_scan_values.geom.data_shape == (1, 109, 120, 120)
+    assert_allclose(
+        result["dnde_scan_values"].data[0, 0, 59, 59], -3.164557e-13, rtol=1e-3
+    )
+    assert_allclose(result["stat_scan"].data[0, 0, 59, 59], 5193.588657, rtol=1e-3)
 
     estimator = TSMapEstimator(
         kernel_width=2 * u.deg, sum_over_energy_groups=True, n_jobs=4
@@ -597,3 +603,9 @@ def test_joint_ts_map_hawc():
     result = estimator.run(datasets)
     assert_allclose(result["flux"].data[0, 59, 59], 1.99452e-13, rtol=1e-3)
     assert_allclose(result["sqrt_ts"].data[0, 59, 59], 11.997135, rtol=1e-3)
+    assert result.stat_scan.geom.data_shape == (1, 109, 120, 120)
+    assert result.dnde_scan_values.geom.data_shape == (1, 109, 120, 120)
+    assert_allclose(
+        result["dnde_scan_values"].data[0, 0, 59, 59], -3.164557e-13, rtol=1e-3
+    )
+    assert_allclose(result["stat_scan"].data[0, 0, 59, 59], 7625.040553, rtol=1e-3)

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -564,12 +564,36 @@ def test_joint_ts_map_hawc():
     datasets = Datasets.read("$GAMMAPY_DATA/hawc/DL4/HAWC_pass4_public_Crab.yaml")
     datasets = Datasets(datasets[-2:])
 
-    estimator = TSMapEstimator(kernel_width=2 * u.deg, sum_over_energy_groups=False)
+    estimator = TSMapEstimator(
+        kernel_width=2 * u.deg, sum_over_energy_groups=False, n_jobs=4
+    )
     result = estimator.run(datasets)
     assert_allclose(result["flux"].data[0, 59, 59], 1.909396e-13, rtol=1e-3)
     assert_allclose(result["sqrt_ts"].data[0, 59, 59], 10.878956, rtol=1e-3)
 
-    estimator = TSMapEstimator(kernel_width=2 * u.deg, sum_over_energy_groups=True)
+    estimator = TSMapEstimator(
+        kernel_width=2 * u.deg,
+        sum_over_energy_groups=False,
+        selection_optional=["stat_scan"],
+        n_jobs=4,
+    )
+    result = estimator.run(datasets)
+    assert_allclose(result["flux"].data[0, 59, 59], 1.909396e-13, rtol=1e-3)
+    assert_allclose(result["sqrt_ts"].data[0, 59, 59], 10.878956, rtol=1e-3)
+
+    estimator = TSMapEstimator(
+        kernel_width=2 * u.deg, sum_over_energy_groups=True, n_jobs=4
+    )
+    result = estimator.run(datasets)
+    assert_allclose(result["flux"].data[0, 59, 59], 1.99452e-13, rtol=1e-3)
+    assert_allclose(result["sqrt_ts"].data[0, 59, 59], 11.997135, rtol=1e-3)
+
+    estimator = TSMapEstimator(
+        kernel_width=2 * u.deg,
+        sum_over_energy_groups=True,
+        selection_optional=["stat_scan"],
+        n_jobs=4,
+    )
     result = estimator.run(datasets)
     assert_allclose(result["flux"].data[0, 59, 59], 1.99452e-13, rtol=1e-3)
     assert_allclose(result["sqrt_ts"].data[0, 59, 59], 11.997135, rtol=1e-3)

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -511,7 +511,7 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         j, i = zip(*positions)
 
         geom = maps[0]["counts"].geom.squash(axis_name="energy")
-        energy_axis = maps[0]["counts"].geom.axes["energy"]
+        energy_axis = geom.axes["energy"]
         dnde_ref = self.model.spectral_model(energy_axis.center)
 
         for name in self.selection_all:


### PR DESCRIPTION
Fix TSmapEstimator for options sum_over_energy_group=False and selection_optional=["stat_scan"]