### PR TITLE
Update release notes from recent release

### DIFF
--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -21,8 +21,9 @@ The general procedure can be broken down into three major steps:
 Feature Freeze and Branching
 ----------------------------
 
-#. Add a new milestone to the GitHub issue tracker for the version ``v<version>.x`` (this will also be used for the
-   next bugfix release). Also create a ``backport-v<version>.x`` label.
+#. Add a new milestone to the `GitHub issue tracker <https://github.com/gammapy/gammapy/milestones>`__ for the version
+   ``v<version>.x`` (this will also be used for the next bugfix release). Also create a ``backport-v<version>.x``
+   `label <https://github.com/gammapy/gammapy/labels>`__.
 #. Update your local ``main`` branch to the latest from remote::
 
     git fetch upstream --tags --prune
@@ -33,7 +34,7 @@ Feature Freeze and Branching
     git branch v<version>.x
 
 #. Stay on the ``main`` branch and make a copy and update the ``docs/release-notes/<version>.rst``
-#. Commit the changes and push to GitHub main.
+#. Commit the changes and push to GitHub ``main``.
 #. Update the entry for the feature freeze in the
    `Gammapy release calendar <https://github.com/gammapy/gammapy/wiki/Release-Calendar>`__.
 
@@ -69,16 +70,15 @@ Releasing the first major release candidate
 
     git push upstream v1.0.x
 
-#. Locally create a new release candidate tag on the ``v1.0``, like ``v1.0rc1`` for Gammapy and push::
+#. Locally create a new release candidate tag on the ``v1.0.x``, like ``v1.0rc1`` for Gammapy and push::
 
     git tag -s v1.0rc1 -m "Tagging v1.0rc1"
-    git push upstream v1.0
+    git push upstream v1.0.x
 
 #. Once the tag is pushed, the docs build and upload to `PyPi <https://pypi.org/>`__ should be triggered automatically.
 #. Check the ``Actions`` on `gammapy repo <https://github.com/gammapy/gammapy>`__ to check that the necessary
    actions have started.
-
-#. Once the docs build if successful find the ``tutorials_jupyter.zip`` file for the release candidate in the
+#. Once the docs build is successful find the ``tutorials_jupyter.zip`` file for the release candidate in the
    `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__ and adapt the ``download/index.json`` to point to it.
 #. Update the entry for the release candidate in the
    `Gammapy release calendar <https://github.com/gammapy/gammapy/wiki/Release-Calendar>`__.
@@ -96,7 +96,7 @@ Releasing the final version of the major release
 
 #. In the `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__:
 
-   * In the ``download/install`` folder, copy a previous environment file file as ``gammapy-1.0-environment.yml``.
+   * In the ``download/install`` folder, copy a previous environment file as ``gammapy-1.0-environment.yml``.
    * Adapt the dependency conda env name and versions as required in this file. Make sure to move ``gammapy=1.0``
      into the dependencies list.
    * Update the datasets entry in the ``download/index.json`` to point to this new release tag. Also update the
@@ -105,7 +105,7 @@ Releasing the final version of the major release
 #. Locally create a new release tag like ``v1.0`` for Gammapy and push::
 
     git tag -s v1.0 -m "Tagging v1.0"
-    git push upstream v1.0
+    git push upstream v1.0.x
 
 #. In the `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__:
 
@@ -125,7 +125,7 @@ Releasing the final version of the major release
 
 #. Finally:
 
-   * Update the Gammapy conda-forge package at https://github.com/conda-forge/gammapy-feedstock
+   * Update the Gammapy conda-forge package at https://github.com/conda-forge/gammapy-feedstock.
    * Encourage the Gammapy developers to try out the new stable version (update and run tests) via the GitHub
      issue for the release and wait a day or two for feedback.
 
@@ -143,7 +143,7 @@ Steps for the day to announce the release:
     * https://groups.google.com/forum/#!forum/astropy-dev
     * CTAO AS WG list (cta-wg-as@cta-observatory.org)
     * hess-forum list (hess-forum@lsw.uni-heidelberg.de)
