### PR TITLE
Add __repr__ method to Geom

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -60,6 +60,9 @@ class Geom(abc.ABC):
     See also: `~gammapy.maps.WcsGeom` and `~gammapy.maps.HpxGeom`.
     """
 
+    def __repr__(self):
+        return self.__str__()
+
     def _repr_html_(self):
         try:
             return self.to_html()


### PR DESCRIPTION
The geom classes don't have a `__repr__` method, which makes them annoying to use in the terminal. 

This PR adds an implementation that simply calls `self.__str__`