### PR TITLE
Warn users when using negative amplitude models in FluxEstimator

### DIFF
--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -154,6 +154,10 @@ class FluxEstimator(ParameterEstimator):
 
         energy_min, energy_max = datasets.energy_ranges
         energy_axis = MapAxis.from_energy_edges([energy_min.min(), energy_max.max()])
+        if model.evaluate(energy_max.max(), norm=self.norm.quantity).value < 0.0:
+            log.warning(
+                "Source model predicts negative counts. Results of estimator should be interpreted with caution"
+            )
 
         with np.errstate(invalid="ignore", divide="ignore"):
             result = model.reference_fluxes(energy_axis=energy_axis)

--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -1,11 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
+import logging
+
 from astropy.table import Column, Table
 from gammapy.maps import Map
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.stats import WStatCountsStatistic
 from ..core import Estimator
 from ..utils import apply_threshold_sensitivity
+
+log = logging.getLogger(__name__)
 
 __all__ = ["SensitivityEstimator"]
 
@@ -48,6 +52,10 @@ class SensitivityEstimator(Estimator):
         if spectral_model is None:
             spectral_model = PowerLawSpectralModel(
                 index=2, amplitude="1 cm-2 s-1 TeV-1"
+            )
+        if spectral_model.integral("1 TeV", "10 TeV") < 0.0:
+            log.warning(
+                "Source model predicts negative counts. Results of estimator should be interpreted with caution"
             )
 
         self.spectral_model = spectral_model

--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 import logging
-
+import astropy.units as u
 from astropy.table import Column, Table
 from gammapy.maps import Map
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
@@ -53,9 +53,9 @@ class SensitivityEstimator(Estimator):
             spectral_model = PowerLawSpectralModel(
                 index=2, amplitude="1 cm-2 s-1 TeV-1"
             )
-        if spectral_model.integral("1 TeV", "10 TeV") < 0.0:
+        if spectral_model.integral(1 * u.TeV, 10 * u.TeV).value < 0.0:
             log.warning(
-                "Source model predicts negative counts. Results of estimator should be interpreted with caution"
+                "Spectral model predicts negative counts. Results of estimator should be interpreted with caution"
             )
 
         self.spectral_model = spectral_model

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -865,3 +865,16 @@ def test_resample_axis():
     axis_new = get_rebinned_axis(flux_points, method="fixed-bins", group_size=3)
     flux_new = flux_points.resample_axis(axis_new)
     assert_allclose(flux_new.flux.data, [[[3.1050191 * 1e-12]]], rtol=1e-5)
+
+
+def test_warning_for_bad_model(caplog):
+    ds, fpe = create_fpe(PowerLawSpectralModel())
+    spectral_model = PowerLawSpectralModel()
+    spectral_model.amplitude.value = -3e-14
+    ds[0].models = SkyModel(spectral_model, name="source")
+    fpe.run(ds)
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert (
+        "Source model predicts negative counts. Results of estimator should be interpreted with caution"
+        in [_.message for _ in caplog.records]
+    )

--- a/gammapy/estimators/points/tests/test_sensitivity.py
+++ b/gammapy/estimators/points/tests/test_sensitivity.py
@@ -35,7 +35,7 @@ def spectrum_dataset():
     return spectrum_dataset
 
 
-def test_cta_sensitivity_estimator(spectrum_dataset, caplog):
+def test_cta_sensitivity_estimator(spectrum_dataset):
     geom = spectrum_dataset.background.geom
 
     dataset_on_off = SpectrumDatasetOnOff.from_spectrum_dataset(
@@ -82,7 +82,7 @@ def test_cta_sensitivity_estimator(spectrum_dataset, caplog):
     assert row["criterion"] == "gamma"
 
 
-def test_integral_estimation(spectrum_dataset, caplog):
+def test_integral_estimation(spectrum_dataset):
     dataset = spectrum_dataset.to_image()
     geom = dataset.background.geom
 
@@ -115,3 +115,17 @@ def test_parameter_sensitivity_estimator(spectrum_dataset):
     assert_allclose(value, 4.67553e-12, rtol=1e-2)
 
     assert_allclose(spectral_model.amplitude.value, default_value, rtol=1e-2)
+
+
+def test_warning_for_bad_model(caplog):
+    spectral_model = PowerLawSpectralModel()
+    spectral_model.amplitude.value = -3e-14
+    SensitivityEstimator(
+        gamma_min=25, bkg_syst_fraction=0.075, spectral_model=spectral_model
+    )
+
+    assert "WARNING" in [_.levelname for _ in caplog.records]
+    assert (
+        "Source model predicts negative counts. Results of estimator should be interpreted with caution"
+        in [_.message for _ in caplog.records]
+    )

--- a/gammapy/estimators/points/tests/test_sensitivity.py
+++ b/gammapy/estimators/points/tests/test_sensitivity.py
@@ -126,6 +126,6 @@ def test_warning_for_bad_model(caplog):
 
     assert "WARNING" in [_.levelname for _ in caplog.records]
     assert (
-        "Source model predicts negative counts. Results of estimator should be interpreted with caution"
+        "Spectral model predicts negative counts. Results of estimator should be interpreted with caution"
         in [_.message for _ in caplog.records]
     )


### PR DESCRIPTION
This will address #5906 for 2.0 release.
In future, we can explore the correct statistical handling for such cases