### PR TITLE
Backport PR #6422 on branch v2.0.x (Drop support for numpy=1.26 and astropy=6.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             allowed_fail: false
           - os: ubuntu-latest
             python: '3.10'
-            tox_env: 'py310-test-alldeps_noray-astropy60-numpy126'
+            tox_env: 'py310-test-alldeps_noray-astropy61-numpy20'
             allowed_fail: false
           - os: ubuntu-latest
             python: '3.10'

--- a/codemeta.json
+++ b/codemeta.json
@@ -545,9 +545,9 @@
     "email": "GAMMAPY-COORDINATION-L@IN2P3.FR",
     "dateModified": "2025-12-16",
     "softwareRequirements": [
-        "numpy>=1.26",
+        "numpy>=2.0",
         "scipy>=1.13",
-        "astropy>=6.0",
+        "astropy>=6.1",
         "regions>=0.9.0",
         "pyyaml>=5.3",
         "click>=8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [
-    "numpy>=1.26",
+    "numpy>=2.0",
     "scipy>=1.13",
-    "astropy>=6.0",
+    "astropy>=6.1",
     "regions>=0.9.0",
     "pyyaml>=5.3",
     "click>=8.0",

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 minversion = 4.0
 envlist =
     py{310,311,312,313}-test{,-alldeps,-devdeps}{,-cov}
-    py{310,311,312,313}-test-numpy{121,122,123,124}
-    py{310,311,312,313}-test-astropy{60,lts}
+    py{310,311,312,313}-test-astropy{61,lts}
     build_docs
     linkcheck
     devdeps
@@ -48,23 +47,19 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy121: with numpy 1.21.*
-    numpy122: with numpy 1.22.*
-    numpy123: with numpy 1.23.*
-    numpy124: with numpy 1.24.*
-    astropy50: with astropy 5.0.*
+    astropy61: with astropy 6.1.*
+    numpy20: with numpy 2.0.*
 
 # The following provides some specific pinnings for key packages
 deps =
 
     cov: coverage
-    numpy126: numpy==1.26.*
-    numpy20: numpy==2.0*
+    numpy20: numpy==2.0.*
     numpy21: numpy==2.1.*
 
-    astropy60: astropy==6.0.*
+    astropy61: astropy==6.1.*
 
-    oldestdeps: numpy==1.26.*
+    oldestdeps: numpy==2.0.*
     oldestdeps: matplotlib==3.9.*
     oldestdeps: scipy==1.13.*
     oldestdeps: pyyaml==6.0.*


### PR DESCRIPTION
Drop support for numpy=1.26 and astropy=6.0

(cherry picked from commit bcc4958c785c6bf713a307bda4b5d1796741f797)

<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request ...

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
