### PR TITLE
Replace deprecated chararray in SensitivityEstimator

### DIFF
--- a/docs/release-notes/6453.bug.rst
+++ b/docs/release-notes/6453.bug.rst
@@ -1,1 +1,0 @@
-Replace deprecated ``np.char.chararray`` with ``np.empty`` using ``dtype="U12"`` in ``SensitivityEstimator._get_criterion`` to fix ``DeprecationWarning``.


### PR DESCRIPTION
Fixes #6453

Replaces the deprecated `np.char.chararray` with a standard NumPy array using `dtype="U12"` in the `_get_criterion` method of `SensitivityEstimator`.
