### PR TITLE
Add an OnOff dataset maker

### DIFF
--- a/docs/release-notes/6824.feature.rst
+++ b/docs/release-notes/6824.feature.rst
@@ -1,0 +1,1 @@
+# Add `~gammapy.makers.OnOffBackgroundMaker` for on-off analysis

--- a/gammapy/makers/__init__.py
+++ b/gammapy/makers/__init__.py
@@ -10,6 +10,7 @@ from .background import (
     RingBackgroundMaker,
     WobbleRegionsFinder,
     OnOffBackgroundMaker,
+    check_run_pair_validity,
 )
 from .core import Maker
 from .map import MapDatasetMaker
@@ -48,4 +49,5 @@ __all__ = [
     "SpectrumDatasetMaker",
     "WobbleRegionsFinder",
     "OnOffBackgroundMaker",
+    "check_run_pair_validity",
 ]

--- a/gammapy/makers/__init__.py
+++ b/gammapy/makers/__init__.py
@@ -9,6 +9,7 @@ from .background import (
     RegionsFinder,
     RingBackgroundMaker,
     WobbleRegionsFinder,
+    OnOffBackgroundMaker,
 )
 from .core import Maker
 from .map import MapDatasetMaker
@@ -46,4 +47,5 @@ __all__ = [
     "SafeMaskMaker",
     "SpectrumDatasetMaker",
     "WobbleRegionsFinder",
+    "OnOffBackgroundMaker",
 ]

