### PR TITLE
Better error message on `MapAxes.__getitem__`

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1818,7 +1818,9 @@ class MapAxes(Sequence):
             for ax in self._axes:
                 if ax.name == idx:
                     return ax
-            raise KeyError(f"No axes: {idx!r}")
+            raise KeyError(
+                f"Axis with name `{idx!r}` not in list of axis name: {self.axes_names}."
+            )
         elif isinstance(idx, slice):
             axes = self._axes[idx]
             return self.__class__(axes=axes)

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1819,7 +1819,7 @@ class MapAxes(Sequence):
                 if ax.name == idx:
                     return ax
             raise KeyError(
-                f"Axis with name `{idx!r}` not in list of axis name: {self.names}."
+                f"Axis with name `{idx!r}` not in list of axis names: {self.names}."
             )
         elif isinstance(idx, slice):
             axes = self._axes[idx]

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -1819,7 +1819,7 @@ class MapAxes(Sequence):
                 if ax.name == idx:
                     return ax
             raise KeyError(
-                f"Axis with name `{idx!r}` not in list of axis name: {self.axes_names}."
+                f"Axis with name `{idx!r}` not in list of axis name: {self.names}."
             )
         elif isinstance(idx, slice):
             axes = self._axes[idx]


### PR DESCRIPTION
This PR follows #5633. 
I moved the error message on `MapAxes.getitem__` via string to this PR.
