### PR TITLE
ASDF serialization for RegionGeom

### DIFF
--- a/docs/release-notes/6771.feature.rst
+++ b/docs/release-notes/6771.feature.rst
@@ -1,0 +1,1 @@
+Add ASDF serialization support for `~gammapy.maps.RegionGeom`.

--- a/gammapy/io/asdf/converters/maps/geom.py
+++ b/gammapy/io/asdf/converters/maps/geom.py
@@ -84,7 +84,6 @@ class RegionGeomConverter(Converter):
             "region": ds9_strings,
             "axes": obj.axes,
             "wcs": obj.wcs,
-            "binsz_wcs": obj.binsz_wcs,
         }
 
         return node
@@ -106,5 +105,4 @@ class RegionGeomConverter(Converter):
             region=region,
             axes=node.get("axes"),
             wcs=node.get("wcs"),
-            binsz_wcs=node.get("binsz_wcs"),
         )

--- a/gammapy/io/asdf/converters/maps/geom.py
+++ b/gammapy/io/asdf/converters/maps/geom.py
@@ -104,5 +104,5 @@ class RegionGeomConverter(Converter):
         return RegionGeom(
             region=region,
             axes=node.get("axes"),
-            wcs=node.get("wcs"),
+            wcs=node["wcs"],
         )

--- a/gammapy/io/asdf/converters/maps/geom.py
+++ b/gammapy/io/asdf/converters/maps/geom.py
@@ -69,3 +69,42 @@ class HpxGeomConverter(Converter):
             region=region,
             axes=node.get("axes"),
         )
