### PR TITLE
Exposing `AnalysisConfig` better

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # Allow to add the canonical html flag on all the pages
-# This permits to precise to web search engine that the pages for the stable version are privileged
+# This allows you to indicate to the web search engine that the pages for the stable version are privileged
 html_baseurl = 'https://docs.gammapy.org/stable/'
 
 # The reST default role (used for this markup: `text`) to use for all
@@ -155,6 +155,10 @@ automodapi_toctreedirnm = 'api'
 
 # Suppress member summaries
 numpydoc_show_class_members = False
+
+# autodoc options to make the AnalysisConfig look nice
+autodoc_class_signature = "separated"
+autodoc_typehints = "description"
 
 # Ensures that when users click the "Copy" button, only the actual code is copied,
 # excluding interactive prompts and indentation markers

--- a/gammapy/analysis/__init__.py
+++ b/gammapy/analysis/__init__.py
@@ -1,7 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Gammapy high level interface (analysis)."""
 
-from .config import AnalysisConfig, GeneralConfig, LogConfig, ObservationsConfig
+from .config import (
+    AnalysisConfig,
+    GeneralConfig,
+    LogConfig,
+    ObservationsConfig,
+    DatasetsConfig,
+    FitConfig,
+    FluxPointsConfig,
+    ExcessMapConfig,
+    LightCurveConfig,
+    BackgroundConfig,
+    SafeMaskConfig,
+    GeomConfig,
+)
 from .core import Analysis
 
 __all__ = [
@@ -10,4 +23,12 @@ __all__ = [
     "GeneralConfig",
     "LogConfig",
     "ObservationsConfig",
+    "DatasetsConfig",
+    "FitConfig",
+    "BackgroundConfig",
+    "SafeMaskConfig",
+    "GeomConfig",
+    "FluxPointsConfig",
+    "ExcessMapConfig",
+    "LightCurveConfig",
 ]

--- a/gammapy/analysis/__init__.py
+++ b/gammapy/analysis/__init__.py
@@ -1,9 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Gammapy high level interface (analysis)."""
-from .config import AnalysisConfig
+
+from .config import AnalysisConfig, GeneralConfig, LogConfig, ObservationsConfig
 from .core import Analysis
 
 __all__ = [
     "Analysis",
     "AnalysisConfig",
+    "GeneralConfig",
+    "LogConfig",
+    "ObservationsConfig",
 ]

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -77,6 +77,11 @@ class MapSelectionEnum(str, Enum):
 
 
 class GammapyBaseConfig(BaseModel):
+    """Base configuration class.
+
+    Provides Pydantic model settings.
+    """
+
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         validate_assignment=True,
@@ -93,6 +98,14 @@ class GammapyBaseConfig(BaseModel):
 
 
 class SkyCoordConfig(GammapyBaseConfig):
+    """Configuration for sky coordinates.
+
+    Attributes:
+        frame : coordinate frame (e.g., 'icrs', 'galactic').
+        lon : Longitude or right ascension.
+        lat : Latitude or declination.
+    """
+
     frame: Optional[FrameEnum] = None
     lon: Optional[AngleType] = None
     lat: Optional[AngleType] = None
@@ -196,6 +209,17 @@ class DatasetsConfig(GammapyBaseConfig):
 
 
 class ObservationsConfig(GammapyBaseConfig):
+    """Configuration for `~gammapy.data.Observations`.
+
+    Attributes:
+        datastore (str): Path to the data store.
+        obs_ids (list of int): List of observation IDs.
+        obs_file (str): Path to a YAML observation file.
+        obs_cone (frame, lat, lon, radius): Cone selection for observations.
+        obs_time (start, stop): Observation time filtering.
+        required_irf (list): Required IRF components, options are "aeff", "edisp", "psf", "bkg"
+    """
+
     datastore: PathType = Path("$GAMMAPY_DATA/hess-dl3-dr1/")
     obs_ids: List[int] = []
     obs_file: Optional[PathType] = None
@@ -205,6 +229,16 @@ class ObservationsConfig(GammapyBaseConfig):
 
 
 class LogConfig(GammapyBaseConfig):
+    """Configuration for logging.
+
+    Attributes:
+        level (str): Logging level (e.g., 'info', 'debug').
+        filename (str): Log file path.
+        filemode (str): File mode ('w' for overwrite, 'a' for append).
+        format (str): Logging format string.
+        datefmt (str): Format for timestamps.
+    """
+
     level: str = "info"
     filename: Optional[PathType] = None
     filemode: Optional[str] = None
@@ -213,6 +247,16 @@ class LogConfig(GammapyBaseConfig):
 
 
 class GeneralConfig(GammapyBaseConfig):
