### PR TITLE
Utility to filter a table parsing string of  logical operations

### DIFF
--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -291,7 +291,7 @@ def logic_parser(table, expression):
 
     Parameters
     ----------
-    table : astropy.table.Table
+    table : `~astropy.table.Table`
         The input table to filter.
     expression : str
         The logical expression to evaluate on each row. The expression can reference
@@ -299,7 +299,7 @@ def logic_parser(table, expression):
 
     Returns
     -------
-    astropy.table.Table
+    table : `~astropy.table.Table`
         A new table containing only the rows that satisfy the expression. If no rows
         match the condition, an empty table with the same column names and data types
         as the input table is returned.

--- a/gammapy/utils/tests/test_scripts.py
+++ b/gammapy/utils/tests/test_scripts.py
@@ -181,7 +181,7 @@ def test_logic_parser():
     assert len(result) == 0
 
 
-def test_logic_parser_key_error():
+def test_logic_parser_error():
     # Create a sample table
     data = {"OBS_ID": [1, 2, 3, 4], "EVENT_TYPE": ["1", "3", "4", "2"]}
     table = Table(data)
@@ -189,6 +189,10 @@ def test_logic_parser_key_error():
     # Define an expression with a non-existent key
     expression = "(NON_EXISTENT_KEY < 3) and (OBS_ID > 1)"
 
-    # Check if KeyError is raised
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError) as excinfo:
         logic_parser(table, expression)
+
+    with pytest.raises(ValueError) as excinfo:
+        expression = "unsupported_expression()"
+        logic_parser(table, expression)
+    assert "Unsupported expression type" in str(excinfo.value)


### PR DESCRIPTION
The pull request Gammapy PR #5780 introduces a new feature that allows users to filter rows in an astropy.table.Table using logical expressions. The goal is to provide a flexible and expressive way to select subsets of data based on conditions involving table columns.

This PR introduces a function to simplify this operation.
Here's what it does:
- Takes an Astropy Table and a logical expression string.
- Evaluates the expression per row using Python's native syntax
- Returns a filtered table based on the evaluated condition.

It uses AST-based evaluation to parse and evaluate only safe, supported Python expressions.
Supports:
- Logical operators: and, or
- Comparison operators: <, >, ==, !=, in, etc.
- Lists and constants
- Any column in the table

The code, tests, and most of this text are AI generated.