### PR TITLE
Correct pydantic deprecation warning

### DIFF
--- a/gammapy/utils/metadata.py
+++ b/gammapy/utils/metadata.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Metadata base container for Gammapy."""
+
 import json
 from typing import ClassVar, Literal, Optional, get_args
 import astropy.units as u
@@ -111,7 +112,9 @@ class MetaData(BaseModel):
                 else:
                     hdr_dict[item] = value
 
-        extra_keys = set(self.model_fields.keys()) - set(fits_export_keys.keys())
+        extra_keys = set(self.__class__.model_fields.keys()) - set(
+            fits_export_keys.keys()
+        )
 
         for key in extra_keys:
             entry = getattr(self, key)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request correct pydantic deprecation warning due to the `models_base`being accessible only from  the model class and no longer from the instance.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
