### PR TITLE
Add backend for Nautilus sampler

### DIFF
--- a/docs/release-notes/feature.6596.rst
+++ b/docs/release-notes/feature.6596.rst
@@ -1,0 +1,1 @@
+Add nautilus-sampler as a possible `~gammapy.modeling.Sampler` backend.

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -49,6 +49,7 @@ dependencies:
   - ultranest
   - numba
   - arviz
+  - nautilus-sampler
   # dev dependencies
   - black=22.6.0
   - codespell

--- a/gammapy/estimators/points/tests/test_collection.py
+++ b/gammapy/estimators/points/tests/test_collection.py
@@ -86,7 +86,7 @@ class MockSamplerMulti(Sampler):
     """Mock sampler for multiple-source."""
 
     def __init__(self, ns=1):
-        super().__init__(backend="mock", sampler_opts={})
+        super().__init__(sampler_opts={})
         self.ns = ns
 
     def run(self, datasets):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -754,6 +754,28 @@ class Parameters(collections.abc.Sequence):
         else:
             raise TypeError(f"Invalid type: {other!r}")
 
+    def _prior_inverse_cdf(self, values):
+        """Returns a list of parameters for a given list of values (that are bound in [0,1]).
+
+        This is obtained by inverting the parameter prior cdf. This requires that priors are
+        set on every parameter. This is used by nested sampling algorithms.
+
+        Parameters
+        ----------
+        values : numpy.array or list of float
+            Input prior values. Expected to be within [0,1].
+
+        Returns
+        -------
+        param_values : list of float
+            List of parameter values corresponding to input priors.
+        """
+        if None in self.prior:
+            raise ValueError(
+                "Some parameters have no prior set. You need priors on all parameters."
+            )
+        return [par.prior._inverse_cdf(val) for par, val in zip(self, values)]
+
     def to_dict(self):
         data = []
 

--- a/gammapy/modeling/sampler.py
+++ b/gammapy/modeling/sampler.py
@@ -87,6 +87,8 @@ class Sampler:
             self.sampler_opts.setdefault("resume", True)
             self.run_opts.setdefault("f_live", 0.01)
             self.run_opts.setdefault("n_eff", 10000)
+        else:
+            raise ValueError(f"Sampler {self.backend} is not supported.")
 
     @staticmethod
     def _update_models_from_posterior(models, result):
@@ -225,10 +227,10 @@ class Sampler:
         datasets, parameters = _parse_datasets(datasets=datasets)
         parameters = parameters.free_unique_parameters
 
+        like = SamplerLikelihood(
+            function=datasets._stat_sum_likelihood, parameters=parameters
+        )
         if self.backend == "ultranest":
-            like = SamplerLikelihood(
-                function=datasets._stat_sum_likelihood, parameters=parameters
-            )
             result_dict = self.sampler_ultranest(parameters, like)
             self._sampler.print_results()
 
@@ -239,8 +241,17 @@ class Sampler:
             result.models = models_copy
 
             return result
-        else:
-            raise ValueError(f"Sampler {self.backend} is not supported.")
+        elif self.backend == "nautilus":
+            result_dict = self.sampler_nautilus(parameters, like)
+            self._sampler.print_status()
+
+            models_copy = datasets.models.copy()
+            self._update_models_from_posterior(models_copy, result_dict)
+
+            result = SamplerResult.from_nautilus(result_dict)
+            result.models = models_copy
+
+            return result
 
 
 class SamplerResult:

--- a/gammapy/modeling/sampler.py
+++ b/gammapy/modeling/sampler.py
@@ -5,6 +5,8 @@ from .utils import _parse_datasets
 
 __all__ = ["Sampler", "SamplerLikelihood", "SamplerResult"]
 
