### PR TITLE
refactor: remove linting dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,6 @@ help:
 	@echo '     docs-show          Open local HTML docs in browser'
 	@echo ''
 	@echo '     trailing-spaces    Remove trailing spaces at the end of lines in *.py files'
-	@echo '     black              Run black code formatter'
-	@echo '     isort              Run isort code formatter to sort imports'
-	@echo '     polish             Run trailing-spaces, black and isort'
 	@echo '     pylint             Run pylint static code analysis'
 	@echo ''
 	@echo ' To get info about your Gammapy installation and setup run this command'
@@ -80,14 +77,6 @@ docs-show:
 trailing-spaces:
 	find $(PROJECT) examples docs -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;
 
-black:
-	black $(PROJECT)
-
-isort:
-	isort -rc gammapy examples docs -s docs/conf.py
-
-polish: black isort trailing-spaces;
-
 # TODO: once the errors are fixed, remove the -E option and tackle the warnings
 # Note: pylint is very thorough, but slow, and has false positives or nitpicky stuff
 pylint:
@@ -103,11 +92,5 @@ pylint:
 # D400: First line should end with a period (not ')')
 # D401: First line should be in imperative mood; try rephrasing (found 'Function')
 # D403: First word of the first line should be properly capitalized ('Add', not 'add')
-pydocstyle:
-	pydocstyle $(PROJECT) \
-	--convention=numpy \
-	--match-dir='^(?!extern).*' \
-	--match='(?!test_).*\.py' \
-	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D205,D400,D401,D403,D410
 
 # TODO: add test and code quality checks for `examples`

--- a/docs/development/dev_howto.rst
+++ b/docs/development/dev_howto.rst
@@ -600,7 +600,7 @@ The checklist below outlines key steps to follow when reviewing a PR.
 4. Check that the CI workflow passes without failure.
 5. Check that the general conventions are fulfilled, :ref:`see here <general-conventions>`.
 6. Check that the code can be understood by reading it.
-7. Confirm all docstrings are correct and formatted correctly.
+7. Confirm all docstrings are correct and formatted correctly, :ref:`see here <docstring-formatting>`.
 8. Check that all commits are signed.
 9. Check that a fragment was added, if necessary, for :ref:`towncrier <release-notes>`.
 10. Where relevant, add examples for the users, :ref:`see here <docstring-code-py-file>`.

--- a/docs/development/dev_howto.rst
+++ b/docs/development/dev_howto.rst
@@ -600,7 +600,7 @@ The checklist below outlines key steps to follow when reviewing a PR.
 4. Check that the CI workflow passes without failure.
 5. Check that the general conventions are fulfilled, :ref:`see here <general-conventions>`.
 6. Check that the code can be understood by reading it.
-7. Confirm all docstrings are correct and formatted correctly, :ref:`see here <docstring-formatting>`.
+7. Confirm all docstrings are correct and formatted correctly.
 8. Check that all commits are signed.
 9. Check that a fragment was added, if necessary, for :ref:`towncrier <release-notes>`.
 10. Where relevant, add examples for the users, :ref:`see here <docstring-code-py-file>`.

--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -189,22 +189,6 @@ Another option is to create a general list of references, as follows:
         * `Author et al. (2023), "Title" <link_to_nasaads>`_
         * `Author2 et al. (2022), "Title2" <link_to_nasaads>`_
 
-.. _docstring-formatting:
-
-Docstring formatting
-^^^^^^^^^^^^^^^^^^^^
-
-It is also important to check that you have correctly formatted your docstring.
-An easy way to check this is by utilising `pydocstyle`. `pydocstyle` utilises the
-PEP257 convention by default, which means a number of errors are automatically ignored.
-In gammapy we chose to opt for the `numpy` convention therefore the flag must be added
-to correctly check the docstrings. To check the docstring for your specific file, i.e.:
-
-.. code-block:: bash
-
-    pydocstyle --convention=numpy gammapy/data/event_list.py
-
-
 
 Sphinx gallery extension
 ------------------------

--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -189,6 +189,13 @@ Another option is to create a general list of references, as follows:
         * `Author et al. (2023), "Title" <link_to_nasaads>`_
         * `Author2 et al. (2022), "Title2" <link_to_nasaads>`_
 
+.. _docstring-formatting:
+
+Docstring formatting
+^^^^^^^^^^^^^^^^^^^^
+
+The docstring formatting is done via `ruff <https://docs.astral.sh/ruff/>`__ tool, which runs as a ``pre-commit`` hook and follow the `numpy docstring style convention <https://numpydoc.readthedocs.io/en/latest/format.html>`__.
+``ruff`` include most of `pydocstyle rules <https://docs.astral.sh/ruff/rules/#pydocstyle-d>`__ except those explicitly excluded in ``pyproject.toml``.
 
 Sphinx gallery extension
 ------------------------

