### PR TITLE
Fix astropy dev link 

### DIFF
--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -8,7 +8,7 @@ Developer guide
 
 The developer documentation is a collection of notes for Gammapy developers and maintainers.
 If something is not covered here, have a look at the very extensive
-`Astropy developer documentation <https://docs.astropy.org/en/latest/development/index.html>`__,
+`Astropy developer documentation <https://docs.astropy.org/en/latest/index_dev.html>`__,
 as well. If you want to contribute to Gammapy just use one of the `contact points <https://gammapy.org/contact.html>`__
 listed on the Gammapy webpage. Ideally you join directly the #dev channel in the Gammapy Slack.
 


### PR DESCRIPTION
The link to the astropy development documentation in developer guide index.rst is broken for docs >=1.2
I put this new link: https://docs.astropy.org/en/latest/index_dev.html.