### PR TITLE
Add names to HowTo, to allow linking

### DIFF
--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -25,6 +25,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Select observations
+    :name: dropdown-select-obs
 
     The `~gammapy.data.DataStore` provides access to a summary table of all observations available.
     It can be used to select observations with various criterion. You can for instance apply a cone search
@@ -39,6 +40,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Make observation duration maps
+    :name: dropdown-obs-map
 
     Gammapy offers a number of methods to explore the content of the various IRFs
     contained in an observation. This is usually done thanks to their ``peek()``
@@ -52,6 +54,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Group observations
+    :name: dropdown-group-obs
 
     `~gammapy.data.Observations` can be grouped depending on a number of various quantities.
     The two methods to do so are manual grouping and hierarchical clustering. The quantity
@@ -65,6 +68,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Make an on-axis equivalent livetime map
+    :name: dropdown-livetime-map
 
     The `~gammapy.data.DataStore` provides access to a summary table of all observations available.
     It can be used to obtain various quantities from your `~gammapy.data.Observations` list, such as livetime.
@@ -78,6 +82,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Compute minimum number of counts of significance per bin
+    :name: dropdown-resample
 
     The `~gammapy.estimators.utils.resample_energy_edges` provides a way to resample the energy bins
     to satisfy a minimum number of counts of significance per bin.
@@ -91,6 +96,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Choose units for plotting
+    :name: dropdown-plotting-units
 
     Units for plotting are handled with a combination of `matplotlib` and `astropy.units`.
     The methods `ax.xaxis.set_units()` and `ax.yaxis.set_units()` allow
@@ -112,6 +118,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Compute the significance of a source
+    :name: dropdown-src-sig
 
     Estimating the significance of a source, or more generally of an additional model
     component (such as e.g. a spectral line on top of a power-law spectrum), is done
@@ -127,6 +134,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Perform data reduction loop with multi-processing
+    :name: dropdown-reduction-loop
 
     There are two ways for the data reduction steps to be implemented. Either a loop is used to
     run the full reduction chain, or the reduction is performed with multi-processing tools by
@@ -140,6 +148,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Compute cumulative significance over time
+    :name: dropdown-cumulative-sig
 
     A classical plot in gamma-ray astronomy is the cumulative significance of a
     source as a function of observing time. In Gammapy, you can produce it with 1D
@@ -155,6 +164,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Implement a custom model
+    :name: dropdown-custom-model
 
     Gammapy allows the flexibility of using user-defined models for analysis.
 
@@ -166,6 +176,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Implement energy dependent spatial models
+    :name: dropdown-edep-spatial
 
     While Gammapy does not ship energy dependent spatial models, it is possible to define
     such models within the modeling framework.
@@ -178,6 +189,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Model astrophysical source spectra
+    :name: dropdown-astro-src-spec
 
     It is possible to combine Gammapy with astrophysical modeling codes, if they
     provide a Python interface. Usually this requires some glue code to be written,
@@ -188,6 +200,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Model temporal profiles
+    :name: dropdown-temp-model
 
     Temporal models can be directly fit on available lightcurves,
     or on the reduced datasets. This is done through a joint fitting of the datasets,
@@ -201,6 +214,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Improve fit convergence with constraints on the source position
+    :name: dropdown-improve-fit
 
     It happens that a 3D fit does not converge with warning messages indicating that the
     scanned positions of the model are outside the valid IRF map range. The type of warning message is:
@@ -219,6 +233,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Reduce memory budget for large datasets
+    :name: dropdown-reduce-mem
 
     When dealing with surveys and large sky regions, the amount of memory required might become
     problematic, in particular because of the default settings of the IRF maps stored in the
@@ -235,6 +250,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Copy part of a data store
+    :name: dropdown-copy-datastore
 
     To share specific data from a database, it might be necessary to create a new data storage with
     a limited set of observations and summary files following the scheme described in gadf_.
