### PR TITLE
Ax formatting of `FluxPoint.plot`

### DIFF
--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -668,11 +668,25 @@ class FluxPoints(FluxMaps):
         if "time" in flux.geom.axes_names:
             flux.geom.axes["time"].time_format = time_format
         ax = flux.plot(ax=ax, **kwargs)
-        ax.set_ylabel(f"{sed_type} [{ax.yaxis.units.to_string(UNIT_STRING_FORMAT)}]")
-        ax.set_yscale("log")
+        self._plot_format_ax(ax, energy_power, sed_type)
         if len(flux.geom.axes) > 1:
             ax.legend()
         return ax
+
+    @staticmethod
+    def _plot_format_ax(ax, energy_power, sed_type):
+        ax.set_xlabel(f"Energy [{ax.xaxis.units.to_string(UNIT_STRING_FORMAT)}]")
+        if energy_power > 0:
+            ax.set_ylabel(
+                f"e{energy_power} * {sed_type} [{ax.yaxis.units.to_string(UNIT_STRING_FORMAT)}]"
+            )
+        else:
+            ax.set_ylabel(
+                f"{sed_type} [{ax.yaxis.units.to_string(UNIT_STRING_FORMAT)}]"
+            )
+
+        ax.set_xscale("log", nonpositive="clip")
+        ax.set_yscale("log", nonpositive="clip")
 
     def plot_ts_profiles(
         self,

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -670,15 +670,16 @@ class FluxPoints(FluxMaps):
             ax = flux.plot(ax=ax, **kwargs)
         else:
             ax = flux.plot(ax=ax, **kwargs)
-            self._plot_format_ax(ax=ax, energy_power=energy_power, sed_type=sed_type)
+            ax.set_xlabel(f"Energy [{ax.xaxis.units.to_string(UNIT_STRING_FORMAT)}]")
+            ax.set_xscale("log", nonpositive="clip")
+        self._plot_format_yax(ax=ax, energy_power=energy_power, sed_type=sed_type)
 
         if len(flux.geom.axes) > 1:
             ax.legend()
         return ax
 
     @staticmethod
-    def _plot_format_ax(ax, energy_power, sed_type):
-        ax.set_xlabel(f"Energy [{ax.xaxis.units.to_string(UNIT_STRING_FORMAT)}]")
+    def _plot_format_yax(ax, energy_power, sed_type):
         if energy_power > 0:
             ax.set_ylabel(
                 f"e{energy_power} * {sed_type} [{ax.yaxis.units.to_string(UNIT_STRING_FORMAT)}]"
@@ -689,7 +690,6 @@ class FluxPoints(FluxMaps):
             )
 
         ax.set_yscale("log", nonpositive="clip")
-        ax.set_xscale("log", nonpositive="clip")
 
     def plot_ts_profiles(
         self,

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -667,8 +667,11 @@ class FluxPoints(FluxMaps):
         flux = scale_plot_flux(flux=flux.to_unit(flux_unit), energy_power=energy_power)
         if "time" in flux.geom.axes_names:
             flux.geom.axes["time"].time_format = time_format
-        ax = flux.plot(ax=ax, **kwargs)
-        self._plot_format_ax(ax, energy_power, sed_type)
+            ax = flux.plot(ax=ax, **kwargs)
+        else:
+            ax = flux.plot(ax=ax, **kwargs)
+            self._plot_format_ax(ax=ax, energy_power=energy_power, sed_type=sed_type)
+
         if len(flux.geom.axes) > 1:
             ax.legend()
         return ax
@@ -685,8 +688,8 @@ class FluxPoints(FluxMaps):
                 f"{sed_type} [{ax.yaxis.units.to_string(UNIT_STRING_FORMAT)}]"
             )
 
-        ax.set_xscale("log", nonpositive="clip")
         ax.set_yscale("log", nonpositive="clip")
+        ax.set_xscale("log", nonpositive="clip")
 
     def plot_ts_profiles(
         self,

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -256,6 +256,33 @@ class TestFluxPoints:
 
 
 @requires_data()
+def test_plot_format_yaxis():
+    path = "$GAMMAPY_DATA/tests/spectrum/flux_points/flux_points.fits"
+    fp = FluxPoints.read(path)
+
+    with mpl_plot_check():
+        ax = fp.plot(sed_type="e2dnde")
+        assert (
+            ax.yaxis.get_label().get_text()
+            == "e2dnde [$\\mathrm{erg\\,s^{-1}\\,cm^{-2}}$]"
+        )
+
+    with mpl_plot_check():
+        ax = fp.plot(sed_type="dnde", energy_power=2)
+        assert (
+            ax.yaxis.get_label().get_text()
+            == "e2 * dnde [$\\mathrm{TeV\\,s^{-1}\\,cm^{-2}}$]"
+        )
+
+    with mpl_plot_check():
+        ax = fp.plot(sed_type="dnde")
+        assert (
+            ax.yaxis.get_label().get_text()
+            == "dnde [$\\mathrm{TeV^{-1}\\,s^{-1}\\,cm^{-2}}$]"
+        )
+
+
+@requires_data()
 def test_flux_points_single_bin_dnde():
     path = make_path("$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits")
     table = Table.read(path)

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -281,6 +281,13 @@ def test_plot_format_yaxis():
             == "dnde [$\\mathrm{TeV^{-1}\\,s^{-1}\\,cm^{-2}}$]"
         )
 
+    with mpl_plot_check():
+        ax = fp.plot(sed_type="dnde", energy_power=2.7)
+        assert (
+            ax.yaxis.get_label().get_text()
+            == "dnde [$\\mathrm{TeV^{-1}\\,s^{-1}\\,cm^{-2}}$]"
+        )
+
 
 @requires_data()
 def test_flux_points_single_bin_dnde():


### PR DESCRIPTION
This PR fixes #5583. 
I added `_plot_format_ax` method from `SpectralModel` to `FluxPoints`.

The output of FluxPoints.plot(sed_type="dnde", energy_power=2) in main is:
<img width="599" alt="Capture d’écran 2024-11-18 à 18 09 08" src="https://github.com/user-attachments/assets/7a35c281-d7ee-49c8-89bd-72ae9a18bdf1">

while the output now is:
<img width="604" alt="Capture d’écran 2024-11-18 à 18 10 09" src="https://github.com/user-attachments/assets/a04edde5-0bbf-4ab2-9a9c-836fffc094d3">
