### PR TITLE
infra: add validation optional deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,10 @@ test_notebooks = [
     "jupyter_client",
     "ipykernel"
 ]
+validation = [
+    "psrecord",
+    "healpy",
+]
 
 [tool.setuptools.packages.find]
 include = ["gammapy*"]


### PR DESCRIPTION
**Description**

closes #6797 

Create `validation` optional deps in pyproject.toml. To be used in gammapy-benchmark ci.
