### PR TITLE
Clearer appearance for the click scipts in the documentation

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -1701,7 +1701,7 @@ class PiecewiseNormSpatialModel(SpatialModel):
     ----------
     coord : `gammapy.maps.MapCoord`
         Flat coordinates list at which the model values are given (nodes).
-    norms : `~numpy.ndarray` or list of `Parameter`
+    norms : `~numpy.ndarray` or list of `gammapy.modeling.Parameter`
         Array with the initial norms of the model at energies ``energy``.
         Normalisation parameters are created for each value.
         Default is one at each node.

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1472,7 +1472,7 @@ class PiecewiseNormSpectralModel(SpectralModel):
     ----------
     energy : `~astropy.units.Quantity`
         Array of energies at which the model values are given (nodes).
-    norms : `~numpy.ndarray` or list of `Parameter`
+    norms : `~numpy.ndarray` or list of `gammapy.modeling.Parameter`
         Array with the initial norms of the model at energies ``energy``.
         Normalisation parameters are created for each value.
         Default is one at each node.

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -134,7 +134,7 @@ def show_info_datasets(outfolder, release):
 @click.option(
     "--release",
     default=RELEASE,
-    help="Number of stable release - ex: 0.18.2)",
+    help="Number of stable release - ex: 2.0)",
     show_default=True,
 )
 @click.option(
@@ -174,7 +174,7 @@ def cli_download_notebooks(release, out):
 @click.option(
     "--release",
     default=RELEASE,
-    help="Number of stable release - ex: 0.18.2)",
+    help="Number of stable release - ex: 2.0)",
     show_default=True,
 )
 @click.option(

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -44,15 +44,14 @@ def cli(log_level, ignore_warnings):  # noqa: D301
 
     For further information, see https://gammapy.org/ and https://docs.gammapy.org/
 
-    \b
     Examples
     --------
+    .. code-block:: console
 
-    \b
-    $ gammapy --help
-    $ gammapy --version
-    $ gammapy info --help
-    $ gammapy info
+       $ gammapy --help
+       $ gammapy --version
+       $ gammapy info --help
+       $ gammapy info
     """
     logging.basicConfig(level=log_level.upper())
 
@@ -64,16 +63,15 @@ def cli(log_level, ignore_warnings):  # noqa: D301
 def cli_analysis():
     """Automation of configuration driven data reduction process.
 
-    \b
     Examples
     --------
+    .. code-block:: console
 
-    \b
-    $ gammapy analysis config
-    $ gammapy analysis run
-    $ gammapy analysis config --overwrite
-    $ gammapy analysis config --filename myconfig.yaml
-    $ gammapy analysis run --filename myconfig.yaml
+       $ gammapy analysis config
+       $ gammapy analysis run
+       $ gammapy analysis config --overwrite
+       $ gammapy analysis config --filename myconfig.yaml
+       $ gammapy analysis run --filename myconfig.yaml
     """
 
 
@@ -81,16 +79,15 @@ def cli_analysis():
 def cli_workflow():
     """Automation of configuration driven data reduction process.
 
-    \b
     Examples
     --------
+    .. code-block:: console
 
-    \b
-    $ gammapy workflow config
-    $ gammapy workflow run
-    $ gammapy workflow config --overwrite
-    $ gammapy workflow config --filename myconfig.yaml
-    $ gammapy workflow run --filename myconfig.yaml
+       $ gammapy workflow config
+       $ gammapy workflow run
+       $ gammapy workflow config --overwrite
+       $ gammapy workflow config --filename myconfig.yaml
+       $ gammapy workflow run --filename myconfig.yaml
     """
 
 
@@ -99,23 +96,23 @@ def cli_workflow():
 def cli_download(ctx):  # noqa: D301
     """Download notebooks and datasets.
 
-    \b
     Download notebooks published in the Gammapy documentation as well as the
     related datasets needed to execute them.
-    \b
-    - The option `notebooks` will download the notebook files into a `gammapy-notebooks`
-    folder created at the current working directory.
-    \b
-    - The option `datasets` will download the datasets used in the documentation into a
-    `gammapy-datasets` folder created at the current working directory.
 
-    \b
+    - The option "notebooks" will download the notebook files into a
+      ``gammapy-notebooks`` folder created at the current working directory.
+
+    - The option "datasets" will download the datasets used in the
+      documentation into a ``gammapy-datasets`` folder created at the current
+      working directory.
+
+
     Examples
     --------
+    .. code-block:: console
 
-    \b
-    $ gammapy download datasets  --out localfolder
-    $ gammapy download notebooks --release 0.18 --out localfolder
+       $ gammapy download datasets  --out localfolder
+       $ gammapy download notebooks --release 2.0 --out localfolder
     """
 
 


### PR DESCRIPTION
As per the title.
The current build looks a bit ugly:
https://docs.gammapy.org/2.0rc1/api-reference/scripts.html

Here is the updated version:
<img width="1011" height="683" alt="Screenshot from 2025-08-21 09-03-40" src="https://github.com/user-attachments/assets/282219e1-37ea-477e-b548-383df801e14a" />
