### PR TITLE
Remove TODO

### DIFF
--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -41,7 +41,6 @@ REQUIRED_COLUMNS = {
     "e2dnde": ["e_ref", "e2dnde"],
     "flux": ["e_min", "e_max", "flux"],
     "eflux": ["e_min", "e_max", "eflux"],
-    # TODO: extend required columns
     "likelihood": [
         "e_min",
         "e_max",

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -65,9 +65,6 @@ class BackgroundIRF(IRF):
         bkg : `Background2D` or `Background2D`
             Background IRF class.
         """
-        # TODO: some of the existing background files have missing HDUCLAS keywords
-        #  which are required to define the correct Gammapy axis names
-
         if "HDUCLAS2" not in table.meta:
             log.warning("Missing 'HDUCLAS2' keyword assuming 'BKG'")
             table = table.copy()

--- a/gammapy/irf/psf/tests/test_map.py
+++ b/gammapy/irf/psf/tests/test_map.py
@@ -216,9 +216,6 @@ def test_psfmap_stacking():
     assert_allclose(psfmap_stack.psf_map.data[0, 20, 20, 20], 1.768388, rtol=1e-6)
     assert_allclose(psfmap_stack.psf_map.data[0, 0, 20, 20], 17.683883, rtol=1e-6)
 
-    # TODO: add a test comparing make_mean_psf and PSFMap.stack for a set of
-    #  observations in an Observations
-
 
 def test_sample_coord():
     psf_map = make_test_psfmap(0.1 * u.deg, shape="gauss")


### PR DESCRIPTION
This removes a couple TODO that are not necessary.

- we can add more required columns as we see fit, this is a TODO from 4 years ag0
- `[gammapy/irf/background` not a TODO just a statement
- the function that it mentions no longer exists

I also saw this one:
https://github.com/gammapy/gammapy/blob/445fd4f59de8a98a1b9db4fdb05443653995c100/gammapy/estimators/points/tests/test_sed.py#L46

Should I create a test dataset for this in gammapy-data and remove this section of code ?