### PR TITLE
Fix integrate_spectum against case in which energy bounds are one-element arrays

### DIFF
--- a/docs/release-notes/6622.bug.rst
+++ b/docs/release-notes/6622.bug.rst
@@ -1,0 +1,3 @@
+Fixed a bug for which spectral models without a closed analytical
+form like BrokenPowerLaw when integrated with energy bounds given as 1-length
+element arrays resulted in ``ValueError: can only convert an array of size 1 to a Python scalar``.

--- a/docs/release-notes/6622.bug.rst
+++ b/docs/release-notes/6622.bug.rst
@@ -1,3 +1,1 @@
-Fixed a bug for which spectral models without a closed analytical
-form like BrokenPowerLaw when integrated with energy bounds given as 1-length
-element arrays resulted in ``ValueError: can only convert an array of size 1 to a Python scalar``.
+Fixes `integrate_spectrum` to allow integration of spectral models without a closed analytical form (e.g. BrokenPowerLaw) with energy bounds given as arrays of length 1.

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -369,7 +369,19 @@ class SpectralModel(ModelBase):
             kwargs = self._convert_evaluate_unit(kwargs, energy_min)
             return self.evaluate_integral(energy_min, energy_max, **kwargs)
         else:
-            return integrate_spectrum(self, energy_min, energy_max, **kwargs)
+            # guard against the case in which energy_min and energy_max are arrays of length 1,
+            # in which case we want to return an array of length 1 instead of a scalar
+            if (
+                not hasattr(self, "evaluate_integral")
+                and hasattr(energy_min, "ndim")
+                and energy_min.ndim > 0
+                and energy_min.size == 1
+            ):
+                return integrate_spectrum(
+                    self, energy_min.squeeze(), energy_max.squeeze(), **kwargs
+                )[np.newaxis]
+            else:
+                return integrate_spectrum(self, energy_min, energy_max, **kwargs)
 
     def integral_error(
         self,

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -153,7 +153,7 @@ def integrate_spectrum(
         energy = np.swapaxes(energy, -1, -2)
     else:
         values = func(energy)
-            
+
     if energy_flux:
         values *= energy
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -158,6 +158,7 @@ def integrate_spectrum(
         values *= energy
 
     # we can call trapz_loglog assuming the last axis is the one to perform integration on.
+    values = values.reshape(energy.shape)
     integral = trapz_loglog(values, energy, axis=-1)
     # integral.shape = (num, n_energy, n_samples) so we sum on axis 0
     return integral.sum(axis=0)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -153,7 +153,7 @@ def integrate_spectrum(
         energy = np.swapaxes(energy, -1, -2)
     else:
         values = func(energy)
-
+            
     if energy_flux:
         values *= energy
 
@@ -369,19 +369,7 @@ class SpectralModel(ModelBase):
             kwargs = self._convert_evaluate_unit(kwargs, energy_min)
             return self.evaluate_integral(energy_min, energy_max, **kwargs)
         else:
-            # guard against the case in which energy_min and energy_max are arrays of length 1,
-            # in which case we want to return an array of length 1 instead of a scalar
-            if (
-                not hasattr(self, "evaluate_integral")
-                and hasattr(energy_min, "ndim")
-                and energy_min.ndim > 0
-                and energy_min.size == 1
-            ):
-                return integrate_spectrum(
-                    self, energy_min.squeeze(), energy_max.squeeze(), **kwargs
-                )[np.newaxis]
-            else:
-                return integrate_spectrum(self, energy_min, energy_max, **kwargs)
+            return integrate_spectrum(self, energy_min, energy_max, **kwargs)
 
     def integral_error(
         self,

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -1258,6 +1258,22 @@ def test_energy_flux_error_exp_cutoff_power_law():
     assert_allclose(eflux_errp.value / 1e-12, 2.052225, rtol=7e-1)
 
 
+def test_integral_bpl():
+    bpl = BrokenPowerLawSpectralModel(
+        index1=2.3,
+        index2=1.7,
+        amplitude=2.0e-12 * u.Unit("cm-2 s-1 TeV-1"),
+        ebreak=10 * u.GeV,
+    )
+
+    e_min = np.array([0.1]) * u.GeV
+    e_max = np.array([11.0]) * u.GeV
+    result_array = bpl.integral(e_min, e_max)
+
+    assert result_array.shape == (1,)
+    assert_allclose(result_array.value, [6.1e-09], rtol=0.01)
+
+
 def test_integral_exp_cut_off_power_law_large_number_of_bins():
     energy = np.geomspace(1, 10, 100) * u.TeV
     energy_min = energy[:-1]

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -1440,6 +1440,34 @@ def test_vectorized_integrate_spectrum():
     assert_allclose(integral.to_value("cm-2s-1"), [9e-12, 9e-13])
     assert vector_integral.shape == (2, 10)
     assert_allclose(vector_integral[:, 0].to_value("cm-2s-1"), [9e-12, 9e-13])
+    
+    energy = [100, 1000] * u.GeV
+
+    integral = integrate_spectrum(model, energy[:-1], energy[1:], ndecade=20)
+    vector_integral = integrate_spectrum(
+        model, energy[:-1], energy[1:], ndecade=20, parameter_samples=parameter_samples
+    )
+
+    assert integral.shape == (1,)
+    assert_allclose(integral.to_value("cm-2s-1"), [9e-12,])
+    assert vector_integral.shape == (1, 10)
+    assert_allclose(vector_integral[:, 0].to_value("cm-2s-1"), [9e-12,])
+
+
+    energy_min, energy_max = [100, 1000] * u.GeV
+    model = BrokenPowerLawSpectralModel()
+    parameter_samples = [np.ones(10) * par.quantity for par in model.parameters]
+
+    integral = integrate_spectrum(model, energy_min, energy_max, ndecade=20)
+    vector_integral = integrate_spectrum(
+        model, energy_min, energy_max, ndecade=20, parameter_samples=parameter_samples
+    )
+
+    assert integral.isscalar
+    assert_allclose(integral.to_value("cm-2s-1"), 9e-12)
+    assert vector_integral.shape == (10,)
+    assert_allclose(vector_integral[0].to_value("cm-2s-1"), 9e-12)
+
 
     # check fail if model is not passed
     with pytest.raises(TypeError):

--- a/gammapy/utils/integrate.py
+++ b/gammapy/utils/integrate.py
@@ -28,7 +28,6 @@ def trapz_loglog(y, x, axis=-1):
 
     # see https://stackoverflow.com/a/56840428
     x, y = np.moveaxis(x, axis, 0), np.moveaxis(y, axis, 0)
-    y = y.reshape(x.shape)
 
     energy_min, energy_max = x[:-1], x[1:]
     vals_energy_min, vals_energy_max = y[:-1], y[1:]

--- a/gammapy/utils/integrate.py
+++ b/gammapy/utils/integrate.py
@@ -28,6 +28,7 @@ def trapz_loglog(y, x, axis=-1):
 
     # see https://stackoverflow.com/a/56840428
     x, y = np.moveaxis(x, axis, 0), np.moveaxis(y, axis, 0)
+    y = y.reshape(x.shape)
 
     energy_min, energy_max = x[:-1], x[1:]
     vals_energy_min, vals_energy_max = y[:-1], y[1:]


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This Pull Requests adds a guard in `SpectralModel.integral()` against the case in which the energy bounds are not scalars, but 1-element arrays, so the result should be a 1-element array and not a scalar.
this is particularly important for models such as BPL which do not call `evaluate_integral ` since they do not have a closed analytical form, falling back to  numerical integration via `integrate_spectrum`.

The latter expected that, if you give it an array of energy bounds (e.g., energy_min and energy_max with shape (N,)), it will return an array of integrals with shape (N,).
However, if you give it a 1-element array (shape (1,)), due to a bug, it returns an array with the shape of the internal quadrature grid (e.g., (99,)), not (1,).

In particular, when we compute flux points with `FluxPointsEstimator`, each energy bin is processed individually, so the integration is called with 1-element arrays.
The code expects the result to have shape (1,) (so it can safely call `.item()` to get a scalar).
But for models such as BPL, it got shape (99,) (the number of quadrature points), so `.item()` failed with `ValueError: can only convert an array of size 1 to a Python scalar`.

Closes #6598

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

The test I added is quite basic and covers the most low-level issue, let me know if you want the complete process up to `FluxPointsEstimator` (personally, I do not think it is necessary as the issue is really more generic).

Ready for review