### PR TITLE
Change fontcolor of navbar

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -75,6 +75,7 @@ p {
 
 .navbar-light .navbar-nav li a.nav-link {
   color: var(--gammapy-lightgray);
+  font-size: 16px;
 }
 
 .navbar-light .navbar-nav li a.nav-link:hover,

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -71,12 +71,10 @@ p {
 .navbar {
   background-color: var(--gammapy-secondary) !important;
   color: white;
-
 }
 
 .navbar-light .navbar-nav li a.nav-link {
   color: var(--gammapy-lightgray);
-  font-size: 16px;
 }
 
 .navbar-light .navbar-nav li a.nav-link:hover,
@@ -84,14 +82,8 @@ p {
   color: rgba(255, 255, 255, 0.5);
 }
 
-#navbar-icon-links i.fa-github-square::before {
-  color: white;
-}
-
-#navbar-icon-links i.fa-square-x-twitter::before {
-  color: white;
-}
-
+#navbar-icon-links i.fa-github-square::before,
+#navbar-icon-links i.fa-square-x-twitter::before,
 #navbar-icon-links i.fa-slack::before {
   color: white;
 }
@@ -388,8 +380,9 @@ a.dropdown-item {
   color : black !important;
 }
 
+/* Change the color of the font in the navbar */
 .nav-internal {
-  color : white !important;
+  color : rgb(209, 213, 218) !important;
 }
 
 .show {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -93,8 +93,10 @@ p {
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30'%3E%3Cpath stroke='white' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
 }
 
-.navbar-light .navbar-toggler {
-  border-color: white;
+/* This changes the 'version' dropdown, the color of the font is white */
+.dropdown-toggle {
+  color: white !important;
+  font-size: 14px;
 }
 
 .col-lg-9 {
@@ -394,14 +396,11 @@ a.dropdown-item {
   color: white;
 }
 
-.dropdown-toggle {
-  color: white !important;
-  font-size: 14px;
-}
-
 .svg-inline--fa {
   color: lightgrey ;
 }
+
+/* This changes the color of the dropdoown itself, when there is a smaller screen */
 .fa-bars {
   color: white !important;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -84,7 +84,6 @@ p {
 }
 
 #navbar-icon-links i.fa-github-square::before,
-#navbar-icon-links i.fa-square-x-twitter::before,
 #navbar-icon-links i.fa-slack::before {
   color: white;
 }


### PR DESCRIPTION
This changes the fontcolor of the navbar from white to grey, such that it is visible in the dropdown. 
Also grouped the logos for better readability.

![image](https://github.com/user-attachments/assets/bbe205e6-b154-4f33-9b35-91bd5bbc8bc3)
