### PR TITLE
Add axis labels to J-Factor map plots in DM profiles tutorial

### DIFF
--- a/examples/tutorials/astrophysics/astro_dark_matter.py
+++ b/examples/tutorials/astrophysics/astro_dark_matter.py
@@ -105,6 +105,8 @@ jfact_map = WcsNDMap(geom=geom, data=jfact.value, unit=jfact.unit)
 plt.figure()
 ax = jfact_map.plot(cmap="viridis", norm=LogNorm(), add_cbar=True)
 plt.title(f"J-Factor [{jfact_map.unit}]")
+ax.set_xlabel("Galactic Longitude")
+ax.set_ylabel("Galactic Latitude")
 
 # 1 deg circle usually used in H.E.S.S. analyses without the +/- 0.3 deg band around the plane
 sky_reg = CircleSkyRegion(center=position, radius=1 * u.deg)
@@ -153,6 +155,8 @@ jfact_map = WcsNDMap(geom=geom, data=jfact_decay.value, unit=jfact_decay.unit)
 plt.figure()
 ax = jfact_map.plot(cmap="viridis", norm=LogNorm(), add_cbar=True)
 plt.title(f"J-Factor [{jfact_map.unit}]")
+ax.set_xlabel("Galactic Longitude")
+ax.set_ylabel("Galactic Latitude")
 
 # 1 deg circle usually used in H.E.S.S. analyses without the +/- 0.3 deg band around the plane
 sky_reg = CircleSkyRegion(center=position, radius=1 * u.deg)


### PR DESCRIPTION
## Summary

Added missing axis labels to the two J-Factor map plots in `examples/tutorials/astrophysics/astro_dark_matter.py`.

## What this does

The plots call `jfact_map.plot(cmap="viridis", norm=LogNorm(), add_cbar=True)` without setting x/y axis labels. The resulting WCS maps have no labels, making it unclear what coordinate system is being used.

Added explicit labels to both J-Factor plots:
```python
ax.set_xlabel("Galactic Longitude")
ax.set_ylabel("Galactic Latitude")
```

## Changes

- `examples/tutorials/astrophysics/astro_dark_matter.py` — added axis labels to both J-Factor map plots

## Testing

Run the tutorial and verify the J-Factor maps now display "Galactic Longitude" on the x-axis and "Galactic Latitude" on the y-axis.

Fixes gammapy/gammapy#6629.