### PR TITLE
Solve issues with sherpa 4.17 and pin version for doc build

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -39,7 +39,7 @@ dependencies:
   - requests
   - tqdm
   # extra dependencies
-  - sherpa=4.16
+  - sherpa
   - healpy
   - ipython
   - jupyter

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,7 +9,7 @@ name: gammapy-dev
 
 channels:
   - conda-forge
-  - sherpa
+  - https://cxc.cfa.harvard.edu/conda/sherpa
 
 variables:
   PYTHONNOUSERSITE: "1"

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -39,6 +39,7 @@ dependencies:
   - requests
   - tqdm
   # extra dependencies
+  - sherpa<=4.15
   - healpy
   - ipython
   - jupyter
@@ -77,7 +78,6 @@ dependencies:
   - pyinstrument
   - memray
   - pip:
-      - sherpa
       - pytest-sphinx
       - ray[default]>=2.9
       - PyGithub

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -39,7 +39,7 @@ dependencies:
   - requests
   - tqdm
   # extra dependencies
-  - sherpa<=4.15
+  - sherpa=4.16
   - healpy
   - ipython
   - jupyter

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -39,7 +39,6 @@ dependencies:
   - requests
   - tqdm
   # extra dependencies
-  - sherpa
   - healpy
   - ipython
   - jupyter
@@ -78,6 +77,7 @@ dependencies:
   - pyinstrument
   - memray
   - pip:
+      - sherpa>=4.17
       - pytest-sphinx
       - ray[default]>=2.9
       - PyGithub

--- a/gammapy/modeling/sherpa.py
+++ b/gammapy/modeling/sherpa.py
@@ -51,8 +51,12 @@ def optimize_sherpa(parameters, function, store_trace=False, **kwargs):
     optimizer.config.update(kwargs)
 
     pars = [par.factor for par in parameters.free_parameters]
-    parmins = [par.factor_min for par in parameters.free_parameters]
-    parmaxes = [par.factor_max for par in parameters.free_parameters]
+    parmins = np.nan_to_num(
+        [par.factor_min for par in parameters.free_parameters], nan=-np.inf
+    )
+    parmaxes = np.nan_to_num(
+        [par.factor_max for par in parameters.free_parameters], nan=np.inf
+    )
 
     statfunc = SherpaLikelihood(function, parameters, store_trace)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,6 @@ test =
 docs =
     astropy>=5.0,<5.3
     numpy<2.0
-    sherpa<4.16
     sphinx-astropy
     sphinx
     sphinx-click

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ console_scripts =
 [options.extras_require]
 all =
     naima
-    sherpa<4.17; platform_system != "Windows"
+    sherpa>=4.17; platform_system != "Windows"
     healpy; platform_system != "Windows"
     requests
     tqdm
@@ -59,7 +59,7 @@ all =
     ray[default]>=2.9
 all_no_ray =
     naima
-    sherpa; platform_system != "Windows"
+    sherpa>=4.17; platform_system != "Windows"
     healpy; platform_system != "Windows"
     requests
     tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ console_scripts =
 [options.extras_require]
 all =
     naima
-    sherpa<=4.15; platform_system != "Windows"
+    sherpa=4.16; platform_system != "Windows"
     healpy; platform_system != "Windows"
     requests
     tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ console_scripts =
 [options.extras_require]
 all =
     naima
-    sherpa; platform_system != "Windows"
+    sherpa<=4.15; platform_system != "Windows"
     healpy; platform_system != "Windows"
     requests
     tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ console_scripts =
 [options.extras_require]
 all =
     naima
-    sherpa>=4.17; platform_system != "Windows"
+    sherpa; platform_system != "Windows"
     healpy; platform_system != "Windows"
     requests
     tqdm
@@ -59,7 +59,7 @@ all =
     ray[default]>=2.9
 all_no_ray =
     naima
-    sherpa>=4.17; platform_system != "Windows"
+    sherpa; platform_system != "Windows"
     healpy; platform_system != "Windows"
     requests
     tqdm
@@ -80,6 +80,7 @@ test =
 docs =
     astropy>=5.0,<5.3
     numpy<2.0
+    sherpa<4.16
     sphinx-astropy
     sphinx
     sphinx-click

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ test =
 docs =
     astropy>=5.0,<5.3
     numpy<2.0
+    sherpa<4.16
     sphinx-astropy
     sphinx
     sphinx-click

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ console_scripts =
 [options.extras_require]
 all =
     naima
-    sherpa=4.16; platform_system != "Windows"
+    sherpa<4.17; platform_system != "Windows"
     healpy; platform_system != "Windows"
     requests
     tqdm


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request solves issues caused by the sherpa v4.17, solving an issue with the sherpa backend that must have appeared with the numpy v2.0. For some reason, the all dependencies environment in the CI never installed sherpa (at least since we moved to numpy>=2) and silently skipped the test on sherpa. 

- The default `np.nan` for parameter min and maxes are causing issues with sherpa. They are now changed to `-np.inf` and `np.inf`.
- sherpa >4.16 is imposed in environment-dev.yml to make sure we use numpy>=2
- a restriction in the docs requirement is introduced in setup.cfg (sherpa<4.16). This is to keep a working environment with numpy <2 . We are still stuck to astropy<=5.3 for docs build. This should be solved but it will require an independent PR.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
