### PR TITLE
Add legend in correct place and remove calls to plt.legend()

### DIFF
--- a/examples/tutorials/analysis-3d/flux_profiles.py
+++ b/examples/tutorials/analysis-3d/flux_profiles.py
@@ -203,6 +203,7 @@ for quantity in quantities:
     profile[quantity].plot(ax=ax, label=quantity.title())
 
 ax.set_ylabel("Counts")
+ax.legend()
 plt.show()
 
 

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -670,6 +670,8 @@ class FluxPoints(FluxMaps):
         ax = flux.plot(ax=ax, **kwargs)
         ax.set_ylabel(f"{sed_type} [{ax.yaxis.units.to_string(UNIT_STRING_FORMAT)}]")
         ax.set_yscale("log")
+        if len(flux.geom.axes) > 1:
+            ax.legend()
         return ax
 
     def plot_ts_profiles(

--- a/gammapy/irf/psf/core.py
+++ b/gammapy/irf/psf/core.py
@@ -279,7 +279,7 @@ class PSF(IRF):
 
         ax.set_yscale("log")
         ax.set_ylabel(f"PSF [{ax.yaxis.units.to_string(UNIT_STRING_FORMAT)}]")
-        plt.legend()
+        ax.legend()
         return ax
 
     def peek(self, figsize=(15, 5)):

--- a/gammapy/irf/psf/map.py
+++ b/gammapy/irf/psf/map.py
@@ -566,7 +566,7 @@ class PSFMap(IRFMap):
         ax.set_xlabel(f"Rad [{ax.xaxis.units.to_string(UNIT_STRING_FORMAT)}]")
         ax.set_ylabel(f"PSF [{ax.yaxis.units.to_string(UNIT_STRING_FORMAT)}]")
         ax.xaxis.set_major_formatter(FormatStrFormatter("%.2f"))
-        plt.legend()
+        ax.legend()
         return ax
 
     def __str__(self):


### PR DESCRIPTION
This allows the legends to be automatically plotted but with the correct call to `ax.legend`.

Related to #5510 which removed the legends completely. 

I also remove the calls to `plt.legend` in two other cases.