### PR TITLE
tests: Add xfail coverage for ASDF I/O roundtrips (WIP)

### DIFF
--- a/gammapy/datasets/tests/test_io.py
+++ b/gammapy/datasets/tests/test_io.py
@@ -16,6 +16,33 @@ from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import requires_data
 
 
+@pytest.mark.xfail(reason="ASDF dataset I/O API is not implemented yet", strict=True)
+@requires_data()
+def test_datasets_asdf_roundtrip(tmp_path):
+    filedata = "$GAMMAPY_DATA/tests/models/gc_example_datasets.yaml"
+    filemodel = "$GAMMAPY_DATA/tests/models/gc_example_models.yaml"
+
+    datasets = Datasets.read(
+        filename=filedata,
+        filename_models=filemodel,
+    )
+
+    datasets.write(
+        filename=tmp_path / "written_datasets.asdf",
+        filename_models=tmp_path / "written_models.yaml",
+        io_format="asdf",
+    )
+
+    datasets_read = Datasets.read(
+        filename=tmp_path / "written_datasets.asdf",
+        filename_models=tmp_path / "written_models.yaml",
+        io_format="asdf",
+    )
+
+    assert len(datasets_read) == len(datasets)
+    assert datasets_read.names == datasets.names
+
+
 @requires_data()
 def test_datasets_to_io(tmp_path):
     filedata = "$GAMMAPY_DATA/tests/models/gc_example_datasets.yaml"

--- a/gammapy/maps/tests/test_core.py
+++ b/gammapy/maps/tests/test_core.py
@@ -159,7 +159,7 @@ def test_map_slice_by_idx(binsz, width, map_type, skydir, axes, unit):
 
 
 @pytest.mark.parametrize("map_type", ["wcs", "hpx"])
-def test_map_meta_read_write(map_type):
+def test_map_meta_fits_read_write(map_type):
     meta = {"user": "test"}
 
     m = Map.create(
@@ -176,6 +176,25 @@ def test_map_meta_read_write(map_type):
     assert header["META"] == '{"user": "test"}'
 
     m2 = Map.from_hdulist(hdulist)
+    assert m2.meta == meta
+
+
+@pytest.mark.xfail(reason="ASDF map I/O API not implemented yet", strict=True)
+@pytest.mark.parametrize("map_type", ["wcs", "hpx"])
+def test_map_meta_asdf_roundtrip(map_type, tmp_path):
+    meta = {"user": "test"}
+
+    m = Map.create(
+        binsz=0.1,
+        width=10.0,
+        map_type=map_type,
+        skydir=SkyCoord(0.0, 30.0, unit="deg"),
+        meta=meta,
+    )
+
+    filename = tmp_path / "meta_map.asdf"
+    m.write(filename, io_format="asdf", overwrite=True)
+    m2 = Map.read(filename, io_format="asdf")
     assert m2.meta == meta
 
 


### PR DESCRIPTION
This is a **tests-only WIP PR** for planned ASDF serialization support in Gammapy.

The goal is to get maintainer feedback on API shape and test expectations before implementation.

## What this PR adds

- `Datasets` ASDF roundtrip test marked `xfail(strict=True)`
- `Map` metadata ASDF roundtrip test marked `xfail(strict=True)`
- Clear separation in naming between legacy FITS path and planned ASDF path

## Why `xfail`

ASDF I/O is not implemented yet anywhere in the project.  
These tests define the intended behavior contract first (TDD), without changing runtime behavior.

## Scope

- No ASDF implementation in this PR
- No changes to existing legacy serialization behavior
- Follow-up PR(s) will implement ASDF I/O and remove `xfail` once passing