### PR TITLE
fix: install sherpa using conda instead of pip in dev env

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,6 +9,7 @@ name: gammapy-dev
 
 channels:
   - conda-forge
+  - https://cxc.cfa.harvard.edu/conda/sherpa # c.f. https://sherpa.readthedocs.io/en/latest/install.html
 
 variables:
   PYTHONNOUSERSITE: "1"
@@ -59,6 +60,7 @@ dependencies:
   - pydocstyle
   - pylint
   - setuptools_scm
+  - sherpa>=4.17
   - sphinx
   - sphinx-astropy
   - sphinx-click
@@ -79,7 +81,6 @@ dependencies:
   - pyinstrument
   - memray
   - pip:
-      - sherpa>=4.17
       - pytest-sphinx
       - ray[default]>=2.9
       - PyGithub


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**

Creating the Gammapy dev environment was failing due to sherpa package installed using pip. 

Following: https://sherpa.readthedocs.io/en/latest/install.html, I moved the sherpa dependency in the conda channel.

Closes #5730


<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

**Dear reviewer**

Maybe there is a good reason to install sherpa using pip instead of conda 'm not aware of.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
