### PR TITLE
Add ts in combine_significance_maps output

### DIFF
--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -440,6 +440,7 @@ def test_joint_excess_map(simple_dataset):
 
     assert_allclose(result["npred_excess"].data.sum(), 2 * 19733.602, rtol=1e-3)
     assert_allclose(result["significance"].data[10, 10], 5.618187, rtol=1e-3)
+    assert_allclose(result["ts"].data[10, 10], 35.526888, rtol=1e-3)
     assert_allclose(
         result["df"].data, 2 * (~np.isnan(result["significance"].data)), rtol=1e-3
     )

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -834,6 +834,7 @@ def combine_significance_maps(maps):
     return dict(
         significance=significance,
         df=df,
+        ts=ts_sum,
         npred_excess=npred_excess_sum,
         estimator_results=maps,
     )


### PR DESCRIPTION
As discussed in dev call add ts in combine_significance_maps output
so if the significance is inf due to precision error it can be recomputed a posteriori (for example with the method of #5641)