### PR TITLE
Update TSmapEstimator docstring for clarity

### DIFF
--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -61,7 +61,7 @@ def _extract_array(array, shape, position):
 
 class TSMapEstimator(Estimator, parallel.ParallelMixin):
     r"""Compute test statistic map from a MapDataset using different optimization methods.
-    The test statistic map is computed above the sky model defined in the dataset.
+    The test statistic map is computed over and above the sky model defined in the dataset.
 
     The map is computed fitting by a single parameter norm fit. The fit is
     simplified by finding roots of the derivative of the fit statistics using


### PR DESCRIPTION
Following a discussion at today's dev call : 

make it clear that this TS map is only what is above the sky model (ie a residual TS map).
Your source of interest should be excluded from the mode if you want to see it in the TS map.

The [ExcessMapEstimator](https://docs.gammapy.org/2.0.1/api/gammapy.estimators.ExcessMapEstimator.html) already specifies it but not the TSMap.


I also wonder if we should change the name of `model` to `kernel_model` because this is not the underlying Sky model used in the excess but the kernel model being tested at each position. This confused me a few times.

 https://github.com/facero/gammapy/blob/a842a71136145da47676e6d22548a8cc6ae48c68/gammapy/estimators/map/ts.py#L76
 
Parameter name `kernel_model` would then be consistent with `kernel_width`.
 One would need to change the example in the docstring and two tutorials  [detect](https://docs.gammapy.org/dev/tutorials/analysis-2d/detect.html), [CTA analysis](https://docs.gammapy.org/2.0.1/tutorials/analysis-3d/cta_data_analysis.html)  and [Fermi](https://docs.gammapy.org/2.0.1/tutorials/data/fermi_lat.html).

Note that this might introduce a break change if the user had specified `TSMapEstimator(model=model, ...)` but not if using `TSMapEstimator(model, ...) `

