### PR TITLE
Fix bug in squash_fluxpoints

### DIFF
--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -52,32 +52,40 @@ def squash_fluxpoints(flux_point, axis):
     if axis.name != "energy":
         geom = geom.to_cube([flux_point.geom.axes["energy"]])
 
-    maps["norm"] = Map.from_geom(geom, data=minimizer.x)
+    maps["norm"] = Map.from_geom(geom, data=minimizer.x.reshape(geom.data_shape))
     maps["norm_err"] = Map.from_geom(
         geom, data=np.sqrt(minimizer.hess_inv.todense()).reshape(geom.data_shape)
     )
-    maps["n_dof"] = Map.from_geom(geom, data=flux_point.geom.axes[axis.name].nbin)
+    maps["n_dof"] = Map.from_geom(
+        geom, data=np.reshape(flux_point.geom.axes[axis.name].nbin, geom.data_shape)
+    )
 
     if "norm_ul" in flux_point.available_quantities:
         delta_ts = flux_point.meta.get("n_sigma_ul", 2) ** 2
         ul = stat_profile_ul_scipy(value_scan, stat_scan, delta_ts=delta_ts)
-        maps["norm_ul"] = Map.from_geom(geom, data=ul.value)
+        maps["norm_ul"] = Map.from_geom(
+            geom, data=np.reshape(ul.value, geom.data_shape)
+        )
 
-    maps["stat"] = Map.from_geom(geom, data=f(minimizer.x))
+    maps["stat"] = Map.from_geom(geom, data=f(minimizer.x).reshape(geom.data_shape))
 
     geom_scan = geom.to_cube([MapAxis.from_nodes(value_scan, name="norm")])
     maps["stat_scan"] = Map.from_geom(
         geom=geom_scan, data=stat_scan.reshape(geom_scan.data_shape)
     )
     try:
-        maps["stat_null"] = Map.from_geom(geom, data=np.sum(flux_point.stat_null.data))
+        maps["stat_null"] = Map.from_geom(
+            geom, data=np.reshape(np.sum(flux_point.stat_null.data), geom.data_shape)
+        )
         maps["ts"] = maps["stat_null"] - maps["stat"]
     except AttributeError:
         log.info(
             "Stat null info not present on original FluxPoints object. TS not computed"
         )
 
-    maps["success"] = Map.from_geom(geom=geom, data=minimizer.success, dtype=bool)
+    maps["success"] = Map.from_geom(
+        geom=geom, data=np.reshape(minimizer.success, geom.data_shape), dtype=bool
+    )
 
     combined_fp = FluxPoints.from_maps(
         maps=maps,

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -15,6 +15,7 @@ from gammapy.datasets import (
 )
 from gammapy.datasets.spectrum import SpectrumDataset
 from gammapy.estimators import FluxPoints, FluxPointsEstimator
+from gammapy.estimators.utils import get_rebinned_axis
 from gammapy.irf import EDispKernelMap, EffectiveAreaTable2D, load_irf_dict_from_file
 from gammapy.makers import MapDatasetMaker
 from gammapy.makers.utils import make_map_exposure_true_energy
@@ -853,3 +854,11 @@ def test_fpe_diff_lengths():
     datasets = Datasets([dataset1, dataset2, dataset3, dataset4])
     with pytest.raises(ValueError):
         fp = fpe.run(datasets)
+
+
+def test_resample_axis():
+    ds, fpe = create_fpe(PowerLawSpectralModel())
+    flux_points = fpe.run(ds)
+    axis_new = get_rebinned_axis(flux_points, method="fixed-bins", group_size=3)
+    flux_new = flux_points.resample_axis(axis_new)
+    assert_allclose(flux_new.flux.data, [[[3.1050191 * 1e-12]]], rtol=1e-5)


### PR DESCRIPTION
This fixes #5670 
The error was occurring because of the prevention of automatic reshaping introduced in #5180