### PR TITLE
Allow for RunTime warning in NaN for test_pwn

### DIFF
--- a/gammapy/astro/source/tests/test_pwn.py
+++ b/gammapy/astro/source/tests/test_pwn.py
@@ -3,6 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.units import Quantity
 from gammapy.astro.source import PWN
+import warnings
 
 t = Quantity([0, 1, 10, 100, 1000, 10000, 100000], "yr")
 pwn = PWN()
@@ -16,5 +17,8 @@ def test_PWN_radius():
 
 def test_magnetic_field():
     """Test SNR luminosity"""
-    b = [np.nan, 1.753e-03, 8.788e-05, 4.404e-06, 2.207e-07, 4.685e-07, 1.481e-06]
-    assert_allclose(pwn.magnetic_field(t).to_value("gauss"), b, rtol=1e-3)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        b = [np.nan, 1.753e-03, 8.788e-05, 4.404e-06, 2.207e-07, 4.685e-07, 1.481e-06]
+        result = pwn.magnetic_field(t).to_value("gauss")
+        assert_allclose(result, b, rtol=1e-3)


### PR DESCRIPTION
This PR is to remove a warning in the tests which is expected as we have a `NaN` at `t=0` (expected behaviour). 

This contributes to  #2103


The other option would be to not include a `t=0`