### PR TITLE
Energy edges instead of center for `aeff-max` in `SafeMaskMaker`

### DIFF
--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -227,7 +227,7 @@ class SafeMaskMaker(Maker):
 
             model = TemplateSpectralModel.from_region_map(aeff)
 
-            energy_true = model.energy
+            energy_true = dataset._geom.axes["energy"].edges
             energy_min = energy_true[np.where(model.values > 0)[0][0]]
             energy_max = energy_true[-1]
 


### PR DESCRIPTION
Fixes #5834