### PR TITLE
Dark Matter module: Include the option of using either CosmiXs or PPPC4 as a source for creating the DM spectra

### DIFF
--- a/docs/release-notes/6232.feature.rst
+++ b/docs/release-notes/6232.feature.rst
@@ -1,0 +1,1 @@
+For the Dark Matter module: Implementation of the possibility of using CosmiXs or PPPC4 as a source for creating Dark Matter spectra.

--- a/docs/release-notes/6232.feature.rst
+++ b/docs/release-notes/6232.feature.rst
@@ -1,1 +1,1 @@
-Implementation of the option of using CosmiXs or PPPC4 as a source models for creating Dark Matter spectra.
+Implementation of the option of using ``CosmiXs`` or ``PPPC4`` as a source models for creating dark matter spectra.

--- a/docs/release-notes/6232.feature.rst
+++ b/docs/release-notes/6232.feature.rst
@@ -1,1 +1,1 @@
-For the Dark Matter module: Implementation of the possibility of using CosmiXs or PPPC4 as a source for creating Dark Matter spectra.
+Implementation of the option of using CosmiXs or PPPC4 as a source models for creating Dark Matter spectra.

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -9,6 +9,7 @@ from gammapy.modeling import Parameter
 from gammapy.modeling.models import SpectralModel, TemplateNDSpectralModel
 from gammapy.utils.scripts import make_path
 from gammapy.utils.table import table_map_columns
+import warnings
 
 __all__ = ["PrimaryFlux", "DarkMatterAnnihilationSpectralModel"]
 
@@ -80,22 +81,60 @@ class PrimaryFlux(TemplateNDSpectralModel):
         "s": "s"
     }
 
+    mapping_dict_PPPC4_to_CosmiXs = {
+        "DM": "mDM",
+        "Log10[x]": "Log[10,x]", 
+        "dNdLog10x[eL]": "eL",
+        "dNdLog10x[eR]": "eR",
+        "dNdLog10x[e]": "e",
+        "dNdLog10x[muL]": "\\[Mu]L",
+        "dNdLog10x[muR]": "\\[Mu]R",
+        "dNdLog10x[mu]": "\\[Mu]",
+        "dNdLog10x[tauL]": "\\[Tau]L",
+        "dNdLog10x[tauR]": "\\[Tau]R",
+        "dNdLog10x[tau]": "\\[Tau]",
+        "dNdLog10x[nue]": "\\[Nu]e",
+        "dNdLog10x[numu]": "\\[Nu]\\[Mu]",
+        "dNdLog10x[nutau]": "\\[Nu]\\[Tau]",
+        "dNdLog10x[u]": "u", # Does not exist explicitly on PPPC4, but it is equivalent to q
+        "dNdLog10x[d]": "d", # Does not exist explicitly on PPPC4, but it is equivalent to q
+        "dNdLog10x[s]": "s", # Does not exist explicitly on PPPC4, but it is equivalent to q
+        "dNdLog10x[c]": "c", 
+        "dNdLog10x[b]": "b",
+        "dNdLog10x[t]": "t",
+        "dNdLog10x[a]": "\\[Gamma]",
+        "dNdLog10x[g]": "g", 
+        "dNdLog10x[W]": "W",
+        "dNdLog10x[WL]": "WL",
+        "dNdLog10x[WT]": "WT",
+        "dNdLog10x[Z]": "Z",
+        "dNdLog10x[ZL]": "ZL",
+        "dNdLog10x[ZT]": "ZT",
+        "dNdLog10x[H]": "h",
+        "dNdLog10x[aZ]": None,  # Does not exist  on PPPC4
+        "dNdLog10x[HZ]": None # Does not exist  on PPPC4
+    }
+
     tag = ["PrimaryFlux", "dm-pf"]
 
     def __init__(self, mDM, channel, source='pppc4'):
 
         if source is None:
             source='pppc4'
+            warnings.warn(
+                f"\nSince no spectra source has been chosen, PPPC4 will be used by default.\n",
+                UserWarning
+            )
 
-        if source.lower() == "pppc4" or not source:
+        if source.lower() == "pppc4":
             table_filename = "$GAMMAPY_DATA/dark_matter_spectra/AtProduction_gammas.dat"
             if channel in ('aZ','HZ'):
                 raise ValueError(
-                    f"\n\nThe channel "+channel+" is not available in PPPC4, please choose another channel or use CosmiXs (cosmixs) as source\n"
+                    f"\n\nThe channel {channel} is not available in PPPC4, please choose another channel or use CosmiXs (cosmixs) as source\n"
                 )
             elif channel in ('d','u', 's'):
                 raise ValueError(
-                    f"\n\nThe channel "+channel+" is not available in PPPC4, please choose the equivalent channel q or use CosmiXs (cosmixs) as source\n"
+                    f"\n\nThe channel {channel} is not available in PPPC4, please choose the equivalent channel q or use CosmiXs (cosmixs) as source\n"
                 )
 
         elif source == 'cosmixs':
@@ -103,7 +142,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
 
             if channel in ("V->e", "V->mu", "V->tau"):
                 raise ValueError(
-                    f"\n\nThe channel "+channel+" is not available in CosmiXs, please choose another channel or use PPPC4 as source\n"
+                    f"\n\nThe channel {channel} is not available in CosmiXs, please choose another channel or use PPPC4 as source\n"
                 )
             elif channel =='q':
                 raise ValueError(
@@ -130,41 +169,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
                 delimiter=" ",
             )
             if source == 'cosmixs':
-
-                mapping_dict = {
-                    "DM": "mDM",
-                    "Log10[x]": "Log[10,x]", 
-                    "dNdLog10x[eL]": "eL",
-                    "dNdLog10x[eR]": "eR",
-                    "dNdLog10x[e]": "e",
-                    "dNdLog10x[muL]": "\\[Mu]L",
-                    "dNdLog10x[muR]": "\\[Mu]R",
-                    "dNdLog10x[mu]": "\\[Mu]",
-                    "dNdLog10x[tauL]": "\\[Tau]L",
-                    "dNdLog10x[tauR]": "\\[Tau]R",
-                    "dNdLog10x[tau]": "\\[Tau]",
-                    "dNdLog10x[nue]": "\\[Nu]e",
-                    "dNdLog10x[numu]": "\\[Nu]\\[Mu]",
-                    "dNdLog10x[nutau]": "\\[Nu]\\[Tau]",
-                    "dNdLog10x[u]": "u", # Does not exist explicitly on PPPC4, but it is equivalent to q
-                    "dNdLog10x[d]": "d", # Does not exist explicitly on PPPC4, but it is equivalent to q
-                    "dNdLog10x[s]": "s", # Does not exist explicitly on PPPC4, but it is equivalent to q
-                    "dNdLog10x[c]": "c", 
-                    "dNdLog10x[b]": "b",
-                    "dNdLog10x[t]": "t",
-                    "dNdLog10x[a]": "\\[Gamma]",
-                    "dNdLog10x[g]": "g", 
-                    "dNdLog10x[W]": "W",
-                    "dNdLog10x[WL]": "WL",
-                    "dNdLog10x[WT]": "WT",
-                    "dNdLog10x[Z]": "Z",
-                    "dNdLog10x[ZL]": "ZL",
-                    "dNdLog10x[ZT]": "ZT",
-                    "dNdLog10x[H]": "h",
-                    "dNdLog10x[aZ]": None,  # Does not exist  on PPPC4
-                    "dNdLog10x[HZ]": None # Does not exist  on PPPC4
-                }
-                self.table = table_map_columns(self.table, mapping_dict)
+                self.table = table_map_columns(self.table, self.mapping_dict_PPPC4_to_CosmiXs)
 
         self.channel = channel
 

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -264,7 +264,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         Type of dark matter particle (k:2 Majorana, k:4 Dirac).
 
     Examples
