### PR TITLE
Unification of Dark Matter Spectral classes

### DIFF
--- a/docs/release-notes/6825.feature.rst
+++ b/docs/release-notes/6825.feature.rst
@@ -1,0 +1,1 @@
+Creation of class `~gammapy.astro.darkmatter.DarkMatterSpectralModel` as the unification of `~gammapy.astro.darkmatter.DarkMatterAnnihilationSpectralModel` and `~gammapy.astro.darkmatter.DarkMatterDecaySpectralModel`. The new class has a parameter `annihilation` to set the type of dark matter process.

--- a/examples/tutorials/astrophysics/dark_matter_basics.py
+++ b/examples/tutorials/astrophysics/dark_matter_basics.py
@@ -71,8 +71,7 @@ from gammapy.astro.darkmatter import (
     JFactory,
     PrimaryFlux,
     profiles,
-    DarkMatterAnnihilationSpectralModel,
-    DarkMatterDecaySpectralModel,
+    DarkMatterSpectralModel,
     add_factor_prior,
 )
 from regions import CircleSkyRegion
@@ -233,6 +232,8 @@ jfactory = JFactory(
     profile=draco_profile,  # Chosen density profile
     distance=distance_dwarf_draco,  # Target distance
     annihilation=True,  # Set if it is annihilation (true) or decay (false)
+    rmax=1
+    * u.kpc,  # Physical size of the dark matter halo in kpc. We set 1 just as an example
 )
 
 # Computation of the J factor
@@ -276,6 +277,7 @@ dfactory = JFactory(
     profile=draco_profile,
     distance=distance_dwarf_draco,
     annihilation=False,  # Set for decay
+    rmax=1 * u.kpc,
 )
 
 # Compute D factor
@@ -323,9 +325,8 @@ print(f"D-factor integrated on 0.1 deg circle: {total_dfact:.3g}")
 # - The J/D-factor uncertainty is added externally via
 #   `~gammapy.astro.darkmatter.add_factor_prior()`, a log-normal prior
 #   term on the likelihood. This should be used once the spectral model is
-#   set (`~gammapy.astro.darkmatter.DarkMatterAnnihilationSpectralModel`
-#   or `~gammapy.astro.darkmatter.DarkMatterDecaySpectralModel`). Check
-#   the next subsections for details.
+#   set (`~gammapy.astro.darkmatter.DarkMatterSpectralModel`). Check the
+#   next subsections for details.
 #
 
 
@@ -558,11 +559,11 @@ fluxes_from_table = PrimaryFlux(mDM=mDM, channel="tau", source=table)
 #
 # :class:`~gammapy.astro.darkmatter.PrimaryFlux` gives you the raw dN/dE
 # table, but it is not yet a model you can plug into Gammapy’s
-# modeling/fitting machinery. For that, Gammapy provides two ready-to-use
-# :class:`~gammapy.modeling.models.SpectralModel` classes:
-#
-# - `~gammapy.astro.darkmatter.DarkMatterAnnihilationSpectralModel`
-# - `~gammapy.astro.darkmatter.DarkMatterDecaySpectralModel`
+# modeling/fitting machinery. For that, Gammapy provides a ready-to-use
+# :class:`~gammapy.modeling.models.SpectralModel`,
+# `~gammapy.astro.darkmatter.DarkMatterSpectralModel`. With this class
+# you can set the spectral model for annihilation or decay scenarios by
+# setting the flag `annihilation` flag to True or False.
 #
 # Internally, they wrap :class:`~gammapy.astro.darkmatter.PrimaryFlux`
 # and apply the corresponding normalization
@@ -598,10 +599,11 @@ E_max = mass_DM
 # Annihilation flux
 #
 
