### PR TITLE
Splitting original stat_sum with & without priors

### DIFF
--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -69,14 +69,18 @@ class Dataset(abc.ABC):
 
     def stat_sum(self):
         """Total statistic given the current model parameters and priors."""
+        prior_stat_sum = 0.0
+        if self.models is not None:
+            prior_stat_sum = self.models.parameters.prior_stat_sum()
+        return self._stat_sum_no_prior() + prior_stat_sum
+
+    def _stat_sum_no_prior(self):
+        """Total statistic given the current model parameters without the priors."""
         stat = self.stat_array()
 
         if self.mask is not None:
             stat = stat[self.mask.data]
-        prior_stat_sum = 0.0
-        if self.models is not None:
-            prior_stat_sum = self.models.parameters.prior_stat_sum()
-        return np.sum(stat, dtype=np.float64) + prior_stat_sum
+        return np.sum(stat, dtype=np.float64)
 
     @abc.abstractmethod
     def stat_array(self):

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -237,19 +237,18 @@ class Datasets(collections.abc.MutableSequence):
         return np.array(contributions)
 
     def stat_sum(self):
-        """Total statistic given the current model parameters and priors."""
-        prior_stat_sum = 0.0
-        if self.models is not None:
-            prior_stat_sum = self.models.parameters.prior_stat_sum()
-        return self._stat_sum_likelihood() + prior_stat_sum
+        """Compute joint statistic function value."""
+        stat_sum = 0
+        for dataset in self:
+            stat_sum += dataset.stat_sum()
+        return stat_sum
 
     def _stat_sum_likelihood(self):
         """Total statistic given the current model parameters without the priors."""
-        stat = self.stat_array()
-
-        if self.mask is not None:
-            stat = stat[self.mask.data]
-        return np.sum(stat, dtype=np.float64)
+        stat_sum = 0
+        for dataset in self:
+            stat_sum += dataset._stat_sum_likelihood()
+        return stat_sum
 
     def select_time(self, time_min, time_max, atol="1e-6 s"):
         """Select datasets in a given time interval.

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -755,6 +755,7 @@ def test_prior_stat_sum(sky_model, geom, geom_etrue):
 
     uniformprior = UniformPrior(min=0, max=np.inf, weight=1)
     datasets.models.parameters["amplitude"].prior = uniformprior
+    assert_allclose(datasets._stat_sum_likelihood(), 12825.9370, rtol=1e-3)
     assert_allclose(datasets.stat_sum(), 12825.9370, rtol=1e-3)
 
     datasets.models.parameters["amplitude"].value = -1e-12


### PR DESCRIPTION
This PR is a small brick of the larger Nested Sampling discussed in the PIG #5499 

We introduce `stat_sum_no_prior` that returns the statistics without the prior term. 
`stat_sum_no_prior` is now reused in the `stat_sum` function.
This function is private to avoid overloading.