-    ----------
+    --------
     This is how to instantiate a `DarkMatterAnnihilationSpectralModel` model::
 
         >>> import astropy.units as u

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -40,10 +40,10 @@ class PrimaryFlux(TemplateNDSpectralModel):
 
     References
     ----------
-    .. [1] `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection", <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
-    .. [2] `Cirelli et al. (2016), "PPPC 4 DM ID: A Poor Particle Physicist Cookbook for Dark Matter Indirect Detection", <http://www.marcocirelli.net/PPPC4DMID.html>`_
-    .. [3] `Arina et al. (2024), "CosmiXs: Cosmic messenger spectra for indirect dark matter searches", <https://arxiv.org/abs/2312.01153>`
-    .. [4] `Di Mauro et al. (2025)`
+    .. [1] `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection" <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    .. [2] `Cirelli et al. (2016), "PPPC 4 DM ID: A Poor Particle Physicist Cookbook for Dark Matter Indirect Detection" <http://www.marcocirelli.net/PPPC4DMID.html>`_
+    .. [3] `Arina et al. (2024), "CosmiXs: Cosmic messenger spectra for indirect dark matter searches" <https://arxiv.org/abs/2312.01153>`_
+    .. [4] `Di Mauro et al. (2025)`_
 
     """
 
@@ -304,8 +304,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
 
     References
     ----------
-    `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
-    <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection" <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     THERMAL_RELIC_CROSS_SECTION = 3e-26 * u.Unit("cm3 s-1")
@@ -419,8 +418,7 @@ class DarkMatterDecaySpectralModel(SpectralModel):
 
     References
     ----------
-    `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
-    <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection" <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
 
     LIFETIME_AGE_OF_UNIVERSE = 4.3e17 * u.Unit("s")

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -24,7 +24,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
     allows the interpolation between different dark matter masses.
 
     Parameters
-   --------
+    ----------
     mDM : `~astropy.units.Quantity`
         Dark matter particle mass as rest mass energy.
     channel: str
@@ -33,7 +33,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
         Data source for the spectra. Choose between 'PPPC4' and 'cosmixs'.
 
     References
-   --------
+    ----------
     * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
       <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     * `Cirelli et al. (2016), "PPPC 4 DM ID: A Poor Particle Physicist Cookbook for Dark Matter Indirect Detection"
@@ -116,7 +116,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
             raise FileNotFoundError(
                 f"\n\nFile not found: {table_filename}\n"
                 "You may download the dataset needed with the following command:\n"
-                "gammapy download datasetssrc dark_matter_spectra"
+                "gammapy download datasets --src dark_matter_spectra"
             )
         else:
             ascii_format ="ascii.commented_header" if source == 'cosmixs' else "ascii.fast_basic"
@@ -181,7 +181,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
         )
 
         interp_kwargs = {"extrapolate": True, "fill_value": 0, "values_scale": "lin"}
-        super().__init__(region_map, interp_kwargs=interp_kwargs,)
+        super().__init__(region_map, interp_kwargs=interp_kwargs)
         self.mDM = mDM
         self.mass.frozen = True
 
@@ -247,7 +247,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         \frac{\mathrm d N}{\mathrm dE} \times J(\Delta\Omega)
 
     Parameters
-   --------
+    ----------
     mass : `~astropy.units.Quantity`
         Dark matter mass.
     channel : str
@@ -276,7 +276,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         >>> modelDM = DarkMatterAnnihilationSpectralModel(mass=massDM, channel=channel, jfactor=jfactor)  # noqa: E501
 
     References
-   --------
+    ----------
     `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
     <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
@@ -330,7 +330,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         """Create spectral model from a dictionary.
 
         Parameters
-       --------
+        ----------
         data : dict
             Dictionary with model data.
 
@@ -357,7 +357,7 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         \frac{\mathrm d N}{\mathrm dE} \times J(\Delta\Omega)
 
     Parameters
-   --------
+    ----------
     mass : `~astropy.units.Quantity`
         Dark matter mass.
     channel : str
@@ -384,7 +384,7 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         >>> modelDM = DarkMatterDecaySpectralModel(mass=massDM, channel=channel, jfactor=jfactor)  # noqa: E501
 
     References
