### PR TITLE
Fix unknown arguments defined in Models

### DIFF
--- a/examples/models/spectral/plot_gauss_spectral.py
+++ b/examples/models/spectral/plot_gauss_spectral.py
@@ -23,7 +23,9 @@ import matplotlib.pyplot as plt
 from gammapy.modeling.models import GaussianSpectralModel, Models, SkyModel
 
 energy_bounds = [0.1, 100] * u.TeV
-model = GaussianSpectralModel(norm="1e-2 cm-2 s-1", mean=2 * u.TeV, sigma=0.2 * u.TeV)
+model = GaussianSpectralModel(
+    amplitude="1e-2 cm-2 s-1", mean=2 * u.TeV, sigma=0.2 * u.TeV
+)
 model.plot(energy_bounds)
 plt.grid(which="both")
 plt.ylim(1e-24, 1e-1)

--- a/examples/models/temporal/plot_constant_temporal.py
+++ b/examples/models/temporal/plot_constant_temporal.py
@@ -26,7 +26,7 @@ from gammapy.modeling.models import (
 )
 
 time_range = [Time.now(), Time.now() + 1 * u.d]
-constant_model = ConstantTemporalModel(const=1)
+constant_model = ConstantTemporalModel()
 constant_model.plot(time_range)
 plt.grid(which="both")
 

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -135,7 +135,7 @@ class ModelBase:
         default_parameters = self.default_parameters.copy()
 
         for key in kwargs.keys():
-            if key not in default_parameters.names:
+            if key != "covariance_data" and key not in default_parameters.names :
                 raise NameError(f"Unknown Parameter name '{key}'")
 
         for par in default_parameters:

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -134,6 +134,10 @@ class ModelBase:
         # Copy default parameters from the class to the instance
         default_parameters = self.default_parameters.copy()
 
+        for key in kwargs.keys():
+            if key not in default_parameters.names:
+                raise NameError(f"Unknown Parameter name '{key}'")
+
         for par in default_parameters:
             value = kwargs.get(par.name, par)
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1693,18 +1693,6 @@ class LogParabolaNormSpectralModel(SpectralModel):
     alpha = Parameter("alpha", 0)
     beta = Parameter("beta", 0)
 
-    def __init__(self, norm=None, reference=None, alpha=None, beta=None, **kwargs):
-        if norm is not None:
-            kwargs.update({"norm": norm})
-        if beta is not None:
-            kwargs.update({"beta": beta})
-        if reference is not None:
-            kwargs.update({"reference": reference})
-        if alpha is not None:
-            kwargs.update({"alpha": alpha})
-
-        super().__init__(**kwargs)
-
     @classmethod
     def from_log10(cls, norm, reference, alpha, beta):
         """Construct from :math:`log_{10}` parametrization."""

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -255,8 +255,6 @@ class ConstantTemporalModel(TemporalModel):
 
     tag = ["ConstantTemporalModel", "const"]
 
-    const = Parameter("const", "1")
-
     @staticmethod
     def evaluate(time):
         """Evaluate at given times."""

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -254,14 +254,11 @@ class ConstantTemporalModel(TemporalModel):
     """
 
     tag = ["ConstantTemporalModel", "const"]
-    const = Parameter("const", "1")
-
-    const = Parameter("const", "1")
 
     @staticmethod
-    def evaluate(time, const):
+    def evaluate(time):
         """Evaluate at given times."""
-        return const * np.ones(time.shape) * u.one
+        return np.ones(time.shape) * u.one
 
     def integral(self, t_min, t_max):
         """Evaluate the integrated flux within the given time intervals.
@@ -278,9 +275,7 @@ class ConstantTemporalModel(TemporalModel):
         norm : `~astropy.units.Quantity`
             Integrated flux norm on the given time intervals.
         """
-        pars = self.parameters
-        const = pars["const"]
-        return const * (t_max - t_min) / self.time_sum(t_min, t_max)
+        return (t_max - t_min) / self.time_sum(t_min, t_max)
 
 
 class LinearTemporalModel(TemporalModel):

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -256,6 +256,8 @@ class ConstantTemporalModel(TemporalModel):
     tag = ["ConstantTemporalModel", "const"]
     const = Parameter("const", "1")
 
+    const = Parameter("const", "1")
+
     @staticmethod
     def evaluate(time, const):
         """Evaluate at given times."""

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -255,6 +255,8 @@ class ConstantTemporalModel(TemporalModel):
 
     tag = ["ConstantTemporalModel", "const"]
 
+    const = Parameter("const", "1")
+
     @staticmethod
     def evaluate(time):
         """Evaluate at given times."""

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -276,7 +276,9 @@ class ConstantTemporalModel(TemporalModel):
         norm : `~astropy.units.Quantity`
             Integrated flux norm on the given time intervals.
         """
