### PR TITLE
ASDF serialization for WcsNDMap class

### DIFF
--- a/docs/release-notes/6790.feature.rst
+++ b/docs/release-notes/6790.feature.rst
@@ -1,0 +1,1 @@
+Add ASDF serialization support for `~gammapy.maps.WcsNDMap`.

--- a/gammapy/io/asdf/converters/maps/ndmap.py
+++ b/gammapy/io/asdf/converters/maps/ndmap.py
@@ -1,0 +1,28 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from asdf.extension import Converter
+
+
+class WcsNDMapConverter(Converter):
+    tags = ["asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0"]
+    types = ["gammapy.maps.wcs.ndmap.WcsNDMap"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        node = {
+            "geom": obj.geom,
+            "data": obj.data,
+            "unit": str(obj.unit),
+        }
+        if obj.meta:
+            node["meta"] = obj.meta
+
+        return node
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from gammapy.maps import WcsNDMap
+
+        return WcsNDMap(
+            geom=node["geom"],
+            data=node["data"],
+            meta=node.get("meta", {}),
+            unit=node.get("unit", ""),
+        )

--- a/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
@@ -126,3 +126,35 @@ def test_wcsndmap_roundtrip_compressed(tmp_path):
         assert_allclose(result.data, m.data)
         assert result.unit == m.unit
         assert result.meta == m.meta
+
+
+tested_wcs_ndmap_dtypes = [
+    (np.float32, "m2", None),
+    (np.float64, "", {"test": "dtype"}),
+    (bool, "", None),
+]
+
+
+@pytest.mark.parametrize(
+    ("dtype", "unit", "meta"),
+    tested_wcs_ndmap_dtypes,
+)
+def test_wcsndmap_roundtrip_dtype(dtype, unit, meta, tmp_path):
+    file_path = tmp_path / "test.asdf"
+    geom = WcsGeom.create(
+        npix=10, binsz=1.0, proj="AIT", skydir=skydir, frame="galactic", axes=axes1
+    )
+    m = WcsNDMap(geom, unit=unit, meta=meta)
+    if dtype is bool:
+        m.data = np.arange(m.data.size).reshape(m.geom.data_shape) % 2 == 0
+    else:
+        m.data = np.arange(m.data.size, dtype=dtype).reshape(m.geom.data_shape)
+    with asdf.AsdfFile() as af:
+        af["map"] = m
+        af.write_to(file_path)
+    with asdf.open(file_path) as af:
+        result = af["map"]
+        assert_allclose(result.data, m.data)
+        assert result.unit == m.unit
+        assert result.meta == m.meta
+        assert result.data.dtype == m.data.dtype

--- a/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
@@ -92,7 +92,7 @@ def test_wcsndmap_roundtrip(
         npix=npix, binsz=binsz, frame=frame, proj=proj, skydir=skydir, axes=axes
     )
     m = WcsNDMap(geom, unit=unit, meta=meta)
-    m.data = np.arange(m.data.size).reshape(m.geom.data_shape)
+    m.data = np.arange(m.data.size, dtype=m.data.dtype).reshape(m.geom.data_shape)
     with asdf.AsdfFile() as af:
         af["map"] = m
         af.write_to(file_path)
@@ -117,7 +117,7 @@ def test_wcsndmap_roundtrip_compressed(tmp_path):
             "t_stop": Time("2020-01-02"),
         },
     )
-    m.data = np.arange(m.data.size).reshape(m.geom.data_shape)
+    m.data = np.arange(m.data.size, dtype=m.data.dtype).reshape(m.geom.data_shape)
     with asdf.AsdfFile() as af:
         af["map"] = m
         af.write_to(file_path, all_array_compression="zlib")

--- a/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
@@ -6,8 +6,6 @@ import astropy.units as u
 from numpy.testing import assert_allclose
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
-
-
 from gammapy.maps import WcsGeom, WcsNDMap, MapAxis
 
 asdf = pytest.importorskip("asdf")
@@ -20,8 +18,7 @@ axes2 = [
 ]
 skydir = SkyCoord(110.0, 75.0, unit="deg", frame="icrs")
 
