### PR TITLE
Fix bug causing selection of dimmest sources instead of brightest.

### DIFF
--- a/docs/release-notes/6750.docs.rst
+++ b/docs/release-notes/6750.docs.rst
@@ -1,0 +1,1 @@
+Fix issue in Fermi-LAT tutorial where dimmest sources are used for fitting rather than brightest.

--- a/examples/tutorials/data/fermi_lat.py
+++ b/examples/tutorials/data/fermi_lat.py
@@ -444,11 +444,11 @@ print("Number of source models", len(models_4fgl_gc))
 # for all the sources we want to keep frozen).
 #
 
-sources_ouside_roi = models_4fgl_gc.select_mask(~mask_fit, use_evaluation_region=False)
-sources_inside_roi = Models([m for m in models_4fgl_gc if m not in sources_ouside_roi])
+sources_outside_roi = models_4fgl_gc.select_mask(~mask_fit, use_evaluation_region=False)
+sources_inside_roi = Models([m for m in models_4fgl_gc if m not in sources_outside_roi])
 
 geom_true = datasets[0].exposure.geom
-sources_outside_roi = sources_ouside_roi.to_template_sky_model(
+sources_outside_roi = sources_outside_roi.to_template_sky_model(
     geom_true, name="sources_outside"
 )
 
@@ -489,7 +489,7 @@ n_brightest = 3
 integrated_flux = u.Quantity(
     [m.spectral_model.integral(10 * u.GeV, 1 * u.TeV) for m in sources_inside_roi]
 )
-order = np.argsort(integrated_flux)
+order = np.argsort(integrated_flux)[::-1]
 selected_sources = Models([sources_inside_roi[int(ii)] for ii in order[:n_brightest]])
 
 print(selected_sources.names)


### PR DESCRIPTION
Commit: Fix bug causing selection of dimmest sources instead of brightest. Also spelling error of ouside instead of outside in variable names. Signed-off-by: Nicki R. Bond <nicola.bond@ucdconnect.ie>

**Description**
1. Fixed bug where three dimmest sources were selected rather than three brightest sources in Fermi-LAT tutorial by slicing the list. I described this bug and my approach to fix it in much more detail here: #6749 
2. Fixed typo of "ouside" to "outside" in three places.

**Dear reviewer**
This is ready for review. This is my first PR on this repo so please let me know if I have done something wrong. 

To test you can use
```
print("Name, Integrated flux")
for source, flux in zip(sources_inside_roi, integrated_flux):
    print(f"{source.name}\t{flux.value:.3e}")
```
in the existing Fermi-LAT tutorial. 

Thanks, 
Nicki



