### PR TITLE
Fix `e_peak` implementation of `SuperExpCutoffPowerLaw4FGLDR3SpectralModel`

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1619,7 +1619,12 @@ class SuperExpCutoffPowerLaw4FGLDR3SpectralModel(SpectralModel):
         index_1 = self.index_1.quantity
         index_2 = self.index_2.quantity
         expfactor = self.expfactor.quantity
-        if ((index_1 > 2) and (index_2 > 0)) or (expfactor <= 0) or (index_2 <= 0):
+        index_0 = index_1 - expfactor / index_2
+        if (
+            ((index_2 < 0) and (index_0 < 2))
+            or (expfactor <= 0)
+            or ((index_2 > 0) and (index_0 >= 2))
+        ):
             return np.nan * reference.unit
         return reference * (1 + (index_2 / expfactor) * (2 - index_1)) ** (1 / index_2)
 

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -1309,3 +1309,20 @@ def test_template_ND_EBL(tmpdir):
 def test_incorrect_param_name():
     with pytest.raises(NameError):
         PowerLawSpectralModel(indxe=2)
+
+
+def test_e_peak_super_4FGLDR3():
+    model = SuperExpCutoffPowerLaw4FGLDR3SpectralModel()
+    assert_quantity_allclose(model.e_peak, TEST_MODELS[9]["e_peak"], rtol=1e-2)
+
+    model.index_1.value = 3
+    model.index_2.value = 0.5
+    model.expfactor.value = 0.5
+    assert_quantity_allclose(model.e_peak, np.nan * u.TeV)
+
+    model.index_2.value = 2
+    model.expfactor.value = -1
+    assert_quantity_allclose(model.e_peak, np.nan * u.TeV)
+
+    model.index_2.value = -1
+    assert_quantity_allclose(model.e_peak, np.nan * u.TeV)


### PR DESCRIPTION
My former implementation (#5694) of the energy at the peak of the SED in the `SuperExpCutoffPowerLaw4FGLDR3SpectralModel` is wrong. 
I corrected it according to  https://iopscience.iop.org/article/10.3847/1538-4357/acee67 Eq. 21. 
@AtreyeeS, I think that you mentioned this in the former PR, but I didn't got it at the time.
I also added more test accordingly which I think cover most cases.