### PR TITLE
Remove deprecated json_encoders in workflow

### DIFF
--- a/gammapy/workflow/config.py
+++ b/gammapy/workflow/config.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping
 from enum import Enum
 from pathlib import Path
 from typing import List, Optional
-from astropy import units as u
 import yaml
 from pydantic import BaseModel, ConfigDict
 from gammapy.makers import MapDatasetMaker
@@ -94,7 +93,6 @@ class GammapyBaseConfig(BaseModel):
         extra="forbid",
         validate_default=True,
         use_enum_values=True,
-        json_encoders={u.Quantity: lambda v: f"{v.value} {v.unit}"},
     )
 
     def _repr_html_(self):


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request is a small fix to remove deprecated json_encoders in `GammapyBaseConfig`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
