### PR TITLE
Fix bug in `FluxCollectionEstimator` for extra frozen models

### DIFF
--- a/docs/release-notes/6721.bug.rst
+++ b/docs/release-notes/6721.bug.rst
@@ -1,0 +1,1 @@
+Fixes incorrect calling of dataset for frozen models in `~gammapy.estimators.FluxCollectionEstimator`.

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -435,7 +435,7 @@ class FluxCollectionEstimator:
             )
             fp_models.append(template_model)
 
-        npred_frozen = fp_dataset.npred_signal(frozen_names, stack=True)
+        npred_frozen = dataset.npred_signal(frozen_names, stack=True)
         bkg_frozen = TemplateNPredModel(
             npred_frozen,
             name="frozen_" + fp_dataset.name,

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -301,7 +301,7 @@ class FluxCollectionEstimator:
     """Estimate the flux points from a collection of sources simultaneously.
 
     This estimator computes spectral flux points for a *collection of sources*
-    over a set of predefined energy bins. The normalizations of all
+    over a set of predefined energy bins. The normalisations of all
     `~gammapy.modeling.models.SkyModel` objects listed in ``models`` are fitted
     jointly in each energy bin, while all other `~gammapy.modeling.models.SkyModel`
     components in the datasets remain frozen. Re-optimization of each dataset’s
@@ -330,10 +330,10 @@ class FluxCollectionEstimator:
         Norm parameter used for the fit.
         Default is None and a new parameter is created with value=1, name="norm".
         If the `solver` is a sampler the default prior is uniform between [-10, 10].
-    solver : `~gammapy.modeling.Fit` or `~gammapy.modeling.Sampler`
+    solver : `~gammapy.modeling.Fit` or `~gammapy.modeling.Sampler`, optional
         Fit or Sampler instance specifying the backend and options.
         Default is a Sampler with options live_points=300, frac_remain=0.3.
-    reoptimize : bool
+    reoptimize : bool, optional
         Whether to reoptimize each dataset.background_model. Default is False.
         Only SkyModel given in `models` will be fitted the others remain frozen,
         regardless of this option.
@@ -583,7 +583,7 @@ class FluxCollectionEstimator:
         Returns
         -------
         result : dict
-            Dict with results
+            Dictionary with results
         """
         datasets = Datasets(datasets)
         if len(datasets) == 0:
@@ -618,7 +618,7 @@ class FluxCollectionEstimator:
         Parameters
         ----------
         fp_results : dict
-            dict used to generate the flux points table.
+            Dictionary used to generate the flux points table.
 
         Returns
         -------

--- a/gammapy/estimators/points/tests/test_collection.py
+++ b/gammapy/estimators/points/tests/test_collection.py
@@ -7,7 +7,6 @@ import numpy as np
 import astropy.units as u
 import pytest
 
-
 from gammapy.maps import Map, WcsGeom, MapAxis
 from gammapy.modeling import Fit, Sampler
 from gammapy.modeling.models import (
@@ -17,7 +16,6 @@ from gammapy.modeling.models import (
     FoVBackgroundModel,
 )
 from gammapy.datasets import MapDataset, Datasets
-
 from gammapy.estimators.points.sed import FluxCollectionEstimator
 
 
@@ -230,6 +228,36 @@ def test_run_multi_source(simple_dataset, energy_edges, mock_fit, mock_sampler_m
     assert "test-source-2" in samples
     assert len(samples["test-source"]) == nbin
     assert samples["test-source"][0].shape[0] == 200
+
+    # Also test two sources that are applied to the dataset, but only one is used in the FCP
+    fit_est = FluxCollectionEstimator(
+        energy_edges=energy_edges,
+        models=[m1],
+        solver=mock_fit,
+        selection_optional=["errn-errp"],
+    )
+
+    sampler_est = FluxCollectionEstimator(
+        energy_edges=energy_edges,
+        models=[m1],
+        solver=mock_sampler_multi,
+    )
+
+    for est in [fit_est, sampler_est]:
+        result = est.run(Datasets([simple_dataset]))
+        flux_points = result["flux_points"]
+        nbin = len(energy_edges) - 1
+
+        fp = flux_points["test-source"]
+        assert len(fp["dnde"].data) == nbin
+        assert np.all(np.isfinite(fp["dnde"]))
+        assert np.all(np.isfinite(fp["dnde_errn"]))
+        assert np.all(np.isfinite(fp["dnde_errp"]))
+        assert np.all(np.isfinite(fp["dnde_ul"]))
+        assert np.all(np.isfinite(fp["ts"]))
+        assert np.all(fp["ts"] >= 0)
+
+    assert result["solver_results"].shape == (nbin,)
 
 
 def test_run_multi_dataset(simple_dataset, energy_edges, mock_fit):


### PR DESCRIPTION
**Description**
This pull request fixes a bug in the `FluxCollectionEstimator` for the extra models that are frozen and not considered for the `FluxCollectionEstimator` are not called correctly

**Dear reviewer**
This PR is ready for review. I found it through trying to use the FCP with 10's of models in which some where frozen and not included in the calculation.
A test was added to catch this

**AI usage disclosure**
No AI tools were used
