### PR TITLE
Return axes from template spatial model plots

### DIFF
--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -396,7 +396,7 @@ class SpatialModel(ModelBase):
         m = self._get_plot_map(geom)
         if m.geom.is_image:
             raise TypeError("Use .plot() for 2D Maps")
-        m.plot_interactive(ax=ax, **kwargs)
+        return m.plot_interactive(ax=ax, **kwargs)
 
     def plot_position_error(self, ax=None, **kwargs):
         """Plot position error.
@@ -1604,7 +1604,7 @@ class TemplateSpatialModel(SpatialModel):
         """
         if geom is None:
             geom = self.map.geom
-        super().plot(ax=ax, geom=geom, **kwargs)
+        return super().plot(ax=ax, geom=geom, **kwargs)
 
     def plot_interactive(self, ax=None, geom=None, **kwargs):
         """Plot spatial model.
@@ -1625,7 +1625,7 @@ class TemplateSpatialModel(SpatialModel):
         """
         if geom is None:
             geom = self.map.geom
-        super().plot_interactive(ax=ax, geom=geom, **kwargs)
+        return super().plot_interactive(ax=ax, geom=geom, **kwargs)
 
 
 class TemplateNDSpatialModel(SpatialModel):

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -460,6 +460,17 @@ def test_sky_diffuse_map_normalize():
     assert_allclose(integral.value, 1, rtol=1e-4)
 
 
+def test_template_spatial_model_plot_returns_axes():
+    model_map = Map.create(map_type="wcs", width=(1, 1), binsz=0.5, unit="sr-1")
+    model_map.data += 1.0
+    model = TemplateSpatialModel(model_map, normalize=False)
+
+    with mpl_plot_check():
+        ax = model.plot()
+
+    assert ax is not None
+
+
 def test_sky_diffuse_map_copy():
     # define model map with a constant value of 1
     model_map = Map.create(map_type="wcs", width=(1, 1), binsz=0.5, unit="sr-1")


### PR DESCRIPTION
[![BRIK64 Proof](https://brik64.dev/api/proofs/brik_proof_gammapy_6628_20260510/badge.svg)](https://brik64.dev/proofs/brik_proof_gammapy_6628_20260510)

## Summary

- return the axes from `TemplateSpatialModel.plot()` so the method matches its docstring
- return the axes from `TemplateSpatialModel.plot_interactive()` as well, matching the base `SpatialModel` plotting contract
- add a regression test for the `TemplateSpatialModel.plot()` return value

Closes #6628.

## BRIK64 verification credit

This bounded plot-return contract was prepared with [BRIK64](https://brik64.com), a verification ecosystem that models critical logic as bounded circuits and checks the resulting scope with generated regression fixtures.

For this PR, BRIK64 was used to lift and compare the return-value logic behind `SpatialModel.plot_interactive()`, `TemplateSpatialModel.plot()`, and `TemplateSpatialModel.plot_interactive()`. The submitted code remains ordinary Python and requires no BRIK64 dependency.

The certificate covers only this bounded plotting return-contract scope; it does not certify the full repository, matplotlib rendering behavior, security, deployment behavior, generated tests, or future changes.

## Tests

- `./.venv/bin/python -m pytest gammapy/modeling/models/tests/test_spatial.py::test_template_spatial_model_plot_returns_axes -q` - passed
