### PR TITLE
Update Fermi-LAT 4FGL catalog and add support for FL16Y

### DIFF
--- a/docs/release-notes/6617.feature.rst
+++ b/docs/release-notes/6617.feature.rst
@@ -1,0 +1,1 @@
+Update Fermi-LAT 4FGL catalog and add support for FL16Y list in `gammapy.catalog.SourceCatalog4FGL`.

--- a/examples/models/spatial/plot_template.py
+++ b/examples/models/spatial/plot_template.py
@@ -20,7 +20,7 @@ from gammapy.modeling.models import (
     TemplateSpatialModel,
 )
 
-filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
+filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits.gz"
 
 m = Map.read(filename)
 m = m.copy(unit="sr^-1")

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -908,7 +908,7 @@ class SourceCatalogObject3FGL(SourceCatalogObjectFermiBase):
                     lon_0=ra, lat_0=dec, r_0=r_0, e=e, phi=phi, frame="icrs"
                 )
             elif morph_type in ["Map", "Ring", "2D Gaussian x2"]:
-                filename = de["Spatial_Filename"].strip()
+                filename = de["Spatial_Filename"].strip() + ".gz"
                 path = make_path(
                     "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v15/Templates/"
                 )
@@ -1077,7 +1077,7 @@ class SourceCatalogObject2FHL(SourceCatalogObjectFermiBase):
                     lon_0=ra, lat_0=dec, r_0=r_0, e=e, phi=phi, frame="icrs"
                 )
             elif morph_type in ["Map", "Ring", "2D Gaussian x2"]:
-                filename = de["Spatial_Filename"].strip()
+                filename = de["Spatial_Filename"].strip() + ".gz"
                 path = make_path(
                     "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v15/Templates/"
                 )
@@ -1342,7 +1342,7 @@ class SourceCatalogObject3FHL(SourceCatalogObjectFermiBase):
                     lon_0=ra, lat_0=dec, r_0=r_0, e=e, phi=phi, frame="icrs"
                 )
             elif morph_type in ["SpatialMap"]:
-                filename = de["Spatial_Filename"].strip()
+                filename = de["Spatial_Filename"].strip() + ".gz"
                 path = make_path(
                     "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/"
                 )

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -515,10 +515,12 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
                     path_extended = (
                         "$GAMMAPY_DATA/catalogs/fermi/Extended_12years/Templates/"
                     )
-                else:
+                elif de["version"] < 39:
                     path_extended = (
                         "$GAMMAPY_DATA/catalogs/fermi/Extended_14years/Templates/"
                     )
+                else:
+                    path_extended = "$GAMMAPY_DATA/catalogs/fermi/LAT_extended_sources_16years/Templates/"
                 path = make_path(path_extended)
                 with warnings.catch_warnings():  # ignore FITS units warnings
                     warnings.simplefilter("ignore", FITSFixedWarning)
@@ -1905,9 +1907,13 @@ class SourceCatalog4FGL(SourceCatalog):
     - https://arxiv.org/abs/2005.11208 (DR2)
     - https://arxiv.org/abs/2201.11184 (DR3)
     - https://arxiv.org/abs/2307.12546 (DR4)
+    - https://arxiv.org/abs/2602.22148 (FL16Y)
 
     By default we use the file of the DR4 final release (gll_psc_v35.fit.gz)
     from https://fermi.gsfc.nasa.gov/ssc/data/access/lat/14yr_catalog/
