### PR TITLE
Add examples and adapt references

### DIFF
--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -121,7 +121,7 @@ significance or p-value. To obtain the test statistic, call
 `~gammapy.modeling.Dataset.stat_sum` for the model corresponding to your two
 hypotheses (or take this value from the print output when running the fit), and
 take the difference. Note that in Gammapy, the fit statistic is defined as
-:math:`S = 2 * log(L)` for likelihood :math:`L`, such that :math:`TS = S_0 - S_1`. See
+:math:`S = - 2 * log(L)` for likelihood :math:`L`, such that :math:`TS = S_0 - S_1`. See
 :ref:`datasets` for an overview of fit statistics used.
 
 .. accordion-footer::

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -120,8 +120,8 @@ component, then use the test statistic values from both fits to compute the
 significance or p-value. To obtain the test statistic, call
 `~gammapy.modeling.Dataset.stat_sum` for the model corresponding to your two
 hypotheses (or take this value from the print output when running the fit), and
-take the difference. Note that in Gammapy, the fit statistic is defined as ``S =
-- 2 * log(L)`` for likelihood ``L``, such that ``TS = S_0 - S_1``. See
+take the difference. Note that in Gammapy, the fit statistic is defined as
+:math:`S = 2 * log(L)` for likelihood :math:`L`, such that :math:`TS = S_0 - S_1`. See
 :ref:`datasets` for an overview of fit statistics used.
 
 .. accordion-footer::
@@ -366,11 +366,10 @@ or
 To do a pulsar analysis, one must compute the pulsar phase of
 each event and put this new information in a new `~gammapy.data.Observation`.
 Computing pulsar phases can be done using an external library such as
