### PR TITLE
Correct CI fail  (astropy 7)

### DIFF
--- a/gammapy/visualization/tests/test_utils.py
+++ b/gammapy/visualization/tests/test_utils.py
@@ -88,6 +88,10 @@ def test_plot_map_rgb():
 
     axis = MapAxis([0, 1, 2, 3], node_type="edges")
     map_allsky = WcsNDMap.create(binsz=10 * u.deg, axes=[axis])
+
+    # Astropy 7 does not support uniformly 0 maps
+    map_allsky.data += 1
+
     with mpl_plot_check():
         plot_map_rgb(map_allsky)
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request corrects the bug that appeared with astropy 7. It is just a failing test because rgb plotting does not work with empty maps.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
