### PR TITLE
Implicit support of map dataset instead of observation in DatasetMaker

### DIFF
--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -166,7 +166,7 @@ class MapDatasetMaker(Maker):
         exposure : `~gammapy.maps.Map`
             Exposure map.
         """
-        if getattr(observation, "exposure"):
+        if getattr(observation, "exposure", None):
             return observation.exposure.interp_to_geom(
                 geom=geom,
             )

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -401,7 +401,7 @@ class MapDatasetMaker(Maker):
         if isinstance(observation, Observation):
             kwargs["meta_table"] = self.make_meta_table(observation)
             kwargs["meta"] = self._make_metadata(kwargs["meta_table"])
-        elif isinstance(observation, MapDataset):
+        elif getattr(observation, "meta"):
             kwargs["meta"] = observation.meta
 
         mask_safe = Map.from_geom(dataset.counts.geom, dtype=bool)

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -5,6 +5,7 @@ from astropy.table import Table
 from regions import PointSkyRegion
 from gammapy.datasets import MapDatasetMetaData
 from gammapy.irf import EDispKernelMap, PSFMap
+from gammapy.data import Observation
 from gammapy.maps import Map
 from .core import Maker
 from .utils import (
@@ -165,6 +166,10 @@ class MapDatasetMaker(Maker):
         exposure : `~gammapy.maps.Map`
             Exposure map.
         """
+        if getattr(observation, "exposure"):
+            return observation.exposure.interp_to_geom(
+                geom=geom,
+            )
         if isinstance(observation.aeff, Map):
             return observation.aeff.interp_to_geom(
                 geom=geom,
@@ -393,8 +398,11 @@ class MapDatasetMaker(Maker):
             Map dataset.
         """
         kwargs = {"gti": observation.gti}
-        kwargs["meta_table"] = self.make_meta_table(observation)
-        kwargs["meta"] = self._make_metadata(kwargs["meta_table"])
+        if isinstance(observation, Observation):
+            kwargs["meta_table"] = self.make_meta_table(observation)
+            kwargs["meta"] = self._make_metadata(kwargs["meta_table"])
+        else:
+            kwargs["meta"] = observation.meta
 
         mask_safe = Map.from_geom(dataset.counts.geom, dtype=bool)
         mask_safe.data[...] = True

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -401,7 +401,7 @@ class MapDatasetMaker(Maker):
         if isinstance(observation, Observation):
             kwargs["meta_table"] = self.make_meta_table(observation)
             kwargs["meta"] = self._make_metadata(kwargs["meta_table"])
-        else:
+        elif isinstance(observation, MapDataset):
             kwargs["meta"] = observation.meta
 
         mask_safe = Map.from_geom(dataset.counts.geom, dtype=bool)

--- a/gammapy/makers/tests/test_map.py
+++ b/gammapy/makers/tests/test_map.py
@@ -410,6 +410,10 @@ def test_interpolate_map_dataset():
     ).data
     assert_allclose(psfkernel_preinterp, psfkernel_postinterp, atol=1e-4)
 
+    # test running maker with dataset
+    maker = MapDatasetMaker(selection=["exposure", "edisp", "psf"])
+    dataset = maker.run(dataset, dataset)
+
 
 @requires_data()
 @pytest.mark.xfail


### PR DESCRIPTION
Implicit support of map dataset instead of observation in DatasetMaker.
Related to #5649 : If ones don't want to create an Observation object for Fermi-LAT data (and  in general data with DL4 irfs), we could instead support using a map dataset as input irfs container in makers.  This would require very little change to work as shown in this draft PR.
