### PR TITLE
Add a new method to compute ts and sigma in gammapy.stats.utils

### DIFF
--- a/gammapy/stats/tests/test_utils.py
+++ b/gammapy/stats/tests/test_utils.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 from gammapy.stats.utils import sigma_to_ts, ts_to_sigma
+import pytest
 
 
 def test_sigma_ts_conversion():
-
     sigma_ref = 3
     ts_ref = 9
     df = 1
@@ -19,3 +19,17 @@ def test_sigma_ts_conversion():
     assert_allclose(ts, ts_ref)
     sigma = ts_to_sigma(ts, df=df)
     assert_allclose(sigma, sigma_ref)
+
+    sigma_ref = 3
+    ts_ref = 9
+    df = 1
+    ts = sigma_to_ts(3, df=df, method="cowan")
+    assert_allclose(ts, ts_ref)
+    sigma = ts_to_sigma(ts, df=df, method="cowan")
+    assert_allclose(sigma, sigma_ref)
+
+    with pytest.raises(ValueError):
+        sigma_to_ts(3, df=df, method="wrong_name")
+
+    with pytest.raises(ValueError):
+        ts_to_sigma(9, df=df, method="wrong_name")

--- a/gammapy/stats/utils.py
+++ b/gammapy/stats/utils.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
-from scipy.stats import chi2
+from scipy.stats import chi2, ncx2
 
 
-def sigma_to_ts(n_sigma, df=1):
-    """Convert number of sigma to delta ts according to the Wilks' theorem.
+def sigma_to_ts(n_sigma, df=1, method="wilk"):
+    """Convert number of sigma to delta ts.
 
     The theorem is valid only if:
     - the two hypotheses tested can be defined in the same parameters space
@@ -17,27 +17,43 @@ def sigma_to_ts(n_sigma, df=1):
         Significance in number of sigma.
     df : int
         Number of degree of freedom.
+    method : str
+        Method used to compute the statistics:
+            * wilk : applies Wilk's theorem [1]
+                The theorem is valid only if :
+                - the two hypotheses tested can be defined in the same parameters space
+                - the true value is not at the boundary of this parameters space
+
+            * cowan : uses the statistic described in Cowan et al. (2011) [2]
+        Default is `wilk`.
 
     Returns
     -------
     ts : float
         Test statistic
 
-    Reference
-    ---------
-    Wilks theorem: https://en.wikipedia.org/wiki/Wilks%27_theorem
+    References
+    ----------
+    .. [1] Wilks theorem: https://en.wikipedia.org/wiki/Wilks%27_theorem
+
+    .. [2] Cowan et al. (2011), European Physical Journal C, 71, 1554.
+        doi:10.1140/epjc/s10052-011-1554-0.
     """
-    p_value = chi2.sf(n_sigma**2, df=1)
-    return chi2.isf(p_value, df=df)
+    if method == "wilk":
+        p_value = chi2.sf(n_sigma**2, df=1)
+        return chi2.isf(p_value, df=df)
+    elif method == "cowan":
+        ts = n_sigma**2
+        p_value = ncx2.sf(ts, df=1, nc=ts)
+        return ncx2.isf(p_value, df=df, nc=ts)
+    else:
+        raise ValueError(
+            f"Invalid method : {method}, posible options are 'wilk' or 'cowan'"
+        )
 
 
-def ts_to_sigma(ts, df=1):
-    """Convert delta ts to number of sigma according to the Wilks' theorem.
-
-    The theorem is valid only if :
-    - the two hypotheses tested can be defined in the same parameters space
-    - the true value is not at the boundary of this parameters space
-    Reference:  https://en.wikipedia.org/wiki/Wilks%27_theorem
+def ts_to_sigma(ts, df=1, method="wilk"):
+    """Convert delta ts to number of sigma.
 
     Parameters
     ----------
@@ -45,11 +61,36 @@ def ts_to_sigma(ts, df=1):
         Test statistic.
     df : int
         Number of degree of freedom.
+    method : str
+        Method used to compute the statistics:
+            * wilk : applies Wilk's theorem [1]
+                The theorem is valid only if :
+                - the two hypotheses tested can be defined in the same parameters space
+                - the true value is not at the boundary of this parameters space
+
+            * cowan : uses the statistic described in Cowan et al. (2011) [2]
+        Default is `wilk`.
 
     Returns
     -------
     n_sigma : float
         Significance in number of sigma.
+
+    References
+    ----------
+    .. [1] Wilks theorem: https://en.wikipedia.org/wiki/Wilks%27_theorem
+
+    .. [2] Cowan et al. (2011), European Physical Journal C, 71, 1554.
+        doi:10.1140/epjc/s10052-011-1554-0.
+
     """
-    p_value = chi2.sf(ts, df=df)
-    return np.sqrt(chi2.isf(p_value, df=1))
+    if method == "wilk":
+        p_value = chi2.sf(ts, df=df)
+        return np.sqrt(chi2.isf(p_value, df=1))
+    elif method == "cowan":
+        p_value = ncx2.sf(ts, df=df, nc=ts)
+        return np.sqrt(ncx2.isf(p_value, df=1, nc=ts))
+    else:
+        raise ValueError(
+            f"Invalid method : {method}, posible options are 'wilk' or 'cowan'"
+        )


### PR DESCRIPTION
Add a new method "cowan" in `ts_to_sigma` and `sigma_to_ts` considering
that the  ts  distribution follows a noncentral chi-square distribution for r-degrees of freedom with noncentrality parameter equal to ts (applicable for the asimov dataset).

I'm not sure if this is valid when df!=1.