### PR TITLE
Handle JFactory central pixel

### DIFF
--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -68,6 +68,37 @@ def test_compute_differential_jfactor_large_separation():
     assert np.all(np.isfinite(jfactor.value))
 
 
+@pytest.mark.parametrize("annihilation", [True, False])
+def test_compute_differential_jfactor_central_pixel(annihilation):
+    geom = WcsGeom.create(
+        skydir=(0, 0),
+        npix=3,
+        binsz=0.05,
+        frame="galactic",
+    )
+
+    jfactory = JFactory(
+        geom=geom,
+        profile=profiles.NFWProfile(),
+        distance=8.33 * u.kpc,
+        rmax=1 * u.kpc,
+        annihilation=annihilation,
+    )
+
+    diff_jfactor = jfactory.compute_differential_jfactor(ndecade=100)
+    jfactor = jfactory.compute_jfactor(ndecade=100)
+
+    center = (1, 1)
+
+    assert geom.separation(geom.center_skydir)[center] == 0 * u.deg
+    assert np.isfinite(diff_jfactor[center].value)
+    assert np.isfinite(jfactor[center].value)
+    assert_quantity_allclose(
+        jfactor[center],
+        diff_jfactor[center] * geom.solid_angle()[center],
+    )
+
+
 def test_compute_differential_jfactor_outside_halo_no_intersection():
     geom = WcsGeom.create(skydir=(0, 0), width=(120, 2), binsz=1, frame="galactic")
     separation = geom.separation(geom.center_skydir)

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -96,6 +96,29 @@ class JFactory:
 
         return 0 * u.Unit("GeV2 cm-5" if self.annihilation else "GeV cm-2")
 
+    def _integrate_central_pixel(self, ndecade):
+        """Estimate the pixel-averaged line-of-sight integral at the halo center."""
+        central_geom = self.geom.to_image().cutout(
+            position=self.geom.center_skydir,
+            width=self.geom.pixel_scales,
+        )
+        # Use an even factor so no subpixel center coincides with the halo center.
+        subgeom = central_geom.upsample(2)
+
+        separation = subgeom.separation(self.geom.center_skydir).rad
+        impact = u.Quantity(
+            value=np.sin(separation) * self.distance,
+            unit=self.distance.unit,
+        )
+
+        values = [
+            self._integrate_los(impact_i, separation_i, ndecade)
+            for impact_i, separation_i in zip(impact.ravel(), separation.ravel())
+        ]
+        values = u.Quantity(values).reshape(impact.shape)
+
+        return (values * subgeom.solid_angle()).sum() / central_geom.solid_angle().sum()
+
     def compute_differential_jfactor(self, ndecade=1e4):
         r"""Compute differential J-Factor.
 
@@ -159,7 +182,9 @@ class JFactory:
             value=np.sin(separation) * self.distance, unit=self.distance.unit
         )
         val = [
-            self._integrate_los(impact_i, separation_i, ndecade)
+            self._integrate_central_pixel(ndecade)
+            if separation_i == 0
+            else self._integrate_los(impact_i, separation_i, ndecade)
             for impact_i, separation_i in zip(impact.ravel(), separation.ravel())
         ]
         integral_unit = u.Unit("GeV2 cm-5") if self.annihilation else u.Unit("GeV cm-2")


### PR DESCRIPTION
**Description**

This pull request fixes #6769.

When a WCS pixel center coincides exactly with the halo center, the corresponding line of sight has zero impact parameter, causing the radial integration to reach a lower bound of zero, which is incompatible with the logarithmic radial sampling used in the integration.

For this specific case, when the chosen map pixelization includes a pixel exactly at the halo center, the central pixel is now subdivided into a 2×2 grid and the line-of-sight integral is evaluated at the four subpixel centers. The pixel value is then obtained from their solid-angle-weighted average. The treatment of all other pixels remains unchanged, and the overall angular accuracy of the map remains determined by the pixelization chosen by the user.

The returned value remains a differential J/D-factor, so `compute_jfactor()` continues to obtain the pixel-integrated value through multiplication by the pixel solid angle.

Tests were added for both annihilation and decay.

