### PR TITLE
ASDF serialization for HpxGeom

### DIFF
--- a/docs/release-notes/6761.feature.rst
+++ b/docs/release-notes/6761.feature.rst
@@ -1,0 +1,1 @@
+Add ASDF serialization support for `~gammapy.maps.HpxGeom`.

--- a/gammapy/io/asdf/converters/maps/geom.py
+++ b/gammapy/io/asdf/converters/maps/geom.py
@@ -29,3 +29,43 @@ class WcsGeomConverter(Converter):
             crpix=crpix,
             axes=node.get("axes"),
         )
+
+
+class HpxGeomConverter(Converter):
+    tags = ["asdf://gammapy.org/gammapy/tags/maps/hpxgeom-1.0.0"]
+    types = ["gammapy.maps.hpx.geom.HpxGeom"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        node = {
+            "nside": obj.nside,
+            "nest": obj.nest,
+            "frame": obj.frame,
+            "axes": obj.axes,
+        }
+        if obj.region is not None:
+            node["region"] = obj.region
+        if obj.region == "explicit":
+            node["ipix"] = obj._ipix
+
+        return node
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from gammapy.maps import HpxGeom
+
+        nside = node["nside"]
+        region = node.get("region")
+        if region == "explicit":
+            import numpy as np
+            from gammapy.maps.hpx.utils import unravel_hpx_index
+
+            ipix = np.array(node["ipix"])
+            npix_max = 12 * np.max(nside) ** 2
+            region = unravel_hpx_index(ipix, np.array([npix_max]))
+
+        return HpxGeom(
+            nside=nside,
+            nest=node.get("nest", True),
+            frame=node.get("frame", "icrs"),
+            region=region,
+            axes=node.get("axes"),
+        )

--- a/gammapy/io/asdf/converters/maps/tests/test_geom.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_geom.py
@@ -126,6 +126,9 @@ tested_hpx_geom = [
         ],
     ),
     (8, True, "galactic", "DISK(110.,75.,10.)", None),
+    (8, False, "icrs", "DISK_INC(110.,75.,10.,4)", None),
+    (8, True, "icrs", "HPX_PIXEL(NESTED,2,3)", None),
+    (8, False, "icrs", "HPX_PIXEL(RING,2,3)", None),
 ]
 
 

--- a/gammapy/io/asdf/converters/maps/tests/test_geom.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_geom.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from astropy.coordinates import SkyCoord
 from numpy.testing import assert_allclose
-from gammapy.maps import MapAxis, WcsGeom
+from gammapy.maps import MapAxis, WcsGeom, HpxGeom
 
 asdf = pytest.importorskip("asdf")
 pytest.importorskip("asdf.testing")
@@ -86,3 +86,202 @@ def test_wcs_geom_invalid():
     buff = yaml_to_asdf(f"example: {example.strip()}")
     with pytest.raises(asdf.exceptions.ValidationError):
         asdf.open(buff)