-   --------
+    ----------
     `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
     <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     """
@@ -434,7 +434,7 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         """Create spectral model from dictionary.
 
         Parameters
-       --------
+        ----------
         data : dict
             Dictionary with model data.
 

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -35,7 +35,8 @@ class PrimaryFlux(TemplateNDSpectralModel):
         channel: str
             Annihilation channel. List available channels with `~gammapy.spectrum.PrimaryFlux.allowed_channels`.
         source: str
-            Data source for the spectra. Choose between 'PPPC4' and 'cosmixs'.
+            Data source for the spectra. Choose between 'pppc4' and 'cosmixs'.
+            Delfault is 'pppc4'.
 
         References
         ----------
@@ -288,6 +289,9 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         Redshift value.
     k: int
         Type of dark matter particle (k:2 Majorana, k:4 Dirac).
+    source: str
+        Data source for the spectra. Choose between 'pppc4' and 'cosmixs'.
+        Delfault is 'pppc4'.
 
     Examples
     --------
@@ -400,6 +404,9 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         is used.
     z: float
         Redshift value.
+    source: str
+        Data source for the spectra. Choose between 'pppc4' and 'cosmixs'.
+        Delfault is 'pppc4'.
 
     Examples
     --------

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -83,7 +83,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
 
     mapping_dict_PPPC4_to_CosmiXs = {
         "DM": "mDM",
-        "Log10[x]": "Log[10,x]", 
+        "Log10[x]": "Log[10,x]",
         "dNdLog10x[eL]": "eL",
         "dNdLog10x[eR]": "eR",
         "dNdLog10x[e]": "e",
@@ -96,14 +96,14 @@ class PrimaryFlux(TemplateNDSpectralModel):
         "dNdLog10x[nue]": "\\[Nu]e",
         "dNdLog10x[numu]": "\\[Nu]\\[Mu]",
         "dNdLog10x[nutau]": "\\[Nu]\\[Tau]",
-        "dNdLog10x[u]": "u", # Does not exist explicitly on PPPC4, but it is equivalent to q
-        "dNdLog10x[d]": "d", # Does not exist explicitly on PPPC4, but it is equivalent to q
-        "dNdLog10x[s]": "s", # Does not exist explicitly on PPPC4, but it is equivalent to q
-        "dNdLog10x[c]": "c", 
+        "dNdLog10x[u]": "u",  # Does not exist explicitly on PPPC4, but it is equivalent to q
+        "dNdLog10x[d]": "d",  # Does not exist explicitly on PPPC4, but it is equivalent to q
+        "dNdLog10x[s]": "s",  # Does not exist explicitly on PPPC4, but it is equivalent to q
+        "dNdLog10x[c]": "c",
         "dNdLog10x[b]": "b",
         "dNdLog10x[t]": "t",
         "dNdLog10x[a]": "\\[Gamma]",
-        "dNdLog10x[g]": "g", 
+        "dNdLog10x[g]": "g",
         "dNdLog10x[W]": "W",
         "dNdLog10x[WL]": "WL",
         "dNdLog10x[WT]": "WT",
@@ -112,7 +112,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
         "dNdLog10x[ZT]": "ZT",
         "dNdLog10x[H]": "h",
         "dNdLog10x[aZ]": None,  # Does not exist  on PPPC4
-        "dNdLog10x[HZ]": None # Does not exist  on PPPC4
+        "dNdLog10x[HZ]": None  # Does not exist  on PPPC4
     }
 
     tag = ["PrimaryFlux", "dm-pf"]
@@ -120,19 +120,19 @@ class PrimaryFlux(TemplateNDSpectralModel):
     def __init__(self, mDM, channel, source='pppc4'):
 
         if source is None:
-            source='pppc4'
+            source = 'pppc4'
             warnings.warn(
-                f"\nSince no spectra source has been chosen, PPPC4 will be used by default.\n",
+                "\nSince no spectra source has been chosen, PPPC4 will be used by default.\n",
                 UserWarning
             )
 
         if source.lower() == "pppc4":
             table_filename = "$GAMMAPY_DATA/dark_matter_spectra/AtProduction_gammas.dat"
-            if channel in ('aZ','HZ'):
+            if channel in ('aZ', 'HZ'):
                 raise ValueError(
                     f"\n\nThe channel {channel} is not available in PPPC4, please choose another channel or use CosmiXs (cosmixs) as source\n"
                 )
-            elif channel in ('d','u', 's'):
+            elif channel in ('d', 'u', 's'):
                 raise ValueError(
                     f"\n\nThe channel {channel} is not available in PPPC4, please choose the equivalent channel q or use CosmiXs (cosmixs) as source\n"
                 )
@@ -144,15 +144,15 @@ class PrimaryFlux(TemplateNDSpectralModel):
                 raise ValueError(
                     f"\n\nThe channel {channel} is not available in CosmiXs, please choose another channel or use PPPC4 as source\n"
                 )
-            elif channel =='q':
+            elif channel == 'q':
                 raise ValueError(
-                    f"\n\nThe channel q is not available in cosmixs, please choose an equivalent channel such as d, u or s or use PPPC4 as source\n"
+                    "\n\nThe channel q is not available in cosmixs, please choose an equivalent channel such as d, u or s or use PPPC4 as source\n"
                 )
         else:
             raise ValueError(
-                f"\n\nData source is not valid, please choose between PPPC4 or cosmixs\n"
+                "\n\nData source is not valid, please choose between PPPC4 or cosmixs\n"
             )
-    
+
         self.table_path = make_path(table_filename)
         if not self.table_path.exists():
             raise FileNotFoundError(
@@ -161,7 +161,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
                 "gammapy download datasets --src dark_matter_spectra"
             )
         else:
-            ascii_format ="ascii.commented_header" if source == 'cosmixs' else "ascii.fast_basic"
+            ascii_format = "ascii.commented_header" if source == 'cosmixs' else "ascii.fast_basic"
             self.table = Table.read(
                 str(self.table_path),
                 format=ascii_format,
@@ -182,7 +182,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
         log10x_axis = MapAxis.from_nodes(log10x, name="energy_true")
 
         channel_name = self.channel_registry[self.channel]
-        
+
         geom = RegionGeom(region=None, axes=[log10x_axis, mass_axis])
         region_map = Map.from_geom(
             geom=geom, data=self.table[channel_name].reshape(geom.data_shape)
@@ -243,6 +243,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
         dN_dlogx = super().evaluate(log10x, *args)
         dN_dE = dN_dlogx / (energy * np.log(10))
         return dN_dE
+
 
 class DarkMatterAnnihilationSpectralModel(SpectralModel):
     r"""Dark matter annihilation spectral model.

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -21,33 +21,30 @@ __all__ = [
 class PrimaryFlux(TemplateNDSpectralModel):
     """DM-annihilation gamma-ray spectra.
 
-        Based on the precomputed models of PPPC4 DM ID by Cirelli et al. (2016), CosmiXs by Arina et al. (2024); Di Mauro et al. (2025). All available
-        annihilation channels can be found there. The dark matter mass will be set
-        to the nearest available value. The spectra will be available as
-        `~gammapy.modeling.models.TemplateNDSpectralModel` for a chosen dark matter mass and
-        annihilation channel. Using a `~gammapy.modeling.models.TemplateNDSpectralModel`
-        allows the interpolation between different dark matter masses.
+    Based on the precomputed models of PPPC4 DM ID by [1]_, [2]_ and CosmiXs by [3]_, [4]_.
+    All available annihilation channels can be found there. The dark matter mass will be set
+    to the nearest available value. The spectra will be available as
+    `~gammapy.modeling.models.TemplateNDSpectralModel` for a chosen dark matter mass and
+    annihilation channel. Using a `~gammapy.modeling.models.TemplateNDSpectralModel`
+    allows the interpolation between different dark matter masses.
 
-        Parameters
-        ----------
-        mDM : `~astropy.units.Quantity`
-            Dark matter particle mass as rest mass energy.
-        channel: str
-            Annihilation channel. List available channels with `~gammapy.spectrum.PrimaryFlux.allowed_channels`.
-        source: str
-            Data source for the spectra. Choose between 'pppc4' and 'cosmixs'.
-            Delfault is 'pppc4'.
+    Parameters
+    ----------
+    mDM : `~astropy.units.Quantity`
+        Dark matter particle mass as rest mass energy.
+    channel: str
+        Annihilation channel. List available channels with `~gammapy.spectrum.PrimaryFlux.allowed_channels`.
+    source: str
+        Data source for the spectra. Choose between 'pppc4' and 'cosmixs'.
+        Delfault is 'pppc4'.
 
-        References
-        ----------
-        * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
-          <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
-        * `Cirelli et al. (2016), "PPPC 4 DM ID: A Poor Particle Physicist Cookbook for Dark Matter Indirect Detection"
-          <http://www.marcocirelli.net/PPPC4DMID.html>`_
-          *`Arina et al. (2024), "CosmiXs: Cosmic messenger spectra for indirect dark matter searches"
-          <https://arxiv.org/abs/2312.01153>`
+    References
+    ----------
+    .. [1] `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection", <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+    .. [2] `Cirelli et al. (2016), "PPPC 4 DM ID: A Poor Particle Physicist Cookbook for Dark Matter Indirect Detection", <http://www.marcocirelli.net/PPPC4DMID.html>`_
+    .. [3] `Arina et al. (2024), "CosmiXs: Cosmic messenger spectra for indirect dark matter searches", <https://arxiv.org/abs/2312.01153>`
+    .. [4] `Di Mauro et al. (2025)`
 
