### PR TITLE
The scale parameter is not read by TemplatePhaseCurveTemporalModel

### DIFF
--- a/docs/release-notes/6807.bug.rst
+++ b/docs/release-notes/6807.bug.rst
@@ -1,0 +1,1 @@
+Fix how the `TemplatePhaseCurveTemporalModel` in `~gammapy/modeling/models/temporal` handles the `scale` parameter when read from a dict.

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -1041,6 +1041,7 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
         f0=_f0_default,
         f1=_f1_default,
         f2=_f2_default,
+        **kwargs,
     ):
         """Read phasecurve model table from FITS file.
 
@@ -1065,6 +1066,7 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
             f0=f0,
             f1=f1,
             f2=f2,
+            **kwargs,
         )
 
     @staticmethod
@@ -1179,6 +1181,9 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
         filename = data["temporal"]["filename"]
         normalize = data["temporal"].get("normalize", True)
         kwargs = {par.name: par for par in params}
+        if scale := data["temporal"].get("scale"):
+            kwargs["scale"] = scale
+
         return cls.read(filename, normalize, **kwargs)
 
     def to_dict(self, full_output=False):

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -1054,6 +1054,9 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
             Filename with path.
         normalize : bool, optional
             Flag to normalize phase curve integral over phase to 1. Default is True.
+        **kwargs : dict
+            Keyword arguments passed to the class constructor (e.g. the `scale`
+            parameter can be passed here).
         """
         filename = str(make_path(path))
 

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -583,3 +583,26 @@ def test_template_temporal_model_format():
     temporal_model = LightCurveTemplateTemporalModel.read(path)
     mod_dict = temporal_model.to_dict()
     assert mod_dict["temporal"]["format"] == "table"
+
+
+def test_phase_curve_model_scale_serialisation(tmp_path):
+    phase = np.linspace(0.0, 1, 101)
+    norm = np.ones_like(phase)
+    table = Table(data={"PHASE": phase, "NORM": norm})
+
+    t_ref = Time("2028-06-01", scale="tdb")
+    phase_model = TemplatePhaseCurveTemporalModel(
+        table=table,
+        filename=tmp_path / "test_scale.fits",
+        t_ref=t_ref.mjd * u.d,
+        scale="tt",
+    )
+
+    phase_model.write()
+
+    model_dict = phase_model.to_dict()
+    assert model_dict["temporal"]["scale"] == "tt"
+
+    new_model = TemplatePhaseCurveTemporalModel.from_dict(model_dict)
+
+    assert new_model.scale == "tt"

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -587,7 +587,8 @@ def test_template_temporal_model_format():
 
 def test_phase_curve_model_scale_serialisation(tmp_path):
     phase = np.linspace(0.0, 1, 101)
-    norm = np.ones_like(phase)
+    norm = np.sin(phase * np.pi)
+
     table = Table(data={"PHASE": phase, "NORM": norm})
 
     t_ref = Time("2028-06-01", scale="tdb")
@@ -606,3 +607,4 @@ def test_phase_curve_model_scale_serialisation(tmp_path):
     new_model = TemplatePhaseCurveTemporalModel.from_dict(model_dict)
 
     assert new_model.scale == "tt"
+    assert_allclose(new_model(t_ref), 0.1298182, rtol=3e-8)


### PR DESCRIPTION
This PR fixes a bug in the `modeling.models.temporal.TemplatePhaseCurveTemporalModel`, which does not read properly the `scale` parameter when parsing from a .yaml file. This is important, expecially in the context of the CTAO science data challenge as the pulsars and binaries have specific `scale` parameters.
The PR introduces a change in the `read` and `from_dict` methods of that class. A unit test has been introduced.