### PR TITLE
Remove rule E501

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ ignore = [
     "B006","B007", "B008", "B009", "B017", "B018", "B024", "B028",
     "D101", "D103", "D200", "D202", "D208", "D209", "D214", "D215", "D301", "D404", "D409", "D410", "D411", "D419",
     "DTZ011",
-    "E741",
+    "E741", "E501",
     "F401",
     "N801", "N805", "N815", "N816", "N818",
     "S113", "S202", "S301", "S307", "S324",  "S603",
@@ -191,7 +191,7 @@ max-doc-length = 100
 
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["E402"]
-"test_*.py" = ["D", "E501"]
+"test_*.py" = ["D"]
 "docs/conf.py" = ["I"]
 
 [tool.ruff.format]
@@ -206,6 +206,9 @@ skip-magic-trailing-comma = false
 
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"
+
+# formatting of code example in docstring.
+docstring-code-format = true
 
 # Including towncrier to create the changelog
 [tool.towncrier]


### PR DESCRIPTION
If I understood correctly this post :
https://stackoverflow.com/a/77796620
E501 is not needed to enforce the line length, if line-length entry is defined
ruff format will reformat the code but not docstring (except code in docstring) on pre-commit. 
From what I tested locally it seems to match the previous behaviour.
