### PR TITLE
License checker

### DIFF
--- a/dev/contributors.py
+++ b/dev/contributors.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import re
 import subprocess
 import sys

--- a/dev/license_checker.py
+++ b/dev/license_checker.py
@@ -64,15 +64,15 @@ def prepend_line(
 
     Parameters
     ----------
-        file_path: `pathlib.Path`
-            Path to the file.
-        original_file: `io.TextIOWrapper`
-           Instance of the open original file.
-        reserved_first_line: str, Optional
-            Whether the original file starts with a reserved first line, e.g. shebang
-            (`#!`) for executable or `# -*- coding: utf-8 -*-` in docs python file.
-            If that is the case, put the license statement on the second line.
-            Default if False.
+    file_path: `pathlib.Path`
+        Path to the file.
+    original_file: `io.TextIOWrapper`
+       Instance of the open original file.
+    reserved_first_line: str, Optional
+        Whether the original file starts with a reserved first line, e.g. shebang
+        (`#!`) for executable or `# -*- coding: utf-8 -*-` in docs python file.
+        If that is the case, put the license statement on the second line.
+        Default if False.
     """
 
     file_descriptor, tmp_path = tempfile.mkstemp(dir=file_path.parent)

--- a/dev/license_checker.py
+++ b/dev/license_checker.py
@@ -1,0 +1,144 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This script check that all the file in a given folder and its subfolder start with
+the license statement. Can also be applied to single file. If the `--fix` or `-f`
+option is used, fix by prepending the license statement at the beginning of the file.
+
+Usage:
+  python license_checker <PATH> [Options]
+  Options:
+    --fix, -f:  Fix by prepending the license statement to the top of the file
+    --help, -h: Display this message
+"""
+
+import pathlib
+from dataclasses import dataclass
+from typing import Sequence
+import tempfile
+import os
+import io
+
+
+LICENSE_STATEMENT = "# Licensed under a 3-clause BSD style license - see LICENSE.rst"
+
+
+TAB = "  "
+
+
+RESERVED_FIRST_LINE = ("#!", "# -*- coding: utf-8 -*-")
+
+
+class NoArgumentError(Exception):
+    pass
+
+
+@dataclass
+class PrintColor:
+    WARNGING: str = "\033[93m"
+    ENDC: str = "\033[0m"
+    FAIL: str = "\033[91m"
+    OKBLUE: str = "\033[94m"
+
+
+def print_usage():
+    print("Usage:")
+    print(f"{TAB}python license_checker <PATH> [Options]")
+    print(f"{TAB}Options:")
+    print(
+        f"{TAB}{
+            TAB
+        }--fix, -f:  Fix by prepending the license statement to the top of the file"
+    )
+    print(f"{TAB}{TAB}--help, -h: Display this message")
+
+
+def prepend_line(
+    file_path: pathlib.Path,
+    original_file: io.TextIOWrapper,
+    reserved_first_line: bool = False,
+):
+    """
+    Prepend the license statement to a file. Uses `tempfile` to prevent data losses.
+
+    Parameters
+    ----------
+        file_path: `pathlib.Path`
+            Path to the file.
+        original_file: `io.TextIOWrapper`
+           Instance of the open original file.
+        reserved_first_line: str, Optional
+            Whether the original file starts with a reserved first line, e.g. shebang
+            (`#!`) for executable or `# -*- coding: utf-8 -*-` in docs python file.
+            If that is the case, put the license statement on the second line.
+            Default if False.
+    """
+
+    file_descriptor, tmp_path = tempfile.mkstemp(dir=file_path.parent)
+
+    with os.fdopen(file_descriptor, "w") as tmp_file:
+        if reserved_first_line:
+            tmp_file.write(original_file.readline())
+        tmp_file.write(LICENSE_STATEMENT + "\n")
+        tmp_file.writelines(original_file)
+    os.replace(tmp_path, file_path)
+
+
+def check_and_fix(file: pathlib.Path, fix: bool = False):
+    """
+    Check that the file start with the license statement. Fix it if the `fix`
+    parameter is set to `True`.
+
+    Parameters
+    ----------
+    file: pathlib.Path
+        Path to the file.
+    fix: bool, Optional
+        Whether to fix by prepending the license statement to the file.
+        Default is False.
+    """
+    reserved_first_line = False
+    with open(file, "r") as f:
+        line = f.readline().strip()
+        if line.startswith(RESERVED_FIRST_LINE):
+            reserved_first_line = True
+            line = f.readline().strip()
+        if line != LICENSE_STATEMENT:
+            print(
+                f"{PrintColor.FAIL}{file}{
+                    PrintColor.ENDC
+                } does not start with the license statement !"
+            )
+            print(f"Start with:\n\t{PrintColor.WARNGING}{line}{PrintColor.ENDC}")
+            if fix:
+                print(f"{PrintColor.OKBLUE}Fixing...{PrintColor.ENDC}\n")
+                _ = f.seek(0)
+                prepend_line(file, f, reserved_first_line)
+            else:
+                print()
+
+
+def main(argv: Sequence[str] | None = None):
+    try:
+        if argv[0] in ["--help", "-h"]:
+            print_usage()
+            exit()
+        root_path = pathlib.Path(argv[0])
+    except IndexError:
+        raise NoArgumentError("Missing required argument: path to apply this script")
+
+    fix = False
+    if (len(argv) == 2) and (argv[1] in ["--fix", "-f"]):
+        fix = True
+    if root_path.is_file():
+        check_and_fix(root_path, fix)
+
+    files = map(pathlib.Path, root_path.rglob("*.py"))
+
+    for file in files:
+        check_and_fix(file, fix)
+
+
+if __name__ == "__main__":
+    import sys
+
+    main(sys.argv[1:])