+
+
+class RegionGeomConverter(Converter):
+    tags = ["asdf://gammapy.org/gammapy/tags/maps/regiongeom-1.0.0"]
+    types = ["gammapy.maps.region.geom.RegionGeom"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        from gammapy.utils.regions import compound_region_to_regions
+
+        region = compound_region_to_regions(obj.region)
+        ds9_strings = [_.serialize(format="ds9") for _ in region]
+        node = {
+            "region": ds9_strings,
+            "axes": obj.axes,
+            "wcs": obj.wcs,
+            "binsz_wcs": obj.binsz_wcs,
+        }
+
+        return node
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from gammapy.maps import RegionGeom
+        from regions import Regions
+        from gammapy.utils.regions import regions_to_compound_region
+
+        ds9_strings = node["region"]
+
+        region = [Regions.parse(_, format="ds9")[0] for _ in ds9_strings]
+        for _ in region:
+            _.meta.clear()
+            _.visual.clear()
+
+        region = regions_to_compound_region(region)
+        return RegionGeom(
+            region=region,
+            axes=node.get("axes"),
+            wcs=node.get("wcs"),
+            binsz_wcs=node.get("binsz_wcs"),
+        )

--- a/gammapy/io/asdf/converters/maps/tests/test_geom.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_geom.py
@@ -1,9 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import pytest
+import astropy.units as u
 import numpy as np
+import pytest
 from astropy.coordinates import SkyCoord
+from gammapy.maps import HpxGeom, MapAxis, RegionGeom, WcsGeom
 from numpy.testing import assert_allclose
-from gammapy.maps import MapAxis, WcsGeom, HpxGeom
+from regions import (
+    CircleSkyRegion,
+    EllipseSkyRegion,
+    PointSkyRegion,
+    RectangleSkyRegion,
+)
 
 asdf = pytest.importorskip("asdf")
 pytest.importorskip("asdf.testing")
@@ -288,3 +295,77 @@ def test_hpx_geom_read_examples(example):
     else:
         with pytest.raises(asdf.exceptions.ValidationError):
             asdf.open(buff)
+
+
+energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
+center1 = SkyCoord(83.63, 22.01, unit="deg", frame="icrs")
+center2 = SkyCoord(110.0, 75.0, unit="deg", frame="galactic")
+tested_region_geom = [
+    RegionGeom.create(CircleSkyRegion(center=center1, radius=1 * u.deg)),
+    RegionGeom.create(
+        CircleSkyRegion(center=center1, radius=1 * u.deg), axes=[energy_axis]
+    ),
+    RegionGeom.create(
+        RectangleSkyRegion(center=center1, width=1 * u.deg, height=5 * u.deg),
+    ),
+    RegionGeom.create(PointSkyRegion(center=center1)),
+    RegionGeom.from_regions(
+        [
+            CircleSkyRegion(center=center1, radius=1 * u.deg),
+            CircleSkyRegion(
+                center=SkyCoord(84.50, 23.00, unit="deg", frame="icrs"),
+                radius=5 * u.deg,
+            ),
+        ]
+    ),
+    RegionGeom.create(
+        EllipseSkyRegion(
+            center=center1, width=1 * u.deg, height=1 * u.deg, angle=20 * u.deg
+        )
+    ),
+    RegionGeom.create(
+        CircleSkyRegion(center=center2, radius=1 * u.deg),
+        axes=[energy_axis],
+        wcs=WcsGeom.create(
+            skydir=(0, 0), frame="galactic", width="1.5deg", binsz="0.1deg"
+        ).wcs,
+        binsz_wcs=0.01,
+    ),
+]
+
+
+@pytest.mark.parametrize("geom", tested_region_geom)
+def test_regiongeom_roundtrip(geom, tmp_path):
+    file_path = tmp_path / "test.asdf"
+    with asdf.AsdfFile() as af:
+        af["geom"] = geom
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        result = af["geom"]
+        assert result == geom
+        assert result.region == geom.region
+
+
+tested_read_regiongeom_invalid_examples = [
+    {
+        "example": """!<asdf://gammapy.org/gammapy/tags/maps/regiongeom-1.0.0>
+         axes: !<asdf://gammapy.org/gammapy/tags/maps/mapaxes-1.0.0>
+           axes: []
+         binsz_wcs: 0.1 deg
+         """,
+    },
+    {
+        "example": """!<asdf://gammapy.org/gammapy/tags/maps/regiongeom-1.0.0>
+         region: 42
+         binsz_wcs: 0.1 deg
+         """,
+    },
+]
+
+
+@pytest.mark.parametrize("example", tested_read_regiongeom_invalid_examples)
+def test_regiongeom_read_examples(example):
+    buff = yaml_to_asdf(f"example: {example['example'].strip()}")
+    with pytest.raises(asdf.exceptions.ValidationError):
+        asdf.open(buff)

--- a/gammapy/io/asdf/converters/maps/tests/test_geom.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_geom.py
@@ -329,7 +329,6 @@ tested_region_geom = [
         wcs=WcsGeom.create(
             skydir=(0, 0), frame="galactic", width="1.5deg", binsz="0.1deg"
         ).wcs,
-        binsz_wcs=0.01,
     ),
 ]
 
@@ -352,13 +351,11 @@ tested_read_regiongeom_invalid_examples = [
         "example": """!<asdf://gammapy.org/gammapy/tags/maps/regiongeom-1.0.0>
          axes: !<asdf://gammapy.org/gammapy/tags/maps/mapaxes-1.0.0>
            axes: []
-         binsz_wcs: 0.1 deg
          """,
     },
     {
         "example": """!<asdf://gammapy.org/gammapy/tags/maps/regiongeom-1.0.0>
          region: 42
-         binsz_wcs: 0.1 deg
          """,
     },
 ]

--- a/gammapy/io/asdf/extensions.py
+++ b/gammapy/io/asdf/extensions.py
@@ -12,7 +12,11 @@ from .converters.maps.axes import (
     MapAxisConverter,
     TimeMapAxisConverter,
 )
