### PR TITLE
Fix default behavior of sum_over_energy_groups=False case in ExcessMapEstimator

### DIFF
--- a/docs/release-notes/6685.bug.rst
+++ b/docs/release-notes/6685.bug.rst
@@ -1,0 +1,1 @@
+Fix `sum_over_energy_groups=False` case in `gammapy.estimators.ExcessMapEstimator`.

--- a/docs/release-notes/6685.bug.rst
+++ b/docs/release-notes/6685.bug.rst
@@ -1,1 +1,1 @@
-Fix default behavior of `sum_over_energy_groups=False` case in `gammapy.estimators.ExcessMapEstimator` and `gammapy.estimators.TSMapEstimator` .
+Fix default behavior of `sum_over_energy_groups=False` case in `gammapy.estimators.ExcessMapEstimator`.

--- a/docs/release-notes/6685.bug.rst
+++ b/docs/release-notes/6685.bug.rst
@@ -1,1 +1,1 @@
-Fix `sum_over_energy_groups=False` case in `gammapy.estimators.ExcessMapEstimator`.
+Fix default behavior of `sum_over_energy_groups=False` case in `gammapy.estimators.ExcessMapEstimator` and `gammapy.estimators.TSMapEstimator` .

--- a/gammapy/estimators/core.py
+++ b/gammapy/estimators/core.py
@@ -51,13 +51,11 @@ class Estimator(abc.ABC):
     def _get_energy_axis(self, dataset):
         """Energy axis."""
         if self.energy_edges is None:
-            energy_axis = dataset.counts.geom.axes["energy"]
-            if getattr(self, "sum_over_energy_groups", True):
-                energy_axis = energy_axis.squash()
+            return dataset.counts.geom.axes["energy"].squash()
+        elif self.energy_edges == "all":
+            return dataset.counts.geom.axes["energy"]
         else:
-            energy_axis = MapAxis.from_energy_edges(self.energy_edges)
-
-        return energy_axis
+            return MapAxis.from_energy_edges(self.energy_edges)
 
     def copy(self):
         """Copy estimator."""

--- a/gammapy/estimators/core.py
+++ b/gammapy/estimators/core.py
@@ -3,8 +3,10 @@ import abc
 import html
 import inspect
 from copy import deepcopy
+
 import numpy as np
 from astropy import units as u
+
 from gammapy.maps import MapAxis
 from gammapy.modeling.models import ModelBase
 
@@ -49,10 +51,9 @@ class Estimator(abc.ABC):
     def _get_energy_axis(self, dataset):
         """Energy axis."""
         if self.energy_edges is None:
-            energy_axis = dataset.counts.geom.axes["energy"].squash()
-            if getattr(self, "sum_over_energy_groups", False):
-                energy_edges = [energy_axis.edges[0], energy_axis.edges[1]]
-                energy_axis = MapAxis.from_energy_edges(energy_edges)
+            energy_axis = dataset.counts.geom.axes["energy"]
+            if getattr(self, "sum_over_energy_groups", True):
+                energy_axis = energy_axis.squash()
         else:
             energy_axis = MapAxis.from_energy_edges(self.energy_edges)
 

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -10,6 +10,7 @@ from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.maps import Map
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.stats import CashCountsStatistic, WStatCountsStatistic
+from gammapy.utils.deprecation import deprecated_attribute
 
 from ..core import Estimator
 from ..utils import apply_threshold_sensitivity, estimate_exposure_reco_energy
@@ -172,7 +173,8 @@ class ExcessMapEstimator(Estimator):
     energy_edges : list of `~astropy.units.Quantity`, optional
         Edges of the target maps energy bins. The resulting bin edges won't be exactly equal to the input ones,
         but rather the closest values to the energy axis edges of the parent dataset.
-        Default is None: apply the estimator in each energy bin of the parent dataset.
+        Default is None: energy_edges are set as [edge_min, edge_max] of the parent dataset.
+        If "all" alias is used apply the estimator in each energy bin of the parent dataset.
         For further explanation see :ref:`estimators`.
     correlate_off : bool, optional
         Correlate OFF events. Default is True.
@@ -190,10 +192,10 @@ class ExcessMapEstimator(Estimator):
         If True, use `bkg_syst_fraction_sensitivity` and `gamma_min_sensitivity` in the sensitivity computation.
         Default is False which is the same setting as the HGPS catalog.
     sum_over_energy_groups : bool, optional
