### PR TITLE
Correct bug in Fit.covariance when no optimize_results is passed

### DIFF
--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -296,12 +296,15 @@ class Fit:
             )
             datasets.models.covariance = matrix
 
+        if optimize_result:
+            optimize_result.models.covariance = matrix.data.copy()
+
         return CovarianceResult(
             backend=backend,
             method=method,
             success=info["success"],
             message=info["message"],
-            matrix=datasets.models.covariance.data,
+            matrix=matrix.data,
         )
 
     def confidence(self, datasets, parameter, sigma=1, reoptimize=True):

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -296,15 +296,12 @@ class Fit:
             )
             datasets.models.covariance = matrix
 
-        if optimize_result:
-            optimize_result.models.covariance = matrix.data.copy()
-
         return CovarianceResult(
             backend=backend,
             method=method,
             success=info["success"],
             message=info["message"],
-            matrix=optimize_result.models.covariance.data,
+            matrix=datasets.models.covariance.data,
         )
 
     def confidence(self, datasets, parameter, sigma=1, reoptimize=True):

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -367,6 +367,7 @@ def test_write(tmpdir):
     assert "OptimizeResult" in data
 
 
+@requires_data()
 def test_covariance_no_optimize_results():
     spec = SpectrumDatasetOnOff.read(
         "$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs23523.fits"

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -378,5 +378,5 @@ def test_covariance_no_optimize_results():
     fit.optimize([spec])
     res = fit.covariance([spec])
 
-    assert_allclose(res.matrix.data[0, 1], 6.163970e-13)
-    assert_allclose(res.matrix.data[0, 0], 2.239832e-02)
+    assert_allclose(res.matrix.data[0, 1], 6.163970e-13, rtol=1e-3)
+    assert_allclose(res.matrix.data[0, 0], 2.239832e-02, rtol=1e-3)

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -367,7 +367,7 @@ def test_write(tmpdir):
     assert "OptimizeResult" in data
 
 
-def test_covariance():
+def test_covariance_no_optimize_results():
     spec = SpectrumDatasetOnOff.read(
         "$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs23523.fits"
     )

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Unit tests for the Fit class"""
+
 import pytest
 from numpy.testing import assert_allclose
 from astropy.table import Table
@@ -364,3 +365,15 @@ def test_write(tmpdir):
 
     assert "CovarianceResult" not in data
     assert "OptimizeResult" in data
+
+
+def test_covariance():
+    spec = SpectrumDatasetOnOff.read(
+        "$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs23523.fits"
+    )
+    spec.models = [SkyModel.create(spectral_model="pl")]
+
+    fit = Fit()
+    fit.optimize([spec])
+
+    fit.covariance([spec])

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -375,5 +375,7 @@ def test_covariance():
 
     fit = Fit()
     fit.optimize([spec])
+    res = fit.covariance([spec])
 
-    fit.covariance([spec])
+    assert_allclose(res.matrix.data[0, 1], 6.163970e-13)
+    assert_allclose(res.matrix.data[0, 0], 2.239832e-02)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request solves #5367 removing the failure when `optimize_results=None`. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
