### PR TITLE
Fix for Issue #5943

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -359,8 +359,10 @@
         "active"
     ],
     "email": "GAMMAPY-COORDINATION-L@IN2P3.FR",
-    "dateModified": "2025-07-01",
-    "softwareRequirements": [
+
+    "dateModified": "2024-11-29",
+
+  "softwareRequirements": [
         "numpy>=1.21",
         "scipy>=1.5,!=1.10",
         "astropy>=5.0",
@@ -372,3 +374,4 @@
         "matplotlib>=3.4, <3.10"
     ]
 }
+

--- a/codemeta.json
+++ b/codemeta.json
@@ -359,10 +359,8 @@
         "active"
     ],
     "email": "GAMMAPY-COORDINATION-L@IN2P3.FR",
-
-    "dateModified": "2024-11-29",
-
-  "softwareRequirements": [
+    "dateModified": "2025-07-01",
+    "softwareRequirements": [
         "numpy>=1.21",
         "scipy>=1.5,!=1.10",
         "astropy>=5.0",
@@ -374,4 +372,3 @@
         "matplotlib>=3.4, <3.10"
     ]
 }
-

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -396,7 +396,7 @@ class DataStore:
             obs_id = self.obs_ids
 
         if len(np.unique(obs_id)) != len(obs_id):
-            raise UserWarning(f"List of obs_id is not unique!")
+            raise UserWarning("List of obs_id is not unique!")
 
         obs_list = []
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -396,7 +396,7 @@ class DataStore:
             obs_id = self.obs_ids
 
         if len(np.unique(obs_id)) != len(obs_id):
-            raise UserWarning("List of obs_id is not unique!")
+            log.warning("List of obs_id is not unique!")
 
         obs_list = []
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -396,7 +396,10 @@ class DataStore:
             obs_id = self.obs_ids
 
         if len(np.unique(obs_id)) != len(obs_id):
-            log.warning("List of obs_id is not unique!")
+            multiples = np.array(
+                np.unique(obs_id)[(np.unique(obs_id, return_counts=True)[1] > 1)]
+            )
+            log.warning(f"List of obs_id is not unique! Multiples are: {multiples}")
 
         obs_list = []
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -396,9 +396,8 @@ class DataStore:
             obs_id = self.obs_ids
 
         if len(np.unique(obs_id)) != len(obs_id):
-            multiples = np.array(
-                np.unique(obs_id)[(np.unique(obs_id, return_counts=True)[1] > 1)]
-            )
+            uniques = np.unique(obs_id, return_counts=True)
+            multiples = np.array(uniques[0][(uniques[1] > 1)])
             log.warning(f"List of obs_id is not unique! Multiples are: {multiples}")
 
         obs_list = []

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -395,6 +395,9 @@ class DataStore:
         if obs_id is None:
             obs_id = self.obs_ids
 
+        if len(np.unique(obs_id)) != len(obs_id):
+            raise UserWarning(f"List of obs_id is not unique!")
+
         obs_list = []
 
         for _ in progress_bar(obs_id, desc="Obs Id"):

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -255,6 +255,16 @@ def test_data_store_header_info_in_meta(data_store):
 def test_data_store_bad_name():
     with pytest.raises(IOError):
         DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/", "hdu-index.fits.gz", "bad")
+  
+
+@requires_data()
+def test_data_store_doubled_id():
+    """Test that doubled id in obs_id causes UserWarning"""
+
+    # Using example provided in Issue #5943:
+    datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
+    with pytest.raises(UserWarning):
+        datastore.get_observations(obs_id=[23523, 23523])
 
 
 @requires_data()

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -255,7 +255,7 @@ def test_data_store_header_info_in_meta(data_store):
 def test_data_store_bad_name():
     with pytest.raises(IOError):
         DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/", "hdu-index.fits.gz", "bad")
-  
+
 
 @requires_data()
 def test_data_store_doubled_id():

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -264,7 +264,9 @@ def test_data_store_doubled_id(caplog):
     # Using example provided in Issue #5943:
     datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
     datastore.get_observations(obs_id=[23523, 23523])
-    assert "List of obs_id is not unique!" in [_.message for _ in caplog.records]
+    assert "List of obs_id is not unique! Multiples are: [23523]" in [
+        _.message for _ in caplog.records
+    ]
 
 
 @requires_data()

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -258,13 +258,13 @@ def test_data_store_bad_name():
 
 
 @requires_data()
-def test_data_store_doubled_id():
-    """Test that doubled id in obs_id causes UserWarning"""
+def test_data_store_doubled_id(caplog):
+    """Test that doubled id in obs_id causes corresponding log.warning message"""
 
     # Using example provided in Issue #5943:
     datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1")
-    with pytest.raises(UserWarning):
-        datastore.get_observations(obs_id=[23523, 23523])
+    datastore.get_observations(obs_id=[23523, 23523])
+    assert "List of obs_id is not unique!" in [_.message for _ in caplog.records]
 
 
 @requires_data()


### PR DESCRIPTION
Dear all,

this PR is intended to resolve the bug described in #5943. 

Thank you @registerrier for introducing me to the issue and the workflow hereby. As you suggested to me, to solve the bug I implemented a UserWarning in `get_observations(obs_id)` that is raised if `obs_id` is not unique but contains e.g. duplicates, and added a corresponding test (analogue to the existing ones) that checks, if this warning is raised from now on.

@registerrier Would this be the solution you had in mind?

Thank you a lot,

Leander
