### PR TITLE
ASDF serialization for HpxNDMap class

### DIFF
--- a/docs/release-notes/6791.feature.rst
+++ b/docs/release-notes/6791.feature.rst
@@ -1,0 +1,1 @@
+Add ASDF serialization support for `~gammapy.maps.HpxNDMap`.

--- a/gammapy/io/asdf/converters/maps/ndmap.py
+++ b/gammapy/io/asdf/converters/maps/ndmap.py
@@ -26,3 +26,28 @@ class WcsNDMapConverter(Converter):
             meta=node.get("meta", {}),
             unit=node.get("unit", ""),
         )
+
+
+class HpxNDMapConverter(Converter):
+    tags = ["asdf://gammapy.org/gammapy/tags/maps/hpxndmap-1.0.0"]
+    types = ["gammapy.maps.hpx.ndmap.HpxNDMap"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        node = {
+            "geom": obj.geom,
+            "data": obj.data,
+            "unit": str(obj.unit),
+        }
+        if obj.meta:
+            node["meta"] = obj.meta
+        return node
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from gammapy.maps import HpxNDMap
+
+        return HpxNDMap(
+            geom=node["geom"],
+            data=node["data"],
+            meta=node.get("meta", {}),
+            unit=node.get("unit", ""),
+        )

--- a/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
@@ -6,7 +6,7 @@ import astropy.units as u
 from numpy.testing import assert_allclose
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
-from gammapy.maps import WcsGeom, WcsNDMap, MapAxis
+from gammapy.maps import HpxGeom, HpxNDMap, WcsGeom, WcsNDMap, MapAxis
 
 asdf = pytest.importorskip("asdf")
 pytest.importorskip("asdf.testing")
@@ -158,3 +158,121 @@ def test_wcsndmap_roundtrip_dtype(dtype, unit, meta, tmp_path):
         assert result.unit == m.unit
         assert result.meta == m.meta
         assert result.data.dtype == m.data.dtype
+
+
+tested_hpx_ndmap = [
+    # All-sky
+    (8, False, "galactic", None, None, "", None),
+    (
+        8,
+        False,
+        "galactic",
+        None,
+        [MapAxis(np.logspace(0.0, 3.0, 4))],
+        "",
+        {"telescope": "CTA"},
+    ),
+    (
+        [2, 4, 8],
+        False,
+        "galactic",
+        None,
+        [MapAxis(np.logspace(0.0, 3.0, 4))],
+        "m2 s",
+        None,
+    ),
+    (
+        8,
+        False,
+        "galactic",
+        None,
+        [
+            MapAxis(np.logspace(0.0, 3.0, 3), name="axis0"),
+            MapAxis(np.logspace(0.0, 2.0, 4), name="axis1"),
+        ],
+        1 / (u.cm**2 / u.s),
+        None,
+    ),
+    (8, True, "galactic", None, None, "cm2 s-1", {"author": "test"}),
+    (8, False, "icrs", None, None, "m2", {"telescope": "HESS"}),
+    # Partial-sky
+    (8, True, "galactic", "DISK(110.,75.,10.)", None, "", None),
+    (
+        8,
+        False,
+        "galactic",
+        "DISK(110.,75.,10.)",
+        [MapAxis(np.logspace(0.0, 3.0, 4))],
+        "",
+        {"key": "value"},
+    ),
+    (
+        [8, 16, 32],
+        False,
+        "galactic",
+        "DISK(110.,75.,10.)",
+        [MapAxis(np.logspace(0.0, 3.0, 4))],
+        "cm2 s",
+        None,
+    ),
+    (
+        [[8, 16, 32], [8, 8, 16]],
+        False,
+        "galactic",
+        "DISK(110.,75.,10.)",
+        [
+            MapAxis(np.logspace(0.0, 3.0, 3), name="axis0"),
+            MapAxis(np.logspace(0.0, 2.0, 4), name="axis1"),
+        ],
+        "s",
+        None,
+    ),
+    (8, True, "icrs", "DISK_INC(110.,75.,10.,4)", None, "", {"creator": "gammapy"}),
+    (8, True, "icrs", "HPX_PIXEL(NESTED,2,3)", None, "cm2 s-1", None),
+    (8, False, "icrs", "HPX_PIXEL(RING,2,3)", None, "", None),
+]
+
+
+@pytest.mark.parametrize(
+    ("nside", "nested", "frame", "region", "axes", "unit", "meta"), tested_hpx_ndmap
+)
+def test_hpxndmap_roundtrip(nside, nested, frame, region, axes, unit, meta, tmp_path):
+    file_path = tmp_path / "test.asdf"
+    geom = HpxGeom(nside=nside, nest=nested, frame=frame, region=region, axes=axes)
+    m = HpxNDMap(geom, unit=unit, meta=meta)
+    m.data = np.arange(m.data.size).reshape(m.geom.data_shape)
+    with asdf.AsdfFile() as af:
+        af["map"] = m
+        af.write_to(file_path)
+    with asdf.open(file_path) as af:
+        result = af["map"]
+        assert_allclose(result.data, m.data)
+        assert result.unit == m.unit
+        assert result.meta == m.meta
+
+
+def test_hpxnd_roundtrip_compressed(tmp_path):
+    file_path = tmp_path / "test.asdf"
+    geom = HpxGeom(
+        nside=8, nest=False, frame="galactic", region="DISK(110.,75.,10.)", axes=None
+    )
+    idx = geom.get_idx(flat=True)
+    geom = HpxGeom(nside=8, nest=False, frame="galactic", region=idx, axes=None)
+    m = HpxNDMap(
+        geom,
+        unit=1 / (u.cm**2 / u.s),
+        meta={
+            "observation_date": Time("2020-01-15"),
+            "exposure": 7200.0 * u.s,
+            "telescope": "Fermi",
+        },
+    )
+    m.data = np.arange(m.data.size).reshape(m.geom.data_shape)
+    with asdf.AsdfFile() as af:
+        af["map"] = m
+        af.write_to(file_path, all_array_compression="zlib")
+    with asdf.open(file_path) as af:
+        result = af["map"]
+        assert_allclose(result.data, m.data)
+        assert result.unit == m.unit
+        assert result.meta == m.meta

--- a/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
@@ -160,8 +160,7 @@ def test_wcsndmap_roundtrip_dtype(dtype, unit, meta, tmp_path):
         assert result.data.dtype == m.data.dtype
 
 
-tested_hpx_ndmap = [
-    # All-sky
+tested_allsky_hpx_ndmap = [
     (8, False, "galactic", None, None, "", None),
     (
         8,
@@ -195,7 +194,8 @@ tested_hpx_ndmap = [
     ),
     (8, True, "galactic", None, None, "cm2 s-1", {"author": "test"}),
     (8, False, "icrs", None, None, "m2", {"telescope": "HESS"}),
-    # Partial-sky
+]
+tested_partialsky_hpx_ndmap = [
     (8, True, "galactic", "DISK(110.,75.,10.)", None, "", None),
     (
         8,
@@ -231,6 +231,7 @@ tested_hpx_ndmap = [
     (8, True, "icrs", "HPX_PIXEL(NESTED,2,3)", None, "cm2 s-1", None),
     (8, False, "icrs", "HPX_PIXEL(RING,2,3)", None, "", None),
 ]
+tested_hpx_ndmap = tested_allsky_hpx_ndmap + tested_partialsky_hpx_ndmap
 
 
 @pytest.mark.parametrize(

--- a/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
@@ -251,7 +251,7 @@ def test_hpxndmap_roundtrip(nside, nested, frame, region, axes, unit, meta, tmp_
         assert result.meta == m.meta
 
 
-def test_hpxnd_roundtrip_compressed(tmp_path):
+def test_hpxndmap_roundtrip_compressed(tmp_path):
     file_path = tmp_path / "test.asdf"
     geom = HpxGeom(
         nside=8, nest=False, frame="galactic", region="DISK(110.,75.,10.)", axes=None

--- a/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
@@ -241,7 +241,7 @@ def test_hpxndmap_roundtrip(nside, nested, frame, region, axes, unit, meta, tmp_
     file_path = tmp_path / "test.asdf"
     geom = HpxGeom(nside=nside, nest=nested, frame=frame, region=region, axes=axes)
     m = HpxNDMap(geom, unit=unit, meta=meta)
-    m.data = np.arange(m.data.size).reshape(m.geom.data_shape)
+    m.data = np.arange(m.data.size, dtype=m.data.dtype).reshape(m.geom.data_shape)
     with asdf.AsdfFile() as af:
         af["map"] = m
         af.write_to(file_path)
@@ -268,7 +268,7 @@ def test_hpxndmap_roundtrip_compressed(tmp_path):
             "telescope": "Fermi",
         },
     )
-    m.data = np.arange(m.data.size).reshape(m.geom.data_shape)
+    m.data = np.arange(m.data.size, dtype=m.data.dtype).reshape(m.geom.data_shape)
     with asdf.AsdfFile() as af:
         af["map"] = m
         af.write_to(file_path, all_array_compression="zlib")

--- a/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_ndmap.py
@@ -277,3 +277,35 @@ def test_hpxndmap_roundtrip_compressed(tmp_path):
         assert_allclose(result.data, m.data)
         assert result.unit == m.unit
         assert result.meta == m.meta
+
+
+tested_hpx_ndmap_dtypes = [
+    (np.float32, "m2", None),
+    (np.float64, "", {"test": "dtype"}),
+    (bool, "", None),
+]
+
+
+@pytest.mark.parametrize(
+    ("dtype", "unit", "meta"),
+    tested_hpx_ndmap_dtypes,
+)
+def test_hpxndmap_roundtrip_dtype(dtype, unit, meta, tmp_path):
+    file_path = tmp_path / "test.asdf"
+    geom = HpxGeom(
+        nside=8, nest=False, frame="galactic", region="DISK(110.,75.,10.)", axes=axes1
+    )
+    m = HpxNDMap(geom, unit=unit, meta=meta)
+    if dtype is bool:
+        m.data = np.arange(m.data.size).reshape(m.geom.data_shape) % 2 == 0
+    else:
+        m.data = np.arange(m.data.size, dtype=dtype).reshape(m.geom.data_shape)
+    with asdf.AsdfFile() as af:
+        af["map"] = m
+        af.write_to(file_path)
+    with asdf.open(file_path) as af:
+        result = af["map"]
+        assert_allclose(result.data, m.data)
+        assert result.unit == m.unit
+        assert result.meta == m.meta
+        assert result.data.dtype == m.data.dtype

--- a/gammapy/io/asdf/extensions.py
+++ b/gammapy/io/asdf/extensions.py
@@ -17,7 +17,7 @@ from .converters.maps.geom import (
     RegionGeomConverter,
     WcsGeomConverter,
 )
-from .converters.maps.ndmap import WcsNDMapConverter
+from .converters.maps.ndmap import HpxNDMapConverter, WcsNDMapConverter
 
 GAMMAPY_CONVERTERS = [
     MapAxisConverter(),
@@ -27,6 +27,7 @@ GAMMAPY_CONVERTERS = [
     HpxGeomConverter(),
     RegionGeomConverter(),
     WcsGeomConverter(),
+    HpxNDMapConverter(),
     WcsNDMapConverter(),
 ]
 

--- a/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
@@ -20,3 +20,5 @@ tags:
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/regiongeom-1.0.0
 - tag_uri: asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/wcsndmap-1.0.0
+- tag_uri: asdf://gammapy.org/gammapy/tags/maps/hpxndmap-1.0.0
+  schema_uri: asdf://gammapy.org/gammapy/schemas/maps/hpxndmap-1.0.0

--- a/gammapy/io/asdf/resources/schemas/maps/hpxndmap-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/maps/hpxndmap-1.0.0.yaml
@@ -1,0 +1,32 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://gammapy.org/gammapy/schemas/maps/hpxndmap-1.0.0"
+
+title: |
+  Represents HpxNDMap.
+
+description: |
+  Support the serialization of HpxNDMap which represents a HEALPix map with any number of non-spatial dimensions.
+
+type: object
+properties:
+  geom:
+    tag: "asdf://gammapy.org/gammapy/tags/maps/hpxgeom-1.0.0"
+    description: |
+       HEALPix geometry object defining the spatial and non-spatial axes of the map.
+  data:
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    description: |
+       N-dimensional numpy array to store map data values.
+  meta:
+    type: object
+    description: |
+      Dictionary to store meta data.
+  unit:
+    type: string
+    description: |
+      Unit of the map.
+required: [geom, data]
+additionalProperties: false
+...


### PR DESCRIPTION
**Description**
This pull request is part of Google Summer of Code project Serialization Of Map and Model Classes into ASDF (Advanced Scientific Data Format).

It solves part of #6730 , Serialization of HpxNDMap class into ASDF.
**Note**: this branch is based on WcsNDMap-serialization branch so #6790 should be merged first.

**Implementation details**

- `HpxNDMapConverter` : converts HpxNDMap object to/from ASDF.
- `hpxndmap-1.0.0.yaml` : schema that validates HpxNDMap's properties and thier types, the required types is `geom` and `data`.
- `test_ndmap.py`: Round-trip tests for HpxNDMap and  tested for compressed file to ensure the serialization of large HpxNDMap is working.
- Registered both converter and schema.