### PR TITLE
Cleanup`TimeMapAxis.pix_to_coord` validity mask

### DIFF
--- a/docs/release-notes/6384.bug.rst
+++ b/docs/release-notes/6384.bug.rst
@@ -1,1 +1,0 @@
-Fix a bug in `gammapy.maps.axes.pix_to_coord` where np.logical_and(a, b, c) mistakenly treated the 3rd argument as the ufunc 'out' parameter instead of a third condition, potentially skipping the isfinite(idx) check.


### PR DESCRIPTION
- Fix a bug where np.logical_and(a, b, c) mistakenly treated the 3rd argument
  as the ufunc 'out' parameter instead of a third condition, potentially
  skipping the isfinite(idx) check.
- Replace with a correct boolean mask combination:
  (cond1) & (cond2) & np.isfinite(idx).
- Add a regression test that makes np.isfinite() return a read-only array to
  ensure the old implementation fails (writing to out) while the fixed one
  works correctly.

<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**

This pull request fixes a logic error in `TimeMapAxis.pix_to_coord()`.
The original implementation used `np.logical_and(a, b, c)`, assuming the
third argument was an additional condition. However, in NumPy ufunc
semantics the third positional argument is the `out` parameter, used for
storing the result rather than for logical evaluation.

As a consequence, the `np.isfinite(idx)` check was not actually applied as
a condition and could be silently ignored, allowing NaN or invalid indices
to pass the validity mask.

The code is corrected by explicitly combining all conditions using boolean
operations, ensuring `isfinite(idx)` is properly enforced.

A regression test is added that exposes the bug by making
`np.isfinite()` return a read-only array: the old implementation attempts
to write into it (via `out`) and fails, while the fixed implementation
works as expected.

**Dear reviewer**

This PR is ready for review.

The change is minimal and localized, does not affect the public API, and
adds a targeted regression test to guard against future regressions of the
same kind. No documentation update is required, as this is an internal bug
fix.

Feedback is welcome, but the PR should be ready to merge as-is.
