### PR TITLE
Fix tests of EnergyDependentMorphologyEstimator

### DIFF
--- a/gammapy/estimators/energydependentmorphology.py
+++ b/gammapy/estimators/energydependentmorphology.py
@@ -5,6 +5,7 @@ import numpy as np
 from gammapy.datasets import Datasets
 from gammapy.modeling import Fit
 from gammapy.modeling.models import FoVBackgroundModel, Models
+from gammapy.datasets.actors import DatasetsActor
 from gammapy.modeling.selection import TestStatisticNested
 from gammapy.stats.utils import ts_to_sigma
 from .core import Estimator
@@ -317,6 +318,10 @@ class EnergyDependentMorphologyEstimator(Estimator):
                 * "df" : the number of degrees of freedom between null and alternative hypothesis
                 * "significance" : significance of the result
         """
+
+        if not isinstance(datasets, DatasetsActor):
+            datasets = Datasets(datasets=datasets)
+
         if not isinstance(datasets, Datasets) or datasets.is_all_same_type is False:
             raise ValueError("Unsupported datasets type.")
 

--- a/gammapy/estimators/tests/test_energydependentmorphology.py
+++ b/gammapy/estimators/tests/test_energydependentmorphology.py
@@ -2,7 +2,7 @@ import pytest
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from gammapy.datasets import Datasets, MapDataset
+from gammapy.datasets import MapDataset
 from gammapy.estimators.energydependentmorphology import (
     EnergyDependentMorphologyEstimator,
     weighted_chi2_parameter,
@@ -14,7 +14,7 @@ from gammapy.modeling.models import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def create_model():
     source_pos = SkyCoord(5.58, 0.2, unit="deg", frame="galactic")
 
@@ -44,69 +44,67 @@ def create_model():
     return model
 
 
-class TestEnergyDependentEstimator:
-    def __init__(self):
-        energy_edges = [1, 3, 5, 20] * u.TeV
+@pytest.fixture(scope="module")
+def estimator_result(create_model):
+    energy_edges = [1, 3, 5, 20] * u.TeV
+    stacked_dataset = MapDataset.read(
+        "$GAMMAPY_DATA/estimators/mock_DL4/dataset_energy_dependent.fits.gz"
+    )
+    stacked_dataset.models = create_model
+    estimator = EnergyDependentMorphologyEstimator(
+        energy_edges=energy_edges, source="source"
+    )
+    return estimator.run(stacked_dataset)
 
-        stacked_dataset = MapDataset.read(
-            "$GAMMAPY_DATA/estimators/mock_DL4/dataset_energy_dependent.fits.gz"
-        )
-        datasets = Datasets([stacked_dataset])
-        datasets.models = create_model()
 
-        estimator = EnergyDependentMorphologyEstimator(
-            energy_edges=energy_edges, source="source"
-        )
-        self.results = estimator.run(datasets)
+def test_edep(estimator_result):
+    results_edep = estimator_result["energy_dependence"]["result"]
+    assert_allclose(
+        results_edep["lon_0"],
+        [5.6067162, 5.601791, 5.6180701, 5.5973948] * u.deg,
+        rtol=1e-3,
+    )
+    assert_allclose(
+        results_edep["lat_0"],
+        [0.20237541, 0.21819575, 0.18371523, 0.18106852] * u.deg,
+        rtol=1e-3,
+    )
+    assert_allclose(
+        results_edep["sigma"],
+        [0.21563528, 0.25686477, 0.19736596, 0.13505605] * u.deg,
+        rtol=1e-3,
+    )
+    assert_allclose(estimator_result["energy_dependence"]["delta_ts"], 75.62, rtol=1e-3)
 
-    def test_edep(self):
-        results_edep = self.results["energy_dependence"]["result"]
-        assert_allclose(
-            results_edep["lon_0"],
-            [5.6067162, 5.601791, 5.6180701, 5.5973948] * u.deg,
-            atol=1e-5,
-        )
-        assert_allclose(
-            results_edep["lat_0"],
-            [0.20237541, 0.21819575, 0.18371523, 0.18106852] * u.deg,
-            atol=1e-5,
-        )
-        assert_allclose(
-            results_edep["sigma"],
-            [0.21563528, 0.25686477, 0.19736596, 0.13505605] * u.deg,
-            atol=1e-5,
-        )
-        assert_allclose(
-            self.results["energy_dependence"]["delta_ts"], 75.61713199794758, atol=1e-5
-        )
 
-    def test_significance(self):
-        results_src = self.results["src_above_bkg"]
-        assert_allclose(
-            results_src["delta_ts"],
-            [998.0521965029693, 712.8735641098574, 289.81556949490914],
-            atol=1e-5,
-        )
-        assert_allclose(
-            results_src["significance"],
-            [31.27752315246094, 26.34612970747113, 16.54625269423397],
-            atol=1e-5,
-        )
+def test_significance(estimator_result):
+    results_src = estimator_result["src_above_bkg"]
+    assert_allclose(
+        results_src["delta_ts"],
+        [998.0521965029693, 712.8735641098574, 289.81556949490914],
+        rtol=1e-3,
+    )
+    assert_allclose(
+        results_src["significance"],
+        [31.27752315246094, 26.34612970747113, 16.54625269423397],
+        rtol=1e-3,
+    )
 
-    def test_chi2(self):
-        results_edep = self.results["energy_dependence"]["result"]
-        chi2_sigma = weighted_chi2_parameter(
-            results_edep, parameters=["sigma", "lat_0", "lon_0"]
-        )
 
-        assert_allclose(
-            chi2_sigma["chi2"],
-            [87.84278516393066, 4.605432972153188, 1.320491077667271],
-            atol=1e-5,
-        )
+def test_chi2(estimator_result):
+    results_edep = estimator_result["energy_dependence"]["result"]
+    chi2_sigma = weighted_chi2_parameter(
+        results_edep, parameters=["sigma", "lat_0", "lon_0"]
+    )
 
-        assert_allclose(
-            chi2_sigma["significance"],
-            [9.107664118611664, 1.6449173252682943, 0.6484028260024965],
-            atol=1e-5,
-        )
+    assert_allclose(
+        chi2_sigma["chi2"],
+        [87.84278516393066, 4.605432972153188, 1.320491077667271],
+        rtol=1e-3,
+    )
+
+    assert_allclose(
+        chi2_sigma["significance"],
+        [9.107664118611664, 1.6449173252682943, 0.6484028260024965],
+        rtol=1e-3,
+    )


### PR DESCRIPTION
Fixes #5955 

Also allow the estimator to internally convert to `Datasets` during `.run` as for our other estimators.
The test test around 10 sec on my laptop, maybe we can keep the positions frozen/ run only for 2 bands to shorten the execution time