### PR TITLE
Vectorized error evaluation of flux uncertainties based on samples

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -225,7 +225,7 @@ class SpectralModel(ModelBase):
                 Defines random number generator initialisation.
                 Passed to `~gammapy.utils.random.get_random_state`. Default is 42.
         samples : list of `~astropy.units.Quantity`, optional
-            List of parameter samples
+            List of parameter samples in the same order as model.parameters
 
         Returns
         -------
@@ -299,7 +299,7 @@ class SpectralModel(ModelBase):
             Defines random number generator initialisation.
             Passed to `~gammapy.utils.random.get_random_state`. Default is 42.
         samples : list of `~astropy.units.Quantity`, optional
-            List of parameter samples
+            List of parameter samples in the same order as model.parameters
 
         Returns
         -------
@@ -415,7 +415,7 @@ class SpectralModel(ModelBase):
             Defines random number generator initialisation.
             Passed to `~gammapy.utils.random.get_random_state`. Default is 42.
         samples : list of `~astropy.units.Quantity`, optional
-            List of parameter samples
+            List of parameter samples in the same order as model.parameters
 
         Returns
         -------

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -286,6 +286,8 @@ class SpectralModel(ModelBase):
         random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}, optional
             Defines random number generator initialisation.
             Passed to `~gammapy.utils.random.get_random_state`. Default is 42.
+        samples : list of `~astropy.units.Quantity`, optional
+            List of parameter samples
 
         Returns
         -------
@@ -307,14 +309,14 @@ class SpectralModel(ModelBase):
         def fct(*args):
             return m.evaluate(energy[..., np.newaxis], *args)
 