-#. Make sure the release milestone and issue is closed on GitHub
+#. Make sure the release milestone and issue is closed on GitHub.
 #. Update these release notes with any useful infos / steps that you learned
    while making the release (ideally try to script / automate the task or check,
    e.g. as a ``make release-check-xyz`` target).
@@ -151,8 +151,8 @@ Steps for the day to announce the release:
    `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__ master branch
    and tag the release for Binder.
 #. Open a milestone and issue for the next release (and possibly also a milestone for the
-   release after, so that low-priority issues can already be moved there) Find a
-   release manager for the next release, assign the release issue to her / him,
+   release after, so that low-priority issues can already be moved there). Find a
+   release manager for the next release, assign the release issue to them,
    and ideally put a tentative date (to help developers plan their time for the
    coming weeks and months).
 #. Start working on the next release.

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -128,7 +128,7 @@ Releasing the final version of the major release
 
 #. Finally:
 
-   * Update the Gammapy conda-forge package at https://github.com/conda-forge/gammapy-feedstock.
+   * The Gammapy conda-forge package at https://github.com/conda-forge/gammapy-feedstock should be automatically updated within hours and a PR opened. Check that this is the case and if not, perform the manual update of the recipe meta.yaml on your gammapy-feedstock fork and open the PR. Finally, when all tests for all distributions successfully ran, merge the PR.   
    * Encourage the Gammapy developers to try out the new stable version (update and run tests) via the GitHub
      issue for the release and wait a day or two for feedback.
 

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -75,9 +75,11 @@ Releasing the first major release candidate
     git tag -s v1.0rc1 -m "Tagging v1.0rc1"
     git push upstream v1.0.x
 
-#. Once the tag is pushed, the docs build and upload to `PyPi <https://pypi.org/>`__ should be triggered automatically.
-#. Check the ``Actions`` on `gammapy repo <https://github.com/gammapy/gammapy>`__ to check that the necessary
-   actions have started.
+#. Once the tag is pushed, the ``release`` action in charge of packaging and uploading to `PyPi <https://pypi.org/>`__
+   should be triggered automatically. Once complete, it will trigger the docs build on the  ``gammapy-docs``
+   repository.
+#. Check the ``Actions`` on `gammapy repo <https://github.com/gammapy/gammapy>`__  and 
+   `gammapy-docs <https://github.com/gammapy/gammapy-docs>`__  to check that the necessary actions have started.
 #. Once the docs build is successful find the ``tutorials_jupyter.zip`` file for the release candidate in the
    `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__ and adapt the ``download/index.json`` to point to it.
 #. Update the entry for the release candidate in the

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -6,13 +6,16 @@
 How to make a Gammapy release
 *****************************
 
-This page contains step-by-step instructions for how to make a Gammapy release. The general procedure can
-be broken down into three major steps:
+This page contains step-by-step instructions for how to make a Gammapy release. The procedure shown here is inspired by
+the `astropy release scheme <https://docs.astropy.org/en/latest/development/maintainers/releasing.html#release-procedure-for-the-astropy-core-package>`__.
+The general procedure can be broken down into three major steps:
 
 
-* Feature freeze: freeze the core package features, a number of weeks before the release
-* Release candidate: proposed feature release which should be tested, a few weeks before the final release
-* Final release: a final release for the version of the feature release
+* Feature freeze: freeze the core package features and create a new branch for the release. This is typically done two
+  weeks before the release.
+* Release candidate: proposed feature release which should be tested. This is typically done one week before the
+  final release.
+* Final release.
 
 
 Feature Freeze and Branching
@@ -62,7 +65,7 @@ Releasing the first major release candidate
     git checkout v1.0.x
     python ./dev/prepare-release.py --release v1.0rc1
 
-#. Push the branch back to GitHub::
+#. Commit and push the branch back to GitHub::
 
     git push upstream v1.0.x
 
@@ -88,7 +91,7 @@ Releasing the first major release candidate
 Releasing the final version of the major release
 ------------------------------------------------
 
