### PR TITLE
Introduce a FoVFrame in gammapy.utils.coordinates

### DIFF
--- a/gammapy/utils/coordinates/__init__.py
+++ b/gammapy/utils/coordinates/__init__.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Astronomical coordinate calculation utility functions."""
-from .fov import fov_to_sky, sky_to_fov
+
+from .fov import fov_to_sky, sky_to_fov, FoVFrame
 from .other import (
     D_SUN_TO_GALACTIC_CENTER,
     cartesian,
@@ -13,6 +14,7 @@ from .other import (
 __all__ = [
     "cartesian",
     "D_SUN_TO_GALACTIC_CENTER",
+    "FoVFrame",
     "fov_to_sky",
     "galactic",
     "motion_since_birth",

--- a/gammapy/utils/coordinates/fov.py
+++ b/gammapy/utils/coordinates/fov.py
@@ -1,7 +1,91 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy.coordinates import SkyCoord, SkyOffsetFrame
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import (
+    AltAz,
+    Angle,
+    BaseCoordinateFrame,
+    CoordinateAttribute,
+    DynamicMatrixTransform,
+    EarthLocationAttribute,
+    FunctionTransform,
+    RepresentationMapping,
+    SkyCoord,
+    SkyOffsetFrame,
+    TimeAttribute,
+    UnitSphericalRepresentation,
+    frame_transform_graph,
+)
+from astropy.coordinates.matrix_utilities import matrix_transpose, rotation_matrix
 
-__all__ = ["fov_to_sky", "sky_to_fov"]
+__all__ = ["FoVFrame", "fov_to_sky", "sky_to_fov"]
+
+reflect_lon_matrix = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 1]])
+
+
+class FoVFrame(BaseCoordinateFrame):
+    """
+    FoV coordinate frame. Centered on `origin` and aligned on AltAz frame at `location` and `obstime`.
+
+    Longitudes are reversed.
+
+    Attributes
+    ----------
+    origin: astropy.coordinates.SkyCoord[AltAz]
+        Origin of this frame as a HorizonCoordinate
+    obstime: astropy.time.Time
+        Observation time
+    location: astropy.coordinates.EarthLocation
+        Location of the telescope
+    """
+
+    frame_specific_representation_info = {
+        UnitSphericalRepresentation: [
+            RepresentationMapping("lon", "fov_lon"),
+            RepresentationMapping("lat", "fov_lat"),
+        ]
+    }
+    default_representation = UnitSphericalRepresentation
+
+    origin = CoordinateAttribute(default=None, frame=AltAz)
+
+    obstime = TimeAttribute(default=None)
+    location = EarthLocationAttribute(default=None)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # make sure telescope coordinate is in range [-180°, 180°]
+        if isinstance(self._data, UnitSphericalRepresentation):
+            self._data.lon.wrap_angle = Angle(180, unit=u.deg)
+
+
+@frame_transform_graph.transform(FunctionTransform, FoVFrame, FoVFrame)
+def fov_to_fov(from_fov_coord, to_fov_frame):
+    """Transform between two skyoffset frames."""
+    intermediate_from = from_fov_coord.transform_to(from_fov_coord.origin)
+    intermediate_to = intermediate_from.transform_to(to_fov_frame.origin)
+    return intermediate_to.transform_to(to_fov_frame)
+
+
+@frame_transform_graph.transform(DynamicMatrixTransform, AltAz, FoVFrame)
+def altaz_to_fov(altaz_coord, fov_frame):
+    """Convert a reference coordinate to a sky offset frame."""
+    # Define rotation matrices along the position angle vector, and
+    # relative to the origin.
+    origin = fov_frame.origin.represent_as(UnitSphericalRepresentation)
+    mat1 = rotation_matrix(-origin.lat, "y")
+    mat2 = rotation_matrix(origin.lon, "z")
+
+    return reflect_lon_matrix @ mat1 @ mat2
+
+
+@frame_transform_graph.transform(DynamicMatrixTransform, FoVFrame, AltAz)
+def fov_to_altaz(fov_coord, altaz_frame):
+    """Convert an sky offset frame coordinate to the reference frame"""
+    # use the forward transform, but just invert it
+    mat = altaz_to_fov(altaz_frame, fov_coord)
+    return matrix_transpose(mat)
 
 
 def fov_to_sky(lon, lat, lon_pnt, lat_pnt):

--- a/gammapy/utils/coordinates/tests/test_fov.py
+++ b/gammapy/utils/coordinates/tests/test_fov.py
@@ -1,7 +1,124 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 import astropy.units as u
-from gammapy.utils.coordinates import fov_to_sky, sky_to_fov
+from astropy.coordinates import (
+    SkyCoord,
+    EarthLocation,
+    AltAz,
+    UnitSphericalRepresentation,
+)
+from astropy.time import Time
+from gammapy.utils.coordinates import FoVFrame, fov_to_sky, sky_to_fov
+
+
+class TestFoVFrame:
+    @classmethod
+    def setup_class(cls):
+        # Basic setup
+        location = EarthLocation(lat=45 * u.deg, lon=10 * u.deg)
+        obstime = Time("2025-01-01T00:00:00")
+        origin = AltAz(alt=45 * u.deg, az=120 * u.deg)
+
+        cls.fov_frame = FoVFrame(origin=origin, obstime=obstime, location=location)
+        cls.obstime = obstime
+        cls.origin = origin
+        cls.location = location
+
+    def test_creation(self):
+        # Construct a coordinate in FoVFrame
+        fov_coord = SkyCoord(
+            fov_lon=10 * u.deg, fov_lat=5 * u.deg, frame=self.fov_frame
+        )
+
+        # Check that the frame exists and properties are as expected
+        assert isinstance(fov_coord.frame, FoVFrame)
+        assert fov_coord.frame.obstime == self.obstime
+        assert fov_coord.frame.location == self.location
+
+        # Check representation type
+        assert isinstance(fov_coord.data, UnitSphericalRepresentation)
+        assert fov_coord.fov_lon.unit == u.deg
+        assert fov_coord.fov_lat.unit == u.deg
+
+    def test_altaz_transform(self):
+        altaz_frame = AltAz(obstime=self.obstime + 15 * u.min, location=self.location)
+        target = SkyCoord(az=[50, 60] * u.deg, alt=[20, 62] * u.deg, frame=altaz_frame)
+
+        # Transform to FoVFrame and back
+        fov = target.transform_to(self.fov_frame)
+        roundtrip = fov.transform_to(altaz_frame)
+
+        assert_allclose(roundtrip.az.deg, [50, 60])
+        assert_allclose(roundtrip.alt.deg, [20, 62])
+
+    def test_fovframe_transform(self):
+        fov_frame = FoVFrame(
+            origin=AltAz(alt=50 * u.deg, az=110 * u.deg),
+            obstime=self.obstime + 15 * u.min,
+            location=self.location,
+        )
+        target = SkyCoord(
+            fov_lon=[50, 60] * u.deg, fov_lat=[20, 62] * u.deg, frame=fov_frame
+        )
+
+        # Transform to FoVFrame and back
+        fov = target.transform_to(self.fov_frame)
+        roundtrip = fov.transform_to(fov_frame)
+
+        assert_allclose(roundtrip.fov_lon.deg, [50, 60])
+        assert_allclose(roundtrip.fov_lat.deg, [20, 62])
+
+    def test_icrs_transform(self):
+        target = SkyCoord(
+            ra=[10, 30, 45] * u.deg, dec=[-60, -30, 60] * u.deg, frame="icrs"
+        )
+
+        # Transform to FoVFrame and back
+        fov = target.transform_to(self.fov_frame)
+        roundtrip = fov.transform_to("icrs")
+
+        assert_allclose(roundtrip.ra.deg, [10, 30, 45])
+        assert_allclose(roundtrip.dec.deg, [-60, -30, 60])
+
+
+def test_checked_hess_values():
+    # these are cross-checked with the
+    # transformation as implemented in H.E.S.S.
+    fov_altaz_lon = [0.7145614, 0.86603433, -0.05409698, 2.10295248] * u.deg
+    fov_altaz_lat = [-1.60829115, -1.19643974, 0.45800984, 3.26844192] * u.deg
+
+    az_pointing = [52.42056255, 52.24706061, 52.06655505, 51.86795724] * u.deg
+    alt_pointing = [51.11908203, 51.23454751, 51.35376141, 51.48385814] * u.deg
+    altaz_pnt = AltAz(az=az_pointing, alt=alt_pointing)
+
+    fov_frame = FoVFrame(origin=altaz_pnt)
+    fov_coord = SkyCoord(fov_lon=fov_altaz_lon, fov_lat=fov_altaz_lat, frame=fov_frame)
+    altaz = fov_coord.transform_to(altaz_pnt)
+    assert_allclose(altaz.az.value, [51.320575, 50.899125, 52.154053, 48.233023])
+    assert_allclose(altaz.alt.value, [49.505451, 50.030165, 51.811739, 54.700102])
+
+
+def test_simple_altaz_to_fov():
+    altaz_pnt = AltAz(az=0 * u.deg, alt=0 * u.deg)
+    coord = SkyCoord(1, 1, unit="deg", frame=FoVFrame(origin=altaz_pnt)).transform_to(
+        altaz_pnt
+    )
+    assert_allclose(coord.az.value, 359)
+    assert_allclose(coord.alt.value, 1)
+
+    altaz_pnt = AltAz(az=180 * u.deg, alt=0 * u.deg)
+    coord = SkyCoord(-1, 1, unit="deg", frame=FoVFrame(origin=altaz_pnt)).transform_to(
+        altaz_pnt
+    )
+    assert_allclose(coord.az.value, 181)
+    assert_allclose(coord.alt.value, 1)
+
+    altaz_pnt = AltAz(az=0 * u.deg, alt=60 * u.deg)
+    coord = SkyCoord(1, 0, unit="deg", frame=FoVFrame(origin=altaz_pnt)).transform_to(
+        altaz_pnt
+    )
+    assert_allclose(coord.az.value, 358, rtol=1e-3)
+    assert_allclose(coord.alt.value, 59.985, rtol=1e-3)
 
 
 def test_fov_to_sky():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request tries to solve #5041 by introducing a `FoVFrame` coordinate system based on astropy's `BaseCoordinateFrame`. It follows the `NominalFrame` logic implemented in ctapipe except for the longitude reversal which is done with an additional matrix multiplication (not a rotation matrix here).

I have added some tests.

```
geom = WcsGeom.create(width=1, binsz=0.02)
coords = geom.get_coord().skycoord

now = Time.now() 
location = observatory_locations.get("ctao_south")
origin = AltAz(alt=55*u.deg, az=10.5*u.deg)

frame = FoVFrame(obstime=now, location=location, origin=origin)

# transform to FoV frame
new = coords.transform_to(frame)

# transform back to ICRS
back = new.transform_to("icrs")
```
This yields the same result as the current `sky_to_fov`


**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
