### PR TITLE
Render log as math operator in docstrings

### DIFF
--- a/examples/models/spectral/plot_logparabola.py
+++ b/examples/models/spectral/plot_logparabola.py
@@ -13,13 +13,13 @@ It is defined by the following equation:
           - \alpha - \beta \log{ \left( \frac{E}{E_0} \right) }
         }
 
-Note that :math:`log` refers to the natural logarithm. This is consistent
+Note that :math:`\log` refers to the natural logarithm. This is consistent
 with the `Fermi Science Tools
 <https://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/source_models.html>`_
 and `ctools
 <http://cta.irap.omp.eu/ctools-devel/users/user_manual/getting_started/models.html#log-parabola>`_.
-The `Sherpa <http://cxc.harvard.edu/sherpa/ahelp/logparabola.html>`_ package, however, uses :math:`log_{10}`. If you have
-parametrization based on :math:`log_{10}` you can use the
+The `Sherpa <http://cxc.harvard.edu/sherpa/ahelp/logparabola.html>`_ package, however, uses :math:`\log_{10}`. If you have
+parametrization based on :math:`\log_{10}` you can use the
 :func:`~gammapy.modeling.models.LogParabolaSpectralModel.from_log10` method.
 
 """

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1898,7 +1898,7 @@ class LogParabolaSpectralModel(SpectralModel):
 
     @classmethod
     def from_log10(cls, amplitude, reference, alpha, beta):
-        """Construct from :math:`log_{10}` parametrization."""
+        """Construct from :math:`\log_{10}` parametrization."""
         beta_ = beta / np.log(10)
         return cls(amplitude=amplitude, reference=reference, alpha=alpha, beta=beta_)
 
@@ -1962,7 +1962,7 @@ class LogParabola2SpectralModel(SpectralModel):
 
     @classmethod
     def from_log10(cls, amplitude, reference, alpha, beta, escale):
-        """Construct from :math:`log_{10}` parametrization."""
+        """Construct from :math:`\log_{10}` parametrization."""
         beta_ = beta / np.log(10)
         return cls(
             amplitude=amplitude,
@@ -2022,7 +2022,7 @@ class LogParabolaNormSpectralModel(SpectralModel):
 
     @classmethod
     def from_log10(cls, norm, reference, alpha, beta):
-        """Construct from :math:`log_{10}` parametrization."""
+        """Construct from :math:`\log_{10}` parametrization."""
         beta_ = beta / np.log(10)
         return cls(norm=norm, reference=reference, alpha=alpha, beta=beta_)
 


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request fixes the render of log as a math operator in docstrings.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
The PR is ready for review.