-        Only used if ``energy_edges`` is None.
-        If False, apply the estimator in each energy bin of the parent dataset.
-        If True, apply the estimator in only one bin defined by the energy edges of the parent dataset.
+        Only used if `energy_edges=None` and `sum_over_energy_groups=False`
+        then it's equivalent to `energy_edges="all"`. Deprecated since v2.2.
         Default is True.
+
 
     Examples
     --------
@@ -229,6 +231,8 @@ class ExcessMapEstimator(Estimator):
         "acceptance_off",
     ]
 
+    sum_over_energy_groups = deprecated_attribute("sum_over_energy_groups", "2.2")
+
     def __init__(
         self,
         correlation_radius="0.1 deg",
@@ -253,8 +257,10 @@ class ExcessMapEstimator(Estimator):
         self.apply_threshold_sensitivity = apply_threshold_sensitivity
         self.selection_optional = selection_optional
         self.energy_edges = energy_edges
-        self.sum_over_energy_groups = sum_over_energy_groups
         self.correlate_off = correlate_off
+
+        if energy_edges is None and not sum_over_energy_groups:
+            self.energy_edges = "all"
 
         if spectral_model is None:
             spectral_model = PowerLawSpectralModel(index=2)

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -10,7 +10,7 @@ from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.maps import Map
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.stats import CashCountsStatistic, WStatCountsStatistic
-from gammapy.utils.deprecation import deprecated_attribute
+from gammapy.utils.deprecation import deprecated_attribute, deprecated_renamed_argument
 
 from ..core import Estimator
 from ..utils import apply_threshold_sensitivity, estimate_exposure_reco_energy
@@ -233,6 +233,7 @@ class ExcessMapEstimator(Estimator):
 
     sum_over_energy_groups = deprecated_attribute("sum_over_energy_groups", "2.2")
 
+    @deprecated_renamed_argument("sum_over_energy_groups", None, "2.2")
     def __init__(
         self,
         correlation_radius="0.1 deg",
@@ -259,6 +260,7 @@ class ExcessMapEstimator(Estimator):
         self.energy_edges = energy_edges
         self.correlate_off = correlate_off
 
+        # TODO: remove in v2.3 as sum_over_energy_groups is deprecated
         if energy_edges is None and not sum_over_energy_groups:
             self.energy_edges = "all"
 

--- a/gammapy/estimators/map/excess.py
+++ b/gammapy/estimators/map/excess.py
@@ -1,15 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import copy
 import logging
+
 import numpy as np
 from astropy.convolution import Tophat2DKernel
 from astropy.coordinates import Angle
+
 from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.maps import Map
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.stats import CashCountsStatistic, WStatCountsStatistic
+
 from ..core import Estimator
-from ..utils import estimate_exposure_reco_energy, apply_threshold_sensitivity
+from ..utils import apply_threshold_sensitivity, estimate_exposure_reco_energy
 from .core import FluxMaps
 
 __all__ = ["ExcessMapEstimator"]
@@ -190,7 +193,7 @@ class ExcessMapEstimator(Estimator):
         Only used if ``energy_edges`` is None.
         If False, apply the estimator in each energy bin of the parent dataset.
         If True, apply the estimator in only one bin defined by the energy edges of the parent dataset.
-        Default is False.
+        Default is True.
 
     Examples
     --------
@@ -239,7 +242,7 @@ class ExcessMapEstimator(Estimator):
         gamma_min_sensitivity=10,
         bkg_syst_fraction_sensitivity=0.05,
         apply_threshold_sensitivity=False,
-        sum_over_energy_groups=False,
+        sum_over_energy_groups=True,
     ):
         self.correlation_radius = correlation_radius
         self.n_sigma = n_sigma

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -449,8 +449,7 @@ def test_joint_excess_map(simple_dataset):
     stacked_dataset.exposure *= 2
     stacked_dataset.background *= 2
     stacked_dataset.models = [model]
-    estimator = ExcessMapEstimator(0.1 * u.deg, sum_over_energy_groups=True)
-    assert estimator.sum_over_energy_groups
+    estimator = ExcessMapEstimator(0.1 * u.deg)
 
     result = estimator.run(stacked_dataset)
     assert_allclose(result["npred_excess"].data.sum(), 2 * 19733.602, rtol=1e-3)
@@ -479,7 +478,12 @@ def test_maps_alpha(simple_dataset_on_off):
     assert_allclose(result["alpha"].data[:, 10, 10], 1, atol=1e-3)
 
 
-def test_sum_over_energy_groups(simple_dataset_on_off):
+def test_energy_edges_all(simple_dataset_on_off):
+    estimator = ExcessMapEstimator(energy_edges="all")
+    result = estimator.run(simple_dataset_on_off)
+
+    assert result["npred"].data.shape == (2, 20, 20)
+
     estimator = ExcessMapEstimator(sum_over_energy_groups=False)
     result = estimator.run(simple_dataset_on_off)
 

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import pytest
-import numpy as np
-from numpy.testing import assert_allclose
 import astropy.units as u
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
 from gammapy.datasets import MapDataset, MapDatasetOnOff
 from gammapy.estimators import ExcessMapEstimator
 from gammapy.estimators.utils import (
@@ -476,3 +477,15 @@ def test_maps_alpha(simple_dataset_on_off):
     assert_allclose(result["acceptance_on"].data[:, 10, 10], 2, atol=1e-3)
     assert_allclose(result["acceptance_off"].data[:, 10, 10], 2, atol=1e-3)
     assert_allclose(result["alpha"].data[:, 10, 10], 1, atol=1e-3)
+
+
+def test_sum_over_energy_groups(simple_dataset_on_off):
+    estimator = ExcessMapEstimator(sum_over_energy_groups=False)
+    result = estimator.run(simple_dataset_on_off)
+
+    assert result["npred"].data.shape == (2, 20, 20)
+
+    estimator = ExcessMapEstimator()
+    result = estimator.run(simple_dataset_on_off)
+
+    assert result["npred"].data.shape == (1, 20, 20)

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -17,6 +17,7 @@ from gammapy.modeling.models import (
     PowerLawSpectralModel,
     SkyModel,
 )
+from gammapy.utils.deprecation import GammapyDeprecationWarning
 from gammapy.utils.testing import requires_data
 
 
@@ -484,8 +485,9 @@ def test_energy_edges_all(simple_dataset_on_off):
 
     assert result["npred"].data.shape == (2, 20, 20)
 
-    estimator = ExcessMapEstimator(sum_over_energy_groups=False)
-    result = estimator.run(simple_dataset_on_off)
+    with pytest.warns(GammapyDeprecationWarning):
+        estimator = ExcessMapEstimator(sum_over_energy_groups=False)
+        result = estimator.run(simple_dataset_on_off)
 
     assert result["npred"].data.shape == (2, 20, 20)
 

--- a/gammapy/estimators/map/tests/test_excess.py
+++ b/gammapy/estimators/map/tests/test_excess.py
@@ -488,8 +488,7 @@ def test_energy_edges_all(simple_dataset_on_off):
     with pytest.warns(GammapyDeprecationWarning):
         estimator = ExcessMapEstimator(sum_over_energy_groups=False)
         result = estimator.run(simple_dataset_on_off)
-
-    assert result["npred"].data.shape == (2, 20, 20)
+        assert result["npred"].data.shape == (2, 20, 20)
 
     estimator = ExcessMapEstimator()
     result = estimator.run(simple_dataset_on_off)

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -729,10 +729,8 @@ def test_joint_ts_map_hawc():
     datasets = Datasets.read("$GAMMAPY_DATA/hawc/DL4/HAWC_pass4_public_Crab.yaml")
     datasets = Datasets(datasets[-2:])
 
-    energy_edges = datasets[0].counts.geom.axes[0].squash().edges
     estimator = TSMapEstimator(
         kernel_width=2 * u.deg,
-        energy_edges=energy_edges,
         sum_over_energy_groups=False,
         n_jobs=4,
     )
@@ -742,7 +740,6 @@ def test_joint_ts_map_hawc():
 
     estimator = TSMapEstimator(
         kernel_width=2 * u.deg,
-        energy_edges=energy_edges,
         sum_over_energy_groups=False,
         selection_optional=["stat_scan"],
         n_jobs=4,
@@ -883,10 +880,7 @@ def test_excess_map_compatibility():
 
     ts_est_sum = TSMapEstimator(kernel_model=model, sum_over_energy_groups=True)
 
-    energy_edges = dataset.counts.geom.axes[0].squash().edges
-    ts_est = TSMapEstimator(
-        kernel_model=model, energy_edges=energy_edges, sum_over_energy_groups=False
-    )
+    ts_est = TSMapEstimator(kernel_model=model, sum_over_energy_groups=False)
 
     result = est.run(dataset=dataset)
 

--- a/gammapy/estimators/map/tests/test_ts.py
+++ b/gammapy/estimators/map/tests/test_ts.py
@@ -1,13 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from copy import deepcopy
-import pytest
-import numpy as np
-from numpy.testing import assert_allclose
+
 import astropy.units as u
+import numpy as np
+import pytest
 from astropy.coordinates import Angle, SkyCoord
+from numpy.testing import assert_allclose
 from scipy.stats import pearsonr
+
 from gammapy.datasets import Datasets, MapDataset, MapDatasetOnOff
-from gammapy.estimators import TSMapEstimator, ExcessMapEstimator
+from gammapy.estimators import ExcessMapEstimator, TSMapEstimator
 from gammapy.estimators.utils import (
     approximate_profile_map,
     combine_flux_maps,
@@ -727,8 +729,12 @@ def test_joint_ts_map_hawc():
     datasets = Datasets.read("$GAMMAPY_DATA/hawc/DL4/HAWC_pass4_public_Crab.yaml")
     datasets = Datasets(datasets[-2:])
 
+    energy_edges = datasets[0].counts.geom.axes[0].squash().edges
     estimator = TSMapEstimator(
-        kernel_width=2 * u.deg, sum_over_energy_groups=False, n_jobs=4
+        kernel_width=2 * u.deg,
+        energy_edges=energy_edges,
+        sum_over_energy_groups=False,
+        n_jobs=4,
     )
     result = estimator.run(datasets)
     assert_allclose(result["flux"].data[0, 59, 59], 4.034048e-12, rtol=1e-3)
@@ -736,6 +742,7 @@ def test_joint_ts_map_hawc():
 
     estimator = TSMapEstimator(
         kernel_width=2 * u.deg,
+        energy_edges=energy_edges,
         sum_over_energy_groups=False,
         selection_optional=["stat_scan"],
         n_jobs=4,
@@ -876,7 +883,10 @@ def test_excess_map_compatibility():
 
     ts_est_sum = TSMapEstimator(kernel_model=model, sum_over_energy_groups=True)
 
-    ts_est = TSMapEstimator(kernel_model=model, sum_over_energy_groups=False)
+    energy_edges = dataset.counts.geom.axes[0].squash().edges
+    ts_est = TSMapEstimator(
+        kernel_model=model, energy_edges=energy_edges, sum_over_energy_groups=False
+    )
 
     result = est.run(dataset=dataset)
 

--- a/gammapy/estimators/map/ts.py
+++ b/gammapy/estimators/map/ts.py
@@ -2,26 +2,28 @@
 """Functions to compute test statistic images."""
 
 import warnings
-import astropy.units as u
 from itertools import repeat
+
+import astropy.units as u
 import numpy as np
 import scipy.optimize
-from scipy.interpolate import InterpolatedUnivariateSpline
 from astropy.coordinates import Angle
 from astropy.utils import lazyproperty
+from scipy.interpolate import InterpolatedUnivariateSpline
+
 import gammapy.utils.parallel as parallel
 from gammapy.datasets import Datasets
 from gammapy.datasets.map import MapEvaluator
 from gammapy.datasets.utils import get_nearest_valid_exposure_position
 from gammapy.maps import Map, MapAxis, Maps
 from gammapy.modeling.models import PointSpatialModel, PowerLawSpectralModel, SkyModel
-from gammapy.stats.utils import ts_to_sigma
 from gammapy.stats import cash
+from gammapy.stats.utils import ts_to_sigma
 from gammapy.utils.array import shape_2N, symmetric_crop_pad_width
 from gammapy.utils.compilation import get_fit_statistics_compiled
+from gammapy.utils.deprecation import deprecated_renamed_argument
 from gammapy.utils.pbar import progress_bar
 from gammapy.utils.roots import find_roots
-from gammapy.utils.deprecation import deprecated_renamed_argument
 
 from ..core import Estimator
 from ..utils import (
@@ -120,10 +122,11 @@ class TSMapEstimator(Estimator, parallel.ParallelMixin):
 
         Default is None, so only "ts", "norm", "niter", "norm_err", "npred", "npred_excess", "stat", "stat_null" and
         "success" are computed.
-    energy_edges : list of `~astropy.units.Quantity`, optional
+    energy_edges : list of `~astropy.units.Quantity` or str, optional
         Edges of the target maps energy bins. The resulting bin edges won't be exactly equal to the input ones,
         but rather the closest values to the energy axis edges of the parent dataset.
-        Default is None: apply the estimator in each energy bin of the parent dataset.
+        Default is None: energy_edges are set as [edge_min, edge_max] of the parent dataset.
+        If "all" alias is used apply the estimator in each energy bin of the parent dataset.
         For further explanation see :ref:`estimators`.
     sum_over_energy_groups : bool, optional
         Whether to sum over the energy groups or fit the norm on the full energy


### PR DESCRIPTION
Fix sum_over_energy_groups=False case (if energy_edges=None) in ExcessMapEstimator and `gammapy.estimators.TSMapEstimator`.

Resolves #6681