-#. Create a new release tag in the `gammapy-data repo <https://github.com/gammapy/gammapy-data>`__, like ``v1.0``
+#. Create a new tag in the `gammapy-data repo <https://github.com/gammapy/gammapy-data>`__, like ``v1.0``
    or ``v1.1``.
 
 #. In the `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__:
@@ -106,7 +109,7 @@ Releasing the final version of the major release
 
 #. In the `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__:
 
-   * Kill the ``dev-docs`` build.
+   * Kill the possible ``dev-docs`` build actions as they might interfere with the ``release`` docs build.
    * Wait for the triggered ``release`` docs build to finish.
    * Edit ``docs/stable/switcher.json`` to add the new version.
 

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -6,30 +6,47 @@
 How to make a Gammapy release
 *****************************
 
-This page contains step-by-step instructions how to make a Gammapy release. We mostly follow the
-`Astropy release instructions <https://docs.astropy.org/en/latest/development/maintainers/releasing.html#release-procedure-for-the-astropy-core-package>`__
-and just lists the additional required steps.
+This page contains step-by-step instructions for how to make a Gammapy release. The general procedure can
+be broken down into three major steps:
+
+
+* Feature freeze: freeze the core package features, a number of weeks before the release
+* Release candidate: proposed feature release which should be tested, a few weeks before the final release
+* Final release: a final release for the version of the feature release
 
 
 Feature Freeze and Branching
 ----------------------------
 
-#. Follow the `Astropy feature freeze and branching instructions <https://docs.astropy.org/en/latest/development/maintainers/releasing.html#start-of-a-new-release-cycle-feature-freeze-and-branching>`__.
-   Instead of updating the ``whatsnew/<version>.rst`` update the ``docs/release-notes/<version>.rst``.
-#. Update the entry for the feature freeze in the `Gammapy release calendar <https://github.com/gammapy/gammapy/wiki/Release-Calendar>`__.
+#. Add a new milestone to the GitHub issue tracker for the version ``v<version>.x`` (this will also be used for the
+   next bugfix release). Also create a ``backport-v<version>.x`` label.
+#. Update your local ``main`` branch to the latest from remote::
+
+    git fetch upstream --tags --prune
+    git checkout -B main upstream/main
+
+#. Create a new branch with the name of the version::
+
+    git branch v<version>.x
+
+#. Stay on the ``main`` branch and make a copy and update the ``docs/release-notes/<version>.rst``
+#. Commit the changes and push to GitHub main.
+#. Update the entry for the feature freeze in the
+   `Gammapy release calendar <https://github.com/gammapy/gammapy/wiki/Release-Calendar>`__.
 
 
 Releasing the first major release candidate
 -------------------------------------------
 
-A few days before the planned release candidate:
+**A few days before the planned release candidate:**
 
 #. Fill the changelog ``docs/release-notes/<version>.rst`` for the version you are about to release.
 #. Update the author list manually in the  ``CITATION.cff``.
 #. Open a PR including both changes and mark it with the ``backport-v<version>.x`` label.
-   Gather feedback from the Gammapy user and dev community and finally merge and backport to the ``v<version>.x`` branch.
+   Gather feedback from the Gammapy user and dev community and finally merge and backport to the
+   ``v<version>.x`` branch.
 
-On the day of the release candidate:
+**On the day of the release candidate:**
 
 #. In the `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__:
 
@@ -39,14 +56,31 @@ On the day of the release candidate:
    * In the ``download/install`` folder, copy a previous environment file file as ``gammapy-1.0rc1-environment.yml``.
    * Adapt the dependency conda env name and versions as required in this file.
 
