### PR TITLE
Adapt docstring for `TemplateSpectralModel`, tutorial and tests

### DIFF
--- a/examples/models/spectral/plot_template_spectral.py
+++ b/examples/models/spectral/plot_template_spectral.py
@@ -38,8 +38,28 @@ template.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%
-# Spectral correction
-# Corrections to templates can be applied by multiplication with a normalized spectral model,
+# Examples for extrapolation
+# --------------------------
+# The following shows how to implement extrapolation for the template spectral model:
+
+energy = [0.5, 1, 3, 10, 20] * u.TeV
+values = [40, 30, 20, 10, 1] * u.Unit("TeV-1 s-1 cm-2")
+template_noextrapolate = TemplateSpectralModel(
+    energy=energy,
+    values=values,
+    interp_kwargs={"extrapolate": False, "bounds_error": False},
+)
+template_extrapolate = TemplateSpectralModel(
+    energy=energy, values=values, interp_kwargs={"extrapolate": True}
+)
+energy_bounds = [0.2, 80] * u.TeV
+template_extrapolate.plot(energy_bounds, label="Extrapolated", alpha=0.5, color="green")
+template_noextrapolate.plot(energy_bounds, label="Not extrapolated", ls="--")
+plt.legend()
+
+
+# %%
+# Spectral corrections to templates can be applied by multiplication with a normalized spectral model,
 # for example `gammapy.modeling.models.PowerLawNormSpectralModel`.
 # This operation create a new `gammapy.modeling.models.CompoundSpectralModel`
 

--- a/examples/models/spectral/plot_template_spectral.py
+++ b/examples/models/spectral/plot_template_spectral.py
@@ -38,8 +38,8 @@ template.plot(energy_bounds)
 plt.grid(which="both")
 
 # %%
-# Examples for extrapolation
-# --------------------------
+# Example of extrapolation
+# ------------------------
 # The following shows how to implement extrapolation for the template spectral model:
 
 energy = [0.5, 1, 3, 10, 20] * u.TeV

