### PR TITLE
Correctly ignore isort check in docs/conf.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ convention = "numpy"
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["E402"]
 "test_*.py" = ["D"]
+"docs/conf.py" = ["I"]
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.
@@ -185,9 +186,6 @@ skip-magic-trailing-comma = false
 
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"
-
-[tool.ruff.lint.isort]
-skip = ["docs/conf.py"]
 
 # Including towncrier to create the changelog
 [tool.towncrier]


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request fix the pre-commit hook configuration for skipping conf.py from being isort-checked
See failure here: https://github.com/gammapy/gammapy/actions/runs/25097848106/job/73539042968?pr=6618

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
