### PR TITLE
Fix FluxPoints.plot

### DIFF
--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -667,11 +667,8 @@ class FluxPoints(FluxMaps):
         flux = scale_plot_flux(flux=flux.to_unit(flux_unit), energy_power=energy_power)
         if "time" in flux.geom.axes_names:
             flux.geom.axes["time"].time_format = time_format
-            ax = flux.plot(ax=ax, **kwargs)
-        else:
-            ax = flux.plot(ax=ax, **kwargs)
-            ax.set_xlabel(f"Energy [{ax.xaxis.units.to_string(UNIT_STRING_FORMAT)}]")
-            ax.set_xscale("log", nonpositive="clip")
+
+        ax = flux.plot(ax=ax, **kwargs)
         self._plot_format_yax(ax=ax, energy_power=energy_power, sed_type=sed_type)
 
         if len(flux.geom.axes) > 1:


### PR DESCRIPTION
This fixes #5672.
I dont know why the axis label/scale was forced to be energy/log unnecessarily.