### PR TITLE
Fix TSmapEstimator pad_width

### DIFF
--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -589,7 +589,7 @@ def test_with_TemplateSpatialModel():
     )
 
     result = estimator.run(dataset)
-    assert_allclose(result["sqrt_ts"].data[0, 12, 16], 22.932, rtol=1e-3)
+    assert_allclose(result["sqrt_ts"].data[0, 12, 16], 22.3658, rtol=1e-3)
 
 
 def test_joint_ts_map(fake_dataset):
@@ -606,13 +606,13 @@ def test_joint_ts_map(fake_dataset):
     assert estimator.sum_over_energy_groups
 
     result = estimator.run(fake_dataset)
-    assert_allclose(result["npred_excess"].data.sum(), 902.403647, rtol=1e-3)
-    assert_allclose(result["sqrt_ts"].data[0, 10, 10], 1.360219, rtol=1e-3)
+    assert_allclose(result["npred_excess"].data.sum(), 912.92157, rtol=1e-3)
+    assert_allclose(result["sqrt_ts"].data[0, 10, 10], 1.462328, rtol=1e-3)
 
     result = get_combined_significance_maps(estimator, [fake_dataset, fake_dataset2])
 
-    assert_allclose(result["npred_excess"].data.sum(), 2 * 902.403647, rtol=1e-3)
-    assert_allclose(result["significance"].data[10, 10], 1.414529, rtol=1e-3)
+    assert_allclose(result["npred_excess"].data.sum(), 2 * 912.92157, rtol=1e-3)
+    assert_allclose(result["significance"].data[10, 10], 1.563892, rtol=1e-3)
     assert_allclose(
         result["df"].data, 2 * (~np.isnan(result["significance"].data)), rtol=1e-3
     )
@@ -621,7 +621,7 @@ def test_joint_ts_map(fake_dataset):
         model=model, threshold=1, selection_optional="all", sum_over_energy_groups=True
     )
     result = estimator.run([fake_dataset, fake_dataset2])
-    assert_allclose(result["sqrt_ts"].data[0, 10, 10], 1.92364, rtol=1e-3)
+    assert_allclose(result["sqrt_ts"].data[0, 10, 10], 2.063912, rtol=1e-3)
 
 
 @requires_data()

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -2,6 +2,7 @@
 """Functions to compute test statistic images."""
 
 import warnings
+import astropy.units as u
 from itertools import repeat
 import numpy as np
 import scipy.optimize
@@ -594,9 +595,15 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
         datasets_models = datasets.models
 
         pad_width = (0, 0)
+        kernel_width = 0 * u.deg
         for dataset in datasets:
             pad_width_dataset = self.estimate_pad_width(dataset=dataset)
+            kernel_width_dataset = np.max(self.estimate_kernel(dataset).geom.width)
             pad_width = tuple(np.maximum(pad_width, pad_width_dataset))
+            kernel_width = np.maximum(kernel_width, kernel_width_dataset)
+
+        if self.kernel_width is None:
+            self.kernel_width = kernel_width
 
         datasets_padded = Datasets()
         for dataset in datasets:


### PR DESCRIPTION
Resolves #5950
This issue with the TSmapEstimator seems to come from an inconsistancy as pad_width is determined using estimate_kernel computed on the original dataset while later on the estimate_kernel is computed from the padded dataset.
Adding one pixel to the padding fix it.

Could you check it work also for your real use case @LauraOlivera
