### PR TITLE
Order of spectral model parameters not consistent between definition, docstring and evaluate.

### DIFF
--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -796,12 +796,12 @@ def test_map_fit(sky_model, geom, geom_etrue):
     assert_allclose(pars["amplitude"].error, 4.216e-13, rtol=1e-2)
 
     # background norm 1
-    assert_allclose(pars[8].value, 0.5, rtol=1e-2)
-    assert_allclose(pars[8].error, 0.015811, rtol=1e-2)
+    assert_allclose(pars[9].value, 0.5, rtol=1e-2)
+    assert_allclose(pars[9].error, 0.015811, rtol=1e-2)
 
     # background norm 2
-    assert_allclose(pars[11].value, 1, rtol=1e-2)
-    assert_allclose(pars[11].error, 0.02147, rtol=1e-2)
+    assert_allclose(pars[12].value, 1, rtol=1e-2)
+    assert_allclose(pars[12].error, 0.02147, rtol=1e-2)
 
     # test mask_safe evaluation
     dataset_1.mask_safe = geom.energy_mask(energy_min=1 * u.TeV)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -904,12 +904,12 @@ def test_map_fit_ray(sky_model, geom, geom_etrue):
     assert_allclose(pars["amplitude"].error, 4.216e-13, rtol=1e-2)
 
     # background norm 1
-    assert_allclose(pars[8].value, 0.5, rtol=1e-2)
-    assert_allclose(pars[8].error, 0.015811, rtol=1e-2)
+    assert_allclose(pars[9].value, 0.5, rtol=1e-2)
+    assert_allclose(pars[9].error, 0.015811, rtol=1e-2)
 
     # background norm 2
-    assert_allclose(pars[11].value, 1, rtol=1e-2)
-    assert_allclose(pars[11].error, 0.02147, rtol=1e-2)
+    assert_allclose(pars[12].value, 1, rtol=1e-2)
+    assert_allclose(pars[12].error, 0.02147, rtol=1e-2)
 
     with mpl_plot_check():
         actors.plot_residuals()

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -933,8 +933,8 @@ class PowerLawNormSpectralModel(SpectralModel):
     """
 
     tag = ["PowerLawNormSpectralModel", "pl-norm"]
-    norm = Parameter("norm", 1, unit="", interp="log")
     tilt = Parameter("tilt", 0, frozen=True)
+    norm = Parameter("norm", 1, unit="", interp="log")
     reference = Parameter("reference", "1 TeV", frozen=True)
 
     @staticmethod
@@ -1163,10 +1163,10 @@ class SmoothBrokenPowerLawSpectralModel(SpectralModel):
         :math:`\Gamma_2`. Default is 2.
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`. Default is 1e-12 cm-2 s-1 TeV-1.
-    reference : `~astropy.units.Quantity`
-        :math:`E_0`. Default is 1 TeV.
     ebreak : `~astropy.units.Quantity`
         :math:`E_{break}`. Default is 1 TeV.
+    reference : `~astropy.units.Quantity`
+        :math:`E_0`. Default is 1 TeV.
     beta : `~astropy.units.Quantity`
         :math:`\beta`. Default is 1.
 
@@ -1471,12 +1471,6 @@ class SuperExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
 
     Parameters
     ----------
-    index_1 : `~astropy.units.Quantity`
-        :math:`\Gamma_1`.
-        Default is 1.5.
-    index_2 : `~astropy.units.Quantity`
-        :math:`\Gamma_2`.
-        Default is 2.
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`.
         Default is 1e-12 cm-2 s-1 TeV-1.
@@ -1486,6 +1480,12 @@ class SuperExpCutoffPowerLaw3FGLSpectralModel(SpectralModel):
     ecut : `~astropy.units.Quantity`
         :math:`E_{C}`.
         Default is 10 TeV.
+    index_1 : `~astropy.units.Quantity`
+        :math:`\Gamma_1`.
+        Default is 1.5.
+    index_2 : `~astropy.units.Quantity`
+        :math:`\Gamma_2`.
+        Default is 2.
     """
 
     tag = ["SuperExpCutoffPowerLaw3FGLSpectralModel", "secpl-3fgl"]
@@ -1516,10 +1516,6 @@ class SuperExpCutoffPowerLaw4FGLSpectralModel(SpectralModel):
 
     Parameters
     ----------
