### PR TITLE
Update codemeta2zenodo action to version 1.3.0

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -39,7 +39,7 @@ jobs:
           eossr-metadata-validator codemeta.json
 
       - name: Convert CodeMeta to Zenodo
-        uses: escape2020/codemeta2zenodo@v1.2.0
+        uses: escape2020/codemeta2zenodo@v1.3.0
         if: success()
         with:
           overwrite: true


### PR DESCRIPTION
This adds support to convert CodeMeta `@id` into Zenodo ORCID

See comment here: https://github.com/gammapy/gammapy/pull/6500#issuecomment-4183189073