### PR TITLE
Remove isort rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ select = [
   "E",   # pycodestyle errors
   "F",   # pyflakes
   "B",   # flake8-bugbear
-  "I",   # isort
+  #"I",   # isort # uncomment before v3.0
   "PLE", # pylint errors
   "D",   # pydocstyle
   # "UP",   # pyUpgrade


### PR DESCRIPTION
Remove isort rule to avoid further backport conflicts.
To be restored before v3.0
