### PR TITLE
Fixing `FluxPoints` docstring

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -359,11 +359,9 @@
         "active"
     ],
     "email": "GAMMAPY-COORDINATION-L@IN2P3.FR",
-
-    "dateModified": "2024-11-29",
-
-  "softwareRequirements": [
-        "numpy>=1.21",
+    "dateModified": "2025-07-21",
+    "softwareRequirements": [
+        "numpy>=1.21,<2.2",
         "scipy>=1.5,!=1.10",
         "astropy>=5.0",
         "regions>=0.5.0",
@@ -374,4 +372,3 @@
         "matplotlib>=3.4, <3.10"
     ]
 }
-

--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -113,13 +113,33 @@ class FluxPoints(FluxMaps):
 
     Parameters
     ----------
-    table : `~astropy.table.Table`
-        Table with flux point data.
+    data : dict of `~gammapy.maps.Map`
+        The maps dictionary. Expected entries are the following:
 
-    Attributes
-    ----------
-    table : `~astropy.table.Table`
-        Table with flux point data.
+        * norm : the norm factor.
+        * norm_err : optional, the error on the norm factor.
+        * norm_errn : optional, the negative error on the norm factor.
+        * norm_errp : optional, the positive error on the norm factor.
+        * norm_ul : optional, the upper limit on the norm factor.
+        * norm_scan : optional, the norm values of the test statistic scan.
+        * stat_scan : optional, the test statistic scan values.
+        * ts : optional, the delta test statistic associated with the flux value.
+        * sqrt_ts : optional, the square root of the test statistic, when relevant.
+        * success : optional, a boolean tagging the validity of the estimation.
+        * n_dof : optional, the number of degrees of freedom used in TS computation
+        * alpha : optional, normalisation factor to accounts for differences between the test region and the background
+        * acceptance_off : optional, acceptance from the off region
+        * acceptance_on : optional, acceptance from the on region
+
+    reference_model : `~gammapy.modeling.models.SkyModel`, optional
+        The reference model to use for conversions. If None, a model consisting
+        of a point source with a power law spectrum of index 2 is assumed.
+    meta : dict, optional
+        Dict of metadata.
+    gti : `~gammapy.data.GTI`, optional
+        Maps GTI information.
+    filter_success_nan : boolean, optional
+        Set fitted norm and error to NaN when the fit has not succeeded.
 
     Examples
     --------


### PR DESCRIPTION
Dear gammapy team,

This PR fixes  #6003 

I copied the parameters in the docstring of `FluxMaps` to the docstring of `FluxPoints`