+
+
+tested_hpx_geom = [
+    # All-sky
+    (8, False, "galactic", None, None),
+    (8, False, "galactic", None, [MapAxis(np.logspace(0.0, 3.0, 4))]),
+    ([2, 4, 8], False, "galactic", None, [MapAxis(np.logspace(0.0, 3.0, 4))]),
+    (
+        8,
+        False,
+        "galactic",
+        None,
+        [
+            MapAxis(np.logspace(0.0, 3.0, 3), name="axis0"),
+            MapAxis(np.logspace(0.0, 2.0, 4), name="axis1"),
+        ],
+    ),
+    (8, True, "galactic", None, None),
+    (8, False, "icrs", None, None),
+    # Partial-sky
+    (8, False, "galactic", "DISK(110.,75.,10.)", None),
+    (8, False, "galactic", "DISK(110.,75.,10.)", [MapAxis(np.logspace(0.0, 3.0, 4))]),
+    (
+        [8, 16, 32],
+        False,
+        "galactic",
+        "DISK(110.,75.,10.)",
+        [MapAxis(np.logspace(0.0, 3.0, 4))],
+    ),
+    (
+        [[8, 16, 32], [8, 8, 16]],
+        False,
+        "galactic",
+        "DISK(110.,75.,10.)",
+        [
+            MapAxis(np.logspace(0.0, 3.0, 3), name="axis0"),
+            MapAxis(np.logspace(0.0, 2.0, 4), name="axis1"),
+        ],
+    ),
+    (8, True, "galactic", "DISK(110.,75.,10.)", None),
+]
+
+
+@pytest.mark.parametrize(
+    ("nside", "nested", "frame", "region", "axes"), tested_hpx_geom
+)
+def test_hpxgeom_roundtrip(nside, nested, frame, region, axes, tmp_path):
+    file_path = tmp_path / "test.asdf"
+    geom = HpxGeom(nside, nested, frame, region=region, axes=axes)
+    with asdf.AsdfFile() as af:
+        af["geom"] = geom
+        af.write_to(file_path)
+    with asdf.open(file_path) as af:
+        result = af["geom"]
+        if geom.nside.size > 1:
+            assert_allclose(result.nside, geom.nside)
+            assert result.nest == geom.nest
+            assert result.frame == geom.frame
+            assert result.region == geom.region
+            assert result.axes == geom.axes
+        else:
+            assert result == geom
+            assert result.region == geom.region
+
+
+def test_hpxgeom_roundtrip_tuple_region(tmp_path):
+    file_path = tmp_path / "test.asdf"
+    geom = HpxGeom(
+        nside=8, nest=False, frame="galactic", region="DISK(110.,75.,10.)", axes=None
+    )
+    idx = geom.get_idx(flat=True)
+    geom = HpxGeom(nside=8, nest=False, frame="galactic", region=idx, axes=None)
+    with asdf.AsdfFile() as af:
+        af["geom"] = geom
+        af.write_to(file_path)
+    with asdf.open(file_path) as af:
+        result = af["geom"]
+        assert result == geom
+        assert result.region == geom.region
+        assert_allclose(result._ipix, geom._ipix)
+
+
+tested_read_hpxgeom_examples = [
+    {
+        "example": """!<asdf://gammapy.org/gammapy/tags/maps/hpxgeom-1.0.0>
+          axes: !<asdf://gammapy.org/gammapy/tags/maps/mapaxes-1.0.0>
+            axes: []
+          frame: galactic
+          nest: false
+          nside: !core/ndarray-1.1.0
+            data: [8]
+          region: DISK(110.,75.,10.)
+          """,
+        "truth": HpxGeom(
+            nside=8,
+            nest=False,
+            frame="galactic",
+            region="DISK(110.,75.,10.)",
+            axes=None,
+        ),
+    },
+    {
+        "example": """!<asdf://gammapy.org/gammapy/tags/maps/hpxgeom-1.0.0>
+          axes: !<asdf://gammapy.org/gammapy/tags/maps/mapaxes-1.0.0>
+            axes: []
+          nest: false
+          frame: galactic
+          nside: !core/ndarray-1.1.0
+            data: [8]
+          ipix: !core/ndarray-1.1.0
+            data: [6, 15, 16, 28, 29]
+          region: explicit
+          """,
+        "truth": HpxGeom(
+            nside=8,
+            nest=False,
+            frame="galactic",
+            region=(np.array([6, 15, 16, 28, 29]),),
+            axes=None,
+        ),
+    },
+    {
+        "example": """!<asdf://gammapy.org/gammapy/tags/maps/hpxgeom-1.0.0>
+          axes: !<asdf://gammapy.org/gammapy/tags/maps/mapaxes-1.0.0>
+            axes: []
+          frame: icrs
+          nest: true
+          nside: !core/ndarray-1.1.0
+            data: [8]
+          """,
+        "truth": HpxGeom(nside=8, nest=True, region=None, axes=None),
+    },
+    {
+        "example": """!<asdf://gammapy.org/gammapy/tags/maps/hpxgeom-1.0.0>
+          axes: !<asdf://gammapy.org/gammapy/tags/maps/mapaxes-1.0.0>
+            axes:
+            - !<asdf://gammapy.org/gammapy/tags/maps/mapaxis-1.0.0>
+              boundary_type: monotonic
+              interp: log
+              name: energy
+              node_type: edges
+              nodes: !core/ndarray-1.1.0 [1.0, 10.0, 100.0]
+              unit: TeV
+          frame: icrs
+          nest : true
+          nside: !core/ndarray-1.1.0
+            data: [4, 8]
+          """,
+        "truth": HpxGeom(
+            nside=np.array([4, 8]),
+            nest=True,
+            frame="icrs",
+            axes=[
+                MapAxis(
+                    nodes=[1.0, 10.0, 100.0],
+                    unit="TeV",
+                    name="energy",
+                    interp="log",
+                    node_type="edges",
+                )
+            ],
+        ),
+    },
+    {
+        "example": """!<asdf://gammapy.org/gammapy/tags/maps/hpxgeom-1.0.0>
+          nside: !core/ndarray-1.1.0
+            data: [16]
+          nest: invalid
+          frame: icrs """,
+    },
+    {
+        "example": """!<asdf://gammapy.org/gammapy/tags/maps/hpxgeom-1.0.0>
+          nest: true
+          frame: icrs
+          """,
+    },
+]
+
+
+@pytest.mark.parametrize("example", tested_read_hpxgeom_examples)
+def test_hpx_geom_read_examples(example):
+    buff = yaml_to_asdf(f"example: {example['example'].strip()}")
+
+    if example.get("truth") is not None:
+        truth = example["truth"]
+        with asdf.open(buff) as af:
+            result = af["example"]
+            if truth.nside.size > 1:
+                assert_allclose(result.nside, truth.nside)
+                assert result.nest == truth.nest
+                assert result.frame == truth.frame
+                assert result.region == truth.region
+                assert result.axes == truth.axes
+            else:
+                assert result == truth
+                assert result.region == truth.region
+    else:
+        with pytest.raises(asdf.exceptions.ValidationError):
+            asdf.open(buff)

