### PR TITLE
Adapt "Choose units for plotting " HowTo for ISU units

### DIFF
--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -117,7 +117,7 @@ Please give feedback and suggest additions to this page!
         fp.plot(ax=ax, sed_type="e2dnde")
 
     By default Gammapy uses bracket notation for axis labels (e.g. ``Energy [TeV] ``).
-    According to International System of Units the formally correct notation is ``quantity / unit `` ,
+    According to International System of Units the formally correct notation is ``quantity / unit``
     (e.g. ``Energy / TeV`` ).
     To apply this , override the axis labels manually after plotting :
 

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -116,33 +116,25 @@ Please give feedback and suggest additions to this page!
         ax.yaxis.set_units(u.Unit("erg cm-2 s-1"))
         fp.plot(ax=ax, sed_type="e2dnde")
 
-    By default Gammapy uses bracket notation for axis labels (e.g. ``Energy [TeV]``).
-    According to International System of Units the recommended notation is ``quantity / unit``
-    (e.g. ``Energy / TeV`` ).
-    To apply this,override the axis labels manually after plotting:
+    By default, Gammapy uses bracket notation for its axis labels (e.g. ``Energy [TeV]``).
+    According to the International System of Units (`ISU <https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf>`_) the recommended notation is ``quantity / unit``
+    (e.g. ``Energy / TeV``).
+    To adopt these standards one can override the axis labels manually after creating the plot:
 
     .. code::
 
         ax.set_xlabel(r"$E$ / eV")
         ax.set_ylabel(r"$E^2 \, \mathrm{d}N/\mathrm{d}E$ / (erg cm$^{-2}$ s$^{-1}$)")
 
-    Alternatively you can change this behaviour globally for all plots by updating
-    the default label template.
-
-    For modeling plots:
-
-    .. code::
-
-        from gammapy.modeling.models import spectral
-        spectral.DEFAULT_LABEL_TEMPLATE = "{quantity} / {unit}"
-
-    For estimator plots:
+    Alternatively, you can change this behaviour globally for all plots by updating
+    the default label template. An example of this for an estimator plot is:
 
     .. code::
 
         from gammapy.estimators import points
         points.core.DEFAULT_LABEL_TEMPLATE = "{quantity} / {unit}"
 
+    Similarly adapt `gammapy.modeling.models.spectral.DEFAULT_LABEL_TEMPLATE` for spectral models.
 
 .. dropdown:: Compute the significance of a source
     :name: dropdown-src-sig

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -116,6 +116,15 @@ Please give feedback and suggest additions to this page!
         ax.yaxis.set_units(u.Unit("erg cm-2 s-1"))
         fp.plot(ax=ax, sed_type="e2dnde")
 
+    By default Gammapy uses bracket notation for axis labels (e.g. ``Energy [TeV] ``).
+    According to International System of Units the formally correct notation is ``quantity / unit `` ,
+    (e.g. ``Energy / TeV`` ).
+    To apply this , override the axis labels manually after plotting :
+
+    .. code::
+        ax.set_xlabel(r"$E$ / eV")
+        ax.set_ylabel(r"$E^2 \, \mathrm{d}N/\mathrm{d}E$ / (erg cm$^{-2}$ s$^{-1}$)")
+
 
 .. dropdown:: Compute the significance of a source
     :name: dropdown-src-sig

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -116,7 +116,7 @@ Please give feedback and suggest additions to this page!
         ax.yaxis.set_units(u.Unit("erg cm-2 s-1"))
         fp.plot(ax=ax, sed_type="e2dnde")
 
-    By default Gammapy uses bracket notation for axis labels (e.g. ``Energy [TeV] ``).
+    By default Gammapy uses bracket notation for axis labels (e.g. ``Energy [TeV]``).
     According to International System of Units the recommended notation is ``quantity / unit``
     (e.g. ``Energy / TeV`` ).
     To apply this,override the axis labels manually after plotting:
@@ -125,6 +125,23 @@ Please give feedback and suggest additions to this page!
 
         ax.set_xlabel(r"$E$ / eV")
         ax.set_ylabel(r"$E^2 \, \mathrm{d}N/\mathrm{d}E$ / (erg cm$^{-2}$ s$^{-1}$)")
+
+    Alternatively you can change this behaviour globally for all plots by updating
+    the default label template.
+
+    For modeling plots:
+
+    .. code::
+
+        from gammapy.modeling.models import spectral
+        spectral.DEFAULT_LABEL_TEMPLATE = "{quantity} / {unit}"
+
+    For estimator plots:
+
+    .. code::
+
+        from gammapy.estimators import points
+        points.core.DEFAULT_LABEL_TEMPLATE = "{quantity} / {unit}"
 
 
 .. dropdown:: Compute the significance of a source

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -117,11 +117,12 @@ Please give feedback and suggest additions to this page!
         fp.plot(ax=ax, sed_type="e2dnde")
 
     By default Gammapy uses bracket notation for axis labels (e.g. ``Energy [TeV] ``).
-    According to International System of Units the formally correct notation is ``quantity / unit``
+    According to International System of Units the recommended notation is ``quantity / unit``
     (e.g. ``Energy / TeV`` ).
-    To apply this , override the axis labels manually after plotting :
+    To apply this,override the axis labels manually after plotting:
 
     .. code::
+
         ax.set_xlabel(r"$E$ / eV")
         ax.set_ylabel(r"$E^2 \, \mathrm{d}N/\mathrm{d}E$ / (erg cm$^{-2}$ s$^{-1}$)")
 

--- a/docs/user-guide/howto.rst
+++ b/docs/user-guide/howto.rst
@@ -117,8 +117,9 @@ Please give feedback and suggest additions to this page!
         fp.plot(ax=ax, sed_type="e2dnde")
 
     By default, Gammapy uses bracket notation for its axis labels (e.g. ``Energy [TeV]``).
-    According to the International System of Units (`ISU <https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf>`_) the recommended notation is ``quantity / unit``
-    (e.g. ``Energy / TeV``).
+    According to the International System of Units
+    (`ISU <https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf>`_)
+    the recommended notation is ``quantity / unit`` (e.g. ``Energy / TeV``).
     To adopt these standards one can override the axis labels manually after creating the plot:
 
     .. code::
@@ -134,7 +135,8 @@ Please give feedback and suggest additions to this page!
         from gammapy.estimators import points
         points.core.DEFAULT_LABEL_TEMPLATE = "{quantity} / {unit}"
 
-    Similarly adapt `gammapy.modeling.models.spectral.DEFAULT_LABEL_TEMPLATE` for spectral models.
+    Similarly, one can adapt
+    `gammapy.modeling.models.spectral.DEFAULT_LABEL_TEMPLATE` for spectral models.
 
 .. dropdown:: Compute the significance of a source
     :name: dropdown-src-sig


### PR DESCRIPTION
This PR adapts  the `"Choose units for plotting" HowTo` to show users how to apply ISU standard axis labels,
 the addition shows how to manually override axis labels after plotting using `ax.set_xlabel()` and `ax.set_ylabel()`.
closes #5749 