### PR TITLE
`FluxPointsEstimator`: precise the default value of  `reoptimize`

### DIFF
--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -44,7 +44,7 @@ class FluxEstimator(ParameterEstimator):
         Default is None so the optional steps are not executed.
     fit : `Fit`, optional
         Fit instance specifying the backend and fit options.
-        Default is None, so "minuit" is used.
+        Fit instance specifying the backend and fit options. If None, the `~gammapy.modeling.Fit` instance is created internally. Default is None.
     reoptimize : bool, optional
         If True, the free parameters of the other models are fitted in each bin independently,
         together with the norm of the source of interest

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -27,12 +27,12 @@ class FluxEstimator(ParameterEstimator):
     ----------
     source : str or int
         For which source in the model to compute the flux.
-    n_sigma : int
-        Sigma to use for asymmetric error computation.
-    n_sigma_ul : int
-        Sigma to use for upper limit computation.
-    n_sigma_sensitivity : int
-        Sigma to use for sensitivity computation.
+    n_sigma : int, optional
+        Sigma to use for asymmetric error computation. Default is 1.
+    n_sigma_ul : int, optional
+        Sigma to use for upper limit computation. Default is 2.
+    n_sigma_sensitivity : int, optional
+        Sigma to use for sensitivity computation. Default is 5.
     selection_optional : list of str, optional
         Which additional quantities to estimate. Available options are:
 
@@ -42,16 +42,17 @@ class FluxEstimator(ParameterEstimator):
             * "scan": estimate fit statistic profiles.
 
         Default is None so the optional steps are not executed.
-    fit : `Fit`
+    fit : `Fit`, optional
         Fit instance specifying the backend and fit options.
-    reoptimize : bool
+        Default is None, so "minuit" is used.
+    reoptimize : bool, optional
         If True, the free parameters of the other models are fitted in each bin independently,
         together with the norm of the source of interest
         (but the other parameters of the source of interest are kept frozen).
         If False, only the norm of the source of interest is fitted,
         and all other parameters are frozen at their current values.
         Default is False.
-    norm : `~gammapy.modeling.Parameter` or dict
+    norm : `~gammapy.modeling.Parameter` or dict, optional
         Norm parameter used for the fit.
         Default is None and a new parameter is created automatically,
         with value=1, name="norm", scan_min=0.2, scan_max=5, and scan_n_values = 11.

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -45,10 +45,10 @@ class FluxEstimator(ParameterEstimator):
     fit : `Fit`
         Fit instance specifying the backend and fit options.
     reoptimize : bool
-        If True the free parameters of the other models are fitted in each bin independently,
+        If True, the free parameters of the other models are fitted in each bin independently,
         together with the norm of the source of interest
         (but the other parameters of the source of interest are kept frozen).
-        If False only the norm of the source of interest if fitted,
+        If False, only the norm of the source of interest is fitted,
         and all other parameters are frozen at their current values.
         Default is False.
     norm : `~gammapy.modeling.Parameter` or dict

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -44,7 +44,8 @@ class ParameterEstimator(Estimator):
 
         Default is None, so the optional steps are not executed.
     fit : `~gammapy.modeling.Fit`, optional
-        Fit instance specifying the backend and fit options. Default is None, so "minuit" is used.
+        Fit instance specifying the backend and fit options. If None, the `~gammapy.modeling.Fit` instance is created
+        internally. Default is None.
     reoptimize : bool, optional
         Re-optimize other free model parameters. Default is True.
 

--- a/gammapy/estimators/parameter.py
+++ b/gammapy/estimators/parameter.py
@@ -26,14 +26,14 @@ class ParameterEstimator(Estimator):
 
     Parameters
     ----------
-    n_sigma : int
+    n_sigma : int, optional
         Sigma to use for asymmetric error computation. Default is 1.
-    n_sigma_ul : int
+    n_sigma_ul : int, optional
         Sigma to use for upper limit computation. Default is 2.
-    n_sigma_sensitivity : int
+    n_sigma_sensitivity : int, optional
         Sigma to use for sensitivity computation. Default is 5.
-    null_value : float
-        Which null value to use for the parameter.
+    null_value : float, optional
+        Which null value to use for the parameter. Default is 1e-150.
     selection_optional : list of str, optional
         Which additional quantities to estimate. Available options are:
 
@@ -42,10 +42,10 @@ class ParameterEstimator(Estimator):
             * "ul": estimate upper limits.
             * "scan": estimate fit statistic profiles.
 
-        Default is None so the optional steps are not executed.
-    fit : `~gammapy.modeling.Fit`
-        Fit instance specifying the backend and fit options.
-    reoptimize : bool
+        Default is None, so the optional steps are not executed.
+    fit : `~gammapy.modeling.Fit`, optional
+        Fit instance specifying the backend and fit options. Default is None, so "minuit" is used.
+    reoptimize : bool, optional
         Re-optimize other free model parameters. Default is True.
 
     Examples

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -58,7 +58,8 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
         but rather the closest values to the energy axis edges of the parent dataset.
         Default is [1, 10] TeV.
     fit : `Fit`, optional
-        Fit instance specifying the backend and fit options. Default is None, so "scipy" is used.
+        Fit instance specifying the backend and fit options. If None, the `~gammapy.modeling.Fit` instance is created
+        internally. Default is None.
     reoptimize : bool, optional
         If True, the free parameters of the other models are fitted in each bin independently,
         together with the norm of the source of interest
@@ -70,18 +71,16 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
         Whether to sum over the energy groups or fit the norm on the full energy grid. Default is None.
     n_jobs : int, optional
         Number of processes used in parallel for the computation. The number of jobs is limited to the number of
