### PR TITLE
New test to evaluate spectral models (and spot issues like PR-5799)

### DIFF
--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -431,7 +431,7 @@ def test_evaluate():
         par_list = [p.quantity for p in parameters]
         result_eval = model.evaluate(energies, *par_list)
         result_call = model(energies)
-        assert (result_eval == result_call).all()
+        assert_quantity_allclose(result_eval == result_call)
 
 
 def test_model_unit():

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -431,7 +431,7 @@ def test_evaluate():
         par_list = [p.quantity for p in parameters]
         result_eval = model.evaluate(energies, *par_list)
         result_call = model(energies)
-        assert_quantity_allclose(result_eval == result_call)
+        assert_quantity_allclose(result_eval, result_call)
 
 
 def test_model_unit():

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -423,6 +423,17 @@ def test_models(spectrum):
     assert_quantity_allclose(val[0], spectrum["val_at_2TeV"])
 
 
+def test_evaluate():
+    for m in TEST_MODELS:
+        model = m["model"]
+        energies = [1e-12, 1e-6, 1e-2, 1, 1e2, 1e4] * u.TeV
+        parameters = model.parameters
+        par_list = [p.quantity for p in parameters]
+        result_eval = model.evaluate(energies, *par_list)
+        result_call = model(energies)
+        assert (result_eval == result_call).all()
+
+
 def test_model_unit():
     pwl = PowerLawSpectralModel()
     value = pwl(500 * u.MeV)

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -429,7 +429,12 @@ def test_evaluate():
         energies = [1e-12, 1e-6, 1e-2, 1, 1e2, 1e4] * u.TeV
         parameters = model.parameters
         par_list = [p.quantity for p in parameters]
-        result_eval = model.evaluate(energies, *par_list)
+        if isinstance(model, PiecewiseNormSpectralModel):
+            # TODO : check if PiecewiseNormSpectralModel evaluate can work like the others
+            result_eval = model.evaluate(energies)
+        else:
+            result_eval = model.evaluate(energies, *par_list)
+
         result_call = model(energies)
         assert_quantity_allclose(result_eval, result_call)
 


### PR DESCRIPTION
The order of the parameters as defined in some spectral models (EBLAbsorption, PowerLawNormSpectralModel) is not consistent, as the ''evaluate'' calls expect the parameters to be passed in a different order. Adding a test to spot such cases.