--- a/docs/development/doc_howto.rst
+++ b/docs/development/doc_howto.rst
@@ -194,8 +194,11 @@ Another option is to create a general list of references, as follows:
 Docstring formatting
 ^^^^^^^^^^^^^^^^^^^^
 
-The docstring formatting is done via `ruff <https://docs.astral.sh/ruff/>`__ tool, which runs as a ``pre-commit`` hook and follow the `numpy docstring style convention <https://numpydoc.readthedocs.io/en/latest/format.html>`__.
-``ruff`` include most of `pydocstyle rules <https://docs.astral.sh/ruff/rules/#pydocstyle-d>`__ except those explicitly excluded in ``pyproject.toml``.
+The docstring formatting is handled via the `ruff <https://docs.astral.sh/ruff/>`__
+tool, which runs as a ``pre-commit`` hook and follows the
+`numpy docstring style convention <https://numpydoc.readthedocs.io/en/latest/format.html>`__.
+``ruff`` includes most of the `pydocstyle rules <https://docs.astral.sh/ruff/rules/#pydocstyle-d>`__
+except those explicitly excluded in ``pyproject.toml``.
 
 Sphinx gallery extension
 ------------------------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -50,16 +50,12 @@ dependencies:
   - numba
   - arviz
   # dev dependencies
-  - black=22.6.0
   - codespell
-  - flake8
-  - isort
   - jinja2
   - jupytext
   - nbsphinx
   - numdifftools
   - pandoc
-  - pydocstyle
   - pylint
   - setuptools_scm
   - sherpa>=4.17

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,9 @@ skip-magic-trailing-comma = false
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"
 
+[tool.ruff.lint.isort]
+skip = ["docs/conf.py"]
+
 # Including towncrier to create the changelog
 [tool.towncrier]
 package = "gammapy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,13 +143,13 @@ except Exception:
 """
 
 [tool.ruff]
-exclude = ["docs", "dev"]
+exclude = ["docs", "dev", "extern*", "*test_*.py"]
 # Like black
 line-length = 88
 indent-width = 4
 
 [tool.ruff.lint]
-ignore = ["E741"]
+ignore = ["E741", "D100", "D102", "D103", "D104", "D105", "D200", "D202", "D205", "D400", "D401", "D403", "D410"]
 extend-ignore = ["E203","E712"]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ except Exception:
 """
 
 [tool.ruff]
-exclude = ["docs", "dev", "extern*", "*test_*.py"]
 # Like black
 line-length = 79
 indent-width = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,8 +149,17 @@ line-length = 88
 indent-width = 4
 
 [tool.ruff.lint]
-ignore = ["E741", "D100", "D102", "D103", "D104", "D105", "D200", "D202", "D205", "D400", "D401", "D403", "D410"]
-extend-ignore = ["E203","E712"]
+select = ["D", "E"]
+ignore = [
+    "D100", "D102", "D103",
+    "D104", "D105", "D200",
+    "D202", "D205", "D400",
+    "D401", "D403", "D410",
+    "E203","E712", "E741",
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,13 +149,23 @@ line-length = 88
 indent-width = 4
 
 [tool.ruff.lint]
-select = ["D", "E"]
+select = [
+  "E",   # pycodestyle errors
+  "F",   # pyflakes
+  "B",   # flake8-bugbear
+  "I",   # isort
+  "PLE", # pylint errors
+  "D",   # pydocstyle
+  # "UP",   # pyUpgrade
+  "FLY", # flynt
+  "DTZ", # flake8-datetimez
+  "S",   # flake8-bandit
+  "N",   # pep8-naming
+]
 ignore = [
-    "D100", "D102", "D103",
-    "D104", "D105", "D200",
-    "D202", "D205", "D400",
-    "D401", "D403", "D410",
-    "E203","E712", "E741",
+    "D100", "D102", "D104", "D105",
+    "D400", "D401", "D403",
+    "S101",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ except Exception:
 
 [tool.ruff]
 # Like black
-line-length = 79
+line-length = 88
 indent-width = 4
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,6 @@ select = [
 ignore = [
     "D100", "D102", "D104", "D105",
     "D400", "D401", "D403",
-    "S101",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ except Exception:
 [tool.ruff]
 exclude = ["docs", "dev", "extern*", "*test_*.py"]
 # Like black
-line-length = 88
+line-length = 79
 indent-width = 4
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["E402"]
+"test_*.py" = ["D"]
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ select = [
 ]
 ignore = [
     "D100", "D102", "D104", "D105",
-    "D400", "D401", "D403",
+    "D205", "D400", "D401", "D403",
 ]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
**Description**
 Remove linting dependencies handled by `ruff` and related Makefile and docs references.

**Dear reviewer**

I removed the dependencies from the `environment-dev.yml` assuming that this file was built by hand.

One question is what to do with this: https://github.com/gammapy/gammapy/blob/main/docs/development/doc_howto.rst#docstring-formatting

Closes #6059 