### PR TITLE
Infra: Fix parsing paths in coverage report for SonarQube

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ docs/gen_modules
 docs/api
 docs/sg_execution_times.rst
 .coverage
+coverage.xml
 
 dev/crab
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -142,14 +142,13 @@ omit =
 # Make filenames relative to the repository root
 # for the coverage report to match source paths in sonarqube
 relative_files = True
-source =
-    gammapy
+source = gammapy
 
 
 [coverage:paths]
 # Re-mapping paths: map equivalent locations of the code to the
 # first entry path so they match source paths in sonarqube analysis
-gammapy =
+source =
     gammapy
     .tox/*/site-packages/gammapy
     **/site-packages/gammapy

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,7 @@ commands =
     pip freeze
     !cov: pytest --pyargs gammapy {posargs}
     cov: pytest --doctest-rst --pyargs gammapy {toxinidir}/docs --cov gammapy --cov-config={toxinidir}/setup.cfg {posargs}
-    cov: coverage xml -o {toxinidir}/coverage.xml
+    cov: coverage xml -o {toxinidir}/coverage.xml --rcfile={toxinidir}/setup.cfg
 
 [testenv:build_docs]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,7 @@ commands =
 
     pip freeze
     !cov: pytest --pyargs gammapy {posargs}
-    cov: pytest --doctest-rst --pyargs gammapy -k theta {toxinidir}/docs --cov gammapy --cov-config={toxinidir}/setup.cfg {posargs}
+    cov: pytest --doctest-rst --pyargs gammapy {toxinidir}/docs --cov gammapy --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml --rcfile={toxinidir}/setup.cfg
 
 [testenv:cov]

--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,7 @@ commands =
     cov: pytest --doctest-rst --pyargs gammapy {toxinidir}/docs --cov gammapy --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml --rcfile={toxinidir}/setup.cfg
 
-[testenv:*cov]
+[testenv:py310-test-alldeps-cov]
 changedir = {toxinidir}
 usedevelop = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 2.0
+minversion = 4.0
 envlist =
     py{310,311,312,313}-test{,-alldeps,-devdeps}{,-cov}
     py{310,311,312,313}-test-numpy{121,122,123,124}
@@ -98,7 +98,7 @@ commands =
     cov: pytest --doctest-rst --pyargs gammapy {toxinidir}/docs --cov gammapy --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml --rcfile={toxinidir}/setup.cfg
 
-[testenv:cov]
+[testenv:*cov]
 changedir = {toxinidir}
 usedevelop = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -95,8 +95,12 @@ commands =
 
     pip freeze
     !cov: pytest --pyargs gammapy {posargs}
-    cov: pytest --doctest-rst --pyargs gammapy {toxinidir}/docs --cov gammapy --cov-config={toxinidir}/setup.cfg {posargs}
+    cov: pytest --doctest-rst --pyargs gammapy -k theta {toxinidir}/docs --cov gammapy --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml --rcfile={toxinidir}/setup.cfg
+
+[testenv:cov]
+changedir = {toxinidir}
+usedevelop = true
 
 [testenv:build_docs]
 changedir = docs


### PR DESCRIPTION
**Description**

Paths reported in the `coverage.xml` file are still pointing to the absolute path from the tox runner. Hence, sonarqube does not find the corresponding files in the source code.

```
The following error(s) occurred while trying to import coverage report:
Cannot resolve the file path '/home/runner/work/gammapy/gammapy/.tox/py310-test-alldeps-cov/lib/python3.10/site-packages/gammapy/__init__.py' of the coverage report, the file does not exist in all 'source'.
Cannot resolve 262 file paths, ignoring coverage measures for those files
```

Running the command locally, without tox, make the paths refer to `gammapy/`

```
    pytest --doctest-rst --pyargs gammapy ./docs --cov gammapy --cov-config=./setup.cfg
    coverage xml -o ./coverage.xml
```
Running with tox locally (`tox -e cov`) was however still pointing to absolute paths.

The problems seems to come from:

```INI
[testenv]
# Run the tests in a temporary directory to make sure that we don't import
# this package from the source tree
changedir = .tmp/{envname}
```
Setting it to use the `toxinidir` only for coverage run and install in editable mode:

```INI
[testenv:cov]
changedir = {toxinidir}
usedevelop = true
```
make the trick to correct the paths in the coverage relative to repository directory to SQ can do the coverage analysis correctly.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

This PR tries to make coverage command to actually use the settings in `setup.cfg` by passing the path relative to `toxinidir`. `setup.cfg` (and later `.coveragerc`) contains the configuration for coverage tool, mapping the paths relative to `gammapy/` source directory.