--- a/dev/license_checker.py
+++ b/dev/license_checker.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This script check that all the file in a given folder and its subfolder start with
-the license statement. Can also be applied to single file. If the `--fix` or `-f`
-option is used, fix by prepending the license statement at the beginning of the file.
+This script check that all the python files tracked by git in a given folder and its
+subfolder start with the license statement. Can also be applied to single file.
+If the `--fix` or `-f` option is used, fix by prepending the license statement
+at the beginning of the file.
 
 Usage:
   python license_checker <PATH> [Options]
@@ -12,11 +13,13 @@ Usage:
 """
 
 import pathlib
-from dataclasses import dataclass
-from typing import Sequence
+import subprocess
+from typing import Sequence, Iterator
 import tempfile
+from enum import StrEnum
 import os
 import io
+import shutil
 
 
 LICENSE_STATEMENT = "# Licensed under a 3-clause BSD style license - see LICENSE.rst"
@@ -32,12 +35,11 @@ class NoArgumentError(Exception):
     pass
 
 
-@dataclass
-class PrintColor:
-    WARNGING: str = "\033[93m"
-    ENDC: str = "\033[0m"
-    FAIL: str = "\033[91m"
-    OKBLUE: str = "\033[94m"
+class PrintColor(StrEnum):
+    WARNGING = "\033[93m"
+    ENDC = "\033[0m"
+    FAIL = "\033[91m"
+    OKBLUE = "\033[94m"
 
 
 def print_usage():
@@ -56,7 +58,7 @@ def prepend_line(
     file_path: pathlib.Path,
     original_file: io.TextIOWrapper,
     reserved_first_line: bool = False,
-):
+) -> None:
     """
     Prepend the license statement to a file. Uses `tempfile` to prevent data losses.
 
