### PR TITLE
Autofix: TypeError: gammapy.utils.tests.test_parallel.test_run_multiprocessing_wrong_method.<locals>.func() argument after * must be an iterable, not boo

### DIFF
--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -232,6 +232,8 @@ def run_multiprocessing(
         Keyword arguments passed to the pool. The number of processes is limited
         to the number of physical CPUs. Default is None.
     method : {'starmap', 'apply_async'}
+    method : {'starmap', 'apply_async'}, optional
+        Pool method to use. Default is None, which uses the METHOD_DEFAULT.
         Pool method to use. Default is "starmap".
     method_kwargs : dict, optional
         Keyword arguments passed to the method. Default is None.
@@ -243,7 +245,13 @@ def run_multiprocessing(
         backend = BACKEND_DEFAULT
 
     if method is None:
+    if method is None:
         method = METHOD_DEFAULT
+    
+    try:
+        method = PoolMethodEnum(method)
+    except ValueError:
+        raise ValueError(f"Invalid method: {method}. Must be one of {list(PoolMethodEnum)}")
 
     if method_kwargs is None:
         method_kwargs = METHOD_KWARGS_DEFAULT
@@ -279,7 +287,7 @@ def run_multiprocessing(
     log.info(f"Using {processes} processes to compute {task_name}")
 
     with multiprocessing.Pool(**pool_kwargs) as pool:
-        pool_func = POOL_METHODS[PoolMethodEnum(method)]
+        pool_func = POOL_METHODS[method]
         results = pool_func(
             pool=pool,
             func=func,


### PR DESCRIPTION
Added early validation of the 'method' parameter in the run_multiprocessing function to raise a ValueError with a clear message when an invalid method is provided. This addresses the issue reported in the GitHub issue where the error was not being caught properly on single-CPU systems. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    