-    index_1 : `~astropy.units.Quantity`
-        :math:`\Gamma_1`. Default is 1.5.
-    index_2 : `~astropy.units.Quantity`
-        :math:`\Gamma_2`. Default is 2.
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`. Default is 1e-12 cm-2 s-1 TeV-1.
     reference : `~astropy.units.Quantity`
@@ -1528,6 +1524,10 @@ class SuperExpCutoffPowerLaw4FGLSpectralModel(SpectralModel):
         :math:`a`, given as dimensionless value but
         internally assumes unit of :math:`{\rm MeV}^{-\Gamma_2}`.
         Default is 1e-14.
+    index_1 : `~astropy.units.Quantity`
+        :math:`\Gamma_1`. Default is 1.5.
+    index_2 : `~astropy.units.Quantity`
+        :math:`\Gamma_2`. Default is 2.
     """
 
     tag = ["SuperExpCutoffPowerLaw4FGLSpectralModel", "secpl-4fgl"]
@@ -1565,16 +1565,16 @@ class SuperExpCutoffPowerLaw4FGLDR3SpectralModel(SpectralModel):
 
     Parameters
     ----------
-    index_1 : `~astropy.units.Quantity`
-        :math:`\Gamma_1`. Default is 1.5.
-    index_2 : `~astropy.units.Quantity`
-        :math:`\Gamma_2`. Default is 2.
     amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`.  Default is 1e-12 cm-2 s-1 TeV-1.
     reference : `~astropy.units.Quantity`
         :math:`E_0`. Default is 1 TeV.
     expfactor : `~astropy.units.Quantity`
         :math:`a`, given as dimensionless value. Default is 1e-2.
+    index_1 : `~astropy.units.Quantity`
+        :math:`\Gamma_1`. Default is 1.5.
+    index_2 : `~astropy.units.Quantity`
+        :math:`\Gamma_2`. Default is 2.
     """
 
     tag = ["SuperExpCutoffPowerLaw4FGLDR3SpectralModel", "secpl-4fgl-dr3"]
@@ -2027,8 +2027,8 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
     """
 
     tag = ["EBLAbsorptionNormSpectralModel", "ebl-norm"]
-    alpha_norm = Parameter("alpha_norm", 1.0, frozen=True)
     redshift = Parameter("redshift", 0.1, frozen=True)
+    alpha_norm = Parameter("alpha_norm", 1.0, frozen=True)
 
     def __init__(self, energy, param, data, redshift, alpha_norm, interp_kwargs=None):
         self.filename = None
@@ -2188,7 +2188,7 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
             interp_kwargs=interp_kwargs,
         )
 
-    def evaluate(self, energy, alpha_norm, redshift):
+    def evaluate(self, energy, redshift, alpha_norm):
         """Evaluate model for energy and parameter value."""
         absorption = np.clip(self._evaluate_table_model((redshift, energy)), 0, 1)
         return np.power(absorption, alpha_norm)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -2188,7 +2188,7 @@ class EBLAbsorptionNormSpectralModel(SpectralModel):
             interp_kwargs=interp_kwargs,
         )
 
-    def evaluate(self, energy, redshift, alpha_norm):
+    def evaluate(self, energy, alpha_norm, redshift):
         """Evaluate model for energy and parameter value."""
         absorption = np.clip(self._evaluate_table_model((redshift, energy)), 0, 1)
         return np.power(absorption, alpha_norm)

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -233,8 +233,8 @@ def test_absorption_io_invalid_path(tmp_path):
     model_dict = dominguez.to_dict()
     parnames = [_["name"] for _ in model_dict["spectral"]["parameters"]]
     assert parnames == [
-        "alpha_norm",
         "redshift",
+        "alpha_norm",
     ]
     new_model = EBLAbsorptionNormSpectralModel.from_dict(model_dict)
 
@@ -260,8 +260,8 @@ def test_absorption_io_no_filename(tmp_path):
     model_dict = dominguez.to_dict()
     parnames = [_["name"] for _ in model_dict["spectral"]["parameters"]]
     assert parnames == [
-        "alpha_norm",
         "redshift",
+        "alpha_norm",
     ]
 
     new_model = EBLAbsorptionNormSpectralModel.from_dict(model_dict)
@@ -282,8 +282,8 @@ def test_absorption_io(tmp_path):
     model_dict = dominguez.to_dict()
     parnames = [_["name"] for _ in model_dict["spectral"]["parameters"]]
     assert parnames == [
-        "alpha_norm",
         "redshift",
+        "alpha_norm",
     ]
 
     new_model = EBLAbsorptionNormSpectralModel.from_dict(model_dict)


### PR DESCRIPTION
Issue discovered on the EBL evaluation. Order of parameters was wrong in <= 1.3 . evaluate() gives wrong results. 

redshift, alpha_norm but EBL evaluate() expects alpha_norm, redshift