### PR TITLE
Fix SVD convergence error in RegionGeom._rectangle_bbox

### DIFF
--- a/gammapy/maps/region/geom.py
+++ b/gammapy/maps/region/geom.py
@@ -19,6 +19,7 @@ from regions import (
     PixCoord,
     PointSkyRegion,
     RectanglePixelRegion,
+    RectangleSkyRegion,
     Regions,
     SkyRegion,
 )
@@ -157,11 +158,23 @@ class RegionGeom(Geom):
 
         try:
             rectangle_pix = bbox.to_region()
-        except ValueError:
-            rectangle_pix = RectanglePixelRegion(
-                center=PixCoord(*bbox.center[::-1]), width=1, height=1
-            )
-        return rectangle_pix.to_sky(self.wcs)
+            return rectangle_pix.to_sky(self.wcs)
+        except (ValueError, np.linalg.LinAlgError):
+            # `bbox.to_region()` raises `ValueError` for a degenerate
+            # (e.g. point-like) bounding box. Separately, `to_sky()` can
+            # raise `LinAlgError` for a *non*-degenerate pixel rectangle
+            # when the underlying WCS has an extremely coarse pixel
+            # scale (e.g. all-sky maps with a handful of pixels), since
+            # `regions>=0.12` derives the sky rectangle via an SVD of the
+            # local pixel-to-sky Jacobian, which cannot be linearized
+            # over such a large angular extent.
+            #
+            # In both cases, fall back to a minimal region built
+            # directly from the known sky center and the (angular)
+            # pixel scale, bypassing the pixel round-trip entirely.
+            center = compound_region_center(self.region)
+            pix_scale = np.mean(np.abs(proj_plane_pixel_scales(self.wcs))) * u.deg
+            return RectangleSkyRegion(center=center, width=pix_scale, height=pix_scale)
 
     @property
     def width(self):

--- a/gammapy/maps/region/tests/test_geom.py
+++ b/gammapy/maps/region/tests/test_geom.py
@@ -5,7 +5,12 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-from regions import CircleSkyRegion, CompoundSkyRegion, RectangleSkyRegion
+from regions import (
+    CircleSkyRegion,
+    CompoundSkyRegion,
+    RectanglePixelRegion,
+    RectangleSkyRegion,
+)
 import matplotlib.pyplot as plt
 from gammapy.maps import MapAxis, RegionGeom, WcsGeom
 from gammapy.utils.testing import mpl_plot_check
@@ -84,6 +89,53 @@ def test_centers(region):
 def test_width(region):
     geom = RegionGeom.create(region, binsz_wcs=0.01)
     assert_allclose(geom.width.value, [2.02, 2.02])
+
+
+@pytest.mark.parametrize("position", ["0d 0d", "180d 0d", "0d 90d", "180d -90d"])
+def test_rectangle_bbox_point_region_coarse_wcs(position):
+    """Regression test for #6775.
+
+    `RegionGeom.center_skydir` (and anything relying on `_rectangle_bbox`,
+    e.g. `width`) must not raise for a point region defined on top of a
+    very coarse (near all-sky) WCS, such as the one used internally by
+    `EDispMap.from_diagonal_response`. With `regions>=0.12`, converting a
+    pixel rectangle spanning such a large angular extent via `to_sky()`
+    can raise `numpy.linalg.LinAlgError: SVD did not converge`.
+    """
+    position = SkyCoord(position)
+
+    wcs = WcsGeom.create(
+        npix=(2, 2), binsz=180, skydir=(0, 0), frame="icrs", proj="CAR"
+    ).wcs
+
+    geom = RegionGeom.create(position, wcs=wcs)
+
+    center = geom.center_skydir
+    assert np.isfinite(center.data.lon.deg)
+    assert np.isfinite(center.data.lat.deg)
+    assert np.all(np.isfinite(geom.width.value))
+
+
+def test_rectangle_bbox_svd_failure(region, monkeypatch):
+    """Regression test for #6775, independent of the installed ``regions`` version.
+
+    The ``LinAlgError`` raised by ``RectanglePixelRegion.to_sky`` only occurs
+    with ``regions>=0.12``, which is currently excluded by the version pin in
+    ``pyproject.toml``. Forcing the error keeps this branch covered regardless
+    of which ``regions`` version is installed.
+    """
+
+    def _raise(self, wcs):
+        raise np.linalg.LinAlgError("SVD did not converge")
+
+    monkeypatch.setattr(RectanglePixelRegion, "to_sky", _raise)
+
+    geom = RegionGeom.create(region)
+
+    center = geom.center_skydir
+    assert np.isfinite(center.data.lon.deg)
+    assert np.isfinite(center.data.lat.deg)
+    assert np.all(np.isfinite(geom.width.value))
 
 
 def test_create_axis(region, energy_axis, test_axis):


### PR DESCRIPTION
Fixes #6775

With `regions>=0.12`, `RectanglePixelRegion.to_sky()` derives the sky rectangle via an SVD of the local pixel-to-sky Jacobian. `RegionGeom._rectangle_bbox` already has a fallback (`except ValueError`) for when the pixel bounding box is degenerate (e.g. for point-like regions), which builds a hardcoded 1x1 *pixel* rectangle instead. But on a very coarse, near all-sky WCS -- such as the one built internally by `EDispMap.from_diagonal_response` (~180 deg/pixel) -- that "1 pixel" rectangle still spans roughly half the sky, and the SVD can't be linearized over that large an angular extent, so it raises:

    numpy.linalg.LinAlgError: SVD did not converge

regardless of which branch builds the rectangle.

Catch `LinAlgError` alongside the existing `ValueError`, and fall back to a minimal region built directly from the known sky center and the WCS's angular pixel scale, bypassing the pixel round-trip entirely.

This fixes the six failures reported in #6775, all in `gammapy/irf/edisp/tests/test_map.py`: `test_edisp_from_diagonal_response` (3 params), `test_edisp_map_to_edisp_kernel_map`, `test_edisp_kernel_map_stack` and `test_peek`.

Two regression tests are added. `test_rectangle_bbox_point_region_coarse_wcs` covers the real-WCS path, but only reproduces the crash under `regions>=0.12`. Since `pyproject.toml` currently pins `regions<0.12`, `test_rectangle_bbox_svd_failure` forces the `LinAlgError` via monkeypatch so the fallback stays covered on the pinned version too.

Note this does not by itself make gammapy compatible with `regions 0.12`: a separate rotation-angle convention change there causes `test_disk_from_region` and `test_region_to_frame` to fail (see #6736). The `regions<0.12` pin is left in place.

**Description**

This pull request fixes #6775, a crash (`LinAlgError: SVD did not converge`) raised by `RegionGeom._rectangle_bbox` for point-like regions on a very coarse, near all-sky WCS. The fix catches this alongside the existing `ValueError` fallback and builds the fallback rectangle directly in sky coordinates instead of round-tripping through pixel space.

**Dear reviewer**

This is ready for review. It's a small, contained fix scoped to the crash reported in #6775 only -- it does not attempt to make gammapy broadly compatible with `regions>=0.12` (there's a separate, unrelated rotation-angle issue in that version tracked in #6736 that I have not investigated or touched here). Two regression tests are included, one exercising the real-WCS scenario and one forcing the failure via monkeypatch so it's covered under the currently-pinned `regions<0.12` too. Happy to adjust the approach if there's a preferred alternative.

**AI usage disclosure**

Used Claude to help investigate the root cause and draft the fix and tests; I verified everything (reproduction, fix, test results) myself before submitting.