### PR TITLE
 ASDF serialization for GTI 

### DIFF
--- a/docs/release-notes/6831.feature.rst
+++ b/docs/release-notes/6831.feature.rst
@@ -1,0 +1,1 @@
+Add ASDF serialization support for `~gammapy.data.GTI`.

--- a/gammapy/io/asdf/converters/data/__init__.py
+++ b/gammapy/io/asdf/converters/data/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/gammapy/io/asdf/converters/data/gti.py
+++ b/gammapy/io/asdf/converters/data/gti.py
@@ -1,0 +1,21 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from asdf.extension import Converter
+
+
+class GTIConverter(Converter):
+    tags = ["asdf://gammapy.org/gammapy/tags/data/gti-1.0.0"]
+    types = ["gammapy.data.gti.GTI"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        return {
+            "table": obj.table,
+            "reference_time": obj.time_ref,
+        }
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from gammapy.data import GTI
+
+        return GTI(
+            table=node["table"],
+            reference_time=node.get("reference_time"),
+        )

--- a/gammapy/io/asdf/converters/data/tests/__init__.py
+++ b/gammapy/io/asdf/converters/data/tests/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/gammapy/io/asdf/converters/data/tests/test_gti.py
+++ b/gammapy/io/asdf/converters/data/tests/test_gti.py
@@ -1,0 +1,61 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import astropy.units as u
+from astropy.table import Table
+from astropy.time import Time
+
+from gammapy.data import GTI
+from gammapy.utils.testing import assert_time_allclose
+
+asdf = pytest.importorskip("asdf")
+pytest.importorskip("asdf.testing")
+from asdf.testing.helpers import yaml_to_asdf  # noqa: E402
+
+time_ref = Time("2010-01-01", scale="tt")
+
+
+def test_gti_roundtrip(tmp_path):
+    file_path = tmp_path / "test.gti"
+    times = {
+        "START": time_ref + [5, 6, 1, 2] * u.s,
+        "STOP": time_ref + [8, 7, 3, 4] * u.s,
+    }
+    gti = GTI(Table(times), reference_time=time_ref)
+
+    with asdf.AsdfFile() as af:
+        af["gti"] = gti
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        result = af["gti"]
+        assert_time_allclose(result.time_start, gti.time_start)
+        assert_time_allclose(result.time_stop, gti.time_stop)
+        assert_time_allclose(result.time_ref, gti.time_ref)
+
+
+tested_read_gti_example = [
+    {
+        "example": """!<asdf://gammapy.org/gammapy/tags/data/gti-1.0.0>
+         reference_time: !time/time-1.4.0 {scale: tt, value: '2010-01-01 00:00:00.000'}
+          """,
+    },
+    {
+        "example": """!<asdf://gammapy.org/gammapy/tags/data/gti-1.0.0>
+        table: "not a table"
+        reference_time: !time/time-1.4.0 {scale: tt, value: '2010-01-01 00:00:00.000'}
+        """,
+    },
+    {
+        "example": """!<asdf://gammapy.org/gammapy/tags/data/gti-1.0.0>
+        table: !<tag:astropy.org:astropy/table/table-1.3.0> {}
+        reference_time: "2010-01-01"
+        """,
+    },
+]
+
+
+@pytest.mark.parametrize("example", tested_read_gti_example)
+def test_gti_read_examples(example):
+    buff = yaml_to_asdf(f"example: {example['example'].strip()}")
+    with pytest.raises(asdf.exceptions.ValidationError):
+        asdf.open(buff)

--- a/gammapy/io/asdf/converters/data/tests/test_gti.py
+++ b/gammapy/io/asdf/converters/data/tests/test_gti.py
@@ -17,8 +17,8 @@ time_ref = Time("2010-01-01", scale="tt")
 def test_gti_roundtrip(tmp_path):
     file_path = tmp_path / "test.asdf"
     times = {
-        "START": time_ref + [5, 6, 1, 2] * u.s,
-        "STOP": time_ref + [8, 7, 3, 4] * u.s,
+        "START": time_ref + [1, 5, 10, 15] * u.s,
+        "STOP": time_ref + [3, 7, 14, 20] * u.s,
     }
     gti = GTI(Table(times), reference_time=time_ref)
 
@@ -28,6 +28,8 @@ def test_gti_roundtrip(tmp_path):
 
     with asdf.open(file_path) as af:
         result = af["gti"]
+        assert isinstance(result.time_start, Time)
+        assert isinstance(result.time_stop, Time)
         assert_time_allclose(result.time_start, gti.time_start)
         assert_time_allclose(result.time_stop, gti.time_stop)
         assert_time_allclose(result.time_ref, gti.time_ref)

--- a/gammapy/io/asdf/converters/data/tests/test_gti.py
+++ b/gammapy/io/asdf/converters/data/tests/test_gti.py
@@ -15,7 +15,7 @@ time_ref = Time("2010-01-01", scale="tt")
 
 
 def test_gti_roundtrip(tmp_path):
-    file_path = tmp_path / "test.gti"
+    file_path = tmp_path / "test.asdf"
     times = {
         "START": time_ref + [5, 6, 1, 2] * u.s,
         "STOP": time_ref + [8, 7, 3, 4] * u.s,

--- a/gammapy/io/asdf/extensions.py
+++ b/gammapy/io/asdf/extensions.py
@@ -6,6 +6,7 @@ via an ``entry-point`` in the ``pyproject.toml`` file.
 
 from asdf.extension import ManifestExtension
 
+from .converters.data.gti import GTIConverter
 from .converters.maps.axes import (
     LabelMapAxisConverter,
     MapAxesConverter,
@@ -27,6 +28,7 @@ from .converters.maps.ndmap import (
 
 GAMMAPY_CONVERTERS = [
     MapsConverter(),
+    GTIConverter(),
     MapAxisConverter(),
     MapAxesConverter(),
     TimeMapAxisConverter(),

--- a/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
@@ -26,3 +26,5 @@ tags:
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/regionndmap-1.0.0
 - tag_uri: asdf://gammapy.org/gammapy/tags/maps/maps-1.0.0
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/maps-1.0.0
+- tag_uri: asdf://gammapy.org/gammapy/tags/data/gti-1.0.0
+  schema_uri: asdf://gammapy.org/gammapy/schemas/data/gti-1.0.0

--- a/gammapy/io/asdf/resources/schemas/data/gti-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/data/gti-1.0.0.yaml
@@ -1,0 +1,25 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id : "asdf://gammapy.org/gammapy/schemas/data/gti-1.0.0"
+
+title : |
+  Represents GTI.
+
+description: |
+   Support the serialization of GTI (Good Time Intervals).
+
+type: object
+properties:
+  table:
+    tag: "tag:astropy.org:astropy/table/table-1.*"
+    description: |
+      Table containing START/STOP columns.
+  reference_time:
+    tag: "tag:stsci.edu:asdf/time/time-1.*"
+    description: |
+        Reference time for the GTI intervals.
+
+required: [table]
+additionalProperties: false
+...

--- a/gammapy/io/asdf/resources/schemas/data/gti-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/data/gti-1.0.0.yaml
@@ -1,9 +1,9 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id : "asdf://gammapy.org/gammapy/schemas/data/gti-1.0.0"
+id: "asdf://gammapy.org/gammapy/schemas/data/gti-1.0.0"
 
-title : |
+title: |
   Represents GTI.
 
 description: |
@@ -19,7 +19,6 @@ properties:
     tag: "tag:stsci.edu:asdf/time/time-1.*"
     description: |
         Reference time for the GTI intervals.
-
 required: [table]
 additionalProperties: false
 ...


### PR DESCRIPTION
This pull request is part of Google Summer of Code project Serialization Of Map and Model Classes into ASDF (Advanced Scientific Data Format).

closes #6804

**Implementation details**

- `GTIConverter` : converts `GTI` object from/to ASDF.
- `gti-1.0.0` : schema to validate GTI fields where `table` is required by the schema and `reference_time` is optional.
- `test_gti.py:` added round-trip tests for GTI and schema validation tests for invalid read examples.

- Registered both converter and schema.