### PR TITLE
Fix JFactory line-of-sight branch geometry

### DIFF
--- a/docs/release-notes/6819.bug.rst
+++ b/docs/release-notes/6819.bug.rst
@@ -1,1 +1,1 @@
-Fixed the line-of-sight integration geometry in `~gammapy.astro.darkmatter.JFactory` to account for observers inside or outside the radial integration region.
+Fixes the line-of-sight integration geometry in `~gammapy.astro.darkmatter.JFactory` to account for observers inside or outside the radial integration region.

--- a/docs/release-notes/6819.bug.rst
+++ b/docs/release-notes/6819.bug.rst
@@ -1,0 +1,1 @@
+Fixed the line-of-sight integration geometry in `~gammapy.astro.darkmatter.JFactory` to account for observers inside or outside the radial integration region.

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -1,10 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from unittest.mock import patch
 import numpy as np
-import html
 import astropy.units as u
 import pytest
-from numpy.testing import assert_allclose
 
 from gammapy.astro.darkmatter import (
     DarkMatterAnnihilationSpectralModel,
@@ -14,7 +11,6 @@ from gammapy.astro.darkmatter import (
     add_factor_prior,
 )
 from gammapy.maps import WcsGeom
-from gammapy.modeling import Parameter
 from gammapy.utils.testing import assert_quantity_allclose, requires_data
 
 
@@ -92,8 +88,9 @@ def test_compute_differential_jfactor_outside_halo_no_intersection():
     assert np.all(jfactor[separation >= max_intersection_angle] == 0)
 
 
-def test_integrate_los_geometric_path_length(geom):
-    cases = [
+@pytest.mark.parametrize(
+    ("name", "distance", "rmax", "separation"),
+    [
         ("inside_toward", 1, 2, 30),
         ("inside_perpendicular", 1, 2, 90),
         ("inside_away", 1, 2, 120),
@@ -102,58 +99,56 @@ def test_integrate_los_geometric_path_length(geom):
         ("outside_intersects", 10, 2, 5),
         ("outside_misses", 10, 2, 30),
         ("outside_away", 10, 2, 120),
-    ]
-
+    ],
+)
+def test_integrate_los_geometric_path_length(
+    geom,
+    name,
+    distance,
+    rmax,
+    separation,
+):
     density = 1 * u.GeV / u.cm**3
 
     def constant_profile(radius):
         return np.ones(np.shape(radius)) * density
 
-    for name, distance, rmax, separation in cases:
-        jfactory = JFactory(
-            geom=geom,
-            profile=constant_profile,
-            distance=distance * u.kpc,
-            rmax=rmax * u.kpc,
-        )
+    jfactory = JFactory(
+        geom=geom,
+        profile=constant_profile,
+        distance=distance * u.kpc,
+        rmax=rmax * u.kpc,
+    )
 
-        theta = np.deg2rad(separation)
-        impact = jfactory.distance * np.sin(theta)
+    theta = np.deg2rad(separation)
+    impact = jfactory.distance * np.sin(theta)
 
-        actual = jfactory._integrate_los(
-            impact=impact,
-            separation=theta,
-            ndecade=10000,
-        )
+    actual = jfactory._integrate_los(
+        impact=impact,
+        separation=theta,
+        ndecade=10000,
+    )
 
-        discriminant = jfactory.rmax**2 - impact**2
+    discriminant = jfactory.rmax**2 - impact**2
 
-        if discriminant <= 0 * u.kpc**2:
+    if discriminant <= 0 * u.kpc**2:
+        path_length = 0 * u.kpc
+    else:
+        root = np.sqrt(discriminant)
+        los_center = jfactory.distance * np.cos(theta)
+        los_min = los_center - root
+        los_max = los_center + root
+
+        if np.isclose(los_max.to_value(u.kpc), 0, atol=1e-12) or los_max < 0 * u.kpc:
             path_length = 0 * u.kpc
+        elif los_min <= 0 * u.kpc:
+            path_length = los_max
         else:
-            root = np.sqrt(discriminant)
-            los_center = jfactory.distance * np.cos(theta)
-            los_min = los_center - root
-            los_max = los_center + root
+            path_length = los_max - los_min
 
-            if (
-                np.isclose(los_max.to_value(u.kpc), 0, atol=1e-12)
-                or los_max < 0 * u.kpc
-            ):
-                path_length = 0 * u.kpc
-            elif los_min <= 0 * u.kpc:
-                path_length = los_max
-            else:
-                path_length = los_max - los_min
+    expected = density**2 * path_length
 
-        expected = density**2 * path_length
-
-        assert_quantity_allclose(
-            actual,
-            expected,
-            rtol=1e-5,
-            err_msg=f"Failed for geometry: {name}",
-        )
+    assert_quantity_allclose(actual, expected, rtol=1e-5)
 
 
 def test_integrate_los_branch_zero_impact_positive_radius():

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -72,6 +72,90 @@ def test_compute_differential_jfactor_large_separation():
     assert np.all(np.isfinite(jfactor.value))
 
 
+def test_compute_differential_jfactor_outside_halo_no_intersection():
+    geom = WcsGeom.create(skydir=(0, 0), width=(120, 2), binsz=1, frame="galactic")
+    separation = geom.separation(geom.center_skydir)
+
+    jfactory = JFactory(
+        geom=geom,
+        profile=profiles.NFWProfile(),
+        distance=8.33 * u.kpc,
+        rmax=1 * u.kpc,
+    )
+
+    jfactor = jfactory.compute_differential_jfactor(ndecade=100)
+
+    max_intersection_angle = (
+        np.arcsin((jfactory.rmax / jfactory.distance).to_value("")) * u.rad
+    )
+
+    assert np.all(jfactor[separation >= max_intersection_angle] == 0)
+
+
+def test_integrate_los_geometric_path_length(geom):
+    cases = [
+        ("inside_toward", 1, 2, 30),
+        ("inside_perpendicular", 1, 2, 90),
+        ("inside_away", 1, 2, 120),
+        ("boundary_toward", 2, 2, 30),
+        ("boundary_away", 2, 2, 120),
+        ("outside_intersects", 10, 2, 5),
+        ("outside_misses", 10, 2, 30),
+        ("outside_away", 10, 2, 120),
+    ]
+
+    density = 1 * u.GeV / u.cm**3
+
+    def constant_profile(radius):
+        return np.ones(np.shape(radius)) * density
+
+    for name, distance, rmax, separation in cases:
+        jfactory = JFactory(
+            geom=geom,
+            profile=constant_profile,
+            distance=distance * u.kpc,
+            rmax=rmax * u.kpc,
+        )
+
+        theta = np.deg2rad(separation)
+        impact = jfactory.distance * np.sin(theta)
+
+        actual = jfactory._integrate_los(
+            impact=impact,
+            separation=theta,
+            ndecade=10000,
+        )
+
+        discriminant = jfactory.rmax**2 - impact**2
+
+        if discriminant <= 0 * u.kpc**2:
+            path_length = 0 * u.kpc
+        else:
+            root = np.sqrt(discriminant)
+            los_center = jfactory.distance * np.cos(theta)
+            los_min = los_center - root
+            los_max = los_center + root
+
+            if (
+                np.isclose(los_max.to_value(u.kpc), 0, atol=1e-12)
+                or los_max < 0 * u.kpc
+            ):
+                path_length = 0 * u.kpc
+            elif los_min <= 0 * u.kpc:
+                path_length = los_max
+            else:
+                path_length = los_max - los_min
+
+        expected = density**2 * path_length
+
+        assert_quantity_allclose(
+            actual,
+            expected,
+            rtol=1e-5,
+            err_msg=f"Failed for geometry: {name}",
+        )
+
+
 def test_integrate_los_branch_zero_impact_positive_radius():
     geom = WcsGeom.create(binsz=1, npix=2)
     profile = profiles.NFWProfile()

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -205,7 +205,7 @@ def test_dmfluxmap_annihilation(jfact_annihilation):
         / total_jfact
     ).to("cm-2 s-1")
     actual = int_flux[5, 5]
