### PR TITLE
Add a joint sensitivity estimator

### DIFF
--- a/docs/release-notes/6758.feature.rst
+++ b/docs/release-notes/6758.feature.rst
@@ -1,0 +1,1 @@
+# Add a ``JointSensitivityEstimator`` using forward folding approach with Asimov datasets

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -232,7 +232,7 @@ class Datasets(collections.abc.MutableSequence):
     @property
     def energy_axes_are_aligned(self):
         """Whether all contained datasets have aligned energy axis."""
-        axes = [d.counts.geom.axes["energy"] for d in self]
+        axes = [d.geoms["geom"].axes["energy"] for d in self]
         return np.all([axes[0].is_aligned(ax) for ax in axes])
 
     @property

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -234,7 +234,7 @@ class Datasets(collections.abc.MutableSequence):
     @property
     def energy_axes_are_aligned(self):
         """Whether all contained datasets have aligned energy axis."""
-        axes = [d.counts.geom.axes["energy"] for d in self]
+        axes = [d.geoms["geom"].axes["energy"] for d in self]
         return np.all([axes[0].is_aligned(ax) for ax in axes])
 
     @property

--- a/gammapy/estimators/__init__.py
+++ b/gammapy/estimators/__init__.py
@@ -15,6 +15,7 @@ from .points import (
     LightCurveEstimator,
     RegularizedFluxPointsEstimator,
     SensitivityEstimator,
+    JointSensitivityEstimator,
 )
 from .profile import ImageProfile, ImageProfileEstimator
 
@@ -33,6 +34,7 @@ __all__ = [
     "ParameterEstimator",
     "RegularizedFluxPointsEstimator",
     "SensitivityEstimator",
+    "JointSensitivityEstimator",
     "ParameterSensitivityEstimator",
     "TSMapEstimator",
     "EnergyDependentMorphologyEstimator",

--- a/gammapy/estimators/__init__.py
+++ b/gammapy/estimators/__init__.py
@@ -16,6 +16,7 @@ from .points import (
     LightCurveEstimator,
     RegularizedFluxPointsEstimator,
     SensitivityEstimator,
+    JointSensitivityEstimator,
 )
 from .profile import ImageProfile, ImageProfileEstimator
 
@@ -35,6 +36,7 @@ __all__ = [
     "ParameterEstimator",
     "RegularizedFluxPointsEstimator",
     "SensitivityEstimator",
+    "JointSensitivityEstimator",
     "ParameterSensitivityEstimator",
     "TSMapEstimator",
     "EnergyDependentMorphologyEstimator",

--- a/gammapy/estimators/points/__init__.py
+++ b/gammapy/estimators/points/__init__.py
@@ -7,7 +7,7 @@ from .sed import (
     FluxPointsEstimator,
     RegularizedFluxPointsEstimator,
 )
-from .sensitivity import SensitivityEstimator
+from .sensitivity import SensitivityEstimator, JointSensitivityEstimator
 
 __all__ = [
     "FluxCollectionEstimator",
@@ -17,4 +17,5 @@ __all__ = [
     "LightCurveEstimator",
     "RegularizedFluxPointsEstimator",
     "SensitivityEstimator",
+    "JointSensitivityEstimator",
 ]

--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -1,16 +1,23 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 import logging
+from itertools import repeat
 from astropy.table import Column, Table
-from gammapy.maps import Map
+import astropy.units as u
+from gammapy.maps import Map, MapAxis
+from gammapy.datasets import Datasets
+from gammapy.datasets.actors import DatasetsActor
 from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.stats import WStatCountsStatistic
+import gammapy.utils.parallel as parallel
+
 from ..core import Estimator
 from ..utils import apply_threshold_sensitivity
+from .sed import FluxPointsEstimator
 
 log = logging.getLogger(__name__)
 
-__all__ = ["SensitivityEstimator"]
+__all__ = ["SensitivityEstimator", "JointSensitivityEstimator"]
 
 
 class SensitivityEstimator(Estimator):
@@ -205,3 +212,129 @@ class SensitivityEstimator(Estimator):
                 ),
             ]
         )
