### PR TITLE
Fix broadcasting in PhaseCurveTemporalModel integration

### DIFF
--- a/docs/release-notes/6813.bug.rst
+++ b/docs/release-notes/6813.bug.rst
@@ -1,0 +1,1 @@
+Fix broadcasting in `~gammapy.modeling.models.TemplatePhaseCurveTemporalModel.integral`

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -1161,7 +1161,7 @@ class TemplatePhaseCurveTemporalModel(TemporalModel):
             ph_max
         ) - self._interpolator.antiderivative()(0)
         start_integral = self._interpolator.antiderivative()(1)
-        start_integral -= self._interpolator.antiderivative()(ph_min)
+        start_integral = start_integral - self._interpolator.antiderivative()(ph_min)
 
         # Divide by Jacobian (here we neglect variations of frequency during the integration period)
         total = (phase_integral + start_integral + end_integral) / frequency

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -583,3 +583,21 @@ def test_template_temporal_model_format():
     temporal_model = LightCurveTemplateTemporalModel.read(path)
     mod_dict = temporal_model.to_dict()
     assert mod_dict["temporal"]["format"] == "table"
+
+
+def test_lightcurve_temporal_integral_broadcasting():
+    time = np.arange(0, 10, 0.06) * u.hour
+    table = Table()
+    table["TIME"] = time
+    table["NORM"] = np.ones(len(time))
+    table.meta = dict(MJDREFI=55197.0, MJDREFF=0, TIMEUNIT="hour")
+
+    temporal_model = LightCurveTemplateTemporalModel.from_table(table)
+
+    time_start = Time("2010-01-01T00:00:00") + np.array([[1, 3], [5, 7]]) * u.hour
+    time_stop = Time("2010-01-01T00:00:00") + np.array([[2, 3.5], [6, 8]]) * u.hour
+
+    val = temporal_model.integral(time_start, time_stop)
+
+    assert val.shape == (2, 2)
+    assert np.all(np.isfinite(val))

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -590,7 +590,7 @@ def test_lightcurve_temporal_integral_broadcasting():
     table = Table()
     table["TIME"] = time
     table["NORM"] = np.ones(len(time))
-    table.meta = dict(MJDREFI=55197.0, MJDREFF=0, TIMEUNIT="hour")
+    table.meta = {"MJDREFI": 55197.0, "MJDREFF": 0, "TIMEUNIT": "hour"}
 
     temporal_model = LightCurveTemplateTemporalModel.from_table(table)
 


### PR DESCRIPTION
This PR fixes a ValueError related to NumPy broadcasting in the `integral` function of PhaseCurveTemporalModel, spotted during simulations of pulsars for the CTAO SDC.

When integrating a PhaseCurveTemporalModel across time, energy, and spatial bins, `start_integral` can be initialised as a scalar: 
`start_integral = self._interpolator.antiderivative()(1)`

making the subsequent line:
`start_integral -= self._interpolator.antiderivative()(ph_min)`

to possible cause a crash if NumPy attempts to fit any higher-dimensional array returned by `self._interpolator.antiderivative()(ph_min)` into the original scalar.

By replacing `-=` with `start_integral = start_integral - ...`, NumPy is allowed to properly broadcast the operation and dynamically allocate a new array with the correct dimensions, resolving the shape mismatch without altering the underlying math.