### PR TITLE
Adapt hierarchical_clustering test

### DIFF
--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -515,7 +515,7 @@ def test_observations_clustering(data_store):
         names=names,
         apply_standard_scaler=True,
     )
-    features = hierarchical_clustering(features)
+    features = hierarchical_clustering(features, fcluster_kwargs={"t": 2})
     features_array = np.array(
         [
             features[col].data


### PR DESCRIPTION
Adapt the test of `gammapy.utils.cluster.hierarchical_clustering` in order to fix the CI. This is related to changes is scipy.cluster with version 1.15.