-        samples = self._samples(
+        propagated_samples = self._samples(
             fct,
             n_samples=n_pars * n_samples,
             random_state=random_state,
             samples=samples,
         )
 
-        return self._get_errors(samples)
+        return self._get_errors(propagated_samples)
 
     @property
     def pivot_energy(self):
@@ -376,7 +378,14 @@ class SpectralModel(ModelBase):
             return integrate_spectrum(self, energy_min, energy_max, **kwargs)
 
     def integral_error(
-        self, energy_min, energy_max, epsilon=1e-4, n_samples=3500, **kwargs
+        self,
+        energy_min,
+        energy_max,
+        epsilon=1e-4,
+        n_samples=3500,
+        random_state=42,
+        samples=None,
+        **kwargs,
     ):
         """Evaluate the error of the integral flux of a given spectrum in a given energy range.
 
@@ -390,7 +399,11 @@ class SpectralModel(ModelBase):
             Deprecated in v2.0 and unused.
         n_samples : int, optional
             Number of samples to generate per parameter. Default is 3500.
-
+        random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}, optional
+            Defines random number generator initialisation.
+            Passed to `~gammapy.utils.random.get_random_state`. Default is 42.
+        samples : list of `~astropy.units.Quantity`, optional
+            List of parameter samples
 
         Returns
         -------
@@ -419,8 +432,13 @@ class SpectralModel(ModelBase):
                 **kwargs,
             )
 
-        samples = self._samples(fct, n_samples=n_pars * n_samples)
-        return self._get_errors(samples)
+        propagated_samples = self._samples(
+            fct,
+            n_samples=n_pars * n_samples,
+            random_state=random_state,
+            samples=samples,
+        )
+        return self._get_errors(propagated_samples)
 
     def energy_flux(self, energy_min, energy_max, **kwargs):
         r"""Compute energy flux in given energy range.
@@ -447,7 +465,14 @@ class SpectralModel(ModelBase):
             return integrate_spectrum(f, energy_min, energy_max, **kwargs)
 
     def energy_flux_error(
-        self, energy_min, energy_max, epsilon=1e-4, n_samples=3500, **kwargs
+        self,
+        energy_min,
+        energy_max,
+        epsilon=1e-4,
+        n_samples=3500,
+        random_state=42,
+        samples=None,
+        **kwargs,
     ):
         """Evaluate the error of the energy flux of a given spectrum in a given energy range.
 
@@ -461,6 +486,11 @@ class SpectralModel(ModelBase):
             Deprecated in v2.0 and unused.
         n_samples : int, optional
             Number of samples to generate per parameter. Default is 3500.
+        random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}, optional
+            Defines random number generator initialisation.
+            Passed to `~gammapy.utils.random.get_random_state`. Default is 42.
+        samples : list of `~astropy.units.Quantity`, optional
+            List of parameter samples
 
         Returns
         -------
@@ -489,8 +519,13 @@ class SpectralModel(ModelBase):
                 **kwargs,
             )
 
-        samples = self._samples(fct, n_samples=n_pars * n_samples)
-        return self._get_errors(samples)
+        propagated_samples = self._samples(
+            fct,
+            n_samples=n_pars * n_samples,
+            random_state=random_state,
+            samples=samples,
+        )
+        return self._get_errors(propagated_samples)
 
     def reference_fluxes(self, energy_axis):
         """Get reference fluxes for a given energy axis.
@@ -772,7 +807,9 @@ class SpectralModel(ModelBase):
         f2 = self.evaluate(energy * (1 + epsilon), *args)
         return np.log(f1 / f2) / np.log(1 + epsilon)
 
-    def spectral_index_error(self, energy, epsilon=1e-5, n_samples=3500):
+    def spectral_index_error(
+        self, energy, epsilon=1e-5, n_samples=3500, random_state=42, samples=None
+    ):
         """Evaluate the error on spectral index at the given energy.
 
         Parameters
@@ -784,6 +821,11 @@ class SpectralModel(ModelBase):
             Default is 1e-5. Deprecated in v2.0 and unsued.
         n_samples : int, optional
             Number of samples to generate per parameter. Default is 3500.
+        random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}, optional
+            Defines random number generator initialisation.
+            Passed to `~gammapy.utils.random.get_random_state`. Default is 42.
+        samples : list of `~astropy.units.Quantity`, optional
+            List of parameter samples
 
         Returns
         -------
@@ -806,8 +848,13 @@ class SpectralModel(ModelBase):
                 energy[..., np.newaxis], *args, epsilon=1e-5
             )
 
-        samples = self._samples(fct, n_samples=n_pars * n_samples)
-        return self._get_errors(samples)
+        propagated_samples = self._samples(
+            fct,
+            n_samples=n_pars * n_samples,
+            random_state=random_state,
+            samples=samples,
+        )
+        return self._get_errors(propagated_samples)
 
     def inverse(self, value, energy_min=0.1 * u.TeV, energy_max=100 * u.TeV):
         """Return energy for a given function value of the spectral model.

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -103,7 +103,7 @@ def scale_plot_flux(flux, energy_power=0):
 
 
 def integrate_spectrum(
-    func, energy_min, energy_max, ndecade=100, eflux=False, parameter_samples=None
+    func, energy_min, energy_max, ndecade=100, energy_flux=False, parameter_samples=None
 ):
     """Integrate one-dimensional function using the log-log trapezoidal rule.
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -260,9 +260,9 @@ class SpectralModel(ModelBase):
         """
         cdf = stats.norm.cdf
 
-        median = np.percentile(samples, 50, axis=1)
-        errn = median - np.percentile(samples, 100 * cdf(-n_sigma), axis=1)
-        errp = np.percentile(samples, 100 * cdf(n_sigma), axis=1) - median
+        median = np.percentile(samples, 50, axis=-1)
+        errn = median - np.percentile(samples, 100 * cdf(-n_sigma), axis=-1)
+        errp = np.percentile(samples, 100 * cdf(n_sigma), axis=-1) - median
         return u.Quantity(
             [np.atleast_1d(median), np.atleast_1d(errn), np.atleast_1d(errp)],
             unit=samples.unit,
@@ -313,6 +313,7 @@ class SpectralModel(ModelBase):
             random_state=random_state,
             samples=samples,
         )
+
         return self._get_errors(samples)
 
     @property

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1778,11 +1778,11 @@ class SuperExpCutoffPowerLaw4FGLDR3SpectralModel(SpectralModel):
         )
 
         mask = np.abs(index_2 * np.log(energy / reference)) < 1e-2
-        ln_ = np.log(energy[mask] / reference)
+        ln_ = np.log(energy / reference)
         power = -expfactor * (
             ln_ / 2.0 + index_2 / 6.0 * ln_**2.0 + index_2**2.0 / 24.0 * ln_**3
         )
