### PR TITLE
 ASDF: serialization for IRFMap classes

### DIFF
--- a/docs/release-notes/6833.feature.rst
+++ b/docs/release-notes/6833.feature.rst
@@ -1,0 +1,1 @@
+Add ASDF serialization support for `~gammapy.irf.PSFMap`, `~gammapy.irf.RecoPSFMap`, `~gammapy.irf.EDispMap`, `~gammapy.irf.EDispKernelMap`.

--- a/gammapy/io/asdf/converters/irf/__init__.py
+++ b/gammapy/io/asdf/converters/irf/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/gammapy/io/asdf/converters/irf/core.py
+++ b/gammapy/io/asdf/converters/irf/core.py
@@ -1,0 +1,19 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from asdf.extension import Converter
+
+
+class IRFMapConverter(Converter):
+    map_key = None
+    attr_name = None
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        return {
+            self.map_key: getattr(obj, self.attr_name or self.map_key),
+            "exposure_map": obj.exposure_map,
+        }
+
+    def from_yaml_tree(self, node, tag, ctx):
+        return {
+            self.map_key: node[self.map_key],
+            "exposure_map": node.get("exposure_map"),
+        }

--- a/gammapy/io/asdf/converters/irf/core.py
+++ b/gammapy/io/asdf/converters/irf/core.py
@@ -7,10 +7,11 @@ class IRFMapConverter(Converter):
     attr_name = None
 
     def to_yaml_tree(self, obj, tag, ctx):
