### PR TITLE
Infra: Fetch depth from 1 to 0 for upstream repo

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -70,7 +70,7 @@ jobs:
         if: github.event.workflow_run.event == 'pull_request'
         run: |
           git remote add upstream https://github.com/${{ github.repository }}.git
-          git fetch upstream ${{ env.TARGET_BRANCH }} --depth=1
+          git fetch upstream ${{ env.TARGET_BRANCH }} --depth=0
 
       - name: Check artifact
         run: |


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

I think setting the fetch depth to 1 for the upstream is causing problems when trying to get the coverage report. I set it to 0, same as when checking out the repository.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
