### PR TITLE
Add mask plot for spectral

### DIFF
--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1316,7 +1316,15 @@ class MapDataset(Dataset):
         ax = residuals.plot(ax, **kwargs)
         return ax
 
-    def plot_residuals_spectral(self, ax=None, method="diff", region=None, **kwargs):
+    def plot_residuals_spectral(
+        self,
+        ax=None,
+        method="diff",
+        region=None,
+        kwargs_fit=None,
+        kwargs_safe=None,
+        **kwargs,
+    ):
         """Plot spectral residuals.
 
         The residuals are extracted from the provided region, and the normalization
@@ -1392,6 +1400,21 @@ class MapDataset(Dataset):
         ymin = 1.05 * np.nanmin(residuals.data - yerr)
         ymax = 1.05 * np.nanmax(residuals.data + yerr)
         ax.set_ylim(ymin, ymax)
+
+        kwargs_fit = kwargs_fit or {}
+        kwargs_safe = kwargs_safe or {}
+
+        kwargs_fit.setdefault("label", "Mask fit")
+        kwargs_fit.setdefault("color", "tab:green")
+        kwargs_safe.setdefault("label", "Mask safe")
+        kwargs_safe.setdefault("color", "black")
+
+        if self.mask_fit:
+            self.mask_fit.to_region_nd_map().plot_mask(ax=ax, **kwargs_fit)
+
+        if self.mask_safe:
+            self.mask_safe.to_region_nd_map().plot_mask(ax=ax, **kwargs_safe)
+        ax.legend()
         return ax
 
     def plot_residuals(

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1330,6 +1330,8 @@ class MapDataset(Dataset):
         The residuals are extracted from the provided region, and the normalization
         used for its computation can be controlled using the method parameter.
 
+        Both the mask fit and mask safe are taken into account.
+
         The error bars are computed using the uncertainty on the excess with a symmetric assumption.
 
         Parameters

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1305,12 +1305,8 @@ class MapDataset(Dataset):
         )
         residuals = self._compute_residuals(counts_spatial, npred_spatial, method)
 
-        if self.mask_safe is not None:
-            mask = self.mask_safe.reduce_over_axes(func=np.logical_or, keepdims=True)
-            residuals.data[~mask.data] = np.nan
-
-        if self.mask_fit is not None:
-            mask = self.mask_fit.reduce_over_axes(func=np.logical_or, keepdims=True)
+        if self.mask is not None:
+            mask = self.mask.reduce_over_axes(func=np.logical_or, keepdims=True)
             residuals.data[~mask.data] = np.nan
 
         kwargs.setdefault("add_cbar", True)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1309,6 +1309,10 @@ class MapDataset(Dataset):
             mask = self.mask_safe.reduce_over_axes(func=np.logical_or, keepdims=True)
             residuals.data[~mask.data] = np.nan
 
+        if self.mask_fit is not None:
+            mask = self.mask_fit.reduce_over_axes(func=np.logical_or, keepdims=True)
+            residuals.data[~mask.data] = np.nan
+
         kwargs.setdefault("add_cbar", True)
         kwargs.setdefault("cmap", "coolwarm")
         kwargs.setdefault("vmin", -5)

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1337,9 +1337,16 @@ class MapDataset(Dataset):
         ax : `~matplotlib.axes.Axes`, optional
             Axes to plot on. Default is None.
         method : {"diff", "diff/sqrt(model)"}
-            Normalization used to compute the residuals, see `SpectrumDataset.residuals`. Default is "diff".
+            Normalization used to compute the residuals, see `SpectrumDataset.residuals`.
+            Default is "diff".
         region : `~regions.SkyRegion` (required)
             Target sky region. Default is None.
+        kwargs_fit : dict, optional
+            Keyword arguments passed to `~RegionNDMap.plot_mask()` for mask fit.
+            Default is None.
+        kwargs_safe : dict, optional
+            Keyword arguments passed to `~RegionNDMap.plot_mask()` for mask safe.
+            Default is None.
         **kwargs : dict, optional
             Keyword arguments passed to `~matplotlib.axes.Axes.errorbar`.
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1338,11 +1338,13 @@ class MapDataset(Dataset):
         ----------
         ax : `~matplotlib.axes.Axes`, optional
             Axes to plot on. Default is None.
-        method : {"diff", "diff/sqrt(model)"}
+        method : {"diff", "diff/sqrt(model)"}, optional
             Normalization used to compute the residuals, see `SpectrumDataset.residuals`.
             Default is "diff".
-        region : `~regions.SkyRegion` (required)
-            Target sky region. Default is None.
+        region : `~regions.SkyRegion`, optional
+            Target sky region. If None, the full dataset region
+            (i.e., `~gammapy.maps.WcsGeom.footprint_rectangle_sky_region`) is used as the default.
+            Default is None.
         kwargs_fit : dict, optional
             Keyword arguments passed to `~RegionNDMap.plot_mask()` for mask fit.
             Default is None.


### PR DESCRIPTION
This PR is to resolve #5830

Currently the mask is already visible on the `plot_residuals_spatial` however depending on the method you use it is difficult to see it:
![image](https://github.com/user-attachments/assets/40baa500-f2e8-41dc-ab12-4fb7ae5456cd)

![Screenshot from 2025-06-16 18-25-52](https://github.com/user-attachments/assets/912d0622-1947-4d39-8948-392a344b86be)

To account for that a simple adjustment of the code is needed on the `mask_fit`
![image](https://github.com/user-attachments/assets/61e91347-921c-47e4-8919-3365f53d4267)