@@ -83,7 +85,7 @@ def prepend_line(
     os.replace(tmp_path, file_path)
 
 
-def check_and_fix(file: pathlib.Path, fix: bool = False):
+def check_and_fix(file: pathlib.Path, fix: bool = False) -> None:
     """
     Check that the file start with the license statement. Fix it if the `fix`
     parameter is set to `True`.
@@ -117,14 +119,32 @@ def check_and_fix(file: pathlib.Path, fix: bool = False):
                 print()
 
 
-def main(argv: Sequence[str] | None = None):
+def get_git_files(path: pathlib.Path) -> Iterator[pathlib.Path]:
+    """Run a subprocess to get all the python files tracked by git in the directory `path`.
+
+    Parameters
+    ----------
+    path: pathlib.Path
+        Path where to list files with git."""
+    git_path = shutil.which("git")
+    result = subprocess.run(
+        [git_path, "-C", path, "ls-files", "*.py"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    files = map(path.joinpath, map(pathlib.Path, result.stdout.splitlines()))
+    return files
+
+
+def main(argv: Sequence[str] | None = None) -> None:
     try:
         if argv[0] in ["--help", "-h"]:
             print_usage()
             exit()
         root_path = pathlib.Path(argv[0])
     except IndexError:
-        raise NoArgumentError("Missing required argument: path to apply this script")
+        raise NoArgumentError("Missing required argument: path to apply this script.")
 
     fix = False
     if (len(argv) == 2) and (argv[1] in ["--fix", "-f"]):
@@ -132,7 +152,7 @@ def main(argv: Sequence[str] | None = None):
     if root_path.is_file():
         check_and_fix(root_path, fix)
 
-    files = map(pathlib.Path, root_path.rglob("*.py"))
+    files = get_git_files(root_path)
 
     for file in files:
         check_and_fix(file, fix)

--- a/dev/license_checker.py
+++ b/dev/license_checker.py
@@ -125,7 +125,8 @@ def get_git_files(path: pathlib.Path) -> Iterator[pathlib.Path]:
     Parameters
     ----------
     path: pathlib.Path
-        Path where to list files with git."""
+        Path where to list files with git.
+    """
     git_path = shutil.which("git")
     result = subprocess.run(
         [git_path, "-C", path, "ls-files", "*.py"],

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -22,6 +22,34 @@ The general procedure can be broken down into three major steps:
 Some steps differ between the bug fix and feature releases, and the two are detailed accordingly.
 
 
+Pre-release step
+-----------------
+
+Before starting the release procedure, run the ``license_checker`` script to verify that the
+license statement appears at the top of every Python file in the ``gammapy/`` directory.
+
+::
+
+  python dev/license_checker.py gammapy
+
+If any files are missing the license statement, they can be fixed automatically using the
+``-f`` (or ``--fix``) option.
+
+::
+
+  python dev/license_checker.py gammapy --fix
+
+Commit and push the changes:
+
+::
+
+  git checkout -b license_checker
+  git add <FILES>
+  git commit -S -m"Run license_checker"
+  git push origin license_checker
+
+Then open a pull request to merge these changes into ``main``.
+
 Bug fix releases
 ----------------
 
@@ -37,9 +65,9 @@ automatically counted in the next feature release.
 #. To create the changelog, towncrier is utilised on the relevant branch (eg: for a
    bugfix on the 2.0 release). The following workflow should be followed::
 
-    git checkout v2.0.x
-    towncrier build --version=<version> --keep
-    mv ``CHANGELOG.rst`` ``v2.0.x.rst``
+     git checkout v2.0.x
+     towncrier build --version=<version> --keep
+     mv ``CHANGELOG.rst`` ``v2.0.x.rst``
 
    * As we will create the changelog again for the major release, we should utilise the ``keep`` keyword,
      as to not delete the fragments.

--- a/gammapy/datasets/metadata.py
+++ b/gammapy/datasets/metadata.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from typing import ClassVar, Literal, Optional, Union
 import numpy as np
 from astropy.coordinates import SkyCoord

--- a/gammapy/datasets/tests/test_metadata.py
+++ b/gammapy/datasets/tests/test_metadata.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from numpy.testing import assert_allclose
 from astropy.coordinates import SkyCoord

--- a/gammapy/estimators/tests/test_energydependentmorphology.py
+++ b/gammapy/estimators/tests/test_energydependentmorphology.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 import numpy as np
 from astropy import units as u

--- a/gammapy/io/asdf/__init__.py
+++ b/gammapy/io/asdf/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/gammapy/scripts/tutorial_info.py
+++ b/gammapy/scripts/tutorial_info.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 import logging
 import click

--- a/gammapy/utils/types.py
+++ b/gammapy/utils/types.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import json
 from pathlib import Path
 from typing import Annotated

--- a/gammapy/visualization/catalogs.py
+++ b/gammapy/visualization/catalogs.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import matplotlib.pyplot as plt
 import numpy as np
 import logging


### PR DESCRIPTION
This PR introduce a small "dev" python script that checks if the python files in a directory and its sub directory starts with the license statement: `# Licensed under a 3-clause BSD style license - see LICENSE.rst`

I have noticed that a few files had missing license statement, and some are new file that where commited weeks ago. This is probably something that we will miss from time to time. So I decided to make a small tool to check and fix it. 

This script takes a path to a directory and check that all the python files in the directory and sub-directory have the license statement. This can also be applied to single file. The `--fix` (or short `-f`) option fixes this by prepending the statement to the file. When a shebang (`#!`) is the first line of the original file, the license statement is added as the second line of the file. This is also done for docs python file (e.g. `dosc/conf.py`) that starts with `# -*- coding: utf-8 -*-`

In this PR I have used the tool on the `gammapy` folder and the `dev` folder:
`python dev/license_checker.py gammapy`
which give the following output:
<img width="929" height="620" alt="Capture d’écran 2026-07-03 à 17 23 56" src="https://github.com/user-attachments/assets/ebea56e8-9d03-4ec4-8232-f0cf62502178" />

and `python dev_license_checker.py gammapy --fix`
which give the following output:
<img width="934" height="763" alt="Capture d’écran 2026-07-03 à 17 25 15" src="https://github.com/user-attachments/assets/2b3a94cc-1d1b-4809-aec1-c372e1f3c00c" />
