### PR TITLE
Norm `TemplatePhaseCurveTemporalModel`

### DIFF
--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -995,13 +995,8 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
         x = table["PHASE"].data
         y = table["NORM"].data
 
-        try:
-            w = table["WEIGHT"].data
-        except KeyError:
-            w = None
-
         interpolator = scipy.interpolate.InterpolatedUnivariateSpline(
-            x, y, w=w, k=1, ext=2, bbox=[0.0, 1.0]
+            x, y, k=1, ext=2, bbox=[0.0, 1.0]
         )
 
         integral = interpolator.integral(0, 1)
@@ -1091,13 +1086,8 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
         x = self.table["PHASE"].data
         y = self.table["NORM"].data
 
-        try:
-            w = self.table["WEIGHT"].data
-        except KeyError:
-            w = None
-
         return scipy.interpolate.InterpolatedUnivariateSpline(
-            x, y, w=w, k=1, ext=2, bbox=[0.0, 1.0]
+            x, y, k=1, ext=2, bbox=[0.0, 1.0]
         )
 
     def evaluate(self, time, t_ref, phi_ref, f0, f1, f2):

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -428,7 +428,7 @@ def test_phase_curve_model(tmp_path):
 
 def test_phase_curve_model_sample_time():
     phase = np.linspace(0.0, 1, 51)
-    norm = 1 * (phase < 0.5)
+    norm = 1.0 * (phase < 0.5)
     table = Table(data={"PHASE": phase, "NORM": norm})
 
     t_ref = Time("2020-06-01", scale="utc")

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -354,7 +354,6 @@ def test_sine_temporal_model_integral():
 
 @requires_data()
 def test_to_dict(light_curve):
-
     out = light_curve.to_dict()
     assert out["temporal"]["type"] == "LightCurveTemplateTemporalModel"
     assert "lightcrv_PKSB1222+216.fits" in out["temporal"]["filename"]
@@ -362,7 +361,6 @@ def test_to_dict(light_curve):
 
 @requires_data()
 def test_with_skymodel(light_curve):
-
     sky_model = SkyModel(spectral_model=PowerLawSpectralModel())
     out = sky_model.to_dict()
     assert "temporal" not in out
@@ -399,7 +397,7 @@ def test_phase_curve_model(tmp_path):
     )
 
     result = phase_model(t_ref + [0, 0.025, 0.05] * u.s)
-    assert_allclose(result, [0, 0.5, 0], atol=1e-5)
+    assert_allclose(result, [0.000000e00, 1.999989e00, 2.169609e-05], atol=1e-5)
 
     phase_model.filename = str(make_path(tmp_path / "tmp.fits"))
     phase_model.write()
@@ -415,17 +413,17 @@ def test_phase_curve_model(tmp_path):
     )
 
     assert_allclose(new_model.table["PHASE"].data, phase)
-    assert_allclose(new_model.table["NORM"].data, norm)
+    assert_allclose(new_model.table["NORM"].data, norm * 4)
 
     # exact number of phases
     integral = phase_model.integral(t_ref, t_ref + 10 * u.s)
-    assert_allclose(integral, 0.25, rtol=1e-5)
+    assert_allclose(integral, 1.0, rtol=1e-5)
     # long duration. Should be equal to the phase average
     integral = phase_model.integral(t_ref + 1 * u.h, t_ref + 3 * u.h)
-    assert_allclose(integral, 0.25, rtol=1e-5)
+    assert_allclose(integral, 1.0, rtol=1e-5)
     # 1.25 phase
     integral = phase_model.integral(t_ref, t_ref + 62.5 * u.ms)
-    assert_allclose(integral, 0.225, rtol=1e-5)
+    assert_allclose(integral, 1.0, rtol=1e-5)
 
 
 def test_phase_curve_model_sample_time():
@@ -472,7 +470,7 @@ def test_phasecurve_DC1():
     times = Time(t_ref, format="mjd") + [0.0, 0.5, 0.65, 1.0] * P0
     norm = model(times)
 
-    assert_allclose(norm, [0.05, 0.15, 1.0, 0.05])
+    assert_allclose(norm, [0.294118, 0.882353, 5.882353, 0.294118], atol=1e-5)
 
     with mpl_plot_check():
         model.plot_phasogram(n_points=200)

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -423,7 +423,7 @@ def test_phase_curve_model(tmp_path):
     assert_allclose(integral, 1.0, rtol=1e-5)
     # 1.25 phase
     integral = phase_model.integral(t_ref, t_ref + 62.5 * u.ms)
-    assert_allclose(integral, 1.0, rtol=1e-5)
+    assert_allclose(integral, 0.9, rtol=1e-5)
 
 
 def test_phase_curve_model_sample_time():


### PR DESCRIPTION
This PR fixes #5524. 

I create a method to normalise the "NORM" of table. I need to create the interpolator once to compute the integral. 
This way, we can keep the `lazyproperty` on `_interpolator`.  I also added the possibility to use weights with the "WEIGHT" keyword in the table.

I also slightly modify the `integral` method because in the old one, if you integrate over time that correspond to less than a phase (phi_min=0, phi_max=0.4), the integral was wrong (>> than integral over 1 period). 