### PR TITLE
Update olddeps and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
             gammapy_data_path: /home/runner/work/gammapy/gammapy/gammapy-datasets/dev
             allowed_fail: false
           - os: macos-latest
-            python: '3.11'
-            tox_env: 'py311-test'
+            python: '3.13'
+            tox_env: 'py313-test'
             gammapy_data_path: /Users/runner/work/gammapy/gammapy/gammapy-datasets/dev
             allowed_fail: false
           - os: macos-14
@@ -47,7 +47,7 @@ jobs:
             tox_env: 'py311-test'
             allowed_fail: false
           - os: windows-latest
-            python: '3.11'
+            python: '3.12'
             tox_env: 'py311-test-alldeps_noray'
             gammapy_data_path:  D:\a\gammapy\gammapy\gammapy-datasets\dev
             allowed_fail: false
@@ -69,15 +69,15 @@ jobs:
             tox_env: 'codestyle'
             allowed_fail: false
           - os: ubuntu-latest
-            python: '3.9'
-            tox_env: 'py39-test-alldeps_noray-astropy50-numpy121'
+            python: '3.10'
+            tox_env: 'py310-test-alldeps_noray-astropy60-numpy126'
             allowed_fail: false
           - os: ubuntu-latest
-            python: '3.9'
+            python: '3.10'
             tox_env: 'oldestdeps'
             allowed_fail: false
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             tox_env: 'devdeps'
             allowed_fail: true
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 envlist =
-    py{39,310,311,312,313}-test{,-alldeps,-devdeps}{,-cov}
-    py{39,310,311,312,313}-test-numpy{121,122,123,124}
-    py{39,310,311,312,313}-test-astropy{50,lts}
+    py{310,311,312,313}-test{,-alldeps,-devdeps}{,-cov}
+    py{310,311,312,313}-test-numpy{121,122,123,124}
+    py{310,311,312,313}-test-astropy{60,lts}
     build_docs
     linkcheck
     codestyle
@@ -59,22 +59,21 @@ description =
 deps =
 
     cov: coverage
-    numpy121: numpy==1.21.*
-    numpy122: numpy==1.22.*
-    numpy123: numpy==1.23.*
-    numpy124: numpy==1.24.*
+    numpy126: numpy==1.26.*
+    numpy20: numpy==2.0*
+    numpy21: numpy==2.1.*
 
-    astropy50: astropy==5.0.*
+    astropy60: astropy==6.0.*
 
-    oldestdeps: numpy==1.21.*
-    oldestdeps: matplotlib==3.4.*
-    oldestdeps: scipy==1.5.*
-    oldestdeps: pyyaml==5.3.*
-    oldestdeps: astropy==5.0.*
-    oldestdeps: click==7.0.*
-    oldestdeps: regions==0.5.*
-    oldestdeps: pydantic==1.4.*
-    oldestdeps: iminuit==2.8.*
+    oldestdeps: numpy==1.26.*
+    oldestdeps: matplotlib==3.9.*
+    oldestdeps: scipy==1.13.*
+    oldestdeps: pyyaml==6.0.*
+    oldestdeps: astropy==6.1.*
+    oldestdeps: click==8.0.*
+    oldestdeps: regions==0.9.*
+    oldestdeps: pydantic==2.8.*
+    oldestdeps: iminuit==2.26.*
 
     devdeps: scipy>=0.0.dev0
     devdeps: numpy>=0.0.dev0
@@ -82,8 +81,6 @@ deps =
     devdeps: astropy>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
     devdeps: git+https://github.com/scikit-hep/iminuit.git#egg=iminuit
-
-    # build_docs: sphinx-gallery<0.13
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request proposes an upgrade of the CI matrix to stop testing for python 3.9 and increase tests on 3.13. It also changes the minimal versions supported in preparation of version 2.0. (See issue #5776 )

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