-        return {
-            self.map_key: getattr(obj, self.attr_name or self.map_key),
-            "exposure_map": obj.exposure_map,
-        }
+        node = {self.map_key: getattr(obj, self.attr_name or self.map_key)}
+        if obj.exposure_map is not None:
+            node["exposure_map"] = obj.exposure_map
+
+        return node
 
     def from_yaml_tree(self, node, tag, ctx):
         return {

--- a/gammapy/io/asdf/converters/irf/edisp/__init__.py
+++ b/gammapy/io/asdf/converters/irf/edisp/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/gammapy/io/asdf/converters/irf/edisp/map.py
+++ b/gammapy/io/asdf/converters/irf/edisp/map.py
@@ -1,0 +1,26 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from gammapy.io.asdf.converters.irf.core import IRFMapConverter
+
+
+class EDispMapConverter(IRFMapConverter):
+    tags = ["asdf://gammapy.org/gammapy/tags/irf/edispmap-1.0.0"]
+    types = ["gammapy.irf.EDispMap"]
+    map_key = "edisp_map"
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from gammapy.irf import EDispMap
+
+        return EDispMap(**super().from_yaml_tree(node, tag, ctx))
+
+
+class EDispKernelMapConverter(IRFMapConverter):
+    tags = ["asdf://gammapy.org/gammapy/tags/irf/edispkernelmap-1.0.0"]
+    types = ["gammapy.irf.EDispKernelMap"]
+    map_key = "edisp_kernel_map"
+    attr_name = "edisp_map"
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from gammapy.irf import EDispKernelMap
+
+        return EDispKernelMap(**super().from_yaml_tree(node, tag, ctx))

--- a/gammapy/io/asdf/converters/irf/edisp/tests/__init__.py
+++ b/gammapy/io/asdf/converters/irf/edisp/tests/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/gammapy/io/asdf/converters/irf/edisp/tests/test_map.py
+++ b/gammapy/io/asdf/converters/irf/edisp/tests/test_map.py
@@ -34,6 +34,30 @@ def test_edispmap_roundtrip(tmp_path):
         assert result.exposure_map.unit == edispmap.exposure_map.unit
 
 
+def test_edispmap_roundtrip_no_exposure(tmp_path):
+    file_path = tmp_path / "test.asdf"
+    energy_axis_true = MapAxis.from_energy_bounds(
+        "0.3 TeV", "10 TeV", nbin=5, name="energy_true"
+    )
+    edispmap = EDispMap.from_diagonal_response(energy_axis_true)
+    edispmap.exposure_map = None
+
+    with asdf.AsdfFile() as af:
+        af["edispmap"] = edispmap
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        result = af["edispmap"]
+
+        assert type(result) is EDispMap
+        assert result.required_axes == ["migra", "energy_true"]
+
+        assert result.exposure_map is None
+        assert_allclose(result.edisp_map.data, edispmap.edisp_map.data)
+        assert result.edisp_map.geom == edispmap.edisp_map.geom
+        assert result.edisp_map.unit == edispmap.edisp_map.unit
+
+
 def test_edispkernelmap_roundtrip(tmp_path):
     file_path = tmp_path / "test.asdf"
 

--- a/gammapy/io/asdf/converters/irf/edisp/tests/test_map.py
+++ b/gammapy/io/asdf/converters/irf/edisp/tests/test_map.py
@@ -1,0 +1,63 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+from numpy.testing import assert_allclose
+from gammapy.irf import EDispMap, EDispKernelMap
+from gammapy.maps import MapAxis
+
+asdf = pytest.importorskip("asdf")
+pytest.importorskip("asdf.testing")
+
+
+def test_edispmap_roundtrip(tmp_path):
+    file_path = tmp_path / "test.asdf"
+    energy_axis_true = MapAxis.from_energy_bounds(
+        "0.3 TeV", "10 TeV", nbin=5, name="energy_true"
+    )
+    edispmap = EDispMap.from_diagonal_response(energy_axis_true)
+
+    with asdf.AsdfFile() as af:
+        af["edispmap"] = edispmap
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        result = af["edispmap"]
+
+        assert type(result) is EDispMap
+        assert result.required_axes == ["migra", "energy_true"]
+
+        assert_allclose(result.edisp_map.data, edispmap.edisp_map.data)
+        assert result.edisp_map.geom == edispmap.edisp_map.geom
+        assert result.edisp_map.unit == edispmap.edisp_map.unit
+
+        assert_allclose(result.exposure_map.data, edispmap.exposure_map.data)
+        assert result.exposure_map.geom == edispmap.exposure_map.geom
+        assert result.exposure_map.unit == edispmap.exposure_map.unit
+
+
+def test_edispkernelmap_roundtrip(tmp_path):
+    file_path = tmp_path / "test.asdf"
+
+    energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=5, name="energy")
+    energy_axis_true = MapAxis.from_energy_bounds(
+        "0.3 TeV", "30 TeV", nbin=10, per_decade=True, name="energy_true"
+    )
+    edispkernelmap = EDispKernelMap.from_diagonal_response(
+        energy_axis=energy_axis, energy_axis_true=energy_axis_true
+    )
+
+    with asdf.AsdfFile() as af:
+        af["edispkernelmap"] = edispkernelmap
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        result = af["edispkernelmap"]
+        assert type(result) is EDispKernelMap
+        assert result.required_axes == ["energy", "energy_true"]
+
+        assert_allclose(result.edisp_map.data, edispkernelmap.edisp_map.data)
+        assert result.edisp_map.geom == edispkernelmap.edisp_map.geom
+        assert result.edisp_map.unit == edispkernelmap.edisp_map.unit
+
+        assert_allclose(result.exposure_map.data, edispkernelmap.exposure_map.data)
+        assert result.exposure_map.geom == edispkernelmap.exposure_map.geom
+        assert result.exposure_map.unit == edispkernelmap.exposure_map.unit

--- a/gammapy/io/asdf/converters/irf/psf/__init__.py
+++ b/gammapy/io/asdf/converters/irf/psf/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/gammapy/io/asdf/converters/irf/psf/map.py
+++ b/gammapy/io/asdf/converters/irf/psf/map.py
@@ -1,0 +1,26 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+
+from gammapy.io.asdf.converters.irf.core import IRFMapConverter
+
+
+class PSFMapConverter(IRFMapConverter):
+    tags = ["asdf://gammapy.org/gammapy/tags/irf/psfmap-1.0.0"]
+    types = ["gammapy.irf.PSFMap"]
+    map_key = "psf_map"
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from gammapy.irf import PSFMap
+
+        return PSFMap(**super().from_yaml_tree(node, tag, ctx))
+
+
+class RecoPSFMapConverter(IRFMapConverter):
+    tags = ["asdf://gammapy.org/gammapy/tags/irf/recopsfmap-1.0.0"]
+    types = ["gammapy.irf.RecoPSFMap"]
+    map_key = "psf_map"
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from gammapy.irf import RecoPSFMap
+
+        return RecoPSFMap(**super().from_yaml_tree(node, tag, ctx))