-    "
     """
 
     channel_registry = {

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -289,9 +289,9 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         Redshift value.
     k: int
         Type of dark matter particle (k:2 Majorana, k:4 Dirac).
-    source: str
+    source: str, optional
         Data source for the spectra. Choose between 'pppc4' and 'cosmixs'.
-        Delfault is 'pppc4'.
+        Default is 'pppc4'.
 
     Examples
     --------
@@ -404,9 +404,9 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         is used.
     z: float
         Redshift value.
-    source: str
+    source: str, optional
         Data source for the spectra. Choose between 'pppc4' and 'cosmixs'.
-        Delfault is 'pppc4'.
+        Default is 'pppc4'.
 
     Examples
     --------

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -332,6 +332,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         data["spectral"]["jfactor"] = self.jfactor.to_string()
         data["spectral"]["z"] = self.z
         data["spectral"]["k"] = self.k
+        data["spectral"]["source"] = self.source
         return data
 
     @classmethod
@@ -436,6 +437,7 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         data["spectral"]["mass"] = self.mass.to_string()
         data["spectral"]["jfactor"] = self.jfactor.to_string()
         data["spectral"]["z"] = self.z
+        data["spectral"]["source"] = self.source
         return data
 
     @classmethod

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -42,7 +42,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
     .. [1] `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection" <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     .. [2] `Cirelli et al. (2016), "PPPC 4 DM ID: A Poor Particle Physicist Cookbook for Dark Matter Indirect Detection" <http://www.marcocirelli.net/PPPC4DMID.html>`_
     .. [3] `Arina et al. (2024), "CosmiXs: Cosmic messenger spectra for indirect dark matter searches" <https://arxiv.org/abs/2312.01153>`_
-    .. [4] Di Mauro et al. (2025)
+    .. [4] `Di Mauro et al. (2025), "Nailing down the theoretical uncertainties of Dbar spectrum produced from dark matter" <https://arxiv.org/abs/2411.04815>`_
 
     """
 
@@ -399,7 +399,7 @@ class DarkMatterDecaySpectralModel(SpectralModel):
     z : float, optional
         Redshift value. Default is 0.
     source : {"cosmixs", "pppc4"}, optional
-        Data source for the spectra. =Default is 'pppc4'.
+        Data source for the spectra. Default is 'pppc4'.
 
     Examples
     --------

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -264,7 +264,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         Type of dark matter particle (k:2 Majorana, k:4 Dirac).
 
     Examples
-   ------
+    ----------
     This is how to instantiate a `DarkMatterAnnihilationSpectralModel` model::
 
         >>> import astropy.units as u
@@ -335,7 +335,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
             Dictionary with model data.
 
         Returns
-       -----
+        -------
         model : `DarkMatterAnnihilationSpectralModel`
             Dark matter annihilation spectral model.
         """
@@ -439,7 +439,7 @@ class DarkMatterDecaySpectralModel(SpectralModel):
             Dictionary with model data.
 
         Returns
-       -----
+        -------
         model : `DarkMatterDecaySpectralModel`
             Dark matter decay spectral model.
         """

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -17,7 +17,7 @@ __all__ = ["PrimaryFlux", "DarkMatterAnnihilationSpectralModel"]
 class PrimaryFlux(TemplateNDSpectralModel):
     """DM-annihilation gamma-ray spectra.
 
-    Based on the precomputed models of PPPC4 DM ID by Cirelli et al. (2016), CosmiXs by Arina et. al (2023). All available
+    Based on the precomputed models of PPPC4 DM ID by Cirelli et al. (2016), CosmiXs by Arina et. al (2024); Di Mauro et al. (2025). All available
     annihilation channels can be found there. The dark matter mass will be set
     to the nearest available value. The spectra will be available as
     `~gammapy.modeling.models.TemplateNDSpectralModel` for a chosen dark matter mass and

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -82,17 +82,10 @@ class PrimaryFlux(TemplateNDSpectralModel):
 
     tag = ["PrimaryFlux", "dm-pf"]
 
-    def __init__(self, mDM, channel, source='PPPC4'):
+    def __init__(self, mDM, channel, source='pppc4'):
 
-        if source == 'PPPC4':
+        if source.lower() == "pppc4":
             table_filename = "$GAMMAPY_DATA/dark_matter_spectra/AtProduction_gammas.dat"
-        elif source == 'cosmixs':
-            table_filename = 'gammapy/external/CosmiXs/Data/AtProduction-Gamma.dat' #ask how to include it on gammapy datasets
-        else:
-            raise FileNotFoundError(
-                f"\n\nData source is not valid, please choose between PPC¡PC4 or cosmixs\n"
-            )
-        if source == 'PPPC4':
             if channel in ('aZ','HZ'):
                 raise ValueError(
                     f"\n\nThe channel "+channel+" is not available in PPPC4, please choose another channel or use CosmiXs (cosmixs) as source\n"
@@ -103,6 +96,8 @@ class PrimaryFlux(TemplateNDSpectralModel):
                 )
 
         elif source == 'cosmixs':
+            table_filename = 'gammapy/external/CosmiXs/Data/AtProduction-Gamma.dat'
+
             if channel in ("V->e", "V->mu", "V->tau"):
                 raise ValueError(
                     f"\n\nThe channel "+channel+" is not available in CosmiXs, please choose another channel or use PPPC4 as source\n"
@@ -111,6 +106,10 @@ class PrimaryFlux(TemplateNDSpectralModel):
                 raise ValueError(
                     f"\n\nThe channel q is not available in cosmixs, please choose an equivalent channel such as d, u or s or use PPPC4 as source\n"
                 )
+        else:
+            raise ValueError(
+                f"\n\nData source is not valid, please choose between PPPC4 or cosmixs\n"
+            )
     
         self.table_path = make_path(table_filename)
         if not self.table_path.exists():

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -84,7 +84,10 @@ class PrimaryFlux(TemplateNDSpectralModel):
 
     def __init__(self, mDM, channel, source='pppc4'):
 
-        if source.lower() == "pppc4":
+        if source is None:
+            source='pppc4'
+
+        if source.lower() == "pppc4" or not source:
             table_filename = "$GAMMAPY_DATA/dark_matter_spectra/AtProduction_gammas.dat"
             if channel in ('aZ','HZ'):
                 raise ValueError(
@@ -292,13 +295,13 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
     )
     tag = ["DarkMatterAnnihilationSpectralModel", "dm-annihilation"]
 
-    def __init__(self, mass, channel, scale=scale.quantity, jfactor=1, z=0, k=2):
+    def __init__(self, mass, channel, scale=scale.quantity, jfactor=1, z=0, k=2, source='pppc4'):
         self.k = k
         self.z = z
         self.mass = u.Quantity(mass)
         self.channel = channel
         self.jfactor = u.Quantity(jfactor)
-        self.primary_flux = PrimaryFlux(mass, channel=self.channel)
+        self.primary_flux = PrimaryFlux(mass, channel=self.channel, source=source)
         super().__init__(scale=scale)
 
     def evaluate(self, energy, scale):
@@ -401,7 +404,7 @@ class DarkMatterDecaySpectralModel(SpectralModel):
 
     tag = ["DarkMatterDecaySpectralModel", "dm-decay"]
 
-    def __init__(self, mass, channel, scale=scale.quantity, jfactor=1, z=0):
+    def __init__(self, mass, channel, scale=scale.quantity, jfactor=1, z=0, source='pppc4'):
         self.z = z
         self.mass = u.Quantity(mass)
         self.channel = channel

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -32,18 +32,17 @@ class PrimaryFlux(TemplateNDSpectralModel):
     ----------
     mDM : `~astropy.units.Quantity`
         Dark matter particle mass as rest mass energy.
-    channel: str
-        Annihilation channel. List available channels with `~gammapy.spectrum.PrimaryFlux.allowed_channels`.
-    source: str
-        Data source for the spectra. Choose between 'pppc4' and 'cosmixs'.
-        Delfault is 'pppc4'.
+    channel : str
+        Annihilation channel. List available channels with `~gammapy.astro.darkmatter.PrimaryFlux.allowed_channels`.
+    source : {"cosmixs", "pppc4"}, optional
+        Data source for the spectra. Default is 'pppc4'.
 
     References
     ----------
     .. [1] `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection" <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
     .. [2] `Cirelli et al. (2016), "PPPC 4 DM ID: A Poor Particle Physicist Cookbook for Dark Matter Indirect Detection" <http://www.marcocirelli.net/PPPC4DMID.html>`_
     .. [3] `Arina et al. (2024), "CosmiXs: Cosmic messenger spectra for indirect dark matter searches" <https://arxiv.org/abs/2312.01153>`_
-    .. [4] `Di Mauro et al. (2025)`_
+    .. [4] Di Mauro et al. (2025)
 
     """
 
