### PR TITLE
Include pydocstyle and note on bullets points

### DIFF
--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -150,6 +150,14 @@ If you get a zsh error try using putting to ignore block inside quotes
 
     pytest --doctest-modules "--ignore-glob=*/tests" gammapy
 
+It is also important to check that you have correctly formatted your docstring. An easy way to check this
+is with the following for your specific file, i.e.:
+
+.. code-block:: bash
+
+    pydocstyle gammapy/data/event_list.py
+
+
 Sphinx gallery extension
 ------------------------
 
@@ -289,6 +297,27 @@ or Gammapy code a bit (either locally with your editor or online on GitHub or vi
 or search the Numpy or Astropy documentation guidelines mentioned above.
 If that doesn't quickly turn up something useful, please ask by putting a comment on the issue or
 pull request you're working on GitHub, or email the Gammapy mailing list.
+
+
+Correct format for bullet point list
+++++++++++++++++++++++++++++++++++++
+
+To correctly add a bullet point list to the docstring, the following can be implemented:
+
+.. testcode::
+
+        """
+        Docstring explanation.
+
+        Parameters
+        ----------
+        parameter_name : parameter_type
+            Description of the parameter with entries:
+                    * option1 : description1
+                    * option2 : description2
+                    * option3 : description3 over more than
+                    one line.
+        """
 
 Functions or class methods that return a single object
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Before v1.2 there was a large effort made to fix the formatting of docstrings. We did not keep an eye on this as we introduced new functionality throughout the past 8 months. 
Therefore I think it is useful to include in the documentation how to check the docstrings with pydocstyle. We should all be using this before we push a PR so that they are in the correct format

Another thing I added was how to handle bullet points in the docstrings. This is often done incorrectly and therefore not rendered correctly in the docs. Each time I adjust these I have to dig through all the code to find an example which is time wasting. I give here a simple example how to implement it!