### PR TITLE
Display log as math operator in `plot_logparabola2`

### DIFF
--- a/examples/models/spectral/plot_logparabola2.py
+++ b/examples/models/spectral/plot_logparabola2.py
@@ -13,8 +13,8 @@ It is defined by the following equation:
           - \alpha - \beta \log{ \left( \frac{E}{E_s} \right) }
         }
 
-Note that :math:`log` refers to the natural logarithm.
-If you have parametrization based on :math:`log_{10}` you can use the
+Note that :math:`\log` refers to the natural logarithm.
+If you have parametrization based on :math:`\log_{10}` you can use the
 :func:`~gammapy.modeling.models.LogParabola2SpectralModel.from_log10` method.
 
 """


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This PR addresses the changes performed in PR #6444 for the script `plot_logparabola2.py`, which cannot be backported.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
The PR is ready for review.