### PR TITLE
Addition of FitStatistic penalties

### DIFF
--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 from gammapy.maps import Map, RegionGeom
 from gammapy.modeling import Covariance, Parameter, Parameters
 from gammapy.modeling.covariance import CovarianceMixin
+from gammapy.stats.fit_statistics import FitStatisticPenalty
 from gammapy.utils.scripts import from_yaml, make_name, make_path, to_yaml, write_yaml
 
 __all__ = ["Model", "Models", "DatasetModels", "ModelBase"]
@@ -437,11 +438,13 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
     ----------
     models : `SkyModel`, list of `SkyModel` or `Models`
         Sky models.
-    covariance_data : `~numpy.ndarray`
-        Covariance data.
+    covariance_data : `~numpy.ndarray`, optional
+        Covariance data. Default is None.
+    penalties : list of `~gammapy.stats.FitStatisticPenalty`, optional
+        Penalties to be applied to the Models parameters when computing a FitStatistic. Default is None.
     """
 
-    def __init__(self, models=None, covariance_data=None):
+    def __init__(self, models=None, covariance_data=None, penalties=None):
         if models is None:
             models = []
 
@@ -471,6 +474,14 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
         # Set separately because this triggers the update mechanism on the sub-models
         if covariance_data is not None:
             self.covariance = covariance_data
+
+        if penalties is not None:
+            if not isinstance(penalties, (list, tuple)):
+                penalties = [penalties]
+            if not all([isinstance(_, FitStatisticPenalty) for _ in penalties]):
+                raise ValueError("Penalties must be FitStatisticPenalty instances.")
+
+        self._penalties = penalties
 
     @property
     def parameters(self):
@@ -1319,6 +1330,17 @@ class Models(DatasetModels, collections.abc.MutableSequence):
     def set_prior(self, parameters, priors):
         for parameter, prior in zip(parameters, priors):
             parameter.prior = prior
+
+    def set_penalties(self, penalties):
+        """Set the list of FitStatisticPenalty to be applied on the Models."""
+        # TODO: check that penalties parameters apply to models parameters...
+        if penalties is not None:
+            if not isinstance(penalties, (list, tuple)):
+                penalties = [penalties]
+            if not all([isinstance(_, FitStatisticPenalty) for _ in penalties]):
+                raise ValueError("Penalties must be FitStatisticPenalty instances.")
+
+        self._penalties = penalties
 
 
 class restore_models_status:

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -451,6 +451,8 @@ class DatasetModels(collections.abc.Sequence, CovarianceMixin):
         if isinstance(models, (Models, DatasetModels)):
             if covariance_data is None and models.covariance is not None:
                 covariance_data = models.covariance.data
+            if penalties is None and models._penalties is not None:
+                penalties = models._penalties
             models = models._models
         elif isinstance(models, ModelBase):
             models = [models]

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -429,3 +429,171 @@ class ProfileFitStatistic(FitStatistic):
         for idx in np.ndindex(dataset._profile_interpolators.shape):
             stat[idx] = dataset._profile_interpolators[idx](model[idx])
         return stat
+
+
+class FitStatisticPenalty:
+    """Base class for fit statistic penalties.
+
+    Parameters
+    ----------
+    parameters : list of `~gammapy.modeling.Parameter`
+        List of parameters to apply the penalty to.
+    lambda_ : float
+        Regularization strength (Lagrange multiplier).
+    """
+
+    def __init__(self, parameters, lambda_=1.0):
+        self.parameters = parameters  # can we keep it here? Is it safe?
+        self.lambda_ = lambda_
+
+    def stat_sum(self):
+        """Compute the penalty term."""
+        raise NotImplementedError
+
+
+class GaussianPriorPenalty(FitStatisticPenalty):
+    """Penalty based on a multivariate Gaussian prior.
+
+    This implements a quadratic penalty of the form:
+
+        lambda * (x - mean)^T C**-1 (x - mean)
+
+    where x are the parameter values, μ is the prior mean vector,
+    and C is the prior covariance matrix.
+
+    If C is the identity matrix (default), this is equivalent to the L2 (ridge) regression.
+
+    Parameters
+    ----------
+    parameters : list of `~gammapy.modeling.Parameter`
+        Parameters to which the penalty is applied.
+    mean : list of float, optional
+        Prior mean values for each parameter. If not provided, defaults to zeros.
+    covariance : array-like, optional
+        Prior covariance matrix. If not provided, an identity matrix is used.
+    lambda_ : float
+        Regularization strength (Lagrange multiplier).
+    """
+
+    def __init__(self, parameters, mean=None, covariance=None, lambda_=1.0):
+        super().__init__(parameters, lambda_)
+        self.mean = np.array(mean) if mean is not None else np.zeros(len(parameters))
+        self.covariance = (
+            covariance if covariance is not None else np.eye(len(parameters))
+        )
+
+    @property
+    def covariance(self):
+        """Return covariance matrix of the multivariate gaussian."""
+        return self._covariance
+
+    @covariance.setter
+    def covariance(self, matrix):
+        """Set covariance matrix."""
+        from gammapy.modeling import Covariance
+
+        self._covariance = Covariance(self.parameters, matrix)
+        self._inverse_covariance = np.linalg.inv(self._covariance.data)
+
+    def stat_sum(self):
+        """Compute the Gaussian prior penalty."""
+        x = np.array([p.value for p in self.parameters])
+        delta = x - self.mean
+        penalty = np.dot(delta, self._inverse_covariance @ delta)
+
+        return self.lambda_ * penalty
+
+    @classmethod
+    def from_precision(cls, parameters, precision, mean=None, lambda_=1.0):
+        """Create a GaussianPriorPenalty from a precision matrix (inverse covariance).
+
+        Internally uses `~scipy.stats.Covariance.from_precision`
+
+        Parameters
+        ----------
+        parameters : list of `~gammapy.modeling.Parameter` or `~gammapy.modeling.Parameters`
+            Parameters to which the penalty is applied.
+        precision : `~numpy.ndarray`
+            Inverse covariance matrix (precision matrix).
+        mean : `~numpy.ndarray` or None
+            Mean values. If None, uses zero array. Default is None.
+        lambda_ : float
+            Penalty strength (Lagrange multiplier).
+        """
+        from scipy.stats import Covariance
+
+        cov = Covariance.from_precision(precision)
+        mean = mean if mean is not None else np.zeros(len(parameters))
+        return cls(
+            parameters=parameters, mean=mean, covariance=cov.covariance, lambda_=lambda_
+        )
+
+    @classmethod
+    def from_diagonal(cls, parameters, sigma, mean=None, lambda_=1.0):
+        """Create a GaussianPriorPenalty with a diagonal covariance matrix.
+
+        Parameters
+        ----------
+        parameters : list of Parameter
+            Parameters to apply the prior to.
+        sigma : ~numpy.ndarray` or float
+            Standard deviation(s) for each parameter.
+        mean : `~numpy.ndarray` or float, optional
+            Mean values. If None, uses zero array. Default is None.
+        lambda_ : float
+            Penalty scaling factor.
+        """
+        from scipy.stats import Covariance
+
+        sigma = np.broadcast_to(sigma, len(parameters))
+
+        mean = mean if mean is not None else 0
+        mean = np.broadcast_to(mean, len(parameters))
+
+        covariance = Covariance.from_diagonal(sigma**2)
+        return cls(
+            parameters=parameters,
+            mean=mean,
+            covariance=covariance.covariance,
+            lambda_=lambda_,
+        )
+
+    @classmethod
+    def L2_penalty(cls, parameters, mean=None, lambda_=1.0):
+        """Standard ridge (L2) regularization penalty.
+
+        Computes a penalty of the form:  lambda * sum ||x_i - mu_i||²
+        which corresponds to applying an identity covariance gaussian prior.
+
+        Parameters
+        ----------
+        parameters : list of `~gammapy.modeling.Parameter`
+            Parameters to which the penalty is applied.
+        mean : list of float, optional
+            Prior mean values for each parameter. If not provided, defaults to zeros.
+        lambda_ : float
+            Regularization strength (Lagrange multiplier).
+        """
+        return cls.from_diagonal(parameters, sigma=1, mean=mean, lambda_=lambda_)
+
+    @classmethod
+    def SmoothnessPenalty(cls, parameters, lambda_=1.0):
+        """Create a smoothness penalty using finite differences.
+
+        Parameters
+        ----------
+        parameters: list of `~gammapy.modeling.Parameter`
+            Parameters to which the penalty is applied.
+        lambda_: float, optional
+            Penalty strength. Default is 1.
+        """
+        from scipy.sparse import diags
+
+        n_params = len(parameters)
+        diagonals = [
+            2 * np.ones(n_params),  # main diagonal
+            -1 * np.ones(n_params - 1),  # upper diagonal
+            -1 * np.ones(n_params - 1),  # lower diagonal
+        ]
+        Q = diags(diagonals, [0, -1, 1]).toarray()
+        return cls.from_precision(parameters, Q, mean=0, lambda_=lambda_)


### PR DESCRIPTION
**Description**

This pull request introduces `FitStatisticPenalty` classes. 

- *Motivation* : support constraints on multiple parameters e.g. regularity constraints, multiparametric priors

- *Use cases* : 
  - regularized flux points (in true energy, see #5625)
  - background model corrections
  - systematic uncertainty models 
  - etc

- *Proposed approach*:
  - Rather than creating a `MultiNormalPrior` with a logic similar to individual parameter `Prior` objects as in #5468 , the 
     idea here is to define a `FitStatisticPenalty` object. 
  - It takes on init the `Parameters` on which it should apply and implements a `stat_sum()` (could be `evaluate` for clarity) method.  
  - It is set on the `Models` object.
  - It introduces for now a unique `GaussianPriorPenalty` but constructors are provided to build the various useful cases (e.g. 
     diagonal covariance matrix, smoothness constraints). Sub-classing for those cases might be useful though for book- 
     keeping and provenance.
 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