--- a/gammapy/io/asdf/converters/irf/psf/tests/__init__.py
+++ b/gammapy/io/asdf/converters/irf/psf/tests/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/gammapy/io/asdf/converters/irf/psf/tests/test_map.py
+++ b/gammapy/io/asdf/converters/irf/psf/tests/test_map.py
@@ -1,0 +1,68 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+
+from numpy.testing import assert_allclose
+
+from gammapy.irf import PSFMap, RecoPSFMap
+from gammapy.maps import MapAxis, RegionGeom
+import astropy.units as u
+
+asdf = pytest.importorskip("asdf")
+pytest.importorskip("asdf.testing")
+
+
+def test_psfmap_roundtrip(tmp_path):
+    file_path = tmp_path / "test.asdf"
+    energy_axis_true = MapAxis.from_energy_bounds(
+        "1 TeV", "10 TeV", nbin=3, name="energy_true"
+    )
+    geom = RegionGeom.create("icrs;circle(0, 0, 0.1)")
+
+    psf = PSFMap.from_gauss(
+        energy_axis_true=energy_axis_true, sigma=[0.1, 0.2, 0.3] * u.deg, geom=geom
+    )
+
+    with asdf.AsdfFile() as af:
+        af["psf"] = psf
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        result = af["psf"]
+
+        assert type(result) is PSFMap
+        assert result.required_axes == ["rad", "energy_true"]
+
+        assert_allclose(result.psf_map.data, psf.psf_map.data)
+        assert result.psf_map.geom == psf.psf_map.geom
+        assert result.psf_map.unit == psf.psf_map.unit
+
+        assert_allclose(result.exposure_map.data, psf.exposure_map.data)
+        assert result.exposure_map.geom == psf.exposure_map.geom
+        assert result.exposure_map.unit == psf.exposure_map.unit
+
+
+def test_recopsfmap_roundtrip(tmp_path):
+    file_path = tmp_path / "test.asdf"
+    energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3, name="energy")
+    geom = RegionGeom.create("icrs;circle(0, 0, 0.1)")
+    reco_psf = RecoPSFMap.from_gauss(
+        energy_axis=energy_axis, sigma=[0.1, 0.2, 0.3] * u.deg, geom=geom
+    )
+
+    with asdf.AsdfFile() as af:
+        af["reco_psf"] = reco_psf
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        result = af["reco_psf"]
+
+        assert type(result) is RecoPSFMap
+        assert result.required_axes == ["rad", "energy"]
+
+        assert_allclose(result.psf_map.data, reco_psf.psf_map.data)
+        assert result.psf_map.geom == reco_psf.psf_map.geom
+        assert result.psf_map.unit == reco_psf.psf_map.unit
+
+        assert_allclose(result.exposure_map.data, reco_psf.exposure_map.data)
+        assert result.exposure_map.geom == reco_psf.exposure_map.geom
+        assert result.exposure_map.unit == reco_psf.exposure_map.unit

--- a/gammapy/io/asdf/converters/irf/psf/tests/test_map.py
+++ b/gammapy/io/asdf/converters/irf/psf/tests/test_map.py
@@ -4,7 +4,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from gammapy.irf import PSFMap, RecoPSFMap
-from gammapy.maps import MapAxis, RegionGeom
+from gammapy.maps import MapAxis, RegionGeom, WcsGeom
 import astropy.units as u
 
 asdf = pytest.importorskip("asdf")
@@ -21,7 +21,6 @@ def test_psfmap_roundtrip(tmp_path):
     psf = PSFMap.from_gauss(
         energy_axis_true=energy_axis_true, sigma=[0.1, 0.2, 0.3] * u.deg, geom=geom
     )
-
     with asdf.AsdfFile() as af:
         af["psf"] = psf
         af.write_to(file_path)
@@ -41,10 +40,40 @@ def test_psfmap_roundtrip(tmp_path):
         assert result.exposure_map.unit == psf.exposure_map.unit
 
 
+def test_psfmap_roundtrip_no_exposure(tmp_path):
+    file_path = tmp_path / "test.asdf"
+    energy_axis_true = MapAxis.from_energy_bounds(
+        "1 TeV", "10 TeV", nbin=3, name="energy_true"
+    )
+    geom = WcsGeom.create(
+        skydir=(0, 0), frame="galactic", npix=(3, 3), binsz=20.0 * u.deg
+    )
+    psf = PSFMap.from_gauss(
+        energy_axis_true=energy_axis_true, sigma=[0.1, 0.2, 0.3] * u.deg, geom=geom
+    )
+    psf.exposure_map = None
+
+    with asdf.AsdfFile() as af:
+        af["psf"] = psf
+        af.write_to(file_path)
+    with asdf.open(file_path) as af:
+        result = af["psf"]
+        assert type(result) is PSFMap
+        assert result.required_axes == ["rad", "energy_true"]
+
+        assert_allclose(result.psf_map.data, psf.psf_map.data)
+        assert result.psf_map.geom == psf.psf_map.geom
+        assert result.psf_map.unit == psf.psf_map.unit
+
+        assert result.exposure_map is None
+
+
 def test_recopsfmap_roundtrip(tmp_path):
     file_path = tmp_path / "test.asdf"
     energy_axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3, name="energy")