+    """Top-level general configuration.
+
+    Attributes:
+        log (`LogConfig`): Logging configuration.
+        outdir (str): Output directory.
+        n_jobs (int): Number of parallel jobs.
+        datasets_file (str): Path to datasets config file.
+        models_file (str): Path to models config file.
+    """
+
     log: LogConfig = LogConfig()
     outdir: str = "."
     n_jobs: int = 1

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -98,12 +98,16 @@ class GammapyBaseConfig(BaseModel):
 
 
 class SkyCoordConfig(GammapyBaseConfig):
-    """Configuration for sky coordinates.
+    """Configuration for `~astropy.coordinates.SkyCoord`.
 
-    Attributes:
-        frame : coordinate frame (e.g., 'icrs', 'galactic').
-        lon : Longitude or right ascension.
-        lat : Latitude or declination.
+    Attributes
+    ----------
+    frame : str
+        Coordinate frame (e.g., 'icrs', 'galactic').
+    lon : `astropy.units.Quantity`
+        Longitude or right ascension.
+    lat : `astropy.units.Quantity`
+        Latitude or declination.
     """
 
     frame: Optional[FrameEnum] = None
@@ -135,12 +139,42 @@ class TimeRangeConfig(GammapyBaseConfig):
 
 
 class FluxPointsConfig(GammapyBaseConfig):
+    """Configuration for the `~gammapy.estimators.FluxPointsEstimator`.
+
+    Attributes
+    ----------
+    energy : dict
+        Energy binning for the light curve. Should contain the following keys
+        'min' and 'max' (with energy quantities) and 'nbins'.
+    source : str
+        Source name.
+    parameters : dict
+        Optional parameters such as selection filters, options are:
+        "all", "errn-errp", "ul", "scan"
+    """
+
     energy: EnergyAxisConfig = EnergyAxisConfig()
     source: str = "source"
     parameters: dict = {"selection_optional": "all"}
 
 
 class LightCurveConfig(GammapyBaseConfig):
+    """Configuration for the `~gammapy.estimators.LightCurveEstimator`.
+
+    Attributes
+    ----------
+    time_intervals : dict
+        Time intervals for the light curve. Should contain the following keys
+        'start' and 'stop' as time quantities.
+    energy_edges : dict
+        Energy binning for the light curve. Should contain the following keys
+        'min' and 'max' (with energy quantities) and 'nbins'.
+    source : str
+        Source name.
+    parameters : dict
+        Optional parameters such as selection filters.
+    """
+
     time_intervals: TimeRangeConfig = TimeRangeConfig()
     energy_edges: EnergyAxisConfig = EnergyAxisConfig()
     source: str = "source"
@@ -148,22 +182,68 @@ class LightCurveConfig(GammapyBaseConfig):
 
 
 class FitConfig(GammapyBaseConfig):
+    """Configuration for model fitting.
+
+    Attributes
+    ----------
+    fit_range : dict
+        Energy range used during the fit. Should contain the following keys
+        'min' and 'max' (with energy quantities).
+    """
+
     fit_range: EnergyRangeConfig = EnergyRangeConfig()
 
 
 class ExcessMapConfig(GammapyBaseConfig):
+    """Configuration for the `~gammapy.estimators.ExcessMapEstimator`.
+
+    Attributes
+    ----------
+    correlation_radius : `astropy.units.Quantity`
+        Radius for correlation/smoothing.
+    parameters : dict
+        Optional configuration parameters.
+    energy_edges : dict
+        Energy binning for map creation. Should contain the following keys
+        'min' and 'max' (with energy quantities) and 'nbins'.
+    """
+
     correlation_radius: AngleType = "0.1 deg"
     parameters: dict = {}
     energy_edges: EnergyAxisConfig = EnergyAxisConfig()
 
 
 class BackgroundConfig(GammapyBaseConfig):
+    """Configuration for background modeling.
+
+    Attributes
+    ----------
+    method : list of str
+        Background estimation method, the available options are:
+        "reflected", "fov_background", "ring"
+    exclusion : str
+        Path to an exclusion region file.
+    parameters : dict
+        Additional options or method parameters.
+    """
+
     method: Optional[BackgroundMethodEnum] = None
     exclusion: Optional[PathType] = None
     parameters: dict = {}
 
 
 class SafeMaskConfig(GammapyBaseConfig):
+    """Configuration for `~gammapy.makers.SafeMaskMaker`.
+
+    Attributes
+    ----------
+    methods : list of str
+        Masking methods to apply, the available options are:
+        "aeff-default", "aeff-max", "edisp-bias", "offset-max", "bkg-peak"
+    parameters : dict
+        Additional configuration parameters.
+    """
+
     methods: List[SafeMaskMethodsEnum] = [SafeMaskMethodsEnum.aeff_default]
     parameters: dict = {}
 
@@ -185,6 +265,21 @@ class WidthConfig(GammapyBaseConfig):
 
 
 class WcsConfig(GammapyBaseConfig):
+    """Configuration for the WCS geometry.
+
+    Attributes
+    ----------
+    skydir : `SkyCoordConfig`
+        Sky coordinates configuration.
+    binsize : `astropy.units.Quantity`
+        Pixel size in degrees.
+    width : dict
+        Spatial extent of the map. Should contain one or both of the keys
+        'width' and 'height', with angular quantities as values.
+    binsize_irf : `astropy.units.Quantity`
+        Pixel size for IRF-related maps.
+    """
+
     skydir: SkyCoordConfig = SkyCoordConfig()
     binsize: AngleType = "0.02 deg"
     width: WidthConfig = WidthConfig()
@@ -192,12 +287,48 @@ class WcsConfig(GammapyBaseConfig):
 
 
 class GeomConfig(GammapyBaseConfig):
+    """Configuration for geometry.
+
+    Attributes
+    ----------
+    wcs : `WcsConfig`
+        WCS geometry configuration.
+    selection : `astropy.units.Quantity`
+        The only option here is 'offset_max`.
+    axes : `EnergyAxesConfig`
+        Configuration of energy axes.
+    """
+
     wcs: WcsConfig = WcsConfig()
     selection: SelectionConfig = SelectionConfig()
     axes: EnergyAxesConfig = EnergyAxesConfig()
 
 
 class DatasetsConfig(GammapyBaseConfig):
+    """Configuration for dataset reduction.
+
+    Attributes
+    ----------
+    type : str
+        Type of dataset to create (e.g., 'spectrum').
+    stack : bool
+        Whether to stack observations.
+    geom : `GeomConfig`
+        Geometry configuration.
+    map_selection : list of str
+        Select which maps to make, the available options are:
+        'counts', 'exposure', 'background', 'psf', 'edisp'.
+    background : `BackgroundConfig`
+        Background configuration.
+    safe_mask : `SafeMaskConfig`
+        Safe mask configuration.
+    on_region : dict
+        ON-region definition for spectral extraction. Should contain the following keys
+        'frame', 'lat', 'lon' and 'radius', the latter three as angle quantities.
+    containment_correction : bool
+        Whether to apply containment correction.
+    """
+
     type: ReductionTypeEnum = ReductionTypeEnum.spectrum
     stack: bool = True
     geom: GeomConfig = GeomConfig()
@@ -211,13 +342,22 @@ class DatasetsConfig(GammapyBaseConfig):
 class ObservationsConfig(GammapyBaseConfig):
     """Configuration for `~gammapy.data.Observations`.
 
