### PR TITLE
Check if serialized product contains creator metadata

### DIFF
--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -16,6 +16,7 @@ from gammapy.utils.interpolation import (
     ScaledRegularGridInterpolator,
     interpolation_scale,
 )
+from gammapy.utils.metadata import CreatorMetaData, add_creator_metadata
 from gammapy.utils.scripts import make_path
 from .io import IRF_DL3_HDU_SPECIFICATION, IRF_MAP_HDU_SPECIFICATION, gadf_is_pointlike
 
@@ -544,7 +545,7 @@ class IRF(metaclass=abc.ABCMeta):
         name = IRF_DL3_HDU_SPECIFICATION[self.tag]["extname"]
         return fits.BinTableHDU(self.to_table(format=format), name=name)
 
-    def to_hdulist(self, format="gadf-dl3"):
+    def to_hdulist(self, format="gadf-dl3", creation=None):
         """
         Write the HDU list.
 
@@ -552,16 +553,38 @@ class IRF(metaclass=abc.ABCMeta):
         ----------
         format : {"gadf-dl3"}, optional
             Format specification. Default is "gadf-dl3".
+        creation : `~gammapy.utils.metadata.CreatorMetaData`, optional
+            Creation metadata to add to the file. If None, default metadata is added.
+            Default is None.
+
+        Returns
+        -------
+        hdulist : `~astropy.io.fits.HDUList`
+            IRF in HDU list format.
+
         """
         hdu = self.to_table_hdu(format=format)
-        return fits.HDUList([fits.PrimaryHDU(), hdu])
+        hdus = [fits.PrimaryHDU(), hdu]
+        add_creator_metadata([hd.header for hd in hdus], creation)
 
-    def write(self, filename, *args, **kwargs):
+        return fits.HDUList(hdus)
+
+    def write(self, filename, *args, creation=None, **kwargs):
         """Write IRF to fits.
 
         Calls `~astropy.io.fits.HDUList.writeto`, forwarding all arguments.
+
+        Parameters
+        ----------
+        filename : str
+            Filename.
+        creation : `~gammapy.utils.metadata.CreatorMetaData`, optional
+            Creation metadata to add to the file. If None, default metadata is added.
+            Default is None.
         """
-        self.to_hdulist().writeto(str(make_path(filename)), *args, **kwargs)
+        self.to_hdulist(creation=creation).writeto(
+            str(make_path(filename)), *args, **kwargs
+        )
 
     def pad(self, pad_width, axis_name, **kwargs):
         """Pad IRF along a given axis.

--- a/gammapy/irf/core.py
+++ b/gammapy/irf/core.py
@@ -16,7 +16,7 @@ from gammapy.utils.interpolation import (
     ScaledRegularGridInterpolator,
     interpolation_scale,
 )
-from gammapy.utils.metadata import CreatorMetaData, add_creator_metadata
+from gammapy.utils.metadata import add_creator_metadata
 from gammapy.utils.scripts import make_path
 from .io import IRF_DL3_HDU_SPECIFICATION, IRF_MAP_HDU_SPECIFICATION, gadf_is_pointlike
 

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -321,7 +321,7 @@ class EDispKernel(IRF):
         ----------
         format : {"ogip", "ogip-sherpa"}
             Format to use. Default is "ogip".
-        creation : `~gammapy.utils.metadata.CreatorMetadata`, optional
+        creation : `~gammapy.utils.metadata.CreatorMetaData`, optional
             Creation metadata to add to the file. If None, default metadata is added.
             Default is None.
 

--- a/gammapy/irf/edisp/kernel.py
+++ b/gammapy/irf/edisp/kernel.py
@@ -10,7 +10,7 @@ from matplotlib.colors import PowerNorm
 from gammapy.maps import MapAxis
 from gammapy.maps.axes import UNIT_STRING_FORMAT
 from gammapy.utils.scripts import make_path
-from gammapy.utils.metadata import CreatorMetaData
+from gammapy.utils.metadata import add_creator_metadata
 from gammapy.visualization.utils import add_colorbar
 from ..core import IRF
 
@@ -364,13 +364,10 @@ class EDispKernel(IRF):
         ebounds_hdu = self.axes["energy"].to_table_hdu(format=format)
         prim_hdu = fits.PrimaryHDU()
 
-        creation = creation or CreatorMetaData()
-        creation.update_time()
+        hdus = [prim_hdu, hdu, ebounds_hdu]
+        add_creator_metadata([hd.header for hd in hdus], creation)
 
-        for hd in [prim_hdu, hdu, ebounds_hdu]:
-            hd.header.update(creation.to_header())
-
-        return fits.HDUList([prim_hdu, hdu, ebounds_hdu])
+        return fits.HDUList(hdus)
 
     def to_table(self, format="ogip"):
         """Convert to `~astropy.table.Table`.

