### PR TITLE
[PROTOTYPE] Potential modifications to support a future format 

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -409,7 +409,7 @@ class DataStore:
         if "OBS_TABLE_ROW" in self.hdu_table.keys():
             selection = [ind in obs_id for ind in self.obs_table["OBS_ID"]]
             obs_id = self.obs_table["OBS_ID"][selection]
-            obs_table_row = np.where(selection)[0]
+            obs_table_row = self.obs_table["OBS_TABLE_ROW"][selection]
         else:
             obs_table_row = obs_id
 

--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -131,7 +131,7 @@ class HDUIndexTable(Table):
                 f"Invalid hdu_class: {hdu_class}. Valid values are: {valid}"
             )
 
-        if obs_id not in self["OBS_ID"]:
+        if obs_id not in self.obs_id:
             raise IndexError(f"No entry available with OBS_ID = {obs_id}")
 
     def row_idx(self, obs_id, hdu_type=None, hdu_class=None):
@@ -151,7 +151,7 @@ class HDUIndexTable(Table):
         idx : list of int
             List of row indices matching the selection.
         """
-        selection = self["OBS_ID"] == obs_id
+        selection = self.obs_id == obs_id
 
         if hdu_class:
             is_hdu_class = self._hdu_class_stripped == hdu_class
@@ -184,9 +184,17 @@ class HDUIndexTable(Table):
         return np.array([_.strip() for _ in self["HDU_TYPE"]])
 
     @lazyproperty
+    def obs_id(self):
+        """Observation Id"""
+        if "OBS_TABLE_ROW" in self.keys():
+            return self["OBS_TABLE_ROW"]
+        elif "OBS_ID" in self.keys():
+            return self["OBS_ID"]
+
+    @lazyproperty
     def obs_id_unique(self):
         """Observation IDs (unique)."""
-        return np.unique(np.sort(self["OBS_ID"]))
+        return np.unique(np.sort(self.obs_id))
 
     @lazyproperty
     def hdu_type_unique(self):

--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -186,10 +186,16 @@ class HDUIndexTable(Table):
     @lazyproperty
     def obs_id(self):
         """Observation Id"""
-        if "OBS_TABLE_ROW" in self.keys():
-            return self["OBS_TABLE_ROW"]
+        from gammapy.data.data_store import TABLE_MATCHING_KEY
+
+        if TABLE_MATCHING_KEY in self.keys():
+            return self[TABLE_MATCHING_KEY]
         elif "OBS_ID" in self.keys():
             return self["OBS_ID"]
+        else:
+            raise KeyError(
+                "Table matching key {TABLE_MATCHING_KEY} or OBS_ID not found"
+            )
 
     @lazyproperty
     def obs_id_unique(self):

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -334,6 +334,8 @@ def test_data_store_no_events():
 
 @requires_data()
 def test_data_store_future_foramt():
+    import gammapy.data.data_store as hdu_module
+
     irf_dir = "$GAMMAPY_DATA/tests/format/swgo/"
     datastore = DataStore.from_dir(
         irf_dir, "hdu-index-multi.fits.gz", "obs-index-multi.fits.gz"
@@ -361,3 +363,7 @@ def test_data_store_future_foramt():
         obs._events = [_._events for _ in observations]
         # get_observations should stack the entries with the same IRF_name to avoid repeating data reduction
         # and allows obs.events to be a list of events lists to avoid having everything in memory in that case
+
+    with pytest.raises(KeyError):
+        hdu_module.TABLE_MATCHING_KEY = "WRONG"
+        observations = datastore_redu.get_observations()

--- a/gammapy/makers/map.py
+++ b/gammapy/makers/map.py
@@ -139,11 +139,17 @@ class MapDatasetMaker(Maker):
         counts : `~gammapy.maps.Map`
             Counts map.
         """
+
         if geom.is_region and isinstance(geom.region, PointSkyRegion):
             counts = make_counts_rad_max(geom, observation.rad_max, observation.events)
         else:
             counts = Map.from_geom(geom)
-            counts.fill_events(observation.events)
+            if isinstance(observation.events, list):
+                events_lists = observation.events
+            else:
+                events_lists = [observation.events]
+            for events_list in events_lists:
+                counts.fill_events(events_list)
         return counts
 
     @staticmethod


### PR DESCRIPTION
Few ideas on the modifications required in the HDU-Index and OBS-Index table for a future data format and the changes needed in gammapy.

### Format modifications
1. **Independent data partition**:
   - HDU-Index and OBS-Index should contain a single `event_class` with potentially multiple `event_type` or `observation_block`.
   - Each combination of `event_type` and `observation_block` (or any future independent data partition) should be associated with a fixed `irf_name`.
   - A given `irf_name` might not be associated with a well-defined IRF; in such cases, the `FILE_NAME` would be empty.

2. **HDU_NAME Differentiation**:
   - If independent data partitions are stored in the same file, the `HDU_NAME` should be different, maybe combining `HDU_NAME` and `irf_name` to differentiate them.

3. **Identifiers in OBS-Table**:
   - Any identifier used to select independent data partitions, such as `OBS_ID`, `EVENT_TYPE`, `OBS_BLOCK_ID`, and `IRF_NAME`, should only appear in the `obs-index` and not in the `hdu-index`.

4. **Unique Identifier for Independent data partition**:
   - Introduce a new unique identifier on both `obs-index` and `hdu-index` to link each independent data entry in the `obs-table` to the corresponding files in the `hdu-table`. This could be `OBS_TABLE_ROW`.


### Code Modifications in Gammapy
The first changes needed to support the format modification previously described are available in the pull request. Follow-up PRs could include : 

1. **Datastore Method Changes**:
   - Remove the `obs_id` argument from `datastore.get_observations`.
   - Implement all selections using a new method `datastore.select`.

2. **Stacking Entries**:
   - `datastore.get_observations` should stack entries with the same `IRF_name`.
   - Allow `obs.events` to be a list of event lists to avoid having everything in memory and to prevent repeating data reduction of the IRFs.

