### PR TITLE
Add method option to Irf.integrate_log_log

### DIFF
--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -309,7 +309,7 @@ class IRF(metaclass=abc.ABCMeta):
     def _mask_out_bounds(invalid):
         return np.any(invalid, axis=0)
 
-    def integrate_log_log(self, axis_name, **kwargs):
+    def integrate_log_log(self, axis_name, method="linear", **kwargs):
         """Integrate along a given axis.
 
         This method uses log-log trapezoidal integration.
@@ -327,7 +327,8 @@ class IRF(metaclass=abc.ABCMeta):
             Returns 2D array with axes offset.
         """
         axis = self.axes.index(axis_name)
-        data = self.evaluate(**kwargs, method="linear")
+        #        method = kwargs.pop("method", "linear")
+        data = self.evaluate(**kwargs, method=method)
         values = kwargs[axis_name]
         return trapz_loglog(data, values, axis=axis)
 

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -200,6 +200,39 @@ def test_background_3d_integrate(bkg_3d):
     assert_allclose(rate.to("s-1 sr-1").value, [[99000.0, 99000.0]], rtol=1e-5)
 
 
+def test_bkg2d_integrate_nearest():
+    energy = [0.1, 1, 10, 100, 1000] * u.TeV
+    energy_axis = MapAxis.from_energy_edges(energy)
+
+    offset = [0, 1, 2, 3] * u.deg
+    offset_axis = MapAxis.from_edges(offset, name="offset")
+
+    data = np.arange(4, 0, -1)[:, np.newaxis] * np.ones((4, 3))
+    #    data[3,:] = 0.5
+    bkg_2d = Background2D(
+        axes=[energy_axis, offset_axis], data=data, unit="s-1 TeV-1 sr-1"
+    )
+
+    rate = bkg_2d.integrate_log_log(
+        offset=0.5 * u.deg,
+        energy=[0.2, 2, 20, 200] * u.TeV,
+        axis_name="energy",
+    )
+    assert_allclose(
+        rate.to("s-1 sr-1").value, [6.29251, 44.368654, 257.26371], rtol=1e-5
+    )
+
+    rate = bkg_2d.integrate_log_log(
+        offset=0.5 * u.deg,
+        energy=[0.2, 2, 20, 200] * u.TeV,
+        axis_name="energy",
+        method="nearest",
+    )
+    assert_allclose(
+        rate.to("s-1 sr-1").value, [5.942441, 41.266706, 228.908249], rtol=1e-5
+    )
+
+
 @requires_data()
 def test_background_3d_read():
     filename = (


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request solves #5085 by adding a `method` argument to `IRF.integrate_log_log`. It is set by default to `linear` but can be changed to `nearest`.

```
import matplotlib.pyplot as plt
import numpy as np
import astropy.units as u
from gammapy.maps import MapAxis
from gammapy.irf import Background2D

energy=MapAxis.from_energy_bounds(0.1,10,4, unit="TeV")
offset = MapAxis.from_edges(np.linspace(0.,3., 10), unit="deg", name="offset")

data = np.random.poisson(10*np.ones((4,9)))
bkg = Background2D([energy, offset], data, unit="TeV-1s-1sr-1")

energies = np.geomspace(0.03,30,100)*u.TeV
plt.loglog(energies,bkg.evaluate(offset=0.1*u.deg, energy=energies, method="nearest"))
plt.loglog(energies,bkg.evaluate(offset=0.1*u.deg, energy=energies, method="linear"))
```
![download-1](https://github.com/user-attachments/assets/b71759ca-60c5-484d-9c66-43543957e773)

```
integ_near = bkg.integrate_log_log("energy", energy=energies, offset=0.1*u.deg, method="nearest")
integ_lin = bkg.integrate_log_log("energy", energy=energies, offset=0.1*u.deg, method="linear")
plt.loglog(energies[1:], integ_near)
plt.loglog(energies[1:], integ_lin)
```
![download-2](https://github.com/user-attachments/assets/9d9149e0-cafe-4f46-b174-93fec8196269)