+
+
+class JointSensitivityEstimator(FluxPointsEstimator):
+    """A joint sensitivity estimator.
+
+    This class follows the logic of `~gammapy.estimators.FluxPointsEstimator`
+    to compute sensitivity using Asimov datasets.
+    This supports multiple telescopes, or multiple event types from the same telescope.
+    All relevant models must be set on the datasets.
+
+    Parameters
+    ----------
+    source : str or int
+        For which source in the model to compute the flux points.
+    n_sigma_sensitivity : float, optional
+        Detection significance threshold. Default is 2.
+    reoptimize : bool, optional
+        If True, the free parameters of the other models are fitted in each bin independently,
+        together with the norm of the source of interest
+        (but the other parameters of the source of interest are kept frozen).
+        If False, only the norm of the source of interest is fitted,
+        and all other parameters are frozen at their current values.
+        Default is False.
+    energy_edges : `~astropy.units.Quantity`
+        Energy bin edges./
+    n_jobs : int, optional
+        Number of processes used in parallel for the computation. The number of jobs is limited to the number of
+        physical CPUs. If None, defaults to `~gammapy.utils.parallel.N_JOBS_DEFAULT`.
+        Default is None.
+    parallel_backend : {"multiprocessing", "ray"}, optional
+        Which backend to use for multiprocessing. If None, defaults to `~gammapy.utils.parallel.BACKEND_DEFAULT`.
+
+
+    """
+
+    tag = "JointSensitivityEstimator"
+
+    def __init__(
+        self,
+        source=0,
+        n_sigma_sensitivity=2.0,
+        reoptimize=False,
+        energy_edges=[1, 10] * u.TeV,
+        n_jobs=None,
+        parallel_backend=None,
+    ):
+        super().__init__(
+            energy_edges=energy_edges,
+            source=source,
+            n_sigma_sensitivity=n_sigma_sensitivity,
+            reoptimize=reoptimize,
+            n_jobs=n_jobs,
+            selection_optional=["sensitivity"],
+            parallel_backend=parallel_backend,
+            allow_multiple_telescopes=True,
+        )
+
+    def _estimate_sensitivity_one_bin(self, datasets, energy_min, energy_max):
+        """Estimate sensitivity for a single energy bin."""
+        datasets_slice = datasets.slice_by_energy(energy_min, energy_max)
+        if len(datasets_slice) == 0:
+            return None
+
+        models = datasets.models.copy()
+        model = self.get_scale_model(models)
+
+        models[self.source].spectral_model = model
+        datasets_slice.models = models
+
+        with datasets_slice.parameters.restore_status():
+            if not self.reoptimize:
+                datasets_slice.parameters.freeze_all()
+                model.norm.frozen = False
+
+            norm_sensitivity = self.estimate_sensitivity(datasets_slice, model.norm)[
+                "norm_sensitivity"
+            ]
+
+        energy_axis = MapAxis.from_energy_edges(energy_edges=[energy_min, energy_max])
+        ref_fluxes = model.reference_fluxes(energy_axis=energy_axis)
+        e2dnde_sensitivity = norm_sensitivity * ref_fluxes["ref_e2dnde"]
+        dnde_sensitivity = norm_sensitivity * ref_fluxes["ref_dnde"]
+
+        return {
+            "e_ref": ref_fluxes["e_ref"],
+            "e_min": energy_min,
+            "e_max": energy_max,
+            "e2dnde": e2dnde_sensitivity.to("erg / (cm2 s)"),
+            "dnde": dnde_sensitivity.to("1 / (TeV cm2 s)"),
+            "norm_sensitivity": norm_sensitivity,
+        }
+
+    def run(self, datasets):
+        """Run sensitivity estimation over all energy bins.
+
+        Parameters
+        ----------
+        datasets : `~gammapy.datasets.Datasets` or list
+            Input datasets.
+
+        Returns
+        -------
+        table : `~astropy.table.Table`
+            Sensitivity table with columns: ``e_ref``, ``e_min``, ``e_max``,
+            ``e2dnde``, ``dnde``, ``norm_sensitivity``.
+        """
+        if not isinstance(datasets, (Datasets, DatasetsActor)):
+            datasets = Datasets(datasets)
+
+        if not datasets.energy_axes_are_aligned:
+            raise ValueError("All datasets must have aligned energy axes.")
+
+        rows = parallel.run_multiprocessing(
+            self._estimate_sensitivity_one_bin,
+            zip(
+                repeat(datasets),
+                self.energy_edges[:-1],
+                self.energy_edges[1:],
+            ),
+            backend=self.parallel_backend,
+            pool_kwargs=dict(processes=self.n_jobs),
+            task_name="Energy bins",
+        )
+
+        rows = [r for r in rows if r is not None]
+        return Table(rows, meta={"n_sigma_sensitivity": self.n_sigma_sensitivity})

