### PR TITLE
Fix nan output in ts_to_sigma and sigma_to_ts

### DIFF
--- a/gammapy/stats/tests/test_utils.py
+++ b/gammapy/stats/tests/test_utils.py
@@ -4,7 +4,6 @@ from gammapy.stats.utils import sigma_to_ts, ts_to_sigma
 
 
 def test_sigma_ts_conversion():
-
     sigma_ref = 3
     ts_ref = 9
     df = 1
@@ -19,3 +18,19 @@ def test_sigma_ts_conversion():
     assert_allclose(ts, ts_ref)
     sigma = ts_to_sigma(ts, df=df)
     assert_allclose(sigma, sigma_ref)
+
+    df = 1
+    sigma_ref = 50
+    ts_ref = 2500
+    ts = sigma_to_ts(sigma_ref, df=df)
+    assert_allclose(ts, ts_ref)
+    sigma = ts_to_sigma(ts, df=df)
+    assert_allclose(sigma, sigma_ref)
+
+    df = 10
+    sigma_ref = 50
+    ts_ref = 2560
+    ts = sigma_to_ts(sigma_ref, df=df)
+    assert_allclose(ts, ts_ref, rtol=1e-3)
+    sigma = ts_to_sigma(ts, df=df)
+    assert_allclose(sigma, sigma_ref, rtol=1e-3)

--- a/gammapy/stats/tests/test_utils.py
+++ b/gammapy/stats/tests/test_utils.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
 from numpy.testing import assert_allclose
 from gammapy.stats.utils import sigma_to_ts, ts_to_sigma
 
@@ -22,6 +23,22 @@ def test_sigma_ts_conversion():
     df = 1
     sigma_ref = 50
     ts_ref = 2500
+    ts = sigma_to_ts(sigma_ref, df=df)
+    assert_allclose(ts, ts_ref)
+    sigma = ts_to_sigma(ts, df=df)
+    assert_allclose(sigma, sigma_ref)
+
+    df = np.array([1, 1])
+    sigma_ref = np.array([50, 50])
+    ts_ref = np.array([2500, 2500])
+    ts = sigma_to_ts(sigma_ref, df=df)
+    assert_allclose(ts, ts_ref)
+    sigma = ts_to_sigma(ts, df=df)
+    assert_allclose(sigma, sigma_ref)
+
+    df = 1
+    sigma_ref = np.array([50, 50])
+    ts_ref = np.array([2500, 2500])
     ts = sigma_to_ts(sigma_ref, df=df)
     assert_allclose(ts, ts_ref)
     sigma = ts_to_sigma(ts, df=df)

--- a/gammapy/stats/tests/test_utils.py
+++ b/gammapy/stats/tests/test_utils.py
@@ -36,6 +36,14 @@ def test_sigma_ts_conversion():
     sigma = ts_to_sigma(ts, df=df)
     assert_allclose(sigma, sigma_ref)
 
+    df = np.array([[1, 1], [1, 1]])
+    sigma_ref = np.array([[50, 50], [50, 50]])
+    ts_ref = np.array([[2500, 2500], [2500, 2500]])
+    ts = sigma_to_ts(sigma_ref, df=df)
+    assert_allclose(ts, ts_ref)
+    sigma = ts_to_sigma(ts, df=df)
+    assert_allclose(sigma, sigma_ref)
+
     df = 1
     sigma_ref = np.array([50, 50])
     ts_ref = np.array([2500, 2500])

--- a/gammapy/stats/utils.py
+++ b/gammapy/stats/utils.py
@@ -33,9 +33,15 @@ def sigma_to_ts(n_sigma, df=1):
 
     invalid = np.atleast_1d(~np.isfinite(ts))
     if np.any(invalid):
-        sigma_invalid = np.atleast_1d(n_sigma).astype(float)[invalid]
+        n_sigma = np.atleast_1d(n_sigma)
+        sigma_invalid = n_sigma.astype(float)[invalid]
+        df_invalid = df * np.ones(len(n_sigma))[invalid]
+
         ts_invalid = np.array(
-            [_sigma_to_ts_mpmath(sig_val, df) for sig_val in sigma_invalid]
+            [
+                _sigma_to_ts_mpmath(sig_val, df_val)
+                for sig_val, df_val in zip(sigma_invalid, df_invalid)
+            ]
         )
         try:
             ts[invalid] = ts_invalid
@@ -69,9 +75,14 @@ def ts_to_sigma(ts, df=1):
 
     invalid = np.atleast_1d(~np.isfinite(sigma))
     if np.any(invalid):
-        ts_invalid = np.atleast_1d(ts).astype(float)[invalid]
+        ts = np.atleast_1d(ts)
+        ts_invalid = ts.astype(float)[invalid]
+        df_invalid = df * np.ones(len(ts))[invalid]
         sigma_invalid = np.array(
-            [_ts_to_sigma_mpmath(ts_val, df) for ts_val in ts_invalid]
+            [
+                _ts_to_sigma_mpmath(ts_val, df_val)
+                for ts_val, df_val in zip(ts_invalid, df_invalid)
+            ]
         )
         try:
             sigma[invalid] = sigma_invalid

--- a/gammapy/stats/utils.py
+++ b/gammapy/stats/utils.py
@@ -35,7 +35,7 @@ def sigma_to_ts(n_sigma, df=1):
     if np.any(invalid):
         n_sigma = np.atleast_1d(n_sigma)
         sigma_invalid = n_sigma.astype(float)[invalid]
-        df_invalid = df * np.ones(len(n_sigma))[invalid]
+        df_invalid = (df * np.ones(n_sigma.shape))[invalid]
 
         ts_invalid = np.array(
             [
@@ -77,7 +77,7 @@ def ts_to_sigma(ts, df=1):
     if np.any(invalid):
         ts = np.atleast_1d(ts)
         ts_invalid = ts.astype(float)[invalid]
-        df_invalid = df * np.ones(len(ts))[invalid]
+        df_invalid = (df * np.ones(ts.shape))[invalid]
         sigma_invalid = np.array(
             [
                 _ts_to_sigma_mpmath(ts_val, df_val)


### PR DESCRIPTION
Fix `nan` output in `ts_to_sigma` and `sigma_to_ts` caused by limited precision in `scipy.stats.chi2` functions. The solution proposed here rely on `mpmath` package to strore values with a large number of digits when `scipy` fails.