-ann_model = DarkMatterAnnihilationSpectralModel(
+ann_model = DarkMatterSpectralModel(
     mass=mass_DM,
     channel=channel,
     # source = 'cosmixs' # Here the source is also a parameter, since this class wraps Primary flux.
+    # annihilation = True # By default the spectral model is set for the annihilation case
 )
 
 int_flux_ann = (
@@ -625,10 +627,15 @@ jfactory_dec = JFactory(
     profile=draco_profile,
     distance=distance_dwarf_draco,
     annihilation=False,
+    rmax=1 * u.kpc,
 )
 dfact_draco = jfactory_dec.compute_jfactor()
 
-dec_model = DarkMatterDecaySpectralModel(mass=mass_DM, channel=channel)
+dec_model = DarkMatterSpectralModel(
+    mass=mass_DM,
+    channel=channel,
+    annihilation=False,  # Must set the annihilation flag to False to indicate a Decay scenario
+)
 
 int_flux_dec = (
     dfact_draco * dec_model.integral(energy_min=E_min, energy_max=E_max)

--- a/gammapy/astro/darkmatter/__init__.py
+++ b/gammapy/astro/darkmatter/__init__.py
@@ -14,6 +14,7 @@ from .profiles import (
 )
 from .spectra import (
     ContinuumPrimaryFlux,
+    DarkMatterSpectralModel,
     DarkMatterAnnihilationSpectralModel,
     DarkMatterDecaySpectralModel,
     PrimaryFlux,
@@ -24,6 +25,7 @@ __all__ = [
     "add_factor_prior",
     "ContinuumPrimaryFlux",
     "PrimaryFlux",
+    "DarkMatterSpectralModel",
     "DarkMatterAnnihilationSpectralModel",
     "DarkMatterDecaySpectralModel",
     "JFactory",
@@ -35,6 +37,6 @@ __all__ = [
     "NFWProfile",
     "ZhaoProfile",
 ]
-
+SPECTRAL_MODEL_REGISTRY.append(DarkMatterSpectralModel)
 SPECTRAL_MODEL_REGISTRY.append(DarkMatterAnnihilationSpectralModel)
 SPECTRAL_MODEL_REGISTRY.append(DarkMatterDecaySpectralModel)

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -790,8 +790,9 @@ class DarkMatterSpectralModel(SpectralModel):
         """Serialize the model to a dictionary.
 
         Extends the base `~gammapy.modeling.models.SpectralModel.to_dict`
-        output with ``channel``, ``mDM``, ``factor``, ``z``, ``k``, and the
-        serialized ``primary_flux`` (via its own `to_dict`).
+        output with ``channel``, ``mDM``, ``factor``, ``z``, ``k``, the
+        serialized ``primary_flux`` (via its own `to_dict`), ``source``, ``mapping_dict``
+        and ``annihilation``.
 
         Parameters
         ----------
@@ -840,6 +841,8 @@ class DarkMatterSpectralModel(SpectralModel):
             New instance reconstructed from ``data``.
         """
         data = copy.deepcopy(data["spectral"])
+        model_type = data.get("type", "")
+        default_annihilation = "Decay" not in model_type
         data.pop("type")
 
         _RENAMED_FIELDS = {"mass": "mDM", "jfactor": "factor"}
@@ -874,7 +877,7 @@ class DarkMatterSpectralModel(SpectralModel):
 
         data.pop("source", None)
         data.pop("mapping_dict", None)
-        annihilation = data.pop("annihilation", True)
+        annihilation = data.pop("annihilation", default_annihilation)
         parameters = data.pop("parameters")
         scale = next(p["value"] for p in parameters if p["name"] == "scale")
         return cls(

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -535,7 +535,7 @@ class DarkMatterMixin:
         """Init and validate inputs"""
         self._annihilation = annihilation
         if z < 0:
-            raise ValueError(f"Redshift z must be >= 0, got: {self._z}.")
+            raise ValueError(f"Redshift z must be >= 0, got: {z}.")
         if u.Quantity(factor).value <= 0:
             raise ValueError("The astrophysical factor must be strictly positive.")
         self._z = z
@@ -586,6 +586,20 @@ class DarkMatterMixin:
     def channel(self):
         """Channel of the default primary flux spectrum."""
         return self._channel
+
+    @property
+    def _expected_primary_flux_mass(self):
+        """Expected primary flux mass for annihilation.
+
+        Returns
+        -------
+        mass : `~astropy.units.Quantity`
+            Equal to ``mDM``, since in annihilation each dark matter
+            particle pair has a total rest energy of ``2 * mDM``, shared
+            between two particles, and the primary flux tables are indexed
+            by the per-particle mass ``mDM``.
+        """
+        return self._mDM if self._annihilation else self._mDM / 2
 
 
 class DarkMatterSpectralModel(SpectralModel, DarkMatterMixin):
@@ -708,6 +722,7 @@ class DarkMatterSpectralModel(SpectralModel, DarkMatterMixin):
         self,
         mDM,
         channel,
+        *,
         scale=scale.quantity,
         factor=1,
         z=0,
@@ -863,7 +878,7 @@ class DarkMatterSpectralModel(SpectralModel, DarkMatterMixin):
         parameters = data.pop("parameters")
         scale = next(p["value"] for p in parameters if p["name"] == "scale")
         return cls(
-            scale=scale, primary_flux=primary_flux, annihilation=annihilation**data
+            scale=scale, primary_flux=primary_flux, annihilation=annihilation, **data
         )
 
     @property
@@ -871,33 +886,18 @@ class DarkMatterSpectralModel(SpectralModel, DarkMatterMixin):
         """DM particle type (2: Majorana, 4: Dirac)."""
         return self._k
 
-    @property
-    def _expected_primary_flux_mass(self):
-        """Expected primary flux mass for annihilation.
-
-        Returns
-        -------
-        mass : `~astropy.units.Quantity`
-            Equal to ``mDM``, since in annihilation each dark matter
-            particle pair has a total rest energy of ``2 * mDM``, shared
-            between two particles, and the primary flux tables are indexed
-            by the per-particle mass ``mDM``.
-        """
-        return self.mDM if self.annihilation else self.mDM / 2
-
 
 @deprecated("2.2", alternative="DarkMatterSpectralModel")
 class DarkMatterAnnihilationSpectralModel(DarkMatterSpectralModel):
+    scale = Parameter("scale", 1, unit="", interp="log")
     tag = ["DarkMatterAnnihilationSpectralModel", "dm-annihilation"]
-    pass
 
 
 @deprecated("2.2", alternative="DarkMatterSpectralModel")
 class DarkMatterDecaySpectralModel(DarkMatterSpectralModel):
+    scale = Parameter("scale", 1, unit="", interp="log")
     tag = ["DarkMatterDecaySpectralModel", "dm-decay"]
 
     def __init__(self, *args, **kwargs):
         kwargs["annihilation"] = False
         super().__init__(*args, **kwargs)
-
-    pass

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -524,85 +524,11 @@ class PrimaryFlux(ContinuumPrimaryFlux):
 PRIMARY_FLUX_REGISTRY = {cls.tag[0]: cls for cls in (ContinuumPrimaryFlux, PrimaryFlux)}
 
 # ---------------------------------------------------------------------------
-# Spectral models
+# Spectral model
 # ---------------------------------------------------------------------------
 
 
-class DarkMatterMixin:
-    def _validate_init(
-        self, mDM, channel, factor, z, primary_flux, source, mapping_dict, annihilation
-    ):
-        """Init and validate inputs"""
-        self._annihilation = annihilation
-        if z < 0:
-            raise ValueError(f"Redshift z must be >= 0, got: {z}.")
-        if u.Quantity(factor).value <= 0:
-            raise ValueError("The astrophysical factor must be strictly positive.")
-        self._z = z
-        self._mDM = u.Quantity(mDM)
-        self._channel = channel
-        self._factor = u.Quantity(factor)
-        self.source = source
-        self.mapping_dict = mapping_dict
-        if primary_flux is not None:
-            if hasattr(primary_flux, "channel"):
-                primary_flux.channel = channel
-            primary_flux.mDM = self._expected_primary_flux_mass
-        else:
-            primary_flux = ContinuumPrimaryFlux(
-                self._expected_primary_flux_mass,
-                channel=self.channel,
-                source=self.source,
-                mapping_dict=self.mapping_dict,
-            )
-        self._primary_flux = primary_flux
-
-    @property
-    def annihilation(self):
-        """Annihilation/Decay flag"""
-        return self._annihilation
-
-    @property
-    def mDM(self):
-        """Dark matter mass."""
-        return self._mDM
-
-    @property
-    def factor(self):
-        """Astrophysical Factor."""
-        return self._factor
-
-    @property
-    def z(self):
-        """Source redshift (must be >= 0)."""
-        return self._z
-
-    @property
-    def primary_flux(self):
-        """Primary flux model."""
-        return self._primary_flux
-
-    @property
-    def channel(self):
-        """Channel of the default primary flux spectrum."""
-        return self._channel
-
-    @property
-    def _expected_primary_flux_mass(self):
-        """Expected primary flux mass for annihilation.
-
-        Returns
-        -------
-        mass : `~astropy.units.Quantity`
-            Equal to ``mDM``, since in annihilation each dark matter
-            particle pair has a total rest energy of ``2 * mDM``, shared
-            between two particles, and the primary flux tables are indexed
-            by the per-particle mass ``mDM``.
-        """
-        return self._mDM if self._annihilation else self._mDM / 2
-
-
-class DarkMatterSpectralModel(SpectralModel, DarkMatterMixin):
+class DarkMatterSpectralModel(SpectralModel):
     r"""Dark matter spectral model.
 
     Computes the differential gamma-ray flux expected from dark matter
@@ -732,16 +658,90 @@ class DarkMatterSpectralModel(SpectralModel, DarkMatterMixin):
         mapping_dict=None,
         annihilation=True,
     ):
-        if annihilation:
+        self._annihilation = annihilation
+
+        if self._annihilation:
             if k not in (2, 4):
                 raise ValueError(f"k must be 2 (Majorana) or 4 (Dirac), got: {k}.")
             self._k = k
         else:
             self._k = None
-        self._validate_init(
-            mDM, channel, factor, z, primary_flux, source, mapping_dict, annihilation
-        )
+
+        if z < 0:
+            raise ValueError(f"Redshift z must be >= 0, got: {z}.")
+
+        if u.Quantity(factor).value <= 0:
+            raise ValueError("The astrophysical factor must be strictly positive.")
+
+        self._z = z
+        self._mDM = u.Quantity(mDM)
+        self._channel = channel
+        self._factor = u.Quantity(factor)
+        self.source = source
+        self.mapping_dict = mapping_dict
+        if primary_flux is not None:
+            if hasattr(primary_flux, "channel"):
+                primary_flux.channel = channel
+            primary_flux.mDM = self._expected_primary_flux_mass
+        else:
+            primary_flux = ContinuumPrimaryFlux(
+                self._expected_primary_flux_mass,
+                channel=self.channel,
+                source=self.source,
+                mapping_dict=self.mapping_dict,
+            )
+        self._primary_flux = primary_flux
+
         super().__init__(scale=scale)
+
+    @property
+    def annihilation(self):
+        """Annihilation/Decay flag"""
+        return self._annihilation
+
+    @property
+    def mDM(self):
+        """Dark matter mass."""
+        return self._mDM
+
+    @property
+    def factor(self):
+        """Astrophysical Factor."""
+        return self._factor
+
+    @property
+    def z(self):
+        """Source redshift (must be >= 0)."""
+        return self._z
+
+    @property
+    def primary_flux(self):
+        """Primary flux model."""
+        return self._primary_flux
+
+    @property
+    def channel(self):
+        """Channel of the default primary flux spectrum."""
+        return self._channel
+
+    @property
+    def k(self):
+        """DM particle type (2: Majorana, 4: Dirac)."""
+        return self._k
+
+    @property
+    def _expected_primary_flux_mass(self):
+        """Expected primary flux mass for annihilation.
+
+        Returns
+        -------
+        mass : `~astropy.units.Quantity`
+            Equal to ``mDM``, since in annihilation each dark matter
+            particle pair has a total rest energy of ``2 * mDM``, shared
+            between two particles, and the primary flux tables are indexed
+            by the per-particle mass ``mDM``.
+        """
+        return self._mDM if self._annihilation else self._mDM / 2
 
     def evaluate(self, energy, scale):
         """Evaluate the dark matter annihilation differential flux.
@@ -881,16 +881,15 @@ class DarkMatterSpectralModel(SpectralModel, DarkMatterMixin):
             scale=scale, primary_flux=primary_flux, annihilation=annihilation, **data
         )
 
-    @property
-    def k(self):
-        """DM particle type (2: Majorana, 4: Dirac)."""
-        return self._k
-
 
 @deprecated("2.2", alternative="DarkMatterSpectralModel")
 class DarkMatterAnnihilationSpectralModel(DarkMatterSpectralModel):
     scale = Parameter("scale", 1, unit="", interp="log")
     tag = ["DarkMatterAnnihilationSpectralModel", "dm-annihilation"]
+
+    def __init__(self, *args, **kwargs):
+        kwargs["annihilation"] = True
+        super().__init__(*args, **kwargs)
 
 
 @deprecated("2.2", alternative="DarkMatterSpectralModel")

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -23,6 +23,7 @@ from gammapy.utils.table import table_map_columns
 
 __all__ = [
     "ContinuumPrimaryFlux",
+    "DarkMatterSpectralModel",
     "DarkMatterAnnihilationSpectralModel",
     "DarkMatterDecaySpectralModel",
     "PrimaryFlux",
@@ -529,15 +530,14 @@ PRIMARY_FLUX_REGISTRY = {cls.tag[0]: cls for cls in (ContinuumPrimaryFlux, Prima
 
 class DarkMatterMixin:
     def _validate_init(
-        self, mDM, channel, factor, z, primary_flux, source, mapping_dict
+        self, mDM, channel, factor, z, primary_flux, source, mapping_dict, annihilation
     ):
         """Init and validate inputs"""
-
+        self._annihilation = annihilation
         if z < 0:
             raise ValueError(f"Redshift z must be >= 0, got: {self._z}.")
         if u.Quantity(factor).value <= 0:
             raise ValueError("The astrophysical factor must be strictly positive.")
-
         self._z = z
         self._mDM = u.Quantity(mDM)
         self._channel = channel
@@ -556,6 +556,11 @@ class DarkMatterMixin:
                 mapping_dict=self.mapping_dict,
             )
         self._primary_flux = primary_flux
+
+    @property
+    def annihilation(self):
+        """Annihilation/Decay flag"""
+        return self._annihilation
 
     @property
     def mDM(self):
@@ -583,15 +588,15 @@ class DarkMatterMixin:
         return self._channel
 
 
-class DarkMatterAnnihilationSpectralModel(SpectralModel, DarkMatterMixin):
-    r"""Dark matter annihilation spectral model.
+class DarkMatterSpectralModel(SpectralModel, DarkMatterMixin):
+    r"""Dark matter spectral model.
 
     Computes the differential gamma-ray flux expected from dark matter
-    annihilation in a region with a given J-factor, combining the
-    thermally averaged annihilation cross-section, the chosen primary
+    annihilation or decay in a region with a given  astrophysical factor, combining the
+    thermally averaged annihilation cross-section or particle decay lifetime, the chosen primary
     particle-physics spectrum, and a fit-time normalization scale.
 
-    The gamma-ray flux is computed as:
+    For annihilation, the gamma-ray flux is computed as:
 
     .. math::
         \frac{\mathrm d \phi}{\mathrm d E} =
@@ -605,19 +610,32 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel, DarkMatterMixin):
     annihilation, and :math:`J(\Delta\Omega)` is the astrophysical
     J-factor.
 
+    For decay, the flux is computed as:
+
+        .. math::
+            \frac{\mathrm d \phi}{\mathrm d E} =
+            \frac{\Gamma}{4\pi m_{\mathrm{DM}}}
+            \frac{\mathrm d N}{\mathrm dE} \times J(\Delta\Omega)
+
+    where :math:`\Gamma = 1/\tau` is the decay rate (inverse lifetime),
+    :math:`m_{\mathrm{DM}}` is the dark matter mass,
+    :math:`\mathrm dN/\mathrm dE` is the primary photon spectrum per decay,
+    and :math:`J(\Delta\Omega)` is the astrophysical D-factor (here denoted
+    generically as the astrophysical factor).
+
     Parameters
     ----------
     mDM : `~astropy.units.Quantity`
         Dark matter particle mass.
     channel : str
-        Annihilation channel for the primary flux spectrum e.g. ``"b"`` for bb̄. See
+        Annihilation/Decay channel for the primary flux spectrum e.g. ``"b"`` for bb̄. See
         `ContinuumPrimaryFlux.channel_registry` for available channels.
     scale : float, optional
         Dimensionless normalization parameter applied multiplicatively to
         the predicted flux, intended to be left free in spectral fits.
         Default is 1.
     factor : `~astropy.units.Quantity`, optional
-        Astrophysical J-factor (integrated squared dark matter density
+        Astrophysical factor (integrated squared dark matter density
         along the line of sight and over the solid angle), needed when a
         `~gammapy.modeling.models.PointSpatialModel` is used for the
         spatial component. Default is 1 (dimensionless).
@@ -625,26 +643,48 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel, DarkMatterMixin):
         Redshift of the source. The primary flux is evaluated at the
         redshifted energy ``energy * (1 + z)``. Default is 0.
     k : int, optional
-        Dark matter particle type: ``2`` for Majorana particles (which are
+        Only used in the case of annihilation. Dark matter particle type: ``2`` for Majorana particles (which are
         their own antiparticles, giving a factor of 2 in the annihilation
         rate) or ``4`` for Dirac particles. Default is 2.
     primary_flux : primary flux model, optional
         Primary photon spectrum per annihilation event. Must be an
         instance of `ContinuumPrimaryFlux`. If not provided, a default
         `ContinuumPrimaryFlux` is constructed using ``mDM`` and ``channel``.
+    source : str, optional
+            Data source for the spectral tables. Options are:
+
+            * ``"pppc4"`` (default): Cirelli et al. (2011, 2016) PPPC4DMID
+                tables.
+            * ``"cosmixs"``: Cirelli et al. (2024) / CosmiXs tables.
+            * A path to a custom file readable by `astropy.table.Table.read`
+                (extensions ``.dat``, ``.txt``, ``.csv``, or ``.ecsv``).
+
+            If a custom file path is provided, it must contain ``"mDM"`` and
+            ``"Log[10,x]"`` columns (after applying ``mapping_dict`` if given),
+            plus columns named after the requested annihilation channel(s)
+            using the internal channel registry naming convention.
+    mapping_dict : dict, optional
+        Mapping dictionary used to rename the columns of a custom source
+        file to the expected internal column names. Only used when
+        ``source`` is a custom file path. Format is
+        ``{actual_column_name: expected_column_name}``, and must cover the
+        mandatory columns ``"mDM"`` and ``"Log[10,x]"``.
+    annihilation : bool
+        Boolean value indicating if the dark matter spectral model comes from an
+        annihilation or decay scenario. Default is True, which indicates annihilation.
 
     Examples
     --------
-    This is how to instantiate a `DarkMatterAnnihilationSpectralModel`::
+    This is how to instantiate a `DarkMatterSpectralModel`::
 
         >>> import astropy.units as u
-        >>> from gammapy.astro.darkmatter import DarkMatterAnnihilationSpectralModel
+        >>> from gammapy.astro.darkmatter import DarkMatterSpectralModel
 
         >>> channel = "b"
         >>> mDM = 5000*u.Unit("GeV")
         >>> factor = 3.41e19 * u.Unit("GeV2 cm-5")
-        >>> modelDM = DarkMatterAnnihilationSpectralModel(mDM=mDM,
-          channel=channel, factor=factor)  # noqa: E501
+        >>> modelDM = DarkMatterSpectralModel(mDM=mDM,
+          channel=channel, factor=factor, annihilation=True)  # noqa: E501
 
     References
     ----------
@@ -656,8 +696,11 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel, DarkMatterMixin):
     THERMAL_RELIC_CROSS_SECTION = 3e-26 * u.Unit("cm3 s-1")
     """Thermally averaged annihilation cross-section."""
 
+    LIFETIME_AGE_OF_UNIVERSE = 4.3e17 * u.Unit("s")
+    """Use age of univserse as lifetime"""
+
     scale = Parameter("scale", 1, unit="", interp="log")
-    tag = ["DarkMatterAnnihilationSpectralModel", "dm-annihilation"]
+    tag = ["DarkMatterSpectralModel", "dm-spectralmodel"]
 
     @deprecated_renamed_argument("mass", "mDM", "2.2")
     @deprecated_renamed_argument("jfactor", "factor", "2.2")
@@ -672,20 +715,29 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel, DarkMatterMixin):
         primary_flux=None,
         source=None,
         mapping_dict=None,
+        annihilation=True,
     ):
-        if k not in (2, 4):
-            raise ValueError(f"k must be 2 (Majorana) or 4 (Dirac), got: {k}.")
-        self._k = k
-        self._validate_init(mDM, channel, factor, z, primary_flux, source, mapping_dict)
+        if annihilation:
+            if k not in (2, 4):
+                raise ValueError(f"k must be 2 (Majorana) or 4 (Dirac), got: {k}.")
+            self._k = k
+        else:
+            self._k = None
+        self._validate_init(
+            mDM, channel, factor, z, primary_flux, source, mapping_dict, annihilation
+        )
         super().__init__(scale=scale)
 
     def evaluate(self, energy, scale):
         """Evaluate the dark matter annihilation differential flux.
 
-        Computes
+        For annihilation, computes:
         ``flux = scale * factor * THERMAL_RELIC_CROSS_SECTION
         * primary_flux(energy * (1 + z)) / k / mDM**2 / (4 * pi)``.
 
+        For decay, computes:
+        ``flux = scale * factor * primary_flux(energy * (1 + z))
+        / LIFETIME_AGE_OF_UNIVERSE / mDM / (4 * pi)``.
         Parameters
         ----------
         energy : `~astropy.units.Quantity`
@@ -698,17 +750,26 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel, DarkMatterMixin):
         flux : `~astropy.units.Quantity`
             Differential gamma-ray flux per unit energy.
         """
-        flux = (
-            scale
-            * self.factor
-            * self.THERMAL_RELIC_CROSS_SECTION
-            * self.primary_flux(energy=energy * (1 + self.z))
-            / self.k
-            / self.mDM
-            / self.mDM
-            / (4 * np.pi)
-        )
-        return flux
+        if self.annihilation:
+            return (
+                scale
+                * self.factor
+                * self.THERMAL_RELIC_CROSS_SECTION
+                * self.primary_flux(energy=energy * (1 + self.z))
+                / self.k
+                / self.mDM
+                / self.mDM
+                / (4 * np.pi)
+            )
+        else:
+            return (
+                scale
+                * self.factor
+                * self.primary_flux(energy=energy * (1 + self.z))
+                / self.LIFETIME_AGE_OF_UNIVERSE
+                / self.mDM
+                / (4 * np.pi)
+            )
 
     def to_dict(self, full_output=False):
         """Serialize the model to a dictionary.
@@ -738,6 +799,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel, DarkMatterMixin):
         data["spectral"]["primary_flux"] = self.primary_flux.to_dict()
         data["spectral"]["source"] = self.source
         data["spectral"]["mapping_dict"] = self.mapping_dict
+        data["spectral"]["annihilation"] = self.annihilation
         return data
 
     @classmethod
@@ -797,9 +859,12 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel, DarkMatterMixin):
 
         data.pop("source", None)
         data.pop("mapping_dict", None)
+        annihilation = data.pop("annihilation", True)
         parameters = data.pop("parameters")
         scale = next(p["value"] for p in parameters if p["name"] == "scale")
-        return cls(scale=scale, primary_flux=primary_flux, **data)
+        return cls(
+            scale=scale, primary_flux=primary_flux, annihilation=annihilation**data
+        )
 
     @property
     def k(self):
@@ -818,231 +883,21 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel, DarkMatterMixin):
             between two particles, and the primary flux tables are indexed
             by the per-particle mass ``mDM``.
         """
-        return self.mDM
+        return self.mDM if self.annihilation else self.mDM / 2
 
 
-class DarkMatterDecaySpectralModel(SpectralModel, DarkMatterMixin):
-    r"""Dark matter decay spectral model.
+@deprecated("2.2", alternative="DarkMatterSpectralModel")
+class DarkMatterAnnihilationSpectralModel(DarkMatterSpectralModel):
+    tag = ["DarkMatterAnnihilationSpectralModel", "dm-annihilation"]
+    pass
 
-    Computes the differential gamma-ray flux expected from the decay of
-    dark matter particles in a region with a given D-factor, combining the
-    decay lifetime, the chosen primary particle-physics spectrum, and a
-    fit-time normalization scale.
 
-    The gamma-ray flux is computed as:
-
-    .. math::
-        \frac{\mathrm d \phi}{\mathrm d E} =
-        \frac{\Gamma}{4\pi m_{\mathrm{DM}}}
-        \frac{\mathrm d N}{\mathrm dE} \times J(\Delta\Omega)
-
-    where :math:`\Gamma = 1/\tau` is the decay rate (inverse lifetime),
-    :math:`m_{\mathrm{DM}}` is the dark matter mass,
-    :math:`\mathrm dN/\mathrm dE` is the primary photon spectrum per decay,
-    and :math:`J(\Delta\Omega)` is the astrophysical D-factor (here denoted
-    generically as the astrophysical factor).
-
-    Parameters
-    ----------
-    mDM : `~astropy.units.Quantity`
-        Dark matter particle mass.
-    channel : str
-        Decay channel for the primary flux spectrum,
-        e.g. ``"b"`` for bb̄. See `ContinuumPrimaryFlux.channel_registry`
-        for available channels.
-    scale : float, optional
-        Dimensionless normalization parameter applied multiplicatively to
-        the predicted flux, intended to be left free in spectral fits.
-        Default is 1.
-    factor : `~astropy.units.Quantity`, optional
-        Astrophysical D-factor (integrated dark matter density along the
-        line of sight and over the solid angle), needed when a
-        `~gammapy.modeling.models.PointSpatialModel` is used for the
-        spatial component. Default is 1 (dimensionless).
-    z : float, optional
-        Redshift of the source. The primary flux is evaluated at the
-        redshifted energy ``energy * (1 + z)``. Default is 0.
-    primary_flux : primary flux model, optional
-        Primary photon spectrum per decay event. Must be an instance of
-        `ContinuumPrimaryFlux`. If not provided, a default
-        `ContinuumPrimaryFlux` is constructed using ``mDM / 2`` (the energy
-        scale relevant for two-body decay products) and ``channel``.
-
-    Examples
-    --------
-    This is how to instantiate a `DarkMatterDecaySpectralModel`::
-
-        >>> import astropy.units as u
-        >>> from gammapy.astro.darkmatter import DarkMatterDecaySpectralModel
-
-        >>> channel = "b"
-        >>> mDM = 5000*u.Unit("GeV")
-        >>> factor = 3.41e19 * u.Unit("GeV cm-2")
-        >>> modelDM = DarkMatterDecaySpectralModel(mDM=mDM,
-        channel=channel, factor=factor)
-
-    References
-    ----------
-    .. [1] `Cirelli et al. (2016), "PPPC 4 DM ID: A Poor Particle Physicist
-       Cookbook for Dark Matter Indirect Detection"
-       <http://www.marcocirelli.net/PPPC4DMID.html>`_
-    """
-
-    LIFETIME_AGE_OF_UNIVERSE = 4.3e17 * u.Unit("s")
-    """Use age of univserse as lifetime"""
-
-    scale = Parameter("scale", 1, unit="", interp="log")
-
+@deprecated("2.2", alternative="DarkMatterSpectralModel")
+class DarkMatterDecaySpectralModel(DarkMatterSpectralModel):
     tag = ["DarkMatterDecaySpectralModel", "dm-decay"]
 
-    @deprecated_renamed_argument("mass", "mDM", "2.2")
-    @deprecated_renamed_argument("jfactor", "factor", "2.2")
-    def __init__(
-        self,
-        mDM,
-        channel,
-        scale=scale.quantity,
-        factor=1,
-        z=0,
-        primary_flux=None,
-        source=None,
-        mapping_dict=None,
-    ):
-        self._validate_init(mDM, channel, factor, z, primary_flux, source, mapping_dict)
-        super().__init__(scale=scale)
+    def __init__(self, *args, **kwargs):
+        kwargs["annihilation"] = False
+        super().__init__(*args, **kwargs)
 
-    def evaluate(self, energy, scale):
-        """Evaluate the dark matter decay differential flux.
-
-        Computes
-        ``flux = scale * factor * primary_flux(energy * (1 + z))
-        / LIFETIME_AGE_OF_UNIVERSE / mDM / (4 * pi)``.
-
-        Parameters
-        ----------
-        energy : `~astropy.units.Quantity`
-            Energy values (array-like) at which to evaluate the flux.
-        scale : float
-            Current value of the ``scale`` normalization parameter.
-        Returns
-        -------
-        flux : `~astropy.units.Quantity`
-            Differential gamma-ray flux per unit energy.
-        """
-        flux = (
-            scale
-            * self.factor
-            * self.primary_flux(energy=energy * (1 + self.z))
-            / self.LIFETIME_AGE_OF_UNIVERSE
-            / self.mDM
-            / (4 * np.pi)
-        )
-        return flux
-
-    def to_dict(self, full_output=False):
-        """Serialize the model to a dictionary.
-
-        Extends the base `~gammapy.modeling.models.SpectralModel.to_dict`
-        output with ``channel``, ``mDM``, ``factor``, ``z``, and the
-        serialized ``primary_flux`` (via its own `to_dict`). The ``scale``
-        and ``lifetime`` parameters are included via the base class's
-        ``parameters`` serialization.
-
-        Parameters
-        ----------
-        full_output : bool, optional
-            Passed through to the parent class's `to_dict`. Default is
-            False.
-
-        Returns
-        -------
-        data : dict
-            Dictionary representation suitable for round-tripping via
-            `from_dict`.
-        """
-        data = super().to_dict(full_output=full_output)
-        data["spectral"]["channel"] = self.channel
-        data["spectral"]["mDM"] = self.mDM.to_string()
-        data["spectral"]["factor"] = self.factor.to_string()
-        data["spectral"]["z"] = self.z
-        data["spectral"]["primary_flux"] = self.primary_flux.to_dict()
-        data["spectral"]["source"] = self.source
-        data["spectral"]["mapping_dict"] = self.mapping_dict
-        return data
-
-    @classmethod
-    def from_dict(cls, data):
-        """Construct a `DarkMatterDecaySpectralModel` from a dictionary.
-
-        Reconstructs the ``primary_flux`` sub-model using the registry of
-        known primary flux types, extracts the ``scale`` and ``lifetime``
-        parameter values (with units) from the serialized parameter list,
-        and passes the remaining fields through to the constructor.
-
-        Parameters
-        ----------
-        data : dict
-            Dictionary with a top-level ``"spectral"`` key, as produced by
-            `to_dict`, containing ``mDM``, ``channel``, ``factor``, ``z``,
-            ``primary_flux``, and ``parameters`` (including ``scale`` and
-            ``lifetime``).
-
-        Returns
-        -------
-        model : `DarkMatterDecaySpectralModel`
-            New instance reconstructed from ``data``.
-        """
-        data = copy.deepcopy(data["spectral"])
-        data.pop("type")
-
-        _RENAMED_FIELDS = {"mass": "mDM", "jfactor": "factor"}
-        for old_name, new_name in _RENAMED_FIELDS.items():
-            if old_name in data:
-                warnings.warn(
-                    f"The '{old_name}' field is deprecated since v2.2 and will "
-                    f"be removed in a future version. Use '{new_name}' instead. "
-                    f"This serialized model appears to use the old format.",
-                    GammapyDeprecationWarning,
-                )
-                data[new_name] = data.pop(old_name)
-
-        pf_data = data.pop("primary_flux", None)
-
-        if pf_data is None:
-            # Old format
-            primary_flux = ContinuumPrimaryFlux(
-                data.get("mDM", data.get("mass")),
-                channel=data["channel"],
-                source=data.get("source"),
-                mapping_dict=data.get("mapping_dict"),
-            )
-        else:
-            pf_cls = PRIMARY_FLUX_REGISTRY.get(pf_data["type"])
-            if pf_cls is None:
-                raise ValueError(
-                    f"Unknown primary_flux type: '{pf_data['type']}'. "
-                    f"Available: {list(PRIMARY_FLUX_REGISTRY.keys())}"
-                )
-            primary_flux = pf_cls.from_dict(pf_data)
-
-        data.pop("source", None)
-        data.pop("mapping_dict", None)
-
-        parameters = data.pop("parameters")
-        scale = next(p["value"] for p in parameters if p["name"] == "scale")
-
-        return cls(scale=scale, primary_flux=primary_flux, **data)
-
-    @property
-    def _expected_primary_flux_mass(self):
-        """Expected primary flux mass for decay.
-
-        Returns
-        -------
-        mass : `~astropy.units.Quantity`
-            Equal to ``mDM / 2``, since a decaying dark matter particle of
-            mass ``mDM`` produces two-body final states each carrying
-            roughly half the rest energy, and the primary flux tables are
-            indexed by this per-product mass scale.
-        """
-        return self.mDM / 2
+    pass

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -552,10 +552,10 @@ class DarkMatterSpectralModel(SpectralModel):
 
     For decay, the flux is computed as:
 
-        .. math::
-            \frac{\mathrm d \phi}{\mathrm d E} =
-            \frac{\Gamma}{4\pi m_{\mathrm{DM}}}
-            \frac{\mathrm d N}{\mathrm dE} \times J(\Delta\Omega)
+    .. math::
+        \frac{\mathrm d \phi}{\mathrm d E} =
+        \frac{\Gamma}{4\pi m_{\mathrm{DM}}}
+        \frac{\mathrm d N}{\mathrm dE} \times J(\Delta\Omega)
 
     where :math:`\Gamma = 1/\tau` is the decay rate (inverse lifetime),
     :math:`m_{\mathrm{DM}}` is the dark matter mass,
@@ -819,7 +819,7 @@ class DarkMatterSpectralModel(SpectralModel):
 
     @classmethod
     def from_dict(cls, data):
-        """Construct a `DarkMatterAnnihilationSpectralModel` from a dictionary.
+        """Construct a `DarkMatterSpectralModel` from a dictionary.
 
         Reconstructs the ``primary_flux`` sub-model using the registry of
         known primary flux types, extracts the ``scale`` parameter value
@@ -836,7 +836,7 @@ class DarkMatterSpectralModel(SpectralModel):
 
         Returns
         -------
-        model : `DarkMatterAnnihilationSpectralModel`
+        model : `DarkMatterSpectralModel`
             New instance reconstructed from ``data``.
         """
         data = copy.deepcopy(data["spectral"])

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -599,3 +599,40 @@ def test_dm_decay_from_dict_missing_primary_flux_key_custom_source():
     data["spectral"].pop("primary_flux", None)
     new_model = DarkMatterSpectralModel.from_dict(data)
     assert new_model.primary_flux.source == "cosmixs"
+
+
+@requires_data()
+def test_backward_compat_old_annihilation_dict_via_registry():
+    """Test for serialization of an annihilation dict that was serialized before the
+    'annihilation' field existed (old DarkMatterDecaySpectralModel format, pre-unification).
+    """
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", k=2)
+    data = model.to_dict()
+    data["spectral"]["type"] = "DarkMatterAnnihilationSpectralModel"
+    data["spectral"].pop("annihilation", None)
+
+    new_model = DarkMatterSpectralModel.from_dict(data)
+
+    assert new_model.annihilation is True
+    assert new_model.k == 2
+    assert_quantity_allclose(new_model.mDM, model.mDM)
+    assert new_model.channel == model.channel
+
+
+@requires_data()
+def test_backward_compat_old_decay_dict_direct_base_class():
+    """Test for serialization of a decay dict that was serialized before the
+    'annihilation' field existed (old DarkMatterDecaySpectralModel format, pre-unification).
+    """
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", annihilation=False)
+    data = model.to_dict()
+    data["spectral"]["type"] = "DarkMatterDecaySpectralModel"
+    data["spectral"].pop("annihilation", None)
+    data["spectral"].pop("k", None)
+
+    new_model = DarkMatterSpectralModel.from_dict(data)
+
+    assert new_model.annihilation is False
+    assert new_model.k is None
+    assert_quantity_allclose(new_model.mDM, model.mDM)
+    assert new_model.channel == model.channel

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -315,6 +315,15 @@ def test_k_value_roundtrip(k):
     assert new_model.k == k
 
 
+def test_invalid_factor():
+    with pytest.raises(
+        ValueError, match="The astrophysical factor must be strictly positive."
+    ):
+        DarkMatterSpectralModel(
+            mDM=1 * u.TeV, channel="b", factor=-1 * u.Unit("GeV2 cm-5")
+        )
+
+
 # Full spectral models (annihilation / decay) with default ContinuumPrimaryFlux
 
 

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_allclose
 
 from gammapy.astro.darkmatter import (
     ContinuumPrimaryFlux,
+    DarkMatterSpectralModel,
     DarkMatterAnnihilationSpectralModel,
     DarkMatterDecaySpectralModel,
     PrimaryFlux,
@@ -41,10 +42,18 @@ def test_primary_flux_deprecated():
 @requires_data()
 def test_mass_argument_deprecated():
     with pytest.warns(GammapyDeprecationWarning, match="mass"):
-        DarkMatterAnnihilationSpectralModel(channel="W", mass=1 * u.TeV)
+        DarkMatterSpectralModel(channel="W", mass=1 * u.TeV)
 
-    with pytest.warns(GammapyDeprecationWarning, match="mass"):
-        DarkMatterDecaySpectralModel(channel="W", mass=1 * u.TeV)
+
+@requires_data()
+def test_spectralclasses_deprecated():
+    with pytest.warns(
+        GammapyDeprecationWarning, match="DarkMatterAnnihilationSpectralModel"
+    ):
+        DarkMatterAnnihilationSpectralModel(channel="W", mDM=1 * u.TeV)
+
+    with pytest.warns(GammapyDeprecationWarning, match="DarkMatterDecaySpectralModel"):
+        DarkMatterDecaySpectralModel(channel="W", mDM=1 * u.TeV)
 
 
 @pytest.mark.parametrize(
@@ -159,7 +168,7 @@ def test_dm_spectral_model_custom_io(tmp_path):
     )
     assert custom_flux.mapping_dict == mapping
 
-    model = DarkMatterAnnihilationSpectralModel(
+    model = DarkMatterSpectralModel(
         mDM=500 * u.GeV,
         channel="b",
         factor=3.41e19 * u.Unit("GeV2 cm-5"),
@@ -262,8 +271,8 @@ def test_decay_expected_primary_flux_mass_is_half():
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        model = DarkMatterDecaySpectralModel(
-            mDM=mDM, channel="b", primary_flux=test_flux
+        model = DarkMatterSpectralModel(
+            mDM=mDM, channel="b", primary_flux=test_flux, annihilation=False
         )
 
     assert_quantity_allclose(model.primary_flux.mDM, mDM / 2)
@@ -284,20 +293,25 @@ def warnings_should_not_warn(category):
     return _cm()
 
 
-# k parameter (DarkMatterAnnihilationSpectralModel)
+def test_negative_redshift():
+    with pytest.raises(ValueError, match="Redshift z must be >= 0"):
+        DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", z=-1)
+
+
+# k parameter (DarkMatterSpectralModel)
 
 
 def test_invalid_k_value():
     with pytest.raises(ValueError, match="k must be 2 .Majorana. or 4 .Dirac."):
-        DarkMatterAnnihilationSpectralModel(mDM=1 * u.TeV, channel="b", k=3)
+        DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", k=3)
 
 
 @requires_data()
 @pytest.mark.parametrize("k", [2, 4])
 def test_k_value_roundtrip(k):
-    model = DarkMatterAnnihilationSpectralModel(mDM=1 * u.TeV, channel="b", k=k)
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", k=k)
     data = model.to_dict()
-    new_model = DarkMatterAnnihilationSpectralModel.from_dict(data)
+    new_model = DarkMatterSpectralModel.from_dict(data)
     assert new_model.k == k
 
 
@@ -305,35 +319,17 @@ def test_k_value_roundtrip(k):
 
 
 @pytest.mark.parametrize(
-    "model_class, factor_unit, expected_flux, expected_dnde, source",
+    "factor_unit, expected_flux, expected_dnde, source, annihilation",
     [
-        (
-            DarkMatterAnnihilationSpectralModel,
-            "GeV2 cm-5",
-            6.19575457e-14,
-            2.97831615e-16,
-            None,
-        ),
-        (
-            DarkMatterDecaySpectralModel,
-            "GeV cm-2",
-            3.209234e-2,
-            2.33485775e-5,
-            "pppc4",
-        ),
-        (
-            DarkMatterAnnihilationSpectralModel,
-            "GeV2 cm-5",
-            6.03197683e-14,
-            3.52065879e-16,
-            "cosmixs",
-        ),
-        (DarkMatterDecaySpectralModel, "GeV cm-2", 0.031677, 2.77187e-05, "cosmixs"),
+        ("GeV2 cm-5", 6.19575457e-14, 2.97831615e-16, None, True),
+        ("GeV cm-2", 3.209234e-2, 2.33485775e-5, "pppc4", False),
+        ("GeV2 cm-5", 6.03197683e-14, 3.52065879e-16, "cosmixs", True),
+        ("GeV cm-2", 0.031677, 2.77187e-05, "cosmixs", False),
     ],
 )
 @requires_data()
 def test_dm_spectral_model(
-    tmp_path, factor_unit, model_class, expected_flux, expected_dnde, source
+    tmp_path, factor_unit, expected_flux, expected_dnde, source, annihilation
 ):
     channel = "b"
     mass = 5 * u.TeV
@@ -342,11 +338,17 @@ def test_dm_spectral_model(
     energy_max = 10 * u.TeV
 
     pf = ContinuumPrimaryFlux(mass / 2.0, channel, source=source)
-    model = model_class(mDM=mass, channel=channel, factor=factor, primary_flux=pf)
+    model = DarkMatterSpectralModel(
+        mDM=mass,
+        channel=channel,
+        factor=factor,
+        primary_flux=pf,
+        annihilation=annihilation,
+    )
 
     flux = model.integral(energy_min=energy_min, energy_max=energy_max).to("cm-2 s-1")
 
-    if model_class is DarkMatterDecaySpectralModel:
+    if annihilation is False:
         dnde = model.evaluate(energy=1 * u.TeV, scale=1).to("cm-2 s-1 TeV-1")
     else:
         dnde = model.evaluate(energy=1 * u.TeV, scale=1).to("cm-2 s-1 TeV-1")
@@ -369,7 +371,7 @@ def test_dm_spectral_model(
 
 @requires_data()
 def test_dm_annihilation_to_dict_structure():
-    model = DarkMatterAnnihilationSpectralModel(mDM=1 * u.TeV, channel="b")
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", annihilation=True)
     data = model.to_dict()
 
     assert data["spectral"]["channel"] == "b"
@@ -377,36 +379,36 @@ def test_dm_annihilation_to_dict_structure():
     assert "primary_flux" in data["spectral"]
     assert data["spectral"]["primary_flux"]["type"] == "ContinuumPrimaryFlux"
 
-    new_model = DarkMatterAnnihilationSpectralModel.from_dict(data)
+    new_model = DarkMatterSpectralModel.from_dict(data)
     assert new_model.channel == model.channel
     assert new_model.k == model.k
 
 
 @requires_data()
 def test_unknown_primary_flux_type_in_from_dict():
-    model = DarkMatterAnnihilationSpectralModel(mDM=1 * u.TeV, channel="b")
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b")
     data = model.to_dict()
     data["spectral"]["primary_flux"]["type"] = "NotARealFluxType"
 
     with pytest.raises(ValueError, match="Unknown primary_flux type"):
-        DarkMatterAnnihilationSpectralModel.from_dict(data)
+        DarkMatterSpectralModel.from_dict(data)
 
 
 @requires_data()
 def test_decay_expected_primary_flux_mass_direct():
-    model = DarkMatterDecaySpectralModel(mDM=2 * u.TeV, channel="b")
+    model = DarkMatterSpectralModel(mDM=2 * u.TeV, channel="b", annihilation=False)
     result = model._expected_primary_flux_mass
     assert_quantity_allclose(result, 1 * u.TeV)
 
 
 @requires_data()
 def test_unknown_primary_flux_type_in_decay_from_dict():
-    model = DarkMatterDecaySpectralModel(mDM=1 * u.TeV, channel="b")
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", annihilation=False)
     data = model.to_dict()
     data["spectral"]["primary_flux"]["type"] = "NotARealFluxType"
 
     with pytest.raises(ValueError, match="Unknown primary_flux type"):
-        DarkMatterDecaySpectralModel.from_dict(data)
+        DarkMatterSpectralModel.from_dict(data)
 
 
 @requires_data()
@@ -423,7 +425,7 @@ def test_dm_annihilation_evaluation_on_dataset():
         skydir=(0, 0), binsz=0.1, width=(1, 1), frame="galactic", axes=[energy_axis]
     )
     pf = ContinuumPrimaryFlux(1 * u.TeV, "b")
-    spectral_model = DarkMatterAnnihilationSpectralModel(
+    spectral_model = DarkMatterSpectralModel(
         mDM=1 * u.TeV,
         channel="b",
         factor=3.41e19 * u.Unit("GeV2 cm-5"),
@@ -460,8 +462,12 @@ def test_dm_decay_evaluation_on_dataset():
         skydir=(0, 0), binsz=0.1, width=(1, 1), frame="galactic", axes=[energy_axis]
     )
     pf = ContinuumPrimaryFlux(0.5 * u.TeV, "b")
-    spectral_model = DarkMatterDecaySpectralModel(
-        mDM=1 * u.TeV, channel="b", factor=3.41e19 * u.Unit("GeV cm-2"), primary_flux=pf
+    spectral_model = DarkMatterSpectralModel(
+        mDM=1 * u.TeV,
+        channel="b",
+        factor=3.41e19 * u.Unit("GeV cm-2"),
+        primary_flux=pf,
+        annihilation=False,
     )
     sky_model = SkyModel(
         spectral_model=spectral_model,
@@ -485,10 +491,10 @@ def test_dm_decay_evaluation_on_dataset():
 def test_dm_decay_from_dict_missing_primary_flux_key():
     """A dict serialized before 'primary_flux' existed must still be loadable via from_dict, reconstructing the
     primary flux from the legacy flat 'source'/'mapping_dict' fields."""
-    model = DarkMatterDecaySpectralModel(mDM=1 * u.TeV, channel="b")
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", annihilation=False)
     data = model.to_dict()
     data["spectral"].pop("primary_flux", None)
-    new_model = DarkMatterDecaySpectralModel.from_dict(data)
+    new_model = DarkMatterSpectralModel.from_dict(data)
     assert_quantity_allclose(new_model.mDM, model.mDM)
     assert_allclose(new_model.factor.value, model.factor.value, rtol=1e-2)
     assert new_model.channel == model.channel
@@ -496,11 +502,11 @@ def test_dm_decay_from_dict_missing_primary_flux_key():
 
 @requires_data()
 def test_dm_annihilation_from_dict_missing_primary_flux_key():
-    """Backward-compatibility check for DarkMatterAnnihilationSpectralModel."""
-    model = DarkMatterAnnihilationSpectralModel(mDM=1 * u.TeV, channel="b")
+    """Backward-compatibility check for DarkMatterSpectralModel."""
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b")
     data = model.to_dict()
     data["spectral"].pop("primary_flux", None)
-    new_model = DarkMatterAnnihilationSpectralModel.from_dict(data)
+    new_model = DarkMatterSpectralModel.from_dict(data)
     assert_quantity_allclose(new_model.mDM, model.mDM)
     assert_allclose(new_model.factor.value, model.factor.value, rtol=1e-2)
     assert new_model.channel == model.channel
@@ -509,12 +515,12 @@ def test_dm_annihilation_from_dict_missing_primary_flux_key():
 @requires_data()
 def test_dm_decay_from_dict_missing_primary_flux_and_old_field_names():
     """Dict with both no 'primary_flux' key AND old field names ('mass' instead of 'mDM')."""
-    model = DarkMatterDecaySpectralModel(mDM=1 * u.TeV, channel="b")
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", annihilation=False)
     data = model.to_dict()
     data["spectral"].pop("primary_flux", None)
     data["spectral"]["mass"] = data["spectral"].pop("mDM")
     with pytest.warns(GammapyDeprecationWarning, match="'mass'"):
-        new_model = DarkMatterDecaySpectralModel.from_dict(data)
+        new_model = DarkMatterSpectralModel.from_dict(data)
     assert_quantity_allclose(new_model.mDM, model.mDM)
     assert new_model.channel == model.channel
 
@@ -522,12 +528,12 @@ def test_dm_decay_from_dict_missing_primary_flux_and_old_field_names():
 @requires_data()
 def test_dm_annihilation_from_dict_missing_primary_flux_and_old_field_names():
     """Dict with both no 'primary_flux' key AND old field names ('mass' instead of 'mDM')."""
-    model = DarkMatterAnnihilationSpectralModel(mDM=1 * u.TeV, channel="b")
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", annihilation=False)
     data = model.to_dict()
     data["spectral"].pop("primary_flux", None)
     data["spectral"]["mass"] = data["spectral"].pop("mDM")
     with pytest.warns(GammapyDeprecationWarning, match="'mass'"):
-        new_model = DarkMatterAnnihilationSpectralModel.from_dict(data)
+        new_model = DarkMatterSpectralModel.from_dict(data)
     assert_quantity_allclose(new_model.mDM, model.mDM)
     assert new_model.channel == model.channel
 
@@ -535,12 +541,12 @@ def test_dm_annihilation_from_dict_missing_primary_flux_and_old_field_names():
 @requires_data()
 def test_dm_decay_from_dict_both_old_field_names_warns_and_maps():
     """Dict using both old field names ('mass' and 'jfactor') at once must map both and warn for each."""
-    model = DarkMatterDecaySpectralModel(mDM=1 * u.TeV, channel="b")
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", annihilation=False)
     data = model.to_dict()
     data["spectral"]["mass"] = data["spectral"].pop("mDM")
     data["spectral"]["jfactor"] = data["spectral"].pop("factor")
     with pytest.warns(GammapyDeprecationWarning) as record:
-        new_model = DarkMatterDecaySpectralModel.from_dict(data)
+        new_model = DarkMatterSpectralModel.from_dict(data)
     messages = [str(w.message) for w in record]
     assert any("'mass'" in m for m in messages)
     assert any("'jfactor'" in m for m in messages)
@@ -552,12 +558,12 @@ def test_dm_decay_from_dict_both_old_field_names_warns_and_maps():
 @requires_data()
 def test_dm_annihilation_from_dict_both_old_field_names_warns_and_maps():
     """Dict using both old field names ('mass' and 'jfactor') at once must map both and warn for each."""
-    model = DarkMatterAnnihilationSpectralModel(mDM=1 * u.TeV, channel="b")
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b")
     data = model.to_dict()
     data["spectral"]["mass"] = data["spectral"].pop("mDM")
     data["spectral"]["jfactor"] = data["spectral"].pop("factor")
     with pytest.warns(GammapyDeprecationWarning) as record:
-        new_model = DarkMatterAnnihilationSpectralModel.from_dict(data)
+        new_model = DarkMatterSpectralModel.from_dict(data)
     messages = [str(w.message) for w in record]
     assert any("'mass'" in m for m in messages)
     assert any("'jfactor'" in m for m in messages)
@@ -568,17 +574,19 @@ def test_dm_annihilation_from_dict_both_old_field_names_warns_and_maps():
 
 @requires_data()
 def test_dm_decay_from_dict_unknown_primary_flux_type_raises():
-    model = DarkMatterDecaySpectralModel(mDM=1 * u.TeV, channel="b")
+    model = DarkMatterSpectralModel(mDM=1 * u.TeV, channel="b", annihilation=False)
     data = model.to_dict()
     data["spectral"]["primary_flux"]["type"] = "not_a_real_type"
     with pytest.raises(ValueError, match="Unknown primary_flux type"):
-        DarkMatterDecaySpectralModel.from_dict(data)
+        DarkMatterSpectralModel.from_dict(data)
 
 
 @requires_data()
 def test_dm_decay_from_dict_missing_primary_flux_key_custom_source():
-    model = DarkMatterDecaySpectralModel(mDM=1 * u.TeV, channel="b", source="cosmixs")
+    model = DarkMatterSpectralModel(
+        mDM=1 * u.TeV, channel="b", source="cosmixs", annihilation=False
+    )
     data = model.to_dict()
     data["spectral"].pop("primary_flux", None)
-    new_model = DarkMatterDecaySpectralModel.from_dict(data)
+    new_model = DarkMatterSpectralModel.from_dict(data)
     assert new_model.primary_flux.source == "cosmixs"

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -7,8 +7,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from gammapy.astro.darkmatter import (
-    DarkMatterAnnihilationSpectralModel,
-    DarkMatterDecaySpectralModel,
+    DarkMatterSpectralModel,
     JFactory,
     profiles,
     add_factor_prior,
@@ -48,10 +47,11 @@ def jfact_decay(geom):
 
 @pytest.fixture
 def dm_decay_model():
-    return DarkMatterDecaySpectralModel(
+    return DarkMatterSpectralModel(
         mDM=5000 * u.Unit("GeV"),
         channel="b",
         factor=3.41e19 * u.Unit("GeV cm-2"),
+        annihilation=False,
     )
 
 
@@ -112,9 +112,7 @@ def test_dmfluxmap_annihilation(jfact_annihilation):
         float(jfact_annihilation.mean().value), unit=jfact_annihilation.unit
     )
 
-    diff_flux = DarkMatterAnnihilationSpectralModel(
-        mDM=massDM, channel=channel, factor=total_jfact
-    )
+    diff_flux = DarkMatterSpectralModel(mDM=massDM, channel=channel, factor=total_jfact)
     int_flux = (
         diff_flux.integral(energy_min=energy_min, energy_max=energy_max)
         * jfact_annihilation
@@ -133,7 +131,7 @@ def test_dmfluxmap_decay(jfact_decay):
     massDM = 1 * u.TeV
     channel = "W"
 
-    diff_flux = DarkMatterDecaySpectralModel(mDM=massDM, channel=channel)
+    diff_flux = DarkMatterSpectralModel(mDM=massDM, channel=channel, annihilation=False)
     int_flux = (
         jfact_decay
         * diff_flux.integral(energy_min=energy_min, energy_max=energy_max)

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -184,7 +184,7 @@ def add_factor_prior(model, sigma, mu=1.0):
 
     Parameters
     ----------
-    model : `~gammapy.astro.darkmatter.DarkMatterAnnihilationSpectralModel` or `~gammapy.astro.darkmatter.DarkMatterDecaySpectralModel`
+    model : `~gammapy.astro.darkmatter.DarkMatterSpectralModel`
         Model whose ``scale`` parameter will get the prior attached.
         ``scale`` is unfrozen as part of this call.
     sigma : float
@@ -195,7 +195,7 @@ def add_factor_prior(model, sigma, mu=1.0):
 
     Returns
     -------
-    model : `DarkMatterAnnihilationSpectralModel` or `DarkMatterDecaySpectralModel`
+    model : `DarkMatterSpectralModel`
         The same model instance, with the prior attached, for chaining.
     """
     model.scale.frozen = False


### PR DESCRIPTION
This PR covers @6780 and consists in the unification of the current Dark Matter Spectral classes that covers the scenarios of annihilation and Decay. Both classes shared a lot of code and the purpose was the same but with minor discrepancies. With this modification only one class is provided with a parameter that indicates in which scenario the user is working, so the implementation is clearer and simpler.