-#. Update the ``CITATION.cff`` date and version by running the ``dev/prepare-release.py`` script.
-#. Locally create a new release candidate tag on the v1.0.x, like ``v1.0rc1`` for Gammapy and push. For details see the
-   `Astropy release candidate instructions <https://docs.astropy.org/en/latest/development/maintainers/releasing.html#releasing-the-first-feature-release-candidate>`__.
-#. Once the tag is pushed the docs build and upload to `PyPi <https://pypi.org/>`__ should be triggered automatically.
-#. Once the docs build has succeeded find the ``tutorials_jupyter.zip`` file for the release candidate
-   in the `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__ and adapt the ``download/index.json`` to point to it.
-#. Update the entry for the release candidate in the `Gammapy release calendar <https://github.com/gammapy/gammapy/wiki/Release-Calendar>`__.
-#. Create a testing page like `Gammapy v1.0rc testing <https://github.com/gammapy/gammapy/wiki/Gammapy-v1.0rc-testing>`__.
+#. Switch to the correct branch and update the ``CITATION.cff`` date and version by running the
+   ``dev/prepare-release.py`` script::
+
+    git checkout v1.0.x
+    python ./dev/prepare-release.py --release v1.0rc1
+
+#. Push the branch back to GitHub::
+
+    git push upstream v1.0.x
+
+#. Locally create a new release candidate tag on the ``v1.0``, like ``v1.0rc1`` for Gammapy and push::
+
+    git tag -s v1.0rc1 -m "Tagging v1.0rc1"
+    git push upstream v1.0
+
+#. Once the tag is pushed, the docs build and upload to `PyPi <https://pypi.org/>`__ should be triggered automatically.
+#. Check the ``Actions`` on `gammapy repo <https://github.com/gammapy/gammapy>`__ to check that the necessary
+   actions have started.
+
+#. Once the docs build if successful find the ``tutorials_jupyter.zip`` file for the release candidate in the
+   `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__ and adapt the ``download/index.json`` to point to it.
+#. Update the entry for the release candidate in the
+   `Gammapy release calendar <https://github.com/gammapy/gammapy/wiki/Release-Calendar>`__.
+#. Create a testing page like
+   `Gammapy v1.0rc testing <https://github.com/gammapy/gammapy/wiki/Gammapy-v1.0rc-testing>`__.
 #. Advertise the release candidate and motivate developers and users to report test fails and bugs and list them
    on the page created before.
 
@@ -54,35 +88,43 @@ On the day of the release candidate:
 Releasing the final version of the major release
 ------------------------------------------------
 
-#. Create a new release tag in the `gammapy-data repo <https://github.com/gammapy/gammapy-data>`__, like ``v1.0`` or ``v1.1``.
-
-#. Update the datasets entry in the ``download/index.json`` file in the
-   `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__ to point to this new release tag.
-
-#. Locally create a new release tag like ``v1.0`` for Gammapy and push. For details see the
-   `Astropy release candidate instructions <https://docs.astropy.org/en/latest/development/maintainers/releasing.html#tagging-the-final-release>`__,
-   but leave out the ``rc1`` suffix.
-
-#. In the `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__:
-
-   * Wait for the triggered docs build to finish.
-   * Edit ``stable/switcher.json`` to add the new version.
+#. Create a new release tag in the `gammapy-data repo <https://github.com/gammapy/gammapy-data>`__, like ``v1.0``
+   or ``v1.1``.
 
 #. In the `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__:
 
-   * Mention the release on the front page and on the news page.
    * In the ``download/install`` folder, copy a previous environment file file as ``gammapy-1.0-environment.yml``.
