### PR TITLE
jfactory integral calculation description

### DIFF
--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -138,7 +138,7 @@ class ZhaoProfile(DMProfile):
     ----------
     .. [1] `Zhao (1996), "Analytical models for galactic nuclei"
       <https://ui.adsabs.harvard.edu/abs/1996MNRAS.278..488Z>`_
-    * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
+    .. [2] `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
       <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utilities to compute J-factor maps."""
+
 import html
 import numpy as np
 import astropy.units as u
@@ -48,6 +49,52 @@ class JFactory:
         .. math::
             \frac{\mathrm d J_\text{decay}}{\mathrm d \Omega} =
             \int_{\mathrm{LoS}} \mathrm d l \rho(l)
+
+        Parameters
+        ----------
+        ndecade : float, optional
+            Number of sampling points per decade in radius used for the numerical
+            integration. Default is 1e4.
+
+        Returns
+        -------
+        jfactor : `~astropy.units.Quantity`
+            Differential j-factor.
+
+        Notes
+        -----
+        The line-of-sight (LoS) integral should include both the near and far
+        sides of the halo. To account for this, the integration is split into
+        two regions:
+
+        1. :math:`[r_{\min}, r_{\max}]` - from the observer to the source,
+           counted twice to include contributions from both near and far sides.
+        2. :math:`[r_{\max}, 4 r_{\max}]` - from the source to infinity.
+           The upper limit is truncated at :math:`4 r_{\max}` because
+           contributions beyond this are negligible.
+
+        Hence, the effective integration domain is:
+
+        .. math::
+            2 \times [r_{\min}, r_{\max}] \;+\; [r_{\max}, 4 r_{\max}].
+
+        The LoS integral is converted into a radial integral over the profile through:
+
+        .. math::
+            r^2 = l^2 + r_{\max}^2 - 2 dl \cos \theta
+
+        Rearranging for the differential gives:
+
+        .. math::
+            \mathrm dl = \frac{2 r}{\sqrt{r^2 - r_{\min}^2}} \, \mathrm dr.
+
+        This substitution allows the integral to be evaluated directly as
+        radial integrals using ``profile.integral``, giving
+
+        .. math::
+            \int_0^{l_\mathrm{max}} \rho^2(r(l, \theta)) \, \mathrm dl
+            = 2 \int_{r_{\min}}^{r_{\max}} \frac{r \, \rho^2(r)}{\sqrt{r^2 - r_{\min}^2}} \, \mathrm dr
+              + \int_{r_{\max}}^{4 r_{\max}} \frac{r \, \rho^2(r)}{\sqrt{r^2 - r_{\min}^2}} \, \mathrm dr.
         """
         separation = self.geom.separation(self.geom.center_skydir).rad
         rmin = u.Quantity(
@@ -85,6 +132,17 @@ class JFactory:
             J(\Delta\Omega) =
            \int_{\Delta\Omega} \mathrm d \Omega^{\prime}
            \frac{\mathrm d J}{\mathrm d \Omega^{\prime}}
+
+        Parameters
+        ----------
+        ndecade : float, optional
+            Number of sampling points per decade in radius used for the numerical
+            integration. Default is 1e4.
+
+        Returns
+        -------
+        jfactor : `~astropy.units.Quantity`
+            The j-factor.
         """
         diff_jfact = self.compute_differential_jfactor(ndecade)
         return diff_jfact * self.geom.to_image().solid_angle()


### PR DESCRIPTION
This fixes #5296

The explanation which I utilised to create this comes from:
 https://gist.github.com/katrinstreil/eeee9f2969dbc037888f876d5f4e5b9d

**The current implementation has a lot of information:**

<img width="734" height="706" alt="Screenshot from 2025-08-21 15-17-29" src="https://github.com/user-attachments/assets/240b446a-4bb7-4bc7-9208-11bdaac7ce21" />


**Otherwise we could go for a more minimalist approach:**

<img width="734" height="296" alt="Screenshot from 2025-08-21 15-17-35" src="https://github.com/user-attachments/assets/b9a3cb4a-620d-4895-af9f-dc0f99969275" />


I also added the parameters and returns to the docstring and adapted the ZhaoProfile because it was causing a warning in the docs build