### PR TITLE
FoV frame initialization.

### DIFF
--- a/docs/release-notes/6456.bug.rst
+++ b/docs/release-notes/6456.bug.rst
@@ -1,0 +1,1 @@
+Adds check on `~gammapy.utils.coordinates.FoVAltAzFrame` init method to ensure `origin` is consistent with `location` and `obstime`.

--- a/gammapy/utils/coordinates/fov.py
+++ b/gammapy/utils/coordinates/fov.py
@@ -73,7 +73,51 @@ class FoVAltAzFrame(BaseCoordinateFrame):
     obstime = TimeAttribute(default=None)
     location = EarthLocationAttribute(default=None)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, origin=None, obstime=None, location=None, **kwargs):
+        if not isinstance(origin, (AltAz, SkyCoord)):
+            raise TypeError(
+                f"origin must be AltAz SkyCoord , got {type(origin).__name__} instead."
+            )
+        if isinstance(origin, SkyCoord) and not isinstance(origin.frame, AltAz):
+            raise TypeError("origin must be AltAz.")
+
+        if obstime is None and origin.obstime is not None:
+            obstime = origin.obstime
+        if location is None and origin.location is not None:
+            location = origin.location
+
+        kwargs["origin"] = origin
+        kwargs["location"] = location
+        kwargs["obstime"] = obstime
+
+        # Validate obstime consistency
+        if obstime is not None and origin.obstime is not None:
+            if obstime.shape != origin.obstime.shape:
+                raise ValueError(
+                    f"obstime shape mismatch: frame obstime has shape "
+                    f"{obstime.shape} but origin.obstime has shape "
+                    f"{origin.obstime.shape}."
+                )
+            if not np.all(obstime == origin.obstime):
+                raise ValueError(
+                    "obstime mismatch: frame obstime and origin.obstime must be equal."
+                )
+
+        # Validate location consistency
+        if location is not None and origin.location is not None:
+            if not np.all(location == origin.location):
+                raise ValueError(
+                    "location mismatch: frame location and origin.location must be equal."
+                )
+
+        # Validate shape consistency between origin and obstime
+        if obstime is not None and origin.shape != obstime.shape:
+            raise ValueError(
+                f"origin shape {origin.shape} is inconsistent with "
+                f"obstime shape {obstime.shape}. For a time-varying frame, "
+                f"origin must be an array of AltAz coordinates, one per obstime."
+            )
+
         super().__init__(*args, **kwargs)
 
         # make sure telescope coordinate is in range [-180°, 180°]

--- a/gammapy/utils/coordinates/fov.py
+++ b/gammapy/utils/coordinates/fov.py
@@ -24,6 +24,32 @@ __all__ = ["FoVAltAzFrame", "FoVICRSFrame", "fov_to_sky", "sky_to_fov"]
 reflect_lon_matrix = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 1]])
 
 
