### PR TITLE
Fix links label for CompoundSpectralModel

### DIFF
--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -55,26 +55,21 @@ def _set_model_link(shared_register, model):
     return shared_register
 
 
-def _set_models_link(models):
-    from . import SkyModel, CompoundSpectralModel
-
-    shared_register = {}
+def _flatten_models(models):
+    flat_models = []
     for model in models:
-        if isinstance(model, SkyModel):
-            if isinstance(model.spectral_model, CompoundSpectralModel):
-                spectral_models = model.spectral_model._models
-            else:
-                spectral_models = [model.spectral_model]
-            submodels = spectral_models + [
-                model.spatial_model,
-                model.temporal_model,
-            ]
-
-            for submodel in submodels:
-                if submodel is not None:
-                    shared_register = _set_model_link(shared_register, submodel)
+        if hasattr(model, "_models"):
+            flat_models.extend(_flatten_models(model._models))
         else:
-            shared_register = _set_model_link(shared_register, model)
+            flat_models.append(model)
+    return flat_models
+
+
+def _set_models_link(models):
+    shared_register = {}
+    flat_models = _flatten_models(models)
+    for model in flat_models:
+        shared_register = _set_model_link(shared_register, model)
 
 
 def _get_model_class_from_dict(data):

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -56,16 +56,20 @@ def _set_model_link(shared_register, model):
 
 
 def _set_models_link(models):
-    from . import SkyModel
+    from . import SkyModel, CompoundSpectralModel
 
     shared_register = {}
     for model in models:
         if isinstance(model, SkyModel):
-            submodels = [
-                model.spectral_model,
+            if isinstance(model.spectral_model, CompoundSpectralModel):
+                spectral_models = model.spectral_model._models
+            else:
+                spectral_models = [model.spectral_model]
+            submodels = spectral_models + [
                 model.spatial_model,
                 model.temporal_model,
             ]
+
             for submodel in submodels:
                 if submodel is not None:
                     shared_register = _set_model_link(shared_register, submodel)

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -19,6 +19,7 @@ from gammapy.modeling.models import (
     Model,
     Models,
     PiecewiseNormSpectralModel,
+    PowerLawNormSpectralModel,
     PowerLawSpectralModel,
     PowerLawTemporalModel,
     SineTemporalModel,
@@ -494,6 +495,31 @@ def test_link_label(models):
             assert "reference" in line
             n_link += 1
     assert n_link == 2
+
+
+def test_link_label_compound():
+    shared_pl = PowerLawSpectralModel(
+        index=2.2, amplitude="1e-12 cm-2 s-1 TeV-1", reference="1 TeV"
+    )
+    norm1 = PowerLawNormSpectralModel(norm=1.0, tilt=0.0)
+    norm2 = PowerLawNormSpectralModel(norm=0.5, tilt=0.0)
+    model1 = SkyModel(name="model-1", spectral_model=shared_pl * norm1)
+    model2 = SkyModel(name="model-2", spectral_model=shared_pl * norm2)
+    models = Models([model1, model2])
+    models.parameters.free_unique_parameters.to_table()
+    assert len(models.parameters.free_unique_parameters.to_table()) == 4
+    assert len(models.parameters.free_unique_parameters) == 4
+
+    models_copy = models.copy()
+    assert len(models_copy.parameters.free_unique_parameters.to_table()) == 4
+    assert (
+        models_copy[0].spectral_model.model1.index
+        == models_copy[1].spectral_model.model1.index
+    )
+    assert (
+        models_copy[0].spectral_model.model1.amplitude
+        == models_copy[1].spectral_model.model1.amplitude
+    )
 
 
 def test_to_dict_not_default():

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -504,7 +504,7 @@ def test_link_label_compound():
     norm1 = PowerLawNormSpectralModel(norm=1.0, tilt=0.0)
     norm2 = PowerLawNormSpectralModel(norm=0.5, tilt=0.0)
     model1 = SkyModel(name="model-1", spectral_model=shared_pl * norm1)
-    model2 = SkyModel(name="model-2", spectral_model=shared_pl * norm2)
+    model2 = SkyModel(name="model-2", spectral_model=shared_pl * norm2 * norm1)
     models = Models([model1, model2])
     models.parameters.free_unique_parameters.to_table()
     assert len(models.parameters.free_unique_parameters.to_table()) == 4
@@ -514,11 +514,11 @@ def test_link_label_compound():
     assert len(models_copy.parameters.free_unique_parameters.to_table()) == 4
     assert (
         models_copy[0].spectral_model.model1.index
-        == models_copy[1].spectral_model.model1.index
+        == models_copy[1].spectral_model.model1.model1.index
     )
     assert (
         models_copy[0].spectral_model.model1.amplitude
-        == models_copy[1].spectral_model.model1.amplitude
+        == models_copy[1].spectral_model.model1.model1.amplitude
     )
 
 

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -19,6 +19,7 @@ from gammapy.modeling.models import (
     Model,
     Models,
     PiecewiseNormSpectralModel,
+    PointSpatialModel,
     PowerLawNormSpectralModel,
     PowerLawSpectralModel,
     PowerLawTemporalModel,
@@ -501,17 +502,24 @@ def test_link_label_compound():
     shared_pl = PowerLawSpectralModel(
         index=2.2, amplitude="1e-12 cm-2 s-1 TeV-1", reference="1 TeV"
     )
+    shared_point = PointSpatialModel()
     norm1 = PowerLawNormSpectralModel(norm=1.0, tilt=0.0)
     norm2 = PowerLawNormSpectralModel(norm=0.5, tilt=0.0)
-    model1 = SkyModel(name="model-1", spectral_model=shared_pl * norm1)
-    model2 = SkyModel(name="model-2", spectral_model=shared_pl * norm2 * norm1)
+    model1 = SkyModel(
+        name="model-1", spatial_model=shared_point, spectral_model=shared_pl * norm1
+    )
+    model2 = SkyModel(
+        name="model-2",
+        spatial_model=shared_point,
+        spectral_model=shared_pl * norm2 * norm1,
+    )
     models = Models([model1, model2])
-    models.parameters.free_unique_parameters.to_table()
-    assert len(models.parameters.free_unique_parameters.to_table()) == 4
-    assert len(models.parameters.free_unique_parameters) == 4
+
+    assert len(models.parameters.free_unique_parameters.to_table()) == 6
+    assert len(models.parameters.free_unique_parameters) == 6
 
     models_copy = models.copy()
-    assert len(models_copy.parameters.free_unique_parameters.to_table()) == 4
+    assert len(models_copy.parameters.free_unique_parameters.to_table()) == 6
     assert (
         models_copy[0].spectral_model.model1.index
         == models_copy[1].spectral_model.model1.model1.index


### PR DESCRIPTION
As discussed in the help channel the copy (and likely serialisation) breaks the link between CompoundSpectralModel. This PR resolves it by collecting correctly the  compound spectral models in `_set_models_link`