### PR TITLE
Solve CI fails caused by new iminuit and pytest version

### DIFF
--- a/dev/codespell/ignore-words.txt
+++ b/dev/codespell/ignore-words.txt
@@ -13,3 +13,4 @@ OptIn
 slac
 unparseable
 compiletime
+THIRDPARTY

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -136,7 +136,6 @@ def get_energy_dependent_temporal_model():
 
 
 @pytest.fixture()
-@requires_data()
 def energy_dependent_temporal_sky_model(models):
     models[0].spatial_model = PointSpatialModel(
         lon_0="0 deg", lat_0="0 deg", frame="galactic"

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -34,7 +34,6 @@ import importlib
 
 
 @pytest.fixture(scope="session")
-@requires_data()
 def models():
     filename = get_pkg_data_filename("./data/examples.yaml")
     models_data = read_yaml(filename)

--- a/gammapy/modeling/tests/test_iminuit.py
+++ b/gammapy/modeling/tests/test_iminuit.py
@@ -96,7 +96,7 @@ def test_iminuit_limits():
     # Check that minuit sees the limit factors correctly
     params = minuit.init_params
 
-    assert not params["x"].has_limits
+    assert not params["par_000_x"].has_limits
     assert params["par_001_y"].has_limits
     assert_allclose(params["par_001_y"].lower_limit, 3.01)
     assert params["par_001_y"].upper_limit is None

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ cov =
 test =
     pytest-astropy
     pytest-xdist
-    pytest<9.0
+    pytest
     docutils
     sphinx
 docs =


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request solves the issues introduced by pytest version 9.0 and the latest iminuit. 

Fixtures with additional decorators such as `require_data` are no longer working. They were ignored with a warning before. The additional decorators have been removed. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