-        cutoff[mask] = (energy[mask] / reference) ** power
+        cutoff[mask] = ((energy / reference) ** power)[mask]
         return pwl * cutoff
 
     @property

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -688,6 +688,8 @@ class SpectralModel(ModelBase):
         energy_power=0,
         n_points=100,
         n_samples=3500,
+        random_state=42,
+        samples=None,
         **kwargs,
     ):
         """Plot spectral model error band.
@@ -721,6 +723,11 @@ class SpectralModel(ModelBase):
             Number of evaluation nodes. Default is 100.
         n_samples : int, optional
             Number of samples generated per parameter to estimate the error band. Default is 3500.
+        random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}, optional
+            Defines random number generator initialisation.
+            Passed to `~gammapy.utils.random.get_random_state`. Default is 42.
+        samples : list of `~astropy.units.Quantity`, optional
+            List of parameter samples
         **kwargs : dict
             Keyword arguments forwarded to `matplotlib.pyplot.fill_between`.
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -109,7 +109,7 @@ def integrate_spectrum(
 
     Internally an oversampling of the energy bins to "ndecade" is used.
 
-    To compute the integral func(E)*E (e.g. to get an energy flux) one can set eflux to True.
+    To compute the integral func(E)*E (e.g. to get an energy flux) one can set `energy_flux` to True.
 
     Parameters
     ----------
@@ -126,7 +126,7 @@ def integrate_spectrum(
         List of parameter quantities to pass to `func.evaluate` if it exists.
         This provides vectorized integral evaluation for parameter samples.
         If None, evaluation is performed with a simple call to `func`. Default is None.
-    eflux : bool, optional
+    energy_flux : bool, optional
         If True, the function will integrate func(E)*E, to compute the energy flux.
         Default is False.
     """
@@ -156,7 +156,7 @@ def integrate_spectrum(
     else:
         values = func(energy)
 
-    if eflux:
+    if energy_flux:
         values *= energy
 
     # we can call trapz_loglog assuming the last axis is the one to perform integration on.
@@ -440,7 +440,7 @@ class SpectralModel(ModelBase):
                 energy_min,
                 energy_max,
                 parameter_samples=args,
-                eflux=False,
+                energy_flux=False,
                 **kwargs,
             )
 
@@ -502,7 +502,7 @@ class SpectralModel(ModelBase):
             Defines random number generator initialisation.
             Passed to `~gammapy.utils.random.get_random_state`. Default is 42.
         samples : list of `~astropy.units.Quantity`, optional
-            List of parameter samples
+            List of parameter samples in the same order as model.parameters
 
         Returns
         -------
@@ -527,7 +527,7 @@ class SpectralModel(ModelBase):
                 energy_min,
                 energy_max,
                 parameter_samples=args,
-                eflux=True,
+                energy_flux=True,
                 **kwargs,
             )
 
@@ -744,7 +744,7 @@ class SpectralModel(ModelBase):
             Defines random number generator initialisation.
             Passed to `~gammapy.utils.random.get_random_state`. Default is 42.
         samples : list of `~astropy.units.Quantity`, optional
-            List of parameter samples
+            List of parameter samples in the same order as model.parameters
         **kwargs : dict
             Keyword arguments forwarded to `matplotlib.pyplot.fill_between`.
 
@@ -864,7 +864,7 @@ class SpectralModel(ModelBase):
             Defines random number generator initialisation.
             Passed to `~gammapy.utils.random.get_random_state`. Default is 42.
         samples : list of `~astropy.units.Quantity`, optional
-            List of parameter samples
+            List of parameter samples in the same order as model.parameters
 
         Returns
         -------

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -1385,9 +1385,7 @@ def test_e_peak_super_4FGLDR3():
 def test_vectorized_integrate_spectrum():
     model = PowerLawSpectralModel()
 
-    parameter_samples = {}
-    for par in model.parameters:
-        parameter_samples[par.name] = np.ones(10) * par.quantity
+    parameter_samples = [np.ones(10) * par.quantity for par in model.parameters]
 
     energy = [100, 1000, 10000] * u.GeV
 


### PR DESCRIPTION
Simplification of #5881 only for performance improvement without refactoring.
Keep only the new `integrate_spectrum` function of @registerrier and insert it in the current system for error computation.
Could also add `samples` as an option to all _error methods (maybe in a separate PR ?). 