### PR TITLE
Fix stale MapEvaluator position cache (#6492)

### DIFF
--- a/gammapy/datasets/evaluator.py
+++ b/gammapy/datasets/evaluator.py
@@ -131,7 +131,7 @@ class MapEvaluator:
         if isinstance(self.model, TemplateNPredModel):
             return False
         elif not self.contributes:
-            return False
+            return self.irf_position_changed
         elif self.exposure is None:
             return True
         elif self.geom.is_region:

--- a/gammapy/datasets/tests/test_evaluator.py
+++ b/gammapy/datasets/tests/test_evaluator.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import numpy as np
+from gammapy.datasets import MapDataset
 from copy import deepcopy
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -277,3 +278,45 @@ def test_norm_only_changed():
     spectral_model.amplitude.value *= 2
     spectral_model.index.value *= 2
     assert not evaluator.parameter_norm_only_changed
+
+
+def test_evaluator_position_cache_recovery():
+    """Test if the Evaluator position cache is properly synced when the model is moved out of and back into the FoV."""
+    energy_axis = MapAxis.from_energy_bounds(".1 TeV", "10 TeV", nbin=2, name="energy")
+    geom = WcsGeom.create(
+        skydir=(0, 0), width=1 * u.deg, axes=[energy_axis], frame="galactic"
+    )
+
+    dataset = MapDataset.create(geom=geom, name="test_dataset")
+    dataset.exposure = Map.from_geom(geom.as_energy_true, unit="m2 s")
+    dataset.exposure.data += 1.0
+
+    # Critical: A mask is required so that `contributes` can become False when the model is moved outside
+    dataset.mask_safe = Map.from_geom(geom, data=True)
+
+    spatial_model = PointSpatialModel(
+        lon_0=0 * u.deg, lat_0=0 * u.deg, frame="galactic"
+    )
+    model = SkyModel(
+        name="source",
+        spectral_model=PowerLawSpectralModel(),
+        spatial_model=spatial_model,
+    )
+    dataset.models = [model]
+
+    # 1. Initial npred
+    dataset.npred()
+
+    # 2. Move out of FoV
+    spatial_model.lon_0.value = 10.0
+    dataset.npred()
+
+    # 3. Move back to original position
+    spatial_model.lon_0.value = 0.0
+    dataset.npred()
+
+    # The fix ensures that the cache is recovered correctly
+    evaluator = dataset._evaluators["source"]
+    assert_allclose(
+        evaluator.position.separation(spatial_model.position).deg, 0.0, atol=1e-6
+    )


### PR DESCRIPTION

<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

Resolves #6492. This PR fixes an issue where the MapEvaluator position cache remained stale because the needs_update property incorrectly short-circuited to False when the model's contribution was False.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
