### PR TITLE
Add information in guide to add links to documentation

### DIFF
--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -204,6 +204,26 @@ and gallery examples by using RST syntax like this:
 This will link to the tutorial :doc:`/tutorials/starting/analysis_2` from the tutorial base folder. The file
 suffix will be automatically inferred by Sphinx.
 
+Links to documentation
+++++++++++++++++++++++
+
+To make a reference to a heading within an RST file, first you need to define an explicit target for the heading:
+
+.. code-block:: rst
+
+    .. _datasets:
+
+    Datasets (DL4)
+    ==============
+
+
+The reference is the rendered as ``datasets``. 
+To link to this in the documentation you can use:
+
+.. code-block:: rst
+
+    :ref:`datasets`
+
 
 API Links
 +++++++++


### PR DESCRIPTION
We already show how to link to tutorials, but we can also link to other pieces of documentation with the following lines. 
I think this is very useful to show as it saves times trying to google how to do this everytime!

![image](https://github.com/user-attachments/assets/1e4cfdbb-c509-43c6-9122-843ea3a04e1b)
