### PR TITLE
Set  apply_irf["edisp"]=False in create_fermi_isotropic_diffuse_model

### DIFF
--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -1234,5 +1234,5 @@ def create_fermi_isotropic_diffuse_model(filename, **kwargs):
         spatial_model=spatial_model,
         spectral_model=spectral_model,
         name="fermi-diffuse-iso",
-        apply_irf={"psf": False, "exposure": True, "edisp": True},
+        apply_irf={"psf": False, "exposure": True, "edisp": False},
     )


### PR DESCRIPTION
Set  apply_irf["edisp"]=False in create_fermi_isotropic_diffuse_model

See https://fermi.gsfc.nasa.gov/ssc/data/access/lat/BackgroundModels.html :

![Screenshot 2024-12-18 at 14 55 21](https://github.com/user-attachments/assets/dc2e8a0b-f8a2-403c-8e1d-978fa68ba197)

