### PR TITLE
3PC pulse profile

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1665,7 +1665,6 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
 
         Returns
         -------
-
         best_fit_profile: `~gammapy.maps.RegionNDMap`
             Map containing the best fit.
         """

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1671,7 +1671,7 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         """
         table = Table.read(self._auxiliary_filename, hdu=2)
 
-        # For radio pulse profile, Ph_min and Ph_max are the equal and are bin center.
+        # For best-fit profile, Ph_min and Ph_max are equal and represent bin centers.
         phases = MapAxis.from_nodes(table["Ph_Min"], name="phase", interp="lin")
         profile_map = RegionNDMap.create(
             region=None, axes=[phases], data=table["Intensity"]
@@ -1694,7 +1694,7 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         except ValueError:
             raise ValueError(f"Radio profile is not available for pulsar {self.name}.")
 
-        # For radio pulse profile, Ph_min and Ph_max are the equal and are bin center.
+        # For radio pulse profile, Ph_min and Ph_max are equal and represent bin centers.
         phases = MapAxis.from_nodes(table["Ph_Min"], name="phase", interp="lin")
         profile_map = RegionNDMap.create(
             region=None, axes=[phases], data=table["Norm_Intensity"]

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1691,11 +1691,13 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         """
         table = Table.read(self._auxiliary_filename, hdu="RADIO_PROFILE")
 
+        # Need to do this because some PSR (J0540-6919) has duplicates
+        ph_node, unique_idx = np.unique(table["Ph_Min"], return_index=True)
+        data = table["Norm_Intensity"][unique_idx]
+
         # For radio pulse profile, Ph_min and Ph_max are equal and represent bin centers.
-        phases = MapAxis.from_nodes(table["Ph_Min"], name="phase", interp="lin")
-        profile_map = RegionNDMap.create(
-            region=None, axes=[phases], data=table["Norm_Intensity"]
-        )
+        phases = MapAxis.from_nodes(ph_node, name="phase", interp="lin")
+        profile_map = RegionNDMap.create(region=None, axes=[phases], data=data)
         return profile_map
 
     @property

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1720,7 +1720,6 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
 
         Returns
         -------
-
         map_dict: dict of `~gammapy.maps.RegionNDMap`
             Dictionary of map containing the pulse profile in different energy bin.
         """

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1707,13 +1707,14 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         These profiles are stored in a dictionary of `~gammapy.maps.RegionNDMap` objects, one per energy bin.
 
         The dictionary keys correspond to specific energy ranges as follows:
-            * `GT100_WtCnt`: > 0.1 GeV
-            * `50_100_WtCt`: 0.05 – 0.1 GeV
-            * `100_300_WtCt`: 0.1 – 0.3 GeV
-            * `300_1000_WtCt`: 0.3 – 1 GeV
-            * `1000_3000_WtCt`: 1 – 3 GeV
-            * `3000_100000_WtCt`: 3 – 1000 GeV
-            * `10000_100000_WtCt`: 10 – 1000 GeV
+
+        - `GT100_WtCnt`: > 0.1 GeV
+        - `50_100_WtCt`: 0.05 – 0.1 GeV
+        - `100_300_WtCt`: 0.1 – 0.3 GeV
+        - `300_1000_WtCt`: 0.3 – 1 GeV
+        - `1000_3000_WtCt`: 1 – 3 GeV
+        - `3000_100000_WtCt`: 3 – 1000 GeV
+        - `10000_100000_WtCt`: 10 – 1000 GeV
 
         Each pulse profile has an associated uncertainty map, which can be accessed by
         prepending `"Unc_"` to the corresponding key in the dictionary.

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1674,7 +1674,7 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         # For radio pulse profile, Ph_min and Ph_max are the equal and are bin center.
         phases = MapAxis.from_nodes(table["Ph_Min"], name="phase", interp="lin")
         profile_map = RegionNDMap.create(
-            region=None, axes=[phases], data=table["Norm_Intensity"]
+            region=None, axes=[phases], data=table["Intensity"]
         )
         return profile_map
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1666,17 +1666,17 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         Returns
         -------
 
-        best_fit: `~gammapy.maps.RegionNDMap`
+        best_fit_profile: `~gammapy.maps.RegionNDMap`
             Map containing the best fit.
         """
         table = Table.read(self._auxiliary_filename, hdu="BEST_FIT_LC")
 
         # For best-fit profile, Ph_min and Ph_max are equal and represent bin centers.
         phases = MapAxis.from_nodes(table["Ph_Min"], name="phase", interp="lin")
-        profile_map = RegionNDMap.create(
+        best_fit_profile = RegionNDMap.create(
             region=None, axes=[phases], data=table["Intensity"]
         )
-        return profile_map
+        return best_fit_profile
 
     @property
     def pulse_profile_radio(self):
@@ -1697,8 +1697,8 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
 
         # For radio pulse profile, Ph_min and Ph_max are equal and represent bin centers.
         phases = MapAxis.from_nodes(ph_node, name="phase", interp="lin")
-        profile_map = RegionNDMap.create(region=None, axes=[phases], data=data)
-        return profile_map
+        radio_profile = RegionNDMap.create(region=None, axes=[phases], data=data)
+        return radio_profile
 
     @property
     def pulse_profiles(self):
@@ -1721,7 +1721,7 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         Returns
         -------
 
-        dict_map: dict of `~gammapy.maps.RegionNDMap`
+        map_dict: dict of `~gammapy.maps.RegionNDMap`
             Dictionary of map containing the pulse profile in different energy bin.
         """
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1703,9 +1703,9 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
     def pulse_profiles(self):
         """
         The 3PC pulse profiles are provided in different energy ranges, each represented in weighted counts.
-        These profiles are stored in a dictionary of `~gammapy.maps.RegionNDMap` objects, one per energy bin.
+        These profiles are stored in a `~gammapy.maps.Maps` of `~gammapy.maps.RegionNDMap`, one per energy bin.
 
-        The dictionary keys correspond to specific energy ranges as follows:
+        The `~gammapy.maps.Maps` keys correspond to specific energy ranges as follows:
 
         - `GT100_WtCnt`: > 0.1 GeV
         - `50_100_WtCt`: 0.05 – 0.1 GeV
@@ -1716,11 +1716,11 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         - `10000_100000_WtCt`: 10 – 1000 GeV
 
         Each pulse profile has an associated uncertainty map, which can be accessed by
-        prepending `"Unc_"` to the corresponding key in the dictionary.
+        prepending `"Unc_"` to the corresponding key.
 
         Returns
         -------
-        maps: dict of `~gammapy.maps.Maps`
+        maps: `~gammapy.maps.Maps`
             Maps containing the pulse profile in the different energy bin.
         """
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1669,7 +1669,7 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         best_fit: `~gammapy.maps.RegionNDMap`
             Map containing the best fit.
         """
-        table = Table.read(self._auxiliary_filename, hdu=2)
+        table = Table.read(self._auxiliary_filename, hdu="BEST_FIT_LC")
 
         # For best-fit profile, Ph_min and Ph_max are equal and represent bin centers.
         phases = MapAxis.from_nodes(table["Ph_Min"], name="phase", interp="lin")
@@ -1690,7 +1690,7 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
             Map containing the radio profile.
         """
         try:
-            table = Table.read(self._auxiliary_filename, hdu=3)
+            table = Table.read(self._auxiliary_filename, hdu="RADIO_PROFILE")
         except ValueError:
             raise ValueError(f"Radio profile is not available for pulsar {self.name}.")
 
@@ -1726,7 +1726,7 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
             Dictionary of map containing the pulse profile in different energy bin.
         """
 
-        table = Table.read(self._auxiliary_filename, hdu=1)
+        table = Table.read(self._auxiliary_filename, hdu="GAMMA_LC")
         phases = MapAxis.from_edges(
             np.unique(np.concatenate([table["Ph_Min"], table["Ph_Max"]])),
             name="phase",

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1689,10 +1689,7 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         radio_profile: `~gammapy.maps.RegionNDMap`
             Map containing the radio profile.
         """
-        try:
-            table = Table.read(self._auxiliary_filename, hdu="RADIO_PROFILE")
-        except ValueError:
-            raise ValueError(f"Radio profile is not available for pulsar {self.name}.")
+        table = Table.read(self._auxiliary_filename, hdu="RADIO_PROFILE")
 
         # For radio pulse profile, Ph_min and Ph_max are equal and represent bin centers.
         phases = MapAxis.from_nodes(table["Ph_Min"], name="phase", interp="lin")

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1708,9 +1708,9 @@ class SourceCatalogObject3PC(SourceCatalogObjectFermiPCBase):
         These profiles are stored in a dictionary of `~gammapy.maps.RegionNDMap` objects, one per energy bin.
 
         The dictionary keys correspond to specific energy ranges as follows:
-            * `GT100_WtCnt`: > 0.1 MeV
-            * `50_100_WtCt`: 0.05 – 0.1 MeV
-            * `100_300_WtCt`: 0.1 – 0.3 MeV
+            * `GT100_WtCnt`: > 0.1 GeV
+            * `50_100_WtCt`: 0.05 – 0.1 GeV
+            * `100_300_WtCt`: 0.1 – 0.3 GeV
             * `300_1000_WtCt`: 0.3 – 1 GeV
             * `1000_3000_WtCt`: 1 – 3 GeV
             * `3000_100000_WtCt`: 3 – 1000 GeV

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -29,6 +29,7 @@ from gammapy.utils.testing import (
     modify_unit_order_astropy_5_3,
     requires_data,
 )
+from gammapy.maps import RegionNDMap
 
 SOURCES_2PC = [
     dict(
@@ -895,12 +896,26 @@ class TestFermi3PCObject:
         desired = [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 5.146455e-08]
         assert_allclose(flux_points.flux_ul.data.flat, desired, rtol=1e-5)
 
-    @pytest.mark.xfail
-    def test_lightcurve(self, ref=SOURCES_3PC_NONE[0]):
-        # TODO: add lightcurve test when lightcurve is introduce to the class.
-        lightcurve = self.cat[ref["idx"]].lightcurve
+    def test_pulse_profile(self, ref=SOURCES_3PC[1]):
+        profiles = self.cat[ref["idx"]].pulse_profiles
+        assert len(profiles) == 14
+        assert list(profiles.keys())[0] == "GT100_WtCnt"
+        assert isinstance(profiles["3000_100000_WtCt"], RegionNDMap)
 
-        assert lightcurve is not None
+        assert_allclose(profiles["300_1000_WtCt"].data[45], 32.64874, rtol=1e-4)
+
+    def test_pulse_radio(self, ref=SOURCES_3PC[0]):
+        profile = self.cat[ref["idx"]].pulse_profile_radio
+        assert isinstance(profile, RegionNDMap)
+        assert_allclose(profile.data[10], 1287.9535, rtol=1e-3)
+
+        with pytest.raises(ValueError):
+            self.cat["J1826-1256"].pulse_profile_radio
+
+    def test_best_fit(self, ref=SOURCES_3PC[1]):
+        profile = self.cat[ref["idx"]].pulse_profile_best_fit
+        assert isinstance(profile, RegionNDMap)
+        assert_allclose(profile.data[67], 69.34279, rtol=1e-4)
 
 
 @requires_data()

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -909,7 +909,7 @@ class TestFermi3PCObject:
         assert isinstance(profile, RegionNDMap)
         assert_allclose(profile.data[10], 1287.9535, rtol=1e-3)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(KeyError):
             self.cat["J1826-1256"].pulse_profile_radio
 
     def test_best_fit(self, ref=SOURCES_3PC[1]):


### PR DESCRIPTION
I added pulse profiles, which were missing from the 3PC implementation (#5058). 
3PC pulse profile are given in different energy bins, namely:
- \> 0.1 GeV
- 0.05 - 0.1 GeV
- 0.1 - 0.3 GeV
- 0.3 - 1 GeV
- 1 - 3 GeV
- 3 - 1000 GeV
- 10 - 1000 GeV

For this reason I could not bundle everything in one `RegionNDMap`. Therefore I created a dict for each of the above energy bins and an associated map. The keys of the dict are the same as in the 3PC auxiliary file. 
The radio profile and the best fit are simply `RegionNDMap`. For some pulsar, there is no radio emission (Radio-Quiet pulsar), therefore the property raise a `ValueError`. Is this exception good enough or do we prefer a simple warning ? Or a custom Exception ?

Each of the 3 table of the auxiliary file contains metadata such as follow:
```python
OrderedDict([('EXTNAME', 'RADIO_PROFILE'),
             ('LCFREQ', 1400.0),
             ('TELESCOP', 'JBO'),
             ('CHECKSUM', '8F59A9562C568956'),
             ('DATASUM', '3511893980')])
``` 
for Radio 
Or
```python
OrderedDict([('EXTNAME', 'GAMMA_LC'),
             ('TELESCOP', 'Fermi'),
             ('INSTRUME', 'LAT'),
             ('CHECKSUM', '4fQO6ZPL4fPL4ZPL'),
             ('DATASUM', '3858353760')])
```
for LAT pulse profile.

Should this go somewhere ? I think it is especially useful for Radio as it gives the frequency and telescope.