### PR TITLE
combine_flux_maps  supports for different energy axes

### DIFF
--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -440,6 +440,32 @@ def test_ts_map_stat_scan(fake_dataset):
         combine_flux_maps([maps, maps1], method="test")
 
 
+def test_ts_map_stat_scan_different_energy(fake_dataset):
+    model = fake_dataset.models["source"]
+
+    dataset = fake_dataset.downsample(25)
+
+    estimator = TSMapEstimator(
+        model,
+        kernel_width="0.3 deg",
+        energy_edges=[200, 3500] * u.GeV,
+        selection_optional=["stat_scan"],
+    )
+
+    estimator_1 = TSMapEstimator(
+        model,
+        kernel_width="0.3 deg",
+        selection_optional=["stat_scan"],
+        energy_edges=[0.2, 10] * u.TeV,
+    )
+
+    maps = estimator.run(dataset)
+    maps_1 = estimator_1.run(dataset)
+
+    combined_map = combine_flux_maps([maps_1, maps], method="profile")
+    assert combined_map.ts.data.shape == (1, 2, 2)
+
+
 def test_ts_map_with_model(fake_dataset):
     model = fake_dataset.models["source"]
     fake_dataset = fake_dataset.copy()

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -959,7 +959,7 @@ def combine_flux_maps(
             if k == 0:
                 stat_scan = map_stat_scan
             else:
-                stat_scan += map_stat_scan
+                stat_scan.data += map_stat_scan.data
 
         return get_flux_map_from_profile(
             {"stat_scan": stat_scan},


### PR DESCRIPTION
Minor change such as `combine_flux_maps` can support maps  with different energy axes.
Works only if the first map energy range encompass the one of the other maps.