--- a/examples/models/spectral/plot_template_spectral.py
+++ b/examples/models/spectral/plot_template_spectral.py
@@ -47,7 +47,7 @@ values = [40, 30, 20, 10, 1] * u.Unit("TeV-1 s-1 cm-2")
 template_noextrapolate = TemplateSpectralModel(
     energy=energy,
     values=values,
-    interp_kwargs={"extrapolate": False, "bounds_error": False},
+    interp_kwargs={"extrapolate": False},
 )
 template_extrapolate = TemplateSpectralModel(
     energy=energy, values=values, interp_kwargs={"extrapolate": True}

--- a/examples/models/spectral/plot_template_spectral.py
+++ b/examples/models/spectral/plot_template_spectral.py
@@ -53,8 +53,10 @@ template_extrapolate = TemplateSpectralModel(
     energy=energy, values=values, interp_kwargs={"extrapolate": True}
 )
 energy_bounds = [0.2, 80] * u.TeV
-template_extrapolate.plot(energy_bounds, label="Extrapolated", alpha=0.5, color="green")
-template_noextrapolate.plot(energy_bounds, label="Not extrapolated", ls="--")
+template_extrapolate.plot(energy_bounds, label="Extrapolated", alpha=0.4, color="blue")
+template_noextrapolate.plot(
+    energy_bounds, label="Not extrapolated", ls="--", color="black"
+)
 plt.legend()
 
 

--- a/examples/models/spectral/plot_template_spectral.py
+++ b/examples/models/spectral/plot_template_spectral.py
@@ -40,7 +40,7 @@ plt.grid(which="both")
 # %%
 # Example of extrapolation
 # ------------------------
-# The following shows how to implement extrapolation for the template spectral model:
+# The following shows how to implement extrapolation of a template spectral model:
 
 energy = [0.5, 1, 3, 10, 20] * u.TeV
 values = [40, 30, 20, 10, 1] * u.Unit("TeV-1 s-1 cm-2")
@@ -61,7 +61,7 @@ plt.legend()
 # %%
 # Spectral corrections to templates can be applied by multiplication with a normalized spectral model,
 # for example `gammapy.modeling.models.PowerLawNormSpectralModel`.
-# This operation create a new `gammapy.modeling.models.CompoundSpectralModel`
+# This operation creates a new `gammapy.modeling.models.CompoundSpectralModel`
 
 new_model = template * PowerLawNormSpectralModel(norm=2, tilt=0)
 

--- a/examples/tutorials/data/fermi_lat.py
+++ b/examples/tutorials/data/fermi_lat.py
@@ -273,13 +273,13 @@ plt.show()
 #
 # To load the isotropic diffuse model with Gammapy, use the
 # `~gammapy.modeling.models.TemplateSpectralModel`. We are using
-# `'fill_value': 'extrapolate'` to extrapolate the model above 500 GeV:
+# `'extrapolate': True` to extrapolate the model above 500 GeV:
 #
 
 filename = "$GAMMAPY_DATA/fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt"
 
 diffuse_iso = create_fermi_isotropic_diffuse_model(
-    filename=filename, interp_kwargs={"fill_value": None}
+    filename=filename, interp_kwargs={"extrapolate": True}
 )
 
 

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -1195,7 +1195,7 @@ class TemplateNPredModel(ModelBase):
 def create_fermi_isotropic_diffuse_model(filename, **kwargs):
     """Read Fermi isotropic diffuse model.
 
-    See `LAT Background models <https://fermi.gsfc.nasa.gov/ssc/data/access/lat/BackgroundModels.html>`__  # noqa: E501
+    See `LAT Background models <https://fermi.gsfc.nasa.gov/ssc/data/access/lat/BackgroundModels.html>`__.
 
     Parameters
     ----------

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1758,7 +1758,7 @@ class TemplateSpectralModel(SpectralModel):
         Array with the values of the model at energies ``energy``.
     interp_kwargs : dict
         Interpolation option passed to `~gammapy.utils.interpolation.ScaledRegularGridInterpolator`.
-        By default, all values outside the interpolation range are set to zero.
+        By default, all values outside the interpolation range are set to NaN.
         If you want to apply linear extrapolation you can pass `interp_kwargs={'extrapolate':
         True, 'method': 'linear'}`. If you want to choose the interpolation
         scaling applied to values, you can use `interp_kwargs={"values_scale": "log"}`.

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Spectral models for Gammapy."""
+
 import logging
 import operator
 import os
@@ -1397,7 +1398,6 @@ class ExpCutoffPowerLawNormSpectralModel(SpectralModel):
     def __init__(
         self, index=None, norm=None, reference=None, lambda_=None, alpha=None, **kwargs
     ):
-
         if index is None:
             warnings.warn(
                 "The default index value changed from 1.5 to 0 since v1.2",
@@ -1708,7 +1708,6 @@ class LogParabolaNormSpectralModel(SpectralModel):
     beta = Parameter("beta", 0)
 
     def __init__(self, norm=None, reference=None, alpha=None, beta=None, **kwargs):
-
         if alpha is None:
             warnings.warn(
                 "The default alpha value changed from 2 to 0 since v1.2",
@@ -1758,10 +1757,10 @@ class TemplateSpectralModel(SpectralModel):
     values : `~numpy.ndarray`
         Array with the values of the model at energies ``energy``.
     interp_kwargs : dict
-        Interpolation keyword arguments passed to `scipy.interpolate.RegularGridInterpolator`.
-        By default all values outside the interpolation range are set to zero.
-        If you want to apply linear extrapolation you can pass `interp_kwargs={'fill_value':
-        'extrapolate', 'kind': 'linear'}`. If you want to choose the interpolation
+        Interpolation option passed to `~gammapy.utils.interpolation.ScaledRegularGridInterpolator`.
+        By default, all values outside the interpolation range are set to zero.
+        If you want to apply linear extrapolation you can pass `interp_kwargs={'extrapolate':
+        True, 'method': 'linear'}`. If you want to choose the interpolation
         scaling applied to values, you can use `interp_kwargs={"values_scale": "log"}`.
     meta : dict, optional
         Meta information, meta['filename'] will be used for serialisation.

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -659,6 +659,13 @@ def test_fermi_isotropic():
     assert flux.unit == "MeV-1 cm-2 s-1 sr-1"
     assert isinstance(model.spectral_model, CompoundSpectralModel)
 
+    model_options = create_fermi_isotropic_diffuse_model(
+        filename=filename,
+        interp_kwargs={"extrapolate": True, "method": "nearest"},
+    )
+    flux_options = model_options(**coords)
+    assert_allclose(flux_options.value, 1.456e-13, rtol=1e-3)
+
 
 class MyCustomGaussianModel(SpatialModel):
     """My custom gaussian model.

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -774,6 +774,18 @@ def test_template_spectral_model_compound():
     assert np.allclose(new_model(energy), 2 * values)
 
 
+def test_template_spectral_model_options():
+    energy = [1.00e06, 1.25e06, 1.58e06, 1.99e06] * u.MeV
+    values = [4.39e-7, 1.96e-7, 8.80e-7, 3.94e-7] * u.Unit("MeV-1 s-1 sr-1")
+
+    model = TemplateSpectralModel(
+        energy=energy,
+        values=values,
+        interp_kwargs={"extrapolate": True, "method": "linear"},
+    )
+    assert np.allclose(model(energy), values)
+
+
 def test_covariance_spectral_model_compound():
     model = TEST_MODELS[2]["model"] + TEST_MODELS[1]["model"]
     covar = np.eye(len(model.parameters))
@@ -1227,7 +1239,6 @@ def test_template_ND_no_energy(tmpdir):
 
 @requires_data()
 def test_template_ND_EBL(tmpdir):
-
     # TODO: add RegionNDMap.read(format="xspec")
     # Create EBL data array
     filename = "$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz"

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Interpolation utilities."""
+
 import html
 from itertools import compress
 import numpy as np
@@ -66,8 +67,9 @@ class ScaledRegularGridInterpolator:
         values_scaled = self.scale(values)
         points_scaled = self._scale_points(points=points)
 
+        kwargs.setdefault("bounds_error", False)
+
         if extrapolate:
-            kwargs.setdefault("bounds_error", False)
             kwargs.setdefault("fill_value", None)
 
         method = kwargs.get("method", None)


### PR DESCRIPTION
[In this tutorial](https://docs.gammapy.org/dev/tutorials/data/fermi_lat.html#isotropic-diffuse-background), we are using 'fill_value': 'extrapolate' to extrapolate the model above 500 GeV . But actually we have 'fill_value':'None', and this is not the correct implementation.

The `kwargs` are the input to `TemplateSpectralModel`, which are then passed to `gammapy.utils.interpolation.ScaledRegularGridInterpolator`. 
I have updated the docstring, tutorial and added tests.