### PR TITLE
Event filtering in the MapDatasetMaker

### DIFF
--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -116,7 +116,7 @@ class MapDatasetMaker(Maker):
         background_oversampling=None,
         background_interp_missing_data=True,
         background_pad_offset=True,
-        evt_filter={"gti": True},
+        event_filter={"gti": True},
         check_overlapping_intervals=True,
     ):
         self.background_oversampling = background_oversampling
@@ -132,11 +132,11 @@ class MapDatasetMaker(Maker):
             raise ValueError(f"{difference} is not a valid method.")
         self.selection = selection
 
-        if not set(evt_filter.keys()).issubset(self.available_filter):
+        if not set(event_filter.keys()).issubset(self.available_filter):
             raise ValueError(
-                f"Available methods associated to the 'evt_filter' argument are {self.available_filter}"
+                f"Available methods associated to the 'event_filter' argument are {self.available_filter}"
             )
-        self.evt_filter = evt_filter
+        self.event_filter = event_filter
 
         self.check_overlapping_intervals = check_overlapping_intervals
 
@@ -397,21 +397,21 @@ class MapDatasetMaker(Maker):
         observation : `~gammapy.data.Observation`
             Filtered observation.
         """
-        if "none" in list(self.evt_filter.keys()):
+        if "none" in list(self.event_filter.keys()):
             return observation
 
-        if "gti" in list(self.evt_filter.keys()):
+        if "gti" in list(self.event_filter.keys()):
             if observation.gti is not None:
                 ti = observation.gti.time_intervals
                 if not check_time_intervals(ti, self.check_overlapping_intervals):
                     raise ValueError("Observation GTI not valid.")
                 return observation.select_time(ti)
-        if "uti" in list(self.evt_filter.keys()):
+        if "uti" in list(self.event_filter.keys()):
             if not check_time_intervals(
-                self.evt_filter("uti"), self.check_overlapping_intervals
+                self.event_filter("uti"), self.check_overlapping_intervals
             ):
                 raise ValueError("User time intervals not valid.")
-            return observation.select_time(self.evt_filter("uti"))
+            return observation.select_time(self.event_filter("uti"))
 
     def run(self, dataset, observation):
         """Make map dataset.

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -576,7 +576,7 @@ def test_map_maker_ti(observations):
     )
 
     print(observations[0])
-    maker_obs1 = MapDatasetMaker(evt_filter={"none": True})
+    maker_obs1 = MapDatasetMaker(event_filter={"none": True})
     map_dataset1 = maker_obs1.run(reference, observations[0])
     assert_allclose(map_dataset1.gti.time_delta, 1800.0 * u.s)
 

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -483,7 +483,6 @@ def test_dataset_hawc():
     results["NN"] = [6.57154247837e16, 62, 0.76743538]
 
     for which in ["GP", "NN"]:
-
         # paths and file names
         data_path = "$GAMMAPY_DATA/hawc/crab_events_pass4/"
         hdu_filename = "hdu-index-table-" + which + "-Crab.fits.gz"
@@ -561,3 +560,24 @@ def test_meta_data_creation(observations):
     stacked_meta = MapDatasetMetaData._from_meta_table(dataset0.meta_table)
     assert stacked_meta.obs_info[0].obs_id == 110380
     assert stacked_meta.obs_info[1].obs_id == 111140
+
+
+@requires_data()
+def test_map_maker_ti(observations):
+    # Test for different event selection
+
+    geom_reco = geom(ebounds=[0.1, 1, 10])
+    e_true = MapAxis.from_edges(
+        [0.1, 0.5, 2.5, 10.0], name="energy_true", unit="TeV", interp="log"
+    )
+
+    reference = MapDataset.create(
+        geom=geom_reco, energy_axis_true=e_true, binsz_irf=1.0
+    )
+
+    print(observations[0])
+    maker_obs1 = MapDatasetMaker(evt_filter={"none": True})
+    map_dataset1 = maker_obs1.run(reference, observations[0])
+    assert_allclose(map_dataset1.gti.time_delta, 1800.0 * u.s)
+
+    return False

