### PR TITLE
Fix shape issues in the FluxCollectionEstimator

### DIFF
--- a/docs/release-notes/6756.bug.rst
+++ b/docs/release-notes/6756.bug.rst
@@ -1,1 +1,1 @@
-Add unit support to the violins plot used with the `~gammapy.estimators.FluxCollection`
+Add unit support to the violins plot from `gammapy.utils.visualization.plot_samples_violin_vs_energy` used with the `~gammapy.estimators.FluxCollectionEstimator`

--- a/docs/release-notes/6785.bug.rst
+++ b/docs/release-notes/6785.bug.rst
@@ -1,1 +1,1 @@
-Fix the `~gammapy.estimators.FluxCollectionEstimator` to support computation over datasets with spatial geometry, and single flux point.
+Fix the `~gammapy.estimators.FluxCollectionEstimator` to support computation over datasets with different spatial geometries, and single flux point.

--- a/docs/release-notes/6785.bug.rst
+++ b/docs/release-notes/6785.bug.rst
@@ -1,0 +1,1 @@
+Fix the `~gammapy.estimators.FluxCollectionEstimator` to support computation over datasets with spatial geometry, and single flux point.

--- a/gammapy/estimators/__init__.py
+++ b/gammapy/estimators/__init__.py
@@ -9,6 +9,7 @@ from .map import ASmoothMapEstimator, ExcessMapEstimator, FluxMaps, TSMapEstimat
 from .metadata import FluxMetaData
 from .parameter import ParameterEstimator, ParameterSensitivityEstimator
 from .points import (
+    FluxCollectionEstimator,
     FluxPoints,
     FluxPointsEstimator,
     FluxProfileEstimator,
@@ -23,6 +24,7 @@ __all__ = [
     "Estimator",
     "ESTIMATOR_REGISTRY",
     "ExcessMapEstimator",
+    "FluxCollectionEstimator",
     "FluxMaps",
     "FluxPoints",
     "FluxPointsEstimator",
@@ -44,6 +46,7 @@ ESTIMATOR_REGISTRY = Registry(
     [
         ExcessMapEstimator,
         TSMapEstimator,
+        FluxCollectionEstimator,
         FluxPointsEstimator,
         ASmoothMapEstimator,
         LightCurveEstimator,

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -600,8 +600,8 @@ class FluxCollectionEstimator:
         if len(datasets) == 0:
             raise ValueError("datasets cannot be empty")
 
-        if not datasets.is_all_same_geom:
-            raise ValueError("Inconsistent geometries between datasets")
+        if not datasets.energy_axes_are_aligned:
+            raise ValueError("Energy axes are not aligned between datasets")
 
         for d in datasets:
             d.npred()  # precompute npred
@@ -672,7 +672,9 @@ class FluxCollectionEstimator:
             dnde_dict = {}
             for model_idx, m in enumerate(self.models):
                 dnde_dict[m.name] = []
-                dnde_ref = fp_dict["flux_points"][m.name]["dnde_ref"].squeeze()
+                dnde_ref = np.atleast_1d(
+                    fp_dict["flux_points"][m.name]["dnde_ref"].squeeze()
+                )
                 for dnde, fp in zip(dnde_ref, fp_results):
                     points = fp["solver_results"]["weighted_samples"]["points"]
                     dnde_dict[m.name].append(dnde * points[:, model_idx])

--- a/gammapy/estimators/points/sed.py
+++ b/gammapy/estimators/points/sed.py
@@ -355,6 +355,8 @@ class FluxCollectionEstimator:
         Sampler solver always compute errn-errp and ul.
     """
 
+    tag = "FluxCollectionEstimator"
+
     def __init__(
         self,
         energy_edges,

--- a/gammapy/estimators/points/tests/test_collection.py
+++ b/gammapy/estimators/points/tests/test_collection.py
@@ -144,7 +144,7 @@ def test_asymmetric_errors_present(simple_dataset, energy_edges, mock_fit):
 
 
 def test_inconsistent_geometry_raises(simple_dataset, mock_fit):
-    # dataset with different geom
+    # dataset with 2d geom
     geom2 = WcsGeom.create(npix=(3, 3), binsz=0.1)
     ds2 = simple_dataset.copy(name="bad-ds")
     ds2.counts = Map.from_geom(geom2, data=np.ones(geom2.data_shape))
@@ -155,6 +155,15 @@ def test_inconsistent_geometry_raises(simple_dataset, mock_fit):
         models=[model],
         solver=mock_fit,
     )
+
+    with pytest.raises(KeyError):
+        est.run(Datasets([simple_dataset, ds2]))
+
+    # dataset with energy axis not aligned
+    axis = MapAxis.from_energy_bounds(0.1, 7, 1, unit="TeV")
+    geom2 = WcsGeom.create(npix=20, binsz=0.02, axes=[axis])
+    ds2 = simple_dataset.copy(name="bad-ds")
+    ds2.counts = Map.from_geom(geom2, data=np.ones(geom2.data_shape))
 
     with pytest.raises(ValueError):
         est.run(Datasets([simple_dataset, ds2]))
@@ -261,7 +270,7 @@ def test_run_multi_source(simple_dataset, energy_edges, mock_fit, mock_sampler_m
 
 
 def test_run_multi_dataset(simple_dataset, energy_edges, mock_fit):
-    ds2 = simple_dataset.copy(name="dataset-2")
+    ds2 = simple_dataset.downsample(factor=2, name="dataset-2")
     ds2.counts = ds2.counts.copy(data=12 * np.ones(ds2.counts.data.shape))
     ds2.background = ds2.background.copy(data=9 * np.ones(ds2.background.data.shape))
 


### PR DESCRIPTION
- Allow to use datasets with different spatial geometries, only  check that the energy axes are aligned.
- Fix output for single energy bin
