### PR TITLE
Correct effective livetime map bug

### DIFF
--- a/docs/release-notes/6643.bug.rst
+++ b/docs/release-notes/6643.bug.rst
@@ -1,0 +1,1 @@
+Corrects `~gammapy.makers.utils.make_effective_livetime_map` to use observation pointing to compute livetime map.

--- a/gammapy/makers/tests/test_utils.py
+++ b/gammapy/makers/tests/test_utils.py
@@ -1,12 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import pytest
 import numpy as np
-from numpy.testing import assert_allclose
+import pytest
 from astropy import units as u
-from astropy.coordinates import SkyCoord, AltAz
+from astropy.coordinates import AltAz, SkyCoord
 from astropy.table import Table
 from astropy.time import Time
+from numpy.testing import assert_allclose
 from regions import PointSkyRegion
+
 from gammapy.data import (
     GTI,
     DataStore,
@@ -23,8 +24,11 @@ from gammapy.irf import (
 )
 from gammapy.makers import WobbleRegionsFinder
 from gammapy.makers.utils import (
+    ThetaSquaredTable,
+    _get_fov_coord,
     _map_spectrum_weight,
     guess_instrument_fov,
+    integrate_project_irf_on_geom,
     make_counts_off_rad_max,
     make_counts_rad_max,
     make_edisp_kernel_map,
@@ -32,17 +36,13 @@ from gammapy.makers.utils import (
     make_map_background_irf,
     make_map_exposure_true_energy,
     make_observation_time_map,
-    ThetaSquaredTable,
-    _get_fov_coord,
     project_irf_on_geom,
-    integrate_project_irf_on_geom,
 )
 from gammapy.maps import HpxGeom, MapAxis, RegionGeom, WcsGeom, WcsNDMap
 from gammapy.modeling.models import ConstantSpectralModel
-from gammapy.utils.coordinates import FoVAltAzFrame
+from gammapy.utils.coordinates import FoVAltAzFrame, FoVICRSFrame
 from gammapy.utils.testing import requires_data
 from gammapy.utils.time import time_ref_to_dict
-from gammapy.utils.coordinates import FoVICRSFrame
 
 
 @pytest.fixture(scope="session")
@@ -784,20 +784,36 @@ def test_make_effective_livetime_map():
     energy_axis_true = MapAxis.from_energy_bounds(
         10 * u.GeV, 1 * u.TeV, nbin=2, name="energy_true"
     )
-    geom = WcsGeom.create(
-        skydir=source_pos,
-        binsz=0.02,
-        width=(6, 6),
-        frame="galactic",
-        proj="CAR",
-        axes=[energy_axis_true],
-    )
+
+    geom_kwargs = {
+        "binsz": 0.02,
+        "width": (6, 6),
+        "frame": "galactic",
+        "proj": "CAR",
+        "axes": [energy_axis_true],
+    }
+
+    geom = WcsGeom.create(skydir=source_pos, **geom_kwargs)
+    geom_offset = WcsGeom.create(skydir=offset_pos, **geom_kwargs)
+
     obs_time = make_effective_livetime_map(observations, geom, offset_max=2.5 * u.deg)
+    obs_time_other = make_effective_livetime_map(
+        observations, geom_offset, offset_max=2.5 * u.deg
+    )
+
     obs_time_center = obs_time.get_by_coord((source_pos, energy_axis_true.center))
-    assert_allclose(obs_time_center, [0, 1.2847], rtol=1e-3)
+    obs_time_center_other = obs_time_other.get_by_coord(
+        (source_pos, energy_axis_true.center)
+    )
+    assert_allclose(obs_time_center, [0, 1.2779], rtol=1e-3)
+    assert_allclose(obs_time_center_other, [0, 1.2779], rtol=1e-3)
 
     obs_time_offset = obs_time.get_by_coord((offset_pos, energy_axis_true.center))
-    assert_allclose(obs_time_offset, [0, 0.242814], rtol=1e-3)
+    obs_time_offset_other = obs_time_other.get_by_coord(
+        (offset_pos, energy_axis_true.center)
+    )
+    assert_allclose(obs_time_offset, obs_time_offset_other, rtol=2e-2)
+    assert_allclose(obs_time_offset, [0, 0.4303], rtol=1e-3)
 
     assert obs_time.unit == u.hr
 

--- a/gammapy/makers/utils.py
+++ b/gammapy/makers/utils.py
@@ -1,23 +1,24 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
-import numpy as np
+
 import astropy.units as u
+import numpy as np
 from astropy.coordinates import SkyCoord
-from astropy.coordinates.erfa_astrom import erfa_astrom, ErfaAstromInterpolator
+from astropy.coordinates.erfa_astrom import ErfaAstromInterpolator, erfa_astrom
 from astropy.table import Table
 from astropy.time import Time
+from regions import CircleSkyRegion
+
 from gammapy.data import FixedPointingInfo, PointingMode
-from gammapy.irf import EDispMap, FoVAlignment, PSFMap
+from gammapy.irf import BackgroundIRF, EDispMap, FoVAlignment, PSFMap
 from gammapy.makers import background
-from gammapy.irf import BackgroundIRF
-from gammapy.maps import Map, RegionNDMap, MapAxis
+from gammapy.maps import Map, MapAxis, RegionNDMap
 from gammapy.maps.utils import broadcast_axis_values_to_geom
 from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.stats import WStatCountsStatistic
-from gammapy.utils.coordinates import FoVICRSFrame, FoVAltAzFrame
-from gammapy.utils.regions import compound_region_to_regions
-from regions import CircleSkyRegion
+from gammapy.utils.coordinates import FoVAltAzFrame, FoVICRSFrame
 from gammapy.utils.deprecation import deprecated
+from gammapy.utils.regions import compound_region_to_regions
 
 __all__ = [
     "make_counts_off_rad_max",
@@ -60,6 +61,7 @@ def _compute_rotation_time_steps(
         Pointing direction.
     location : `astropy.coordinates.EarthLocation`
         Observatory location
+
     Returns
     -------
     times : `~astropy.time.Time`
@@ -211,6 +213,7 @@ def make_map_background_irf(
         Default is True.
     location : `astropy.coordinates.EarthLocation`, optional
         Observatory location
+
     Returns
     -------
     background : `~gammapy.maps.WcsNDMap`
@@ -799,7 +802,7 @@ def make_effective_livetime_map(observations, geom, offset_max=None):
         mask = offset < offset_max
 
         exposure = make_map_exposure_true_energy(
-            pointing=geom.center_skydir,
+            pointing=obs.get_pointing_icrs(obs.tmid),
             livetime=obs.observation_live_time_duration,
             aeff=obs.aeff,
             geom=geom_obs,
@@ -908,7 +911,6 @@ def project_irf_on_geom(geom, irf, fov_frame, use_region_center=True):
     map : `~gammapy.maps.Map`
         Map containing the projected IRF.
     """
-
     if not use_region_center:
         image_geom = geom.to_wcs_geom().to_image()
         region_coord, weights = geom.get_wcs_coord_and_weights()


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request solves issue #6642 using the observation pointing direction instead of the geom center to compute the effective livetime. The test is adapted to check that two different geometries yield comparable results.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
