### PR TITLE
Adapt intructions for static figures

### DIFF
--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -42,13 +42,13 @@ Check Python code
 Code in RST files
 +++++++++++++++++
 
-Most of the documentation of Gammapy is present in RST files that are converted into HTML pages using
-Sphinx during the build documentation process. You may include snippets of Python code in these RST files
-within blocks labelled with ``.. code-block:: python`` Sphinx directive. However, this code could not be
-tested, and it will not be possible to know if it fails in following versions of Gammapy. That's why we
-recommend using the ``.. testcode::`` directive to enclose code that will be tested against the results
-present in a block labelled with ``.. testoutput::`` directive. If not ``.. testoutput::`` directive is provided,
-only execution tests will be performed.
+Most of the documentation of Gammapy is present in `restructured text (RST)`_ files that are converted
+into HTML pages using Sphinx during the build documentation process. You may include snippets of Python
+code in these RST files within blocks labelled with ``.. code-block:: python`` Sphinx directive. However,
+this code could not be tested, and it will not be possible to know if it fails in following versions of
+Gammapy. That's why we recommend using the ``.. testcode::`` directive to enclose code that will be tested
+against the results present in a block labelled with ``.. testoutput::`` directive. If not ``.. testoutput::``
+directive is provided, only execution tests will be performed.
 
 For example, we could check that the code below does not fail, since it does not provide any output.
 
@@ -293,24 +293,32 @@ Include png files as images
 In the RST files
 ++++++++++++++++
 
-Gammapy has a ``gp-image`` directive to include an image from ``$GAMMAPY_DATA/figures/``,
-use the ``gp-image`` directive instead of the usual Sphinx ``image`` directive like this:
+To include an image is your rst file first add it to the `docs/_static` folder.
+Then you can use the usual Sphinx ``image`` directive like this:
 
 .. code-block:: rst
 
-    .. gp-image:: detect/fermi_ts_image.png
+    .. image:: _static/gammapy_banner.png
         :scale: 100%
 
-More info on the `image directive <http://www.sphinx-doc.org/en/stable/rest.html#images>`__.
+If you wish to add an image to a tutorial you can utilise the following:
+
+.. code-block:: rst
+
+    #.. figure:: ../../_static/gammapy_maps.png
+    #   :alt: Gammapy Maps Illustration
+    #
+    #   Gammapy Maps Illustration
+
+More information on the image directive can be found `here <http://www.sphinx-doc.org/en/stable/rest.html#images>`__.
 
 Documentation guidelines
 ------------------------
 
 Like almost all Python projects, the Gammapy documentation is written in a format called
-`restructured text (RST)`_ and built using `Sphinx`_.
-We mostly follow the `Astropy documentation guidelines <https://docs.astropy.org/en/latest/development/docguide.html>`,
-which are based on the `Numpy docstring standard`_,
-which is what most scientific Python packages use.
+`restructured text (RST)`_ and built using `Sphinx`_. We mostly follow the
+`Astropy documentation guidelines <https://docs.astropy.org/en/latest/development/docguide.html>`__,
+which are based on the `Numpy docstring standard`_, which is what most scientific Python packages use.
 
 .. _restructured text (RST): http://sphinx-doc.org/rest.html
 .. _Sphinx: http://sphinx-doc.org/

--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -310,6 +310,7 @@ If you wish to add an image to a tutorial you can utilise the following:
     #
     #   Gammapy Maps Illustration
 
+Where `:alt` is used to create a caption for the image. 
 More information on the image directive can be found `here <http://www.sphinx-doc.org/en/stable/rest.html#images>`__.
 
 Documentation guidelines

--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -293,7 +293,7 @@ Include png files as images
 In the RST files
 ++++++++++++++++
 
-To include an image is your rst file first add it to the `docs/_static` folder.
+To include an image in your rst file, first add it to the `docs/_static` folder.
 Then you can use the usual Sphinx ``image`` directive like this:
 
 .. code-block:: rst


### PR DESCRIPTION
This PR is to resolve #5811


I made a comment there regarding what to do with the unused figures in `gammapy-data`