### PR TITLE
Correct x-axis unit in `FluxPointsDataset.plot_residuals`

### DIFF
--- a/docs/release-notes/6615.bug.rst
+++ b/docs/release-notes/6615.bug.rst
@@ -1,0 +1,1 @@
+Correct `FluxPointsDataset.plot_residuals()` x-axis unit, remove `ax_spectrum` and `ax_residuals` parameter in `FluxPointsDataset.plot_fit()` and adjust documentation.

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -550,7 +550,7 @@ class FluxPointsDataset(Dataset):
             ax.axhline(0, color=kwargs["color"], lw=0.5)
 
             # format axes
-            ax.set_xlabel(f"Energy [{self._energy_unit.to_string(UNIT_STRING_FORMAT)}]")
+            ax.set_xlabel(f"Energy [{ax.xaxis.units.to_string(UNIT_STRING_FORMAT)}]")
             ax.set_xscale("log")
             label = self._residuals_labels[method]
             ax.set_ylabel(f"Residuals\n {label}")

--- a/gammapy/datasets/flux_points.py
+++ b/gammapy/datasets/flux_points.py
@@ -422,8 +422,6 @@ class FluxPointsDataset(Dataset):
 
     def plot_fit(
         self,
-        ax_spectrum=None,
-        ax_residuals=None,
         kwargs_spectrum=None,
         kwargs_residuals=None,
     ):
@@ -433,10 +431,6 @@ class FluxPointsDataset(Dataset):
 
         Parameters
         ----------
-        ax_spectrum : `~matplotlib.axes.Axes`, optional
-            Axes to plot flux points and best fit model on. Default is None.
-        ax_residuals : `~matplotlib.axes.Axes`, optional
-            Axes to plot residuals on. Default is None.
         kwargs_spectrum : dict, optional
             Keyword arguments passed to `~FluxPointsDataset.plot_spectrum`. Default is None.
         kwargs_residuals : dict, optional
@@ -468,13 +462,9 @@ class FluxPointsDataset(Dataset):
         fig = plt.figure(figsize=(9, 7))
 
         gs = GridSpec(7, 1)
-        if ax_spectrum is None:
-            ax_spectrum = fig.add_subplot(gs[:5, :])
-            if ax_residuals is None:
-                plt.setp(ax_spectrum.get_xticklabels(), visible=False)
-
-        if ax_residuals is None:
-            ax_residuals = fig.add_subplot(gs[5:, :], sharex=ax_spectrum)
+        ax_spectrum = fig.add_subplot(gs[:5, :])
+        plt.setp(ax_spectrum.get_xticklabels(), visible=False)
+        ax_residuals = fig.add_subplot(gs[5:, :], sharex=ax_spectrum)
 
         kwargs_spectrum = kwargs_spectrum or {}
         kwargs_residuals = kwargs_residuals or {}


### PR DESCRIPTION

**Description**

This PR corrects the x-axis unit label for `FluxPointsDataset.plot_residuals` . Potential further fixes for `FluxPointsDataset.plot_spectrum`, `FluxPointsDataset.plot_residuals`, or `FluxPointsDataset.plot_fit` to be added.

This PR resolves #6599.


**Dear reviewer**

This issue is still under investigation. Keeping this PR as a draft for now.