### PR TITLE
Tutorial setup command line option

### DIFF
--- a/examples/tutorials/README.rst
+++ b/examples/tutorials/README.rst
@@ -24,7 +24,12 @@ You can read them here, or execute them using a temporary cloud server in Binder
 To execute them locally, you have to first install Gammapy locally (see
 :ref:`installation`) and download the tutorial notebooks and example datasets (see
 :ref:`getting-started`). Once Gammapy is installed, remember that you can always
-use ``gammapy info`` to check your setup.
+use ``gammapy tutorial setup`` to check your tutorial setup, or in your script with
+
+.. code-block:: python
+
+    from gammapy.utils.check import check_tutorials_setup
+    check_tutorials_setup()
 
 Gammapy is a Python package built on `Numpy`_ and `Astropy`_, so to use it
 effectively, you have to learn the basics. Many good free resources are

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -152,5 +152,9 @@ def add_subcommands():
 
     cli_workflow.add_command(cli_run_workflow)
 
+    from .tutorial_info import cli_tutorial
+
+    cli.add_command(cli_tutorial)
+
 
 add_subcommands()

--- a/gammapy/scripts/tests/test_tutorial_info.py
+++ b/gammapy/scripts/tests/test_tutorial_info.py
@@ -1,0 +1,16 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from gammapy.scripts.main import cli
+from gammapy.utils.testing import run_cli
+
+
+def test_cli_tutorial_info():
+    result = run_cli(cli, ["tutorial", "setup", "--help"])
+    assert "Usage" in result.output
+
+
+def test_cli_tutorial_info_no_args():
+    result = run_cli(cli, ["tutorial", "setup"])
+    assert "System" in result.output
+    assert "Gammapy package" in result.output
+    assert "Other packages" in result.output
+    assert "Gammapy environment variables" in result.output

--- a/gammapy/scripts/tests/test_tutorial_info.py
+++ b/gammapy/scripts/tests/test_tutorial_info.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 from gammapy.scripts.main import cli
-from gammapy.utils.testing import run_cli
+from gammapy.utils.testing import requires_dependency, run_cli
 
 
 def test_cli_tutorial_info():
@@ -8,7 +9,10 @@ def test_cli_tutorial_info():
     assert "Usage" in result.output
 
 
-def test_cli_tutorial_info_no_args():
+@requires_dependency("requests")
+@requires_dependency("tqdm")
+@pytest.mark.remote_data
+def test_cli_tutorial_info_no_args(tmp_path):
     result = run_cli(cli, ["tutorial", "setup"])
     assert "System" in result.output
     assert "Gammapy package" in result.output

--- a/gammapy/scripts/tutorial_info.py
+++ b/gammapy/scripts/tutorial_info.py
@@ -1,0 +1,34 @@
+import os
+import logging
+import click
+from gammapy.scripts.info import cli_info
+from gammapy.scripts.download import cli_download_datasets
+
+log = logging.getLogger(__name__)
+
+RELEASE = "latest"  # Or set to a specific release version if needed
+
+
+@click.group(name="tutorial")
+def cli_tutorial():
+    """Gammapy tutorial helper commands."""
+
+
+@cli_tutorial.command(name="setup")
+@click.option(
+    "--path",
+    default="./gammapy-data",
+    show_default=True,
+    help="Path to download the datasets if needed.",
+)
+def cli_tutorial_setup(path):
+    """Check tutorial setup and show environment info."""
+    if "GAMMAPY_DATA" not in os.environ:
+        log.info(f"GAMMAPY_DATA not set. Downloading to '{path}'...")
+        cli_download_datasets.callback(out=path, release=RELEASE)
+        os.environ["GAMMAPY_DATA"] = path
+    else:
+        log.info(f"GAMMAPY_DATA is already set to '{os.environ['GAMMAPY_DATA']}'")
+
+    # Call the original info command
+    cli_info.callback(system=True, version=True, dependencies=True, envvar=True)


### PR DESCRIPTION
There was a discussion in the dev call (20/06/25) regarding https://github.com/gammapy/gammapy/issues/5816

We might not need to include the `check setup` in every tutorial, but rather somewhere else in the docs. I changed the intro of the tutorials to include this new cli


If we are happy with something like this we could remove `check setup` from each tutorial