### PR TITLE
Fix final warnings in docs build

### DIFF
--- a/gammapy/data/metadata.py
+++ b/gammapy/data/metadata.py
@@ -47,9 +47,9 @@ class ObservationMetaData(MetaData):
     ----------
     obs_info : `~gammapy.utils.ObsInfoMetaData`
         The general observation information.
-    pointing : `~gammapy.utils.PointingInfoMetaData
+    pointing : `~gammapy.utils.PointingInfoMetaData`
         The pointing metadata.
-    target : `~gammapy.utils.TargetMetaData
+    target : `~gammapy.utils.TargetMetaData`
         The target metadata.
     creation : `~gammapy.utils.CreatorMetaData`
         The creation metadata.

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -40,8 +40,7 @@ def _get_reference_model(model, energy_bounds, margin_percent=70):
 
 
 class FluxPointsDataset(Dataset):
-    """Bundle a set of flux points with a parametric model,
-    to compute fit statistic function using chi2 statistics.
+    """Bundle a set of flux points with a parametric model, to compute fit statistic function using chi2 statistics.
 
     For more information see :ref:`datasets`.
 
@@ -60,23 +59,21 @@ class FluxPointsDataset(Dataset):
         One line per observation for stacked datasets.
     stat_type : str
         Method used to compute the statistics:
-        * chi2 : estimate from chi2 statistics.
-        * profile : estimate from interpolation of the likelihood profile.
-        * distrib : Assuming gaussian errors the likelihood is given by the
-                    probability density function of the normal distribution.
-                    For the upper limit case it is necessary to marginalize over the unknown measurement,
-                    So we integrate the normal distribution up to the upper limit value
-                    which gives the complementary error function.
-                    See eq. C7 of Mohanty et al (2013) :
-                    https://iopscience.iop.org/article/10.1088/0004-637X/773/2/168/pdf
+
+                * chi2 : estimate from chi2 statistics.
+                * profile : estimate from interpolation of the likelihood profile.
+                * distrib : Assuming gaussian errors the likelihood is given by the probability density function
+                  of the normal distribution. For the upper limit case it is necessary to marginalize over the unknown
+                  measurement, so we integrate the normal distribution up to the upper limit value which gives the
+                  complementary error function. See eq. C7 of `Mohanty et al (2013) <https://iopscience.iop.org/article/10.1088/0004-637X/773/2/168/pdf>`__
 
         Default is `chi2`, in that case upper limits are ignored and the mean of asymetrics error is used.
-        However it is recommended to use `profile` if `stat_scan` is available on flux points.
+        However, it is recommended to use `profile` if `stat_scan` is available on flux points.
         The `distrib` case provides an approximation if the profile is not available.
     stat_kwargs : dict
         Extra arguments specifying the interpolation scheme of the likelihood profile.
         Used only if `stat_type=="profile"`. In that case the default is :
-        `stat_kwargs={"interp_scale":"sqrt", "extrapolate":True}
+        `stat_kwargs={"interp_scale":"sqrt", "extrapolate":True}`
 
     Examples
     --------


### PR DESCRIPTION
Fix some docs that are causing warnings in the docs build!

We now ~only~ have 52 warnings..... 


These all come from pydantic (out of our control) such as
`/home/feijen/Documents/github/gammapy/.tox/build_docs/lib/python3.11/site-packages/pydantic/main.py:docstring of pydantic.main.BaseModel.model_copy:9: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]`