-    desired = 5.902332e-12 / u.cm**2 / u.s
+    desired = 5.84534173e-12 / u.cm**2 / u.s
 
     assert_quantity_allclose(actual, desired, rtol=1e-3)
 
@@ -224,7 +224,7 @@ def test_dmfluxmap_decay(jfact_decay):
         / diff_flux.jfactor
     ).to("cm-2 s-1")
     actual = int_flux[5, 5]
-    desired = 1.277e-3 / u.cm**2 / u.s
+    desired = 1.09754e-3 / u.cm**2 / u.s
     assert_quantity_allclose(actual, desired, rtol=1e-3)
 
 

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -133,18 +133,16 @@ class JFactory:
             r_\perp = D \sin\theta.
 
         The integration is split into two regions:
-        
-        1.  :math:`D < r_{\max}`: the observer is inside the integration radius
-        (:math:`D < r_{\max}`), directions with
-        :math:`\theta < \pi / 2` cross the inner radial interval twice,
-        while directions with :math:`\theta \geq \pi / 2` contain only
+
+        1. :math:`D < r_{\max}`: the observer is inside the integration radius.
+        Directions with :math:`\theta < \pi / 2` cross the inner radial interval
+        twice, while directions with :math:`\theta \geq \pi / 2` contain only
         the outward branch.
 
