### PR TITLE
Update dev howto.rst for issue #5972

### DIFF
--- a/docs/development/dev_howto.rst
+++ b/docs/development/dev_howto.rst
@@ -959,3 +959,9 @@ script can be used as follows::
 
 If the path of the output file is not provided, the script will be written in the same folder as the notebook and with
 the same name.
+
+Skip GitHub Actions on local fork
++++++++++++++++++++++++++++++++++
+If not explicitly needed, it can be convenient to skip the GitHub Actions for pushes onto local forks and only perform them on the upstream, once a pull request is opened.
+This way computation power is saved and automatic commits by the Actions are avoided in the forks commit-history. An easy way to achieve this, is to deactivate the
+GitHub Actions completely for the fork, following the GitHub documentation: `here. <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-select-actions-and-reusable-workflows-to-run>`__.

--- a/docs/development/dev_howto.rst
+++ b/docs/development/dev_howto.rst
@@ -519,6 +519,7 @@ Making a pull request which skips GitHub Actions
 For minor PRs (eg: correcting typos in doc-strings) we can skip GitHub Actions.
 Adding ``[ci skip]`` in a specific commit message will skip CI for that specific commit which can be useful for draft or incomplete PR.
 For details, `see here. <https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/>`__
+See also section: Skip GitHub Actions on local fork, below.
 
 Fix non-Unix line endings
 +++++++++++++++++++++++++
@@ -965,3 +966,4 @@ Skip GitHub Actions on local fork
 If not explicitly needed, it can be convenient to skip the GitHub Actions for pushes onto local forks and only perform them on the upstream, once a pull request is opened.
 This way computation power is saved and automatic commits by the Actions are avoided in the forks commit-history. An easy way to achieve this, is to deactivate the
 GitHub Actions completely for the fork, following the GitHub documentation, `see here. <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository>`__
+See also section: Making a pull request which skips GitHub Actions, above.

--- a/docs/development/dev_howto.rst
+++ b/docs/development/dev_howto.rst
@@ -964,4 +964,4 @@ Skip GitHub Actions on local fork
 +++++++++++++++++++++++++++++++++
 If not explicitly needed, it can be convenient to skip the GitHub Actions for pushes onto local forks and only perform them on the upstream, once a pull request is opened.
 This way computation power is saved and automatic commits by the Actions are avoided in the forks commit-history. An easy way to achieve this, is to deactivate the
-GitHub Actions completely for the fork, following the GitHub documentation: `here. <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-select-actions-and-reusable-workflows-to-run>`__.
+GitHub Actions completely for the fork, following the GitHub documentation, `see here. <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository>`

--- a/docs/development/dev_howto.rst
+++ b/docs/development/dev_howto.rst
@@ -964,4 +964,4 @@ Skip GitHub Actions on local fork
 +++++++++++++++++++++++++++++++++
 If not explicitly needed, it can be convenient to skip the GitHub Actions for pushes onto local forks and only perform them on the upstream, once a pull request is opened.
 This way computation power is saved and automatic commits by the Actions are avoided in the forks commit-history. An easy way to achieve this, is to deactivate the
-GitHub Actions completely for the fork, following the GitHub documentation, `see here. <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository>`
+GitHub Actions completely for the fork, following the GitHub documentation, `see here. <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository>`__


### PR DESCRIPTION
Dear all,

this PR is intended to resolve issue #5972. I want to thank @registerrier for the idea and discussion!

It updates the developer guide in `gammapy/docs/development/dev_howto.rst` by adding a brief paragraph on how to deactivate GitHub Actions for forks.

A paragraph on the related problem to skip the GitHub Actions for specific commits was already part of the documentation and I added a sentence as cross-reference in each of the paragraphs. Is there a way to add a link to the other paragraph?

Thank you a lot,
Leander
