### PR TITLE
Remove is_norm in parameter.from_dict for backward compatibility

### DIFF
--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -692,6 +692,7 @@ class Parameters(collections.abc.Sequence):
 
         for par in data:
             link_label = par.pop("link", None)
+            par.pop("is_norm", None)
             parameter = Parameter(**par)
             parameter._link_label_io = link_label
             parameters.append(parameter)

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -245,6 +245,11 @@ def test_parameters_s():
     assert_allclose(pars[1].factor, 20)
     assert_allclose(pars[1].scale, 1)
 
+    # test for backward compatibilty
+    pars_dict[0]["is_norm"] = True
+    pars = Parameters.from_dict(pars_dict)
+    assert not hasattr(pars[0], "is_norm")
+
 
 def test_parameter_scan_values():
     p = Parameter(name="test", value=0, error=1)


### PR DESCRIPTION
Remove is_norm in parameter.from_dict for backward compatibility