### PR TITLE
Robots.txt in docs for search engine referencing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -340,3 +340,8 @@ sphinx_gallery_conf = {
 html_context = {
     "default_mode": "light",
 }
+
+# Add any extra paths that contain custom files (such as robots.txt or
+# .htaccess) here, relative to this directory. These files are copied
+# directly to the root of the documentation.
+html_extra_path = ["robots.txt"]

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /*/dev/
+Allow: /*/stable/
+Disallow: /
+
+Sitemap: https://docs.gammapy.org/stable/sitemap.xml

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,5 +1,4 @@
 User-agent: *
-Allow: /*/dev/
 Allow: /*/stable/
 Disallow: /
 


### PR DESCRIPTION
Add robots.txt to address #6612 
This should limit the search engine referencing of older docs versions and help discoverability be AI agent in general.

Still need to build the sitemap.xml in sphinx before merging.
It seems this can be done in Sphinx via something like :
```
extensions = [
    ...
    "sphinx_sitemap",
]
html_baseurl = "https://docs.gammapy.org/stable/"
```

but this needs to be tested.