### PR TITLE
Fix time shift from sampled events with `MapDatasetEventSampler`

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -206,7 +206,9 @@ class MapDatasetEventSampler:
 
         coords = npred.sample_coord(n_events=n_events, random_state=self.random_state)
 
-        coords["time"] = Time(coords["time"], format="mjd", scale="tt")
+        coords["time"] = Time(
+            coords["time"], format="mjd", scale=dataset.gti.time_ref.scale
+        )
 
         table = self._make_table(coords, dataset.gti.time_ref)
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -308,7 +308,7 @@ def test_sample_coord_time_energy_random_seed(
 
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [0.2998, 1.932196, 266.404988, -28.936178],
+        [0.29982, 1.932196, 266.404988, -28.936178],
         rtol=1e-3,
     )
 
@@ -327,7 +327,7 @@ def test_sample_coord_time_energy_unit(dataset, energy_dependent_temporal_sky_mo
     assert len(events) == 1254
     assert_allclose(
         [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [854.108591, 6.22904, 266.404988, -28.936178],
+        [854.10859, 6.22904, 266.404988, -28.936178],
         rtol=1e-6,
     )
 
@@ -366,6 +366,7 @@ def test_mde_sample_sources_psf_update(dataset, models):
 def test_sample_sources_energy_dependent(dataset, energy_dependent_temporal_sky_model):
     dataset.models = energy_dependent_temporal_sky_model
 
+    print(dataset.gti.time_start.scale)
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.sample_sources(dataset=dataset)
 
@@ -377,6 +378,9 @@ def test_sample_sources_energy_dependent(dataset, energy_dependent_temporal_sky_
     assert_allclose(events.table["DEC_TRUE"][0], -28.936178, rtol=1e-5)
 
     assert_allclose(events.table["TIME"][0], 95.464699, rtol=1e-5)
+
+    dt = np.max(events.table["TIME"]) - np.min(events.table["TIME"])
+    assert dt <= dataset.gti.time_sum.to("s").value + sampler.t_delta.to("s").value
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -280,7 +280,6 @@ def test_sample_coord_time_energy(dataset, energy_dependent_temporal_sky_model):
     )
     dataset.models = new_mod
     events = sampler.run(dataset, obs)
-    print(events.table.meta)
     assert dataset.gti.time_ref.scale == events.table.meta["TIMESYS"]
 
 
@@ -333,9 +332,16 @@ def test_sample_coord_time_energy_random_seed(
     assert len(events) == 1256
 
     assert_allclose(
-        [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [0.29982, 1.932196, 266.404988, -28.936178],
+        [events[0][1], events[0][2], events[0][3]],
+        [1.932196, 266.404988, -28.936178],
         rtol=1e-3,
+    )
+
+    # Important: do not increase the tolerance!
+    assert_allclose(
+        events[0][0],
+        0.29982,
+        rtol=1.5e-6,
     )
 
 
@@ -352,9 +358,16 @@ def test_sample_coord_time_energy_unit(dataset, energy_dependent_temporal_sky_mo
 
     assert len(events) == 1254
     assert_allclose(
-        [events[0][0], events[0][1], events[0][2], events[0][3]],
-        [854.10859, 6.22904, 266.404988, -28.936178],
+        [events[0][1], events[0][2], events[0][3]],
+        [6.22904, 266.404988, -28.936178],
         rtol=1e-6,
+    )
+
+    # Important: do not increase the tolerance!
+    assert_allclose(
+        events[0][0],
+        854.10859,
+        rtol=1.5e-6,
     )
 
 


### PR DESCRIPTION
This PR solves the issue #5452 .
The times of sampled events from energy-dependent temporal models were affected by a time shift due to a mismatch between the time scales when applying `MapDatasetEventSampler._sample_coord_time_energy`. 
The default `scale` for the times of the sampled events is `tt`. However, the times may be in a different `scale` if the `dataset.gti` times are in a different `scale`.

