### PR TITLE
Update release instruction after v2.0.1 release

### DIFF
--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -193,7 +193,7 @@ Releasing the final version
    * Update the datasets entry in the ``download/index.json`` to point to this new release tag. Also update the
      notebook entry, typically the link extensions are the same between versions.
 
-#. In the `gammapy repo https://github.com/gammapy/gammapy>`__, switch to the correct branch and update the ``CITATION.cff`` date and version by running the
+#. In the `gammapy repo <https://github.com/gammapy/gammapy>`__, switch to the correct branch and update the ``CITATION.cff`` date and version by running the
    ``dev/prepare-release.py`` script::
 
     git checkout v2.0.x


### PR DESCRIPTION
We will need to define better how to use town crier for the bug fixes.
The changelog needs to be pushed on the `main` branch. However, the `main` lists all the fragments, and not only the ones specific to this release.

This time we manually choose the relevant fragments, but this can get complex in future.