--- a/gammapy/makers/background/__init__.py
+++ b/gammapy/makers/background/__init__.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .fov import FoVBackgroundMaker
+from .onoffpair import OnOffBackgroundMaker
 from .phase import PhaseBackgroundMaker
 from .reflected import (
     ReflectedRegionsBackgroundMaker,
@@ -18,4 +19,5 @@ __all__ = [
     "RegionsFinder",
     "RingBackgroundMaker",
     "WobbleRegionsFinder",
+    "OnOffBackgroundMaker",
 ]

--- a/gammapy/makers/background/__init__.py
+++ b/gammapy/makers/background/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .fov import FoVBackgroundMaker
-from .onoffpair import OnOffBackgroundMaker
+from .onoffpair import OnOffBackgroundMaker, check_run_pair_validity
 from .phase import PhaseBackgroundMaker
 from .reflected import (
     ReflectedRegionsBackgroundMaker,
@@ -20,4 +20,5 @@ __all__ = [
     "RingBackgroundMaker",
     "WobbleRegionsFinder",
     "OnOffBackgroundMaker",
+    "check_run_pair_validity",
 ]

--- a/gammapy/makers/background/onoffpair.py
+++ b/gammapy/makers/background/onoffpair.py
@@ -4,6 +4,7 @@
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
+from astropy.table import QTable
 
 from gammapy.data import EventList
 from gammapy.datasets import (
@@ -15,6 +16,87 @@ from gammapy.datasets import (
 from ..core import Maker
 from gammapy.maps import Map
 from gammapy.utils.coordinates import fov_to_sky, sky_to_fov
+
+__all__ = ["OnOffBackgroundMaker", "check_run_pair_validity"]
+
+
+def check_run_pair_validity(
+    on_observations,
+    off_observations,
+    energy_range,
+    zenith_tol=10 * u.deg,
+    aeff_tol=0.1,
+):
+    """Validity check over a list of ON/OFF pairs.
+
+    Parameters
+    ----------
+    on_observations : list of `~gammapy.data.Observation` or `~gammapy.data.Observations`
+        The ON observations list
+    off_observations : list of `~gammapy.data.Observation` or `~gammapy.data.Observations`
+        The OFF observation list
+    energy_range : `~gammapy.maps.MapAxis`
+        The energy axis on which to check the effective area
+    zenith_tol : `~astropy.units.Quantity`, optional
+        Zenith tolerance, default 10 deg.
+    aeff_tol : float, optional
+        Effective-area fractional-deviation tolerance, default 0.1.
+
+    Returns
+    -------
+    table : `~astropy.table.QTable`
+        One row per pair, with columns ``obs_id``, ``off_obs_id``,
+        ``zenith_on``, ``zenith_off``, ``delta_zenith``, ``zenith_ok``,
+        ``aeff_max_frac_deviation`` and ``aeff_ok``.
+    """
+    if len(on_observations) != len(off_observations):
+        raise ValueError(
+            "on_observations and off_observations must have equal length; "
+            f"got {len(on_observations)} and {len(off_observations)}"
+        )
+
+    results = []
+    for on_obs, off_obs in zip(on_observations, off_observations):
+        zenith_on = 90.0 * u.deg - on_obs.get_pointing_altaz(on_obs.tmid).alt
+        zenith_off = 90.0 * u.deg - off_obs.get_pointing_altaz(off_obs.tmid).alt
+        delta_zenith = abs(zenith_on - zenith_off)
+        aeff_dev = _aeff_max_frac_deviation(on_obs, off_obs, energy_range)
+        aeff_ok = aeff_dev is not None and aeff_dev < aeff_tol
+        result = {
+            "obs_id": on_obs.obs_id,
+            "off_obs_id": off_obs.obs_id,
+            "zenith_on": zenith_on,
+            "zenith_off": zenith_off,
+            "delta_zenith": delta_zenith,
+            "zenith_ok": bool(delta_zenith < zenith_tol),
+            "aeff_max_frac_deviation": aeff_dev,
+            "aeff_ok": bool(aeff_ok),
+        }
+        results.append(result)
+
+    return QTable(results)
+
+
+def _aeff_max_frac_deviation(on_observation, off_observation, energy_axis):
+    """Max fractional deviation between the two effective areas."""
+    aeff_on = on_observation.aeff
+    aeff_off = off_observation.aeff
+    if aeff_on is None or aeff_off is None:
+        return None
+
+    energy = energy_axis.center
+    offset = aeff_on.axes["offset"].center
+    energy_grid, offset_grid = np.meshgrid(energy, offset, indexing="ij")
+
+    a_on = aeff_on.evaluate(energy_true=energy_grid, offset=offset_grid).to_value("m2")
+    a_off = aeff_off.evaluate(energy_true=energy_grid, offset=offset_grid).to_value(
+        "m2"
+    )
+
+    mask = a_on > 0
+    if not np.any(mask):
+        return None
+    return float(np.max(np.abs(a_off[mask] - a_on[mask]) / a_on[mask]))
 
 
 class OnOffBackgroundMaker(Maker):

--- a/gammapy/makers/background/onoffpair.py
+++ b/gammapy/makers/background/onoffpair.py
@@ -1,0 +1,120 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""On-Off background estimation for dedicated On Off Pair runs"""
+
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+from gammapy.data import EventList
+from gammapy.datasets import (
+    MapDataset,
+    MapDatasetOnOff,
+    SpectrumDataset,
+    SpectrumDatasetOnOff,
+)
+from ..core import Maker
+from gammapy.maps import Map
+from gammapy.utils.coordinates import fov_to_sky, sky_to_fov
+
+
+class OnOffBackgroundMaker(Maker):
+    """Estimate OFF background from a paired OFF observation.
+
+    Turns a reduced ``MapDataset`` / ``SpectrumDataset``
+    into its OnOff counterpart by mirroring the OFF run's events into
+    the ON pointing FoV frame and setting acceptances from livetime.
+
+    On-off pairs should be created beforehand by the user.
+
+    Parameters
+    ----------
+    acceptance_method : str, optional
+        Allowed option are {"livetime_ratio"}
+        Default is "livetime"
+        Strategy for the acceptance calculation
+        "livetime_ratio" takes the ratio of livetimes, flat acceptance
+    """
+
+    tag = "OnOffBackgroundMaker"
+
+    available_acceptance_methods = ["livetime_ratio"]
+
+    def __init__(self, acceptance_method="livetime_ratio"):
+        if acceptance_method not in self.available_acceptance_methods:
+            raise ValueError(
+                f"Unknown acceptance_method {acceptance_method!r}, "
+                f"choose from {self.available_acceptance_methods}"
+            )
+        self.acceptance_method = acceptance_method
+
+    def _mirror_off_events(self, on_observation, off_observation):
+        """Reproject OFF events into the ON pointing FoV frame (aligned with RA/DEC)."""
+        events = off_observation.events
+        off_pointing = off_observation.get_pointing_icrs(off_observation.tmid)
+        on_pointing = on_observation.get_pointing_icrs(on_observation.tmid)
+
+        fov_lon, fov_lat = sky_to_fov(
+            events.radec.ra, events.radec.dec, off_pointing.ra, off_pointing.dec
+        )
+        off_ra, off_dec = fov_to_sky(fov_lon, fov_lat, on_pointing.ra, on_pointing.dec)
+        table = events.table.copy()
+        off_coord = SkyCoord(off_ra, off_dec, frame="icrs")
+        table["RA"] = off_coord.ra
+        table["DEC"] = off_coord.dec
+        return EventList(table)
+
+    def _make_acceptance(self, dataset, on_observation, off_observation):
+        geom = dataset.counts.geom
+        t_on = on_observation.observation_live_time_duration.to_value("s")
+        t_off = off_observation.observation_live_time_duration.to_value("s")
+
+        if self.acceptance_method == "livetime_ratio":
+            acceptance = Map.from_geom(geom, unit="", data=t_on)
+            acceptance_off = Map.from_geom(geom, unit="", data=t_off)
+            return acceptance, acceptance_off
+
+        raise ValueError(f"Unhandled acceptance_method {self.acceptance_method!r}")
+
+    def run(self, dataset, on_observation, off_observation):
+        """Create background using dedicated off pointing.
+
+        Parameters
+        ----------
+        dataset : `~gammapy.datasets.MapDataset` or `~gammapy.datasets.SpectrumDataset`
+            Reduced dataset for the ON observation
+        on_observation : `~gammapy.data.Observation`
+            The ON observation.
+        off_observation : `~gammapy.data.Observation`
+            The paired OFF observation.
+
+        Returns
+        -------
+        dataset : `~gammapy.datasets.MapDatasetOnOff` or `~gammapy.datasets.SpectrumDatasetOnOff`
+        """
+        geom = dataset.counts.geom
+        counts_off = Map.from_geom(geom, unit="")
+        counts_off.fill_events(self._mirror_off_events(on_observation, off_observation))
+
+        acceptance, acceptance_off = self._make_acceptance(
+            dataset, off_observation, on_observation
+        )
+
+        if isinstance(dataset, SpectrumDataset):
+            return SpectrumDatasetOnOff.from_spectrum_dataset(
+                dataset=dataset,
+                acceptance=acceptance,
+                acceptance_off=acceptance_off,
+                counts_off=counts_off,
+                name=dataset.name,
+            )
+        elif isinstance(dataset, MapDataset):
+            return MapDatasetOnOff.from_map_dataset(
+                dataset=dataset,
+                acceptance=acceptance,
+                acceptance_off=acceptance_off,
+                counts_off=counts_off,
+                name=dataset.name,
+            )
+        raise TypeError(
+            f"Expected MapDataset or SpectrumDataset, got {type(dataset).__name__}"
+        )

--- a/gammapy/makers/background/tests/test_onoff.py
+++ b/gammapy/makers/background/tests/test_onoff.py
@@ -6,14 +6,17 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
-
 from gammapy.data import DataStore
 from gammapy.datasets import (
     MapDataset,
     MapDatasetOnOff,
     SpectrumDatasetOnOff,
 )
-from gammapy.makers import MapDatasetMaker, OnOffBackgroundMaker
+from gammapy.makers import (
+    MapDatasetMaker,
+    OnOffBackgroundMaker,
+    check_run_pair_validity,
+)
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.utils.testing import requires_data
 
@@ -83,3 +86,42 @@ def test_run_spectrum_dataset(spectrum_dataset, observations):
     assert_allclose(result.background.data.sum(), 41.4, atol=1e-1)
     assert result.acceptance.geom == result.counts.geom
     assert_allclose(result.alpha.data[0], 1.03, atol=1e-2)
+
+
+@requires_data()
+def test_check_run_pair_validity():
+    datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
+    obs_ids = [23523, 23526, 23559, 23592]
+    on_observations = datastore.get_observations(obs_ids)
+    off_obs_ids = [23736, 21851, 22022, 26827]
+    off_observations = datastore.get_observations(off_obs_ids)
+
+    energy_axis_true = MapAxis.from_energy_bounds(
+        "0.8 TeV", "20 TeV", 8, name="energy_true"
+    )
+    with pytest.raises(ValueError):
+        check_run_pair_validity(
+            on_observations, off_observations[:-1], energy_axis_true
+        )
+
+    table = check_run_pair_validity(on_observations, off_observations, energy_axis_true)
+    assert table.colnames == [
+        "obs_id",
+        "off_obs_id",
+        "zenith_on",
+        "zenith_off",
+        "delta_zenith",
+        "zenith_ok",
+        "aeff_max_frac_deviation",
+        "aeff_ok",
+    ]
+    assert len(table) == 4
+    # pairing and identity are carried through positionally
+    assert_allclose(table["obs_id"], obs_ids)
+    assert_allclose(table["off_obs_id"], off_obs_ids)
+    assert_allclose(table["delta_zenith"].value, [2.19, 4.06, 2.48, 1.00], rtol=1e-2)
+    assert np.all(table["zenith_ok"])
+    assert_allclose(
+        table["aeff_max_frac_deviation"].value, [0.306, 0.134, 0.112, 0.171], atol=1e-2
+    )
+    assert not np.all(table["aeff_ok"])

--- a/gammapy/makers/background/tests/test_onoff.py
+++ b/gammapy/makers/background/tests/test_onoff.py
@@ -1,0 +1,85 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from regions import CircleSkyRegion
+
+from gammapy.data import DataStore
+from gammapy.datasets import (
+    MapDataset,
+    MapDatasetOnOff,
+    SpectrumDatasetOnOff,
+)
+from gammapy.makers import MapDatasetMaker, OnOffBackgroundMaker
+from gammapy.maps import MapAxis, WcsGeom
+from gammapy.utils.testing import requires_data
+
+
+@pytest.fixture(scope="session")
+def observations():
+    datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
+    on = datastore.obs(23523)  # Crab
+    off = datastore.obs(26850)  # empty-field OFF run
+    return on, off
+
+
+@pytest.fixture
+def energy_axis():
+    return MapAxis.from_energy_bounds("0.1 TeV", "40 TeV", 8, name="energy")
+
+
+@pytest.fixture
+def map_dataset(energy_axis, observations):
+    on, _ = observations
+    geom = WcsGeom.create(
+        skydir=(83.633, 22.014),
+        binsz=0.05,
+        width=(4, 4),
+        frame="icrs",
+        axes=[energy_axis],
+    )
+    empty = MapDataset.create(geom=geom, name="23523")
+    return MapDatasetMaker(selection=["counts", "exposure", "psf", "edisp"]).run(
+        empty, on
+    )
+
+
+@pytest.fixture
+def spectrum_dataset(energy_axis, map_dataset):
+    region = CircleSkyRegion(SkyCoord(83.633, 22.014, unit="deg"), 0.11 * u.deg)
+    return map_dataset.to_spectrum_dataset(region)
+
+
+def test_init_invalid_method():
+    with pytest.raises(ValueError):
+        OnOffBackgroundMaker(acceptance_method="xx")
+
+
+@requires_data()
+def test_run_map_dataset(map_dataset, observations):
+    on, off = observations
+    result = OnOffBackgroundMaker().run(map_dataset, on, off)
+
+    assert isinstance(result, MapDatasetOnOff)
+    assert np.allclose(result.counts.data, map_dataset.counts.data)
+    assert result.counts_off.data.sum() == 7662
+    assert result.counts_off.geom == result.counts.geom
+    assert_allclose(result.background.data.sum(), 7937, atol=1e-1)
+    assert result.psf is not None
+    assert result.edisp is not None
+
+
+@requires_data()
+def test_run_spectrum_dataset(spectrum_dataset, observations):
+    on, off = observations
+    result = OnOffBackgroundMaker().run(spectrum_dataset, on, off)
+
+    assert isinstance(result, SpectrumDatasetOnOff)
+    assert result.counts_off.data.sum() == 40
+    assert result.counts_off.geom == result.counts.geom
+    assert_allclose(result.background.data.sum(), 41.4, atol=1e-1)
+    assert result.acceptance.geom == result.counts.geom
+    assert_allclose(result.alpha.data[0], 1.03, atol=1e-2)


### PR DESCRIPTION
This address #6635 

I add a maker for this now, it is a very simple one actually.
One can even set the dataset.counts_off = dataset_off.counts if the zenith angle matching is perfect and there are no projection effects. 
For now, the only acceptance correction is based on the livetime. I thought of adding one by scaling the aeff, but I dont know if thats completely correct. That can be added later as per requirement.

If this looks OK, I can add a tutorial in a separate PR