### PR TITLE
Solve IRF circular import 

### DIFF
--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 from astropy.io import fits
-from gammapy.data.hdu_index_table import HDUIndexTable
 from gammapy.utils.fits import HDULocation
 from gammapy.utils.scripts import make_path
 
@@ -151,6 +150,8 @@ def _get_hdu_type_and_class(header):
 
     Contains a workaround to support CTA 1DC irf file.
     """
+    from gammapy.data.hdu_index_table import HDUIndexTable
+
     hdu_clas2 = header.get("HDUCLAS2", "")
     hdu_clas4 = header.get("HDUCLAS4", "")
 


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request solves #5987 by moving import of HDUIndexTable in function `_get_hdu_type_and_class` in irf/io.py

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
