### PR TITLE
Update spectral HLI tutorial

### DIFF
--- a/examples/tutorials/analysis-1d/spectral_analysis_hli.py
+++ b/examples/tutorials/analysis-1d/spectral_analysis_hli.py
@@ -395,7 +395,6 @@ ax_spectrum, ax_residuals = analysis.datasets[0].plot_fit()
 ax_spectrum.set_ylim(0.1, 200)
 ax_spectrum.set_xlim(0.2, 60)
 ax_residuals.set_xlim(0.2, 60)
-analysis.datasets[0].plot_masks(ax=ax_spectrum)
 plt.show()
 
 

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -487,7 +487,6 @@ class FluxPointsDataset(Dataset):
         ax_residuals=None,
         kwargs_spectrum=None,
         kwargs_residuals=None,
-        axis_name="energy",
     ):
         """Plot flux points, best fit model and residuals in two panels.
 
@@ -503,6 +502,7 @@ class FluxPointsDataset(Dataset):
             Keyword arguments passed to `~FluxPointsDataset.plot_spectrum`. Default is None.
         kwargs_residuals : dict, optional
             Keyword arguments passed to `~FluxPointsDataset.plot_residuals`. Default is None.
+
         Returns
         -------
         ax_spectrum, ax_residuals : `~matplotlib.axes.Axes`


### PR DESCRIPTION
Resolves #5531 in part
> [spectral_analysis_hli](https://docs.gammapy.org/dev/tutorials/analysis-1d/spectral_analysis_hli.html#exploration-of-the-fit-results): Two mask fit ranges are plotted, and 2 mask safe (but not in residuals as expected)


This comes from the line `analysis.datasets[0].plot_masks(ax=ax_spectrum)`. 
It appears the plotting of the masks already occurs in `plot_fit` which it did not previously. We need to understand that!