### PR TITLE
Add axis labels to DM profiles plot

### DIFF
--- a/docs/release-notes/6641.docs.rst
+++ b/docs/release-notes/6641.docs.rst
@@ -1,0 +1,1 @@
+Explicitly convert radii and density to fixed units (``kpc`` and ``GeV cm-3``) in the ``astro_dark_matter`` tutorial plot, and simplify axis labels to avoid exposing internal units of ``DMProfile``.

--- a/docs/release-notes/6641.docs.rst
+++ b/docs/release-notes/6641.docs.rst
@@ -1,1 +1,0 @@
-Explicitly convert radii and density to fixed units (``kpc`` and ``GeV cm-3``) in the ``astro_dark_matter`` tutorial plot, and simplify axis labels to avoid exposing internal units of ``DMProfile``.

--- a/examples/tutorials/astrophysics/astro_dark_matter.py
+++ b/examples/tutorials/astrophysics/astro_dark_matter.py
@@ -55,14 +55,20 @@ from gammapy.maps import WcsGeom, WcsNDMap
 #
 
 profiles.DMProfile.__subclasses__()
+radii = np.logspace(-3, 2, 100) * u.kpc
 
 for profile in profiles.DMProfile.__subclasses__():
     p = profile()
     p.scale_to_local_density()
-    radii = np.logspace(-3, 2, 100) * u.kpc
-    plt.plot(radii, p(radii), label=p.__class__.__name__)
+    plt.plot(
+        radii.to("kpc"),
+        p(radii).to("GeV cm-3"),
+        label=p.__class__.__name__,
+    )
 
 plt.loglog()
+plt.xlabel("Radius [kpc]")
+plt.ylabel(r"Density [GeV cm$^{-3}$]")
 plt.axvline(8.5, linestyle="dashed", color="black", label="local density")
 plt.legend()
 plt.show()


### PR DESCRIPTION
**Description**

This pull request adds missing x and y axis labels to the dark matter profiles plot in the `astro_dark_matter` tutorial.

Fixes #6629.


**Dear reviewer**

This is a small documentation improvement to make the plot more informative and consistent with scientific plotting standards. The change is minimal and does not affect existing functionality.