### PR TITLE
Push the web search engine to display first the stable version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,6 +95,10 @@ source_suffix = '.rst'
 # The master toctree document.
 master_doc = 'index'
 
+# Allow to add the canonical html flag on all the pages
+# This permits to precise to web search engine that the pages for the stable version are privileged
+html_baseurl = 'https://docs.gammapy.org/stable/'
+
 # The reST default role (used for this markup: `text`) to use for all
 # documents. Set to the "smart" one.
 default_role = 'obj'


### PR DESCRIPTION
**Description**

This pull request is linked to the issue #5753.
The canonization of urls (see thie [link](https://developers.google.com/search/docs/crawling-indexing/canonicalization)) permits to search engine to know which pages are preferred compared to others. This mechanism is used here to tag the `stable` version as the preferred one when displaying search results.
To achieve that, the `html_baseurl` sphinx command permits that... Normally ;)

** Other possible solution
One could use [sphinx-sitemap](https://sphinx-sitemap.readthedocs.io/en/latest/), but it requires adding a library...
You can see the pros and cons on all methods [here](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls).