-        physical CPUs. If None, use `~gammapy.utils.parallel.N_JOBS_DEFAULT`.
+        physical CPUs. If None, defaults to `~gammapy.utils.parallel.N_JOBS_DEFAULT`.
         Default is None.
     parallel_backend : {"multiprocessing", "ray"}, optional
-        Which backend to use for multiprocessing. Default is None.
+        Which backend to use for multiprocessing. If None, defaults to `~gammapy.utils.parallel.BACKEND_DEFAULT`.
     norm : `~gammapy.modeling.Parameter` or dict, optional
         Norm parameter used for the fit.
-        Default is None and a new parameter is created automatically,
-        with value=1, name="norm", scan_min=0.2, scan_max=5, and scan_n_values = 11.
-        By default, the min and max are not set and derived from the source model,
-        unless the source model does not have one and only one norm parameter.
-        If a dict is given the entries should be a subset of
-        `~gammapy.modeling.Parameter` arguments.
+        Default is None and a new parameter is created automatically, with value=1, name="norm",
+        scan_min=0.2, scan_max=5, and scan_n_values = 11. By default, the min and max are not set
+        (consider setting them if errors or upper limits computation fails). If a dict is given,
+        the entries should be a subset of `~gammapy.modeling.Parameter` arguments.
 
     Notes
     -----

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -69,9 +69,9 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
     sum_over_energy_groups : bool, optional
         Whether to sum over the energy groups or fit the norm on the full energy grid. Default is None.
     n_jobs : int, optional
-        Number of processes used in parallel for the computation. Default is None, unless
-        `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified. The number of jobs is
-        limited to the number of physical CPUs.
+        Number of processes used in parallel for the computation. The number of jobs is limited to the number of
+        physical CPUs. If None, use `~gammapy.utils.parallel.N_JOBS_DEFAULT`.
+        Default is None.
     parallel_backend : {"multiprocessing", "ray"}, optional
         Which backend to use for multiprocessing. Default is None.
     norm : `~gammapy.modeling.Parameter` or dict, optional

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -37,11 +37,11 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
     ----------
     source : str or int
         For which source in the model to compute the flux points.
-    n_sigma : int
+    n_sigma : int, optional
         Number of sigma to use for asymmetric error computation. Default is 1.
-    n_sigma_ul : int
+    n_sigma_ul : int, optional
         Number of sigma to use for upper limit computation. Default is 2.
-    n_sigma_sensitivity : int
+    n_sigma_sensitivity : int, optional
         Sigma to use for sensitivity computation. Default is 5.
     selection_optional : list of str, optional
         Which additional quantities to estimate. Available options are:
@@ -56,33 +56,36 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
     energy_edges : list of `~astropy.units.Quantity`, optional
         Edges of the flux points energy bins. The resulting bin edges won't be exactly equal to the input ones,
         but rather the closest values to the energy axis edges of the parent dataset.
-        Default is None: apply the estimator in each energy bin of the parent dataset.
-        For further explanation see :ref:`estimators`.
-    fit : `Fit`
-        Fit instance specifying the backend and fit options.
-    reoptimize : bool
+        Default is [1, 10] TeV.
+    fit : `Fit`, optional
+        Fit instance specifying the backend and fit options. Default is None, so "scipy" is used.
+    reoptimize : bool, optional
         If True, the free parameters of the other models are fitted in each bin independently,
         together with the norm of the source of interest
         (but the other parameters of the source of interest are kept frozen).
         If False, only the norm of the source of interest is fitted,
         and all other parameters are frozen at their current values.
         Default is False.
-    sum_over_energy_groups : bool
-        Whether to sum over the energy groups or fit the norm on the full energy grid.
-    n_jobs : int
-        Number of processes used in parallel for the computation. Default is one, unless
+    sum_over_energy_groups : bool, optional
+        Whether to sum over the energy groups or fit the norm on the full energy grid. Default is None.
+    n_jobs : int, optional
+        Number of processes used in parallel for the computation. Default is None, unless
         `~gammapy.utils.parallel.N_JOBS_DEFAULT` was modified. The number of jobs is
         limited to the number of physical CPUs.
-    parallel_backend : {"multiprocessing", "ray"}
-        Which backend to use for multiprocessing.
-    norm : `~gammapy.modeling.Parameter` or dict
-        Norm parameter used for the fit
+    parallel_backend : {"multiprocessing", "ray"}, optional
+        Which backend to use for multiprocessing. Default is None.
+    norm : `~gammapy.modeling.Parameter` or dict, optional
+        Norm parameter used for the fit.
         Default is None and a new parameter is created automatically,
         with value=1, name="norm", scan_min=0.2, scan_max=5, and scan_n_values = 11.
-        By default the min and max are not set and derived from the source model,
+        By default, the min and max are not set and derived from the source model,
         unless the source model does not have one and only one norm parameter.
         If a dict is given the entries should be a subset of
         `~gammapy.modeling.Parameter` arguments.
+
+    Notes
+    -----
+    For further explanation, see :ref:`estimators`.
     """
 
     tag = "FluxPointsEstimator"

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -61,11 +61,12 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
     fit : `Fit`
         Fit instance specifying the backend and fit options.
     reoptimize : bool
-        If True the free parameters of the other models are fitted in each bin independently,
+        If True, the free parameters of the other models are fitted in each bin independently,
         together with the norm of the source of interest
         (but the other parameters of the source of interest are kept frozen).
-        If False only the norm of the source of interest if fitted,
+        If False, only the norm of the source of interest is fitted,
         and all other parameters are frozen at their current values.
+        Default is False.
     sum_over_energy_groups : bool
         Whether to sum over the energy groups or fit the norm on the full energy grid.
     n_jobs : int


### PR DESCRIPTION
**Description**

This pull request aim is given in its title... and fixes some typo.

The default is False because its parent class, `FluxEstimator` is False as default...