### PR TITLE
Add a warning in TemplateSpatialModel for presence of nan values

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Spatial models."""
+
 import logging
 import os
 import numpy as np
@@ -1305,6 +1306,8 @@ class TemplateSpatialModel(SpatialModel):
             log.warning("Map has negative values. Check and fix this!")
         if (map.data == 0.0).all():
             log.warning("Map values are all zeros. Check and fix this!")
+        if np.isnan(map.data).any():
+            log.warning("Map has NaN values. Check and fix this!")
         if not map.geom.is_image and (map.data.sum(axis=(1, 2)) == 0).any():
             log.warning(
                 "Map values are all zeros in at least one energy bin. Check and fix this!"

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -487,6 +487,14 @@ def test_sky_diffuse_map_empty(caplog):
         )
         assert np.all(np.isfinite(model.map.data))
 
+    # model with nan
+    model_map.data[0, 0, 0] = np.nan
+    with caplog.at_level(logging.WARNING):
+        TemplateSpatialModel(model_map, normalize=True)
+        assert "Map has NaN values. Check and fix this!" in [
+            _.message for _ in caplog.records
+        ]
+
 
 @pytest.mark.parametrize("model_cls", SPATIAL_MODEL_REGISTRY)
 def test_model_from_dict(tmpdir, model_cls):


### PR DESCRIPTION
Presence of any nan value in a Template map silently creates all nan values in the normalised template as reported in #5379 This becomes very difficult to debug.

This PR adds a warning similar to some other invalid inputs.
It remains the users responsibiltity to understand how to interpret and fix the nans