### PR TITLE
Update MapAxis and TimeMapAxis interp parameter in documentation

### DIFF
--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -95,7 +95,7 @@ class MapAxis:
     nodes : `~numpy.ndarray` or `~astropy.units.Quantity`
         Array of node values.  These will be interpreted as either bin
         edges or centers according to ``node_type``.
-    interp : {'lin', 'log', 'sqrt'}
+    interp : {'lin', 'log', 'sqrt'}, optional
         Interpolation method used to transform between axis and pixel
         coordinates. Default is 'lin'.
     name : str, optional
@@ -2300,7 +2300,7 @@ class TimeMapAxis:
         Reference time to use.
     name : str, optional
         Axis name. Default is "time".
-    interp : {'lin'}
+    interp : {'lin'}, optional
         Interpolation method used to transform between axis and pixel
         coordinates. For now only 'lin' is supported. Default is 'lin'.
     """


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
This PR updates the docstrings for `gammapy.maps.axes.MapAxis` and `gammapy.maps.axes.TimeMapAxis` to mark the `interp` parameter as `optional`.