-    geom = RegionGeom.create("icrs;circle(0, 0, 0.1)")
+    geom = WcsGeom.create(
+        skydir=(0, 0), frame="galactic", npix=(3, 3), binsz=20.0 * u.deg
+    )
     reco_psf = RecoPSFMap.from_gauss(
         energy_axis=energy_axis, sigma=[0.1, 0.2, 0.3] * u.deg, geom=geom
     )

--- a/gammapy/io/asdf/extensions.py
+++ b/gammapy/io/asdf/extensions.py
@@ -26,6 +26,9 @@ from .converters.maps.ndmap import (
     WcsNDMapConverter,
 )
 
+from .converters.irf.psf.map import PSFMapConverter, RecoPSFMapConverter
+from .converters.irf.edisp.map import EDispMapConverter, EDispKernelMapConverter
+
 GAMMAPY_CONVERTERS = [
     MapsConverter(),
     GTIConverter(),
@@ -39,6 +42,10 @@ GAMMAPY_CONVERTERS = [
     HpxNDMapConverter(),
     RegionNDMapConverter(),
     WcsNDMapConverter(),
+    PSFMapConverter(),
+    RecoPSFMapConverter(),
+    EDispMapConverter(),
+    EDispKernelMapConverter(),
 ]
 
 GAMMAPY_EXTENSIONS = [

--- a/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/manifests/gammapy-1.0.0.yaml
@@ -28,3 +28,11 @@ tags:
   schema_uri: asdf://gammapy.org/gammapy/schemas/maps/maps-1.0.0
 - tag_uri: asdf://gammapy.org/gammapy/tags/data/gti-1.0.0
   schema_uri: asdf://gammapy.org/gammapy/schemas/data/gti-1.0.0
+- tag_uri: asdf://gammapy.org/gammapy/tags/irf/psfmap-1.0.0
+  schema_uri: asdf://gammapy.org/gammapy/schemas/irf/psfmap-1.0.0
+- tag_uri: asdf://gammapy.org/gammapy/tags/irf/recopsfmap-1.0.0
+  schema_uri: asdf://gammapy.org/gammapy/schemas/irf/recopsfmap-1.0.0
+- tag_uri: asdf://gammapy.org/gammapy/tags/irf/edispmap-1.0.0
+  schema_uri: asdf://gammapy.org/gammapy/schemas/irf/edispmap-1.0.0
+- tag_uri: asdf://gammapy.org/gammapy/tags/irf/edispkernelmap-1.0.0
+  schema_uri: asdf://gammapy.org/gammapy/schemas/irf/edispkernelmap-1.0.0

--- a/gammapy/io/asdf/resources/schemas/irf/edispkernelmap-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/irf/edispkernelmap-1.0.0.yaml
@@ -1,0 +1,33 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://gammapy.org/gammapy/schemas/irf/edispkernelmap-1.0.0"
+
+title: |
+  Represents EDispKernelMap.
+
+description: |
+     Support the serialization of EDispKernelMap, which represents an energy
+     dispersion kernel map with (energy, energy_true) axes.
+
+type: object
+properties:
+  edisp_kernel_map:
+    anyOf:
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/hpxndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/regionndmap-1.0.0"
+    description: |
+      Holds the energy dispersion probability values as a Map object,
+      with two non-spatial axes, in this order: energy and energy_true.
+  exposure_map:
+    anyOf:
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/hpxndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/regionndmap-1.0.0"
+    description: |
+      Optional field holding exposure-weighting values as a Map.
+
+required: [edisp_kernel_map]
+additionalProperties: false
+...

--- a/gammapy/io/asdf/resources/schemas/irf/edispmap-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/irf/edispmap-1.0.0.yaml
@@ -1,0 +1,34 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://gammapy.org/gammapy/schemas/irf/edispmap-1.0.0"
+
+title: |
+  Represents EDispMap.
+
+description: |
+     Support the serialization of EDispMap, which represents an energy
+     dispersion map with (migra, energy_true) axes.
+
+
+type: object
+properties:
+  edisp_map:
+    anyOf:
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/hpxndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/regionndmap-1.0.0"
+    description: |
+      Holds the energy dispersion probability values as a Map object,
+      with two non-spatial axes, in this order: migra and energy_true.
+  exposure_map:
+    anyOf:
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/hpxndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/regionndmap-1.0.0"
+    description: |
+          Optional field holding exposure-weighting values as a Map.
+
+required: [edisp_map]
+additionalProperties: false
+...

--- a/gammapy/io/asdf/resources/schemas/irf/psfmap-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/irf/psfmap-1.0.0.yaml
@@ -1,0 +1,33 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://gammapy.org/gammapy/schemas/irf/psfmap-1.0.0"
+
+title: |
+  Represents PSFMap.
+
+description: |
+     Support the serialization of PSFMap, which represents a point spread
+     function map with (rad, energy_true) axes.
+
+type: object
+properties:
+  psf_map:
+    anyOf:
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/hpxndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/regionndmap-1.0.0"
+    description: |
+      Holds the actual PSF probability-density values as a Map object,
+      with two non-spatial axes, in this exact order: rad and energy_true.
+  exposure_map:
+    anyOf:
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/hpxndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/regionndmap-1.0.0"
+    description: |
+      Optional field holding exposure-weighting values as a Map.
+
+required: [psf_map]
+additionalProperties: false
+...

--- a/gammapy/io/asdf/resources/schemas/irf/recopsfmap-1.0.0.yaml
+++ b/gammapy/io/asdf/resources/schemas/irf/recopsfmap-1.0.0.yaml
@@ -1,0 +1,33 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://gammapy.org/gammapy/schemas/irf/recopsfmap-1.0.0"
+
+title: |
+  Represents RecoPSFMap.
+
+description: |
+     Support the serialization of RecoPSFMap, a PSFMap variant defined using
+     the reconstructed energy axis instead of energy_true.
+
+type: object
+properties:
+  psf_map:
+    anyOf:
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/hpxndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/regionndmap-1.0.0"
+    description: |
+      Holds the actual PSF probability-density values as a Map object,
+      with two non-spatial axes, in this exact order: rad and energy axes.
+  exposure_map:
+    anyOf:
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/wcsndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/hpxndmap-1.0.0"
+      - tag: "asdf://gammapy.org/gammapy/tags/maps/regionndmap-1.0.0"
+    description: |
+       Optional field holding exposure-weighting values as a Map.
+
+required: [psf_map]
+additionalProperties: false
+...


### PR DESCRIPTION
This pull request is part of Google Summer of Code project Serialization Of Map and Model Classes into ASDF (Advanced Scientific Data Format).
Closes #6829.

Note : `PSFMap`, `RecoPSFMap`, `EDispMap`, `EDispKernelMap` differ only in `tag` and `required_axes`.

### **Implementation details**

**Converters:**

- `IRFMapConverter` : 
    - works as a base class, is not registered and has no tags or types.
    - All implemented classes inherit from IRFMap, which holds two Map fields (the IRF map + exposure map).
    - each converter sets `map_key` to the YAML field name for its IRF map, and only overrides `attr_name` when the object's property name differs from that key as with `EDispKernelMap`.
    
- `PSFMapConverter`, `RecoPSFMapConverter`, `EDispMapConverter` : All Inherit from `IRFMapConverter` and all set its `map_key` directly.
- `EDispKernelMapConverter`: Inherits from `IRFMapConverter` and additionally sets `attr_name` to "edisp_map"  since its property name differs from its `map_key`  which is "edisp_kernel_map".


**Schemas**

`psfmap-1.0.0.yaml`, `recopsfmap-1.0.0.yaml`, `edispmap-1.0.0.yaml`, `edispkernelmap-1.0.0.yaml`

- all schemas almost share the same structure differing in the descriptions/Title.
- properties are the IRF map is required and `exposure_map` is optional.
 Both properties accept any of the three existing serialized `NDMap` types (`WcsNDMap`, `HpxNDMap`, `RegionNDMap`) via `anyOf`.

**Testing** 
- Added round-trip tests for all classes.
- checked the read object type and required_axes is exactly as expected.