### PR TITLE
Correct Datasets.stat_sum() to apply prior only once

### DIFF
--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -81,11 +81,7 @@ class Dataset(abc.ABC):
 
     def stat_sum(self):
         """Total statistic given the current model parameters and priors."""
-        prior_stat_sum = 0.0
-        if self.models is not None:
-            prior_stat_sum = self.models.parameters.prior_stat_sum()
-
-        return self._fit_statistic.stat_sum_dataset(self) + prior_stat_sum
+        return self._fit_statistic.stat_sum_dataset(self)
 
     def _stat_sum_likelihood(self):
         """Total statistic given the current model parameters without the priors."""
@@ -247,10 +243,15 @@ class Datasets(collections.abc.MutableSequence):
 
     def stat_sum(self):
         """Compute joint statistic function value."""
-        stat_sum = 0
+        prior_stat_sum = 0.0
+        if self.models is not None:
+            prior_stat_sum = self.models.parameters.prior_stat_sum()
+
+        stat_sum = 0.0
         for dataset in self:
             stat_sum += dataset.stat_sum()
-        return stat_sum
+
+        return stat_sum + prior_stat_sum
 
     def _stat_sum_likelihood(self):
         """Total statistic given the current model parameters without the priors."""

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -31,7 +31,9 @@ class MyDataset(Dataset):
 
     def __init__(self, name="test"):
         self._name = name
-        self._models = Models([MyModel(x=1.99, y=2.99e3, z=3.99e-2)])
+        model = MyModel(x=1.99, y=2.99e3, z=3.99e-2)
+        model.name = name
+        self._models = Models([model])
         self.data_shape = (1,)
         self.meta_table = Table()
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request corrects a bug in `Datasets.stat_sum()`. 

Currently priors are computed on each dataset and added to the dataset `stat_sum`. This is incorrect. Prior on a parameter should be added only once to the total likelihood.

This PR modes prior_stat_sum computation to `Datasets` to avoid this issue. A test is added that ensures that the change to the stat_sum is correct when the same model is applied to several datasets.


**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
