### PR TITLE
Unify references

### DIFF
--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -150,6 +150,26 @@ If you get a zsh error try using putting to ignore block inside quotes
 
     pytest --doctest-modules "--ignore-glob=*/tests" gammapy
 
+References can also be added to docstrings for proper documentation of specific equations or usage examples. There are
+a few ways to do this. Firstly if you reference a specific equation you can utilise the following syntax:
+
+.. code-block:: text
+
+        From Equation (1) in [1]_.
+
+        References
+        ----------
+        .. [1] `Author et al. (2023), "Title" <link_to_nasaads>`_
+
+Another option is to create a general list of references, as follows:
+
+.. code-block:: text
+
+        References
+        ----------
+        * `Author et al. (2023), "Title" <link_to_nasaads>`_
+        * `Author2 et al. (2022), "Title2" <link_to_nasaads>`_
+
 It is also important to check that you have correctly formatted your docstring. An easy way to check this
 is with the following for your specific file, i.e.:
 

--- a/docs/user-guide/references.rst
+++ b/docs/user-guide/references.rst
@@ -51,7 +51,7 @@ Glossary
       Short for "data level 4": it is used to mention or describe binned-science data, ie
       N-dim maps (multi-dimensional histograms) of the spatial, temporal and/or spectral
       components of the DL3 data in instrumental units (e.g. counts). See :ref:`maps` and
-     :ref:`data flow <data_flow>`.
+      :ref:`data flow <data_flow>`.
 
     DL5
       Short for "data level 5": it is used to mention or describe advanced-science data, ie

--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -136,7 +136,7 @@ class ZhaoProfile(DMProfile):
 
     References
     ----------
-    * .. [1] `Zhao (1996), "Analytical models for galactic nuclei"
+    .. [1] `Zhao (1996), "Analytical models for galactic nuclei"
       <https://ui.adsabs.harvard.edu/abs/1996MNRAS.278..488Z>`_
     * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
       <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_

--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Dark matter profiles."""
+
 import abc
 import html
 import numpy as np
@@ -110,13 +111,15 @@ class DMProfile(abc.ABC):
 class ZhaoProfile(DMProfile):
     r"""Zhao Profile.
 
-    This is taken from equation 1 from Zhao (1996). It is a generalization of the NFW profile. The volume density
+    It is a generalization of the NFW profile. The volume density
     is parametrized with a double power-law. Scale radii smaller than the scale radius are described with a slope of
     :math:`-\gamma` and scale radii larger than the scale radius are described with a slope of :math:`-\beta`.
     :math:`\alpha` is a measure for the width of the transition region.
 
     .. math::
         \rho(r) = \rho_s \left(\frac{r_s}{r}\right)^\gamma \left(1 + \left(\frac{r}{r_s}\right)^\frac{1}{\alpha} \right)^{(\gamma - \beta) \alpha}
+
+    Equation (1) from [1]_.
 
     Parameters
     ----------
@@ -133,8 +136,10 @@ class ZhaoProfile(DMProfile):
 
     References
     ----------
-    * `1996MNRAS.278..488Z <https://ui.adsabs.harvard.edu/abs/1996MNRAS.278..488Z>`_
-    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    * .. [1] `Zhao (1996), "Analytical models for galactic nuclei"
+      <https://ui.adsabs.harvard.edu/abs/1996MNRAS.278..488Z>`_
+    * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
+      <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 24.42 * u.kpc
@@ -185,8 +190,10 @@ class NFWProfile(DMProfile):
 
     References
     ----------
-    * `1997ApJ...490..493 <https://ui.adsabs.harvard.edu/abs/1997ApJ...490..493N>`_
-    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    * `Navarro et al. (1997), "A Universal Density Profile from Hierarchical Clustering"
+      <https://ui.adsabs.harvard.edu/abs/1997ApJ...490..493N>`_
+    * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
+      <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 24.42 * u.kpc
@@ -224,8 +231,10 @@ class EinastoProfile(DMProfile):
 
     References
     ----------