-        If the observer is outside the integration radius
-        (:math:`D \geq r_{\max}`), the line of sight contributes only when
-        it points toward the halo and intersects the integration sphere,
-        i.e. when :math:`\theta < \pi / 2` and
-        :math:`r_\perp < r_{\max}`.
+        2. :math:`D \geq r_{\max}`: the observer is outside the integration radius.
+        The line of sight contributes only when it points toward the halo and
+        intersects the integration sphere, i.e. when :math:`\theta < \pi / 2`
+        and :math:`r_\perp < r_{\max}`.
 
         Each radial branch is evaluated using
 
@@ -152,9 +150,9 @@ class JFactory:
             \mathrm dl =
             \frac{r}{\sqrt{r^2-r_\perp^2}}\,\mathrm dr.
 
-        The apparent singularity at :math:`r=r_\perp` is integrable and is
-        removed numerically with the substitution
-        :math:`r=r_\perp\cosh t`.
+        The apparent singularity at :math:`r = r_\perp` is integrable. To avoid
+        evaluating it directly, each radial branch is integrated with the
+        substitution :math:`r = r_\perp\cosh t`.
         """
         separation = self.geom.separation(self.geom.center_skydir).rad
         impact = u.Quantity(

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -84,18 +84,17 @@ class JFactory:
         rmax = self.rmax
 
         if distance < rmax:
+            integral = self._integrate_los_branch(impact, distance, rmax, ndecade)
             if separation < np.pi / 2:
-                return 2 * self._integrate_los_branch(
+                integral += 2 * self._integrate_los_branch(
                     impact, impact, distance, ndecade
-                ) + self._integrate_los_branch(impact, distance, rmax, ndecade)
-
-            return self._integrate_los_branch(impact, distance, rmax, ndecade)
+                )
+            return integral
 
         if separation < np.pi / 2 and impact < rmax:
             return 2 * self._integrate_los_branch(impact, impact, rmax, ndecade)
 
-        integral_unit = u.Unit("GeV2 cm-5") if self.annihilation else u.Unit("GeV cm-2")
-        return 0 * integral_unit
+        return 0 * u.Unit("GeV2 cm-5" if self.annihilation else "GeV cm-2")
 
     def compute_differential_jfactor(self, ndecade=1e4):
         r"""Compute differential J-Factor.

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -78,6 +78,25 @@ class JFactory:
 
         return np.trapezoid(values, t)
 
