### PR TITLE
Correct the docstring of `EnergyDispersion2D`

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -23,7 +23,8 @@ class BackgroundIRF(IRF):
 
     Parameters
     ----------
-    axes : list of `MapAxis` or `MapAxes` object
+    axes : list of `~gammapy.maps.MapAxis` or `~gammapy.maps.MapAxes`
+        Axes.
     data : `~np.ndarray`
         Data array.
     unit : str or `~astropy.units.Unit`
@@ -107,8 +108,11 @@ class Background3D(BackgroundIRF):
 
     Parameters
     ----------
-    axes : list of `MapAxis` or `MapAxes` object
-        Required data axes: ["energy", "fov_lon", "fov_lat"] in the given order.
+    axes : list of `~gammapy.maps.MapAxis` or `~gammapy.maps.MapAxes`
+        Required axes (in the given order) are:
+            * energy (reconstructed energy axis)
+            * fov_lon (field of view longitude)
+            * fov_lon (field of view latitude)
     data : `~np.ndarray`
         Data array.
     unit : str or `~astropy.units.Unit`
@@ -259,8 +263,10 @@ class Background2D(BackgroundIRF):
 
     Parameters
     ----------
-    axes : list of `MapAxis` or `MapAxes` object
-        Required data axes: ["energy", "offset"] in the given order.
+    axes : list of `~gammapy.maps.MapAxis` or `~gammapy.maps.MapAxes`
+        Required axes (in the given order) are:
+            * energy (reconstructed energy axis)
+            * offset (field of view offset axis)
     data : `~np.ndarray`
         Data array.
     unit : str or `~astropy.units.Unit`

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -42,7 +42,7 @@ class IRF(metaclass=abc.ABCMeta):
 
     Parameters
     ----------
-    axes : list of `MapAxis` or `MapAxes`
+    axes : list of `~gammapy.maps.MapAxis` or `~gammapy.maps.MapAxes`
         Axes.
     data : `~numpy.ndarray` or `~astropy.units.Quantity`, optional
         Data. Default is 0.

--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -26,11 +26,11 @@ class EnergyDispersion2D(IRF):
 
     Parameters
     ----------
-    axes : list of `MapAxis` or `MapAxes`
-        Axes with the following names :
-            * energy_axis_true (True energy axis.)
-            * migra_axis (Energy migration axis.)
-            * offset_axis (Field of view offset axis.)
+    axes : list of `~gammapy.maps.MapAxis` or `~gammapy.maps.MapAxes`
+        Required axes (in the given order) are:
+            * energy_true (true energy axis)
+            * migra (energy migration axis)
+            * offset (field of view offset axis)
     data : `~numpy.ndarray`
         Energy dispersion probability density.
 

--- a/gammapy/irf/edisp/core.py
+++ b/gammapy/irf/edisp/core.py
@@ -26,12 +26,11 @@ class EnergyDispersion2D(IRF):
 
     Parameters
     ----------
-    energy_axis_true : `MapAxis`
-        True energy axis.
-    migra_axis : `MapAxis`
-        Energy migration axis.
-    offset_axis : `MapAxis`
-        Field of view offset axis.
+    axes : list of `MapAxis` or `MapAxes`
+        Axes with the following names :
+            * energy_axis_true (True energy axis.)
+            * migra_axis (Energy migration axis.)
+            * offset_axis (Field of view offset axis.)
     data : `~numpy.ndarray`
         Energy dispersion probability density.
 
@@ -39,7 +38,7 @@ class EnergyDispersion2D(IRF):
     --------
     Read energy dispersion IRF from disk:
 
-    >>> from gammapy.maps import MapAxis
+    >>> from gammapy.maps import MapAxis, MapAxes
     >>> from gammapy.irf import EnergyDispersion2D
     >>> filename = '$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz'
     >>> edisp2d = EnergyDispersion2D.read(filename, hdu="EDISP")
@@ -50,6 +49,14 @@ class EnergyDispersion2D(IRF):
     >>> energy_axis = MapAxis.from_bounds(0.1, 20, nbin=60, unit="TeV", interp="log", name='energy')
     >>> edisp = edisp2d.to_edisp_kernel(offset='1.2 deg', energy_axis=energy_axis,
     ...                                 energy_axis_true=energy_axis.copy(name='energy_true'))
+
+    Create energy dispersion IRF from axes:
+
+    >>> energy_axis_true = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=10, name="energy_true")
+    >>> offset_axis = MapAxis.from_bounds(0, 1, nbin=3, unit="deg", name="offset", node_type="edges")
+    >>> migra_axis = MapAxis.from_bounds(0, 3, nbin=3, name="migra", node_type="edges")
+    >>> axes = MapAxes([energy_axis_true, migra_axis, offset_axis])
+    >>> edisp2d_axes = EnergyDispersion2D(axes=axes)
 
     See Also
     --------

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -22,10 +22,10 @@ class EDispKernel(IRF):
 
     Parameters
     ----------