--- a/gammapy/estimators/points/sensitivity.py
+++ b/gammapy/estimators/points/sensitivity.py
@@ -243,7 +243,10 @@ class JointSensitivityEstimator(FluxPointsEstimator):
         Default is None.
     parallel_backend : {"multiprocessing", "ray"}, optional
         Which backend to use for multiprocessing. If None, defaults to `~gammapy.utils.parallel.BACKEND_DEFAULT`.
-
+    sensitivity_type : {"differential", "integral"}, optional
+        - "differential": sensitivity per bin (non-overlapping)
+        - "integral": cumulative sensitivity above increasing E_min thresholds
+        Default is "differential".
 
     """
 
@@ -257,7 +260,9 @@ class JointSensitivityEstimator(FluxPointsEstimator):
         energy_edges=[1, 10] * u.TeV,
         n_jobs=None,
         parallel_backend=None,
+        sensitivity_type="differential",
     ):
+        self.sensitivity_type = sensitivity_type
         super().__init__(
             energy_edges=energy_edges,
             source=source,
@@ -268,6 +273,16 @@ class JointSensitivityEstimator(FluxPointsEstimator):
             parallel_backend=parallel_backend,
             allow_multiple_telescopes=True,
         )
+
+    @property
+    def _energy_edges(self):
+        """energy ranges based on sensitivity type."""
+        if self.sensitivity_type == "differential":
+            return list(zip(self.energy_edges[:-1], self.energy_edges[1:]))
+        elif self.sensitivity_type == "integral":
+            return [(e_min, self.energy_edges[-1]) for e_min in self.energy_edges[:-1]]
+        else:
+            raise ValueError(f"Unknown sensitivity_type: {self.sensitivity_type}")
 
     def _estimate_sensitivity_one_bin(self, datasets, energy_min, energy_max):
         """Estimate sensitivity for a single energy bin."""
@@ -317,6 +332,8 @@ class JointSensitivityEstimator(FluxPointsEstimator):
         table : `~astropy.table.Table`
             Sensitivity table with columns: ``e_ref``, ``e_min``, ``e_max``,
             ``e2dnde``, ``dnde``, ``norm_sensitivity``.
+            For integral mode, rows show cumulative sensitivity above increasing thresholds.
+
         """
         if not isinstance(datasets, (Datasets, DatasetsActor)):
             datasets = Datasets(datasets)
@@ -326,15 +343,17 @@ class JointSensitivityEstimator(FluxPointsEstimator):
 
         rows = parallel.run_multiprocessing(
             self._estimate_sensitivity_one_bin,
-            zip(
-                repeat(datasets),
-                self.energy_edges[:-1],
-                self.energy_edges[1:],
-            ),
+            zip(repeat(datasets), *zip(*self._energy_edges)),
             backend=self.parallel_backend,
             pool_kwargs=dict(processes=self.n_jobs),
             task_name="Energy bins",
         )
 
         rows = [r for r in rows if r is not None]
