### PR TITLE
Improve HowTo page titles

### DIFF
--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -111,7 +111,7 @@ Please give feedback and suggest additions to this page!
         fp.plot(ax=ax, sed_type="e2dnde")
 
 
-.. dropdown:: Compute the significance of a detected source
+.. dropdown:: Compute the significance of a source
 
     Estimating the significance of a source, or more generally of an additional model
     component (such as e.g. a spectral line on top of a power-law spectrum), is done


### PR DESCRIPTION
This PR updates the titles for the "Compute source significance" and "Compute cumulative significance" dropdowns on the HowTo page to make them clearer and easier for users to understand.

"Compute source significance" → Significance of a Detected Source

"Compute cumulative significance" → Cumulative Significance Over Time

This resolves #5824