-    Attributes:
-        datastore (str): Path to the data store.
-        obs_ids (list of int): List of observation IDs.
-        obs_file (str): Path to a YAML observation file.
-        obs_cone (frame, lat, lon, radius): Cone selection for observations.
-        obs_time (start, stop): Observation time filtering.
-        required_irf (list): Required IRF components, options are "aeff", "edisp", "psf", "bkg"
+    Attributes
+    ----------
+    datastore : str
+        Path to the data store.
+    obs_ids : list of int
+        List of observation IDs.
+    obs_file : str
+        Path to a YAML observation file.
+    obs_cone : dict
+        Cone selection for observations. Should contain the following keys
+        'frame', 'lat', 'lon' and 'radius', the latter three as angle quantities.
+    obs_time : dict
+        Observation time filtering.  Should contain the following keys
+        'start' and 'stop' as time quantities.
+    required_irf : list
+        Required IRF components, options are "aeff", "edisp", "psf", "bkg"
     """
 
     datastore: PathType = Path("$GAMMAPY_DATA/hess-dl3-dr1/")
@@ -231,12 +371,18 @@ class ObservationsConfig(GammapyBaseConfig):
 class LogConfig(GammapyBaseConfig):
     """Configuration for logging.
 
-    Attributes:
-        level (str): Logging level (e.g., 'info', 'debug').
-        filename (str): Log file path.
-        filemode (str): File mode ('w' for overwrite, 'a' for append).
-        format (str): Logging format string.
-        datefmt (str): Format for timestamps.
+    Attributes
+    ----------
+    level : str
+        Logging level (e.g., 'info', 'debug').
+    filename : str
+        Log file path.
+    filemode : str
+        File mode ('w' for overwrite, 'a' for append).
+    format : str
+        Logging format string.
+    datefmt : str
+        Format for timestamps.
     """
 
     level: str = "info"
@@ -249,12 +395,18 @@ class LogConfig(GammapyBaseConfig):
 class GeneralConfig(GammapyBaseConfig):
     """Top-level general configuration.
 
