### PR TITLE
Backport PR #6252 on branch v2.0.x (Fix plot_error for models evaluated with not finite values)

### DIFF
--- a/docs/release-notes/6252.bug.rst
+++ b/docs/release-notes/6252.bug.rst
@@ -1,0 +1,1 @@
+Fix plot_error for models evaluated with not finite values

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -268,11 +268,12 @@ class SpectralModel(ModelBase):
             Median, negative, and positive errors
 
         """
-        cdf = stats.norm.cdf
 
-        median = np.percentile(samples, 50, axis=-1)
-        errn = median - np.percentile(samples, 100 * cdf(-n_sigma), axis=-1)
-        errp = np.percentile(samples, 100 * cdf(n_sigma), axis=-1) - median
+        samples[~np.isfinite(samples)] = np.nan
+        cdf = stats.norm.cdf
+        median = np.nanpercentile(samples, 50, axis=-1)
+        errn = median - np.nanpercentile(samples, 100 * cdf(-n_sigma), axis=-1)
+        errp = np.nanpercentile(samples, 100 * cdf(n_sigma), axis=-1) - median
         return u.Quantity(
             [np.atleast_1d(median), np.atleast_1d(errn), np.atleast_1d(errp)],
             unit=samples.unit,

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -1433,6 +1433,27 @@ def test_vectorized_integrate_spectrum():
         )
 
 
+def test_plot_error_invalid():
+    ecpl = ExpCutoffPowerLawSpectralModel(
+        index=2.0,
+        reference=1 * u.TeV,
+        amplitude="2.2e-13 TeV-1 s-1 cm-2",
+        lambda_=0.09 / u.TeV,
+        alpha=5.1,
+    )
+    ecpl.index.error = 0.35
+    ecpl.amplitude.error = 0.7e-13
+    ecpl.alpha.error = 3
+    ecpl.lambda_.error = 0.045
+
+    with mpl_plot_check():
+        plt.figure()
+        ecpl.plot([1, 100] * u.TeV, energy_power=2)
+        ecpl.plot_error([1, 100] * u.TeV, energy_power=2)
+        plt.ylim(1e-15, 1e-11)
+        plt.show()
+
+
 def test_bpl_evalaute_array():
     model = BrokenPowerLawSpectralModel(
         index1=1.5 * u.Unit(""),


### PR DESCRIPTION
Fix plot_error for models evaluated with not finite values

(cherry picked from commit f620161b62353686bf563a71451d04febd9be4c3)

<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request ...

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
