### PR TITLE
Cleanup variable name in `estimate_min_e2dnde` 

### DIFF
--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -89,7 +89,7 @@ class SensitivityEstimator(Estimator):
         return excess
 
     def estimate_min_e2dnde(self, excess, dataset):
-        """Estimate dnde from a given minimum excess.
+        """Estimate e2dnde from a given minimum excess.
 
         Parameters
         ----------
@@ -111,8 +111,8 @@ class SensitivityEstimator(Estimator):
         phi_0 = excess / npred
 
         dnde_model = self.spectral_model(energy=energy)
-        dnde = phi_0.data[:, 0, 0] * dnde_model * energy**2
-        return dnde.to("erg / (cm2 s)")
+        e2dnde = phi_0.data[:, 0, 0] * dnde_model * energy**2
+        return e2dnde.to("erg / (cm2 s)")
 
     def _get_criterion(self, excess, bkg):
         is_gamma_limited = excess == self.gamma_min


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request fixes the usage of e2dnde in `estimate_min_e2dnde`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
The PR is ready for review.