### PR TITLE
Add missing fragment files for next version

### DIFF
--- a/docs/release-notes/6141.feature.rst
+++ b/docs/release-notes/6141.feature.rst
@@ -1,0 +1,1 @@
+Extra sensitivity options were added to `~gammapy.estimators.map.FluxMaps`. The additional options we now support are: "dnde_sensitivity", "e2dnde_sensitivity", "eflux_sensitivity".

--- a/docs/release-notes/6159.bug.rst
+++ b/docs/release-notes/6159.bug.rst
@@ -1,0 +1,1 @@
+Fixed `gammapy.irf.EDispKernel.plot_bias` so the correct axis is now being called for the ``xaxis.units``.

--- a/docs/release-notes/6164.bug.rst
+++ b/docs/release-notes/6164.bug.rst
@@ -1,0 +1,1 @@
+Fixed the incorrect brackets in the error calculation for `~gammapy.stats.compute_flux_doubling`.


### PR DESCRIPTION
This PR is related to the addition of towncrier ([#6130](https://github.com/gammapy/gammapy/pull/6130)).
As we want towncrier to be implemented for v2.0.1 and beyond, we need to add the missing fragments to files. 
We can collect any other missing fragments here. 

We know we don't want to include every PR in the changelog though, so there are number which are not/should not be implemented.