-        return (t_max - t_min) / self.time_sum(t_min, t_max)
+        pars = self.parameters
+        const = pars["const"]
+        return const * (t_max - t_min) / self.time_sum(t_min, t_max)
 
 
 class LinearTemporalModel(TemporalModel):

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -254,11 +254,12 @@ class ConstantTemporalModel(TemporalModel):
     """
 
     tag = ["ConstantTemporalModel", "const"]
+    const = Parameter("const", "1")
 
     @staticmethod
-    def evaluate(time):
+    def evaluate(time, const):
         """Evaluate at given times."""
-        return np.ones(time.shape) * u.one
+        return const * np.ones(time.shape) * u.one
 
     def integral(self, t_min, t_max):
         """Evaluate the integrated flux within the given time intervals.

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -754,7 +754,9 @@ def test_sky_model_create():
 
 
 def test_integrate_geom():
-    model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1 * u.deg, frame="icrs")
+    model = GaussianSpatialModel(
+        lon_0="0d", lat_0="0d", sigma=0.1 * u.deg, frame="icrs"
+    )
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     sky_model = SkyModel(spectral_model=spectral_model, spatial_model=model)
 
@@ -771,7 +773,9 @@ def test_integrate_geom():
 
 
 def test_evaluate_integrate_nd_geom():
-    model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1 * u.deg, frame="icrs")
+    model = GaussianSpatialModel(
+        lon_0="0d", lat_0="0d", sigma=0.1 * u.deg, frame="icrs"
+    )
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     sky_model = SkyModel(spectral_model=spectral_model, spatial_model=model)
 
