### PR TITLE
Replace np.dot by np.matmul

### DIFF
--- a/gammapy/datasets/utils.py
+++ b/gammapy/datasets/utils.py
@@ -65,7 +65,7 @@ def apply_edisp(input_map, edisp):
     if edisp is not None:
         loc = input_map.geom.axes.index("energy_true")
         data = np.rollaxis(input_map.data, loc, len(input_map.data.shape))
-        data = np.dot(data, edisp.pdf_matrix)
+        data = np.matmul(data, edisp.pdf_matrix)
         data = np.rollaxis(data, -1, loc)
         energy_axis = edisp.axes["energy"].copy(name="energy")
     else:


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request replaces `np.dot` by `np.matmul` in `apply_edisp` function. This improves performances of `aply_edisp` on typical geometries by a factor of a few. Edisp convolution is not the bottleneck in the calculation so the overall gain on benchmarks is marginal. But this might provide more substantial gains in some cases.

**Dear reviewer**
On the following example the change is 4ms to 0.8ms.

```
import astropy.units as u
from gammapy.irf import EDispKernel, PSFKernel
from gammapy.datasets.utils import apply_edisp
from gammapy.maps import MapAxis, Map
import numpy as np

axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=30, name="energy_true")
m = Map.create(
        skydir=(0.8, 0.8),
     width=(2, 2),
     binsz=0.02,
     axes=[axis],
    frame="galactic"
)
size = np.prod(m.data.shape)
m.data = np.arange(size).reshape(m.data.shape)
e_true = m.geom.axes[0]
e_reco = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=20)
edisp = EDispKernel.from_diagonal_response(energy_axis_true=e_true, energy_axis=e_reco)

map_edisp = apply_edisp(m, edisp)
```