-[PINT](https://nanograv-pint.readthedocs.io/en/latest/) or
-[Tempo2](https://www.pulsarastronomy.net/pulsar/software/tempo2). A
-[Gammapy Recipe](https://gammapy.github.io/gammapy-recipes/_build/html/index.html)
-showing how to use PINT within the Gammapy framework is available
-[here](https://gammapy.github.io/gammapy-recipes/_build/html/notebooks/pulsar_phase/pulsar_phase_computation.html).
+`PINT <https://nanograv-pint.readthedocs.io/en/latest/>`__ or
+`Tempo2 <https://www.pulsarastronomy.net/pulsar/software/tempo2>`__. A
+gammapy recipe showing how to use PINT within the Gammapy framework is available
+`here <https://gammapy.github.io/gammapy-recipes/_build/html/notebooks/pulsar_phase/pulsar_phase_computation.html>`__.
 For brevity, the code below shows how to add a dummy phase column to a new
 `~gammapy.data.EventList` and `~gammapy.data.Observation`.
 

--- a/gammapy/estimators/map/asmooth.py
+++ b/gammapy/estimators/map/asmooth.py
@@ -27,7 +27,7 @@ class ASmoothMapEstimator(Estimator):
 
     Achieves a roughly constant sqrt(TS) of features across the whole image.
 
-    Algorithm based on https://ui.adsabs.harvard.edu/abs/2006MNRAS.368...65E .
+    Algorithm based on [1]_.
 
     The algorithm was slightly adapted to also allow Li & Ma  to estimate the
     sqrt(TS) of a feature in the image.
@@ -60,6 +60,11 @@ class ASmoothMapEstimator(Estimator):
     >>> scales = u.Quantity(np.arange(0.1, 1, 0.1), unit="deg")
     >>> smooth = ASmoothMapEstimator(threshold=3, scales=scales, energy_edges=[1, 10] * u.TeV)
     >>> images = smooth.run(dataset)
+
+    References
+    ----------
+    .. [1] `Ebeling et al. (2006), "ASMOOTH: a simple and efficient algorithm for adaptive kernel smoothing of
+      two-dimensional imaging data" <https://ui.adsabs.harvard.edu/abs/2006MNRAS.368…65E>`_
     """
 
     tag = "ASmoothMapEstimator"

--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -113,12 +113,12 @@ class FluxMaps:
     It contains a set of `~gammapy.maps.Map` objects that store the estimated
     flux as a function of energy as well as associated quantities (typically
     errors, upper limits, delta TS and possibly raw quantities such counts,
-    excesses etc). It also contains a reference model to convert the flux
+    excesses etc.). It also contains a reference model to convert the flux
     values in different formats. Usually, this should be the model used to
     produce the flux map.
 
-    The associated map geometry can use a `RegionGeom` to store the equivalent
-    of flux points, or a `WcsGeom`/`HpxGeom` to store an energy dependent flux map.
+    The associated map geometry can use a `~gammapy.maps.RegionGeom` to store the equivalent
+    of flux points, or a `~gammapy.maps.WcsGeom`/`~gammapy.maps.HpxGeom` to store an energy dependent flux map.
 
     The container relies internally on the 'Likelihood' SED type defined in
     :ref:`gadf:flux-points` and offers convenience properties to convert to

--- a/gammapy/estimators/points/lightcurve.py
+++ b/gammapy/estimators/points/lightcurve.py
@@ -60,7 +60,7 @@ class LightCurveEstimator(FluxPointsEstimator):
         but rather the closest values to the energy axis edges of the parent dataset.
         Default is None: apply the estimator in each energy bin of the parent dataset.
         For further explanation see :ref:`estimators`.
-    fit : `Fit`
+    fit : `~gammapy.modeling.Fit`
         Fit instance specifying the backend and fit options.
     reoptimize : bool
         If True the free parameters of the other models are fitted in each bin independently,

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -187,14 +187,6 @@ def find_peaks_in_flux_map(maps, threshold, min_distance=1):
     >>> maps = estimator.run(dataset)
     >>> # Find the peaks which are above 5 sigma
     >>> sources = find_peaks_in_flux_map(maps, threshold=5, min_distance=0.1*u.deg)
-    >>> print(sources[:4])
-     x   y      ra       dec    ...   norm  norm_err     flux      flux_err
-               deg       deg    ...                  1 / (s cm2) 1 / (s cm2)
-    --- --- --------- --------- ... ------- -------- ----------- -----------
-    158 135 266.05019 -28.70181 ... 0.28551  0.06450   2.827e-12   6.385e-13
-     92 133 267.07022 -27.31834 ... 0.37058  0.08342   3.669e-12   8.259e-13
-    176 134 265.80492 -29.09805 ... 0.30561  0.06549   3.025e-12   6.484e-13
-    282 150 263.78083 -31.12704 ... 0.55027  0.12611   5.448e-12   1.249e-12
 
     """
     quantity_for_peaks = maps["sqrt_ts"]

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -857,16 +857,12 @@ def get_combined_significance_maps(estimator, datasets):
 
     Examples
     --------
-    >>> from gammapy.datasets import MapDataset
+    >>> from gammapy.datasets import Datasets
     >>> from gammapy.estimators import ExcessMapEstimator
     >>> from gammapy.estimators.utils import get_combined_significance_maps
-    >>> dataset1 = MapDataset.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
-    >>> dataset2 = dataset1.copy(name="copy")
-    >>> dataset2.counts *= 2
-    >>> dataset2.exposure *= 2
-    >>> dataset2.background *= 2
-    >>> estimator = ExcessMapEstimator(correlation_radius="0.1 deg")
-    >>> combined = get_combined_significance_maps(estimator, [dataset1, dataset2])
+    >>> datasets = Datasets.read("$GAMMAPY_DATA/hawc/DL4/HAWC_pass4_public_Crab.yaml")
+    >>> estimator = ExcessMapEstimator(correlation_radius="0.2 deg")
+    >>> combined = get_combined_significance_maps(estimator, datasets)
 
     References
     ----------
@@ -1080,16 +1076,12 @@ def get_combined_flux_maps(
 
     Examples
     --------
-    >>> from gammapy.datasets import MapDataset
-    >>> from gammapy.estimators import ExcessMapEstimator
+    >>> from gammapy.datasets import Datasets
+    >>> from gammapy.estimators import TSMapEstimator
     >>> from gammapy.estimators.utils import get_combined_flux_maps
-    >>> dataset1 = MapDataset.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
-    >>> dataset2 = dataset1.copy(name="copy")
-    >>> dataset2.counts *= 2
-    >>> dataset2.exposure *= 2
-    >>> dataset2.background *= 2
-    >>> estimator = ExcessMapEstimator(correlation_radius="0.1 deg")
-    >>> combined = get_combined_flux_maps(estimator, [dataset1, dataset2])
+    >>> datasets = Datasets.read("$GAMMAPY_DATA/hawc/DL4/HAWC_pass4_public_Crab.yaml")
+    >>> estimator = TSMapEstimator()
+    >>> combined = get_combined_flux_maps(estimator, datasets)
 
     See also
     --------

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -97,17 +97,7 @@ def find_peaks(image, threshold, min_distance=1):
     >>> maps = estimator.run(dataset)
     >>> # Find the peaks which are above 5 sigma
     >>> sources = find_peaks(maps["sqrt_ts"], threshold=5, min_distance="0.25 deg")
-    >>> print(sources)
-    value   x   y      ra       dec
-                      deg       deg
-    ------ --- --- --------- ---------
-    32.191 161 118 266.41924 -28.98772
-      18.7 125 124 266.80571 -28.14079
-    9.4498 257 122 264.86178 -30.97529
-    9.3784 204 103 266.14201 -30.10041
-    5.3493 282 150 263.78083 -31.12704
     """
-    # Input validation
 
     if not isinstance(image, WcsNDMap):
         raise TypeError("find_peaks only supports WcsNDMap")


### PR DESCRIPTION
As in title, but with a query:

In `estimators.utils.py` -- do we really want to print the sources?
I think this is difficult to keep track of, as things tend to change such as formatting and we have to keep updating the output.  It is easy for the user to see the example and use it themselves.