### PR TITLE
Add requires_module decorator

### DIFF
--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -254,7 +254,9 @@ def requires_module(module_name):
 
                 return wrapper
             else:
-                return obj  # Fallback: return as-is
+                raise TypeError(
+                    "requires_module can only be used on methods or properties."
+                )
 
     return decorator
 

--- a/gammapy/utils/tests/test_scripts.py
+++ b/gammapy/utils/tests/test_scripts.py
@@ -99,3 +99,11 @@ def test_requires_module():
         match="The 'nonexistent_module' module is required to use this property.",
     ):
         _ = result.prop_unavailable
+
+    with pytest.raises(
+        TypeError, match="requires_module can only be used on methods or properties."
+    ):
+
+        @requires_module("nonexistent_module")
+        class InvalidUsage:
+            pass


### PR DESCRIPTION
A decorator that conditionally enables a method or property based on the availability of a module.
Used to activate some methods/properties only when ray is available.
Splitted from #5900