### PR TITLE
CI fix : no yield in tests

### DIFF
--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -320,9 +320,7 @@ def test_naima_model():
         amplitude=2e33 / u.eV, e_0=10 * u.TeV, alpha=2.5
     )
     radiative_model = naima.radiative.PionDecay(particle_distribution, nh=1 * u.cm**-3)
-    yield Model.create(
-        "NaimaSpectralModel", "spectral", radiative_model=radiative_model
-    )
+    Model.create("NaimaSpectralModel", "spectral", radiative_model=radiative_model)
 
 
 def make_all_models():


### PR DESCRIPTION
Fix CI error :
`ERROR ../../.tox/py311-test/lib/python3.11/site-packages/gammapy/modeling/models/tests/test_io.py - Failed: 'yield' keyword is allowed in fixtures, but not in tests (test_naima_model)`