+    def _integrate_los(self, impact, separation, ndecade):
+        """Integrate the physical forward line of sight."""
+        distance = self.distance
+        rmax = self.rmax
+
+        if distance < rmax:
+            if separation < np.pi / 2:
+                return 2 * self._integrate_los_branch(
+                    impact, impact, distance, ndecade
+                ) + self._integrate_los_branch(impact, distance, rmax, ndecade)
+
+            return self._integrate_los_branch(impact, distance, rmax, ndecade)
+
+        if separation < np.pi / 2 and impact < rmax:
+            return 2 * self._integrate_los_branch(impact, impact, rmax, ndecade)
+
+        integral_unit = u.Unit("GeV2 cm-5") if self.annihilation else u.Unit("GeV cm-2")
+        return 0 * integral_unit
+
     def compute_differential_jfactor(self, ndecade=1e4):
         r"""Compute differential J-Factor.
 
@@ -102,46 +121,47 @@ class JFactory:
 
         Notes
         -----
-        The line-of-sight (LoS) integral should include both the near and far
-        sides of the halo. To account for this, the integration is split into
-        two regions:
-
-        1. :math:`[r_\perp, r_{\max}]` - from the observer to the source,
-           counted twice to include contributions from both near and far sides.
-        2. :math:`[r_{\max}, 4 r_{\max}]` - from the source to infinity.
-           The upper limit is truncated at :math:`4 r_{\max}` because
-           contributions beyond this are negligible.
-
-        Hence, the effective integration domain is:
+        The line-of-sight geometry is defined by
 
         .. math::
-            2 \times [r_\perp, r_{\max}] \;+\; [r_{\max}, 4 r_{\max}].
+            r(l)^2 = D^2 + l^2 - 2 D l \cos\theta,
 
-        The impact parameter is given by:
-
-        .. math::
-            r_\perp = r_{\max} \sin \theta.
-
-        The LoS integral is converted into radial branches with:
+        where :math:`D` is the observer-to-halo-center distance and
+        :math:`l \geq 0` is the physical forward line-of-sight coordinate.
+        The impact parameter of the corresponding infinite line is
 
         .. math::
-            \mathrm dl = \frac{r}{\sqrt{r^2 - r_\perp^2}} \, \mathrm dr.
+            r_\perp = D \sin\theta.
 
-        The apparent singularity at :math:`r = r_\perp` is integrable. To avoid
-        evaluating it directly, each radial branch is integrated with the
-        substitution :math:`r = r_\perp \cosh t`.
+        If the observer is inside the integration radius
+        (:math:`D < r_{\max}`), directions with
+        :math:`\theta < \pi / 2` cross the inner radial interval twice,
+        while directions with :math:`\theta \geq \pi / 2` contain only
+        the outward branch.
+
+        If the observer is outside the integration radius
+        (:math:`D \geq r_{\max}`), the line of sight contributes only when
+        it points toward the halo and intersects the integration sphere,
+        i.e. when :math:`\theta < \pi / 2` and
+        :math:`r_\perp < r_{\max}`.
+
+        Each radial branch is evaluated using
+
+        .. math::
+            \mathrm dl =
+            \frac{r}{\sqrt{r^2-r_\perp^2}}\,\mathrm dr.
+
+        The apparent singularity at :math:`r=r_\perp` is integrable and is
+        removed numerically with the substitution
+        :math:`r=r_\perp\cosh t`.
         """
         separation = self.geom.separation(self.geom.center_skydir).rad
         impact = u.Quantity(
             value=np.sin(separation) * self.distance, unit=self.distance.unit
         )
-        rmax = self.rmax
         val = [
-            (
-                2 * self._integrate_los_branch(impact_i, impact_i, rmax, ndecade)
-                + self._integrate_los_branch(impact_i, rmax, 4 * rmax, ndecade)
-            )
-            for impact_i in impact.ravel()
+            self._integrate_los(impact_i, separation_i, ndecade)
+            for impact_i, separation_i in zip(impact.ravel(), separation.ravel())
         ]
         integral_unit = u.Unit("GeV2 cm-5") if self.annihilation else u.Unit("GeV cm-2")
         jfact = u.Quantity(val).to(integral_unit).reshape(impact.shape)

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -132,7 +132,9 @@ class JFactory:
         .. math::
             r_\perp = D \sin\theta.
 
-        If the observer is inside the integration radius
+        The integration is split into two regions:
+        
+        1.  :math:`D < r_{\max}`: the observer is inside the integration radius
         (:math:`D < r_{\max}`), directions with
         :math:`\theta < \pi / 2` cross the inner radial interval twice,
         while directions with :math:`\theta \geq \pi / 2` contain only

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -127,7 +127,7 @@ class JFactory:
 
         where :math:`D` is the observer-to-halo-center distance and
         :math:`l \geq 0` is the physical forward line-of-sight coordinate.
-        The impact parameter of the corresponding infinite line is
+        The impact parameter of the corresponding infinite line is given by:
 
         .. math::
             r_\perp = D \sin\theta.


### PR DESCRIPTION
This PR resolves #6760, updating the `JFactory` line-of-sight integration to use the physical forward line of sight for arbitrary observer positions relative to the halo integration radius.

Following the separation of `distance` and `rmax` introduced in #6743, the LoS branch decomposition now distinguishes between observers located inside and outside `rmax`. 

The documentation of `compute_differential_jfactor()` was updated accordingly.

Two regression tests were added:

- a test through the public `compute_differential_jfactor()` interface checking that non-intersecting lines of sight give zero contribution;
- a geometric test using a constant-density profile and several observer/angle configurations, comparing the numerical integral with the analytic path length through the integration sphere.