### PR TITLE
ASDF serialization for Maps

### DIFF
--- a/docs/release-notes/6830.feature.rst
+++ b/docs/release-notes/6830.feature.rst
@@ -1,0 +1,1 @@
+Add ASDF serialization support for `~gammapy.maps.Maps`.

--- a/gammapy/io/asdf/converters/maps/maps.py
+++ b/gammapy/io/asdf/converters/maps/maps.py
@@ -1,0 +1,15 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from asdf.extension import Converter
+
+
+class MapsConverter(Converter):
+    tags = ["asdf://gammapy.org/gammapy/tags/maps/maps-1.0.0"]
+    types = ["gammapy.maps.maps.Maps"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        return {key: value for key, value in obj.items()}
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from gammapy.maps import Maps
+
+        return Maps(**node)

--- a/gammapy/io/asdf/converters/maps/tests/test_map.py
+++ b/gammapy/io/asdf/converters/maps/tests/test_map.py
@@ -1,0 +1,26 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+
+from gammapy.maps import MapAxis, WcsGeom, Map, Maps
+
+asdf = pytest.importorskip("asdf")
+pytest.importorskip("asdf.testing")
+
+
+def test_maps_roundtrip(tmp_path):
+    file_path = tmp_path / "test.asdf"
+    maps = Maps()
+    axis = MapAxis.from_edges([1, 2, 3, 4], name="axis", unit="cm")
+    geom = WcsGeom.create(npix=10, axes=[axis])
+    maps["map1"] = Map.from_geom(geom, data=1, meta={"testing": "map1"}, unit="cm")
+    maps["map2"] = Map.from_geom(geom, data=2, meta={"testing": "map2"}, unit="m2")
+
+    with asdf.AsdfFile() as af:
+        af["maps"] = maps
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        result = af["maps"]
+        assert result.keys() == maps.keys()
+        for key in maps:
+            assert maps[key].is_allclose(result[key])

--- a/gammapy/io/asdf/extensions.py
+++ b/gammapy/io/asdf/extensions.py
@@ -18,6 +18,7 @@ from .converters.maps.geom import (
     WcsGeomConverter,
 )
 
+from .converters.maps.maps import MapsConverter
 from .converters.maps.ndmap import (
     HpxNDMapConverter,
     RegionNDMapConverter,
@@ -25,6 +26,7 @@ from .converters.maps.ndmap import (
 )
 
 GAMMAPY_CONVERTERS = [
+    MapsConverter(),
     MapAxisConverter(),
     MapAxesConverter(),
     TimeMapAxisConverter(),

--- a/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
@@ -24,3 +24,5 @@ tags:
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/hpxndmap-1.0.0
 - tag_uri: asdf://gammapy.org/gammapy/tags/maps/regionndmap-1.0.0
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/regionndmap-1.0.0
+- tag_uri: asdf://gammapy.org/gammapy/tags/maps/maps-1.0.0
+  schema_uri: asdf://gammapy.org/gammapy/schemas/maps/maps-1.0.0

--- a/gammapy/io/asdf/resources/schemas/maps/maps-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/maps/maps-1.0.0.yaml
@@ -1,0 +1,19 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://gammapy.org/gammapy/schemas/maps/maps-1.0.0"
+
+title: |
+  Represents Maps.
+
+description: |
+  Support the serialization of Maps which is a dictionary containing Map objects sharing the same geometry.
+
+type: object
+additionalProperties:
+  anyOf:
+    - tag: "asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0"
+    - tag: "asdf://gammapy.org/gammapy/tags/maps/hpxndmap-1.0.0"
+    - tag: "asdf://gammapy.org/gammapy/tags/maps/regionndmap-1.0.0"
+
+...


### PR DESCRIPTION
This pull request is part of Google Summer of Code project Serialization Of Map and Model Classes into ASDF (Advanced Scientific Data Format).


closes #6800

**Implementation details**

- `MapsConverter` : converts `Maps` object from/to ASDF.

- `maps-1.0.0` : schema to validate `Maps` which is a dictionary of NDMap objects already serialized in gammapy.

- `test_map`.py: added round-trip tests for `Maps`.

- Registered both converter and schema.
