### PR TITLE
Fix typo in edisp plotting

### DIFF
--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -654,7 +654,7 @@ class EDispKernel(IRF):
             ax.plot(energy, bias, **kwargs)
 
         ax.set_xlabel(
-            f"$E_\\mathrm{{True}}$ [{ax.yaxis.units.to_string(UNIT_STRING_FORMAT)}]"
+            f"$E_\\mathrm{{True}}$ [{ax.xaxis.units.to_string(UNIT_STRING_FORMAT)}]"
         )
         ax.set_ylabel(
             "($E_\\mathrm{{Reco}} - E_\\mathrm{{True}}) / E_\\mathrm{{True}}$"


### PR DESCRIPTION
@LeanderSchlegel  noticed that in the docs [here](https://docs.gammapy.org/2.0/user-guide/irf/edisp.html#as-a-function-of-true-energy-gadf-ogip-rmf) the x axis label was not correctly showing the units. 

This is a simple fix where we were accidentally calling the yaxis, instead of xaxis