### PR TITLE
Fix link of doc licences in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,9 +69,9 @@ Licence
 Gammapy is licensed under a 3-clause BSD style license - see the
 `LICENSE.rst <https://github.com/gammapy/gammapy/blob/master/LICENSE.rst>`_ file.
 
-The Gammapy documentation is licensed under the `CC BY-NC-SA<https://creativecommons.org/licenses/by-nc-sa/4.0/>`_
+The Gammapy documentation is licensed under the `CC BY-NC-SA <https://creativecommons.org/licenses/by-nc-sa/4.0/>`_
 license. Examples, recipes, and other code in the documentation are additionally licensed under the
-`BSD 3-Clause "New" or "Revised"<https://opensource.org/license/BSD-3-Clause>`_ license.
+`BSD 3-Clause "New" or "Revised" <https://opensource.org/license/BSD-3-Clause>`_ license.
 
 Supporting the project
 ++++++++++++++++++++++


### PR DESCRIPTION
There is a missing space between the shown text and the link that makes it not being properly displayed (see current README page).