--- a/gammapy/utils/tests/test_time.py
+++ b/gammapy/utils/tests/test_time.py
@@ -11,6 +11,7 @@ from gammapy.utils.time import (
     time_ref_to_dict,
     time_relative_to_ref,
     unique_time_info,
+    check_time_intervals,
 )
 
 
@@ -92,3 +93,36 @@ def test_check_time_info():
     ]
 
     assert unique_time_info(rows) is False
+
+
+def test_check_time_intervals():
+    assert check_time_intervals(1.0) is False
+    assert check_time_intervals([]) is False
+    assert check_time_intervals([53090.130, 53090.140]) is False
+
+    aa = [
+        Time(53090.130, format="mjd", scale="tt"),
+        Time(53090.140, format="mjd", scale="tt"),
+    ]
+    bb = [
+        Time(53090.150, format="mjd", scale="tt"),
+        Time(53090.160, format="mjd", scale="tt"),
+    ]
+    ti = [aa, bb]
+    assert check_time_intervals(ti) is True
+
+    cc = [
+        Time(53090.140, format="mjd", scale="tt"),
+        Time(53090.160, format="mjd", scale="tt"),
+    ]
+    ti = [aa, cc]
+    assert check_time_intervals(ti) is True
+
+    dd = [
+        Time(53080.150, format="mjd", scale="tt"),
+        Time(53091.160, format="mjd", scale="tt"),
+    ]
+    ti = [aa, bb, dd]
+    assert check_time_intervals(ti) is False
+
+    assert check_time_intervals(ti, False) is True

--- a/gammapy/utils/time.py
+++ b/gammapy/utils/time.py
@@ -1,15 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Time related utility functions."""
+
+import logging
 import numpy as np
 import astropy.units as u
 from astropy.time import Time, TimeDelta
+from astropy.stats import interval_overlap_length
+from itertools import combinations
 
 __all__ = [
     "absolute_time",
     "time_ref_from_dict",
     "time_ref_to_dict",
     "time_relative_to_ref",
+    "check_time_intervals",
 ]
+
+log = logging.getLogger(__name__)
 
 TIME_KEYWORDS = ["MJDREFI", "MJDREFF", "TIMEUNIT", "TIMESYS", "TIMEREF"]
 
@@ -213,4 +220,46 @@ def unique_time_info(rows):
         for name in TIME_KEYWORDS:
             if first_obs[name] != row[name] or row[name] is None:
                 return False
+    return True
+
+
+def check_time_intervals(time_intervals, check_overlapping_intervals=True):
+    """Check that the intervals are made of `astropy.time.Time` objects and are disjoint.
+
+    Parameters
+    ----------
+    time_intervals : array of intervals of `astropy.time.Time`
+        List of time intervals to check
+    check_overlapping_intervals: bool
+        Check whether the intervals are disjoint. Default: True.
+
+    Returns
+    -------
+        valid: bool
+    """
+    # Note: this function will be moved into a future class `TimeInterval`
+    ti = np.asarray(time_intervals)
+    if ti.shape == () or ti.shape == (0,):
+        return False
+    if ti.shape == (2,) or ti.shape == (2, 1):
+        if not np.all([isinstance(_, Time) for _ in ti]):
+            return False
+    else:
+        for xx in ti:
+            if not np.all([isinstance(_, Time) for _ in xx]):
+                return False
+        if (ti[:-1] <= ti[1:]).all() is False:
+            log.warning("Sorted time intervals is required")
+            return False
+
+    if not check_overlapping_intervals:
+        return True
+    for xx in combinations(ti, 2):
+        i1 = [xx[0][0].to_value("gps"), xx[0][1].to_value("gps")]
+        i2 = [xx[1][0].to_value("gps"), xx[1][1].to_value("gps")]
+        if interval_overlap_length(i1, i2) > 0.0:
+            i1 = [xx[0][0], xx[0][1]]
+            i2 = [xx[1][0], xx[1][1]]
+            log.warning(f"Overlapping GTIs: {i1} and {i2}")
+            return False
     return True


### PR DESCRIPTION
**Description**

This pull request adds options to filter event during the data reduction through the `MapDatasetMaker`. By default, events are filtered with the observatory GTIs.

**Dear reviewer**
This is a draft and needs to be finished with tests once the PR #5305 is merged.

@MRegeard, for the pulsar data flow, should we add something elsewhere?