@@ -244,6 +260,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Interpolate onto a different geometry
+    :name: dropdown-interp-geom
 
     To interpolate maps onto a different geometry use `~gammapy.maps.Map.interp_to_geom`.
 
@@ -254,6 +271,7 @@ Please give feedback and suggest additions to this page!
        To the tutorial...
 
 .. dropdown:: Suppress warnings
+    :name: dropdown-suppress-warn
 
     In general it is not recommended to suppress warnings from code because they
     might point to potential issues or help debugging a non-working script. However
@@ -272,6 +290,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Avoid NaN results in Flux Point estimation
+    :name: dropdown-UL
 
     Sometimes, upper limit values may show as ``nan`` while running a `~gammapy.estimators.FluxPointsEstimator`
     or a `~gammapy.estimators.LightCurveEstimator`. This likely arises because the min/max range of the `norm` parameter
@@ -287,6 +306,7 @@ Please give feedback and suggest additions to this page!
        To the tutorial...
 
 .. dropdown:: Display a progress bar
+    :name: dropdown-progress-bar
 
     Gammapy provides the possibility of displaying a
     progress bar to monitor the advancement of time-consuming processes. To activate this
@@ -312,6 +332,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Change plotting style and color-blind friendly visualizations
+    :name: dropdown-colorblind-friendly
 
     As the Gammapy visualisations are using the library `matplotlib` that provides color styles,
     it is possible to change the default colors map of the Gammapy plots. Using using the
@@ -347,6 +368,7 @@ Please give feedback and suggest additions to this page!
 
 
 .. dropdown:: Add PHASE information to your data
+    :name: dropdown-phase-info
 
     To do a pulsar analysis, one must compute the pulsar phase of
     each event and put this new information in a new `~gammapy.data.Observation`.

--- a/docs/user-guide/visualization/index.rst
+++ b/docs/user-guide/visualization/index.rst
@@ -18,7 +18,7 @@ used in gamma-ray astronomy (`colormap_hess` and `colormap_milagro`).
     :include-source:
 
 Color-blind friendly visualizations can be achieved using the `style sheet of matplotlib <https://matplotlib.org/stable/gallery/style_sheets/style_sheets_reference.html>`_
-(see the :ref:`how_to` section).
+(see the :ref:`dropdown-colorblind-friendly` section).
 
 Survey panel plots
 ------------------

--- a/gammapy/estimators/points/lightcurve.py
+++ b/gammapy/estimators/points/lightcurve.py
@@ -100,7 +100,7 @@ class LightCurveEstimator(FluxPointsEstimator):
 
     Notes
     -----
-    In case of failure of upper limits computation (e.g. nan), see the User Guide :ref:`how_to`.
+    In case of failure of upper limits computation (e.g. nan), see the User Guide: :ref:`dropdown-UL`.
     """
 
     tag = "LightCurveEstimator"

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -60,7 +60,7 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
         Edges of the flux points energy bins. The resulting bin edges won't be exactly equal to the input ones,
         but rather the closest values to the energy axis edges of the parent dataset.
         Default is [1, 10] TeV.
-    fit : `Fit`, optional
+    fit : `~gammapy.modeling.Fit`, optional
         Fit instance specifying the backend and fit options. If None, the `~gammapy.modeling.Fit` instance is created
         internally. Default is None.
     reoptimize : bool, optional
@@ -88,7 +88,7 @@ class FluxPointsEstimator(FluxEstimator, parallel.ParallelMixin):
     Notes
     -----
     - For further explanation, see :ref:`estimators`.
-    - In case of failure of upper limits computation (e.g. nan), see the User Guide :ref:`how_to`.
+    - In case of failure of upper limits computation (e.g. nan), see the User Guide: :ref:`dropdown-UL`.
 
     Examples
     --------


### PR DESCRIPTION
This PR adds names to each of the dropdowns so we can link to them in other parts of the documentation. 

I adapt the places we already had links to the general HowTo also