### PR TITLE
Add option to convert PointSkyRegion to CircleSkyRegion while creating masks

### DIFF
--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -21,6 +21,7 @@ from regions import (
     RectanglePixelRegion,
     Regions,
     SkyRegion,
+    CircleSkyRegion,
 )
 import matplotlib.pyplot as plt
 from gammapy.utils.regions import (
@@ -720,7 +721,7 @@ class RegionGeom(Geom):
         return hdulist
 
     @classmethod
-    def from_regions(cls, regions, **kwargs):
+    def from_regions(cls, regions, point_to_radius=None, **kwargs):
         """Create region geometry from list of regions.
 
         The regions are combined with union to a compound region.
@@ -729,6 +730,10 @@ class RegionGeom(Geom):
         ----------
         regions : list of `~regions.SkyRegion` or str
             Regions.
+        point_to_radius : `~astropy.units.Quantity`, optional
+            If specified, a `~regions.PointSkyRegion` is converted
+            to a `~regions.CircleSkyRegion` of radius `point_to_radius`.
+            Default is None.
         **kwargs: dict
             Keyword arguments forwarded to `RegionGeom`.
 
@@ -747,7 +752,12 @@ class RegionGeom(Geom):
             regions = None
 
         if regions:
-            regions = regions_to_compound_region(regions)
+            regions1 = []
+            for reg in regions:
+                if isinstance(reg, PointSkyRegion) and point_to_radius is not None:
+                    reg = CircleSkyRegion(reg.center, radius=point_to_radius)
+                regions1.append(reg)
+            regions = regions_to_compound_region(regions1)
 
         return cls(region=regions, **kwargs)
 

--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -15,7 +15,7 @@ from astropy.wcs.utils import (
     proj_plane_pixel_scales,
     wcs_to_celestial_frame,
 )
-from regions import RectangleSkyRegion, PointSkyRegion, CircleSkyRegion
+from regions import RectangleSkyRegion, PointSkyRegion, CircleSkyRegion, Regions
 from gammapy.utils.array import round_up_to_even, round_up_to_odd
 from gammapy.utils.compat import COPY_IF_NEEDED
 from ..axes import MapAxes
@@ -1007,6 +1007,9 @@ class WcsGeom(Geom):
 
         if not self.is_regular:
             raise ValueError("Multi-resolution maps not supported yet")
+
+        if not isinstance(regions, list) or isinstance(regions, Regions):
+            regions = [regions]
 
         regions1 = []
         for reg in regions:

--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -15,7 +15,7 @@ from astropy.wcs.utils import (
     proj_plane_pixel_scales,
     wcs_to_celestial_frame,
 )
-from regions import RectangleSkyRegion, PointSkyRegion, CircleSkyRegion, Regions
+from regions import RectangleSkyRegion
 from gammapy.utils.array import round_up_to_even, round_up_to_odd
 from gammapy.utils.compat import COPY_IF_NEEDED
 from ..axes import MapAxes
@@ -971,9 +971,10 @@ class WcsGeom(Geom):
             For ``inside=False``, set pixels in the region to False.
             Default is True.
         point_to_radius : `~astropy.units.Quantity`, optional
-            If specified a `~regions.PointSkyRegion` is converted
+            If specified, a `~regions.PointSkyRegion` is converted
             to a `~regions.CircleSkyRegion` of radius `point_to_radius`
             while creating the mask.
+            Default is None.
 
         Returns
         -------
@@ -1008,16 +1009,9 @@ class WcsGeom(Geom):
         if not self.is_regular:
             raise ValueError("Multi-resolution maps not supported yet")
 
-        if not isinstance(regions, list) or isinstance(regions, Regions):
-            regions = [regions]
-
-        regions1 = []
-        for reg in regions:
-            if isinstance(reg, PointSkyRegion) and point_to_radius is not None:
-                reg = CircleSkyRegion(reg.center, radius=point_to_radius)
-            regions1.append(reg)
-
-        geom = RegionGeom.from_regions(regions1, wcs=self.wcs)
+        geom = RegionGeom.from_regions(
+            regions, wcs=self.wcs, point_to_radius=point_to_radius
+        )
         idx = self.get_idx()
         mask = geom.contains_wcs_pix(idx)
 

--- a/gammapy/maps/wcs/tests/test_geom.py
+++ b/gammapy/maps/wcs/tests/test_geom.py
@@ -6,7 +6,7 @@ import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
 from astropy.io import fits
 from astropy.time import Time
-from regions import CircleSkyRegion
+from regions import CircleSkyRegion, PointSkyRegion
 from gammapy.maps import Map, MapAxis, TimeMapAxis, WcsGeom
 from gammapy.maps.utils import _check_binsz, _check_width
 from gammapy.utils.scripts import make_path
@@ -432,7 +432,8 @@ def test_region_mask():
 
     r1 = CircleSkyRegion(SkyCoord(0, 0, unit="deg"), 1 * u.deg)
     r2 = CircleSkyRegion(SkyCoord(20, 20, unit="deg"), 1 * u.deg)
-    regions = [r1, r2]
+    r3 = PointSkyRegion(SkyCoord(2, -2, unit="deg"))
+    regions = [r1, r2, r3]
 
     mask = geom.region_mask(regions)
     assert mask.data.dtype == bool
@@ -440,6 +441,9 @@ def test_region_mask():
 
     mask = geom.region_mask(regions, inside=False)
     assert np.sum(mask.data) == 8
+
+    mask = geom.region_mask(regions, inside=False, point_to_radius=0.5 * u.deg)
+    assert np.sum(mask.data) == 7
 
 
 def test_energy_mask():


### PR DESCRIPTION
It is often useful to create exclusion masks from known sources in the FoV, eg

```
regions = models.to_regions()
mask = dataset._geom.region_mask(models.to_regions(), inside=False)
```

However, when there is Point source in the FoV, the region mask does not get applied for that. This is annoying.

Here, I introduce the option to convert the PointSkyRegion to a CircleSkyRegion with a radius specified by the user and use that for the mask. 