-   * Adapt the dependency conda env name and versions as required in this file.
-   * Adapt the entry in the ``download/index.json`` file to point ot the correct environment file.
-   * Find the ``tutorials_jupyter.zip`` file for the new release in the `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__
-     and adapt the ``download/index.json`` to point to it.
+   * Adapt the dependency conda env name and versions as required in this file. Make sure to move ``gammapy=1.0``
+     into the dependencies list.
+   * Update the datasets entry in the ``download/index.json`` to point to this new release tag. Also update the
+     notebook entry, typically the link extensions are the same between versions.
 
-#. Update the entry for the actual release in the `Gammapy release calendar <https://github.com/gammapy/gammapy/wiki/Release-Calendar>`__.
+#. Locally create a new release tag like ``v1.0`` for Gammapy and push::
+
+    git tag -s v1.0 -m "Tagging v1.0"
+    git push upstream v1.0
+
+#. In the `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__:
+
+   * Kill the ``dev-docs`` build.
+   * Wait for the triggered ``release`` docs build to finish.
+   * Edit ``docs/stable/switcher.json`` to add the new version.
+
+#. In the `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__:
+
+   * Find the ``tutorials_jupyter.zip`` file for the new release in the
+     `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__ and confirm the link in
+     ``download/index.json`` is correct.
+   * Mention the release on the front page and on the news page.
+
+#. Update the entry for the actual release in the
+   `Gammapy release calendar <https://github.com/gammapy/gammapy/wiki/Release-Calendar>`__.
 
 #. Finally:
 
    * Update the Gammapy conda-forge package at https://github.com/conda-forge/gammapy-feedstock
-   * Encourage the Gammapy developers to try out the new stable version (update and run tests) via the GitHub issue for the release and wait a day or two for feedback.
+   * Encourage the Gammapy developers to try out the new stable version (update and run tests) via the GitHub
+     issue for the release and wait a day or two for feedback.
 
 
 Post release
@@ -120,7 +162,7 @@ Make a Bugfix release
    `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__. The ``datasets`` entry should point to last
    stable version, like ``v1.0`` or ``v1.1``. We do not provide bug-fix release for data.
 
-#. Follow the  `Astropy bug fix release instructions <https://docs.astropy.org/en/latest/development/maintainers/releasing.html#maintaining-bug-fix-releases>`__.
+#. Follow the `Astropy bug fix release instructions <https://docs.astropy.org/en/latest/development/maintainers/releasing.html#maintaining-bug-fix-releases>`__.
 
 #. Follow the instructions for a major release for the updates of ``CITATION.cff``, the modifications in the
    `gammapy-docs` and `gammapy-webpage` repos as well as the conda builds.

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -21,6 +21,16 @@ The general procedure can be broken down into three major steps:
 Feature Freeze and Branching
 ----------------------------
 
+**A few days before the feature freeze:**
+
+#. Fill the changelog ``docs/release-notes/<version>.rst`` for the version you are about to release.
+#. Update the author list manually in the  ``CITATION.cff``.
+#. Open a PR including both changes and mark it with the ``backport-v<version>.x`` label.
+   Gather feedback from the Gammapy user and dev community and finally merge and backport to the
+   ``v<version>.x`` branch.
+
+**On the day of the feature freeze:**
+
 #. Add a new milestone to the `GitHub issue tracker <https://github.com/gammapy/gammapy/milestones>`__ for the version
    ``v<version>.x`` (this will also be used for the next bugfix release). Also create a ``backport-v<version>.x``
    `label <https://github.com/gammapy/gammapy/labels>`__.
@@ -41,16 +51,6 @@ Feature Freeze and Branching
 
 Releasing the first major release candidate
 -------------------------------------------
-
-**A few days before the planned release candidate:**
-
-#. Fill the changelog ``docs/release-notes/<version>.rst`` for the version you are about to release.
-#. Update the author list manually in the  ``CITATION.cff``.
-#. Open a PR including both changes and mark it with the ``backport-v<version>.x`` label.
-   Gather feedback from the Gammapy user and dev community and finally merge and backport to the
-   ``v<version>.x`` branch.
-
-**On the day of the release candidate:**
 
 #. In the `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__:
 
@@ -118,7 +118,8 @@ Releasing the final version of the major release
    * Find the ``tutorials_jupyter.zip`` file for the new release in the
      `gammapy-docs repo <https://github.com/gammapy/gammapy-docs>`__ and confirm the link in
      ``download/index.json`` is correct.
-   * Mention the release on the front page and on the news page.
+   * Mention the release on the front page and on the news page. Both the ``news.html`` and ``index.html`` should be
+     edited at this step to include the correct version numbers.
 
 #. Update the entry for the actual release in the
    `Gammapy release calendar <https://github.com/gammapy/gammapy/wiki/Release-Calendar>`__.
