### PR TITLE
Skips stacking if no valid mask_safe

### DIFF
--- a/docs/release-notes/6621.bug.rst
+++ b/docs/release-notes/6621.bug.rst
@@ -1,0 +1,1 @@
+Skips stacking if no valid mask_safe, fix gti preventing stacking of invalid dataset

--- a/docs/release-notes/6621.bug.rst
+++ b/docs/release-notes/6621.bug.rst
@@ -1,1 +1,1 @@
-Skips stacking if no valid mask_safe, fix gti preventing stacking of invalid dataset
+`~gammapy.datasets.MapDataset.stack(other)` now skips stacking if other mask_safe is invalid. This prevents stacking gti of invalid dataset.

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1145,6 +1145,10 @@ class MapDataset(Dataset):
             Non-finite values are replaced by zero if True. Default is True.
 
         """
+
+        if other.mask_safe and not np.any(other.mask_safe):
+            return
+
         if self.counts and other.counts:
             self.counts.stack(
                 other.counts, weights=other.mask_safe, nan_to_num=nan_to_num

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1378,6 +1378,18 @@ def test_stack_npred():
     npred_stacked = stacked.npred()
 
     assert_allclose(npred_stacked.data, stacked_npred.data)
+    assert_allclose(stacked.gti.time_sum, 3600 * u.s)
+
+    dataset_3 = MapDataset.create(
+        geom,
+        energy_axis_true=axis_etrue,
+        name="dataset-2",
+        gti=GTI.create("60 min", "90 min"),
+    )
+    dataset_3.mask_safe = dataset_2.mask_safe.copy()
+    dataset_3.mask_safe.data = False
+    stacked.stack(dataset_3)
+    assert_allclose(stacked.gti.time_sum, 3600 * u.s)
 
 
 def to_cube(image):


### PR DESCRIPTION
Prevents unnecessary computation when stacking map datasets if the `mask_safe` array of the `other` dataset indicates no valid data points.

- Improves efficiency by short-circuiting the stacking process early.
- Avoids potential issues that could arise from processing fully masked or empty datasets.
- Fix gti preventing stacking of invalid dataset gti