### PR TITLE
Added spatial model to FoVBackgroundMaker init

### DIFF
--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -39,7 +39,7 @@ class FoVBackgroundMaker(Maker):
         none is defined on the dataset. By default, use pl-norm.
     spatial_model : SpatialModel or str
         Spatial model to use for the `FoVBackgroundModel`, if
-        none is defined on the dataset. By default, use none.
+        none is defined on the dataset. By default, use None.
         The unit of the spatial model is dropped.
     min_counts : int
         Minimum number of counts, or residuals counts if a SkyModel is set,

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -37,6 +37,9 @@ class FoVBackgroundMaker(Maker):
     spectral_model : SpectralModel or str
         Reference norm spectral model to use for the `FoVBackgroundModel`, if
         none is defined on the dataset. By default, use pl-norm.
+    spatial_model : SpatialModel or str
+        Spatial model to use for the `FoVBackgroundModel`, if
+        none is defined on the dataset. By default, use none.
     min_counts : int
         Minimum number of counts, or residuals counts if a SkyModel is set,
         required outside the exclusion region.
@@ -53,6 +56,7 @@ class FoVBackgroundMaker(Maker):
         method="scale",
         exclusion_mask=None,
         spectral_model="pl-norm",
+        spatial_model=None,
         min_counts=0,
         min_npred_background=0,
         fit=None,
@@ -65,10 +69,14 @@ class FoVBackgroundMaker(Maker):
         if isinstance(spectral_model, str):
             spectral_model = Model.create(tag=spectral_model, model_type="spectral")
 
+        if isinstance(spatial_model, str):
+            spatial_model = Model.create(tag=spatial_model, model_type="spatial")
+
         if not spectral_model.is_norm_spectral_model:
             raise ValueError("Spectral model must be a norm spectral model")
 
         self.default_spectral_model = spectral_model
+        self.default_spatial_model = spatial_model
 
         if fit is None:
             fit = Fit()
