### PR TITLE
Add slack notification for failure of workflows

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -32,5 +32,5 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: failure()
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_WEBHOOK }}
           SLACK_MESSAGE: 'doctest run failed'

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -27,3 +27,10 @@ jobs:
 
       - name: Run doctests
         run: pytest --doctest-glob="*.rst" docs/ --ignore=docs/development/pigs/
+
+      - name: slack notification
+        uses: rtCamp/action-slack-notify@v2
+        if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: 'doctest run failed'

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -36,3 +36,9 @@ jobs:
         continue-on-error: true
         run: |
           tox -e linkcheck -- -j auto
+      - name: slack notification
+        uses: rtCamp/action-slack-notify@v2
+        if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: 'doctest run failed'

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -40,5 +40,5 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: failure()
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_WEBHOOK }}
           SLACK_MESSAGE: 'doctest run failed'

--- a/.github/workflows/nightly_builds.yml
+++ b/.github/workflows/nightly_builds.yml
@@ -14,3 +14,14 @@ jobs:
         - cp3*-manylinux_x86_64*
         - cp3*-macosx*
         - cp3*-win_amd64*
+
+  notify_slack_failure:
+    needs: build_wheels
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: slack notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: 'nightly wheel build failed'

--- a/.github/workflows/nightly_builds.yml
+++ b/.github/workflows/nightly_builds.yml
@@ -23,5 +23,5 @@ jobs:
       - name: slack notification
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_WEBHOOK }}
           SLACK_MESSAGE: 'nightly wheel build failed'


### PR DESCRIPTION
This PR fixes #6619 with the same logic as the [benchmarks](https://github.com/gammapy/gammapy-benchmarks/blob/main/.github/workflows/scheduled.yml#L94)

And added the web hook here:
https://github.com/gammapy/gammapy/settings/secrets/actions