### PR TITLE
Workflow to check the building of wheels nightly

### DIFF
--- a/.github/workflows/nightly_builds.yml
+++ b/.github/workflows/nightly_builds.yml
@@ -1,0 +1,16 @@
+name: Nightly wheel building
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * *'  # Every day at 05:00 UTC
+
+jobs:
+  build_wheels:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v2
+    with:
+      upload_to_pypi: false
+      targets: |
+        - cp3*-manylinux_x86_64*
+        - cp3*-macosx*
+        - cp3*-win_amd64*


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

As proposed in #5708 and #6042 here is a workflow to build the wheels nightly and catch any potential issue in the process early.

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This workflow makes use of `OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml` but removing the publishing part to PyPI. Wheels are available as artifacts. See e.g. https://github.com/morcuended/gammapy/actions/runs/16780075849

Later, this could be extented with https://scientific-python.org/specs/spec-0004/