### PR TITLE
Add class instance caching for WcsGeom and HpxGeom

### DIFF
--- a/gammapy/maps/hpx/geom.py
+++ b/gammapy/maps/hpx/geom.py
@@ -8,6 +8,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.units import Quantity
 from gammapy.utils.array import is_power2
+from gammapy.utils.cache import CacheEquivalentMixin
 from ..axes import MapAxes
 from ..coord import MapCoord, skycoord_to_lonlat
 from ..geom import Geom, pix_tuple_to_idx
@@ -31,7 +32,7 @@ from .utils import (
 __all__ = ["HpxGeom"]
 
 
-class HpxGeom(Geom):
+class HpxGeom(Geom, CacheEquivalentMixin):
     """Geometry class for HEALPix maps.
 
     This class performs mapping between partial-sky indices (pixel

--- a/gammapy/maps/wcs/geom.py
+++ b/gammapy/maps/wcs/geom.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import copy
+from gammapy.utils.cache import CacheEquivalentMixin
 from functools import lru_cache
 import numpy as np
 import astropy.units as u
@@ -60,7 +61,7 @@ def get_resampled_wcs(wcs, factor, downsampled):
     return wcs
 
 
-class WcsGeom(Geom):
+class WcsGeom(Geom, CacheEquivalentMixin):
     """Geometry class for WCS maps.
 
     This class encapsulates both the WCS transformation object and

--- a/gammapy/maps/wcs/tests/test_geom.py
+++ b/gammapy/maps/wcs/tests/test_geom.py
@@ -687,3 +687,19 @@ def test_wcs_geom_with_timeaxis():
         [[4.000e-01, 2.000e-01, 0.000e00, 3.598e02, 3.596e02]],
         rtol=1e-5,
     )
+
+
+def test_instance_cache():
+    kwargs = dict(skydir=(83.63, 22.01), width=5, binsz=0.02)
+
+    geom1 = WcsGeom.create(**kwargs)
+    geom2 = WcsGeom.create(**kwargs)
+    geom3 = WcsGeom.create(width=5, binsz=0.02, skydir=(83.63, 22.01))  # reordered
+
+    assert geom1 is geom2
+    assert geom1 is geom3
+    assert len([ref for ref in WcsGeom._instances if ref() is not None]) == 1
+
+    geom4 = WcsGeom.create(width=5, binsz=0.05, skydir=(83.63, 22.01))  # different
+    assert geom4 is not geom1
+    assert len([ref for ref in WcsGeom._instances if ref() is not None]) == 2

--- a/gammapy/utils/cache.py
+++ b/gammapy/utils/cache.py
@@ -1,0 +1,30 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Utilities for caching"""
+
+import weakref
+
+
+class CacheEquivalentMixin:
+    """Cache class instance using equality condition.
+    Simpler for classes with complex arguements that are not hashable.
+    """
+
+    _instances = []
+
+    def __new__(cls, *args, **kwargs):
+        # Clean up dead references
+        cls._instances = [ref for ref in cls._instances if ref() is not None]
+
+        # Create a temporary instance to compare
+        temp = super().__new__(cls)
+        temp.__init__(*args, **kwargs)
+
+        # Search for an equivalent instance
+        for ref in cls._instances:
+            instance = ref()
+            if instance is not None and instance == temp:
+                return instance
+
+        # Store a weak reference to the new instance
+        cls._instances.append(weakref.ref(temp))
+        return temp

--- a/gammapy/utils/tests/test_cache.py
+++ b/gammapy/utils/tests/test_cache.py
@@ -1,0 +1,43 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from gammapy.utils.cache import CacheEquivalentMixin
+
+
+class Dummy(CacheEquivalentMixin):
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    def __eq__(self, other):
+        return isinstance(other, Dummy) and self.a == other.a and self.b == other.b
+
+    def __repr__(self):
+        return f"MyObject(x={self.x}, y={self.y})"
+
+
+class Dummy2(CacheEquivalentMixin):
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    def __eq__(self, other):
+        return isinstance(other, Dummy2) and self.a == other.a and self.b == other.b
+
+    def __repr__(self):
+        return f"MyObject(x={self.x}, y={self.y})"
+
+
+def test_dummy_cache():
+    x = Dummy(1, 2)
+    y = Dummy(1, 2)
+    z = Dummy2(1, 2)
+
+    u = Dummy(1, 3)
+    v = Dummy2(1, 3)
+    w = Dummy2(1, 3)
+
+    assert x is y
+    assert z is not y
+
+    assert u is not x
+    assert v is not z
+    assert v is w


### PR DESCRIPTION
Add class instance caching for WcsGeom and HpxGeom.
This avoid in memory duplication of geoms and their associated coordinates caching.
Requires #5979.