+
+    FL16Y break the 4FGL incremental catalog continuity but can be still open with this class
+    (this feature will be deprecated once 5FGL is available).
 
     One source is represented by `~gammapy.catalog.SourceCatalogObject4FGL`.
     """

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1906,7 +1906,7 @@ class SourceCatalog4FGL(SourceCatalog):
     - https://arxiv.org/abs/2201.11184 (DR3)
     - https://arxiv.org/abs/2307.12546 (DR4)
 
-    By default we use the file of the DR4 initial release
+    By default we use the file of the DR4 final release (gll_psc_v35.fit.gz)
     from https://fermi.gsfc.nasa.gov/ssc/data/access/lat/14yr_catalog/
 
     One source is represented by `~gammapy.catalog.SourceCatalogObject4FGL`.
@@ -1916,7 +1916,7 @@ class SourceCatalog4FGL(SourceCatalog):
     description = "LAT 14-year point source catalog"
     source_object_class = SourceCatalogObject4FGL
 
-    def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v32.fit.gz"):
+    def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v35.fit.gz"):
         filename = make_path(filename)
         table = Table.read(filename, hdu="LAT_Point_Source_Catalog")
         table_standardise_units_inplace(table)

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -222,6 +222,14 @@ def test_4FGL_DR4(ref):
 
 
 @requires_data()
+def test_FL16Y(ref):
+    cat = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v40.fit.gz")
+
+    models = cat.to_models()
+    assert len(models) == len(cat.table)
+
+
+@requires_data()
 class TestFermi4FGLObject:
     @classmethod
     def setup_class(cls):

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -203,7 +203,7 @@ SOURCES_3FHL = [
 @requires_data()
 @pytest.mark.parametrize("ref", SOURCES_4FGL_DR4, ids=lambda _: _["name"])
 def test_4FGL_DR4(ref):
-    cat = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v32.fit.gz")
+    cat = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v35.fit.gz")
     source = cat[ref["name"]]
     model = source.spectral_model()
     fp = source.flux_points
@@ -387,7 +387,7 @@ class TestFermi4FGLObject:
         assert_allclose(table["flux_errn"][0], 4.437058e-8, rtol=1e-3)
 
     def test_lightcurve_dr4(self):
-        dr4 = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v32.fit.gz")
+        dr4 = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v35.fit.gz")
         source_dr4 = dr4[self.source_name]
         table = source_dr4.lightcurve(interval="1-year").to_table(
             format="lightcurve", sed_type="flux"

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -222,7 +222,7 @@ def test_4FGL_DR4(ref):
 
 
 @requires_data()
-def test_FL16Y(ref):
+def test_FL16Y():
     cat = SourceCatalog4FGL("$GAMMAPY_DATA/catalogs/fermi/gll_psc_v40.fit.gz")
 
     models = cat.to_models()

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -672,7 +672,7 @@ def test_with_TemplateSpatialModel():
     # Test for bug reported in 4920
     dataset = MapDataset.read("$GAMMAPY_DATA/cta-1dc-gc/cta-1dc-gc.fits.gz")
     dataset = dataset.downsample(10)
-    filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
+    filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits.gz"
     model = TemplateSpatialModel.read(filename, normalize=False)
     model.position = SkyCoord(0, 0, unit="deg", frame="galactic")
     sky_model = SkyModel(spatial_model=model, spectral_model=PowerLawSpectralModel())

--- a/gammapy/modeling/models/tests/data/examples.yaml
+++ b/gammapy/modeling/models/tests/data/examples.yaml
@@ -123,7 +123,7 @@ components:
   type: SkyModel
   spatial:
     type: TemplateSpatialModel
-    filename: $GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits
+    filename: $GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits.gz
     normalize: false
     parameters: []
   spectral:

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -350,7 +350,7 @@ def test_sky_diffuse_constant():
 @requires_data()
 @requires_dependency("ipywidgets")
 def test_sky_diffuse_map(caplog):
-    filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"  # noqa: E501
+    filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits.gz"  # noqa: E501
     model = TemplateSpatialModel.read(filename, normalize=False)
     lon = [258.5, 0] * u.deg
     lat = -39.8 * u.deg
@@ -808,7 +808,7 @@ def test_piecewise_spatial_model_3d():
 
 @requires_data()
 def test_template_ND(tmpdir, caplog):
-    filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"  # noqa: E501
+    filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits.gz"  # noqa: E501
     map_ = Map.read(filename)
     map_.data[map_.data < 0] = 0
     geom2d = map_.geom
@@ -855,7 +855,7 @@ def test_template_ND(tmpdir, caplog):
 
 @requires_data()
 def test_templatespatial_write(tmpdir, caplog):
-    filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
+    filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits.gz"
     map_ = Map.read(filename)
     with caplog.at_level(logging.WARNING):
         template = TemplateSpatialModel(map_)
@@ -871,7 +871,7 @@ def test_templatespatial_write(tmpdir, caplog):
 
 @requires_data()
 def test_template_spatial_parameters_copy():
-    filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
+    filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits.gz"
     model = TemplateSpatialModel.read(filename, normalize=False)
     model.position = SkyCoord(0, 0, unit="deg", frame="galactic")
     model_copy = model.copy()


### PR DESCRIPTION
Requires https://github.com/gammapy/gammapy-data/pull/87

- add 4FGL-DR4 final release and remove initial release as default
- add support for FL16y list (using the same class as 4FGL for simplicity, will remove support for FL16y once 5FGL is out)
- compress fits files for old catalogs