### PR TITLE
Harmonise SamplerResult output for Nautilus

### DIFF
--- a/gammapy/modeling/sampler.py
+++ b/gammapy/modeling/sampler.py
@@ -199,8 +199,7 @@ class Sampler:
             "logz": self._sampler.log_z,
             "posterior": {"mean": mean, "stdev": stdev},
             "samples": self._sampler.posterior(equal_weight=True)[0],
-            "points": points,
-            "log_w": log_w,
+            "weighted_samples": dict(points=points, weights=np.exp(log_w)),
             "log_l": log_l,
         }
         return result

--- a/gammapy/modeling/tests/test_sampler.py
+++ b/gammapy/modeling/tests/test_sampler.py
@@ -96,6 +96,14 @@ def test_run(backend, datasets_sampler, models_sampler):
         result.samples.shape[1]
         == datasets_sampler.models.parameters.free_unique_parameters.value.shape[0]
     )
+    assert (
+        result.sampler_results["weighted_samples"]["points"].shape[1]
+        == datasets_sampler.models.parameters.free_unique_parameters.value.shape[0]
+    )
+    assert (
+        result.sampler_results["weighted_samples"]["weights"].shape[0]
+        == result.sampler_results["weighted_samples"]["points"].shape[0]
+    )
 
     required_keys = [
         "logz",


### PR DESCRIPTION
Harmonise `SamplerResult` output for `nautilus` backend.
Fix a bug using `FluxCollectionEstimator` which access the `weighted_samples` in the results dict.

This doesn't require a changelog entry as Nautilus was introduced in the current dev cycle.