### PR TITLE
Fix broken link to another tutorial

### DIFF
--- a/examples/tutorials/analysis-time/light_curve_flare.py
+++ b/examples/tutorials/analysis-time/light_curve_flare.py
@@ -337,4 +337,4 @@ plt.show()
 
 #####################################################################
 # We can use the sliced lightcurve to understand the variability,
-# as shown in the doc:`/tutorials/analysis-time/variability_estimation` tutorial.
+# as shown in the :doc:`/tutorials/analysis-time/variability_estimation` tutorial.


### PR DESCRIPTION
Fix broken link to another tutorial at the bottom of the tutorial https://docs.gammapy.org/dev/tutorials/analysis-time/light_curve_flare.html because of a missing leading colon.
