### PR TITLE
Add missing space in docstring to fix rendering of link

### DIFF
--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -512,7 +512,7 @@ class PointingInfo:
 
     @lazyproperty
     def altaz(self):
-        """ALT / AZ position computed from RA / DEC as a`~astropy.coordinates.SkyCoord`."""
+        """ALT / AZ position computed from RA / DEC as a `~astropy.coordinates.SkyCoord`."""
         return self.radec.transform_to(self.altaz_frame)
 
     @lazyproperty


### PR DESCRIPTION
Very minor fix for the wrongly rendered link in the documentation, https://docs.gammapy.org/dev/api/gammapy.data.PointingInfo.html#gammapy.data.PointingInfo.altaz