@@ -282,13 +281,12 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
     jfactor : `~astropy.units.Quantity`
         Integrated J-Factor needed when `~gammapy.modeling.models.PointSpatialModel`
         is used.
-    z: float
-        Redshift value.
-    k: int
-        Type of dark matter particle (k:2 Majorana, k:4 Dirac).
-    source: str, optional
-        Data source for the spectra. Choose between 'pppc4' and 'cosmixs'.
-        Default is 'pppc4'.
+    z : float, optional
+        Redshift value. Default is 0.
+    k : int, optional
+        Type of dark matter particle (k:2 Majorana, k:4 Dirac). Default is 2.
+    source : {"cosmixs", "pppc4"}, optional
+        Data source for the spectra. Default is 'pppc4'.
 
     Examples
     --------
@@ -398,11 +396,10 @@ class DarkMatterDecaySpectralModel(SpectralModel):
     jfactor : `~astropy.units.Quantity`
         Integrated J-Factor needed when `~gammapy.modeling.models.PointSpatialModel`
         is used.
-    z: float
-        Redshift value.
-    source: str, optional
-        Data source for the spectra. Choose between 'pppc4' and 'cosmixs'.
-        Default is 'pppc4'.
+    z : float, optional
+        Redshift value. Default is 0.
+    source : {"cosmixs", "pppc4"}, optional
+        Data source for the spectra. =Default is 'pppc4'.
 
     Examples
     --------

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -11,38 +11,42 @@ from gammapy.utils.scripts import make_path
 from gammapy.utils.table import table_map_columns
 import warnings
 
-__all__ = ["PrimaryFlux", "DarkMatterAnnihilationSpectralModel", "DarkMatterDecaySpectralModel"]
+__all__ = [
+    "PrimaryFlux",
+    "DarkMatterAnnihilationSpectralModel",
+    "DarkMatterDecaySpectralModel",
+]
 
 
 class PrimaryFlux(TemplateNDSpectralModel):
     """DM-annihilation gamma-ray spectra.
 
-    Based on the precomputed models of PPPC4 DM ID by Cirelli et al. (2016), CosmiXs by Arina et al. (2024); Di Mauro et al. (2025). All available
-    annihilation channels can be found there. The dark matter mass will be set
-    to the nearest available value. The spectra will be available as
-    `~gammapy.modeling.models.TemplateNDSpectralModel` for a chosen dark matter mass and
-    annihilation channel. Using a `~gammapy.modeling.models.TemplateNDSpectralModel`
-    allows the interpolation between different dark matter masses.
+        Based on the precomputed models of PPPC4 DM ID by Cirelli et al. (2016), CosmiXs by Arina et al. (2024); Di Mauro et al. (2025). All available
+        annihilation channels can be found there. The dark matter mass will be set
+        to the nearest available value. The spectra will be available as
+        `~gammapy.modeling.models.TemplateNDSpectralModel` for a chosen dark matter mass and
+        annihilation channel. Using a `~gammapy.modeling.models.TemplateNDSpectralModel`
+        allows the interpolation between different dark matter masses.
 
-    Parameters
-    ----------
-    mDM : `~astropy.units.Quantity`
-        Dark matter particle mass as rest mass energy.
-    channel: str
-        Annihilation channel. List available channels with `~gammapy.spectrum.PrimaryFlux.allowed_channels`.
-    source: str
-        Data source for the spectra. Choose between 'PPPC4' and 'cosmixs'.
+        Parameters
+        ----------
+        mDM : `~astropy.units.Quantity`
+            Dark matter particle mass as rest mass energy.
+        channel: str
+            Annihilation channel. List available channels with `~gammapy.spectrum.PrimaryFlux.allowed_channels`.
+        source: str
+            Data source for the spectra. Choose between 'PPPC4' and 'cosmixs'.
 
-    References
-    ----------
-    * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
-      <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
-    * `Cirelli et al. (2016), "PPPC 4 DM ID: A Poor Particle Physicist Cookbook for Dark Matter Indirect Detection"
-      <http://www.marcocirelli.net/PPPC4DMID.html>`_
-      *`Arina et al. (2024), "CosmiXs: Cosmic messenger spectra for indirect dark matter searches"
-      <https://arxiv.org/abs/2312.01153>`
+        References
+        ----------
+        * `Marco et al. (2011), "PPPC 4 DM ID: a poor particle physicist cookbook for dark matter indirect detection"
+          <https://ui.adsabs.harvard.edu/abs/2011JCAP...03..051C>`_
+        * `Cirelli et al. (2016), "PPPC 4 DM ID: A Poor Particle Physicist Cookbook for Dark Matter Indirect Detection"
+          <http://www.marcocirelli.net/PPPC4DMID.html>`_
+          *`Arina et al. (2024), "CosmiXs: Cosmic messenger spectra for indirect dark matter searches"
+          <https://arxiv.org/abs/2312.01153>`
 
-"
+    "
     """
 
     channel_registry = {
@@ -78,7 +82,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
         "HZ": "HZ",
         "d": "d",
         "u": "u",
-        "s": "s"
+        "s": "s",
     }
 
     mapping_dict_PPPC4_to_CosmiXs = {
@@ -112,24 +116,27 @@ class PrimaryFlux(TemplateNDSpectralModel):
         "dNdLog10x[ZT]": "ZT",
         "dNdLog10x[H]": "h",
         "dNdLog10x[aZ]": None,  # Does not exist  on PPPC4
-        "dNdLog10x[HZ]": None  # Does not exist  on PPPC4
+        "dNdLog10x[HZ]": None,  # Does not exist  on PPPC4
     }
 
     tag = ["PrimaryFlux", "dm-pf"]
 