+SAMPLER_BACKENDS = {"ultranest", "nautilus"}
+
 
 class Sampler:
     """Sampler class.
@@ -82,11 +84,12 @@ class Sampler:
             self.sampler_opts.setdefault("step_sampler", False)
             self.sampler_opts.setdefault("nsteps", 10)
         elif self.backend == "nautilus":
-            self.sampler_opts.setdefault("n_live", 2000)
+            self.sampler_opts.setdefault("n_live", 400)
             self.sampler_opts.setdefault("filepath", None)
             self.sampler_opts.setdefault("resume", True)
             self.run_opts.setdefault("f_live", 0.01)
-            self.run_opts.setdefault("n_eff", 10000)
+            self.run_opts.setdefault("n_eff", 2000)
+            self.run_opts.setdefault("verbose", True)
         else:
             raise ValueError(f"Sampler {self.backend} is not supported.")
 
@@ -295,6 +298,15 @@ class SamplerResult:
         kwargs["success"] = ultranest_result["insertion_order_MWW_test"]["converged"]
         kwargs["samples"] = ultranest_result["samples"]
         kwargs["sampler_results"] = ultranest_result
+        return cls(**kwargs)
+
+    @classmethod
+    def from_nautilus(cls, nautilus_result):
+        kwargs = {}
+        kwargs["nfev"] = nautilus_result["ncall"]
+        kwargs["success"] = nautilus_result["success"]
+        kwargs["samples"] = nautilus_result["samples"]
+        kwargs["sampler_results"] = nautilus_result
         return cls(**kwargs)
 
 

--- a/gammapy/modeling/sampler.py
+++ b/gammapy/modeling/sampler.py
@@ -145,18 +145,10 @@ class Sampler:
         """
         import ultranest
 
-        def _prior_inverse_cdf(values):
-            """Returns a list of model parameters for a given list of values (that are bound in [0,1])."""
-            if None in parameters.prior:
-                raise ValueError(
-                    "Some parameters have no prior set. You need priors on all parameters."
-                )
-            return [par.prior._inverse_cdf(val) for par, val in zip(parameters, values)]
-
         self._sampler = ultranest.ReactiveNestedSampler(
             parameters.names,
             like.fcn,
-            transform=_prior_inverse_cdf,
+            transform=parameters._prior_inverse_cdf,
             log_dir=self.sampler_opts["log_dir"],
             resume=self.sampler_opts["resume"],
         )
@@ -184,15 +176,8 @@ class Sampler:
         import nautilus
         import numpy as np
 
