### PR TITLE
Avoid matplotlib 3.10 in CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     click>=7.0
     pydantic>=2.5.0
     iminuit>=2.8.0
-    matplotlib>=3.4, !=3.10
+    matplotlib>=3.4, <3.10
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     click>=7.0
     pydantic>=2.5.0
     iminuit>=2.8.0
-    matplotlib>=3.4
+    matplotlib>=3.4, !=3.10
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Fix CI sphinx all-deps : fix the following error in doc build :
```
Traceback (most recent call last):
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/sphinx/config.py", line 529, in eval_config_file
    exec(code, namespace)  # NoQA: S102
  File "/home/runner/work/gammapy/gammapy/docs/conf.py", line 43, in <module>
    from gammapy.utils.docs import SubstitutionCodeBlock, gammapy_sphinx_ext_activate
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/gammapy/utils/docs.py", line 28, in <module>
    from gammapy.analysis import AnalysisConfig
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/gammapy/analysis/__init__.py", line 3, in <module>
    from .config import AnalysisConfig
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/gammapy/analysis/config.py", line 12, in <module>
    from gammapy.makers import MapDatasetMaker
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/gammapy/makers/__init__.py", line 3, in <module>
    from .background import (
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/gammapy/makers/background/__init__.py", line 2, in <module>
    from .fov import FoVBackgroundMaker
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/gammapy/makers/background/fov.py", line 5, in <module>
    from gammapy.maps import Map, RegionGeom
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/gammapy/maps/__init__.py", line 10, in <module>
    from .region import RegionGeom, RegionNDMap
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/gammapy/maps/region/__init__.py", line 2, in <module>
    from .geom import RegionGeom
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/gammapy/maps/region/geom.py", line 11, in <module>
    from astropy.visualization.wcsaxes import WCSAxes
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/astropy/visualization/wcsaxes/__init__.py", line 19, in <module>
    from .helpers import *
  File "/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/astropy/visualization/wcsaxes/helpers.py", line 8, in <module>
    from mpl_toolkits.axes_grid1.anchored_artists import AnchoredEllipse, AnchoredSizeBar
ImportError: cannot import name 'AnchoredEllipse' from 'mpl_toolkits.axes_grid1.anchored_artists' (/home/runner/work/gammapy/gammapy/.tox/build_docs/lib/python3.10/site-packages/mpl_toolkits/axes_grid1/anchored_artists.py)

```