### PR TITLE
Remove deprecated pydantic copy in tutorial

### DIFF
--- a/examples/tutorials/analysis-3d/analysis_3d.py
+++ b/examples/tutorials/analysis-3d/analysis_3d.py
@@ -91,10 +91,10 @@ print(config)
 # future reference.
 #
 
-config_stack = config.copy(deep=True)
+config_stack = config.model_copy(deep=True)
 config_stack.datasets.stack = True
 
-config_joint = config.copy(deep=True)
+config_joint = config.model_copy(deep=True)
 config_joint.datasets.stack = False
 
 # To prevent unnecessary cluttering, we write it in a separate folder.


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request adapts the call to `AnalysisConfig.copy()` which inherits from pydantic `BaseModel.copy()`. The method is deprecated and one should use `BaseModel.model_copy()` instead. 

Another option is to create an `GammapyBaseConfig.copy()` method and encapsulate the pydantic call instead. Since this is the only place where we use `copy`. I suppose it is simpler to adapt the tutorial with the proper pydantic call.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