@@ -105,8 +113,16 @@ class FoVBackgroundMaker(Maker):
             Map dataset including background model.
 
         """
+
+        if self.default_spatial_model:
+            spatial_model = self.default_spatial_model.copy()
+        else:
+            spatial_model = None
+
         bkg_model = FoVBackgroundModel(
-            dataset_name=dataset.name, spectral_model=self.default_spectral_model.copy()
+            dataset_name=dataset.name,
+            spectral_model=self.default_spectral_model.copy(),
+            spatial_model=spatial_model,
         )
 
         if dataset.models is None:

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -40,6 +40,7 @@ class FoVBackgroundMaker(Maker):
     spatial_model : SpatialModel or str
         Spatial model to use for the `FoVBackgroundModel`, if
         none is defined on the dataset. By default, use none.
+        The unit of the spatial model is dropped.
     min_counts : int
         Minimum number of counts, or residuals counts if a SkyModel is set,
         required outside the exclusion region.

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -34,7 +34,7 @@ class FoVBackgroundMaker(Maker):
         The normalization method to be applied. Default 'scale'.
     exclusion_mask : `~gammapy.maps.WcsNDMap`
         Exclusion mask.
-    spectral_model : SpectralModel or str
+    spectral_model : SpectralModel or str, optional
         Reference norm spectral model to use for the `FoVBackgroundModel`, if
         none is defined on the dataset. By default, use pl-norm.
     spatial_model : SpatialModel or str, optional

--- a/gammapy/makers/background/fov.py
+++ b/gammapy/makers/background/fov.py
@@ -37,7 +37,7 @@ class FoVBackgroundMaker(Maker):
     spectral_model : SpectralModel or str
         Reference norm spectral model to use for the `FoVBackgroundModel`, if
         none is defined on the dataset. By default, use pl-norm.
-    spatial_model : SpatialModel or str
+    spatial_model : SpatialModel or str, optional
         Spatial model to use for the `FoVBackgroundModel`, if
         none is defined on the dataset. By default, use None.
         The unit of the spatial model is dropped.

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -12,6 +12,7 @@ from gammapy.modeling import Fit
 from gammapy.modeling.models import (
     FoVBackgroundModel,
     PointSpatialModel,
+    ConstantSpatialModel,
     PowerLawNormSpectralModel,
     PowerLawSpectralModel,
     SkyModel,
@@ -152,7 +153,6 @@ def test_fov_bkg_maker_fit_nocounts(obs_dataset, exclusion_mask):
 
 @requires_data()
 def test_fov_bkg_maker_with_source_model(obs_dataset, exclusion_mask, caplog):
-
     test_dataset = obs_dataset.copy(name="test-fov")
 
     # crab model
@@ -326,3 +326,36 @@ def test_fov_background_maker_str():
     exclusion_mask = Map.create(binsz=0.2, width=(2, 2))
     maker_fov = FoVBackgroundMaker(exclusion_mask=exclusion_mask)
     assert "FoVBackgroundMaker" in str(maker_fov)
+
+
+@requires_data()
+def test_fov_backgr_maker_spatial_model(obs_dataset, exclusion_mask):
+    # test definition of FoVBackgroundMaker with spatial model
+    bkg_spatial_model = ConstantSpatialModel()
+
+    fov_bkg_maker = FoVBackgroundMaker(
+        method="fit",
+        exclusion_mask=exclusion_mask,
+        spectral_model="pl-norm",
+        spatial_model=bkg_spatial_model,
+    )
+    fov_bkg_maker2 = FoVBackgroundMaker(
+        method="fit",
+        exclusion_mask=exclusion_mask,
+        spectral_model="pl-norm",
+        spatial_model="const",
+    )
+
+    test_dataset = obs_dataset.copy(name="test-fov")
+
+    dataset = fov_bkg_maker.run(test_dataset)
+    dataset2 = fov_bkg_maker2.run(test_dataset)
+
+    bkg_model_spec = dataset.models[f"{dataset.name}-bkg"].spectral_model
+    bkg_model_spec2 = dataset2.models[f"{dataset2.name}-bkg"].spectral_model
+    assert not bkg_model_spec.norm.frozen
+    assert not bkg_model_spec2.norm.frozen
+    assert_allclose(bkg_model_spec.norm.value, 0.830779, rtol=1e-4)
+    assert_allclose(bkg_model_spec.tilt.value, 0.0, rtol=1e-4)
+    assert_allclose(bkg_model_spec2.norm.value, 0.830779, rtol=1e-4)
+    assert_allclose(bkg_model_spec2.tilt.value, 0.0, rtol=1e-4)

--- a/gammapy/makers/background/tests/test_fov.py
+++ b/gammapy/makers/background/tests/test_fov.py
@@ -351,11 +351,12 @@ def test_fov_backgr_maker_spatial_model(obs_dataset, exclusion_mask):
     dataset = fov_bkg_maker.run(test_dataset)
     dataset2 = fov_bkg_maker2.run(test_dataset)
 
+    assert dataset.models[f"{dataset.name}-bkg"].spatial_model is not None
+    assert dataset2.models[f"{dataset2.name}-bkg"].spatial_model is not None
+
     bkg_model_spec = dataset.models[f"{dataset.name}-bkg"].spectral_model
     bkg_model_spec2 = dataset2.models[f"{dataset2.name}-bkg"].spectral_model
     assert not bkg_model_spec.norm.frozen
     assert not bkg_model_spec2.norm.frozen
     assert_allclose(bkg_model_spec.norm.value, 0.830779, rtol=1e-4)
-    assert_allclose(bkg_model_spec.tilt.value, 0.0, rtol=1e-4)
     assert_allclose(bkg_model_spec2.norm.value, 0.830779, rtol=1e-4)
-    assert_allclose(bkg_model_spec2.tilt.value, 0.0, rtol=1e-4)


### PR DESCRIPTION

**Description**
As mentioned in issue #5077 the spatial model can not be directly defined upon initializing the FoVBackgroundMaker. This PR aims to solve this by adding a `spatial_model` parameter. Its default is `None` and the Maker works without it. If a spatial model is set, it should now work equivalently to the spectral model.

A test was also added to ensure the correct behaviour of the FoVBackgroundMaker if it is initialized with a spatial model.
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

This pull request should be ready, feedback is welcome!