@@ -143,12 +144,31 @@ Steps for the day to announce the release:
     * https://groups.google.com/forum/#!forum/astropy-dev
     * CTAO AS WG list (cta-wg-as@cta-observatory.org)
     * hess-forum list (hess-forum@lsw.uni-heidelberg.de)
+
 #. Make sure the release milestone and issue is closed on GitHub.
 #. Update these release notes with any useful infos / steps that you learned
    while making the release (ideally try to script / automate the task or check,
    e.g. as a ``make release-check-xyz`` target).
-#. Update the version numbers in `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__
-   ``master`` branch to allow the Binder ``Dockerfile`` to be updated.
+#. Update the version numbers in `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__ ``master``
+   branch to allow the Binder ``Dockerfile`` to be updated:
+
+    * In `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__ update the
+      ``master`` branch::
+
+        git checkout master
+        git pull
+
+    * Update the four files: ``postBuild``, ``requirements.txt``, ``runtime.txt``, and ``start`` in the ``master`` branch::
+
+        git add postBuild requirements.txt runtime.txt start
+        git commit -s -m "Update binder configuration for new release"
+        git push origin master
+
+    * Tag the new version and push to the upstream repository::
+
+        git tag -s v1.3 -m "Tagging v1.3"
+        git push origin v1.3
+
 #. Open a milestone and issue for the next release (and possibly also a milestone for the
    release after, so that low-priority issues can already be moved there). Find a
    release manager for the next release, assign the release issue to them,

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -147,9 +147,8 @@ Steps for the day to announce the release:
 #. Update these release notes with any useful infos / steps that you learned
    while making the release (ideally try to script / automate the task or check,
    e.g. as a ``make release-check-xyz`` target).
-#. Update version number in Binder ``Dockerfile`` in
-   `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__ master branch
-   and tag the release for Binder.
+#. Update the version numbers in `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__
+   ``master`` branch to allow the Binder ``Dockerfile`` to be updated.
 #. Open a milestone and issue for the next release (and possibly also a milestone for the
    release after, so that low-priority issues can already be moved there). Find a
    release manager for the next release, assign the release issue to them,
@@ -162,8 +161,8 @@ Make a Bugfix release
 ---------------------
 
 #. Add an entry for the bug-fix release like ``v1.0.1`` or ``v1.1.2`` in the ``download/index.json`` file in the
-   `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__. The ``datasets`` entry should point to last
-   stable version, like ``v1.0`` or ``v1.1``. We do not provide bug-fix release for data.
+   `gammapy-webpage repo <https://github.com/gammapy/gammapy-webpage>`__. The ``datasets`` entry should point to the
+   last stable version, like ``v1.0`` or ``v1.1``. We do not provide bug-fix release for data.
 
 #. Follow the `Astropy bug fix release instructions <https://docs.astropy.org/en/latest/development/maintainers/releasing.html#maintaining-bug-fix-releases>`__.
 


### PR DESCRIPTION
I took extensive notes as we performed each step of the feature release for v1.3

It was clear that we are no longer following exactly what astropy does and therefore I adapt the release notes to be our own. 
I hope these are accurate. I did not update the bug fix yet, but we can do that at a later stage (pending if there is a v1.3.1? )

This PR resolves https://github.com/gammapy/gammapy/issues/5623

@registerrier @QRemy perhaps you have comments in case I missed anything?

Updated:

[docs_build1](https://github.com/user-attachments/assets/19b2e25d-c852-475d-b90c-c728565c9f49), [docs_build2](https://github.com/user-attachments/assets/3d0cc338-d08f-41db-8607-e07b2b5b1d61), [docs_build3](https://github.com/user-attachments/assets/3643522a-0afa-46da-b171-38ab44f7ab06), [docs_build4](https://github.com/user-attachments/assets/667867cc-f8fe-4848-a8dd-86e394ce93a9)