### PR TITLE
Use "np.nonzero" for SonarQube - Part 1

### DIFF
--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -499,7 +499,7 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
             """
             )
 
-        x, y = np.where(np.squeeze(mask_2d))
+        x, y = np.nonzero(np.squeeze(mask_2d))
         positions = list(zip(x, y))
 
         inputs = zip(

--- a/gammapy/estimators/utils.py
+++ b/gammapy/estimators/utils.py
@@ -1225,7 +1225,7 @@ def interpolate_profile_map(flux_map, dnde_scan_axis=None):
     mask_valid = ~np.isnan(flux_map.dnde.data)
     dnde_scan_values = flux_map.dnde_scan_values.quantity.to_value(dnde_scan_axis.unit)
 
-    for ij, il, ik in zip(*np.where(mask_valid)):
+    for ij, il, ik in zip(*np.nonzero(mask_valid)):
         spline = InterpolatedUnivariateSpline(
             dnde_scan_values[ij, :, il, ik],
             flux_map.stat_scan.data[ij, :, il, ik],
@@ -1268,7 +1268,7 @@ def approximate_profile_map(
         sqrt_ts_threshold_ul = flux_map.sqrt_ts_threshold_ul
 
     mask_valid = ~np.isnan(flux_map.dnde.data)
-    ij, il, ik = np.where(mask_valid)
+    ij, il, ik = np.nonzero(mask_valid)
     loc = flux_map.dnde.data[mask_valid][:, None]
     value = dnde_coord[ij, :, il, ik]
     try:
@@ -1311,7 +1311,7 @@ def approximate_profile_map(
         mask_ul = (flux_map.sqrt_ts.data < sqrt_ts_threshold_ul) & ~np.isnan(
             flux_map.dnde_ul.data
         )
-        ij, il, ik = np.where(mask_ul)
+        ij, il, ik = np.nonzero(mask_ul)
         value = dnde_coord[ij, :, il, ik]
         loc_ul = flux_map.dnde_ul.data[mask_ul][:, None]
         scale_ul = flux_map.dnde_ul.data[mask_ul][:, None]

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -239,7 +239,7 @@ class SafeMaskMaker(Maker):
             model = TemplateSpectralModel.from_region_map(aeff)
 
             energy_true = model.energy
-            energy_min = energy_true[np.where(model.values > 0)[0][0]]
+            energy_min = energy_true[np.nonzero(model.values > 0)[0][0]]
             energy_max = energy_true[-1]
 
             aeff_thres = (self.aeff_percent / 100) * aeff.quantity.max()

--- a/gammapy/modeling/covariance.py
+++ b/gammapy/modeling/covariance.py
@@ -60,7 +60,7 @@ class Covariance:
         npars = len(parameters)
         matrix_expanded = np.zeros((npars, npars))
         mask_frozen = [par.frozen for par in parameters]
-        pars_index = [np.where(np.array(parameters) == p)[0][0] for p in parameters]
+        pars_index = [np.nonzero(np.array(parameters) == p)[0][0] for p in parameters]
         mask_duplicate = [pars_idx != idx for idx, pars_idx in enumerate(pars_index)]
         mask = np.array(mask_frozen) | np.array(mask_duplicate)
         free_parameters = ~(mask | mask[:, np.newaxis])

--- a/gammapy/stats/variability.py
+++ b/gammapy/stats/variability.py
@@ -262,7 +262,7 @@ def structure_function(flux, flux_err, time, tdelta_precision=5):
     norm = np.zeros(shape)
 
     for i, distance in enumerate(distances):
-        indexes = np.array(np.where(dist_matrix == distance))
+        indexes = np.array(np.nonzero(dist_matrix == distance))
         for index in indexes.T:
             f = (flux[index[1], ...] - flux[index[0], ...]) ** 2
             w = (flux[index[1], ...] / flux_err[index[1], ...]) * (

--- a/gammapy/utils/roots.py
+++ b/gammapy/utils/roots.py
@@ -115,7 +115,7 @@ def find_roots(
     x = scale.inverse(np.linspace(a, b, nbin + 1))
     if len(x) > 2:
         signs = np.sign([f(xk, *args) for xk in x])
-        ind = np.where(signs[:-1] != signs[1:])[0]
+        ind = np.nonzero(signs[:-1] != signs[1:])[0]
     else:
         ind = [0]
     nroots = max(1, len(ind))

--- a/gammapy/visualization/utils.py
+++ b/gammapy/visualization/utils.py
@@ -336,7 +336,7 @@ def plot_distribution(
 
         cutout_mask.data = np.logical_and(cutout_mask.data, mask.data)
 
-    idx_x, idx_y = np.where(cutout_mask)
+    idx_x, idx_y = np.nonzero(cutout_mask)
 
     data = cutout.data[..., idx_x, idx_y]
 


### PR DESCRIPTION

This pull request is associated to a "CRITICAL" flag by the SonarCube reliability diagnostic (see the issue https://github.com/gammapy/gammapy/issues/6239).

It expects to use`np.nonzero` instead of `np.where`, as these are boolean quantities this works well