### PR TITLE
Fix discrepancy in exposure maps unit  attached to edsip and psf from FermipyDatasetsReader

### DIFF
--- a/gammapy/datasets/tests/test_io.py
+++ b/gammapy/datasets/tests/test_io.py
@@ -229,7 +229,7 @@ def test_fermipy_datasets_reader():
         datasets[0]._psf_kernel.psf_kernel_map.data.sum(axis=(1, 2)), 1, rtol=1e-5
     )
     assert_allclose(
-        datasets[0].edisp.exposure_map.data, datasets[0].psf.exposure_map.data
+        datasets[0].edisp.exposure_map.quantity, datasets[0].psf.exposure_map.quantity
     )
     assert datasets[0].name == "P8R3_SOURCEVETO_V3_PSF1_v1"
     assert datasets.models.names[0] == "isotropic_P8R3_SOURCEVETO_V3_PSF1_v1"

--- a/gammapy/datasets/tests/test_io.py
+++ b/gammapy/datasets/tests/test_io.py
@@ -231,5 +231,8 @@ def test_fermipy_datasets_reader():
     assert_allclose(
         datasets[0].edisp.exposure_map.quantity, datasets[0].psf.exposure_map.quantity
     )
+    assert datasets[0].edisp.exposure_map.unit == datasets[0].psf.exposure_map.unit
+    assert datasets[0].edisp.exposure_map.unit == datasets[0].exposure.unit
+
     assert datasets[0].name == "P8R3_SOURCEVETO_V3_PSF1_v1"
     assert datasets.models.names[0] == "isotropic_P8R3_SOURCEVETO_V3_PSF1_v1"

--- a/gammapy/datasets/utils.py
+++ b/gammapy/datasets/utils.py
@@ -289,7 +289,7 @@ def create_map_dataset_from_dl4(data, geom=None, energy_axis_true=None, name=Non
         dataset.background = Map.from_geom(geom, data=0.0)
 
     if dataset.edisp.exposure_map and np.all(dataset.edisp.exposure_map.data) == 0.0:
-        dataset.edisp.exposure_map.data = dataset.psf.exposure_map.data
+        dataset.edisp.exposure_map.quantity = dataset.psf.exposure_map.quantity
 
     return dataset
 


### PR DESCRIPTION
Fix discrepancy in exposure maps units  attached to edsip and psf from the FermipyDatasetsReader.
This should ensure that stacking is performed correctly as discussed on slack.
