### PR TITLE
Replace deprecated keyword by RADESYSa

### DIFF
--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -992,7 +992,7 @@ class EventListChecker(Checker):
         # They are currently listed as required in the spec,
         # but I think we should just require ICRS and those
         # are irrelevant, should not be used.
-        # 'RADECSYS',
+        # 'RADESYSa',
         # 'EQUINOX',
         "ORIGIN",
         "TELESCOP",

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -470,7 +470,7 @@ class MapDatasetEventSampler:
         meta["DEC_PNT"] = fixed_icrs.dec.deg
 
         meta["EQUINOX"] = "J2000"
-        meta["RADECSYS"] = "icrs"
+        meta["RADESYSa"] = "icrs"
 
         meta["CREATOR"] = "Gammapy {}".format(__version__)
         meta["EUNIT"] = "TeV"

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -614,7 +614,7 @@ def test_mde_run(dataset, models, caplog, tmp_path):
     assert_allclose(meta["RA_PNT"], 266.4049882865447)
     assert_allclose(meta["DEC_PNT"], -28.936177761791473)
     assert meta["EQUINOX"] == "J2000"
-    assert meta["RADECSYS"] == "icrs"
+    assert meta["RADESYSa"] == "icrs"
     assert "Gammapy" in meta["CREATOR"]
     assert meta["EUNIT"] == "TeV"
     assert meta["EVTVER"] == ""
@@ -724,7 +724,7 @@ def test_mde_run_switchoff(dataset, models):
     assert meta["RA_PNT"] == 266.4049882865447
     assert_allclose(meta["ONTIME"], 3600.0)
     assert meta["OBS_ID"] == 1001
-    assert meta["RADECSYS"] == "icrs"
+    assert meta["RADESYSa"] == "icrs"
 
 
 @requires_data()


### PR DESCRIPTION
Dear all,

this small PR addresses Issue #5985 as a first step, by updating the deprecated keyword for the coordinate system (see https://docs.astropy.org/en/latest/api/astropy.wcs.Wcsprm.html) with its recommended update "RADESYSa" in the three identified code-files of gammypy.

In a separate future PR for the gammapy-data repository, the datafiles can be updated accordingly.

**Dear reviewer**
In a first try in #5985, I could only update the keyword update in the FITS capitalized as "RADESYSA", but most likely this can be still changed, shall we stay with the writing "RADESYSa"?
Do you know if I missed maybe any occurrence of the old keyword, that still needs to be updated?

Thank you a lot,
Leander