--- a/gammapy/utils/metadata.py
+++ b/gammapy/utils/metadata.py
@@ -20,6 +20,7 @@ from .types import AltAzSkyCoordType, ICRSSkyCoordType, SkyCoordType, TimeType
 __all__ = [
     "MetaData",
     "CreatorMetaData",
+    "add_creator_metadata",
     "ObsInfoMetaData",
     "PointingInfoMetaData",
     "TimeInfoMetaData",
@@ -199,6 +200,28 @@ class CreatorMetaData(MetaData):
     def update_time(self):
         """Change creation date to Time.now()."""
         self.date = Time.now()
+
+
+def add_creator_metadata(headers, creation=None):
+    """Add creator metadata to one or more FITS headers, in place.
+
+    Parameters
+    ----------
+    headers : `~astropy.io.fits.Header` or list of `~astropy.io.fits.Header`
+        Header(s) to update in place. When several are passed they all receive
+        the same creation metadata (a single timestamp).
+    creation : `~gammapy.utils.metadata.CreatorMetaData`, optional
+        Existing creation metadata. If None, a new one is created
+        (current Gammapy version and time). Default is None.
+    """
+    creation = creation or CreatorMetaData()
+    creation.update_time()
+
+    if not isinstance(headers, (list, tuple)):
+        headers = [headers]
+
+    for header in headers:
+        header.update(creation.to_header())
 
 
 class ObsInfoMetaData(MetaData):

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -21,6 +21,7 @@ from gammapy.maps import MapAxis
 from gammapy.utils.metadata import (
     METADATA_FITS_KEYS,
     CreatorMetaData,
+    add_creator_metadata,
     MetaData,
     ObsInfoMetaData,
     PointingInfoMetaData,
@@ -326,6 +327,14 @@ class TestMetaDataPropagation:
             "rad_max_2d": (rad_max, {"creator"}),
             "psf": (psf, {"creator"}),
         }
+
+    def test_add_metadata(self):
+        header = self.products["aeff_2d"][0].to_table_hdu().header
+        add_creator_metadata(header)
+        assert header["CREATOR"].startswith("Gammapy")
+        creation = CreatorMetaData(date="2022-01-01", creator="Test", origin="CTA")
+        add_creator_metadata(header, creation)
+        assert header["CREATOR"] == "Test"
 
     def test_metadata_propagation(self):
         missing = []

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -1,11 +1,23 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from typing import ClassVar, Literal, Optional
 import pytest
+import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import AltAz, SkyCoord
 from astropy.io import fits
 from astropy.time import Time
+import astropy.units as u
 from pydantic import ValidationError
+from gammapy.irf import (
+    Background3D,
+    EDispKernel,
+    EffectiveAreaTable2D,
+    EnergyDependentMultiGaussPSF,
+    EnergyDispersion2D,
+    RadMax2D,
+    PSF3D,
+)
+from gammapy.maps import MapAxis
 from gammapy.utils.metadata import (
     METADATA_FITS_KEYS,
     CreatorMetaData,
@@ -253,3 +265,76 @@ def test_subclass_to_from_header():
     # no new attributes allowed
     with pytest.raises(ValidationError):
         test_meta.extra = 3
+
+
+# --- container tag -> header keywords that must always be present -------------
+# Keys mirror METADATA_FITS_KEYS in gammapy/utils/metadata.py (ORIGIN is optional).
+REQUIRED_KEYWORDS = {
+    "creator": ["CREATOR", "CREATED"],
+    # "obs_info": ["TELESCOP", "INSTRUME"],
+    # "pointing": ["RA_PNT", "DEC_PNT"],
+    # "target":   ["OBJECT"],
+    # "time_info":["TSTART", "TSTOP"],
+}
+
+
+class TestMetaDataPropagation:
+    def setup_method(self):
+        # IRF products
+        energy_axis_true = MapAxis.from_energy_bounds(
+            "1 TeV", "10 TeV", nbin=9, name="energy_true"
+        )
+        energy_axis = energy_axis_true.copy(name="energy")  # reco, for bkg / rad_max
+        offset_axis = MapAxis.from_bounds(
+            0, 1, nbin=3, unit="deg", name="offset", node_type="edges"
+        )
+        migra_axis = MapAxis.from_bounds(0, 3, nbin=3, name="migra", node_type="edges")
+        fov_lon_axis = MapAxis.from_bounds(-6, 6, nbin=10, unit="deg", name="fov_lon")
+        fov_lat_axis = MapAxis.from_bounds(-6, 6, nbin=10, unit="deg", name="fov_lat")
+        rad_axis = MapAxis.from_bounds(
+            0, 1, nbin=10, unit="deg", name="rad", node_type="edges"
+        )
+        aeff = EffectiveAreaTable2D(
+            axes=[energy_axis_true, offset_axis], data=np.random.rand(9, 3), unit="m2"
+        )
+        edisp = EnergyDispersion2D(
+            axes=[energy_axis_true, migra_axis, offset_axis],
+            data=np.random.rand(9, 3, 3),
+        )
+        edisp_kernel = EDispKernel.from_diagonal_response(energy_axis_true, energy_axis)
+        bkg = Background3D(
+            axes=[energy_axis, fov_lon_axis, fov_lat_axis],
+            data=np.random.rand(9, 10, 10),
+            unit="s-1 MeV-1 sr-1",
+        )
+        rad_max = RadMax2D(
+            axes=[energy_axis, offset_axis], data=np.random.rand(9, 3), unit="deg"
+        )
+        psf = PSF3D(
+            axes=[energy_axis_true, offset_axis, rad_axis],
+            data=np.random.rand(9, 3, 10),
+            unit="sr-1",
+        )
+
+        # TO-DO: Data, datasets, maps products
+
+        self.products = {
+            "aeff_2d": (aeff, {"creator"}),
+            "edisp_2d": (edisp, {"creator"}),
+            "edisp_kernel": (edisp_kernel, {"creator"}),
+            "bkg_3d": (bkg, {"creator"}),
+            "rad_max_2d": (rad_max, {"creator"}),
+            "psf": (psf, {"creator"}),
+        }
+
+    def test_metadata_propagation(self):
+        missing = []
+        for label, (product, containers) in self.products.items():
+            header = product.to_hdulist()[0].header
+            for tag in containers:
+                for key in REQUIRED_KEYWORDS[tag]:
+                    if key not in header:
+                        missing.append(f"{label}: {key} ({tag})")
+            if "creator" in containers:
+                assert header["CREATOR"].startswith("Gammapy")
+        assert not missing, "Missing metadata keywords:\n" + "\n".join(missing)

--- a/gammapy/utils/tests/test_metadata.py
+++ b/gammapy/utils/tests/test_metadata.py
@@ -268,8 +268,6 @@ def test_subclass_to_from_header():
         test_meta.extra = 3
 
 
-# --- container tag -> header keywords that must always be present -------------
-# Keys mirror METADATA_FITS_KEYS in gammapy/utils/metadata.py (ORIGIN is optional).
 REQUIRED_KEYWORDS = {
     "creator": ["CREATOR", "CREATED"],
     # "obs_info": ["TELESCOP", "INSTRUME"],


### PR DESCRIPTION
This PR addresses the issue #5598: Check and test whether all serialised products contain the Creator metadata

Based on the discussion in the issue, for now I suggest using a helper function `add_creator_metadata` defined in gammapy.utils.metadata.py that is called at serialization when using product.to_hdulist()

It takes the header as an argument, and update it with a given creation object or with a default one if none is provided.
I based the implementation on the existing procedure for the EdispKernel serialization.

My idea would be to build similar helpers for each MetaData container, then maybe a global helper function to be called at serialization.
The test is also designed with the idea in mind to check for the other containers.

So far, I only implemented it for the IRF products. This is only a proposition, so I leave it as a draft and will implement the other products if I get the green light.