-    energy_axis_true : `~gammapy.maps.MapAxis`
-        True energy axis. Its name must be "energy_true".
-    energy_axis : `~gammapy.maps.MapAxis`
-        Reconstructed energy axis. Its name must be "energy".
+    axes : list of `~gammapy.maps.MapAxis` or `~gammapy.maps.MapAxes`
+        Required axes (in the given order) are:
+            * energy_true (true energy axis)
+            * energy (reconstructed energy axis)
     data : array_like
         2D energy dispersion matrix.
 
@@ -233,7 +233,10 @@ class EDispKernel(IRF):
                     chan_max = l.field("F_CHAN")[k] + l.field("N_CHAN")[k]
 
                     pdf_matrix[i, chan_min:chan_max] = l.field("MATRIX")[
-                        m_start : m_start + l.field("N_CHAN")[k]  # noqa: E203
+                        m_start : m_start
+                        + l.field("N_CHAN")[
+                            k
+                        ]  # noqa: E203
                     ]
                     m_start += l.field("N_CHAN")[k]
 

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -20,10 +20,10 @@ class EffectiveAreaTable2D(IRF):
 
     Parameters
     ----------
-    energy_axis_true : `MapAxis`
-        True energy axis.
-    offset_axis : `MapAxis`
-        Field of view offset axis.
+    axes : list of `~gammapy.maps.MapAxis` or `~gammapy.maps.MapAxes`
+        Required axes (in the given order) are:
+            * energy_true (true energy axis)
+            * offset (field of view offset axis)
     data : `~astropy.units.Quantity`
         Effective area.
     meta : dict

--- a/gammapy/irf/psf/parametric.py
+++ b/gammapy/irf/psf/parametric.py
@@ -302,9 +302,9 @@ class EnergyDependentMultiGaussPSF(ParametricPSF):
     ----------
     axes : list of `~gammapy.maps.MapAxis` or `~gammapy.maps.MapAxes`
         Required axes (in the given order) are:
-            * energy_true (true energy axis.)
-            * migra_axis (energy migration axis.)
-            * offset_axis (field of view offset axis.)
+            * energy_true (true energy axis)
+            * migra_axis (energy migration axis)
+            * offset_axis (field of view offset axis)
     data : `~numpy.recarray`
         Data array.
     meta : dict

--- a/gammapy/irf/psf/parametric.py
+++ b/gammapy/irf/psf/parametric.py
@@ -300,8 +300,11 @@ class EnergyDependentMultiGaussPSF(ParametricPSF):
 
     Parameters
     ----------
-    axes : list of `MapAxis`
-        Required axes are ["energy_true", "offset"].
+    axes : list of `~gammapy.maps.MapAxis` or `~gammapy.maps.MapAxes`
+        Required axes (in the given order) are:
+            * energy_true (true energy axis.)
+            * migra_axis (energy migration axis.)
+            * offset_axis (field of view offset axis.)
     data : `~numpy.recarray`
         Data array.
     meta : dict

--- a/gammapy/irf/psf/table.py
+++ b/gammapy/irf/psf/table.py
@@ -15,12 +15,11 @@ class PSF3D(PSF):
 
     Parameters
     ----------
-    energy_axis_true : `MapAxis`
-        True energy axis.
-    offset_axis : `MapAxis`
-        Offset axis.
-    rad_axis : `MapAxis`
-        Rad axis.
+    axes : list of `~gammapy.maps.MapAxis` or `~gammapy.maps.MapAxes`
+        Required axes (in the given order) are:
+            * energy_true (true energy axis)
+            * migra (energy migration axis)
+            * rad (rad axis)
     data : `~astropy.units.Quantity`
         PSF (3-dim with axes: psf[rad_index, offset_index, energy_index].
     meta : dict

--- a/gammapy/irf/rad_max.py
+++ b/gammapy/irf/rad_max.py
@@ -22,10 +22,10 @@ class RadMax2D(IRF):
 
     Parameters
     ----------
-    energy_axis : `MapAxis`
-        Reconstructed energy axis.
-    offset_axis : `MapAxis`
-        Field of view offset axis.
+    axes : list of `~gammapy.maps.MapAxis` or `~gammapy.maps.MapAxes`
+        Required axes (in the given order) are:
+            * energy (reconstructed energy axis)
+            * offset (field of view offset axis)
     data : `~astropy.units.Quantity`
         Applied directional cut.
     meta : dict


### PR DESCRIPTION
This PR resolves #5530
It also adjusts the other docstrings where `axes` is utilised