### PR TITLE
Add a function to retrieve free and unique parameters 

### DIFF
--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -699,6 +699,11 @@ class Parameters(collections.abc.Sequence):
         return self.__class__(dict.fromkeys(self._parameters))
 
     @property
+    def free_unique_parameters(self):
+        """List of free and unique parameters."""
+        return self.__class__([par for par in self.unique_parameters if not par.frozen])
+
+    @property
     def names(self):
         """List of parameter names."""
         return [par.name for par in self._parameters]

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -194,6 +194,32 @@ def test_unique_parameters():
     assert parameters_unique.names == ["a", "b", "c"]
 
 
+def test_free_parameters():
+    a = Parameter("a", 1, frozen=False)
+    b = Parameter("b", 2, frozen=True)
+    c = Parameter("c", 2, frozen=False)
+
+    parameters = Parameters([a, b, c])
+    free = parameters.free_parameters
+    frozen = parameters.frozen_parameters
+    assert free.names == ["a", "c"]
+    assert frozen.names == ["b"]
+    assert all(par.frozen for par in frozen)
+    assert all(not par.frozen for par in free)
+
+
+def test_free_unique_parameters():
+    a = Parameter("a", 1, frozen=False)
+    b = Parameter("b", 2, frozen=True)
+    c = Parameter("c", 4, frozen=False)
+    d = Parameter("d", 4, frozen=False)
+    d = a
+    parameters = Parameters([a, b, c, d])
+    free_unique = parameters.free_unique_parameters
+    assert free_unique.names == ["a", "c"]
+    assert all(not par.frozen for par in free_unique)
+
+
 def test_parameters_getitem(pars):
     assert pars[1].name == "ham"
     assert pars["ham"].name == "ham"


### PR DESCRIPTION
Currently there is no easy way to retrieve the list of parameters that are not frozen AND that are not linked.

This problem arised in issue #5908  in the sampler module when one is linking some parameters to other.
What was happening was that the sampler was received all free parameters including the link parameter twice.

This PR introduces a `parameters.free_unique_parameters` to retrieve free AND not linked parameters by simply combining the existing `unique_parameters` and `free_parameters`.

Also adds a test for free_parameters which wasn't tested before.

This partially solves  issue #5908. The other issue is that copying a model forgets about the link between param. This would need another PR.
