### PR TITLE
Fix MapDatasetOnOff._to_asimov_dataset to use nominal background instead of marginalised estimate

### DIFF
--- a/docs/release-notes/6762.bug.rst
+++ b/docs/release-notes/6762.bug.rst
@@ -1,1 +1,1 @@
-# Fix Asimov dataset computation for `~gammapy.datasets.MapDatasetOff` when no counts are present
+Fix Asimov dataset computation for `~gammapy.datasets.MapDatasetOff`: use alpha * N_OFF as expected background. 

--- a/docs/release-notes/6762.bug.rst
+++ b/docs/release-notes/6762.bug.rst
@@ -1,0 +1,1 @@
+# Fix Asimov dataset computation for MapDatasetOff when no counts are present

--- a/docs/release-notes/6762.bug.rst
+++ b/docs/release-notes/6762.bug.rst
@@ -1,1 +1,1 @@
-# Fix Asimov dataset computation for MapDatasetOff when no counts are present
+# Fix Asimov dataset computation for `~gammapy.datasets.MapDatasetOff` when no counts are present

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2892,8 +2892,11 @@ class MapDatasetOnOff(MapDataset):
         )
 
     def _to_asimov_dataset(self):
-        """Create Asimov dataset from the current models."""
-        npred = self.npred()
+        """Create Asimov dataset from the current models.
+        Uses the nominal background (alpha * counts_off) instead of the
+        misginalised background estimate."""
+
+        npred = self.npred_signal() + self.background
         data = np.nan_to_num(npred.data, copy=True, nan=0.0, posinf=0.0, neginf=0.0)
         npred.data = data.astype("float")
 

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -2894,7 +2894,7 @@ class MapDatasetOnOff(MapDataset):
     def _to_asimov_dataset(self):
         """Create Asimov dataset from the current models.
         Uses the nominal background (alpha * counts_off) instead of the
-        misginalised background estimate."""
+        profiled background estimate."""
 
         npred = self.npred_signal() + self.background
         data = np.nan_to_num(npred.data, copy=True, nan=0.0, posinf=0.0, neginf=0.0)

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1503,7 +1503,7 @@ def test_map_dataset_on_off_to_asimov(images):
     asimov_dataset1 = dataset._to_asimov_dataset()
     counts_asimov1 = asimov_dataset1.counts.data.sum()
     assert_allclose(npred_sum, counts_asimov1, rtol=1e-3)
-    assert asimov_dataset1.counts_off is not None
+    assert asimov_dataset1.counts_off == dataset.counts_off
 
 
 @requires_data()

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -1495,11 +1495,15 @@ def test_map_dataset_on_off_to_asimov(images):
     dataset = get_map_dataset_onoff(images)
 
     npred_sum = dataset.npred().data.sum()
-
     asimov_dataset = dataset._to_asimov_dataset()
     counts_asimov = asimov_dataset.counts.data.sum()
+    assert_allclose(npred_sum, counts_asimov, rtol=1e-3)
 
-    assert_allclose(npred_sum, counts_asimov)
+    dataset.counts = None
+    asimov_dataset1 = dataset._to_asimov_dataset()
+    counts_asimov1 = asimov_dataset1.counts.data.sum()
+    assert_allclose(npred_sum, counts_asimov1, rtol=1e-3)
+    assert asimov_dataset1.counts_off is not None
 
 
 @requires_data()

--- a/gammapy/estimators/points/tests/test_sed.py
+++ b/gammapy/estimators/points/tests/test_sed.py
@@ -271,7 +271,7 @@ def test_run_pwl(fpe_pwl, tmpdir):
     assert_allclose(actual, [1.216227, 1.035472, 1.316878], rtol=1e-2)
 
     actual = table["norm_sensitivity"].data
-    assert_allclose(actual, [0.15901235, 0.13117017, 0.55880332], rtol=1e-2)
+    assert_allclose(actual, [0.265929, 0.217676, 0.579713], rtol=1e-2)
 
     actual = table["sqrt_ts"].data
     assert_allclose(actual, [18.568429, 18.054651, 7.057121], rtol=1e-2)


### PR DESCRIPTION
Now uses the self.background so that computation works when the counts map is absent