### PR TITLE
Updates to documentation conf and css

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           gammapy download datasets
       - name: test build docs
         run: |
-          tox -e build_docs -- -j auto
+          tox -e build_docs
       - name: check links
         continue-on-error: true
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           file: ./coverage.xml
           verbose: true
   sphinx:
-    name: Linux python 3.9 sphinx all-deps
+    name: Linux python 3.11 sphinx all-deps
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -132,10 +132,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python ${{ matrix.python }}
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: '3.11'
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,11 @@ jobs:
         continue-on-error: true
         run: |
           tox -e linkcheck -- -j auto
+      - name: Upload HTML output
+        uses: actions/upload-artifact@v4
+        with:
+          name: gammapy-doc-html
+          path: docs/_build/html/
   conda-build:
     name: Linux python 3.9 conda-build all-deps
     runs-on: ubuntu-latest

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -41,7 +41,7 @@ p {
 
 
 .navbar-light .navbar-toggler-icon {
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30'%3E%3Cpath stroke='white' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
+  background-image: urdropdownl("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30'%3E%3Cpath stroke='white' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
 }
 
 .navbar-light .navbar-toggler {
@@ -328,8 +328,10 @@ a.dropdown-item {
   color : black !important;
 }
 
+/* Change the color of the font in the navbar */
 .nav-internal {
   color : white !important;
+  color : rgb(209, 213, 218) !important;
 }
 
 .show {
@@ -340,6 +342,7 @@ a.dropdown-item {
   color: white;
 }
 
+/* This changes the 'version' dropdown, the color of the font is white */
 .dropdown-toggle {
   color: white !important;
   font-size: 14px;
@@ -348,6 +351,8 @@ a.dropdown-item {
 .svg-inline--fa {
   color: lightgrey ;
 }
+
+/* This changes the color of the dropdown itself, when there is a smaller screen */
 .fa-bars {
   color: white !important;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -39,7 +39,6 @@ p {
   color: white;
 }
 
-
 .navbar-light .navbar-toggler-icon {
   background-image: urdropdownl("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30'%3E%3Cpath stroke='white' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
 }
@@ -48,11 +47,20 @@ p {
   border-color: white;
 }
 
-.col-lg-9 {
-  -ms-flex: 0 0 77.25%;
-  flex: 0 0 77.25%;
-  flex-basis: 77.25%;
-  max-width: 77.25%;
+.nav-link, .nav-item {
+  color : rgb(119, 117, 122) !important;
+}
+
+/* Change the color of the font in the navbar */
+.nav-internal {
+  color : white !important;
+  color : rgb(209, 213, 218) !important;
+}
+
+/* This changes the 'version' dropdown, the color of the font is white */
+.dropdown-toggle {
+  color: white !important;
+  font-size: 14px;
 }
 
 /* pre */
@@ -178,6 +186,7 @@ table.docutils {
   margin: 0px;
 }
 
+/* Change the size of images on the main index page*/
 .intro-card .sd-card-img-top {
   height: 52px;
   width: 52px;
@@ -234,10 +243,8 @@ table.docutils {
 }
 
 /* intro to tutorial collapsed cards */
-
 .tutorial-accordion {
-  margin-top: 20px;
-  margin-bottom: 20px;
+  margin: 20px;
 }
 
 .tutorial-card .card-header.card-link .btn {
@@ -274,7 +281,7 @@ table.docutils {
 
 .tutorial-card .badge {
   background-color: #130654;
-  margin: 10px 10px 10px 10px;
+  margin: 10px;
   padding: 5px;
 }
 
@@ -291,10 +298,8 @@ table.docutils {
   background-color: grey;
 }
 
-.sphx-glr-footer {
-  text-align: left  !important;
-}
-
+/* We could get rid of all the following */
+/* This just sets the look of the download button */
 .sphx-glr-download a {
 background-color: #d9edf7 !important;
 border: 1px solid #bce8f1 !important;
@@ -308,6 +313,7 @@ color: #3a87ad !important;
 .sphx-glr-download a:hover {
 background-color: #d9edf7 !important;
 }
+/* We could get rid of all prior */
 
 .search-button__default-text {
   color: white;
@@ -317,21 +323,13 @@ background-color: #d9edf7 !important;
   color: white;
 }
 
-.nav-link {
-  color : rgb(119, 117, 122) !important;
-}
-.nav-item {
-  color : rgb(119, 117, 122) !important;
+/* This changes the color of the dropdown itself, when there is a smaller screen */
+.fa-bars {
+  color: white !important;
 }
 
 a.dropdown-item {
   color : black !important;
-}
-
-/* Change the color of the font in the navbar */
-.nav-internal {
-  color : white !important;
-  color : rgb(209, 213, 218) !important;
 }
 
 .show {
@@ -342,23 +340,8 @@ a.dropdown-item {
   color: white;
 }
 
-/* This changes the 'version' dropdown, the color of the font is white */
-.dropdown-toggle {
-  color: white !important;
-  font-size: 14px;
-}
-
 .svg-inline--fa {
   color: lightgrey ;
-}
-
-/* This changes the color of the dropdown itself, when there is a smaller screen */
-.fa-bars {
-  color: white !important;
-}
-
-#pst-page-navigation-heading-2{
-  color: red;
 }
 
 .sphinx-bs{
@@ -370,7 +353,6 @@ a.dropdown-item {
   background-color: var(--pst-color-surface);
   border: 1px solid var(--pst-color-border);
   border-radius: 1.5em;
-  /*color: var(--pst-color-text-muted);*/
   display: inline-flex;
   padding: .5em;
   background: var(--gammapy-secondary);

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,47 +1,3 @@
- html {
-  /* Font features used in this theme */
-  --pst-color-surface: #f3f4f5;
-  --pst-color-border: #d1d5da;
-  /* Base font size - applied at body/html level */
-  --pst-font-size-base: 14px;
-
-  /* Heading font sizes based on bootstrap sizing */
-  --pst-font-size-h1: 2.5rem;
-  --pst-font-size-h2: 2rem;
-  --pst-font-size-h3: 1.75rem;
-  --pst-font-size-h4: 1.5rem;
-  --pst-font-size-h5: 1.25rem;
-  --pst-font-size-h6: 1.1rem;
-
-  /* Smaller than heading font sizes */
-  --pst-font-size-milli: 0.9rem;
-
-  /* Sidebar styles */
-  --pst-sidebar-font-size: 0.9rem;
-  --pst-sidebar-font-size-mobile: 1.1rem;
-  --pst-sidebar-header-font-size: 1.2rem;
-  --pst-sidebar-header-font-weight: 600;
-
-  /* Admonition styles */
-  --pst-admonition-font-weight-heading: 600;
-
-  /* Font weights */
-  --pst-font-weight-caption: 300;
-  --pst-font-weight-heading: 400;
-
-  /* Font family */
-  /* These are adapted from https://systemfontstack.com/ */
-  --pst-font-family-base-system: -apple-system, BlinkMacSystemFont, Segoe UI,
-    "Helvetica Neue", Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
-    Segoe UI Symbol;
-  --pst-font-family-monospace-system: "SFMono-Regular", Menlo, Consolas, Monaco,
-    Liberation Mono, Lucida Console, monospace;
-
-  --pst-font-family-base: var(--pst-font-family-base-system);
-  --pst-font-family-heading: var(--pst-font-family-base-system);
-  --pst-font-family-monospace: var(--pst-font-family-monospace-system);
-}
-
 :root {
   --gammapy-primary: rgb(224, 10, 52);
   --gammapy-secondary: #1e254a;
@@ -49,22 +5,17 @@
 }
 
 
-body {
-  color: rgb(30, 37, 74);
+/* Typography */
+body,
+p {
+  color: var(--gammapy-secondary);
   font-family: "Fira Sans", sans-serif;
   font-size: 15px;
-  font-weight: 400;
   line-height: 20px;
-
-  /* override variables of sphinx-design */
+  font-weight: 400;
   --sd-color-secondary: var(--gammapy-secondary);
   --sd-color-secondary-highlight: #666;
   --pst-color-secondary: var(--gammapy-secondary);
-}
-
-p {
-  color: rgb(30, 37, 74);
-  font-family: "Fira Sans", sans-serif;
 }
 
 /* navbar */
@@ -88,14 +39,13 @@ p {
   color: white;
 }
 
+
 .navbar-light .navbar-toggler-icon {
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30'%3E%3Cpath stroke='white' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
 }
 
-/* This changes the 'version' dropdown, the color of the font is white */
-.dropdown-toggle {
-  color: white !important;
-  font-size: 14px;
+.navbar-light .navbar-toggler {
+  border-color: white;
 }
 
 .col-lg-9 {
@@ -103,10 +53,6 @@ p {
   flex: 0 0 77.25%;
   flex-basis: 77.25%;
   max-width: 77.25%;
-}
-
-.bd-sidebar, .bd-toc {
-  position: relative;
 }
 
 /* pre */
@@ -382,9 +328,8 @@ a.dropdown-item {
   color : black !important;
 }
 
-/* Change the color of the font in the navbar */
 .nav-internal {
-  color : rgb(209, 213, 218) !important;
+  color : white !important;
 }
 
 .show {
@@ -395,21 +340,20 @@ a.dropdown-item {
   color: white;
 }
 
+.dropdown-toggle {
+  color: white !important;
+  font-size: 14px;
+}
+
 .svg-inline--fa {
   color: lightgrey ;
 }
-
-/* This changes the color of the dropdoown itself, when there is a smaller screen */
 .fa-bars {
   color: white !important;
 }
 
 #pst-page-navigation-heading-2{
   color: red;
-}
-
-.bd-page-width {
-  max-width: 100rem;
 }
 
 .sphinx-bs{
@@ -426,4 +370,3 @@ a.dropdown-item {
   padding: .5em;
   background: var(--gammapy-secondary);
 }
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ from pkg_resources import get_distribution
 from sphinx_gallery.sorting import ExplicitOrder
 
 # Load utils docs functions
-from gammapy.utils.docs import SubstitutionCodeBlock, gammapy_sphinx_ext_activate
+from gammapy.utils.docs import SubstitutionCodeBlock, DynamicPRLinkTransform, gammapy_sphinx_ext_activate
 
 # flake8: noqa
 
@@ -48,6 +48,7 @@ def setup(app):
     """
     app.add_config_value("substitutions", [], "html")
     app.add_directive("substitution-code-block", SubstitutionCodeBlock)
+    app.add_post_transform(DynamicPRLinkTransform)
 
 
 conf = ConfigParser()
@@ -118,6 +119,12 @@ extensions = [
     # Needed for the plot:: functionality in rst
     "matplotlib.sphinxext.plot_directive",
 ]
+
+# Define shorthand for GitHub pull requests and issues
+extlinks = {
+    'pr': ('https://github.com/gammapy/gammapy/pull/%s', '[#%s]'),
+    'issue': ('https://github.com/gammapy/gammapy/issues/%s', '[#%s]')
+}
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -234,11 +241,6 @@ html_theme_options = {
             "name": "Github",
             "url": "https://github.com/gammapy/gammapy",
             "icon": "fab fa-github-square",
-        },
-        {
-            "name": "Twitter",
-            "url": "https://twitter.com/gammapyST",
-            "icon": "fab fa-square-x-twitter",
         },
         {
             "name": "Slack",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,9 +33,6 @@ import os
 from configparser import ConfigParser
 from pkg_resources import get_distribution
 
-# Load all the global Astropy configuration
-from sphinx_astropy.conf import *
-
 # Sphinx-gallery config
 from sphinx_gallery.sorting import ExplicitOrder
 
@@ -43,7 +40,6 @@ from sphinx_gallery.sorting import ExplicitOrder
 from gammapy.utils.docs import SubstitutionCodeBlock, gammapy_sphinx_ext_activate
 
 # flake8: noqa
-
 
 # Add our custom directives to Sphinx
 def setup(app):
@@ -92,63 +88,94 @@ plot_html_show_source_link = False
 # If true, figures, tables and code-blocks are automatically numbered if they have a caption
 numfig = False
 
-# If your documentation needs a minimal Sphinx version, state it here.
-# needs_sphinx = "1.1"
+# The suffix of source filenames.
+source_suffix = '.rst'
 
-# We currently want to link to the latest development version of the astropy docs,
-# so we override the `intersphinx_mapping` entry pointing to the stable docs version
-# that is listed in `astropy/sphinx/conf.py`.
-intersphinx_mapping.pop("h5py", None)
-intersphinx_mapping["matplotlib"] = ("https://matplotlib.org/", None)
-intersphinx_mapping["astropy"] = ("http://docs.astropy.org/en/latest/", None)
-intersphinx_mapping["regions"] = (
-    "https://astropy-regions.readthedocs.io/en/latest/",
-    None,
-)
-intersphinx_mapping["reproject"] = ("https://reproject.readthedocs.io/en/latest/", None)
-intersphinx_mapping["naima"] = ("https://naima.readthedocs.io/en/latest/", None)
-intersphinx_mapping["gadf"] = (
-    "https://gamma-astro-data-formats.readthedocs.io/en/latest/",
-    None,
-)
-intersphinx_mapping["iminuit"] = ("https://iminuit.readthedocs.io/en/latest/", None)
-intersphinx_mapping["pandas"] = ("https://pandas.pydata.org/pandas-docs/stable/", None)
+# The master toctree document.
+master_doc = 'index'
+
+# The reST default role (used for this markup: `text`) to use for all
+# documents. Set to the "smart" one.
+default_role = 'obj'
+
+# Add any Sphinx extension module names here, as strings.
+extensions = [
+    "sphinx_click.ext",
+    'sphinx_copybutton',
+    "sphinx_design",
+    "sphinx_gallery.gen_gallery",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    # Order for sphinx_automodapi is important
+    "sphinx_automodapi.automodapi",
+    "sphinx_automodapi.smart_resolver",
+    # Allows for mapping to other documentation projects
+    "sphinx.ext.intersphinx",
+    # Allows for Numpy docstring format
+    "numpydoc",
+    # Needed for the plot:: functionality in rst
+    "matplotlib.sphinxext.plot_directive",
+]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-#exclude_patterns.append("_templates")
-exclude_patterns.append("**.ipynb_checkpoints")
-exclude_patterns.append("user-guide/model-gallery/*/*.ipynb")
-exclude_patterns.append("user-guide/model-gallery/*/*.md5")
-exclude_patterns.append("user-guide/model-gallery/*/*.py")
+exclude_patterns = [
+    "**.ipynb_checkpoints",
+    "user-guide/model-gallery/*/*.ipynb",
+    "user-guide/model-gallery/*/*.md5",
+    "user-guide/model-gallery/*/*.py",
+    "_build",
+]
 
-extensions.extend(
-    [
-        "sphinx_click.ext",
-        "sphinx.ext.mathjax",
-        "sphinx_gallery.gen_gallery",
-        "sphinx.ext.doctest",
-        "sphinx_design",
-        "sphinx_copybutton",
-        "sphinx_automodapi.smart_resolver",
-    ]
-)
+# Define intersphinx_mapping
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+	"matplotlib": ("https://matplotlib.org/", None),
+	"astropy": ("https://docs.astropy.org/en/stable/", None),
+	"regions": ("https://astropy-regions.readthedocs.io/en/latest/", None),
+	"reproject": ("https://reproject.readthedocs.io/en/latest/", None),
+	"naima": ("https://naima.readthedocs.io/en/latest/", None),
+	"gadf": ("https://gamma-astro-data-formats.readthedocs.io/en/latest/", None),
+	"iminuit": ("https://iminuit.readthedocs.io/en/latest/", None),
+	"pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+	}
 
-nbsphinx_execute = "never"
+# -- Options for autosummary/autodoc output ------------------------------------
+# Enable generation of stub files
+autosummary_generate = True
+
+# Document inherited members
+automodsumm_inherited_members = True
+
+# Include class and __init__ docstrings
+autoclass_content = "both"
+
+# Directory for API docs
+automodapi_toctreedirnm = 'api'
+
+# Suppress member summaries
+numpydoc_show_class_members = False
+
+# Ensures that when users click the "Copy" button, only the actual code is copied,
+# excluding interactive prompts and indentation markers
+# https://sphinx-copybutton.readthedocs.io/en/latest/use.html#using-regexp-prompt-identifiers
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True
-# --
 
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
-rst_epilog += """
+rst_epilog = """
 .. |Table| replace:: :class:`~astropy.table.Table`
 """
 
 # This is added to keep the links to PRs in release notes
 changelog_links_docpattern = [".*changelog.*", "whatsnew/.*", "release-notes/.*"]
 
-# -- Project information ------------------------------------------------------
+# -- Project information -------------------------------------------------------
 
 # This does not *have* to match the package name, but typically does
 project = setup_cfg["name"]
@@ -156,39 +183,26 @@ author = setup_cfg["author"]
 copyright = "{}, {}".format(datetime.datetime.now().year, setup_cfg["author"])
 
 version = get_distribution(project).version
-release = "X.Y.Z"
-switch_version = version
-if "dev" in version:
-    switch_version = "dev"
-else:
-    release = version
+release = "X.Y.Z" if "dev" in version else version
+switch_version = "dev" if "dev" in version else release
+# release = "X.Y.Z"
+# switch_version = version
+# if "dev" in version:
+#     switch_version = "dev"
+# else:
+#     release = version
 
 substitutions = [
     ("|release|", release),
 ]
 # -- Options for HTML output ---------------------------------------------------
 
-# A NOTE ON HTML THEMES
-# The global astropy configuration uses a custom theme, "bootstrap-astropy",
-# which is installed along with astropy. A different theme can be used or
-# the options for this theme can be modified by overriding some
-# variables set in the global configuration. The variables set in the
-# global configuration are listed below, commented out.
-
-# Add any paths that contain custom themes here, relative to this directory.
-# To use a different custom theme, add the directory containing the theme.
-# html_theme_path = []
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes. To override the custom theme, set this to the
-# name of a builtin theme or the name of a custom theme in html_theme_path.
 html_theme = "pydata_sphinx_theme"
 
 # Static files to copy after template files
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 html_js_files = ["matomo.js"]
-
 templates_path = ["_templates"]
 
 
@@ -250,7 +264,6 @@ html_theme_options = {
     "footer_end": ["sphinx-version", "theme-version"]
 }
 
-
 gammapy_sphinx_ext_activate()
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -268,16 +281,12 @@ latex_documents = [
 man_pages = [("index", project.lower(), f"{project} Documentation", [author], 1)]
 
 
-# -- Other options --
+# -- Other options -------------------------------------------------------------
 
 github_issues_url = "https://github.com/gammapy/gammapy/issues/"
 
-# http://sphinx-automodapi.readthedocs.io/en/latest/automodapi.html
-# show inherited members for classes
-automodsumm_inherited_members = True
-
 # In `about.rst` and `references.rst` we are giving lists of citations
-# (e.g. papers using Gammapy) that partly aren"t referenced from anywhere
+# (e.g. papers using Gammapy) that partly aren't referenced from anywhere
 # in the Gammapy docs. This is normal, but Sphinx emits a warning.
 # The following config option suppresses the warning.
 # http://www.sphinx-doc.org/en/stable/rest.html#citations
@@ -297,7 +306,6 @@ binder_config = {
     "use_jupyter_lab": True,
 }
 
-# nitpicky = True
 sphinx_gallery_conf = {
     "examples_dirs": [
         "../examples/models",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,12 +185,6 @@ copyright = "{}, {}".format(datetime.datetime.now().year, setup_cfg["author"])
 version = get_distribution(project).version
 release = "X.Y.Z" if "dev" in version else version
 switch_version = "dev" if "dev" in version else release
-# release = "X.Y.Z"
-# switch_version = version
-# if "dev" in version:
-#     switch_version = "dev"
-# else:
-#     release = version
 
 substitutions = [
     ("|release|", release),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,12 +120,6 @@ extensions = [
     "matplotlib.sphinxext.plot_directive",
 ]
 
-# Define shorthand for GitHub pull requests and issues
-extlinks = {
-    'pr': ('https://github.com/gammapy/gammapy/pull/%s', '[#%s]'),
-    'issue': ('https://github.com/gammapy/gammapy/issues/%s', '[#%s]')
-}
-
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = [

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -8,6 +8,7 @@
 .. _ctools: http://cta.irap.omp.eu/ctools
 .. _3ML: https://github.com/threeML/threeML
 .. _numpy: http://www.numpy.org/
+.. _astropy: https://www.astropy.org
 .. _affiliated package: http://www.astropy.org/affiliated/index.html
 .. _regions: https://astropy-regions.readthedocs.io
 .. _reproject: https://reproject.readthedocs.io

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,8 +80,6 @@ test =
     sphinx
 docs =
     astropy
-    numpy
-    sherpa
     numpydoc
     sphinx
     sphinx_automodapi

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,8 +80,8 @@ test =
     sphinx
 docs =
     astropy
-    numpy<2.0
-    sherpa<4.17
+    numpy
+    sherpa
     numpydoc
     sphinx
     sphinx_automodapi

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,15 +79,16 @@ test =
     docutils
     sphinx
 docs =
-    astropy>=5.0,<5.3
+    astropy
     numpy<2.0
     sherpa<4.17
-    sphinx-astropy
+    numpydoc
     sphinx
+    sphinx_automodapi
     sphinx-click
-    sphinx-gallery
-    sphinx-design
     sphinx-copybutton
+    sphinx-design
+    sphinx-gallery
     pydata-sphinx-theme
     nbformat
     docutils


### PR DESCRIPTION
This PR is to start the update of the documentation.

I have been able to remove sphinx-astropy, which resolves #5486. This mainly involved updating the `extensions` and `intersphinx_mapping`. I have tested the `conf` a number of times to check that we have all the necessary elements. 

I started to adapt the `css` but this needs further work and a future dedicated discussion on how we want to proceed. If we wish to keep our current theme or not etc. 


Note: There are some nice additions we could think about using:
https://pydata-sphinx-theme.readthedocs.io/en/stable/examples/kitchen-sink/admonitions.html