-    def __init__(self, mDM, channel, source='pppc4'):
-
+    def __init__(self, mDM, channel, source="pppc4"):
         if source is None:
-            source = 'pppc4'
+            source = "pppc4"
             warnings.warn(
                 "\nSince no spectra source has been chosen, PPPC4 will be used by default.\n",
-                UserWarning
+                UserWarning,
             )
         self.source = source.lower()
         if self.source == "pppc4":
-            table_filename = "$GAMMAPY_DATA/dark_matter_spectra/PPPC4DMID/AtProduction_gammas.dat"
-        elif self.source == 'cosmixs':
-            table_filename = "$GAMMAPY_DATA/dark_matter_spectra/cosmixs/AtProduction-Gamma.dat"
+            table_filename = (
+                "$GAMMAPY_DATA/dark_matter_spectra/PPPC4DMID/AtProduction_gammas.dat"
+            )
+        elif self.source == "cosmixs":
+            table_filename = (
+                "$GAMMAPY_DATA/dark_matter_spectra/cosmixs/AtProduction-Gamma.dat"
+            )
         else:
             raise ValueError(
                 "\n\nData source is not valid, please choose between PPPC4 or cosmixs\n"
@@ -143,15 +150,21 @@ class PrimaryFlux(TemplateNDSpectralModel):
                 "gammapy download datasets --src dark_matter_spectra"
             )
         else:
-            ascii_format = "ascii.commented_header" if self.source == 'cosmixs' else "ascii.fast_basic"
+            ascii_format = (
+                "ascii.commented_header"
+                if self.source == "cosmixs"
+                else "ascii.fast_basic"
+            )
             self.table = Table.read(
                 str(self.table_path),
                 format=ascii_format,
                 guess=False,
                 delimiter=" ",
             )
-            if self.source == 'cosmixs':
-                self.table = table_map_columns(self.table, self.mapping_dict_PPPC4_to_CosmiXs)
+            if self.source == "cosmixs":
+                self.table = table_map_columns(
+                    self.table, self.mapping_dict_PPPC4_to_CosmiXs
+                )
 
         self.channel = channel
 
@@ -214,23 +227,23 @@ class PrimaryFlux(TemplateNDSpectralModel):
             )
         else:
             if self.source == "pppc4":
-                if channel in ('aZ', 'HZ'):
+                if channel in ("aZ", "HZ"):
                     raise ValueError(
                         f"\n\nThe channel {channel} is not available in PPPC4, please choose another channel or use CosmiXs (cosmixs) as source\n"
                     )
-                elif channel in ('d', 'u', 's'):
+                elif channel in ("d", "u", "s"):
                     raise ValueError(
                         f"\n\nThe channel {channel} is not available in PPPC4, please choose the equivalent channel q or use CosmiXs (cosmixs) as source\n"
                     )
                 else:
                     self._channel = channel
 
-            elif self.source == 'cosmixs':
+            elif self.source == "cosmixs":
                 if channel in ("V->e", "V->mu", "V->tau"):
                     raise ValueError(
                         f"\n\nThe channel {channel} is not available in CosmiXs, please choose another channel or use PPPC4 as source\n"
                     )
-                elif channel == 'q':
+                elif channel == "q":
                     raise ValueError(
                         "\n\nThe channel q is not available in cosmixs, please choose an equivalent channel such as d, u or s or use PPPC4 as source\n"
                     )
@@ -305,7 +318,9 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
     )
     tag = ["DarkMatterAnnihilationSpectralModel", "dm-annihilation"]
 
-    def __init__(self, mass, channel, scale=scale.quantity, jfactor=1, z=0, k=2, source='pppc4'):
+    def __init__(
+        self, mass, channel, scale=scale.quantity, jfactor=1, z=0, k=2, source="pppc4"
+    ):
         self.k = k
         self.z = z
         self.mass = u.Quantity(mass)
@@ -416,7 +431,9 @@ class DarkMatterDecaySpectralModel(SpectralModel):
 
     tag = ["DarkMatterDecaySpectralModel", "dm-decay"]
 
-    def __init__(self, mass, channel, scale=scale.quantity, jfactor=1, z=0, source='pppc4'):
+    def __init__(
+        self, mass, channel, scale=scale.quantity, jfactor=1, z=0, source="pppc4"
+    ):
         self.z = z
         self.mass = u.Quantity(mass)
         self.channel = channel

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -127,7 +127,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
             )
 
         if source.lower() == "pppc4":
-            table_filename = "$GAMMAPY_DATA/dark_matter_spectra/AtProduction_gammas.dat"
+            table_filename = "$GAMMAPY_DATA/dark_matter_spectra/PPPC4DMID/AtProduction_gammas.dat"
             if channel in ('aZ', 'HZ'):
                 raise ValueError(
                     f"\n\nThe channel {channel} is not available in PPPC4, please choose another channel or use CosmiXs (cosmixs) as source\n"
@@ -138,7 +138,7 @@ class PrimaryFlux(TemplateNDSpectralModel):
                 )
 
         elif source == 'cosmixs':
