### PR TITLE
Warning fixes in some tests

### DIFF
--- a/gammapy/datasets/tests/test_flux_points.py
+++ b/gammapy/datasets/tests/test_flux_points.py
@@ -134,7 +134,7 @@ def test_flux_point_dataset_with_time_axis(tmp_path):
     flux_points = FluxPoints.from_table(table=table)
     flux_points_dataset = FluxPointsDataset(data=flux_points)
     temporal_model = ExpDecayTemporalModel()
-    temporal_model.t_ref.value = Time(["2010-01-01"]).mjd
+    temporal_model.t_ref.value = Time(["2010-01-01"]).mjd[0]
     temporal_model.t0.quantity = 5.0 * u.hr
     model = SkyModel(
         spectral_model=PowerLawSpectralModel(), temporal_model=temporal_model

--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -116,7 +116,7 @@ class SensitivityEstimator(Estimator):
     def _get_criterion(self, excess, bkg):
         is_gamma_limited = excess == self.gamma_min
         is_bkg_syst_limited = excess == bkg * self.bkg_syst_fraction
-        criterion = np.chararray(excess.shape, itemsize=12)
+        criterion = np.array(excess.shape, itemsize=12, dtype="str")
         criterion[is_gamma_limited] = "gamma"
         criterion[is_bkg_syst_limited] = "bkg"
         criterion[~np.logical_or(is_gamma_limited, is_bkg_syst_limited)] = (

--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -116,7 +116,7 @@ class SensitivityEstimator(Estimator):
     def _get_criterion(self, excess, bkg):
         is_gamma_limited = excess == self.gamma_min
         is_bkg_syst_limited = excess == bkg * self.bkg_syst_fraction
-        criterion = np.array(excess.shape, itemsize=12, dtype="str")
+        criterion = np.chararray(excess.shape, itemsize=12)
         criterion[is_gamma_limited] = "gamma"
         criterion[is_bkg_syst_limited] = "bkg"
         criterion[~np.logical_or(is_gamma_limited, is_bkg_syst_limited)] = (


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This PR is to partially resolve #5752. It focuses on the DeprecationWarnings. Besides the Pydantic ones, there are 5 DeprecationWarnings in total (see also comment below):

1. gammapy/datasets/tests/test_flux_points.py::test_flux_point_dataset_with_time_axis gammapy/modeling/parameter.py:334:
DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)

  This is a problem in the test itself, because Time.mjd returns a single-element array. Solved by selecting the element instead of the whole array.