### PR TITLE
ASDF serialization for WcsGeom

### DIFF
--- a/docs/release-notes/6751.feature.rst
+++ b/docs/release-notes/6751.feature.rst
@@ -1,0 +1,1 @@
+Add ASDF serialization support for `~gammapy.maps.WcsGeom`.

--- a/gammapy/io/asdf/converters/maps/geom.py
+++ b/gammapy/io/asdf/converters/maps/geom.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from asdf.extension import Converter
+
+
+class WcsGeomConverter(Converter):
+    tags = ["asdf://gammapy.org/gammapy/tags/maps/wcsgeom-1.0.0"]
+    types = ["gammapy.maps.wcs.geom.WcsGeom"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        return {
+            "wcs": obj.wcs,
+            "npix": [obj.npix[0], obj.npix[1]],
+            "cdelt": [obj._cdelt[0], obj._cdelt[1]],
+            "crpix": [obj._crpix[0], obj._crpix[1]],
+            "axes": obj.axes,
+        }
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from gammapy.maps import WcsGeom
+        import numpy as np
+
+        npix = tuple(np.array(x) for x in node["npix"])
+        cdelt = tuple(np.array(x) for x in node["cdelt"])
+        crpix = tuple(np.array(x) for x in node["crpix"])
+        return WcsGeom(
+            wcs=node["wcs"],
+            npix=npix,
+            cdelt=cdelt,
+            crpix=crpix,
+            axes=node.get("axes"),
+        )

--- a/gammapy/io/asdf/converters/maps/tests/test_geom.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_geom.py
@@ -1,0 +1,68 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import numpy as np
+from astropy.coordinates import SkyCoord
+from numpy.testing import assert_allclose
+from gammapy.maps import MapAxis, WcsGeom
+
+asdf = pytest.importorskip("asdf")
+pytest.importorskip("asdf.testing")
+from asdf.testing.helpers import yaml_to_asdf  # noqa: E402
+
+axes1 = [MapAxis(np.logspace(0.0, 3.0, 3), interp="log", name="energy")]
+axes2 = [
+    MapAxis(np.logspace(0.0, 3.0, 3), interp="log", name="energy"),
+    MapAxis(np.logspace(1.0, 3.0, 4), interp="lin"),
+]
+skydir = SkyCoord(110.0, 75.0, unit="deg", frame="icrs")
+
+tested_wcs_geom = [
+    (None, 10.0, "galactic", "AIT", skydir, None),
+    (None, 10.0, "galactic", "AIT", skydir, axes1),
+    (None, [10.0, 20.0], "galactic", "AIT", skydir, axes1),
+    (None, 10.0, "galactic", "AIT", skydir, axes2),
+    (None, [[10.0, 20.0, 30.0], [10.0, 20.0, 30.0]], "galactic", "AIT", skydir, axes2),
+    (10, 0.1, "galactic", "AIT", skydir, None),
+    (10, 0.1, "galactic", "AIT", skydir, axes1),
+    (10, [0.1, 0.2], "galactic", "AIT", skydir, axes1),
+]
+
+
+@pytest.mark.parametrize(
+    ("npix", "binsz", "frame", "proj", "skydir", "axes"), tested_wcs_geom
+)
+def test_wcsgeom_roundtrip(npix, binsz, frame, proj, skydir, axes, tmp_path):
+    file_path = tmp_path / "test.asdf"
+    geom = WcsGeom.create(
+        npix=npix,
+        binsz=binsz,
+        frame=frame,
+        proj=proj,
+        skydir=skydir,
+        axes=axes,
+    )
+    with asdf.AsdfFile() as af:
+        af["geom"] = geom
+        af.write_to(file_path)
+    with asdf.open(file_path) as af:
+        result = af["geom"]
+        assert result.is_allclose(geom)
+        if not geom.is_regular:
+            assert_allclose(result._cdelt[0], geom._cdelt[0])
+            assert_allclose(result._cdelt[1], geom._cdelt[1])
+            assert_allclose(result._crpix[0], geom._crpix[0])
+            assert_allclose(result._crpix[1], geom._crpix[1])
+
+
+def test_wcs_geom_invalid():
+    example = """!<asdf://gammapy.org/gammapy/tags/maps/wcsgeom-1.0.0>
+            npix:
+              - !core/ndarray-1.1.0
+                data: [50]
+              - !core/ndarray-1.1.0
+                data: [100]
+             """
+
+    buff = yaml_to_asdf(f"example: {example.strip()}")
+    with pytest.raises(asdf.exceptions.ValidationError):
+        asdf.open(buff)

--- a/gammapy/io/asdf/converters/maps/tests/test_geom.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_geom.py
@@ -18,13 +18,13 @@ skydir = SkyCoord(110.0, 75.0, unit="deg", frame="icrs")
 
 tested_wcs_geom = [
     (None, 10.0, "galactic", "AIT", skydir, None),
-    (None, 10.0, "galactic", "AIT", skydir, axes1),
+    (None, 10.0, "icrs", "AIT", skydir, axes1),
     (None, [10.0, 20.0], "galactic", "AIT", skydir, axes1),
-    (None, 10.0, "galactic", "AIT", skydir, axes2),
+    (None, 10.0, "icrs", "AIT", skydir, axes2),
     (None, [[10.0, 20.0, 30.0], [10.0, 20.0, 30.0]], "galactic", "AIT", skydir, axes2),
-    (10, 0.1, "galactic", "AIT", skydir, None),
+    (10, 0.1, "icrs", "AIT", skydir, None),
     (10, 0.1, "galactic", "AIT", skydir, axes1),
-    (10, [0.1, 0.2], "galactic", "AIT", skydir, axes1),
+    (10, [0.1, 0.2], "icrs", "AIT", skydir, axes1),
 ]
 
 
@@ -52,6 +52,26 @@ def test_wcsgeom_roundtrip(npix, binsz, frame, proj, skydir, axes, tmp_path):
             assert_allclose(result._cdelt[1], geom._cdelt[1])
             assert_allclose(result._crpix[0], geom._crpix[0])
             assert_allclose(result._crpix[1], geom._crpix[1])
+
+
+def test_wcs_geom_roundtrip_offcenter(tmp_path):
+    from astropy.wcs import WCS
+
+    file_path = tmp_path / "test.asdf"
+    w = WCS(naxis=2)
+    w.wcs.ctype = ["RA---CAR", "DEC--CAR"]
+    w.wcs.crval = [83.63, 22.01]
+    w.wcs.cdelt = [-0.02, 0.02]
+    w.wcs.crpix = [30.0, 45.0]
+    w.array_shape = (100, 80)
+    geom = WcsGeom(wcs=w)
+    with asdf.AsdfFile() as af:
+        af["geom"] = geom
+        af.write_to(file_path)
+    with asdf.open(file_path) as af:
+        result = af["geom"]
+        assert result.is_allclose(geom)
+        assert_allclose(result.wcs.wcs.crpix, [30.0, 45.0])
 
 
 def test_wcs_geom_invalid():

--- a/gammapy/io/asdf/extensions.py
+++ b/gammapy/io/asdf/extensions.py
@@ -12,12 +12,14 @@ from .converters.maps.axes import (
     MapAxisConverter,
     TimeMapAxisConverter,
 )
+from .converters.maps.geom import WcsGeomConverter
 
 GAMMAPY_CONVERTERS = [
     MapAxisConverter(),
     MapAxesConverter(),
     TimeMapAxisConverter(),
     LabelMapAxisConverter(),
+    WcsGeomConverter(),
 ]
 
 GAMMAPY_EXTENSIONS = [

--- a/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
@@ -12,3 +12,5 @@ tags:
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/labelmapaxis-1.0.0
 - tag_uri: asdf://gammapy.org/gammapy/tags/maps/mapaxes-1.0.0
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/mapaxes-1.0.0
+- tag_uri: asdf://gammapy.org/gammapy/tags/maps/wcsgeom-1.0.0
+  schema_uri: asdf://gammapy.org/gammapy/schemas/maps/wcsgeom-1.0.0

--- a/gammapy/io/asdf/resources/schemas/maps/wcsgeom-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/maps/wcsgeom-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id : "asdf://gammapy.org/gammapy/schemas/maps/wcsgeom-1.0.0"
+id: "asdf://gammapy.org/gammapy/schemas/maps/wcsgeom-1.0.0"
 
 title: |
   Represents WcsGeom.
@@ -39,6 +39,6 @@ properties:
     description: |
       Axes for non-spatial dimensions.
 
-required: [wcs]
+required: [wcs, npix, cdelt, crpix]
 additionalProperties: false
 ...

--- a/gammapy/io/asdf/resources/schemas/maps/wcsgeom-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/maps/wcsgeom-1.0.0.yaml
@@ -1,0 +1,44 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id : "asdf://gammapy.org/gammapy/schemas/maps/wcsgeom-1.0.0"
+
+title: |
+  Represents WcsGeom.
+
+description: |
+  Support the serialization of WcsGeom which is a geometry class for WCS maps.
+
+
+type: object
+properties:
+  wcs:
+    tag: "tag:astropy.org:astropy/wcs/wcs-1.*"
+    description: |
+      WCS projection object.
+  npix:
+    type: array
+    items:
+      tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    description: |
+      Number of pixels in each spatial dimension.
+  cdelt:
+    type: array
+    items:
+      tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    description: |
+      Pixel size in each image plane.
+  crpix:
+    type: array
+    items:
+      tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    description: |
+      Reference pixel coordinate in each image plane.
+  axes:
+    tag: "asdf://gammapy.org/gammapy/tags/maps/mapaxes-1.0.0"
+    description: |
+      Axes for non-spatial dimensions.
+
+required: [wcs]
+additionalProperties: false
+...


### PR DESCRIPTION
**Description**
This pull request is part of Google Summer of Code project Serialization Of Map and Model Classes into ASDF (Advanced Scientific Data Format).

It solves part of #6728 which is serialization of `gammapy.maps.WcsGeom` into ASDF.


**WcsGeom serialized parameters are:**
`wcs`, `npix`, `cdelt`, `crpix`, `axes` ,the only required parameter for validation is `wcs`,
`npix`, `cdelt`, and `crpix` are always serialized to correctly support multi-resolution maps.

**Implementation details**

- `WcsGeomConverter` : converts `WcsGeom` object to/from ASDF.
-  `wcsgeom-1.0.0.yaml`: is the schema that validates `WcsGeom` fields and their types.

- `test_geom.py` : 
  - Round-trip tests for `WcsGeom` covering all used cases.
  - `assert_allclose` checks on `cdelt` and `crpix` for multi-resolution maps 
      which is not checked using ` is_allclose` method.
  - Schema validation test for the invalid case of missing required `wcs` field.  
  
**Note:** 
Testing schema read for a valid example is not possible due to the complexity of the WCS structure, so only the invalid case is tested.

