### PR TITLE
Avoid quantity and str multiplication (deprecated in astropy v7.1)

### DIFF
--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -140,7 +140,7 @@ def make_map_exposure_true_energy(
     coords["energy_true"] = broadcast_axis_values_to_geom(geom, "energy_true")
     exposure = aeff.evaluate(**coords)
 
-    data = (exposure * livetime).to("m2 s")
+    data = (exposure * u.Quantity(livetime)).to("m2 s")
     meta = {"livetime": livetime, "is_pointlike": aeff.is_pointlike}
 
     if not use_region_center:


### PR DESCRIPTION
Fix CI devdeps : astropy.utils.exceptions.AstropyDeprecationWarning: products involving a unit and a 'str' instance are deprecated since v7.1. 