### PR TITLE
Add random_variable  property on prior

### DIFF
--- a/gammapy/modeling/models/prior.py
+++ b/gammapy/modeling/models/prior.py
@@ -79,7 +79,7 @@ class Prior(ModelBase):
 
     def _inverse_cdf(self, value):
         """Return inverse CDF for prior."""
-        return self.random_variable.ppf(value)
+        return self._random_variable.ppf(value)
 
     @property
     def weight(self):
@@ -167,11 +167,9 @@ class GaussianPrior(Prior):
         return ((value - mu) / sigma) ** 2
 
     @property
-    def random_variable(self):
+    def _random_variable(self):
         """Return random variable object for prior."""
         return norm(self.mu.value, self.sigma.value)
-
-
 
 
 class UniformPrior(Prior):
@@ -204,7 +202,7 @@ class UniformPrior(Prior):
             return 1.0
 
     @property
-    def random_variable(self):
+    def _random_variable(self):
         """Return random variable object for prior."""
         return uniform(self.min.value, self.max.value - self.min.value)
 
@@ -238,6 +236,6 @@ class LogUniformPrior(Prior):
         return -2 * rv.logpdf(value)
 
     @property
-    def random_variable(self):
+    def _random_variable(self):
         """Return random variable object for prior."""
         return loguniform(self.min.value, self.max.value)

--- a/gammapy/modeling/models/prior.py
+++ b/gammapy/modeling/models/prior.py
@@ -172,10 +172,6 @@ class GaussianPrior(Prior):
         return norm(self.mu.value, self.sigma.value)
 
 
-@property
-def loguniform_rv(self):
-    """Return random variable object for prior."""
-    return loguniform(self.min.value, self.max.value)
 
 
 class UniformPrior(Prior):

--- a/gammapy/modeling/models/prior.py
+++ b/gammapy/modeling/models/prior.py
@@ -77,6 +77,10 @@ class Prior(ModelBase):
             [_ for _ in cls.__dict__.values() if isinstance(_, PriorParameter)]
         )
 
+    def _inverse_cdf(self, value):
+        """Return inverse CDF for prior."""
+        return self.random_variable.ppf(value)
+
     @property
     def weight(self):
         """Weight multiplied to the prior when evaluated."""
@@ -162,10 +166,16 @@ class GaussianPrior(Prior):
         """Evaluate the Gaussian prior."""
         return ((value - mu) / sigma) ** 2
 
-    def _inverse_cdf(self, value):
-        """Return inverse CDF for prior."""
-        rv = norm(self.mu.value, self.sigma.value)
-        return rv.ppf(value)
+    @property
+    def random_variable(self):
+        """Return random variable object for prior."""
+        return norm(self.mu.value, self.sigma.value)
+
+
+@property
+def loguniform_rv(self):
+    """Return random variable object for prior."""
+    return loguniform(self.min.value, self.max.value)
 
 
 class UniformPrior(Prior):
@@ -197,10 +207,10 @@ class UniformPrior(Prior):
         else:
             return 1.0
 
-    def _inverse_cdf(self, value):
-        """Return inverse CDF for prior."""
-        rv = uniform(self.min.value, self.max.value - self.min.value)
-        return rv.ppf(value)
+    @property
+    def random_variable(self):
+        """Return random variable object for prior."""
+        return uniform(self.min.value, self.max.value - self.min.value)
 
 
 class LogUniformPrior(Prior):
@@ -231,7 +241,7 @@ class LogUniformPrior(Prior):
         rv = loguniform(min, max)
         return -2 * rv.logpdf(value)
 
-    def _inverse_cdf(self, value):
-        """Return inverse CDF for prior."""
-        rv = loguniform(self.min.value, self.max.value)
-        return rv.ppf(value)
+    @property
+    def random_variable(self):
+        """Return random variable object for prior."""
+        return loguniform(self.min.value, self.max.value)


### PR DESCRIPTION
Add `random_variable`  property on Priors.
It's  a small cleanup but il also allows to compute all the prior properties directly for example `random_variable.entropy()` .