### PR TITLE
Put back sphinx click extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,7 @@ default_role = 'obj'
 
 # Add any Sphinx extension module names here, as strings.
 extensions = [
+    "sphinx_click.ext",
     'sphinx_copybutton',
     "sphinx_design",
     "sphinx_gallery.gen_gallery",

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -41,6 +41,7 @@
 .. _emcee: http://dan.iel.fm/emcee/current/
 .. _ctapipe: https://github.com/cta-observatory/ctapipe
 .. _click: http://click.pocoo.org/
+.. _sphinx-click: https://github.com/click-contrib/sphinx-click
 .. _pycrflux: https://github.com/akira-okumura/pycrflux
 .. _VHEObserverTools: https://github.com/kialio/VHEObserverTools
 .. _PINT: https://github.com/nanograv/PINT

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -62,6 +62,7 @@ dependencies:
   - setuptools_scm
   - sherpa>=4.17
   - sphinx
+  - sphinx-click
   - sphinx-gallery
   - sphinx-design
   - sphinx-copybutton

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,6 +85,7 @@ docs =
     numpydoc
     sphinx
     sphinx_automodapi
+    sphinx-click
     sphinx-copybutton
     sphinx-design
     sphinx-gallery


### PR DESCRIPTION
This PR put back sphinx click extension that was removed by #5795. 
We need it to build the `gammapy.script` API reference page.