### PR TITLE
Adapt warning message in point source sensitivity tutorial

### DIFF
--- a/examples/tutorials/analysis-1d/cta_sensitivity.py
+++ b/examples/tutorials/analysis-1d/cta_sensitivity.py
@@ -119,8 +119,9 @@ dataset.exposure *= containment
 ######################################################################
 # Next, correct the background estimation.
 #
-# Warning: this neglects the energy dispersion by computing the containment
-# radius from the PSF in true energy but using the reco energy axis.
+# .. WARNING::
+#    This neglects the energy dispersion by computing the containment
+#    radius from the PSF in true energy but using the reco energy axis.
 #
 
 on_radii = obs.psf.containment_radius(
@@ -180,9 +181,9 @@ display(sensitivity_table)
 
 fig, ax = plt.subplots()
 
-ax.set_prop_cycle(cycler("marker", "s*v") + cycler("color", "rgb"))
+ax.set_prop_cycle(cycler("marker", "s*v") + cycler("color", "rkb"))
 
-for criterion in ("significance", "gamma", "bkg"):
+for criterion in ("bkg", "significance", "gamma"):
     mask = sensitivity_table["criterion"] == criterion
     t = sensitivity_table[mask]
 

--- a/examples/tutorials/details/mask_maps.py
+++ b/examples/tutorials/details/mask_maps.py
@@ -118,7 +118,7 @@ from gammapy.maps import Map, WcsGeom
 #
 
 filename = "$GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml"
-datasets = Datasets.read(filename=filename)
+datasets = Datasets.read(filename=filename, checksum=False)
 dataset = datasets["Fermi-LAT"]
 
 


### PR DESCRIPTION
Minor fix to tutorial to make the warning more visible by using Sphinx and adapting the plot to be colorblind friendly and changing the order of plotting such that the labels are more intuitive 