-            table_filename = 'gammapy/external/CosmiXs/Data/AtProduction-Gamma.dat'
+            table_filename = "$GAMMAPY_DATA/dark_matter_spectra/cosmixs/AtProduction-Gamma.dat"
 
             if channel in ("V->e", "V->mu", "V->tau"):
                 raise ValueError(
@@ -308,6 +308,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         self.channel = channel
         self.jfactor = u.Quantity(jfactor)
         self.primary_flux = PrimaryFlux(mass, channel=self.channel, source=source)
+        self.source = source
         super().__init__(scale=scale)
 
     def evaluate(self, energy, scale):
@@ -416,7 +417,8 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         self.mass = u.Quantity(mass)
         self.channel = channel
         self.jfactor = u.Quantity(jfactor)
-        self.primary_flux = PrimaryFlux(self.mass / 2, channel=self.channel)
+        self.primary_flux = PrimaryFlux(self.mass / 2, channel=self.channel, source=source)
+        self.source = source
         super().__init__(scale=scale)
 
     def evaluate(self, energy, scale):

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -445,7 +445,9 @@ class DarkMatterDecaySpectralModel(SpectralModel):
         self.mass = u.Quantity(mass)
         self.channel = channel
         self.jfactor = u.Quantity(jfactor)
-        self.primary_flux = PrimaryFlux(self.mass / 2, channel=self.channel, source=source)
+        self.primary_flux = PrimaryFlux(
+            self.mass / 2, channel=self.channel, source=source
+        )
         self.source = source
         super().__init__(scale=scale)
 

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -111,7 +111,7 @@ def test_dm_decay_spectral_model(tmpdir):
     assert new_models[0].spectral_model.mass.unit == u.TeV
 
 
-#Test using CosmiXs as a spectra source
+# Test using CosmiXs as a spectra source
 @requires_data()
 def test_primary_flux_cosmixs():
     with pytest.raises(ValueError):

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -52,7 +52,7 @@ def test_dm_annihilation_spectral_model(tmpdir):
     energy_max = 10 * u.TeV
 
     model = DarkMatterAnnihilationSpectralModel(
-        mass=massDM, channel=channel, jfactor=jfactor
+        mass=massDM, channel=channel, jfactor=jfactor, source='pppc4'
     )
     integral_flux = model.integral(energy_min=energy_min, energy_max=energy_max).to(
         "cm-2 s-1"
@@ -86,7 +86,7 @@ def test_dm_decay_spectral_model(tmpdir):
     energy_min = 0.01 * u.TeV
     energy_max = 10 * u.TeV
 
-    model = DarkMatterDecaySpectralModel(mass=massDM, channel=channel, jfactor=jfactor)
+    model = DarkMatterDecaySpectralModel(mass=massDM, channel=channel, jfactor=jfactor, source='pppc4')
     integral_flux = model.integral(energy_min=energy_min, energy_max=energy_max).to(
         "cm-2 s-1"
     )

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -38,8 +38,6 @@ def test_primary_flux_interpolation(mass, expected_flux, source, expected_except
         with pytest.raises(expected_exception):
             primflux = PrimaryFlux(channel="aZ", mDM=mass * u.TeV, source=source)
         return
-
-    # casos normales
     primflux = PrimaryFlux(channel="W", mDM=mass * u.TeV, source=source)
     actual = primflux(500 * u.GeV)
     assert_quantity_allclose(actual, expected_flux / u.GeV, rtol=1e-5)

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -175,17 +175,6 @@ def test_dm_annihilation_spectral_model_cosmixs(tmpdir):
     assert new_models[0].spectral_model.mass.unit == u.TeV
 
 
-def test_dm_decay_spectral_model_cosmixs_missing_file():
-    channel = "b"
-    massDM = 5 * u.TeV
-    jfactor = 3.41e19 * u.Unit("GeV cm-2")
-
-    with pytest.raises(FileNotFoundError):
-        DarkMatterDecaySpectralModel(
-            mass=massDM, channel=channel, jfactor=jfactor, source="cosmixs"
-        )
-
-
 @requires_data()
 def test_dm_decay_spectral_model_cosmixs(tmpdir):
     channel = "b"

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -23,10 +23,21 @@ def test_primary_flux():
 
 
 @pytest.mark.parametrize(
-    "mass, expected_flux, source", [(1.6, 0.00025037,'pppc4'), (11, 0.00549445,'cosmixs'), (75, 0.02028309,None)]
+    "mass, expected_flux, source, expected_exception",
+    [
+        (1.6, 0.00025037, 'pppc4', None),
+        (11, 0.00549445, 'cosmixs', None),
+        (75, None, 'nonexistend', ValueError),
+    ]
 )
 @requires_data()
-def test_primary_flux_interpolation(mass, expected_flux, source):
+def test_primary_flux_interpolation(mass, expected_flux, source, expected_exception):
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            primflux = PrimaryFlux(channel="W", mDM=mass * u.TeV, source=source)
+        return
+
+    # casos normales
     primflux = PrimaryFlux(channel="W", mDM=mass * u.TeV, source=source)
     actual = primflux(500 * u.GeV)
     assert_quantity_allclose(actual, expected_flux / u.GeV, rtol=1e-5)

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -52,7 +52,13 @@ def test_primary_flux_interpolation(mass, expected_flux, source, expected_except
             2.97831615e-16,
             None,
         ),
-        (DarkMatterDecaySpectralModel, "GeV cm-2", 4.80283595e-2, 2.3088e-4, "pppc4"),
+        (
+            DarkMatterDecaySpectralModel,
+            "GeV cm-2",
+            3.209234e-2,
+            2.33485775e-05,
+            "pppc4",
+        ),
         (
             DarkMatterAnnihilationSpectralModel,
             "GeV2 cm-5",
@@ -60,7 +66,7 @@ def test_primary_flux_interpolation(mass, expected_flux, source, expected_except
             3.52065879e-16,
             "cosmixs",
         ),
-        (DarkMatterDecaySpectralModel, "GeV cm-2", 4.675951e-2, 2.7292e-4, "cosmixs"),
+        (DarkMatterDecaySpectralModel, "GeV cm-2", 0.031677, 2.771877e-05, "cosmixs"),
     ],
 )
 @requires_data()

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -25,12 +25,11 @@ def test_primary_flux():
 @pytest.mark.parametrize(
     "mass, expected_flux, source, expected_exception",
     [
-        (1.6, 0.00025037, 'pppc4', None),
-        (11, 0.00549445, 'cosmixs', None),
-        (75, None, 'nonexistend', ValueError),
-        (75, None, 'pppc4', ValueError),
-
-    ]
+        (1.6, 0.00025037, "pppc4", None),
+        (11, 0.00549445, "cosmixs", None),
+        (75, None, "nonexistend", ValueError),
+        (75, None, "pppc4", ValueError),
+    ],
 )
 @requires_data()
 def test_primary_flux_interpolation(mass, expected_flux, source, expected_exception):
@@ -52,7 +51,7 @@ def test_dm_annihilation_spectral_model(tmpdir):
     energy_max = 10 * u.TeV
 
     model = DarkMatterAnnihilationSpectralModel(
-        mass=massDM, channel=channel, jfactor=jfactor, source='pppc4'
+        mass=massDM, channel=channel, jfactor=jfactor, source="pppc4"
     )
     integral_flux = model.integral(energy_min=energy_min, energy_max=energy_max).to(
         "cm-2 s-1"
@@ -86,7 +85,9 @@ def test_dm_decay_spectral_model(tmpdir):
     energy_min = 0.01 * u.TeV
     energy_max = 10 * u.TeV
 
-    model = DarkMatterDecaySpectralModel(mass=massDM, channel=channel, jfactor=jfactor, source='pppc4')
+    model = DarkMatterDecaySpectralModel(
+        mass=massDM, channel=channel, jfactor=jfactor, source="pppc4"
+    )
     integral_flux = model.integral(energy_min=energy_min, energy_max=energy_max).to(
         "cm-2 s-1"
     )
@@ -166,7 +167,9 @@ def test_dm_decay_spectral_model_cosmixs(tmpdir):
     energy_min = 0.01 * u.TeV
     energy_max = 10 * u.TeV
 
-    model = DarkMatterDecaySpectralModel(mass=massDM, channel=channel, jfactor=jfactor, source="cosmixs")
+    model = DarkMatterDecaySpectralModel(
+        mass=massDM, channel=channel, jfactor=jfactor, source="cosmixs"
+    )
     integral_flux = model.integral(energy_min=energy_min, energy_max=energy_max).to(
         "cm-2 s-1"
     )

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -28,13 +28,15 @@ def test_primary_flux():
         (1.6, 0.00025037, 'pppc4', None),
         (11, 0.00549445, 'cosmixs', None),
         (75, None, 'nonexistend', ValueError),
+        (75, None, 'pppc4', ValueError),
+
     ]
 )
 @requires_data()
 def test_primary_flux_interpolation(mass, expected_flux, source, expected_exception):
     if expected_exception:
         with pytest.raises(expected_exception):
