### PR TITLE
Add missing space that was breaking the cross reference link

### DIFF
--- a/examples/tutorials/starting/analysis_2.py
+++ b/examples/tutorials/starting/analysis_2.py
@@ -58,7 +58,7 @@ In practice, we have to:
   - Apply the makers sequentially to produce the current `~gammapy.datasets.MapDataset`
   - Stack it on the target one.
 
-- Define the`~gammapy.modeling.models.SkyModel` to apply to the dataset.
+- Define the `~gammapy.modeling.models.SkyModel` to apply to the dataset.
 - Create a `~gammapy.modeling.Fit` object and run it to fit the model
   parameters
 - Apply a `~gammapy.estimators.FluxPointsEstimator` to compute flux points for


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request adds a missing space before a cross-reference link to  `gammapy.modeling.models.SkyModel` in the tutorial (https://docs.gammapy.org/dev/tutorials/starting/analysis_2.html#proposed-approach) to correctly render the link.
