### PR TITLE
Git-ignore `sg_execution_times.rst` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ gammapy/gammapy.cfg
 docs/_generated
 docs/gen_modules
 docs/api
+docs/sg_execution_times.rst
 .coverage
 
 dev/crab


### PR DESCRIPTION
PR to gitignore `sg_execution_times.rst` file produced during build of docs. 