-        def _prior_inverse_cdf(values):
-            if None in parameters.prior:
-                raise ValueError(
-                    "Some parameters have no prior set. You need priors on all parameters."
-                )
-            return [par.prior._inverse_cdf(val) for par, val in zip(parameters, values)]
-
         self._sampler = nautilus.Sampler(
-            prior=_prior_inverse_cdf,
+            prior=parameters._prior_inverse_cdf,
             likelihood=like.fcn,
             n_dim=len(parameters),
             n_live=self.sampler_opts["n_live"],

--- a/gammapy/modeling/sampler.py
+++ b/gammapy/modeling/sampler.py
@@ -5,7 +5,24 @@ from .utils import _parse_datasets
 
 __all__ = ["Sampler", "SamplerLikelihood", "SamplerResult"]
 
-SAMPLER_BACKENDS = {"ultranest", "nautilus"}
+SAMPLER_BACKENDS = ["ultranest", "nautilus"]
+
+DEFAULT_SAMPLER_OPTS = {
+    "ultranest": {
+        "live_points": 400,
+        "frac_remain": 0.5,
+        "log_dir": None,
+        "resume": "subfolder",
+        "step_sampler": False,
+        "nsteps": 10,
+    },
+    "nautilus": {"n_live": 2000, "filepath": None, "resume": True},
+}
+
+DEFAULT_RUN_OPTS = {
+    "ultranest": {},
+    "nautilus": {"f_live": 0.01, "n_eff": 2000, "verbose": True},
+}
 
 
 class Sampler:
@@ -71,27 +88,18 @@ class Sampler:
     # TODO: add "zeusmc", "emcee"
 
     def __init__(self, backend="ultranest", sampler_opts=None, run_opts=None):
+        if backend not in SAMPLER_BACKENDS:
+            raise ValueError(f"Sampler {backend} is not supported.")
+
         self._sampler = None
         self.backend = backend
         self.sampler_opts = {} if sampler_opts is None else sampler_opts
         self.run_opts = {} if run_opts is None else run_opts
 
-        if self.backend == "ultranest":
-            self.sampler_opts.setdefault("live_points", 400)
-            self.sampler_opts.setdefault("frac_remain", 0.5)
-            self.sampler_opts.setdefault("log_dir", None)
-            self.sampler_opts.setdefault("resume", "subfolder")
-            self.sampler_opts.setdefault("step_sampler", False)
-            self.sampler_opts.setdefault("nsteps", 10)
-        elif self.backend == "nautilus":
-            self.sampler_opts.setdefault("n_live", 400)
-            self.sampler_opts.setdefault("filepath", None)
-            self.sampler_opts.setdefault("resume", True)
-            self.run_opts.setdefault("f_live", 0.01)
-            self.run_opts.setdefault("n_eff", 2000)
-            self.run_opts.setdefault("verbose", True)
-        else:
-            raise ValueError(f"Sampler {self.backend} is not supported.")
+        for key, value in DEFAULT_SAMPLER_OPTS[backend].items():
+            self.sampler_opts.setdefault(key, value)
+        for key, value in DEFAULT_RUN_OPTS[backend].items():
+            self.run_opts.setdefault(key, value)
 
     @staticmethod
     def _update_models_from_posterior(models, result):
@@ -177,7 +185,7 @@ class Sampler:
         import numpy as np
 
         def _prior_inverse_cdf(values):
-            if None in parameters:
+            if None in parameters.prior:
                 raise ValueError(
                     "Some parameters have no prior set. You need priors on all parameters."
                 )
@@ -194,7 +202,6 @@ class Sampler:
 
         success = self._sampler.run(**self.run_opts)
 
-        # Build a result dict compatible with the rest of the pipeline
         points, log_w, log_l = self._sampler.posterior()
         weights = np.exp(log_w - log_w.max())
         weights /= weights.sum()
@@ -236,25 +243,16 @@ class Sampler:
         if self.backend == "ultranest":
             result_dict = self.sampler_ultranest(parameters, like)
             self._sampler.print_results()
-
-            models_copy = datasets.models.copy()
-            self._update_models_from_posterior(models_copy, result_dict)
-
             result = SamplerResult.from_ultranest(result_dict)
-            result.models = models_copy
-
-            return result
         elif self.backend == "nautilus":
             result_dict = self.sampler_nautilus(parameters, like)
             self._sampler.print_status()
-
-            models_copy = datasets.models.copy()
-            self._update_models_from_posterior(models_copy, result_dict)
-
             result = SamplerResult.from_nautilus(result_dict)
-            result.models = models_copy
 
-            return result
+        models_copy = datasets.models.copy()
+        self._update_models_from_posterior(models_copy, result_dict)
+        result.models = models_copy
+        return result
 
 
 class SamplerResult:

--- a/gammapy/modeling/sampler.py
+++ b/gammapy/modeling/sampler.py
@@ -13,10 +13,12 @@ class Sampler:
 
     Parameters
     ----------
-    backend : {"ultranest"}
+    backend : {"ultranest", "nautilus"}
         Global backend used for sampler. Default is "ultranest".
         UltraNest: Most options can be found in the
         `UltraNest doc <https://johannesbuchner.github.io/UltraNest/>`__.
+        Nautilus uses neural-network-guided nested sampling. See the
+    `   `Nautilus documentation <https://nautilus-sampler.readthedocs.io/>`__.
     sampler_opts : dict, optional
         Sampler options passed to the sampler. See the full list of options on the
         `UltraNest documentation <https://johannesbuchner.github.io/UltraNest/ultranest.html#ultranest.integrator.ReactiveNestedSampler>`__.
@@ -79,6 +81,12 @@ class Sampler:
             self.sampler_opts.setdefault("resume", "subfolder")
             self.sampler_opts.setdefault("step_sampler", False)
             self.sampler_opts.setdefault("nsteps", 10)
+        elif self.backend == "nautilus":
+            self.sampler_opts.setdefault("n_live", 2000)
+            self.sampler_opts.setdefault("filepath", None)
+            self.sampler_opts.setdefault("resume", True)
+            self.run_opts.setdefault("f_live", 0.01)
+            self.run_opts.setdefault("n_eff", 10000)
 
     @staticmethod
     def _update_models_from_posterior(models, result):
@@ -157,6 +165,47 @@ class Sampler:
             **self.run_opts,
         )
 
