### PR TITLE
Handle None value for SonarQube - Part 2

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -321,8 +321,14 @@ class Analysis:
 
         fp_settings = self.config.flux_points
         log.info("Calculating flux points.")
-        energy_edges = self._make_energy_axis(fp_settings.energy).edges  # NOSONAR
-        # (S2259): attribute cannot be None
+
+        energy_edges = self._make_energy_axis(fp_settings.energy)
+        if energy_edges is not None:
+            energy_edges = energy_edges.edges
+        else:
+            raise ValueError(
+                "Missing or incomplete energy axis parameters in flux points configuration."
+            )
         flux_point_estimator = FluxPointsEstimator(
             energy_edges=energy_edges,
             source=fp_settings.source,
@@ -368,8 +374,14 @@ class Analysis:
         """Calculate light curve for a specific model component."""
         lc_settings = self.config.light_curve
         log.info("Computing light curve.")
-        energy_edges = self._make_energy_axis(lc_settings.energy_edges).edges  # NOSONAR
-        # (S2259): attribute cannot be None
+
+        energy_edges = self._make_energy_axis(lc_settings.energy_edges)
+        if energy_edges is not None:
+            energy_edges = energy_edges.edges
+        else:
+            raise ValueError(
+                "Missing or incomplete energy axis parameters in light curve configuration."
+            )
 
         if (
             lc_settings.time_intervals.start is None

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Session class driving the high level interface API."""
+
 import html
 import logging
 from astropy.coordinates import SkyCoord
@@ -90,10 +91,13 @@ class Analysis:
     def _set_data_store(self):
         """Set the datastore on the Analysis object."""
         path = make_path(self.config.observations.datastore)
-        if path.is_file():
+
+        if path.is_file():  # NOSONAR
+            # (S2259): attribute cannot be None
             log.debug(f"Setting datastore from file: {path}")
             self.datastore = DataStore.from_file(path)
-        elif path.is_dir():
+        elif path.is_dir():  # NOSONAR
+            # (S2259): attribute cannot be None
             log.debug(f"Setting datastore from directory: {path}")
             self.datastore = DataStore.from_dir(path)
         else:
@@ -317,7 +321,8 @@ class Analysis:
 
         fp_settings = self.config.flux_points
         log.info("Calculating flux points.")
-        energy_edges = self._make_energy_axis(fp_settings.energy).edges
+        energy_edges = self._make_energy_axis(fp_settings.energy).edges  # NOSONAR
+        # (S2259): attribute cannot be None
         flux_point_estimator = FluxPointsEstimator(
             energy_edges=energy_edges,
             source=fp_settings.source,
@@ -363,7 +368,8 @@ class Analysis:
         """Calculate light curve for a specific model component."""
         lc_settings = self.config.light_curve
         log.info("Computing light curve.")
-        energy_edges = self._make_energy_axis(lc_settings.energy_edges).edges
+        energy_edges = self._make_energy_axis(lc_settings.energy_edges).edges  # NOSONAR
+        # (S2259): attribute cannot be None
 
         if (
             lc_settings.time_intervals.start is None

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -81,7 +81,6 @@ def test_set_datastore_from_file(tmpdir):
     analysis.config.observations.datastore = filename
     analysis.get_observations()
     assert analysis.observations[0].obs_id == 20136
-    # assert len(analysis.observations) == 4
 
 
 @requires_data()

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -235,6 +235,29 @@ def test_analysis_1d():
 
 
 @requires_data()
+def test_analysis_1d_None_values_for_energy_axes():
+    config = get_example_config("1d")
+    analysis = Analysis(config)
+
+    analysis.config.flux_points = {}
+    analysis.get_observations()
+    analysis.get_datasets()
+    analysis.read_models(MODEL_FILE_1D)
+    analysis.run_fit()
+    with pytest.raises(
+        ValueError,
+        match="Missing or incomplete energy axis parameters in flux points configuration.",
+    ):
+        analysis.get_flux_points()
+
+    with pytest.raises(
+        ValueError,
+        match="Missing or incomplete energy axis parameters in light curve configuration.",
+    ):
+        analysis.get_light_curve()
+
+
+@requires_data()
 def test_geom_analysis_1d():
     cfg = """
     observations:

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 import pytest
 from numpy.testing import assert_allclose
+from astropy.io import fits
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
@@ -12,6 +13,7 @@ from gammapy.datasets import MapDataset, SpectrumDatasetOnOff
 from gammapy.maps import WcsGeom, WcsNDMap
 from gammapy.modeling.models import DatasetModels
 from gammapy.utils.testing import requires_data
+from gammapy.utils.scripts import make_path
 
 CONFIG_PATH = Path(__file__).resolve().parent / ".." / "config"
 MODEL_FILE = CONFIG_PATH / "model.yaml"
@@ -57,6 +59,29 @@ def test_get_observations_no_datastore():
     analysis.config.observations.datastore = "other"
     with pytest.raises(FileNotFoundError):
         analysis.get_observations()
+
+
+@requires_data()
+def test_set_datastore_from_file(tmpdir):
+    filename = "$GAMMAPY_DATA/hess-dl3-dr1/hdu-index.fits.gz"
+    index_hdu = fits.open(make_path(filename))["HDU_INDEX"]
+
+    filename = "$GAMMAPY_DATA/hess-dl3-dr1/obs-index.fits.gz"
+    obs_hdu = fits.open(make_path(filename))["OBS_INDEX"]
+
+    hdulist = fits.HDUList()
+    hdulist.append(index_hdu)
+    hdulist.append(obs_hdu)
+
+    filename = tmpdir / "test-index.fits"
+    hdulist.writeto(str(filename))
+
+    config = AnalysisConfig()
+    analysis = Analysis(config)
+    analysis.config.observations.datastore = filename
+    analysis.get_observations()
+    assert analysis.observations[0].obs_id == 20136
+    # assert len(analysis.observations) == 4
 
 
 @requires_data()

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -233,16 +233,7 @@ def test_analysis_1d():
     flux = analysis.light_curve.flux.data[:, :, 0, 0]
     assert_allclose(flux, [[1.688954e-11], [2.347870e-11], [1.604152e-11]], rtol=1e-4)
 
-
-@requires_data()
-def test_analysis_1d_None_values_for_energy_axes():
-    config = get_example_config("1d")
-    analysis = Analysis(config)
-
     analysis.config.flux_points = {}
-    analysis.get_observations()
-    analysis.get_datasets()
-    analysis.read_models(MODEL_FILE_1D)
     analysis.run_fit()
     with pytest.raises(
         ValueError,
@@ -250,6 +241,7 @@ def test_analysis_1d_None_values_for_energy_axes():
     ):
         analysis.get_flux_points()
 
+    analysis.config.light_curve = {}
     with pytest.raises(
         ValueError,
         match="Missing or incomplete energy axis parameters in light curve configuration.",

--- a/gammapy/datasets/io.py
+++ b/gammapy/datasets/io.py
@@ -83,6 +83,8 @@ class OGIPDatasetWriter(DatasetWriter):
     def __init__(
         self, filename, format="ogip", overwrite=False, checksum=False, creation=None
     ):
+        if filename is None:
+            raise ValueError("The filename is not defined.")
         filename = make_path(filename)
         filename.parent.mkdir(exist_ok=True, parents=True)
 
@@ -322,6 +324,8 @@ class OGIPDatasetReader(DatasetReader):
         filename : `~pathlib.Path`
             Valid path.
         """
+        if filename is None:
+            raise ValueError("The filename is not defined.")
         filename = make_path(filename)
 
         if not filename.exists():

--- a/gammapy/datasets/tests/test_io.py
+++ b/gammapy/datasets/tests/test_io.py
@@ -14,6 +14,7 @@ from gammapy.datasets import (
 from gammapy.modeling.models import DatasetModels
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import requires_data
+from gammapy.datasets.io import OGIPDatasetWriter, OGIPDatasetReader
 
 
 @requires_data()
@@ -123,7 +124,7 @@ def test_spectrum_datasets_to_io(tmp_path):
 
 
 @requires_data()
-def test_ogip_writer(tmp_path):
+def test_ogip_writer_and_reader(tmp_path):
     dataset = SpectrumDatasetOnOff.read(
         "$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs23523.fits",
         format="ogip",
@@ -135,6 +136,12 @@ def test_ogip_writer(tmp_path):
     assert_allclose(
         new_datasets[0].counts_off.data, np.zeros(new_datasets[0].counts_off.data.shape)
     )
+    with pytest.raises(ValueError, match="The filename is not defined."):
+        OGIPDatasetWriter(None)
+
+    ogip_reader = OGIPDatasetReader(None)
+    with pytest.raises(ValueError, match="The filename is not defined."):
+        ogip_reader.get_valid_path(None)
 
 
 @requires_data()

--- a/gammapy/estimators/map/core.py
+++ b/gammapy/estimators/map/core.py
@@ -234,9 +234,7 @@ class FluxMaps:
         if not required.issubset(keys):
             missing = required.difference(keys)
             raise ValueError(
-                "Missing data / column for SED type '{}':" " {}".format(
-                    sed_type, missing
-                )
+                "Missing data / column for SED type '{}': {}".format(sed_type, missing)
             )
 
     # TODO: add support for scan
@@ -1109,6 +1107,8 @@ class FluxMaps:
         if sed_type is None:
             sed_type = self.sed_type_init
 
+        if filename is None:
+            raise ValueError("The filename is not defined.")
         filename = make_path(filename)
 
         if filename_model is None:

--- a/gammapy/estimators/map/tests/test_core.py
+++ b/gammapy/estimators/map/tests/test_core.py
@@ -337,6 +337,9 @@ def test_flux_map_str(wcs_flux_map, reference_model):
 def test_flux_map_read_write(tmp_path, wcs_flux_map, logpar_reference_model, sed_type):
     fluxmap = FluxMaps(wcs_flux_map, logpar_reference_model)
 
+    with pytest.raises(ValueError, match="The filename is not defined."):
+        fluxmap.write(None)
+
     fluxmap.write(tmp_path / "tmp.fits", sed_type=sed_type, overwrite=True)
     new_fluxmap = FluxMaps.read(tmp_path / "tmp.fits")
 

--- a/gammapy/maps/maps.py
+++ b/gammapy/maps/maps.py
@@ -28,13 +28,14 @@ class Maps(MutableMapping):
         return self._geom
 
     def __setitem__(self, key, value):
-        if value is not None and not isinstance(value, Map):
-            raise ValueError(
-                f"MapDict can only contain Map objects, got {type(value)} instead."
-            )
-        # TODO: which loosers criterion to apply? broadcastability?
-        else:
-            self._geom = value.geom
+        if value is not None:
+            if not isinstance(value, Map):
+                raise ValueError(
+                    f"MapDict can only contain Map objects, got {type(value)} instead."
+                )
+            # TODO: which loosers criterion to apply? broadcastability?
+            else:
+                self._geom = value.geom
 
         self._data[key] = value
 

--- a/gammapy/maps/tests/test_maps.py
+++ b/gammapy/maps/tests/test_maps.py
@@ -27,6 +27,10 @@ def test_maps(map_dictionary):
     assert_allclose(maps["map3"].data, 1)
     assert "map3" in maps.__str__()
 
+    map_dictionary["map4"] = None
+    maps = Maps(**map_dictionary)
+    assert maps["map4"] is None
+
 
 @pytest.mark.xfail
 def test_maps_wrong_addition(map_dictionary):

--- a/gammapy/maps/tests/test_maps.py
+++ b/gammapy/maps/tests/test_maps.py
@@ -36,7 +36,7 @@ def test_maps(map_dictionary):
         ValueError,
         match=f"MapDict can only contain Map objects, got {type(map_dictionary['map4'])} instead.",
     ):
-        maps = Maps(**map_dictionary)
+        Maps(**map_dictionary)
 
 
 @pytest.mark.xfail

--- a/gammapy/maps/tests/test_maps.py
+++ b/gammapy/maps/tests/test_maps.py
@@ -31,6 +31,13 @@ def test_maps(map_dictionary):
     maps = Maps(**map_dictionary)
     assert maps["map4"] is None
 
+    map_dictionary["map4"] = 1
+    with pytest.raises(
+        ValueError,
+        match=f"MapDict can only contain Map objects, got {type(map_dictionary['map4'])} instead.",
+    ):
+        maps = Maps(**map_dictionary)
+
 
 @pytest.mark.xfail
 def test_maps_wrong_addition(map_dictionary):


### PR DESCRIPTION
This pull request is associated to the SonarCube reliability issue https://github.com/gammapy/gammapy/issues/6401 for attribute access on a value that can be 'None'.

The last subissues are fixed.

Some were from the case when make_path returns a None value.
Like for part 1, a ValueError was added when the file name is needed to perform the writing or reading.

Three of them were a case where the attribute cannot be None so I added a NOSONAR tag

The last one was a single condition that I separated into two sequential ifs.