-    * `1965TrAlm...5...87E <https://ui.adsabs.harvard.edu/abs/1965TrAlm...5...87E>`_
-    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    * `Einasto (1965), "On the Construction of a Composite Model for the Galaxy and on the Determination of the System
+      of Galactic Parameters" <https://ui.adsabs.harvard.edu/abs/1965TrAlm...5...87E>`_
+    * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
+      <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 28.44 * u.kpc
@@ -265,8 +274,10 @@ class IsothermalProfile(DMProfile):
 
     References
     ----------
-    * `1991MNRAS.249..523B <https://ui.adsabs.harvard.edu/abs/1991MNRAS.249..523B>`_
-    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    * `Begeman et al. (1991), "Extended rotation curves of spiral galaxies : dark haloes and modified dynamics"
+      <https://ui.adsabs.harvard.edu/abs/1965TrAlm...5...87E>`_
+    * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
+      <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 4.38 * u.kpc
@@ -298,8 +309,10 @@ class BurkertProfile(DMProfile):
 
     References
     ----------
-    * `1995ApJ...447L..25B <https://ui.adsabs.harvard.edu/abs/1995ApJ...447L..25B>`_
-    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    * `Burkert (1995), "The Structure of Dark Matter Halos in Dwarf Galaxies"
+      <https://ui.adsabs.harvard.edu/abs/1965TrAlm...5...87E>`_
+    * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
+      <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 12.67 * u.kpc
@@ -333,8 +346,10 @@ class MooreProfile(DMProfile):
 
     References
     ----------
-    * `2004MNRAS.353..624D <https://ui.adsabs.harvard.edu/abs/2004MNRAS.353..624D>`_
-    * `2011JCAP...03..051C <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    * `Diemand et al. (2004), "Convergence and scatter of cluster density profiles"
+      <https://ui.adsabs.harvard.edu/abs/1965TrAlm...5...87E>`_
+    * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
+      <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     DEFAULT_SCALE_RADIUS = 30.28 * u.kpc

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -31,8 +31,10 @@ class PrimaryFlux(TemplateNDSpectralModel):
 
     References
     ----------
