### PR TITLE
Clear cache immediately after npred_signal computation If USE_NPRED_CACHE = False

### DIFF
--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -103,6 +103,8 @@ class MapEvaluator:
         """Reset cached properties."""
         del self._compute_npred
         del self._compute_flux_spatial
+        self._computation_cache = None
+        self._cached_parameter_previous = None
 
     @property
     def geom(self):
@@ -239,8 +241,6 @@ class MapEvaluator:
                 )
 
         self.reset_cache_properties()
-        self._computation_cache = None
-        self._cached_parameter_previous = None
 
     @lazyproperty
     def _edisp_diagonal(self):

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -866,6 +866,8 @@ class MapDataset(Dataset):
                     npred_geom.stack(npred)
                     labels.append(evaluator_name)
                     npred_list.append(npred_geom)
+                if not USE_NPRED_CACHE:
+                    evaluator.reset_cache_properties()
 
         if npred_list != []:
             label_axis = LabelMapAxis(labels=labels, name="models")


### PR DESCRIPTION
Currently when USE_NPRED_CACHE is false the cache is reset only before new computations.
In this PR the cache is cleared immediately after npred_signal computation. This is particularly useful for simulation in which npred is computed only once for many sources so caching is not necessary and can be very memory consuming