+        return result
+
+    def sampler_nautilus(self, parameters, like):
+        import nautilus
+        import numpy as np
+
+        def _prior_inverse_cdf(values):
+            if None in parameters:
+                raise ValueError(
+                    "Some parameters have no prior set. You need priors on all parameters."
+                )
+            return [par.prior._inverse_cdf(val) for par, val in zip(parameters, values)]
+
+        self._sampler = nautilus.Sampler(
+            prior=_prior_inverse_cdf,
+            likelihood=like.fcn,
+            n_dim=len(parameters),
+            n_live=self.sampler_opts["n_live"],
+            filepath=self.sampler_opts["filepath"],
+            resume=self.sampler_opts["resume"],
+        )
+
+        success = self._sampler.run(**self.run_opts)
+
+        # Build a result dict compatible with the rest of the pipeline
+        points, log_w, log_l = self._sampler.posterior()
+        weights = np.exp(log_w - log_w.max())
+        weights /= weights.sum()
+        mean = np.average(points, weights=weights, axis=0)
+        stdev = np.sqrt(np.average((points - mean) ** 2, weights=weights, axis=0))
+
+        result = {
+            "ncall": self._sampler.n_like,
+            "success": success,
+            "logz": self._sampler.log_z,
+            "posterior": {"mean": mean, "stdev": stdev},
+            "samples": self._sampler.posterior(equal_weight=True)[0],
+            "points": points,
+            "log_w": log_w,
+            "log_l": log_l,
+        }
         return result
 
     def run(self, datasets):

--- a/gammapy/modeling/tests/test_sampler.py
+++ b/gammapy/modeling/tests/test_sampler.py
@@ -1,10 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
-from gammapy.utils.testing import requires_data, requires_dependency
+import importlib
+from gammapy.utils.testing import requires_data
 from numpy.testing import assert_allclose
 from gammapy.modeling.models import SkyModel
 from gammapy.datasets import Datasets, SpectrumDatasetOnOff
