### PR TITLE
Fix RegionGeom's ASDF roundtrip for DS9-format regions

### DIFF
--- a/docs/release-notes/6801.bug.rst
+++ b/docs/release-notes/6801.bug.rst
@@ -1,0 +1,1 @@
+Fix ``RegionGeom`` ASDF roundtrip for DS9-format regions where ``meta`` and ``visual`` were not cleared consistently on write and read.

--- a/docs/release-notes/6801.bug.rst
+++ b/docs/release-notes/6801.bug.rst
@@ -1,1 +1,1 @@
-Fix ``RegionGeom`` ASDF roundtrip for DS9-format regions where ``meta`` and ``visual`` were not cleared consistently on write and read.
+Fix `~gammapy.maps.RegionGeom` ASDF roundtrip for DS9-formatted regions to clear ``meta`` and ``visual`` on write.

--- a/gammapy/io/asdf/converters/maps/geom.py
+++ b/gammapy/io/asdf/converters/maps/geom.py
@@ -79,6 +79,9 @@ class RegionGeomConverter(Converter):
         from gammapy.utils.regions import compound_region_to_regions
 
         region = compound_region_to_regions(obj.region)
+        for _ in region:
+            _.meta.clear()
+            _.visual.clear()
         ds9_strings = [_.serialize(format="ds9") for _ in region]
         node = {
             "region": ds9_strings,

--- a/gammapy/io/asdf/converters/maps/tests/test_geom.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_geom.py
@@ -301,6 +301,7 @@ energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
 center1 = SkyCoord(83.63, 22.01, unit="deg", frame="icrs")
 center2 = SkyCoord(110.0, 75.0, unit="deg", frame="galactic")
 tested_region_geom = [
+    RegionGeom.create("icrs;circle(83.63, 22.01, 1)"),
     RegionGeom.create(CircleSkyRegion(center=center1, radius=1 * u.deg)),
     RegionGeom.create(
         CircleSkyRegion(center=center1, radius=1 * u.deg), axes=[energy_axis]


### PR DESCRIPTION
closes #6792 

As mentioned in the issue description , `meta` and `visual` were only cleared in `from_yaml_tree()` and not in`to_yaml_tree()`. This meant the original DS9 region metadata never got cleared on write as it is cleared on read, which made the roundtrip test fail.

Now both directions clear `meta` and `visual` and a test was added to confirm the fix.
