### PR TITLE
Remove TODO from documentation build

### DIFF
--- a/docs/user-guide/astro/population/index.rst
+++ b/docs/user-guide/astro/population/index.rst
@@ -48,7 +48,7 @@ surface density of pulsars and related objects used in literature:
 
 .. plot:: user-guide/astro/population/plot_radial_distributions.py
 
-TODO: add illustration of Galactocentric z-distribution model and combined (r,
+.. TODO: add illustration of Galactocentric z-distribution model and combined (r,
 z) distribution for the Besancon model.
 
 Spiral arm models

--- a/docs/user-guide/astro/source/index.rst
+++ b/docs/user-guide/astro/source/index.rst
@@ -10,10 +10,7 @@ Introduction
 The `gammapy.astro.source` module contains classes of source models, which can
 be used for population synthesis of galactic gamma-ray sources.
 
-Getting started
-===============
-
-TODO: add basic example.
+.. TODO: add basic example.
 
 Using gammapy.astro.source
 ==========================

--- a/docs/user-guide/utils.rst
+++ b/docs/user-guide/utils.rst
@@ -100,9 +100,9 @@ For now, we use the `gammapy.utils.time.time_ref_from_dict`,
 to convert MET floats to `~astropy.time.Time` objects via the reference times
 stored in FITS headers.
 
-Time differences
-++++++++++++++++
+.. Time differences
+.. ++++++++++++++++
 
-TODO: discuss when to use `~astropy.time.TimeDelta` or `~astropy.units.Quantity`
+.. TODO: discuss when to use `~astropy.time.TimeDelta` or `~astropy.units.Quantity`
 or :term:`MET` floats and where one needs to convert between those and what to watch
 out for.

--- a/docs/user-guide/utils.rst
+++ b/docs/user-guide/utils.rst
@@ -104,5 +104,5 @@ stored in FITS headers.
 .. ++++++++++++++++
 
 .. TODO: discuss when to use `~astropy.time.TimeDelta` or `~astropy.units.Quantity`
-or :term:`MET` floats and where one needs to convert between those and what to watch
-out for.
+.. or :term:`MET` floats and where one needs to convert between those and what to watch
+.. out for.

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -3,6 +3,7 @@
 
 https://github.com/gammapy/gamma-cat
 """
+
 import logging
 import numpy as np
 from astropy import units as u
@@ -236,10 +237,8 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         return model
 
     def spatial_model(self):
-        """Source spatial model (`~gammapy.modeling.models.SpatialModel`).
-
-        TODO: add parameter errors!
-        """
+        """Source spatial model (`~gammapy.modeling.models.SpatialModel`)."""
+        # TODO : support array input if it should vary along the energy axis.
         d = self.data
         morph_type = d["morph_type"]
 

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -27,10 +27,9 @@ class Dataset(abc.ABC):
     - `gammapy.datasets.FluxPointsDataset`
 
     For more information see :ref:`datasets`.
-
-    TODO: add tutorial how to create your own dataset types.
     """
 
+    # TODO: add tutorial how to create your own dataset types.
     _residuals_labels = {
         "diff": "data - model",
         "diff/model": "(data - model) / model",

--- a/gammapy/irf/psf/kernel.py
+++ b/gammapy/irf/psf/kernel.py
@@ -133,8 +133,6 @@ class PSFKernel:
         The map geometry parameters (pixel size, energy bins) are taken from ``geom``.
         The Gaussian width ``sigma`` is a scalar.
 
-        TODO : support array input if it should vary along the energy axis.
-
         Parameters
         ----------
         geom : `~gammapy.maps.WcsGeom`
@@ -151,6 +149,7 @@ class PSFKernel:
         kernel : `~gammapy.irf.PSFKernel`
             The kernel Map with reduced geometry according to the max_radius.
         """
+        # TODO : support array input if it should vary along the energy axis.
         from gammapy.modeling.models import GaussianSpatialModel
 
         gauss = GaussianSpatialModel(sigma=sigma)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1895,9 +1895,6 @@ class TemplateSpectralModel(SpectralModel):
         The input is a table containing absorbed values from a XSPEC model as a
         function of energy.
 
-        TODO: Format of the file should be described and discussed in
-        https://gamma-astro-data-formats.readthedocs.io/en/latest/index.html
-
         Parameters
         ----------
         filename : str
@@ -1913,6 +1910,8 @@ class TemplateSpectralModel(SpectralModel):
         >>> filename = '$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz'
         >>> table_model = TemplateSpectralModel.read_xspec_model(filename=filename, param=0.3)
         """
+        # TODO: Format of the file should be described and discussed in
+        # https://gamma-astro-data-formats.readthedocs.io/en/latest/index.html
         filename = make_path(filename)
 
         # Check if parameter value is in range

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -7,10 +7,6 @@ https://astropy-regions.readthedocs.io
 
 We might add in other conveniences and features here, e.g. sky coord contains
 without a WCS (see "sky and pixel regions" in PIG 10), or some HEALPix integration.
-
-TODO: before Gammapy v1.0, discuss what to do about ``gammapy.utils.regions``.
-Options: keep as-is, hide from the docs, or to remove it completely
-(if the functionality is available in ``astropy-regions`` directly.
 """
 
 import operator


### PR DESCRIPTION
This PR removes the visibility of the TODO in the docs. 
These are notes for the devs and should not be present in the documentation.