### PR TITLE
Ensure `TimeMapAxis` start and stop values are exported to table in isot format

### DIFF
--- a/docs/release-notes/6805.feature.rst
+++ b/docs/release-notes/6805.feature.rst
@@ -1,0 +1,1 @@
+Ensure `gammapy.maps.axes.TimeMapAxis` start and stop values are exported to table in isot format.

--- a/gammapy/maps/axes.py
+++ b/gammapy/maps/axes.py
@@ -3044,7 +3044,8 @@ class TimeMapAxis:
             Table with axis data.
         """
         t = self.to_gti().table
-
+        t["START"].format = "isot"
+        t["STOP"].format = "isot"
         return t
 
     def to_header(self, format="gadf", idx=0):

--- a/gammapy/maps/tests/test_axes.py
+++ b/gammapy/maps/tests/test_axes.py
@@ -666,6 +666,8 @@ def test_timeaxis_table(time_intervals):
     assert table.colnames == ["START", "STOP"]
     assert len(table["START"]) == axis.nbin
     assert (table["START"] == axis.time_min).all()
+    assert table["START"].format == "isot"
+    assert table["STOP"].format == "isot"
 
 
 def test_pix_to_coord_time_axis(time_intervals):


### PR DESCRIPTION
This PR ensures the START and STOP columns are in ISOT format. It is ready to review.