-from .converters.maps.geom import HpxGeomConverter, WcsGeomConverter
+from .converters.maps.geom import (
+    HpxGeomConverter,
+    RegionGeomConverter,
+    WcsGeomConverter,
+)
 
 GAMMAPY_CONVERTERS = [
     MapAxisConverter(),
@@ -20,6 +24,7 @@ GAMMAPY_CONVERTERS = [
     TimeMapAxisConverter(),
     LabelMapAxisConverter(),
     HpxGeomConverter(),
+    RegionGeomConverter(),
     WcsGeomConverter(),
 ]
 

--- a/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
@@ -16,3 +16,5 @@ tags:
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/wcsgeom-1.0.0
 - tag_uri: asdf://gammapy.org/gammapy/tags/maps/hpxgeom-1.0.0
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/hpxgeom-1.0.0
+- tag_uri: asdf://gammapy.org/gammapy/tags/maps/regiongeom-1.0.0
+  schema_uri: asdf://gammapy.org/gammapy/schemas/maps/regiongeom-1.0.0

--- a/gammapy/io/asdf/resources/schemas/maps/regiongeom-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/maps/regiongeom-1.0.0.yaml
@@ -26,10 +26,6 @@ properties:
     tag: "tag:astropy.org:astropy/wcs/wcs-1.*"
     description: |
        Optional WCS object to project the region if needed.
-  binsz_wcs:
-    tag: "tag:astropy.org:astropy/coordinates/angle-*"
-    description: |
-      Angular bin size of the underlying WCS used to evaluate quantities inside the region.
 
 required: [region]
 additionalProperties: false

--- a/gammapy/io/asdf/resources/schemas/maps/regiongeom-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/maps/regiongeom-1.0.0.yaml
@@ -27,6 +27,6 @@ properties:
     description: |
        Optional WCS object to project the region if needed.
 
-required: [region]
+required: [region, wcs]
 additionalProperties: false
 ...

--- a/gammapy/io/asdf/resources/schemas/maps/regiongeom-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/maps/regiongeom-1.0.0.yaml
@@ -25,7 +25,7 @@ properties:
   wcs:
     tag: "tag:astropy.org:astropy/wcs/wcs-1.*"
     description: |
-       Optional WCS object to project the region if needed.
+       WCS object to project the region when needed.
 
 required: [region, wcs]
 additionalProperties: false

--- a/gammapy/io/asdf/resources/schemas/maps/regiongeom-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/maps/regiongeom-1.0.0.yaml
@@ -1,0 +1,36 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://gammapy.org/gammapy/schemas/maps/regiongeom-1.0.0"
+
+title: |
+  Represents RegionGeom.
+
+description: |
+  Support the serialization of RegionGeom which is a map geometry representing a region on the sky.
+
+
+type: object
+properties:
+  region:
+    type: array
+    items:
+      type: string
+    description: |
+      The sky region object, defines what part of the sky it covers.
+  axes:
+    tag: "asdf://gammapy.org/gammapy/tags/maps/mapaxes-1.0.0"
+    description: |
+      Axes for non-spatial dimensions.
+  wcs:
+    tag: "tag:astropy.org:astropy/wcs/wcs-1.*"
+    description: |
+       Optional WCS object to project the region if needed.
+  binsz_wcs:
+    tag: "tag:astropy.org:astropy/coordinates/angle-*"
+    description: |
+      Angular bin size of the underlying WCS used to evaluate quantities inside the region.
+
+required: [region]
+additionalProperties: false
+...


### PR DESCRIPTION
**Description**
 This pull request is part of Google Summer of Code project Serialization Of Map and Model Classes into ASDF (Advanced Scientific Data Format).
It closes #6729.

This PR is based on #6761 and #6751 so both should merged first.

**RegionGeom serialized parameters:** 
`region` ,`axes`, `wcs`, `binsz_wcs`.

AS mentioned in the issue descripton `region` type which is `regions.SkyRegion` doesn't has an ASDF serialization in **Astropy** , It has been decided to serialize it in **DS9 string format** inside gammapy.

**Implementation details**

`RegionGeomConverter`: converts RegionGeom object to/from ASDF.

`regiongeom-1.0.0.yaml`: is the schema that validates RegionGeom fields and their types.

` test_geom.py` : added round-trip tests for RegionGeom objects with different types of `regions.SkyRegion` and test for invalid schema examples.
