### PR TITLE
INFRA: Set exclusions for sonar coverage analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,9 @@
 sonar.projectKey=gammapy_gammapy_8c1bf7fc-018a-4afd-b216-015191d282fa
 sonar.python.coverage.reportPaths=coverage/coverage.xml
 sonar.python.version=3.12
-
+sonar.sources=gammapy
 # ignore examples for coverage and issues, these are sphinx-gallery notebook scripts
 # which aren't really supported by sonarqube and lead to a lot of false positives
-sonar.sources=gammapy
 sonar.exclusions=examples/**,dev/**,coverage/coverage.xml,gammapy/version.py,docs/conf.py
+# Ignore only from coverage measurement
+sonar.coverage.exclusions=**/tests/**,gammapy/conftest.py,gammapy/scripts/jupyter.py,gammapy/utils/notebooks_links.py,gammapy/utils/notebooks_process.py,gammapy/utils/notebooks_test.py,gammapy/utils/docs.py


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request set exclusions for sonar coverage analysis according to coverage omitted patterns in `setup.cfg` 

```INI

[coverage:run]
omit =
    *tests*
    gammapy/extern/*
    gammapy/conftest.py
    # Exclude some code that's only executed by the
    # notebook tests or docs build (not users)
    # from the coverage measurement
    gammapy/scripts/jupyter.py
    gammapy/utils/notebooks_links.py
    gammapy/utils/notebooks_process.py
    gammapy/utils/notebooks_test.py
    gammapy/utils/docs.py
    gammapy/_astropy_init*
    gammapy/conftest.py
    gammapy/*setup_package*
    gammapy/tests/*
    gammapy/*/tests/*
    gammapy/extern/*
    gammapy/version*
    */gammapy/_astropy_init*
    */gammapy/conftest.py
    */gammapy/*setup_package*
    */gammapy/tests/*
    */gammapy/*/tests/*
    */gammapy/extern/*
     */gammapy/version*
```