-    Attributes:
-        log (`LogConfig`): Logging configuration.
-        outdir (str): Output directory.
-        n_jobs (int): Number of parallel jobs.
-        datasets_file (str): Path to datasets config file.
-        models_file (str): Path to models config file.
+    Attributes
+    ----------
+    log : `LogConfig`
+        Logging configuration.
+    outdir : str
+        Output directory.
+    n_jobs : int
+        Number of parallel jobs.
+    datasets_file : str
+        Path to datasets config file.
+    models_file : str
+        Path to models config file.
     """
 
     log: LogConfig = LogConfig()
@@ -270,7 +422,7 @@ class AnalysisConfig(GammapyBaseConfig):
     This class defines the full analysis configuration schema, organised into different sections.
     It can be read from or written to a YAML file using `.read()` and `.write()`, respectively.
 
-    Parameters
+    Attributes
     ----------
     general : `GeneralConfig`
         General settings for output, logging, and file paths.
@@ -280,13 +432,13 @@ class AnalysisConfig(GammapyBaseConfig):
         Settings for the `~gammapy.datasets.Dataset` Including but not limited to geometry (`GeomConfig`),
         background (`BackgroundConfig`), safe mask (`SafeMaskConfig`), and stacking.
     fit : `FitConfig`
-        Settings for the `~gammapy.modeling.Fit` strategy and global fit energy range.
+        Configuration for the `~gammapy.modeling.Fit` strategy and global fit energy range.
     flux_points : `FluxPointsConfig`
-        Settings for the `~gammapy.estimators.FluxPointsEstimator`.
+        Configuration for the `~gammapy.estimators.FluxPointsEstimator`.
     excess_map : `ExcessMapConfig`
-        Settings for the `~gammapy.estimators.ExcessMapEstimator`.
+        Configuration for the `~gammapy.estimators.ExcessMapEstimator`.
     light_curve : `LightCurveConfig`
-        Settings for the `~gammapy.estimators.LightCurveEstimator`.
+        Configuration for the `~gammapy.estimators.LightCurveEstimator`.
 
     Examples
     --------
@@ -342,7 +494,6 @@ class AnalysisConfig(GammapyBaseConfig):
         ----------
         config_str : str
             yaml str
-
         """
         settings = yaml.safe_load(config_str)
         return AnalysisConfig(**settings)

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -221,7 +221,45 @@ class GeneralConfig(GammapyBaseConfig):
 
 
 class AnalysisConfig(GammapyBaseConfig):
-    """Gammapy analysis configuration."""
+    """Gammapy analysis configuration.
+
+    This class defines the full analysis configuration schema, organised into different sections.
+    It can be read from or written to a YAML file using `.read()` and `.write()`, respectively.
+
+    Parameters
+    ----------
+    general : `GeneralConfig`
+        General settings for output, logging, and file paths.
+    observations : `ObservationsConfig`
+        Settings for the `~gammapy.data.Observation` selection including IDs, regions, and time filters.
+    datasets : `DatasetsConfig`
+        Settings for the `~gammapy.datasets.Dataset` Including but not limited to geometry (`GeomConfig`),
+        background (`BackgroundConfig`), safe mask (`SafeMaskConfig`), and stacking.
+    fit : `FitConfig`
+        Settings for the `~gammapy.modeling.Fit` strategy and global fit energy range.
+    flux_points : `FluxPointsConfig`
+        Settings for the `~gammapy.estimators.FluxPointsEstimator`.
+    excess_map : `ExcessMapConfig`
+        Settings for the `~gammapy.estimators.ExcessMapEstimator`.
+    light_curve : `LightCurveConfig`
+        Settings for the `~gammapy.estimators.LightCurveEstimator`.
+
+    Examples
+    --------
+    Read from a yaml file::
+
+    >>> from gammapy.analysis import AnalysisConfig
+    >>> config = AnalysisConfig.read("config.yaml") # doctest: +SKIP
+    >>> print(config.datasets.geom) # doctest: +SKIP
+
+    Create from scratch
+
+    >>> config = AnalysisConfig()
+    >>> config.observations.datastore = "$GAMMAPY_DATA/hess-dl3-dr1"
+    >>> config.observations.obs_cone = {"frame": "icrs", "lon": "83.633 deg", "lat": "22.014 deg", "radius": "5 deg"}
+    >>> print(config.observations.obs_cone.lat.deg)
+    22.014
+    """
 
     general: GeneralConfig = GeneralConfig()
     observations: ObservationsConfig = ObservationsConfig()


### PR DESCRIPTION
This resolves #5181.

I've added some changes to the conf.py such that the pydantic related code looks nicer. 
You can see an obvious difference already between the previous output and this one

As we don't have many of these functionalities exposed, it is unclear how to proceed. 

We could add more of them to the documentation? Thoughts?