### PR TITLE
add axis_name argument and test

### DIFF
--- a/gammapy/estimators/points/core.py
+++ b/gammapy/estimators/points/core.py
@@ -738,6 +738,7 @@ class FluxPoints(FluxMaps):
         ax=None,
         sed_type=None,
         add_cbar=True,
+        axis_name=None,
         **kwargs,
     ):
         """Plot fit statistic SED profiles as a density plot.
@@ -772,7 +773,10 @@ class FluxPoints(FluxMaps):
                 "Profile plotting is only supported for unidimensional maps"
             )
 
-        axis = self.geom.axes.primary_axis
+        if axis_name is None:
+            axis = self.geom.axes.primary_axis
+        else:
+            axis = self.geom.axes[axis_name]
 
         if isinstance(axis, TimeMapAxis) and not axis.is_contiguous:
             axis = axis.to_contiguous()

--- a/gammapy/estimators/points/tests/test_core.py
+++ b/gammapy/estimators/points/tests/test_core.py
@@ -248,6 +248,20 @@ class TestFluxPoints:
         with mpl_plot_check():
             flux_points_likelihood.plot_ts_profiles()
 
+    def test_plot_likelihood_single_interval(self, flux_points_likelihood):
+        lc_1d = FluxPoints.read(
+            "$GAMMAPY_DATA/estimators/pks2155_hess_lc/pks2155_hess_lc.fits",
+            format="lightcurve",
+        )
+        axis_new = get_rebinned_axis(
+            lc_1d, method="fixed-bins", group_size=34, axis_name="time"
+        )
+        l1 = lc_1d.resample_axis(axis_new=axis_new)
+        plt.figure()
+        with mpl_plot_check():
+            ax = l1.plot_ts_profiles(axis_name="time")
+            assert "Time" in str(ax.xaxis.get_label())
+
     def test_plot_likelihood_error(self, flux_points_likelihood):
         del flux_points_likelihood._data["stat_scan"]
 


### PR DESCRIPTION
The pull request fixes the issue #6196 for the `FluxPoints.plot_ts_profiles`. It introduces an additional argument that allows to select the axis to plot.

