### PR TITLE
Missing negative sign in PLEC4 `evaluate`

### DIFF
--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -874,14 +874,14 @@ class TestFermi3PCObject:
         assert flux_points.norm_ul
 
         desired = [
-            5.431500e-06,
-            5.635604e-06,
-            3.341596e-06,
-            1.058516e-06,
-            2.264139e-07,
-            1.421599e-08,
-            6.306778e-10,
-            3.165719e-12,
+            5.43150044e-06,
+            5.6356044e-06,
+            3.34159577e-06,
+            1.05866529e-06,
+            2.26413922e-07,
+            1.42159871e-08,
+            6.30677817e-10,
+            3.16571939e-12,
         ]
         assert_allclose(flux_points.flux.data.flat, desired, rtol=1e-5)
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1600,7 +1600,7 @@ class SuperExpCutoffPowerLaw4FGLDR3SpectralModel(SpectralModel):
 
         mask = np.abs(index_2 * np.log(energy / reference)) < 1e-2
         ln_ = np.log(energy[mask] / reference)
-        power = expfactor * (
+        power = -expfactor * (
             ln_ / 2.0 + index_2 / 6.0 * ln_**2.0 + index_2**2.0 / 24.0 * ln_**3
         )
         cutoff[mask] = (energy[mask] / reference) ** power


### PR DESCRIPTION
According to both the equation in gammapy model gallery, as well as, in Eq. 3 of [4FLG paper](https://arxiv.org/pdf/2201.11184), the `evalutate` method of `SuperExpCutoffPowerLaw4FGLDR3SpectralModel` is missing a negative sign. 