### PR TITLE
Fix ObservationsEventsSampler for observations based on full-enclosure IRFs

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -125,7 +125,7 @@ def create_map_dataset_geoms(
 def _default_energy_axis(observation, energy_bin_per_decade_max=30):
     # number of bins per decade estimated from the energy resolution
     # such as diff(ereco.edges)/ereco.center ~ min(eres)
-    etrue = observation.psf.axes[0].edges  # only where psf is defined
+    etrue = observation.psf.axes[0].center  # only where psf is defined
     eres = observation.edisp.to_edisp_kernel(0 * u.deg).get_resolution(etrue)
     eres = eres[np.isfinite(eres)]
     if eres.size > 0:

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -125,8 +125,8 @@ def create_map_dataset_geoms(
 def _default_energy_axis(observation, energy_bin_per_decade_max=30):
     # number of bins per decade estimated from the energy resolution
     # such as diff(ereco.edges)/ereco.center ~ min(eres)
-    etrue = observation.psf.axes[0].center  # only where psf is defined
-    eres = observation.edisp.to_edisp_kernel(0 * u.deg).get_resolution(etrue)
+    etrue = observation.psf.axes[0]  # only where psf is defined
+    eres = observation.edisp.to_edisp_kernel(0 * u.deg).get_resolution(etrue.center)
     eres = eres[np.isfinite(eres)]
     if eres.size > 0:
         # remove outliers
@@ -140,8 +140,8 @@ def _default_energy_axis(observation, energy_bin_per_decade_max=30):
         nbin_per_decade = energy_bin_per_decade_max
 
     energy_axis = MapAxis.from_energy_bounds(
-        etrue[0],
-        etrue[-1],
+        etrue.edges[0],
+        etrue.edges[-1],
         nbin=nbin_per_decade,
         per_decade=True,
         name="energy",

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -647,7 +647,7 @@ class ObservationEventSampler(MapDatasetEventSampler):
         n_event_bunch=10000,
         dataset_kwargs=None,
     ):
-        self.dataset_kwargs = dataset_kwargs if dataset_kwargs else {}
+        self.dataset_kwargs = dataset_kwargs or {}
         self.random_state = get_random_state(random_state)
         self.oversample_energy_factor = oversample_energy_factor
         self.t_delta = t_delta

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -647,7 +647,7 @@ class ObservationEventSampler(MapDatasetEventSampler):
         n_event_bunch=10000,
         dataset_kwargs=None,
     ):
-        self.dataset_kwargs = dataset_kwargs
+        self.dataset_kwargs = dataset_kwargs if dataset_kwargs else {}
         self.random_state = get_random_state(random_state)
         self.oversample_energy_factor = oversample_energy_factor
         self.t_delta = t_delta

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -14,7 +14,12 @@ import gammapy.irf.psf.map as psf_map_module
 from gammapy.catalog import SourceCatalog3FHL
 from gammapy.data import GTI, DataStore
 from gammapy.datasets import Datasets, MapDataset, MapDatasetOnOff
-from gammapy.datasets.map import RAD_AXIS_DEFAULT, _default_width
+from gammapy.datasets.map import (
+    _default_width,
+    create_map_dataset_from_observation,
+    RAD_AXIS_DEFAULT,
+)
+    
 from gammapy.irf import (
     EDispKernelMap,
     EDispMap,
@@ -2248,3 +2253,13 @@ def test_default_width():
     obs = datastore_magic.get_observations(required_irf="point-like")[0]
     width = _default_width(obs)
     assert_allclose(width, 0.77459669 * u.deg)
+
+
+@requires_data()
+def test_create_map_dataset_from_observation():
+    datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
+    observations = datastore.get_observations()
+    dataset_new = create_map_dataset_from_observation(observations[0])
+
+    assert dataset_new.counts.data.sum() == 0
+    assert_allclose(dataset_new.exposure.data.sum, 43239974121207.85)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -19,7 +19,7 @@ from gammapy.datasets.map import (
     create_map_dataset_from_observation,
     RAD_AXIS_DEFAULT,
 )
-    
+
 from gammapy.irf import (
     EDispKernelMap,
     EDispMap,
@@ -2262,4 +2262,4 @@ def test_create_map_dataset_from_observation():
     dataset_new = create_map_dataset_from_observation(observations[0])
 
     assert dataset_new.counts.data.sum() == 0
-    assert_allclose(dataset_new.exposure.data.sum, 43239974121207.85)
+    assert_allclose(dataset_new.exposure.data.sum(), 43239974121207.85)

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -994,6 +994,13 @@ def test_observation_event_sampler(signal_model, tmp_path):
         deadtime_fraction=0.01,
     )
 
+    # test first with defaults
+    maker = ObservationEventSampler()
+
+    sim_obs = maker.run(obs, [signal_model])
+    assert sim_obs.events is not None
+    assert len(sim_obs.events.table) > 0
+
     dataset_kwargs = dict(
         spatial_width=5 * u.deg,
         spatial_bin_size=0.01 * u.deg,

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -975,6 +975,17 @@ def test_sort_evt_by_time(dataset):
 def test_observation_event_sampler(signal_model, tmp_path):
     from gammapy.datasets.simulate import ObservationEventSampler
 
+    datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
+    obs = datastore.get_observations()[0]
+
+    # first test defaults with HESS
+    # otherwise with CTA the EdispMap computation takes too much time and memory
+    maker = ObservationEventSampler()
+
+    sim_obs = maker.run(obs, None)
+    assert sim_obs.events is not None
+    assert len(sim_obs.events.table) > 0
+
     irfs = load_irf_dict_from_file(
         "$GAMMAPY_DATA/cta-caldb/Prod5-South-20deg-AverageAz-14MSTs37SSTs.180000s-v0.1.fits.gz"
     )
@@ -993,13 +1004,6 @@ def test_observation_event_sampler(signal_model, tmp_path):
         irfs=irfs,
         deadtime_fraction=0.01,
     )
-
-    # test first with defaults
-    maker = ObservationEventSampler()
-
-    sim_obs = maker.run(obs, [signal_model])
-    assert sim_obs.events is not None
-    assert len(sim_obs.events.table) > 0
 
     dataset_kwargs = dict(
         spatial_width=5 * u.deg,


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**

This pull request fixes two small bugs that are preventing `gammapy.data.ObservationsEventsSampler` to work on full-enclosure-based observations (for the point-like case see #5544 ).

I can add a new tutorial with a short snippet on how to use this class (either as a separate PR after this fix PR is merged or directly here if preferred by the maintainers).

Regarding the testing (to be integrated):
- the fix for `dataset_kwargs` is needed because in the test this is always defined, never `None`
- the energy axes fix is needed because of the fix above (if the axis is None when `create_map_dataset_from_observation` is called then the (faulty) function `_default_energy_axis` is called

Closes #5542.
