### PR TITLE
Fix typo in Uniform prior returned value

### DIFF
--- a/examples/tutorials/api/priors.py
+++ b/examples/tutorials/api/priors.py
@@ -296,8 +296,8 @@ plt.show()
 # positive, i.e. physical, values. Instead of setting hard bounds, we can
 # also set a uniform prior, which prefers positive values over negatives.
 #
-# We set the amplitude of the power-law used to simulate the source very
-# small. Together with statistical fluctuations, this will result in some
+# We set the amplitude of the power-law used to simulate the source to a very
+# small value. Together with statistical fluctuations, this could result in some
 # negative amplitude best-fit values.
 #
 
@@ -308,20 +308,19 @@ model_weak = SkyModel(
     name="weak-model",
 )
 model_weak_prior = model_weak.copy(name="weak-model-prior")
-uniform = UniformPrior(max=0)
+uniform = UniformPrior(min=0)
 uniform.weight = 2
 model_weak_prior.parameters["amplitude"].prior = uniform
 
 
 ######################################################################
-# We set the maximum value where the prior is applied to zero. Note that,
-# per default, the minimum value is set to negative infinity. Therefore, the
-# uniform prior is zero, i.e. no influence on the fit at all if the
-# amplitude value is positive.
-#
-# The weight of the prior again quantifies how strong we want prior to
-# being. Here, we are setting it to 2. This value is only applied if the
-# amplitude value is below zero.
+# We set the minimum value to zero and per default, the maximum value
+# is set to positive infinity. Therefore, the uniform prior penalty 
+# is zero, i.e. no influence on the fit at all, if the amplitude value
+# is positive and a penalty (the weight) in the form of a prior likelihood
+# for negative values.
+# Here, we are setting it to 2. This value is only applied if the
+# amplitude value goes below zero.
 #
 
 uni_prior_stat_sums = []
@@ -336,7 +335,7 @@ plt.plot(
     uni_prior_stat_sums,
     color="tab:orange",
     linestyle="dashed",
-    label=f"Uniform Prior\n $max={uniform.max.value}$, weight={uniform.weight}",
+    label=f"Uniform Prior\n $min={uniform.min.value}$, weight={uniform.weight}",
 )
 plt.xlabel("Amplitude Value [1 / (TeV s cm2)]")
 plt.ylabel("Prior")
@@ -438,7 +437,7 @@ class MyCustomPrior(Prior):
         Minimum value.
         Default is -inf.
     max : float
-        Maxmimum value.
+        Maximum value.
         Default is inf.
     """
 
@@ -448,7 +447,7 @@ class MyCustomPrior(Prior):
 
     @staticmethod
     def evaluate(value, sigma):
-        """Evaluate the costom prior."""
+        """Evaluate the custom prior."""
         return value / sigma**2
 
 
@@ -459,10 +458,10 @@ from gammapy.modeling.models import PRIOR_REGISTRY
 PRIOR_REGISTRY.append(MyCustomPrior)
 
 # The custom prior is set on the index of a powerlaw spectral model and is evaluated.
-costomprior = MyCustomPrior(sigma=0.5)
+customprior = MyCustomPrior(sigma=0.5)
 pwl = PowerLawSpectralModel()
-pwl.parameters["index"].prior = costomprior
-costomprior(pwl.parameters["index"])
+pwl.parameters["index"].prior = customprior
+customprior(pwl.parameters["index"])
 
 # The power law spectral model can be written into a dictionary.
 # If the a model is read in from this dictionary, the costum prior is still set on the index.

--- a/examples/tutorials/api/priors.py
+++ b/examples/tutorials/api/priors.py
@@ -294,7 +294,7 @@ plt.show()
 #
 # In the next example, we want to encourage the amplitude to have
 # positive, i.e. physical, values. Instead of setting hard bounds, we can
-# also set a uniform prior, which prefers positive values over negatives.
+# also set a uniform prior, which prefers positive values to negatives.
 #
 # We set the amplitude of the power-law used to simulate the source to a very
 # small value. Together with statistical fluctuations, this could result in some

--- a/examples/tutorials/api/priors.py
+++ b/examples/tutorials/api/priors.py
@@ -464,7 +464,7 @@ pwl.parameters["index"].prior = customprior
 customprior(pwl.parameters["index"])
 
 # The power law spectral model can be written into a dictionary.
-# If the a model is read in from this dictionary, the costum prior is still set on the index.
+# If a model is read in from this dictionary, the custom prior is still set on the index.
 
 print(pwl.to_dict())
 model_read = Model.from_dict(pwl.to_dict())

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -747,7 +747,7 @@ def test_prior_stat_sum(sky_model, geom, geom_etrue):
     datasets.models = models
     dataset.counts = dataset.npred()
 
-    uniformprior = UniformPrior(min=-np.inf, max=0, weight=1)
+    uniformprior = UniformPrior(min=0, max=np.inf, weight=1)
     datasets.models.parameters["amplitude"].prior = uniformprior
     assert_allclose(datasets.stat_sum(), 12825.9370, rtol=1e-3)
 

--- a/gammapy/modeling/models/prior.py
+++ b/gammapy/modeling/models/prior.py
@@ -181,6 +181,6 @@ class UniformPrior(Prior):
     def evaluate(value, min, max):
         """Evaluate the uniform prior."""
         if min < value < max:
-            return 1.0
-        else:
             return 0.0
+        else:
+            return 1.0

--- a/gammapy/modeling/models/tests/test_prior.py
+++ b/gammapy/modeling/models/tests/test_prior.py
@@ -18,7 +18,7 @@ TEST_PRIORS = [
         model=UniformPrior(min=0.0),
         val_at_0=1.0,
         val_at_1=0.0,
-        val_with_weight_2=0.0,
+        val_with_weight_2=2.0,
     ),
 ]
 

--- a/gammapy/modeling/models/tests/test_prior.py
+++ b/gammapy/modeling/models/tests/test_prior.py
@@ -16,8 +16,8 @@ TEST_PRIORS = [
     dict(
         name="uni",
         model=UniformPrior(min=0.0),
-        val_at_0=0.0,
-        val_at_1=1.0,
+        val_at_0=1.0,
+        val_at_1=0.0,
         val_with_weight_2=0.0,
     ),
 ]


### PR DESCRIPTION
**Description**

Adress issue discussed in #5447 
return 0 within (min,max) instead of 1.

Also maybe  we should update the notebook docs here :  
https://docs.gammapy.org/1.2/tutorials/api/priors.html?highlight=priors#example-2-encouraging-positive-amplitude-values

to change max at 0 to min at 0 .
