### PR TITLE
INFRA: Add timeout to Jupytext tutorial workflow, use uv, and cache datasets

### DIFF
--- a/.github/workflows/tutorialjupytexttests.yml
+++ b/.github/workflows/tutorialjupytexttests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   execute-tutorials:
     runs-on: ubuntu-latest
-    timeout-minutes: 45  # Usual run-time is less than 30 min
+    timeout-minutes: 60  # Usual run-time is less than 30 min
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     env:

--- a/.github/workflows/tutorialjupytexttests.yml
+++ b/.github/workflows/tutorialjupytexttests.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   execute-tutorials:
     runs-on: ubuntu-latest
+    timeout-minutes: 45  # Usual run-time is about 30 min
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     env:

--- a/.github/workflows/tutorialjupytexttests.yml
+++ b/.github/workflows/tutorialjupytexttests.yml
@@ -15,27 +15,46 @@ jobs:
       GAMMAPY_DATA: /home/runner/work/gammapy/gammapy/gammapy-datasets/dev
 
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Install uv + Python
+      - name: Install uv
         uses: astral-sh/setup-uv@v8
         with:
           python-version: '3.13'
           enable-cache: true
 
-      - name: Create virtual environment
-        run: uv venv
-
       - name: Install Gammapy and needed dependencies
         run: |
-          uv pip install jupyter jupytext jupyter_client ipykernel
-          uv pip install -e ".[all]"
+          uv add jupyter jupytext jupyter_client ipykernel
+          uv sync --locked --extra all --dev
 
-      - name: Download datasets
-        run: uv run gammapy download dataset
+      # Get latest commit SHA from gammapy-data main branch
+      - name: Get gammapy-data version
+        id: gammapy-data-version
+        run: |
+          COMMIT_SHA=$(curl -s https://api.github.com/repos/gammapy/gammapy-data/commits/main | jq -r '.sha[0:7]')
+          echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "Latest gammapy-data commit: $COMMIT_SHA"
+
+      - name: Cache gammapy-datasets
+        id: cache-gammapy-datasets
+        uses: actions/cache@v5
+        with:
+          path: gammapy-datasets
+          key: gammapy-datasets-${{ steps.gammapy-data-version.outputs.sha }}
+          restore-keys: |
+            gammapy-datasets-
+
+      - name: Download gammapy-datasets only if not cached
+        run: |
+          if [ "${{ steps.cache-gammapy-datasets.outputs.cache-hit }}" != "true" ]; then
+            echo "Cache miss - downloading gammapy-datasets"
+            uv run gammapy download dataset
+          else
+            echo "Using cached gammapy-datasets"
+          fi
 
       - name: Register Jupyter kernel
         run: uv run python -m ipykernel install --name gammapy-dev --user

--- a/.github/workflows/tutorialjupytexttests.yml
+++ b/.github/workflows/tutorialjupytexttests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   execute-tutorials:
     runs-on: ubuntu-latest
-    timeout-minutes: 45  # Usual run-time is about 30 min
+    timeout-minutes: 45  # Usual run-time is less than 30 min
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     env:
@@ -20,21 +20,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - name: Install uv + Python
+        uses: astral-sh/setup-uv@v8
         with:
-          python-version: '3.13' 
+          python-version: '3.13'
+          enable-cache: true
+
+      - name: Create virtual environment
+        run: uv venv
 
       - name: Install Gammapy and needed dependencies
         run: |
-          pip install --upgrade pip
-          pip install jupyter jupytext jupyter_client ipykernel 
-          pip install .[all]
+          uv pip install jupyter jupytext jupyter_client ipykernel
+          uv pip install -e ".[all]"
 
       - name: Download datasets
-        run: |
-          gammapy download datasets
+        run: uv run gammapy download dataset
+
+      - name: Register Jupyter kernel
+        run: uv run python -m ipykernel install --name gammapy-dev --user
 
       - name: Execute tutorials with Jupytext
-        run: |
-          python -m ipykernel install --name gammapy-dev --user
-          jupytext --execute examples/tutorials/*/*.py
+        run: uv run jupytext --execute examples/tutorials/*/*.py

--- a/.github/workflows/tutorialjupytexttests.yml
+++ b/.github/workflows/tutorialjupytexttests.yml
@@ -24,11 +24,12 @@ jobs:
         with:
           python-version: '3.13'
           enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
 
       - name: Install Gammapy and needed dependencies
         run: |
-          uv add jupyter jupytext jupyter_client ipykernel
-          uv sync --locked --extra all --dev
+          uv sync --extra all_no_ray --extra test_notebooks
 
       # Get latest commit SHA from gammapy-data main branch
       - name: Get gammapy-data version

--- a/.github/workflows/tutorialjupytexttests.yml
+++ b/.github/workflows/tutorialjupytexttests.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           if [ "${{ steps.cache-gammapy-datasets.outputs.cache-hit }}" != "true" ]; then
             echo "Cache miss - downloading gammapy-datasets"
-            uv run gammapy download dataset
+            uv run gammapy download datasets
           else
             echo "Using cached gammapy-datasets"
           fi

--- a/.github/workflows/tutorialjupytexttests.yml
+++ b/.github/workflows/tutorialjupytexttests.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: '3.13'
           enable-cache: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,12 @@ docs = [
     "nbformat",
     "docutils",
 ]
+test_notebooks = [
+    "jupyter",
+    "jupytext",
+    "jupyter_client",
+    "ipykernel"
+]
 
 [tool.setuptools.packages.find]
 include = ["gammapy*"]


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request adds timeout of 1 hour to avoid running for up to 6 h when there are problems, which can increase the budget of time used by GH actions.

I also added:
 - cache of gammapy datasets (from 20 s to a few seconds)
 - uv installation with caching (from 3 min to 10 seconds)

This reduces the overall time from 23 min to 17 min

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
Ready for review