### PR TITLE
Fix equation docstring for python 3.12

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1897,7 +1897,7 @@ class LogParabolaSpectralModel(SpectralModel):
 
     @classmethod
     def from_log10(cls, amplitude, reference, alpha, beta):
-        """Construct from :math:`\log_{10}` parametrization."""
+        r"""Construct from :math:`\log_{10}` parametrization."""
         beta_ = beta / np.log(10)
         return cls(amplitude=amplitude, reference=reference, alpha=alpha, beta=beta_)
 
@@ -1961,7 +1961,7 @@ class LogParabola2SpectralModel(SpectralModel):
 
     @classmethod
     def from_log10(cls, amplitude, reference, alpha, beta, escale):
-        """Construct from :math:`\log_{10}` parametrization."""
+        r"""Construct from :math:`\log_{10}` parametrization."""
         beta_ = beta / np.log(10)
         return cls(
             amplitude=amplitude,
@@ -2021,7 +2021,7 @@ class LogParabolaNormSpectralModel(SpectralModel):
 
     @classmethod
     def from_log10(cls, norm, reference, alpha, beta):
-        """Construct from :math:`\log_{10}` parametrization."""
+        r"""Construct from :math:`\log_{10}` parametrization."""
         beta_ = beta / np.log(10)
         return cls(norm=norm, reference=reference, alpha=alpha, beta=beta_)
 


### PR DESCRIPTION
Fix equation docstring for python 3.12
We do test for 3.12 but this was not catch before not sure why.