### PR TITLE
Small adaption to `plot_energy_dependence` docstring

### DIFF
--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -78,7 +78,7 @@ class EffectiveAreaTable2D(IRF):
         ----------
         ax : `~matplotlib.axes.Axes`, optional
             Matplotlib axes. Default is None.
-        offset : `~astropy.coordinates.Angle`, optional
+        offset : list of `~astropy.coordinates.Angle`, optional
             Offset. Default is None.
         kwargs : dict
             Forwarded to plt.plot().


### PR DESCRIPTION
Commonly people try to use a `offset=0.25*u.deg` but actually we accept only a list  `offset=[0.25*u.deg]`. This could be do with the incorrect docstring 