-from gammapy.modeling.sampler import Sampler
+from gammapy.modeling.sampler import Sampler, SAMPLER_BACKENDS
 from gammapy.modeling.models import (
     UniformPrior,
     LogUniformPrior,
@@ -12,56 +13,60 @@ from gammapy.modeling.models import (
     Models,
 )
 
+tested_backends = [_ for _ in SAMPLER_BACKENDS if importlib.util.find_spec(_)]
 
-@requires_dependency("ultranest")
-@requires_data()
-def test_run_missing_prior(backend="ultranest"):
+
+@pytest.fixture()
+def datasets_sampler():
     datasets = Datasets()
     for obs_id in [23523, 23526]:
         dataset = SpectrumDatasetOnOff.read(
             f"$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs{obs_id}.fits"
         )
         datasets.append(dataset)
+    return datasets
 
+
+@pytest.fixture()
+def models_sampler():
     pwl1 = PowerLawSpectralModel(index=2.3)
     pwl1.amplitude.prior = LogUniformPrior(min=1e-12, max=1e-10)
+    pwl1.index.prior = UniformPrior(min=2, max=3)
+    return Models([SkyModel(pwl1, name="source1")])
 
-    models = Models([SkyModel(pwl1, name="source1")])
-    datasets.models = models
+
+def test_invalid_backend_raises():
+    with pytest.raises(ValueError, match="unknown_backend"):
+        Sampler(backend="unknown_backend")
+
+
+@pytest.mark.parametrize("backend", tested_backends)
+@requires_data()
+def test_run_missing_prior(backend, datasets_sampler, models_sampler):
+    models_sampler[0].spectral_model.index.prior = None
+    datasets_sampler.models = models_sampler
 
     sampler_opts = {"live_points": 300}
     sampler = Sampler(backend=backend, sampler_opts=sampler_opts)
     with pytest.raises(ValueError):
-        sampler.run(datasets)
+        sampler.run(datasets_sampler)
 
 
-@requires_dependency("ultranest")
+@pytest.mark.parametrize("backend", tested_backends)
 @requires_data()
-def test_run(backend="ultranest"):
-    datasets = Datasets()
-    for obs_id in [23523, 23526]:
-        dataset = SpectrumDatasetOnOff.read(
-            f"$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs{obs_id}.fits"
-        )
-        datasets.append(dataset)
-
-    pwl1 = PowerLawSpectralModel(index=2.3)
-    pwl1.amplitude.prior = LogUniformPrior(min=1e-12, max=1e-10)
-    pwl1.index.prior = UniformPrior(min=2, max=3)
-
-    models = Models([SkyModel(pwl1, name="source1")])
-    datasets.models = models
+def test_run(backend, datasets_sampler, models_sampler):
+    datasets_sampler.models = models_sampler
 
     sampler_opts = {"live_points": 300}
     sampler = Sampler(backend=backend, sampler_opts=sampler_opts)
 
-    result = sampler.run(datasets)
+    result = sampler.run(datasets_sampler)
 
     assert result.success
     assert sampler._sampler.min_num_live_points == sampler_opts["live_points"]
     assert (
         result.samples.shape[1]
-        == datasets.models.parameters.free_unique_parameters.value.shape[0]
+        == datasets_sampler.models.parameters.free_unique_parameters.value.shape[0]
     )
 
     required_keys = [
@@ -99,38 +104,27 @@ def test_run(backend="ultranest"):
     assert result.models._covariance is None
 
 
-@requires_dependency("ultranest")
+@pytest.mark.parametrize("backend", tested_backends)
 @requires_data()
-def test_run_linked_params(backend="ultranest"):
-    datasets = Datasets()
-    for obs_id in [23523, 23526]:
-        dataset = SpectrumDatasetOnOff.read(
-            f"$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs{obs_id}.fits"
-        )
-        datasets.append(dataset)
-
-    # test with linked parameters
-    pwl1 = PowerLawSpectralModel(index=2.3)
-    pwl1.amplitude.prior = LogUniformPrior(min=1e-12, max=1e-10)
-    pwl1.index.prior = UniformPrior(min=2, max=3)
-
+def test_run_linked_params(backend, datasets_sampler, models_sampler):
+    pwl1 = models_sampler[0].spectral_model
     pwl2 = PowerLawSpectralModel()
     pwl2.index = pwl1.index
     pwl2.amplitude = pwl1.amplitude
 
-    models = Models([SkyModel(pwl1, name="source1"), SkyModel(pwl2, name="source2")])
-    datasets.models = models
+    models_sampler.append(SkyModel(pwl2, name="source2"))
+    datasets_sampler.models = models_sampler
 
     sampler_opts = {"live_points": 300}
     sampler = Sampler(backend=backend, sampler_opts=sampler_opts)
 
-    result = sampler.run(datasets)
+    result = sampler.run(datasets_sampler)
 
     assert result.success
     assert sampler._sampler.min_num_live_points == sampler_opts["live_points"]
     assert (
         result.samples.shape[1]
-        == datasets.models.parameters.free_unique_parameters.value.shape[0]
+        == datasets_sampler.models.parameters.free_unique_parameters.value.shape[0]
     )
 
     required_keys = [

--- a/gammapy/modeling/tests/test_sampler.py
+++ b/gammapy/modeling/tests/test_sampler.py
@@ -47,16 +47,15 @@ def test_sampler_nautilus_defaults():
 
 
 def test_sampler_nautilus_defaults_can_be_overridden():
-    """User-supplied sampler_opts and run_opts take precedence over defaults."""
     sampler = Sampler(
         backend="nautilus",
-        sampler_opts={"n_live": 500, "filepath": "/tmp/ns_run"},
+        sampler_opts={"n_live": 500, "filepath": "test"},
         run_opts={"f_live": 0.001, "n_eff": 500},
     )
 
     assert sampler.sampler_opts["n_live"] == 500
-    assert sampler.sampler_opts["filepath"] == "/tmp/ns_run"
-    assert sampler.run_opts["f_live"] == pytest.approx(0.001)
+    assert sampler.sampler_opts["filepath"] == "test"
+    assert_allclose(sampler.run_opts["f_live"], 0.001)
     assert sampler.run_opts["n_eff"] == 500
 
 

--- a/gammapy/modeling/tests/test_sampler.py
+++ b/gammapy/modeling/tests/test_sampler.py
@@ -35,6 +35,31 @@ def models_sampler():
     return Models([SkyModel(pwl1, name="source1")])
 
 
+def test_sampler_nautilus_defaults():
+    sampler = Sampler(backend="nautilus")
+
+    assert sampler.backend == "nautilus"
+    assert sampler.sampler_opts["n_live"] == 2000
+    assert sampler.sampler_opts["filepath"] is None
+    assert sampler.sampler_opts["resume"] is True
+    assert_allclose(sampler.run_opts["f_live"], 0.01)
+    assert sampler.run_opts["n_eff"] == 2000
+
+
+def test_sampler_nautilus_defaults_can_be_overridden():
+    """User-supplied sampler_opts and run_opts take precedence over defaults."""
+    sampler = Sampler(
+        backend="nautilus",
+        sampler_opts={"n_live": 500, "filepath": "/tmp/ns_run"},
+        run_opts={"f_live": 0.001, "n_eff": 500},
+    )
+
+    assert sampler.sampler_opts["n_live"] == 500
+    assert sampler.sampler_opts["filepath"] == "/tmp/ns_run"
+    assert sampler.run_opts["f_live"] == pytest.approx(0.001)
+    assert sampler.run_opts["n_eff"] == 500
+
+
 def test_invalid_backend_raises():
     with pytest.raises(ValueError, match="unknown_backend"):
         Sampler(backend="unknown_backend")
@@ -57,13 +82,17 @@ def test_run_missing_prior(backend, datasets_sampler, models_sampler):
 def test_run(backend, datasets_sampler, models_sampler):
     datasets_sampler.models = models_sampler
 
-    sampler_opts = {"live_points": 300}
-    sampler = Sampler(backend=backend, sampler_opts=sampler_opts)
+    if backend == "ultranest":
+        sampler_opts = {"live_points": 300}
+        run_opts = {}
+    elif backend == "nautilus":
+        sampler_opts = {"nlive": 300}
+        run_opts = {"n_eff": 200}
+    sampler = Sampler(backend=backend, sampler_opts=sampler_opts, run_opts=run_opts)
 
     result = sampler.run(datasets_sampler)
 
     assert result.success
-    assert sampler._sampler.min_num_live_points == sampler_opts["live_points"]
     assert (
         result.samples.shape[1]
         == datasets_sampler.models.parameters.free_unique_parameters.value.shape[0]
@@ -77,7 +106,9 @@ def test_run(backend, datasets_sampler, models_sampler):
         "ncall",
         "insertion_order_MWW_test",
     ]
-    assert set(required_keys).issubset(result.sampler_results.keys())
+
+    if backend == "ultranest":
+        assert set(required_keys).issubset(result.sampler_results.keys())
 
     assert (
         result.models.parameters["index"].value
@@ -115,27 +146,21 @@ def test_run_linked_params(backend, datasets_sampler, models_sampler):
     models_sampler.append(SkyModel(pwl2, name="source2"))
     datasets_sampler.models = models_sampler
 
-    sampler_opts = {"live_points": 300}
-    sampler = Sampler(backend=backend, sampler_opts=sampler_opts)
+    if backend == "ultranest":
+        sampler_opts = {"live_points": 300}
+        run_opts = {}
+    elif backend == "nautilus":
+        sampler_opts = {"nlive": 300}
+        run_opts = {"n_eff": 200}
+    sampler = Sampler(backend=backend, sampler_opts=sampler_opts, run_opts=run_opts)
 
     result = sampler.run(datasets_sampler)
 
     assert result.success
-    assert sampler._sampler.min_num_live_points == sampler_opts["live_points"]
     assert (
         result.samples.shape[1]
         == datasets_sampler.models.parameters.free_unique_parameters.value.shape[0]
     )
-
-    required_keys = [
-        "logz",
-        "logzerr",
-        "posterior",
-        "samples",
-        "ncall",
-        "insertion_order_MWW_test",
-    ]
-    assert set(required_keys).issubset(result.sampler_results.keys())
 
     assert (
         result.models.parameters["index"].value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ all = [
     "numba",
     "arviz<1",
     "arviz[preview]",
+    "nautilus-sampler",
 ]
 all_no_ray = [
     "naima",
@@ -71,6 +72,7 @@ all_no_ray = [
     "numba",
     "arviz<1",
     "arviz[preview]",
+    "nautilus-sampler",
 ]
 cov = [
     "naima",
@@ -81,6 +83,7 @@ cov = [
     "numba",
     "arviz<1",
     "arviz[preview]",
+    "nautilus-sampler",
 ]
 test = [
     "pytest-astropy",


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request introduces a new backend for the `Sampler` interface. nautilus-sampler uses a different method than ultranest and can be an interesting option in particular for large dimensionality problems.
It uses importance sampling and efficient space exploration using neural networks to reduce the number of evaluations. See the [documentation](https://nautilus-sampler.readthedocs.io/en/latest/index.html)

The addition require little changes. Some adaption of the dictionary output is required to fill `SamplerResult`.

This was triggered after discussion with @facero and used some input from AI, in particular, to design dictionary conversion.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
