### PR TITLE
Fix _default_width for point-like irfs

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -170,7 +170,7 @@ def _default_binsz(observation, spatial_bin_size_min=0.01 * u.deg):
 def _default_width(observation, spatial_width_max=12 * u.deg):
     # width estimated from the rad_max or the offset_max
     if observation.rad_max is not None:
-        width = 2.0 * np.max(observation.rad_max)
+        width = 2.0 * observation.rad_max.quantity.max()
     else:
         width = 2.0 * observation.psf.axes["offset"].edges[-1]
     return np.minimum(width, spatial_width_max)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -12,9 +12,9 @@ from astropy.utils.exceptions import AstropyUserWarning
 from regions import CircleSkyRegion
 import gammapy.irf.psf.map as psf_map_module
 from gammapy.catalog import SourceCatalog3FHL
-from gammapy.data import GTI
+from gammapy.data import GTI, DataStore
 from gammapy.datasets import Datasets, MapDataset, MapDatasetOnOff
-from gammapy.datasets.map import RAD_AXIS_DEFAULT
+from gammapy.datasets.map import RAD_AXIS_DEFAULT, _default_width
 from gammapy.irf import (
     EDispKernelMap,
     EDispMap,
@@ -2240,3 +2240,11 @@ def test_get_psf_kernel_multiscale():
         mask = sep > width
         assert np.all(im.data[mask] == 0)
         assert np.any(im.data[~mask] > 0)
+
+
+@requires_data()
+def test_default_width():
+    datastore_magic = DataStore.from_dir("$GAMMAPY_DATA/magic/rad_max/data")
+    obs = datastore_magic.get_observations(required_irf="point-like")[0]
+    width = _default_width(obs)
+    assert_allclose(width, 0.77459669 * u.deg)


### PR DESCRIPTION
Fix _default_width for point-like irfs.
Currently this case is not used anywhere but it should not fail.