-tested_wcs_ndmap = [
-    # All-sky
+tested_allsky_wcs_ndmap = [
     (None, 10.0, "galactic", "AIT", skydir, None, "", None),
     (None, 10.0, "icrs", "AIT", skydir, axes1, "", {"telescope": "CTA"}),
     (None, [10.0, 20.0], "galactic", "AIT", skydir, axes1, "cm2 s", None),
@@ -36,7 +33,8 @@ tested_wcs_ndmap = [
         "s",
         None,
     ),
-    # Partial-sky
+]
+tested_partialsky_wcs_ndmap = [
     (
         10,
         1.0,
@@ -78,6 +76,8 @@ tested_wcs_ndmap = [
         None,
     ),
 ]
+
+tested_wcs_ndmap = tested_allsky_wcs_ndmap + tested_partialsky_wcs_ndmap
 
 
 @pytest.mark.parametrize(

--- a/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
@@ -12,7 +12,6 @@ from gammapy.maps import WcsGeom, WcsNDMap, MapAxis
 
 asdf = pytest.importorskip("asdf")
 pytest.importorskip("asdf.testing")
-from asdf.testing.helpers import yaml_to_asdf  # noqa: E402
 
 axes1 = [MapAxis(np.logspace(0.0, 3.0, 3), interp="log", name="energy")]
 axes2 = [

--- a/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
@@ -1,0 +1,129 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import numpy as np
+import astropy.units as u
+
+from numpy.testing import assert_allclose
+from astropy.coordinates import SkyCoord
+from astropy.time import Time
+
+
+from gammapy.maps import WcsGeom, WcsNDMap, MapAxis
+
+asdf = pytest.importorskip("asdf")
+pytest.importorskip("asdf.testing")
+from asdf.testing.helpers import yaml_to_asdf  # noqa: E402
+
+axes1 = [MapAxis(np.logspace(0.0, 3.0, 3), interp="log", name="energy")]
+axes2 = [
+    MapAxis(np.logspace(0.0, 3.0, 3), interp="log", name="energy"),
+    MapAxis(np.logspace(1.0, 3.0, 4), interp="lin"),
+]
+skydir = SkyCoord(110.0, 75.0, unit="deg", frame="icrs")
+
+tested_wcs_ndmap = [
+    # All-sky
+    (None, 10.0, "galactic", "AIT", skydir, None, "", None),
+    (None, 10.0, "icrs", "AIT", skydir, axes1, "", {"telescope": "CTA"}),
+    (None, [10.0, 20.0], "galactic", "AIT", skydir, axes1, "cm2 s", None),
+    (None, 10.0, "icrs", "AIT", skydir, axes2, "m2", {"telescope": "HESS"}),
+    (
+        None,
+        [[10.0, 20.0, 30.0], [10.0, 20.0, 30.0]],
+        "galactic",
+        "AIT",
+        skydir,
+        axes2,
+        "s",
+        None,
+    ),
+    # Partial-sky
+    (
+        10,
+        1.0,
+        "icrs",
+        "AIT",
+        skydir,
+        None,
+        "cm2",
+        {
+            "livetime": 100.0 * u.s,
+            "t_start": Time("2020-01-01"),
+            "t_stop": Time("2020-01-02"),
+        },
+    ),
+    (
+        10,
+        1.0,
+        "galactic",
+        "AIT",
+        skydir,
+        axes1,
+        "",
+        {
+            "observation_time": Time("2020-01-01"),
+            "exposure": 50.0 * u.s,
+            "target": skydir,
+        },
+    ),
+    (10, [1.0, 2.0], "icrs", "AIT", skydir, axes1, 1 / (u.cm**2 / u.s), None),
+    (10, 1.0, "galactic", "AIT", skydir, axes2, "cm2 s-1", {"creator": "gammapy"}),
+    (
+        10,
+        [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]],
+        "icrs",
+        "AIT",
+        skydir,
+        axes2,
+        "m2 s",
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("npix", "binsz", "frame", "proj", "skydir", "axes", "unit", "meta"),
+    tested_wcs_ndmap,
+)
+def test_wcsndmap_roundtrip(
+    npix, binsz, frame, proj, skydir, axes, unit, meta, tmp_path
+):
+    file_path = tmp_path / "test.asdf"
+    geom = WcsGeom.create(
+        npix=npix, binsz=binsz, frame=frame, proj=proj, skydir=skydir, axes=axes
+    )
+    m = WcsNDMap(geom, unit=unit, meta=meta)
+    m.data = np.arange(m.data.size).reshape(m.geom.data_shape)
+    with asdf.AsdfFile() as af:
+        af["map"] = m
+        af.write_to(file_path)
+    with asdf.open(file_path) as af:
+        result = af["map"]
+        assert_allclose(result.data, m.data)
+        assert result.unit == m.unit
+        assert result.meta == m.meta
+
+
+def test_wcsndmap_roundtrip_compressed(tmp_path):
+    file_path = tmp_path / "test.asdf"
+    geom = WcsGeom.create(
+        npix=10, binsz=1.0, proj="AIT", skydir=skydir, frame="galactic", axes=axes1
+    )
+    m = WcsNDMap(
+        geom,
+        unit="m2",
+        meta={
+            "livetime": 100.0 * u.s,
+            "t_start": Time("2020-01-01"),
+            "t_stop": Time("2020-01-02"),
+        },
+    )
+    m.data = np.arange(m.data.size).reshape(m.geom.data_shape)
+    with asdf.AsdfFile() as af:
+        af["map"] = m
+        af.write_to(file_path, all_array_compression="zlib")
+    with asdf.open(file_path) as af:
+        result = af["map"]
+        assert_allclose(result.data, m.data)
+        assert result.unit == m.unit
+        assert result.meta == m.meta

--- a/gammapy/io/asdf/extensions.py
+++ b/gammapy/io/asdf/extensions.py
@@ -17,6 +17,7 @@ from .converters.maps.geom import (
     RegionGeomConverter,
     WcsGeomConverter,
 )
+from .converters.maps.ndmap import WcsNDMapConverter
 
 GAMMAPY_CONVERTERS = [
     MapAxisConverter(),
@@ -26,6 +27,7 @@ GAMMAPY_CONVERTERS = [
     HpxGeomConverter(),
     RegionGeomConverter(),
     WcsGeomConverter(),
+    WcsNDMapConverter(),
 ]
 
 GAMMAPY_EXTENSIONS = [

--- a/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
@@ -18,3 +18,5 @@ tags:
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/hpxgeom-1.0.0
 - tag_uri: asdf://gammapy.org/gammapy/tags/maps/regiongeom-1.0.0
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/regiongeom-1.0.0
+- tag_uri: asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0
+  schema_uri: asdf://gammapy.org/gammapy/schemas/maps/wcsndmap-1.0.0

--- a/gammapy/io/asdf/resources/schemas/maps/wcsndmap-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/maps/wcsndmap-1.0.0.yaml
@@ -1,0 +1,33 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://gammapy.org/gammapy/schemas/maps/wcsndmap-1.0.0"
+
+title: |
+  Represents WcsNDMap.
+
+description: |
+  Support the serialization of WcsNDMap which represents a WCS map with any number of non-spatial dimensions.
+
+
+type: object
+properties:
+  geom:
+    tag: "asdf://gammapy.org/gammapy/tags/maps/wcsgeom-1.0.0"
+    description: |
+      WCS geometry defining the spatial and non-spatial axes of the map.
+  data:
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    description: |
+       N-dimensional numpy array to store map data values.
+  meta:
+    type: object
+    description: |
+      Dictionary to store meta data.
+  unit:
+    type: string
+    description: |
+      Unit of the map.
+required: [geom, data]
+additionalProperties: false
+...


### PR DESCRIPTION
**Description**
This pull request is part of Google Summer of Code project Serialization Of Map and Model Classes into ASDF (Advanced Scientific Data Format).

It solves part of #6730 , Serialization of WcsNDMap class into ASDF.

**Implementation details**

- `WcsNDMapConverter` : converts WcsNDMap object to/from ASDF.
- `wcsndmap-1.0.0.yaml` : schema that validates WcsNDMap's properties and thier types, the required types in WcsNDMap is `geom` and `data`.
- `test_ndmap.py`: Round-trip tests for WcsNDMap and  tested for compressed file to ensure the serialization of large WcsNDMap is working.
- Registered both converter and schema.