### PR TITLE
Introduce BasePlotter class

### DIFF
--- a/docs/release-notes/6845.feature.rst
+++ b/docs/release-notes/6845.feature.rst
@@ -1,0 +1,1 @@
+Add `~gammapy.visualization.plotters.BasePlotter` class, first building plot for the new Plotters API defined in PIG 31.

--- a/gammapy/visualization/plotters/__init__.py
+++ b/gammapy/visualization/plotters/__init__.py
@@ -1,0 +1,6 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from .core import BasePlotter
+
+__all__ = [
+    "BasePlotter",
+]

--- a/gammapy/visualization/plotters/core.py
+++ b/gammapy/visualization/plotters/core.py
@@ -1,0 +1,42 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import matplotlib
+
+__all__ = ["BasePlotter"]
+
+
+class BasePlotter:
+    """Base class for Gammapy plotter objects.
+
+    A plotter carries a local matplotlib configuration and exposes plotting
+    methods that receive the object to plot as an argument. It keeps no
+    reference to a data object.
+
+    Parameters
+    ----------
+    rc_params : dict, optional
+        Mapping of `matplotlib.rcParams` keys to values. Entries are validated
+        when set and applied while plotting. Default is None.
+    """
+
+    def __init__(self, rc_params=None):
+        self._rc_params = matplotlib.RcParams()
+        if rc_params is not None:
+            self.rc_params = rc_params
+
+    @property
+    def rc_params(self):
+        """Local matplotlib configuration as a `~matplotlib.RcParams` object."""
+        return self._rc_params
+
+    @rc_params.setter
+    def rc_params(self, value):
+        if not isinstance(value, dict):
+            raise TypeError("rc_params must be a dictionary")
+
+        merged = matplotlib.RcParams(self._rc_params)
+        merged.update(value)
+        self._rc_params = merged
+
+    def _rc_context(self):
+        """Context manager applying the local configuration while plotting."""
+        return matplotlib.rc_context(self._rc_params)

--- a/gammapy/visualization/plotters/tests/__init__.py
+++ b/gammapy/visualization/plotters/tests/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst

--- a/gammapy/visualization/plotters/tests/test_core.py
+++ b/gammapy/visualization/plotters/tests/test_core.py
@@ -1,0 +1,98 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import matplotlib
+from gammapy.visualization import BasePlotter
+
+
+class SubClassPlotter(BasePlotter):
+    def __init__(self, rc_params=None):
+        super().__init__()
+        self.rc_params = {"image.cmap": "afmhot", "image.origin": "lower"}
+        if rc_params:
+            self.rc_params = rc_params
+
+
+def test_init_empty():
+    plotter = BasePlotter()
+    assert isinstance(plotter.rc_params, matplotlib.RcParams)
+    assert len(plotter.rc_params) == 0
+    assert plotter.rc_params is not matplotlib.rcParams
+
+
+def test_init_with_rc_params():
+    plotter = BasePlotter({"image.cmap": "viridis"})
+    assert plotter.rc_params["image.cmap"] == "viridis"
+    assert len(plotter.rc_params) == 1
+
+
+def test_does_not_mutate_global_rc_params():
+    before = dict(matplotlib.rcParams)
+    plotter = BasePlotter({"image.cmap": "afmhot"})
+    plotter.rc_params = {"image.origin": "lower"}
+    assert dict(matplotlib.rcParams) == before
+
+
+def test_instances_are_independent():
+    first = BasePlotter({"image.cmap": "viridis"})
+    second = BasePlotter({"image.cmap": "afmhot"})
+    first.rc_params = {"image.cmap": "gray"}
+    assert second.rc_params["image.cmap"] == "afmhot"
+
+
+def test_invalid_key_raises():
+    with pytest.raises(KeyError):
+        BasePlotter({"not.a.key": "x"})
+
+
+def test_invalid_value_raises():
+    with pytest.raises(ValueError):
+        BasePlotter({"image.origin": "incorrect"})
+
+
+@pytest.mark.parametrize("value", [["image.cmap", "afmhot"], "image.cmap"])
+def test_non_dict_raises(value):
+    plotter = BasePlotter()
+    with pytest.raises(TypeError):
+        plotter.rc_params = value
+
+
+def test_setter_merges_with_existing_config():
+    plotter = BasePlotter({"image.cmap": "viridis", "image.origin": "lower"})
+    plotter.rc_params = {"image.cmap": "afmhot"}
+    assert plotter.rc_params["image.cmap"] == "afmhot"
+    assert plotter.rc_params["image.origin"] == "lower"
+
+
+def test_setter_is_atomic_on_error():
+    plotter = BasePlotter({"image.cmap": "viridis"})
+    with pytest.raises(KeyError):
+        plotter.rc_params = {"image.cmap": "afmhot", "not.a.key": "x"}
+    assert plotter.rc_params["image.cmap"] == "viridis"
+    assert "not.a.key" not in plotter.rc_params
+
+
+def test_rc_context_applies_and_restores():
+    original = matplotlib.rcParams["image.cmap"]
+    plotter = BasePlotter({"image.cmap": "afmhot"})
+    with plotter._rc_context():
+        assert matplotlib.rcParams["image.cmap"] == "afmhot"
+    assert matplotlib.rcParams["image.cmap"] == original
+
+
+def test_rc_context_only_overrides_declared_keys():
+    plotter = BasePlotter({"image.cmap": "afmhot"})
+    with matplotlib.rc_context({"image.origin": "lower"}), plotter._rc_context():
+        assert matplotlib.rcParams["image.cmap"] == "afmhot"
+        assert matplotlib.rcParams["image.origin"] == "lower"
+
+
+def test_subclass_sets_defaults():
+    plotter = SubClassPlotter()
+    assert plotter.rc_params["image.cmap"] == "afmhot"
+    assert plotter.rc_params["image.origin"] == "lower"
+
+
+def test_subclass_rc_params_override_defaults():
+    plotter = SubClassPlotter({"image.cmap": "viridis"})
+    assert plotter.rc_params["image.cmap"] == "viridis"
+    assert plotter.rc_params["image.origin"] == "lower"


### PR DESCRIPTION
<!-- These are hidden comments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, mention its number and use the specific keywords to create a link -->
<!-- See docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
<!-- Example: This PR is to resolve #42 -->

This pull request introduces the `BasePlotter` class according to PIG 31.

The BasePlotter only contains the matplotlib config. It applies the matplotlib `rcParam` validation while maintaining the global matplotlib config clean. 

Future subclasses will implement plot functions using the context manager _rc_context() that applies matplotlib settings defined in the plotter. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want to go through review here? Or if someone should just finish this up and merge it? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing the new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
The PR only introduced new code in visualization.plotters. No re-factoring is performed yet.

**AI usage disclosure**
<!-- Please specify if and how AI tool were utilised: -->
<!-- * Which AI tool or agent was used? -->
<!-- * What is the type of assistance (i.e. code suggestion, explanation..)? -->
<!-- * What was the level of human supervision? -->
Tests were implemented with Claude, reviewed, cleaned-up and simplified. 