### PR TITLE
Add .mailmap entry to consolidate author identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -184,3 +184,6 @@ Roberta Zanin <roberta.zanin@cta-observatory.org> robertazanin <Roberta.Zanin@mp
 Roberta Zanin <roberta.zanin@cta-observatory.org> robertazanin <robertazanin@gmail.com>
 
 José Vinícius de Miranda Cardoso <jvmirca@gmail.com> Ze Vinicius <jvmirca@gmail.com>
+R. Alexander Cerviño-Cortínez <rcervino@ucm.es> <rcervino@ucm.com>
+R. Alexander Cerviño-Cortínez <rcervino@ucm.es> alexcervino <rcervino@ucm.es>
+R. Alexander Cerviño-Cortínez <rcervino@ucm.es> rcervinoucm <rcervino@ucm.es>

--- a/.mailmap
+++ b/.mailmap
@@ -184,6 +184,7 @@ Roberta Zanin <roberta.zanin@cta-observatory.org> robertazanin <Roberta.Zanin@mp
 Roberta Zanin <roberta.zanin@cta-observatory.org> robertazanin <robertazanin@gmail.com>
 
 José Vinícius de Miranda Cardoso <jvmirca@gmail.com> Ze Vinicius <jvmirca@gmail.com>
+
 R. Alexander Cerviño-Cortínez <rcervino@ucm.es> <rcervino@ucm.com>
 R. Alexander Cerviño-Cortínez <rcervino@ucm.es> alexcervino <rcervino@ucm.es>
 R. Alexander Cerviño-Cortínez <rcervino@ucm.es> rcervinoucm <rcervino@ucm.es>


### PR DESCRIPTION
Adds a .mailmap entry at the repo root to consolidate different name variants used across my past commits (all under the same email rcervino@ucm.es) under a single canonical identity: R. Alexander Cerviño-Cortínez`.