-    * `Marco et al. (2011) <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
-    * `Cirelli et al. (2016) <http://www.marcocirelli.net/PPPC4DMID.html>`_
+    * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
+      <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    * `Cirelli et al. (2016), "PPPC 4 DM ID: A Poor Particle Physicist Cookbook for Dark Matter Indirect Detection"
+      <http://www.marcocirelli.net/PPPC4DMID.html>`_
     """
 
     channel_registry = {

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -31,8 +31,8 @@ class PrimaryFlux(TemplateNDSpectralModel):
 
     References
     ----------
-    * `2011JCAP...03..051 <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
-    * Cirelli et al (2016): http://www.marcocirelli.net/PPPC4DMID.html
+    * `Marco et al. (2011) <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    * `Cirelli et al. (2016) <http://www.marcocirelli.net/PPPC4DMID.html>`_
     """
 
     channel_registry = {
@@ -201,7 +201,8 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
 
     References
     ----------
-    * `2011JCAP...03..051 <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
+    <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     THERMAL_RELIC_CROSS_SECTION = 3e-26 * u.Unit("cm3 s-1")
@@ -308,7 +309,8 @@ class DarkMatterDecaySpectralModel(SpectralModel):
 
     References
     ----------
-    * `2011JCAP...03..051 <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
+    <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     LIFETIME_AGE_OF_UNIVERSE = 4.3e17 * u.Unit("s")

--- a/gammapy/astro/population/spatial.py
+++ b/gammapy/astro/population/spatial.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Galactic radial source distribution probability density functions."""
+
 import numpy as np
 from astropy.modeling import Fittable1DModel, Parameter
 from astropy.units import Quantity
@@ -31,7 +32,7 @@ class Paczynski1990(Fittable1DModel):
     .. math::
         f(r) = A r_{exp}^{-2} \exp \left(-\frac{r}{r_{exp}} \right)
 
-    Formula (2) [Paczynski1990]_.
+    Formula (2) in [1]_.
 
     Parameters
     ----------
@@ -47,7 +48,8 @@ class Paczynski1990(Fittable1DModel):
 
     References
     ----------
-    .. [Paczynski1990] https://ui.adsabs.harvard.edu/abs/1990ApJ...348..485P
+    .. [1] `Paczynski (1990), "A Test of the Galactic Origin of Gamma-Ray Bursts"
+       <https://ui.adsabs.harvard.edu/abs/1990ApJ...348..485P>`_
     """
 
     amplitude = Parameter()
@@ -70,7 +72,7 @@ class CaseBattacharya1998(Fittable1DModel):
         f(r) = A \left( \frac{r}{r_{\odot}} \right) ^ \alpha \exp
         \left[ -\beta \left( \frac{ r - r_{\odot}}{r_{\odot}} \right) \right]
 
-    Formula (14) [CaseBattacharya1998]_.
+    Formula (14) in [1]_.
 
     Parameters
     ----------
@@ -88,7 +90,8 @@ class CaseBattacharya1998(Fittable1DModel):
 
     References
     ----------
-    .. [CaseBattacharya1998] https://ui.adsabs.harvard.edu/abs/1998ApJ...504..761C
+    .. [1] `Case et al. (1998), "A New Σ-D Relation and Its Application to the Galactic Supernova Remnant Distribution"
+       <https://ui.adsabs.harvard.edu/abs/1998ApJ...504..761C>`_
     """
 
     amplitude = Parameter()
@@ -115,9 +118,9 @@ class YusifovKucuk2004(Fittable1DModel):
         f(r) = A \left ( \frac{r + r_1}{r_{\odot} + r_1} \right )^a \exp
         \left [-b \left( \frac{r - r_{\odot}}{r_{\odot} + r_1} \right ) \right ]
 
-    Used by Faucher-Guigere and Kaspi. Density at ``r = 0`` is nonzero.
+    Used by Faucher-Giguère and Kaspi. Density at ``r = 0`` is nonzero.
 
-    Formula (15) [YusifovKucuk2004]_.
+    Formula (15) in [1]_.
 
     Parameters
     ----------
@@ -137,7 +140,8 @@ class YusifovKucuk2004(Fittable1DModel):
 
     References
     ----------
-    .. [YusifovKucuk2004] https://ui.adsabs.harvard.edu/abs/2004A%26A...422..545Y
+    .. [1] `Yusifov et al. (2004), "Revisiting the radial distribution of pulsars in the Galaxy"
+       <https://ui.adsabs.harvard.edu/abs/2004A%26A...422..545Y>`_
     """
 
     amplitude = Parameter()
@@ -167,7 +171,7 @@ class YusifovKucuk2004B(Fittable1DModel):
 
     Derived empirically from OB-stars distribution.
 
-    Formula (17) [YusifovKucuk2004]_.
+    Formula (17) in [1]_.
 
     Parameters
     ----------
@@ -185,8 +189,8 @@ class YusifovKucuk2004B(Fittable1DModel):
 
     References
     ----------
-    .. [YusifovKucuk2004] https://ui.adsabs.harvard.edu/abs/2004A%26A...422..545Y
-
+    .. [1] `Yusifov et al. (2004), "Revisiting the radial distribution of pulsars in the Galaxy"
+       <https://ui.adsabs.harvard.edu/abs/2004A%26A...422..545Y>`_
     """
 
     amplitude = Parameter()
@@ -212,7 +216,7 @@ class FaucherKaspi2006(Fittable1DModel):
         f(r) = A \frac{1}{\sqrt{2 \pi} \sigma} \exp
         \left(- \frac{(r - r_0)^2}{2 \sigma ^ 2}\right)
 
-    Appendix B [FaucherKaspi2006]_.
+    Appendix B in [1]_.
 
     Parameters
     ----------
@@ -230,7 +234,8 @@ class FaucherKaspi2006(Fittable1DModel):
 
     References
     ----------
-    .. [FaucherKaspi2006] https://ui.adsabs.harvard.edu/abs/2006ApJ...643..332F
+    .. [1] `Faucher-Giguère and Kaspi (2006), "Birth and Evolution of Isolated Radio Pulsars"
+       <https://ui.adsabs.harvard.edu/abs/2006ApJ...643..332F>`_
     """
 
     amplitude = Parameter()
@@ -256,7 +261,7 @@ class Lorimer2006(Fittable1DModel):
         f(r) = A \left( \frac{r}{r_{\odot}} \right) ^ B \exp
         \left[ -C \left( \frac{r - r_{\odot}}{r_{\odot}} \right) \right]
 
-    Formula (10) [Lorimer2006]_.
+    Formula (10) in [1]_.
 
     Parameters
     ----------
@@ -274,7 +279,8 @@ class Lorimer2006(Fittable1DModel):
 
     References
     ----------
-    .. [Lorimer2006] https://ui.adsabs.harvard.edu/abs/2006MNRAS.372..777L
+    .. [1] `Lorimer et al. (2006), "The Parkes Multibeam Pulsar Survey - VI. Discovery and timing of 142 pulsars and a
+       Galactic population analysis" <https://ui.adsabs.harvard.edu/abs/2006MNRAS.372..777L>`_
     """
 
     amplitude = Parameter()

--- a/gammapy/astro/population/velocity.py
+++ b/gammapy/astro/population/velocity.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Pulsar velocity distribution models."""
+
 import numpy as np
 from astropy.modeling import Fittable1DModel, Parameter
 from astropy.units import Quantity
@@ -22,14 +23,17 @@ class FaucherKaspi2006VelocityMaxwellian(Fittable1DModel):
         f(v) = A \sqrt{ \frac{2}{\pi}} \frac{v ^ 2}{\sigma ^ 3 }
                \exp \left(-\frac{v ^ 2}{2 \sigma ^ 2} \right)
 
-    Reference: https://ui.adsabs.harvard.edu/abs/2006ApJ...643..332F
-
     Parameters
     ----------
     amplitude : float
         Value of the integral.
     sigma : float
         Velocity parameter (km s^-1).
+
+    References
+    ----------
+    .. [1] `Faucher-Giguère and Kaspi (2006), "Birth and Evolution of Isolated Radio Pulsars"
+       <https://ui.adsabs.harvard.edu/abs/2006ApJ...643..332F>`_
     """
 
     amplitude = Parameter()
@@ -47,14 +51,14 @@ class FaucherKaspi2006VelocityMaxwellian(Fittable1DModel):
 
 
 class FaucherKaspi2006VelocityBimodal(Fittable1DModel):
-    r"""Bimodal pulsar velocity distribution. - Faucher & Kaspi (2006).
+    r"""Bimodal pulsar velocity distribution.
 
     .. math::
         f(v) = A\sqrt{\frac{2}{\pi}} v^2 \left[\frac{w}{\sigma_1^3}
         \exp \left(-\frac{v^2}{2\sigma_1^2} \right) + \frac{1-w}{\sigma_2^3}
         \exp \left(-\frac{v^2}{2\sigma_2^2} \right) \right]
 
-    Formula (7) [FaucherKaspi2006]_.
+    Formula (7) in [1]_.
 
     Parameters
     ----------
@@ -69,7 +73,8 @@ class FaucherKaspi2006VelocityBimodal(Fittable1DModel):
 
     References
     ----------
-    .. [FaucherKaspi2006] https://ui.adsabs.harvard.edu/abs/2006ApJ...643..332F
+    .. [1] `Faucher-Giguère and Kaspi (2006), "Birth and Evolution of Isolated Radio Pulsars"
+       <https://ui.adsabs.harvard.edu/abs/2006ApJ...643..332F>`_
     """
 
     amplitude = Parameter()
@@ -97,7 +102,7 @@ class Paczynski1990Velocity(Fittable1DModel):
     .. math::
         f(v) = A\frac{4}{\pi} \frac{1}{v_0 \left[1 + (v / v_0) ^ 2 \right] ^ 2}
 
-    Formula (3) [Paczynski1990]_.
+    Formula (3) in [1]_.
 
     Parameters
     ----------
@@ -108,7 +113,8 @@ class Paczynski1990Velocity(Fittable1DModel):
 
     References
     ----------
-    .. [Paczynski1990] https://ui.adsabs.harvard.edu/abs/1990ApJ...348..485P
+    .. [1] `Paczynski (1990), "A Test of the Galactic Origin of Gamma-Ray Bursts"
+       <https://ui.adsabs.harvard.edu/abs/1990ApJ...348..485P>`_
     """
 
     amplitude = Parameter()

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """HAWC catalogs (https://www.hawc-observatory.org)."""
+
 import abc
 import numpy as np
 from astropy.table import Table
@@ -199,8 +200,8 @@ class SourceCatalog2HWC(SourceCatalog):
 
     References
     ----------
-    .. [1] Abeysekara et al, "The 2HWC HAWC Observatory Gamma Ray Catalog",
-       On ADS: `2017ApJ...843...40A <https://ui.adsabs.harvard.edu/abs/2017ApJ...843...40A>`__
+    .. [1] `Abeysekara et al. (2017), "The 2HWC HAWC Observatory Gamma Ray Catalog"
+       <https://ui.adsabs.harvard.edu/abs/2017ApJ...843...40A>`_
     """
 
     tag = "2hwc"
@@ -317,8 +318,8 @@ class SourceCatalog3HWC(SourceCatalog):
 
     References
     ----------
-    .. [1] 3HWC: The Third HAWC Catalog of Very-High-Energy Gamma-ray Sources",
-       https://data.hawc-observatory.org/datasets/3hwc-survey/index.php
+    .. [1] `Albert et al. (2021), "3HWC: The Third HAWC Catalog of Very-High-Energy Gamma-ray Sources"
+       <https://data.hawc-observatory.org/datasets/3hwc-survey/index.php>`_
     """
 
     tag = "3hwc"

--- a/gammapy/catalog/lhaaso.py
+++ b/gammapy/catalog/lhaaso.py
@@ -155,8 +155,8 @@ class SourceCatalog1LHAASO(SourceCatalog):
 
     References
     ----------
-    .. [1] 1LHAASO: The First LHAASO Catalog of Gamma-Ray Sources,
-       https://ui.adsabs.harvard.edu/abs/2023arXiv230517030C/abstract
+    .. [1] `Cao et al. (2023), "1LHAASO: The First LHAASO Catalog of Gamma-Ray Sources"
+       <https://ui.adsabs.harvard.edu/abs/2023arXiv230517030C/abstract>`_
     """
 
     tag = "1LHAASO"

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -166,7 +166,8 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
 
     References
     ----------
-    [Stewart2009]_
+    .. [Stewart2009]_ `Stewart (2009), “Maximum-likelihood detection of sources among Poissonian noise”
+       <https://ui.adsabs.harvard.edu/abs/2009A%26A...495..989S/abstract>`_
     """
 
     tag = "TSMapEstimator"

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -166,8 +166,8 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
 
     References
     ----------
-    .. [Stewart2009]_ `Stewart (2009), “Maximum-likelihood detection of sources among Poissonian noise”
-       <https://ui.adsabs.harvard.edu/abs/2009A%26A...495..989S/abstract>`_
+    `Stewart (2009), “Maximum-likelihood detection of sources among Poissonian noise”
+    <https://ui.adsabs.harvard.edu/abs/2009A%26A...495..989S/abstract>`_
     """
 
     tag = "TSMapEstimator"

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -502,9 +502,8 @@ def compute_lightcurve_doublingtime(lightcurve, flux_quantity="flux"):
 
     References
     ----------
-    .. [Brown2013] "Locating the γ-ray emission region
-       of the flat spectrum radio quasar PKS 1510−089", Brown et al. (2013)
-       https://academic.oup.com/mnras/article/431/1/824/1054498
+    `Brown et al. (2013), "Locating the γ-ray emission region of the flat spectrum radio quasar PKS 1510−089"
+    <https://academic.oup.com/mnras/article/431/1/824/1054498>`_
     """
     flux = getattr(lightcurve, flux_quantity)
     flux_err = getattr(lightcurve, flux_quantity + "_err")
@@ -578,9 +577,8 @@ def compute_lightcurve_discrete_correlation(
 
     References
     ----------
-    .. [Edelson1988] "THE DISCRETE CORRELATION FUNCTION: A NEW METHOD FOR ANALYZING
-       UNEVENLY SAMPLED VARIABILITY DATA", Edelson et al. (1988)
-       https://ui.adsabs.harvard.edu/abs/1988ApJ...333..646E/abstract
+    `Edelson et al. (1988), "THE DISCRETE CORRELATION FUNCTION: A NEW METHOD FOR ANALYZING
+    UNEVENLY SAMPLED VARIABILITY DATA" <https://ui.adsabs.harvard.edu/abs/1988ApJ...333..646E/abstract>`_
     """
     flux1 = getattr(lightcurve1, flux_quantity)
     flux_err1 = getattr(lightcurve1, flux_quantity + "_err")

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -2148,16 +2148,17 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
 
         References
         ----------
-        .. [1] Franceschini et al. (2008), "Extragalactic optical-infrared background radiation, its time evolution and the cosmic photon-photon opacity",  # noqa: E501
-            `Link <https://ui.adsabs.harvard.edu/abs/2008A%26A...487..837F>`__
-        .. [2] Dominguez et al. (2011), " Extragalactic background light inferred from AEGIS galaxy-SED-type fractions"  # noqa: E501
-            `Link <https://ui.adsabs.harvard.edu/abs/2011MNRAS.410.2556D>`__
-        .. [3] Finke et al. (2010), "Modeling the Extragalactic Background Light from Stars and Dust"
-            `Link <https://ui.adsabs.harvard.edu/abs/2010ApJ...712..238F>`__
-        .. [4] Franceschini et al. (2017), "The extragalactic background light revisited and the cosmic photon-photon opacity"
-            `Link <https://ui.adsabs.harvard.edu/abs/2017A%26A...603A..34F/abstract>`__
-        .. [5] Saldana-Lopez et al. (2021) "An observational determination of the evolving extragalactic background light from the multiwavelength HST/CANDELS survey in the Fermi and CTA era"
-            `Link <https://ui.adsabs.harvard.edu/abs/2021MNRAS.507.5144S/abstract>`__
+        * `Franceschini et al. (2008), "Extragalactic optical-infrared background radiation, its time evolution and the
+          cosmic photon-photon opacity" <https://ui.adsabs.harvard.edu/abs/2008A%26A...487..837F>`_
+        * `Dominguez et al. (2011), " Extragalactic background light inferred from AEGIS galaxy-SED-type fractions"
+          <https://ui.adsabs.harvard.edu/abs/2011MNRAS.410.2556D>`_
+        * `Finke et al. (2010), "Modeling the Extragalactic Background Light from Stars and Dust"
+          <https://ui.adsabs.harvard.edu/abs/2010ApJ...712..238F>`_
+        * `Franceschini et al. (2017), "The extragalactic background light revisited and the cosmic photon-photon opacity"
+          <https://ui.adsabs.harvard.edu/abs/2017A%26A...603A..34F/abstract>`_
+        * `Saldana-Lopez et al. (2021), "An observational determination of the evolving extragalactic background light
+          from the multiwavelength HST/CANDELS survey in the Fermi and CTA era"
+          <https://ui.adsabs.harvard.edu/abs/2021MNRAS.507.5144S/abstract>`_
         """
         return cls.read(
             EBL_DATA_BUILTIN[reference],

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -39,11 +39,11 @@ def cash(n_on, mu_on, truncation_value=TRUNCATION_VALUE):
 
     References
     ----------
-    * `Sherpa statistics page section on the Cash statistic:
+    * `Sherpa statistics page section on the Cash statistic
       <http://cxc.cfa.harvard.edu/sherpa/statistics/#cash>`_
-    * `Sherpa help page on the Cash statistic:
+    * `Sherpa help page on the Cash statistic
       <http://cxc.harvard.edu/sherpa/ahelp/cash.html>`_
-    * `Cash 1979, ApJ 228, 939,
+    * `Cash (1979), ApJ 228, 939,
       <https://ui.adsabs.harvard.edu/abs/1979ApJ...228..939C>`_
     """
     n_on = np.asanyarray(n_on)
@@ -93,11 +93,11 @@ def cstat(n_on, mu_on, truncation_value=TRUNCATION_VALUE):
 
     References
     ----------
-    * `Sherpa stats page section on the C statistic:
+    * `Sherpa stats page section on the C statistic
       <http://cxc.cfa.harvard.edu/sherpa/statistics/#cstat>`_
-    * `Sherpa help page on the C statistic:
+    * `Sherpa help page on the C statistic
       <http://cxc.harvard.edu/sherpa/ahelp/cash.html>`_
-    * `Cash 1979, ApJ 228, 939,
+    * `Cash (1979), ApJ 228, 939
       <https://ui.adsabs.harvard.edu/abs/1979ApJ...228..939C>`_
     """
     n_on = np.asanyarray(n_on, dtype=np.float64)
@@ -146,9 +146,9 @@ def wstat(n_on, n_off, alpha, mu_sig, mu_bkg=None, extra_terms=True):
 
     References
     ----------
-    * `Habilitation M. de Naurois, p. 141,
+    * `Habilitation M. de Naurois, p. 141
       <http://inspirehep.net/record/1122589/files/these_short.pdf>`_
-    * `XSPEC page on Poisson data with Poisson background,
+    * `XSPEC page on Poisson data with Poisson background
       <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html>`_
     """
     # Note: This is equivalent to what's defined on the XSPEC page under the

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -49,9 +49,8 @@ def compute_fvar(flux, flux_err, axis=0):
 
     References
     ----------
-    .. [Vaughan2003] "On characterizing the variability properties of X-ray light
-       curves from active galaxies", Vaughan et al. (2003)
-       https://ui.adsabs.harvard.edu/abs/2003MNRAS.345.1271V
+    `Vaughan et al. (2003), "On characterizing the variability properties of X-ray light
+    curves from active galaxies" <https://ui.adsabs.harvard.edu/abs/2003MNRAS.345.1271V>`_
     """
     flux_mean = np.nanmean(flux, axis=axis)
     n_points = np.count_nonzero(~np.isnan(flux), axis=axis)
@@ -98,10 +97,9 @@ def compute_fpp(flux, flux_err, axis=0):
 
     References
     ----------
-    .. [Edelson2002] "X-Ray Spectral Variability and Rapid Variability
-       of the Soft X-Ray Spectrum Seyfert 1 Galaxies
-       Arakelian 564 and Ton S180", Edelson et al. (2002), equation 3,
-       https://iopscience.iop.org/article/10.1086/323779
+    `Edelson et al. (2002), equation 3, "X-Ray Spectral Variability and Rapid Variability
+    of the Soft X-Ray Spectrum Seyfert 1 Galaxies Arakelian 564 and Ton S180"
+    <https://iopscience.iop.org/article/10.1086/323779>`_
     """
     flux_mean = np.nanmean(flux, axis=axis)
     n_points = np.count_nonzero(~np.isnan(flux), axis=axis)
@@ -152,11 +150,11 @@ def compute_flux_doubling(flux, flux_err, coords, axis=0):
 
     The variable is computed as:
 
-     .. math::
-        doubling = min(\frac{t_(i+1)-t_i}{log_2{f_(i+1)/f_i}})
+    .. math::
+        doubling = min \left( \frac{t_{(i+1)}-t_{i}}{log_2{f_{(i+1)}/f_{i}}} \right)
 
-    where f_i and f_(i+1) are the fluxes measured at subsequent coordinates t_i and t_(i+1).
-    The error is obtained by propagating the relative errors on the flux measures.
+    where :math:`f_i` and :math:`f_{(i+1)}` are the fluxes measured at subsequent coordinates :math:`t_i` and
+    :math:`t_{(i+1)}`. The error is obtained by propagating the relative errors on the flux measures.
 
     Parameters
     ----------
@@ -253,9 +251,8 @@ def structure_function(flux, flux_err, time, tdelta_precision=5):
 
     References
     ----------
-    .. [Emmanoulopoulos2010] "On the use of structure functions to study blazar variability:
-       caveats and problems", Emmanoulopoulos et al. (2010)
-       https://academic.oup.com/mnras/article/404/2/931/968488
+    `Emmanoulopoulos et al. (2010), "On the use of structure functions to study blazar variability:
+    caveats and problems" <https://academic.oup.com/mnras/article/404/2/931/968488>`_
     """
     dist_matrix = (time[np.newaxis, :] - time[:, np.newaxis]).round(
         decimals=tdelta_precision
@@ -311,9 +308,8 @@ def discrete_correlation(flux1, flux_err1, flux2, flux_err2, time1, time2, tau, 
 
     References
     ----------
-    .. [Edelson1988] "THE DISCRETE CORRELATION FUNCTION: A NEW METHOD FOR ANALYZING
-       UNEVENLY SAMPLED VARIABILITY DATA", Edelson et al. (1988)
-       https://ui.adsabs.harvard.edu/abs/1988ApJ...333..646E/abstract
+    `Edelson et al. (1988), "THE DISCRETE CORRELATION FUNCTION: A NEW METHOD FOR ANALYZING
+    UNEVENLY SAMPLED VARIABILITY DATA" <https://ui.adsabs.harvard.edu/abs/1988ApJ...333..646E/abstract>`_
     """
     flux1 = np.rollaxis(flux1, axis, 0)
     flux2 = np.rollaxis(flux2, axis, 0)
@@ -433,8 +429,8 @@ def TimmerKonig_lightcurve_simulator(
 
     References
     ----------
-    .. [Timmer1995] "On generating power law noise", J. Timmer and M, Konig, section 3
-       https://ui.adsabs.harvard.edu/abs/1995A%26A...300..707T/abstract
+    `Timmer and Konig (1995), section 3,  "On generating power law noise"
+    <https://ui.adsabs.harvard.edu/abs/1995A%26A...300..707T/abstract>`_
     """
     if not callable(power_spectrum):
         raise ValueError(


### PR DESCRIPTION
This resolves #5251 

In places such as [here](https://docs.gammapy.org/dev/api/gammapy.estimators.TSMapEstimator.html)
We have the reference which links to the reference page, while this is nice while within the documentation, it is not from the docstring. i.e. if you are coding jupyter and query the class you cannot see the reference properly. 

My preference would be that for the docstring we are explicit in the referencing and leave the `References` list in the `User Guide` for references which are within the documentation descriptions themselves.