### PR TITLE
Fix select_nested_models docstring fit

### DIFF
--- a/examples/tutorials/data/cta.py
+++ b/examples/tutorials/data/cta.py
@@ -18,8 +18,10 @@ CTAO will start taking data in the coming years. For now, to learn how to
 analyse CTAO data and to use Gammapy, if you are a member of the CTAO
 consortium, you can use the simulated dataset from:
 
-- the CTA first data challenge which ran in 2017 and 2018 (https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki),
-- the CTAO Science Data Challenge of 2024 (https://ctaoobservatory.sharepoint.com/:f:/r/sites/share-open-data/Shared%20Documents/Reference%20datasets/Internal%20Science%20Data%20Challenge?csf=1&web=1&e=gNuFzI)
+- the CTA first data challenge which ran in 2017 and 2018 (see `here <https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki>`__
+  for CTAO members)
+- the CTAO Science Data Challenge of 2024 (see `here <https://ctaoobservatory.sharepoint.com/:f:/r/sites/share-open-data/Shared%20Documents/Reference%20datasets/Internal%20Science%20Data%20Challenge?csf=1&web=1&e=gNuFzI>`__
+  for CTAO members)
 
 Gammapy fully supports the FITS data formats (events, IRFs) used in CTA
 1DC and SDC. The XML sky model format is not supported, but are also not needed

--- a/gammapy/modeling/selection.py
+++ b/gammapy/modeling/selection.py
@@ -197,9 +197,10 @@ def select_nested_models(
     n_free_parameters : int, optional
         Number of free parameters to consider between the two hypothesis
         in order to estimate the `ts_threshold` from the `n_sigma` threshold.
-        Default is len(parameters).
+        Default is ``len(parameters)``.
     fit : `Fit`, optional
-        Fit instance specifying the backend and fit options. Default is None.
+        Fit instance specifying the backend and fit options. Default is None, which utilises
+        the "minuit" backend with tol=0.1 and strategy=1.
 
     Returns
     -------


### PR DESCRIPTION
This is to update the `select_nested_models` docstring which does not specify what the `Fit` object is by default.

I also made the links in the CTAO tutorial more clear