--- a/gammapy/io/asdf/extensions.py
+++ b/gammapy/io/asdf/extensions.py
@@ -12,13 +12,14 @@ from .converters.maps.axes import (
     MapAxisConverter,
     TimeMapAxisConverter,
 )
-from .converters.maps.geom import WcsGeomConverter
+from .converters.maps.geom import HpxGeomConverter, WcsGeomConverter
 
 GAMMAPY_CONVERTERS = [
     MapAxisConverter(),
     MapAxesConverter(),
     TimeMapAxisConverter(),
     LabelMapAxisConverter(),
+    HpxGeomConverter(),
     WcsGeomConverter(),
 ]
 

--- a/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
@@ -14,3 +14,5 @@ tags:
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/mapaxes-1.0.0
 - tag_uri: asdf://gammapy.org/gammapy/tags/maps/wcsgeom-1.0.0
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/wcsgeom-1.0.0
+- tag_uri: asdf://gammapy.org/gammapy/tags/maps/hpxgeom-1.0.0
+  schema_uri: asdf://gammapy.org/gammapy/schemas/maps/hpxgeom-1.0.0

--- a/gammapy/io/asdf/resources/schemas/maps/hpxgeom-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/maps/hpxgeom-1.0.0.yaml
@@ -1,0 +1,43 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://gammapy.org/gammapy/schemas/maps/hpxgeom-1.0.0"
+
+title: |
+  Represents HpxGeom.
+
+description: |
+  Support the serialization of HpxGeom which is a geometry class for HEALPix maps.
+
+
+type: object
+properties:
+  nside:
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    description: |
+        HEALPix NSIDE parameter defining pixel resolution.
+  nest:
+    type: boolean
+    description: |
+      Indexing scheme, True for NESTED ordering, False for RING ordering.
+  frame:
+    type: string
+    enum: [icrs, galactic]
+    description: |
+      Coordinate system.
+  region:
+    type: string
+    description: |
+      Spatial geometry for partial-sky maps.
+  axes:
+    tag: "asdf://gammapy.org/gammapy/tags/maps/mapaxes-1.0.0"
+    description: |
+       Axes for non-spatial dimensions.
+  ipix:
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    description: |
+      Explicit pixel indices for partial-sky maps.
+
+required: [nside]
+additionalProperties: false
+...


### PR DESCRIPTION
**Description**
This pull request is part of Google Summer of Code project Serialization Of Map and Model Classes into ASDF (Advanced Scientific Data Format).
It closes #6728 , serialization for `gammapy.maps.HpxGeom` into ASDF.

This PR is based on #6751 so it should merged after it.

HpxGeom serialized parameters are:
`nside`, `nest`, `frame`, `region`, `axes`  and `ipix` ,the only required parameter for validation is `nside`.

**Implementation details**

- `HpxGeomConverter`: converts HpxGeom object to/from ASDF.

- `hpxgeom-1.0.0.yaml:` is the schema that validates HpxGeom fields and their types.

- ` test_geom.py` : added round-trip tests to HpxGeom objects and a  schema validation tests.
