### PR TITLE
Adapt write functionality of Template models

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1493,30 +1493,30 @@ class TemplateSpatialModel(SpatialModel):
         return cls(m, normalize=normalize, filename=filename, **kwargs)
 
     def to_dict(self, full_output=False):
-        """Create dictionary for YAML serilisation."""
+        """Create dictionary for YAML serialisation."""
         data = super().to_dict(full_output)
         data["spatial"]["filename"] = self.filename
         data["spatial"]["normalize"] = self.normalize
         data["spatial"]["unit"] = str(self.map.unit)
         return data
 
-    def write(self, overwrite=False, filename=None):
+    def write(self, filename=None, overwrite=False):
         """
         Write the map.
 
         Parameters
         ----------
-        overwrite: bool, optional
-            Overwrite existing file.
-            Default is False, which will raise a warning if the template file exists already.
-        filename: str, optional
+        filename : str, optional
             Filename of the template model. By default, the template model
             will be saved with the `TemplateSpatialModel.filename` attribute,
             if `filename` is provided this attribute will be updated.
+        overwrite : bool, optional
+            Overwrite existing file.
+            Default is False, which will raise a warning if the template file exists already.
         """
-        if filename is not None:
+        if filename:
             self.filename = filename
-        if self.filename is None:
+        elif not hasattr(self, "filename") or self.filename is None:
             raise IOError("Missing filename")
         if os.path.isfile(make_path(self.filename)) and not overwrite:
             log.warning("Template file already exits, and overwrite is False")
@@ -1629,22 +1629,28 @@ class TemplateNDSpatialModel(SpatialModel):
 
         return u.Quantity(val, self.map.unit, copy=COPY_IF_NEEDED)
 
-    def write(self, overwrite=False):
+    def write(self, filename=None, overwrite=False):
         """
         Write the map.
 
         Parameters
         ----------
-        overwrite: bool, optional
+        filename : str, optional
+            Filename of the template model. By default, the template model
+            will be saved with the `TemplateNDSpatialModel.filename` attribute,
+            if `filename` is provided this attribute will be updated.
+        overwrite : bool, optional
             Overwrite existing file.
             Default is False, which will raise a warning if the template file exists already.
         """
-        if self.filename is None:
+        if filename:
+            self.filename = filename
+        elif not hasattr(self, "filename") or self.filename is None:
             raise IOError("Missing filename")
-        elif os.path.isfile(self.filename) and not overwrite:
+        if os.path.isfile(make_path(self.filename)) and not overwrite:
             log.warning("Template file already exits, and overwrite is False")
         else:
-            self.map.write(self.filename)
+            self.map.write(self.filename, overwrite=overwrite)
 
     @classmethod
     def from_dict(cls, data):

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1916,22 +1916,28 @@ class TemplateNDSpectralModel(SpectralModel):
         val = self.map.interp_by_pix(pixels, **self._interp_kwargs)
         return u.Quantity(val, self.map.unit, copy=COPY_IF_NEEDED)
 
-    def write(self, overwrite=False):
+    def write(self, filename=None, overwrite=False):
         """
         Write the map.
 
         Parameters
         ----------
-        overwrite: bool, optional
+        filename : str, optional
+            Filename of the template model. By default, the template model
+            will be saved with the `TemplateNDSpectralModel.filename` attribute,
+            if `filename` is provided this attribute will be updated.
+        overwrite : bool, optional
             Overwrite existing file.
             Default is False, which will raise a warning if the template file exists already.
         """
-        if self.filename is None:
+        if filename:
+            self.filename = filename
+        elif not hasattr(self, "filename") or self.filename is None:
             raise IOError("Missing filename")
-        elif os.path.isfile(self.filename) and not overwrite:
+        if os.path.isfile(make_path(self.filename)) and not overwrite:
             log.warning("Template file already exits, and overwrite is False")
         else:
-            self.map.write(self.filename)
+            self.map.write(self.filename, overwrite=overwrite)
 
     @classmethod
     def from_dict(cls, data, **kwargs):

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -676,22 +676,26 @@ class LightCurveTemplateTemporalModel(TemporalModel):
         )
         return table
 
-    def write(self, filename, format="table", overwrite=False):
+    def write(self, filename=None, format="table", overwrite=False):
         """Write a model to disk as per the specified format.
 
-        Parameters:
-            filename : str
-                Name of output file.
-            format : {"table" or "map"}
-                If format is "table", it is serialised as a `~astropy.table.Table`.
-                If "map", then it is serialised as a `~gammapy.maps.RegionNDMap`.
-                Default is "table".
-            overwrite : bool, optional
-                Overwrite existing file. Default is False.
+        Parameters
+        ----------
+        filename : str, optional
+            Filename of the template model. By default, the template model
+            will be saved with the `LightCurveTemplateTemporalModel.filename` attribute,
+            if `filename` is provided this attribute will be updated.
+        format : {"table" or "map"}
+            If format is "table", it is serialised as a `~astropy.table.Table`.
+            If "map", then it is serialised as a `~gammapy.maps.RegionNDMap`.
+            Default is "table".
+        overwrite : bool, optional
+            Overwrite existing file. Default is False.
         """
-        if self.filename is None:
+        if filename:
+            self.filename = filename
+        elif not hasattr(self, "filename") or self.filename is None:
             raise IOError("Missing filename")
-
         if format == "table":
             table = self.to_table()
             table.write(filename, overwrite=overwrite)


### PR DESCRIPTION
This resolves #5695 

It changes the template models such that a filename is always required as some point of the process, either on initiation or at the write level.


If the filename in the write function is defined, then it will take that.
Otherwise if filename is defined previously (in the initiation of the class), then it will take that as the filename.
Finally is filename is None then we need to say it is missing