-        return Table(rows, meta={"n_sigma_sensitivity": self.n_sigma_sensitivity})
+        return Table(
+            rows,
+            meta={
+                "n_sigma_sensitivity": self.n_sigma_sensitivity,
+                "sensitivity_type": self.sensitivity_type,
+            },
+        )

--- a/gammapy/estimators/points/tests/test_sensitivity.py
+++ b/gammapy/estimators/points/tests/test_sensitivity.py
@@ -178,14 +178,13 @@ def test_joint_estimator():
         source="source",
         energy_edges=dataset1._geom.axes["energy"].edges,
         n_jobs=4,
-        n_sigma_sensitivity=5,
     )
 
     res = est.run(datasets)
 
-    assert_allclose(res["dnde"][9], 7.44969158e-12, rtol=1e-3)
-    assert_allclose(res["e2dnde"][9], 8.08961662e-12, rtol=1e-3)
-    assert_allclose(res["norm_sensitivity"][9], 0.1104, rtol=1e-3)
+    assert_allclose(res["dnde"][9], 3.837294e-14, rtol=1e-3)
+    assert_allclose(res["e2dnde"][9], 4.77578124e-12, rtol=1e-3)
+    assert_allclose(res["norm_sensitivity"][9], 2.9808, rtol=1e-3)
 
     # test with SpectrumDatasetOnOff
     d1 = SpectrumDatasetOnOff.read(
@@ -194,8 +193,8 @@ def test_joint_estimator():
     d1.models = [SkyModel(spectral_model=spectral_model, name="source")]
     energy_axis = d1._geom.axes["energy"]
     est = JointSensitivityEstimator(
-        energy_edges=energy_axis.edges, source="crab", n_jobs=4, n_sigma_sensitivity=3
+        energy_edges=energy_axis.edges, source="source", n_jobs=4, n_sigma_sensitivity=3
     )
 
     res = est.run(d1)
-    assert_allclose(res["dnde"][7], 6.86442218e-14, rtol=1e-3)
+    assert_allclose(res["dnde"][7], 1.339e-10, rtol=1e-3)

--- a/gammapy/estimators/points/tests/test_sensitivity.py
+++ b/gammapy/estimators/points/tests/test_sensitivity.py
@@ -1,15 +1,24 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from numpy.testing import assert_allclose
-from gammapy.datasets import SpectrumDataset, SpectrumDatasetOnOff, Datasets
+
+import astropy.units as u
+from gammapy.datasets import SpectrumDataset, SpectrumDatasetOnOff, Datasets, MapDataset
+from gammapy.modeling.models import (
+    PowerLawSpectralModel,
+    SkyModel,
+    Models,
+    FoVBackgroundModel,
+    PointSpatialModel,
+)
 from gammapy.estimators import (
     FluxPoints,
     SensitivityEstimator,
     ParameterSensitivityEstimator,
+    JointSensitivityEstimator,
 )
 from gammapy.irf import EDispKernelMap
 from gammapy.maps import MapAxis, RegionNDMap
-from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 
 
 @pytest.fixture()
@@ -138,3 +147,55 @@ def test_warning_for_bad_model(caplog, spectrum_dataset):
         "Spectral model predicts negative flux. Results of estimator should be interpreted with caution"
         in [_.message for _ in caplog.records]
     )
