### PR TITLE
Allow arrows for sidebar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,18 +105,18 @@ default_role = 'obj'
 
 # Add any Sphinx extension module names here, as strings.
 extensions = [
+    # Order for sphinx_automodapi is important
+    "sphinx.ext.autosummary",
+    "sphinx_automodapi.automodapi", # This should come after autosummary
+    "sphinx_automodapi.smart_resolver",
     "sphinx_click.ext",
     'sphinx_copybutton',
     "sphinx_design",
     "sphinx_gallery.gen_gallery",
-    "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     'sphinx.ext.viewcode',
-    # Order for sphinx_automodapi is important
-    "sphinx_automodapi.automodapi",
-    "sphinx_automodapi.smart_resolver",
     # Allows for mapping to other documentation projects
     "sphinx.ext.intersphinx",
     # Allows for Numpy docstring format
@@ -231,8 +231,10 @@ htmlhelp_basename = f"{project}doc"
 
 html_theme_options = {
     "header_links_before_dropdown": 6,
-    "collapse_navigation": True,
+    # False = allow arrows to show for API reference
+    "collapse_navigation": False,
     "navigation_depth": 2,
+    # False = don't show "Previous" and "Next" buttons at the bottom of each page
     "show_prev_next": False,
     # links in menu
     "icon_links": [
@@ -302,6 +304,7 @@ binder_config = {
 }
 
 sphinx_gallery_conf = {
+    # Remove the sphinx comments i.e. sphinx_gallery_thumbnail_number in tutorials
     "remove_config_comments": True,
     "examples_dirs": [
         "../examples/models",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,11 +229,11 @@ html_title = "{} v{}".format(project, release)
 # Output file base name for HTML help builder.
 htmlhelp_basename = f"{project}doc"
 
+# Default for the configuration can be found here
+# https://github.com/pydata/pydata-sphinx-theme/blob/main/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
 html_theme_options = {
     "header_links_before_dropdown": 6,
-    # False = allow arrows to show for API reference
-    "collapse_navigation": False,
-    "navigation_depth": 2,
+    "show_toc_level": 2,
     # False = don't show "Previous" and "Next" buttons at the bottom of each page
     "show_prev_next": False,
     # links in menu

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -338,7 +338,8 @@ sphinx_gallery_conf = {
     "within_subsection_order": "sphinxext.TutorialExplicitOrder",
     "download_all_examples": True,
     "capture_repr": ("_repr_html_", "__repr__"),
-    "nested_sections": False,
+    # Show sidebar dropdowns for menu
+    "nested_sections": True,
     "min_reported_time": 10,
     "show_memory": False,
     "line_numbers": False,

--- a/docs/user-guide/package.rst
+++ b/docs/user-guide/package.rst
@@ -6,8 +6,7 @@ Fundamental Concepts: Gammapy analysis workflow and package structure
 =====================================================================
 
 .. toctree::
-    :hidden:
-    :includehidden:
+    :maxdepth: 2
 
     dl3
     irf/index


### PR DESCRIPTION
This allows for the navigation arrows to present on the LHS sidebar for both the API reference and User guide. 
It also allows for the tutorials to have menus on the LHS and dropdown arrows

