### PR TITLE
Add monthly workflow to run pre-commit over all files with fixes

### DIFF
--- a/.github/workflows/monthly_precommit.yml
+++ b/.github/workflows/monthly_precommit.yml
@@ -61,7 +61,8 @@ jobs:
       - name: Push branch
         if: steps.changes.outputs.changes == 'true'
         run: |
-          git push origin "$FIX_BRANCH"
+          echo "Pushing branch: ${{ steps.create_branch.outputs.branch }}"
+          git push origin "${{ steps.create_branch.outputs.branch }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Closes #6219 

Run `pre-commit run --all-files` then creates a PR applying the fixes.

It needs the updated configuration from #6184 