### PR TITLE
fix: temporary high line length to avoid pre-commit issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ except Exception:
 
 [tool.ruff]
 # Like black
-line-length = 88
+line-length = 200 # TODO: restore to 88 when apply pre-comm on all files
 indent-width = 4
 
 [tool.ruff.lint]


### PR DESCRIPTION
Temporary set a high ruff line length to avoid uncontroled pre-commit issues before we actually run and apply pre-commit on all files (c.f. https://github.com/gammapy/gammapy/issues/6219)

Seen in https://github.com/gammapy/gammapy/pull/6607
