### PR TITLE
parallel.py: Validate method early (issue #5557)

### DIFF
--- a/gammapy/utils/parallel.py
+++ b/gammapy/utils/parallel.py
@@ -251,6 +251,11 @@ def run_multiprocessing(
     if pool_kwargs is None:
         pool_kwargs = POOL_KWARGS_DEFAULT
 
+    try:
+        method_enum = PoolMethodEnum(method)
+    except ValueError as e:
+        raise ValueError(f"Invalid method: {method}") from e
+
     processes = pool_kwargs.get("processes", N_JOBS_DEFAULT)
 
     backend = ParallelBackendEnum.from_str(backend)
@@ -279,7 +284,7 @@ def run_multiprocessing(
     log.info(f"Using {processes} processes to compute {task_name}")
 
     with multiprocessing.Pool(**pool_kwargs) as pool:
-        pool_func = POOL_METHODS[PoolMethodEnum(method)]
+        pool_func = POOL_METHODS[method_enum]
         results = pool_func(
             pool=pool,
             func=func,


### PR DESCRIPTION
Fixes this funny error when building the package on a single-CPU system:

```
=================================== FAILURES =================================== ____________________ test_run_multiprocessing_wrong_method _____________________

    def test_run_multiprocessing_wrong_method():
        def func(arg):
            return arg

        with pytest.raises(ValueError):
>           parallel.run_multiprocessing(
                func, [True, True], method="wrong_name", pool_kwargs=dict(processes=2)
            )

gammapy/utils/tests/test_parallel.py:32:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ gammapy/utils/parallel.py:271: in run_multiprocessing
    return run_loop(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

func = <function test_run_multiprocessing_wrong_method.<locals>.func at 0x7f5b74fe1e40> inputs = [True, True], method_kwargs = {}, task_name = ''

    def run_loop(func, inputs, method_kwargs=None, task_name=""):
        """Loop over inputs and run function."""
        results = []

        callback = method_kwargs.get("callback", None)

        for arguments in progress_bar(inputs, desc=task_name):
>           result = func(*arguments)
E           TypeError: gammapy.utils.tests.test_parallel.test_run_multiprocessing_wrong_method.<locals>.func() argument after * must be an iterable, not bool

gammapy/utils/parallel.py:301: TypeError
```
