### PR TITLE
Simplify drift pointing mode with built-in broadcasting in astropy>=6

### DIFF
--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -18,7 +18,6 @@ from astropy.io import fits
 from astropy.table import Table
 from astropy.units import Quantity
 from astropy.utils import lazyproperty
-from gammapy.utils.compat import COPY_IF_NEEDED
 from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.fits import earth_location_from_dict
 from gammapy.utils.scripts import make_path
@@ -352,17 +351,9 @@ class FixedPointingInfo:
             return self.fixed_icrs.transform_to(frame)
 
         if self.mode == PointingMode.DRIFT:
-            # see https://github.com/astropy/astropy/issues/12965
-            # TODO: should be solved in astropy v6.0. Simplify once the astropy dependency imposes >=6.0
-            alt = self.fixed_altaz.alt
-            az = self.fixed_altaz.az
             return SkyCoord(
-                alt=u.Quantity(
-                    np.full(obstime.shape, alt.deg), u.deg, copy=COPY_IF_NEEDED
-                ),
-                az=u.Quantity(
-                    np.full(obstime.shape, az.deg), u.deg, copy=COPY_IF_NEEDED
-                ),
+                alt=self.fixed_altaz.alt,
+                az=self.fixed_altaz.az,
                 frame=frame,
             )
 


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request does the simplification foreseen in the TODO comment as now Gammapy requires Astropy >= 6.0 (built-in broadcasting is supported).

```
# see https://github.com/astropy/astropy/issues/12965
# TODO: should be solved in astropy v6.0. Simplify once the astropy dependency imposes >=6.0
```

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