+def _validate_obstime_consistency(obstime, origin):
+    """Check that obstime is consistent with origin.obstime."""
+    if obstime is None:
+        return origin.obstime
+    if obstime.shape != origin.obstime.shape:
+        raise ValueError(
+            f"origin and obstime have inconsistent shapes: "
+            f"{origin.obstime.shape} vs {obstime.shape}."
+        )
+    if not np.all(obstime == origin.obstime):
+        raise ValueError(
+            "obstime mismatch: frame obstime and origin.obstime must be equal."
+        )
+
+
+def _validate_location_consistency(location, origin):
+    """Check that location is consistent with origin.location."""
+    if location is None:
+        return origin.location
+
+    if not np.all(location == origin.location):
+        raise ValueError(
+            "location mismatch: frame location and origin.location must be equal."
+        )
+
+
 class FoVAltAzFrame(BaseCoordinateFrame):
     """
     FoV coordinate frame. Centered on `origin` and aligned on AltAz frame at `location` and `obstime`.

--- a/gammapy/utils/coordinates/fov.py
+++ b/gammapy/utils/coordinates/fov.py
@@ -93,11 +93,7 @@ class FoVAltAzFrame(BaseCoordinateFrame):
         # Validate obstime consistency
         if obstime is not None and origin.obstime is not None:
             if obstime.shape != origin.obstime.shape:
-                raise ValueError(
-                    f"obstime shape mismatch: frame obstime has shape "
-                    f"{obstime.shape} but origin.obstime has shape "
-                    f"{origin.obstime.shape}."
-                )
+                raise ValueError("origin and obstime have inconsistent shapes")
             if not np.all(obstime == origin.obstime):
                 raise ValueError(
                     "obstime mismatch: frame obstime and origin.obstime must be equal."

--- a/gammapy/utils/coordinates/fov.py
+++ b/gammapy/utils/coordinates/fov.py
@@ -25,9 +25,11 @@ reflect_lon_matrix = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 1]])
 
 
 def _validate_obstime_consistency(obstime, origin):
-    """Check that obstime is consistent with origin.obstime."""
+    """Check that obstime is consistent with origin.obstime and return obstime."""
     if obstime is None:
         return origin.obstime
+    if origin.obstime is None:
+        return obstime
     if obstime.shape != origin.obstime.shape:
         raise ValueError(
             f"origin and obstime have inconsistent shapes: "
@@ -37,17 +39,20 @@ def _validate_obstime_consistency(obstime, origin):
         raise ValueError(
             "obstime mismatch: frame obstime and origin.obstime must be equal."
         )
+    return obstime
 
 
 def _validate_location_consistency(location, origin):
-    """Check that location is consistent with origin.location."""
+    """Check that location is consistent with origin.location and return location."""
     if location is None:
         return origin.location
 
-    if not np.all(location == origin.location):
+    if origin.location is not None and not np.all(location == origin.location):
         raise ValueError(
             "location mismatch: frame location and origin.location must be equal."
         )
+    else:
+        return location
 
 
 class FoVAltAzFrame(BaseCoordinateFrame):
@@ -107,38 +112,10 @@ class FoVAltAzFrame(BaseCoordinateFrame):
         if isinstance(origin, SkyCoord) and not isinstance(origin.frame, AltAz):
             raise TypeError("origin must be AltAz.")
 
-        if obstime is None and origin.obstime is not None:
-            obstime = origin.obstime
-        if location is None and origin.location is not None:
-            location = origin.location
-
         kwargs["origin"] = origin
-        kwargs["location"] = location
-        kwargs["obstime"] = obstime
-
-        # Validate obstime consistency
-        if obstime is not None and origin.obstime is not None:
-            if obstime.shape != origin.obstime.shape:
-                raise ValueError("origin and obstime have inconsistent shapes")
-            if not np.all(obstime == origin.obstime):
-                raise ValueError(
-                    "obstime mismatch: frame obstime and origin.obstime must be equal."
-                )
-
-        # Validate location consistency
-        if location is not None and origin.location is not None:
-            if not np.all(location == origin.location):
-                raise ValueError(
-                    "location mismatch: frame location and origin.location must be equal."
-                )
-
-        # Validate shape consistency between origin and obstime
-        if obstime is not None and origin.shape != obstime.shape:
-            raise ValueError(
-                f"origin shape {origin.shape} is inconsistent with "
-                f"obstime shape {obstime.shape}. For a time-varying frame, "
-                f"origin must be an array of AltAz coordinates, one per obstime."
-            )
+        if origin is not None:
+            kwargs["location"] = _validate_location_consistency(location, origin)
+            kwargs["obstime"] = _validate_obstime_consistency(obstime, origin)
 
         super().__init__(*args, **kwargs)
 

--- a/gammapy/utils/coordinates/tests/test_fov.py
+++ b/gammapy/utils/coordinates/tests/test_fov.py
@@ -123,7 +123,7 @@ def test_inconsistent_obstime_location_origin_fovaltaz():
         FoVAltAzFrame(origin=origin, location=different_location, obstime=single_time)
 
     time_array = single_time + [0.0, 1.0, 2.0] * u.h
-    with pytest.raises(ValueError, match="origin and obstime have inconsistent shapes"):
+    with pytest.raises(ValueError):
         FoVAltAzFrame(origin=origin, location=location, obstime=time_array)
 
     origins = AltAz(

--- a/gammapy/utils/coordinates/tests/test_fov.py
+++ b/gammapy/utils/coordinates/tests/test_fov.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import (
@@ -15,6 +16,25 @@ from gammapy.utils.coordinates import (
     fov_to_sky,
     sky_to_fov,
 )
+from gammapy.utils.observers import observatory_locations
+from gammapy.utils.testing import assert_time_allclose
+
+
+@pytest.fixture
+def ctao_location():
+    return observatory_locations["ctao_north"]
+
+
+@pytest.fixture
+def single_time():
+    return Time("2026-01-01T00:00:00")
+
+
+@pytest.fixture
+def altaz_origin(location, single_time):
+    return AltAz(
+        az=172 * u.deg, alt=80 * u.deg, location=ctao_location, obstime=single_time
+    )
 
 
 class TestFoVAltAzFrame:
@@ -85,6 +105,39 @@ class TestFoVAltAzFrame:
 
         assert_allclose(roundtrip.ra.deg, [10, 30, 45])
         assert_allclose(roundtrip.dec.deg, [-60, -30, 60])
+
+
+def test_inconsistent_obstime_location_origin_fovaltaz():
+    location = observatory_locations["ctao_north"]
+    single_time = Time("2026-01-01T00:00:00")
+    origin = AltAz(
+        az=172 * u.deg, alt=80 * u.deg, location=location, obstime=single_time
+    )
+
+    different_time = Time("2026-01-01T01:00:00")
+    with pytest.raises(ValueError, match="obstime mismatch"):
+        FoVAltAzFrame(origin=origin, location=location, obstime=different_time)
+
+    different_location = observatory_locations["hess"]
+    with pytest.raises(ValueError, match="location mismatch"):
+        FoVAltAzFrame(origin=origin, location=different_location, obstime=single_time)
+
+    time_array = single_time + [0.0, 1.0, 2.0] * u.h
+    with pytest.raises(ValueError, match="origin and obstime have inconsistent shapes"):
+        FoVAltAzFrame(origin=origin, location=location, obstime=time_array)
+
+    origins = AltAz(
+        az=172 * u.deg, alt=80 * u.deg, location=location, obstime=time_array
+    )
+    # identical origin.obstime and obstime should be accepted
+    fov_frame = FoVAltAzFrame(origin=origins, location=location, obstime=time_array)
+    assert_time_allclose(fov_frame.origin.obstime, fov_frame.obstime)
+
+    with pytest.raises(ValueError, match="origin and obstime have inconsistent shapes"):
+        FoVAltAzFrame(origin=origins, location=location, obstime=time_array[:-1])
+
+    with pytest.raises(ValueError, match="origin and obstime have inconsistent shapes"):
+        FoVAltAzFrame(origin=origins, location=location, obstime=single_time)
 
 
 def test_checked_hess_values():


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request proposes a change to enforce that for the `FovAltAzFrame` `origin` is consistent with `obstime` and `location`.  It is currently possible to assigne a different obstime than that of the `AltAz` defining the origin. This can cause weird side effects and incorrect results.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
