### PR TITLE
Correct CI workflow on v2.0.x to force downloading datasets from 2.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           python -m pip install tqdm requests
           python -m pip install -e .
-          gammapy download datasets
+          gammapy download datasets --release 2.0
       - name: Print Python, pip, and tox versions
         run: |
           python -c "import sys; print(f'Python {sys.version}')"
@@ -116,7 +116,7 @@ jobs:
       - name: Run tests with data
         if: ${{ matrix.gammapy_data }}
         env:
-          GAMMAPY_DATA: ${{ github.workspace }}/gammapy-datasets/dev
+          GAMMAPY_DATA: ${{ github.workspace }}/gammapy-datasets/2.0
         run: tox -e ${{ matrix.tox_env }} -- -n auto
       - name: Upload coverage to codecov
         if: "contains(matrix.tox_env, '-cov')"
@@ -159,7 +159,7 @@ jobs:
         shell: bash -l {0}
     env:
       PYTEST_ADDOPTS: --color=yes -n auto --dist=loadscope
-      GAMMAPY_DATA: /home/runner/work/gammapy/gammapy/gammapy-datasets/dev
+      GAMMAPY_DATA: /home/runner/work/gammapy/gammapy/gammapy-datasets/2.0
 
     if: contains(github.event.pull_request.labels.*.name, 'skip-docs') == false
 
@@ -180,7 +180,7 @@ jobs:
         run: |
           python -m pip install tqdm requests
           python -m pip install -e .
-          gammapy download datasets
+          gammapy download datasets --release 2.0
       - name: test build docs
         run: |
           tox -e build_docs


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request solves an issue with CI caused by changes in gammapy-data.
 
v2.0.x releases are all supposed to use gammapy-data for 2.0 release. So one should not run tests on the dev version of gammapy-data but on the 2.0 release version. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
