### PR TITLE
Overwrite name in ogip spectrum dataset reading

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -359,7 +359,7 @@
         "active"
     ],
     "email": "GAMMAPY-COORDINATION-L@IN2P3.FR",
-    "dateModified": "2024-11-26",
+    "dateModified": "2024-12-20",
     "softwareRequirements": [
         "numpy>=1.21",
         "scipy>=1.5,!=1.10",

--- a/gammapy/datasets/io.py
+++ b/gammapy/datasets/io.py
@@ -285,9 +285,10 @@ class OGIPDatasetReader(DatasetReader):
 
     tag = "ogip"
 
-    def __init__(self, filename, checksum=False):
+    def __init__(self, filename, checksum=False, name=None):
         self.filename = make_path(filename)
         self.checksum = checksum
+        self.name = name
 
     def get_valid_path(self, filename):
         """Get absolute or relative path.
@@ -450,7 +451,10 @@ class OGIPDatasetReader(DatasetReader):
         kwargs = self.read_pha(self.filename, checksum=self.checksum)
         pha_meta = kwargs["counts"].meta
 
-        name = str(pha_meta["OBS_ID"])
+        if self.name is not None:
+            name = self.name
+        else:
+            name = str(pha_meta["OBS_ID"])
         livetime = pha_meta["EXPOSURE"] * u.s
 
         filenames = self.get_filenames(pha_meta=pha_meta)

--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -328,7 +328,7 @@ class SpectrumDatasetOnOff(PlotMixin, MapDatasetOnOff):
         if format == "gadf":
             return super().read(filename, format="gadf", checksum=checksum, **kwargs)
 
-        reader = OGIPDatasetReader(filename=filename, checksum=checksum)
+        reader = OGIPDatasetReader(filename=filename, checksum=checksum, **kwargs)
         return reader.read()
 
     def write(self, filename, overwrite=False, format="ogip", checksum=False):

--- a/gammapy/datasets/tests/test_spectrum.py
+++ b/gammapy/datasets/tests/test_spectrum.py
@@ -548,6 +548,15 @@ class TestSpectrumOnOff:
         assert regions[0].center.is_equivalent_frame(expected_regions[0].center)
         assert_allclose(regions[1].angle, expected_regions[1].angle)
 
+    def test_from_ogip_files_overwrite_name(self, tmp_path):
+        dataset = self.dataset.copy(name="test")
+        dataset.write(tmp_path / "test.fits")
+        new_dataset = SpectrumDatasetOnOff.read(tmp_path / "test.fits")
+        assert new_dataset.name == dataset.name
+
+        new_dataset = SpectrumDatasetOnOff.read(tmp_path / "test.fits", name="new_name")
+        assert new_dataset.name == "new_name"
+
     def test_to_from_ogip_files_no_mask(self, tmp_path):
         dataset = self.dataset.copy(name="test")
         dataset.mask_safe = None
@@ -566,7 +575,6 @@ class TestSpectrumOnOff:
         assert newdataset.counts.meta["ANCRFILE"] == "test_arf.fits.gz"
 
     def test_to_from_ogip_files_no_edisp(self, tmp_path):
-
         mask_safe = RegionNDMap.from_geom(self.on_counts.geom, dtype=bool)
         mask_safe.data += True
 


### PR DESCRIPTION
This PR add the possibility to overwrite ogip spectrum dataset name during reading. 