-            primflux = PrimaryFlux(channel="W", mDM=mass * u.TeV, source=source)
+            primflux = PrimaryFlux(channel="aZ", mDM=mass * u.TeV, source=source)
         return
 
     # casos normales

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -51,7 +51,7 @@ def test_dm_annihilation_spectral_model(tmpdir):
     energy_max = 10 * u.TeV
 
     model = DarkMatterAnnihilationSpectralModel(
-        mass=massDM, channel=channel, jfactor=jfactor, source="pppc4"
+        mass=massDM, channel=channel, jfactor=jfactor
     )
     integral_flux = model.integral(energy_min=energy_min, energy_max=energy_max).to(
         "cm-2 s-1"
@@ -123,6 +123,22 @@ def test_primary_flux_cosmixs():
     desired = 0.00013085 / u.GeV
     assert_quantity_allclose(actual, desired, rtol=1e-4)
 
+    with pytest.raises(ValueError):
+        PrimaryFlux(channel="q", mDM=1 * u.TeV, source="cosmixs")
+    with pytest.raises(ValueError):
+        PrimaryFlux(channel="V->e", mDM=1 * u.TeV, source="cosmixs")
+    with pytest.raises(ValueError):
+        PrimaryFlux(channel="V->mu", mDM=1 * u.TeV, source="cosmixs")
+    with pytest.raises(ValueError):
+        PrimaryFlux(channel="V->tau", mDM=1 * u.TeV, source="cosmixs")
+
+    with pytest.raises(ValueError):
+        PrimaryFlux(channel="d", mDM=1 * u.TeV, source="pppc4")
+    with pytest.raises(ValueError):
+        PrimaryFlux(channel="u", mDM=1 * u.TeV, source="pppc4")
+    with pytest.raises(ValueError):
+        PrimaryFlux(channel="s", mDM=1 * u.TeV, source="pppc4")
+
 
 @requires_data()
 def test_dm_annihilation_spectral_model_cosmixs(tmpdir):
@@ -157,6 +173,17 @@ def test_dm_annihilation_spectral_model_cosmixs(tmpdir):
     assert_allclose(new_models[0].spectral_model.jfactor.value, model.jfactor.value)
     assert new_models[0].spectral_model.mass.value == 5
     assert new_models[0].spectral_model.mass.unit == u.TeV
+
+
+def test_dm_decay_spectral_model_cosmixs_missing_file():
+    channel = "b"
+    massDM = 5 * u.TeV
+    jfactor = 3.41e19 * u.Unit("GeV cm-2")
+
+    with pytest.raises(FileNotFoundError):
+        DarkMatterDecaySpectralModel(
+            mass=massDM, channel=channel, jfactor=jfactor, source="cosmixs"
+        )
 
 
 @requires_data()

--- a/gammapy/utils/table.py
+++ b/gammapy/utils/table.py
@@ -96,6 +96,7 @@ def table_row_to_dict(row, make_quantity=True):
         data[name] = val
     return data
 
+
 def table_map_columns(table, mapping_dict):
     """Change column names according to a mapping dictionary.
 

--- a/gammapy/utils/table.py
+++ b/gammapy/utils/table.py
@@ -95,3 +95,24 @@ def table_row_to_dict(row, make_quantity=True):
             val = Quantity(val, unit=col.unit)
         data[name] = val
     return data
+
+def table_map_columns(table, mapping_dict):
+    """Change column names according to a mapping dictionary.
+
+    Parameters
+    ----------
+    table : `~astropy.table.Table`
+        Table.
+    mapping_dict : dict
+        Mapping dictionary.
+
+    Returns
+    -------
+    table : `~astropy.table.Table`
+        Table with renamed columns.
+    """
+    for col in table.colnames:
+        if col in mapping_dict and mapping_dict[col] is not None:
+            table.rename_column(col, mapping_dict[col])
+
+    return table


### PR DESCRIPTION
Hello, my name is Alexander Cerviño, and I am a PhD student at the High Energies Group (GAE) at the Complutense University of Madrid, supervised by Daniel Nieto. This is my first contribution to Gammapy.

In this contribution regarding the Dark Matter block, I have implemented the possibility of using CosmiXs instead of PPPC4 as a source for creating the DM spectra. The benefit of using CosmiXs is that the results they provide are more accurate since they obtain them while considering more robust approaches and more precise algorithms and physical processes.

For the implementation , I have set an option in the spectra.py file, so the user can choose between any of the sources, with PPPC4 as the default option. I have also made a match between the available channels in both projects and have found and indicated in the code that there are some discrepancies.

One thing to note is that I include the CosmiXs production file as an external source (path: gammapy/external/CosmiXs/Data/AtProduction-Gamma.dat), and I would like to know if it is possible to include it in the datasets module, just to be consistent with the procedure followed with PPPC4.

Additionally, after conducting some tests, I have checked that the differences in the results obtained by using the current Gammapy interpolator and the one provided by CosmiXs are negligible . Therefore , for simplicity, I have considered it correct to keep using the current one.

Thanks!

