### PR TITLE
Cleanup `MapDataset.__init__`

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -540,7 +540,7 @@ class MapDataset(Dataset):
 
         if psf and not isinstance(psf, (PSFMap, HDULocation)):
             raise ValueError(
-                f"'psf' must be a `PSFMap` or `HDULocation` object, got `{type(psf)}` instead."
+                f"'psf' must be a `PSFMap` or `HDULocation` object, got {type(psf)} instead."
             )
         self.psf = psf
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -539,13 +539,13 @@ class MapDataset(Dataset):
 
         if psf and not isinstance(psf, (PSFMap, HDULocation)):
             raise ValueError(
-                f"'psf' must be a 'PSFMap' or `HDULocation` object, got {type(psf)}"
+                f"'psf' must be a `PSFMap` or `HDULocation` object, got `{type(psf)}` instead."
             )
         self.psf = psf
 
         if edisp and not isinstance(edisp, (EDispMap, EDispKernelMap, HDULocation)):
             raise ValueError(
-                "'edisp' must be a 'EDispMap', `EDispKernelMap` or 'HDULocation' "
+                "'edisp' must be a `EDispMap`, `EDispKernelMap` or `HDULocation` "
                 f"object, got `{type(edisp)}` instead."
             )
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -554,10 +554,7 @@ class MapDataset(Dataset):
         self.gti = gti
         self.models = models
         self.meta_table = meta_table
-        if meta is None:
-            self._meta = MapDatasetMetaData()
-        else:
-            self._meta = meta
+        self.meta = meta
 
     @property
     def _psf_kernel(self):
@@ -576,7 +573,10 @@ class MapDataset(Dataset):
 
     @meta.setter
     def meta(self, value):
-        self._meta = value
+        if value is None:
+            self._meta = MapDatasetMetaData()
+        else:
+            self._meta = value
 
     # TODO: keep or remove?
     @property


### PR DESCRIPTION
This is a small PR that put the meta logic in the `__init__` function of `MapDataset` in the setter of meta. 
Plus some corrections in the error message of psf and edisp