### PR TITLE
IRFmap.downsample error fix

### DIFF
--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -987,16 +987,20 @@ class IRFMap:
             Downsampling factor.
         axis_name : str
             Axis to downsample. By default, spatial axes are downsampled.
+            It is not recommended to use this function on a PSFMap rad axis.
         weights : `~gammapy.maps.Map`, optional
-            Map with weights downsampling. Default is None.
+            Map with weights downsampling. Default is IRFMap exposure map.
 
         Returns
         -------
         map : `IRFMap`
             Downsampled IRF map.
         """
+        if not weights:
+            weights=self.exposure_map
+
         irf_map = self._irf_map.downsample(
-            factor=factor, axis_name=axis_name, preserve_counts=True, weights=weights
+            factor=factor, axis_name=axis_name, preserve_counts=False, weights=weights
         )
         if axis_name is None:
             exposure_map = self.exposure_map.downsample(


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request fixes #5492. To avoid further errors it should be fixed together with #5493.
`preserve_counts` was changed from `True` to `False`, weighting with the exposure map was made the default.
Additionally a warning against using this function for downsampling a PSFMap rad axis was added, as for this case the weights are not calculated correctly.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
The pull request is ready for review! Please let me know if anything should be changed/reworded or if I missed anything.
Thank you!