### PR TITLE
fix typo in makers tutorial

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -359,7 +359,7 @@
         "active"
     ],
     "email": "GAMMAPY-COORDINATION-L@IN2P3.FR",
-    "dateModified": "2025-07-02",
+    "dateModified": "2024-11-29",
     "softwareRequirements": [
         "numpy>=1.21",
         "scipy>=1.5,!=1.10",
@@ -372,3 +372,4 @@
         "matplotlib>=3.4, <3.10"
     ]
 }
+

--- a/codemeta.json
+++ b/codemeta.json
@@ -359,8 +359,10 @@
         "active"
     ],
     "email": "GAMMAPY-COORDINATION-L@IN2P3.FR",
+
     "dateModified": "2024-11-29",
-    "softwareRequirements": [
+
+  "softwareRequirements": [
         "numpy>=1.21",
         "scipy>=1.5,!=1.10",
         "astropy>=5.0",

--- a/codemeta.json
+++ b/codemeta.json
@@ -359,10 +359,8 @@
         "active"
     ],
     "email": "GAMMAPY-COORDINATION-L@IN2P3.FR",
-
-    "dateModified": "2024-11-29",
-
-  "softwareRequirements": [
+    "dateModified": "2025-07-02",
+    "softwareRequirements": [
         "numpy>=1.21",
         "scipy>=1.5,!=1.10",
         "astropy>=5.0",
@@ -374,4 +372,3 @@
         "matplotlib>=3.4, <3.10"
     ]
 }
-

--- a/examples/tutorials/api/makers.py
+++ b/examples/tutorials/api/makers.py
@@ -185,7 +185,7 @@ plt.show()
 # FoV background
 # ~~~~~~~~~~~~~~
 #
-# If the background energy dependent morphology is well reproduced by the
+# If the background energy dependent morphology is not well reproduced by the
 # background model stored in the IRF, it might be that its normalization
 # is incorrect and that some spectral corrections are necessary. This is
 # made possible thanks to the `~gammapy.makers.FoVBackgroundMaker`. This


### PR DESCRIPTION
Fix typo :


If the background energy dependent morphology is **NOT** well reproduced by the
background model stored in the IRF, it might be that its normalization is incorrect 

Do we agree this was a typo ?