@@ -816,7 +820,7 @@ def test_evaluate_integrate_nd_geom():
 
 def test_evaluate_integrate_geom_with_time():
     spatial_model = GaussianSpatialModel(
-        lon="0d", lat="0d", sigma=0.1 * u.deg, frame="icrs"
+        lon_0="0d", lat_0="0d", sigma=0.1 * u.deg, frame="icrs"
     )
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     temporal_model = PowerLawTemporalModel()
@@ -891,7 +895,7 @@ def test_evaluate_integrate_geom_with_time():
 
 def test_evaluate_integrate_geom_with_time_and_gti():
     spatial_model = GaussianSpatialModel(
-        lon="0d", lat="0d", sigma=0.1 * u.deg, frame="icrs"
+        lon_0="0d", lat_0="0d", sigma=0.1 * u.deg, frame="icrs"
     )
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     temporal_model = PowerLawTemporalModel()

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -755,7 +755,7 @@ def test_sky_model_create():
 
 def test_integrate_geom():
     model = GaussianSpatialModel(
-        lon_0="0d", lat_0="0d", sigma=0.1 * u.deg, frame="icrs"
+        lon_0="0 deg", lat_0="0 deg", sigma=0.1 * u.deg, frame="icrs"
     )
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     sky_model = SkyModel(spectral_model=spectral_model, spatial_model=model)
@@ -774,7 +774,7 @@ def test_integrate_geom():
 
 def test_evaluate_integrate_nd_geom():
     model = GaussianSpatialModel(
-        lon_0="0d", lat_0="0d", sigma=0.1 * u.deg, frame="icrs"
+        lon_0="0 deg", lat_0="0 deg", sigma=0.1 * u.deg, frame="icrs"
     )
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     sky_model = SkyModel(spectral_model=spectral_model, spatial_model=model)
@@ -820,7 +820,7 @@ def test_evaluate_integrate_nd_geom():
 
 def test_evaluate_integrate_geom_with_time():
     spatial_model = GaussianSpatialModel(
-        lon_0="0d", lat_0="0d", sigma=0.1 * u.deg, frame="icrs"
+        lon_0="0 deg", lat_0="0 deg", sigma=0.1 * u.deg, frame="icrs"
     )
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     temporal_model = PowerLawTemporalModel()
@@ -895,7 +895,7 @@ def test_evaluate_integrate_geom_with_time():
 
 def test_evaluate_integrate_geom_with_time_and_gti():
     spatial_model = GaussianSpatialModel(
-        lon_0="0d", lat_0="0d", sigma=0.1 * u.deg, frame="icrs"
+        lon_0="0 deg", lat_0="0 deg", sigma=0.1 * u.deg, frame="icrs"
     )
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
     temporal_model = PowerLawTemporalModel()

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -572,7 +572,7 @@ models_test = [
 
 @pytest.mark.parametrize(("model_class", "extension_param"), models_test)
 def test_spatial_model_plot_error(model_class, extension_param):
-    model = model_class(lon="0d", lat="0d", sigma=0.2 * u.deg, frame="galactic")
+    model = model_class(lon_0="0d", lat_0="0d", sigma=0.2 * u.deg, frame="galactic")
     model.lat_0.error = 0.04
     model.lon_0.error = 0.02
     model.parameters[extension_param].error = 0.04
@@ -664,7 +664,9 @@ def test_integrate_geom_parameter_issue():
 
 def test_integrate_geom_energy_axis():
     center = SkyCoord("0d", "0d", frame="icrs")
-    model = GaussianSpatialModel(lon="0d", lat="0d", sigma=0.1 * u.deg, frame="icrs")
+    model = GaussianSpatialModel(
+        lon_0="0d", lat_0="0d", sigma=0.1 * u.deg, frame="icrs"
+    )
 
     radius = 1 * u.deg
     square = RectangleSkyRegion(center, radius, radius)

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -572,9 +572,10 @@ models_test = [
 
 @pytest.mark.parametrize(("model_class", "extension_param"), models_test)
 def test_spatial_model_plot_error(model_class, extension_param):
-    model = model_class(lon_0="0d", lat_0="0d", sigma=0.2 * u.deg, frame="galactic")
+    model = model_class(lon_0="0 deg", lat_0="0 deg", frame="galactic")
     model.lat_0.error = 0.04
     model.lon_0.error = 0.02
+    model.parameters[extension_param].value = 0.2
     model.parameters[extension_param].error = 0.04
     model.e.error = 0.002
 
@@ -665,7 +666,7 @@ def test_integrate_geom_parameter_issue():
 def test_integrate_geom_energy_axis():
     center = SkyCoord("0d", "0d", frame="icrs")
     model = GaussianSpatialModel(
-        lon_0="0d", lat_0="0d", sigma=0.1 * u.deg, frame="icrs"
+        lon_0="0 deg", lat_0="0 deg", sigma=0.1 * u.deg, frame="icrs"
     )
 
     radius = 1 * u.deg

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -1303,3 +1303,8 @@ def test_template_ND_EBL(tmpdir):
     assert_allclose(template_new.map.data, region_map.data)
     assert len(template.parameters) == 1
     assert_allclose(template.parameters["redshift"].value, 0.1)
+
+
+def test_incorrect_param_name():
+    with pytest.raises(NameError):
+        PowerLawSpectralModel(indxe=2)

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -387,7 +387,7 @@ def test_with_skymodel(light_curve):
 
 def test_plot_constant_model():
     time_range = [Time.now(), Time.now() + 1 * u.d]
-    constant_model = ConstantTemporalModel(const=1)
+    constant_model = ConstantTemporalModel()
     with mpl_plot_check():
         constant_model.plot(time_range)
 

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -387,7 +387,7 @@ def test_with_skymodel(light_curve):
 
 def test_plot_constant_model():
     time_range = [Time.now(), Time.now() + 1 * u.d]
-    constant_model = ConstantTemporalModel()
+    constant_model = ConstantTemporalModel(const=1)
     with mpl_plot_check():
         constant_model.plot(time_range)
 


### PR DESCRIPTION
This fixes #5413

Currently a test fails `gammapy/modeling/models/tests/test_io.py` but I am not sure how to fix that 


`SpectralModels`:
- `ExpCutoffPowerLawNormSpectralModel` requires the kwargs on super because we have the deprecation there
- super init is required on the `EBLAbsorptionNormSpectralModel` -- because it needs to be able to 'read_builtin' --> this should be fine like this because we do not define a kwargs
- all other inits are empty 

SpatialModels:
- `TemplateSpatialModel` has the kwargs in super init (not sure it can be removed?)
- `PiecewiseNormSpatialModel` same as above?