+
+
+def test_joint_estimator():
+    # test for multiple MapDataset
+    dataset1 = MapDataset.read("$GAMMAPY_DATA/datasets/empty-dl4/empty-dl4.fits.gz")
+    dataset2 = dataset1.copy()
+    datasets = Datasets([dataset1, dataset2])
+    spectral_model = PowerLawSpectralModel()
+    spatial_model = PointSpatialModel(
+        lon_0=187 * u.deg, lat_0=2.6 * u.deg, frame="icrs"
+    )
+    spatial_model.lat_0.frozen = True
+    spatial_model.lon_0.frozen = True
+
+    sky_model = SkyModel(
+        spatial_model=spatial_model, spectral_model=spectral_model, name="source"
+    )
+
+    bkg1 = FoVBackgroundModel(dataset_name=dataset1.name)
+    bkg2 = FoVBackgroundModel(dataset_name=dataset2.name)
+
+    models = Models([sky_model, bkg1, bkg2])
+    datasets.models = models
+
+    dataset1.counts = None
+    dataset2.counts = None
+
+    est = JointSensitivityEstimator(
+        source="source",
+        energy_edges=dataset1._geom.axes["energy"].edges,
+        n_jobs=4,
+        n_sigma_sensitivity=5,
+    )
+
+    res = est.run(datasets)
+
+    assert_allclose(res["dnde"][9], 7.44969158e-12, rtol=1e-3)
+    assert_allclose(res["e2dnde"][9], 8.08961662e-12, rtol=1e-3)
+    assert_allclose(res["norm_sensitivity"][9], 0.1104, rtol=1e-3)
+
+    # test with SpectrumDatasetOnOff
+    d1 = SpectrumDatasetOnOff.read(
+        "$GAMMAPY_DATA/PKS2155-steady/pks2155-304_steady.fits.gz"
+    )
+    d1.models = [SkyModel(spectral_model=spectral_model, name="source")]
+    energy_axis = d1._geom.axes["energy"]
+    est = JointSensitivityEstimator(
+        energy_edges=energy_axis.edges, source="crab", n_jobs=4, n_sigma_sensitivity=3
+    )
+
+    res = est.run(d1)
+    assert_allclose(res["dnde"][7], 6.86442218e-14, rtol=1e-3)

--- a/gammapy/estimators/points/tests/test_sensitivity.py
+++ b/gammapy/estimators/points/tests/test_sensitivity.py
@@ -197,4 +197,15 @@ def test_joint_estimator():
     )
 
     res = est.run(d1)
-    assert_allclose(res["dnde"][7], 1.339e-10, rtol=1e-3)
+    assert_allclose(res["dnde"][7], 6.4675e-14, rtol=1e-3)
+
+    est2 = JointSensitivityEstimator(
+        energy_edges=energy_axis.edges,
+        source="source",
+        n_jobs=4,
+        n_sigma_sensitivity=3,
+        sensitivity_type="integral",
+    )
+
+    res2 = est2.run(d1)
+    assert_allclose(res2["dnde"][7], 1.17289e-14, rtol=1e-3)


### PR DESCRIPTION
This is a very small class for computation of joint sensitivities.
It does exactly what our FluxPointsEstimator does, only the sensitivity part.


This can be useful for sensitivity studies. Using the fpe is complex as it needs a counts map that people have to generate, and there are too many options there. This is simpler and light weight.
Should resolve #5737 and #4712 

There is one issue:

`SpectrumDatasetOnOff._to_asimov_dataset` fails if there are no counts are it cant compute the Wstat Background. What should one put there? @QRemy @registerrier 

I tried to see how this compares with our standard `SensitivityEstimator`
The difference is due to using `SpectrumDataset` and `SpectrumDatasetOnOff` in the two cases.


<img width="586" height="440" alt="image" src="https://github.com/user-attachments/assets/58eae6f8-9ebb-45f9-af43-e7e701a6c330" />

I thought of adding additional options like `gamma_min` and `bkg_sys` but was not sure how to handle them for joint analysis. 
Also did not include `npred` `excess` etc quantities on the return dict as I am not sure is they are really useful for multiple datasets

I will add tutorial (extend the sensitivity one?) in a later PR after the on off dataset issue is resolved