### PR TITLE
Add 'inout' to ignore words list for codespell

### DIFF
--- a/dev/codespell/ignore-words.txt
+++ b/dev/codespell/ignore-words.txt
@@ -14,3 +14,4 @@ slac
 unparseable
 compiletime
 THIRDPARTY
+inout


### PR DESCRIPTION
> The codespell seems to create a false positive making changes  for `inout` a str variable, any idea why ? 
@morcuended @natthan-pigoux 